### PR TITLE
Improve boarding location linking on platforms

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -265,6 +265,7 @@ public class WalkableAreaBuilder {
             // area or a convex point, i.e. the angle is over 180 degrees.
             if (outerRing.isNodeConvex(i)) {
               visibilityNodes.add(node);
+              edgeList.visibilityVertices.add(handler.getVertexForOsmNode(node, areaEntity));
             }
             if (isStartingNode(node, osmWayIds)) {
               visibilityNodes.add(node);
@@ -283,6 +284,7 @@ public class WalkableAreaBuilder {
               // For holes, the internal angle is calculated, so we must swap the sign
               if (!innerRing.isNodeConvex(j)) {
                 visibilityNodes.add(node);
+                edgeList.visibilityVertices.add(handler.getVertexForOsmNode(node, areaEntity));
               }
               if (isStartingNode(node, osmWayIds)) {
                 visibilityNodes.add(node);

--- a/src/main/java/org/opentripplanner/inspector/raster/AreaEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/raster/AreaEdgeRenderer.java
@@ -1,0 +1,106 @@
+package org.opentripplanner.inspector.raster;
+
+import java.awt.Color;
+import java.util.Iterator;
+import java.util.Optional;
+import org.opentripplanner.inspector.raster.EdgeVertexTileRenderer.EdgeVertexRenderer;
+import org.opentripplanner.inspector.raster.EdgeVertexTileRenderer.EdgeVisualAttributes;
+import org.opentripplanner.inspector.raster.EdgeVertexTileRenderer.VertexVisualAttributes;
+import org.opentripplanner.street.model.edge.AreaEdge;
+import org.opentripplanner.street.model.edge.AreaEdgeList;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
+import org.opentripplanner.street.model.vertex.OsmBoardingLocationVertex;
+import org.opentripplanner.street.model.vertex.TransitBoardingAreaVertex;
+import org.opentripplanner.street.model.vertex.TransitEntranceVertex;
+import org.opentripplanner.street.model.vertex.TransitPathwayNodeVertex;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.street.model.vertex.Vertex;
+
+/**
+ * Render bike safety for each edge using a color palette. Display the bike safety factor as label.
+ *
+ * @author laurent
+ */
+public class AreaEdgeRenderer implements EdgeVertexRenderer {
+
+  private static final Color AREA_COLOR = new Color(0.2f, 0.4f, 0.6f);
+  private static final Color OSM_BOARDING_LOCATION_VERTEX_COLOR = new Color(23, 160, 234);
+  private static final Color TRANSIT_STOP_COLOR_VERTEX = new Color(0.0f, 0.0f, 0.8f);
+  private static final Color AREA_COLOR_VERTEX = Color.DARK_GRAY;
+  private static final Color VISIBILITY_COLOR_VERTEX = Color.RED;
+
+  private enum vxType {
+    VISIBILITY_VERTEX,
+    AREA_VERTEX,
+    OTHER_VERTEX,
+  }
+
+  private vxType _getAreaVertexType(Vertex v, Iterator<Edge> iterator) {
+    vxType val = vxType.OTHER_VERTEX;
+
+    while (iterator.hasNext()) {
+      if (iterator.next() instanceof AreaEdge ae) {
+        AreaEdgeList list = ae.getArea();
+        if (list.visibilityVertices.contains(v)) {
+          return vxType.VISIBILITY_VERTEX;
+        }
+        val = vxType.AREA_VERTEX;
+      }
+    }
+    return val;
+  }
+
+  private vxType getAreaVertexType(Vertex v) {
+    vxType type1 = _getAreaVertexType(v, v.getOutgoing().iterator());
+    if (type1 == vxType.VISIBILITY_VERTEX) {
+      return vxType.VISIBILITY_VERTEX;
+    }
+    vxType type2 = _getAreaVertexType(v, v.getIncoming().iterator());
+    if (type2 == vxType.VISIBILITY_VERTEX) {
+      return vxType.VISIBILITY_VERTEX;
+    }
+    if (type1 == vxType.AREA_VERTEX || type2 == vxType.AREA_VERTEX) {
+      return vxType.AREA_VERTEX;
+    }
+    return vxType.OTHER_VERTEX;
+  }
+
+  @Override
+  public Optional<EdgeVisualAttributes> renderEdge(Edge e) {
+    if (e instanceof AreaEdge ae) {
+      return EdgeVisualAttributes.optional(AREA_COLOR, "");
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<VertexVisualAttributes> renderVertex(Vertex v) {
+    if (v instanceof OsmBoardingLocationVertex osmV) {
+      return VertexVisualAttributes.optional(
+        OSM_BOARDING_LOCATION_VERTEX_COLOR,
+        "OSM refs" + osmV.references
+      );
+    } else if (
+      v instanceof TransitStopVertex ||
+      v instanceof TransitEntranceVertex ||
+      v instanceof TransitPathwayNodeVertex ||
+      v instanceof TransitBoardingAreaVertex
+    ) {
+      return VertexVisualAttributes.optional(TRANSIT_STOP_COLOR_VERTEX, v.getDefaultName());
+    } else {
+      vxType type = getAreaVertexType(v);
+      if (type == vxType.VISIBILITY_VERTEX) {
+        return VertexVisualAttributes.optional(VISIBILITY_COLOR_VERTEX, null);
+      } else if (type == vxType.AREA_VERTEX) {
+        return VertexVisualAttributes.optional(AREA_COLOR_VERTEX, null);
+      }
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "Areas";
+  }
+}

--- a/src/main/java/org/opentripplanner/inspector/raster/AreaEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/raster/AreaEdgeRenderer.java
@@ -18,9 +18,8 @@ import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 
 /**
- * Render bike safety for each edge using a color palette. Display the bike safety factor as label.
+ * Render OSM areas only. Show area edge vertices and OSM boarding locations. Highlight visiblity point vertices.
  *
- * @author laurent
  */
 public class AreaEdgeRenderer implements EdgeVertexRenderer {
 

--- a/src/main/java/org/opentripplanner/inspector/raster/TileRendererManager.java
+++ b/src/main/java/org/opentripplanner/inspector/raster/TileRendererManager.java
@@ -43,6 +43,7 @@ public class TileRendererManager {
     );
     renderers.put("elevation", new EdgeVertexTileRenderer(new ElevationEdgeRenderer(graph)));
     renderers.put("pathways", new EdgeVertexTileRenderer(new PathwayEdgeRenderer()));
+    renderers.put("areas", new EdgeVertexTileRenderer(new AreaEdgeRenderer()));
   }
 
   public void registerRenderer(String layer, TileRenderer tileRenderer) {

--- a/src/main/java/org/opentripplanner/street/model/edge/AreaEdgeList.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/AreaEdgeList.java
@@ -39,6 +39,14 @@ public class AreaEdgeList implements Serializable {
     this.references = references;
   }
 
+  public String toString() {
+    return String.format(
+      "AreaEdgeList: visibilityVertices=%s, %s",
+      visibilityVertices,
+      originalEdges
+    );
+  }
+
   /**
    * Safely add a vertex to this area. This creates edges to all other vertices unless those edges
    * would cross one of the original edges.

--- a/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
@@ -62,7 +62,7 @@ class OsmBoardingLocationsModuleTest {
         "osm:node:302563839"
       )
     ),
-    Arguments.of(true, Set.of("osm:node:768590748"))
+    Arguments.of(true, Set.of("osm:node:3223067049", "osm:node:768590748"))
   );
 
   @ParameterizedTest(


### PR DESCRIPTION
### Summary

Boarding locations  (see https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/BoardingLocations.md) are linked with surrounding area geometry using so called visibility points. The set of such points included previously only points, where the platform is joined with other street network. Unfortunately all those points can be obscured behind convex parts of the area geometry, and linking may become quite minimal. This may lead to strange walk routing to the boarding location.

This pull request adds more visibility points to be available in boarding location linking. Sufficient visibility point set will enable improved walk routing on areas in general (new development to appear after this pr).

The PR also adds a new visualization ability to the Debug UI, 'Areas'. Only area edges are drawn. The important visibility points are visualized as red dots. See the attached two images, which demonstrate how additional visibility points improve boarding location linking.
 
Before:
![image](https://user-images.githubusercontent.com/13776096/220281505-c7736427-d28a-4cd0-ab70-3023263e088c.png)

After:
![image](https://user-images.githubusercontent.com/13776096/220281620-73be864a-a7f3-4ee6-9def-31aaa152f1e5.png)



