### PR TITLE
Return scooter rental legs with correct mode

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/dataoverlay/DataOverlayStreetEdgeCostExtension.java
+++ b/src/ext/java/org/opentripplanner/ext/dataoverlay/DataOverlayStreetEdgeCostExtension.java
@@ -50,7 +50,7 @@ class DataOverlayStreetEdgeCostExtension implements StreetEdgeCostExtension, Ser
 
   @Override
   public double calculateExtraCost(State state, int edgeLength, TraverseMode traverseMode) {
-    if (traverseMode.isWalking() || traverseMode.isCycling()) {
+    if (traverseMode.isWalking() || traverseMode.isCyclingIsh()) {
       return calculateDataOverlayPenalties(state) * edgeLength / 1000;
     }
     return 0d;

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/RentalVehicleType.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/RentalVehicleType.java
@@ -78,9 +78,9 @@ public class RentalVehicleType implements Serializable, Comparable<RentalVehicle
     CARGO_BICYCLE(TraverseMode.BICYCLE),
     CAR(TraverseMode.CAR),
     MOPED(TraverseMode.BICYCLE),
-    SCOOTER(TraverseMode.BICYCLE),
-    SCOOTER_STANDING(TraverseMode.BICYCLE),
-    SCOOTER_SEATED(TraverseMode.BICYCLE),
+    SCOOTER(TraverseMode.SCOOTER),
+    SCOOTER_STANDING(TraverseMode.SCOOTER),
+    SCOOTER_SEATED(TraverseMode.SCOOTER),
     OTHER(TraverseMode.BICYCLE);
 
     public final TraverseMode traverseMode;

--- a/src/main/java/org/opentripplanner/street/model/StreetTraversalPermission.java
+++ b/src/main/java/org/opentripplanner/street/model/StreetTraversalPermission.java
@@ -77,7 +77,7 @@ public enum StreetTraversalPermission {
   public boolean allows(TraverseMode mode) {
     if (mode == TraverseMode.WALK && allows(StreetTraversalPermission.PEDESTRIAN)) {
       return true;
-    } else if (mode == TraverseMode.BICYCLE && allows(StreetTraversalPermission.BICYCLE)) {
+    } else if (mode.isCyclingIsh() && allows(StreetTraversalPermission.BICYCLE)) {
       return true;
     } else if (mode == TraverseMode.CAR && allows(StreetTraversalPermission.CAR)) {
       return true;

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -290,9 +290,9 @@ public class StreetEdge
     final double speed =
       switch (traverseMode) {
         case WALK -> walkingBike ? preferences.bike().walkingSpeed() : preferences.walk().speed();
-        case BICYCLE -> preferences.bike().speed();
+        case BICYCLE, SCOOTER -> preferences.bike().speed();
         case CAR -> getCarSpeed();
-        default -> throw new IllegalArgumentException("getSpeed(): Invalid mode " + traverseMode);
+        case FLEX -> throw new IllegalArgumentException("getSpeed(): Invalid mode " + traverseMode);
       };
 
     return isStairs() ? (speed / preferences.walk().stairsTimeFactor()) : speed;

--- a/src/main/java/org/opentripplanner/street/search/TraverseMode.java
+++ b/src/main/java/org/opentripplanner/street/search/TraverseMode.java
@@ -19,7 +19,10 @@ public enum TraverseMode {
     return this == CAR;
   }
 
-  public boolean isCycling() {
+  /**
+   * For the purposes of this check, we pretend that scootering is like cycling.
+   */
+  public boolean isCyclingIsh() {
     return this == BICYCLE || this == SCOOTER;
   }
 

--- a/src/main/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculator.java
+++ b/src/main/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculator.java
@@ -33,7 +33,7 @@ public class SimpleIntersectionTraversalCalculator
 
     if (mode.isDriving()) {
       return computeDrivingTraversalDuration(v, from, to);
-    } else if (mode.isCycling()) {
+    } else if (mode.isCyclingIsh()) {
       return computeCyclingTraversalDuration(v, from, to, toSpeed);
     } else {
       return computeWalkingTraversalDuration(v, from, to, toSpeed);

--- a/src/test/java/org/opentripplanner/street/model/edge/RentalRestrictionExtensionTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/RentalRestrictionExtensionTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
 import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdge;
-import static org.opentripplanner.street.search.TraverseMode.BICYCLE;
+import static org.opentripplanner.street.search.TraverseMode.SCOOTER;
 import static org.opentripplanner.street.search.TraverseMode.WALK;
 import static org.opentripplanner.street.search.state.VehicleRentalState.HAVE_RENTED;
 import static org.opentripplanner.street.search.state.VehicleRentalState.RENTING_FLOATING;
@@ -84,7 +84,7 @@ class RentalRestrictionExtensionTest {
 
     var continueRenting = continueOnFoot.getNextResult();
     assertEquals(RENTING_FLOATING, continueRenting.getVehicleRentalState());
-    assertEquals(BICYCLE, continueRenting.getBackMode());
+    assertEquals(SCOOTER, continueRenting.getBackMode());
     assertTrue(continueRenting.isInsideNoRentalDropOffArea());
 
     var insideZone = restrictedEdge.traverse(continueRenting);

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeRentalTraversalTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeRentalTraversalTest.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.street.model.edge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.opentripplanner.routing.api.request.StreetMode.BIKE_RENTAL;
+import static org.opentripplanner.routing.api.request.StreetMode.SCOOTER_RENTAL;
+import static org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor.BICYCLE;
+import static org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor.CARGO_BICYCLE;
+import static org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor.SCOOTER;
+import static org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor.SCOOTER_SEATED;
+import static org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor.SCOOTER_STANDING;
+import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
+import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdge;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.vehicle_rental.RentalVehicleType;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+import org.opentripplanner.street.search.state.StateEditor;
+import org.opentripplanner.test.support.VariableSource;
+
+public class StreetEdgeRentalTraversalTest {
+
+  StreetVertex v0 = intersectionVertex(0.0, 0.0);
+  StreetVertex v1 = intersectionVertex(2.0, 2.0);
+
+  static Stream<Arguments> rentalCases = Stream.of(
+    of(SCOOTER, SCOOTER_RENTAL),
+    of(SCOOTER_SEATED, SCOOTER_RENTAL),
+    of(SCOOTER_STANDING, SCOOTER_RENTAL),
+    of(BICYCLE, BIKE_RENTAL),
+    of(CARGO_BICYCLE, BIKE_RENTAL)
+  );
+
+  @ParameterizedTest(name = "Form factor {0}, street mode {1} should be able to traverse")
+  @VariableSource("rentalCases")
+  public void scooterBicycleTraversal(
+    RentalVehicleType.FormFactor formFactor,
+    StreetMode streetMode
+  ) {
+    StreetEdge e0 = streetEdge(v0, v1, 50.0, StreetTraversalPermission.BICYCLE);
+    var req = StreetSearchRequest.of().withMode(streetMode).withArriveBy(false).build();
+
+    var editor = new StateEditor(v0, req);
+    editor.beginFloatingVehicleRenting(formFactor, "network", false);
+    var state = editor.makeState();
+
+    assertEquals(state.getNonTransitMode(), formFactor.traverseMode);
+    var afterTraversal = e0.traverse(state);
+
+    assertNotNull(afterTraversal);
+
+    assertEquals(formFactor.traverseMode, afterTraversal.getNonTransitMode());
+  }
+}

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeRentalTraversalTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeRentalTraversalTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.street.model.edge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.opentripplanner.routing.api.request.StreetMode.BIKE_RENTAL;
 import static org.opentripplanner.routing.api.request.StreetMode.SCOOTER_RENTAL;
@@ -14,6 +15,7 @@ import static org.opentripplanner.street.model._data.StreetModelForTest.intersec
 import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdge;
 
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -29,21 +31,35 @@ public class StreetEdgeRentalTraversalTest {
   StreetVertex v0 = intersectionVertex(0.0, 0.0);
   StreetVertex v1 = intersectionVertex(2.0, 2.0);
 
-  static Stream<Arguments> rentalCases = Stream.of(
-    of(SCOOTER, SCOOTER_RENTAL),
-    of(SCOOTER_SEATED, SCOOTER_RENTAL),
-    of(SCOOTER_STANDING, SCOOTER_RENTAL),
-    of(BICYCLE, BIKE_RENTAL),
-    of(CARGO_BICYCLE, BIKE_RENTAL)
-  );
+  @Nonnull
+  private static Stream<Arguments> baseCases(StreetTraversalPermission p) {
+    return Stream.of(
+      of(SCOOTER, SCOOTER_RENTAL, p),
+      of(SCOOTER_SEATED, SCOOTER_RENTAL, p),
+      of(SCOOTER_STANDING, SCOOTER_RENTAL, p),
+      of(BICYCLE, BIKE_RENTAL, p),
+      of(CARGO_BICYCLE, BIKE_RENTAL, p)
+    );
+  }
 
-  @ParameterizedTest(name = "Form factor {0}, street mode {1} should be able to traverse")
-  @VariableSource("rentalCases")
-  public void scooterBicycleTraversal(
+  static Stream<Arguments> allowedToTraverse = Stream
+    .of(
+      StreetTraversalPermission.ALL,
+      StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,
+      StreetTraversalPermission.BICYCLE
+    )
+    .flatMap(StreetEdgeRentalTraversalTest::baseCases);
+
+  @ParameterizedTest(
+    name = "Form factor {0}, street mode {1} should be able to traverse edge with permission {2}"
+  )
+  @VariableSource("allowedToTraverse")
+  void scooterBicycleTraversal(
     RentalVehicleType.FormFactor formFactor,
-    StreetMode streetMode
+    StreetMode streetMode,
+    StreetTraversalPermission permission
   ) {
-    StreetEdge e0 = streetEdge(v0, v1, 50.0, StreetTraversalPermission.BICYCLE);
+    StreetEdge e0 = streetEdge(v0, v1, 50.0, permission);
     var req = StreetSearchRequest.of().withMode(streetMode).withArriveBy(false).build();
 
     var editor = new StateEditor(v0, req);
@@ -56,5 +72,31 @@ public class StreetEdgeRentalTraversalTest {
     assertNotNull(afterTraversal);
 
     assertEquals(formFactor.traverseMode, afterTraversal.getNonTransitMode());
+  }
+
+  static Stream<Arguments> noTraversal = Stream
+    .of(StreetTraversalPermission.CAR, StreetTraversalPermission.NONE)
+    .flatMap(StreetEdgeRentalTraversalTest::baseCases);
+
+  @ParameterizedTest(
+    name = "Form factor {0}, street mode {1} should not be able to traverse edge with permission {2}"
+  )
+  @VariableSource("noTraversal")
+  void noTraversal(
+    RentalVehicleType.FormFactor formFactor,
+    StreetMode streetMode,
+    StreetTraversalPermission permission
+  ) {
+    StreetEdge e0 = streetEdge(v0, v1, 50.0, permission);
+    var req = StreetSearchRequest.of().withMode(streetMode).withArriveBy(false).build();
+
+    var editor = new StateEditor(v0, req);
+    editor.beginFloatingVehicleRenting(formFactor, "network", false);
+    var state = editor.makeState();
+
+    assertEquals(state.getNonTransitMode(), formFactor.traverseMode);
+    var afterTraversal = e0.traverse(state);
+
+    assertNull(afterTraversal);
   }
 }


### PR DESCRIPTION
#4809 surfaced a bug where scooter rental legs are returned with mode `BICYCLE`. Beforehand that fact was papered over in `GraphPathToItineraryMapper`.

This fixes it by properly using `SCOOTER` as the traverse mode for scooter rental legs.

### Issue

Closes #4847 

### Unit tests

Lots added.