### PR TITLE
Fix docker commands in Container-Image.md

### DIFF
--- a/docs/Container-Image.md
+++ b/docs/Container-Image.md
@@ -18,9 +18,9 @@ curl -L https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf -o be
 # download GTFS
 curl -L https://vbb.de/vbbgtfs -o berlin/vbb-gtfs.zip
 # build graph and save it onto the host system via the volume
-docker run --rm -v ./berlin:/var/opentripplanner docker.io/opentripplanner/opentripplanner:latest --build --save
+docker run --rm -v "/$(pwd)/berlin:/var/opentripplanner" docker.io/opentripplanner/opentripplanner:latest --build --save 
 # load and serve graph
-docker run -it --rm -p 8080:8080 -v ./berlin:/var/opentripplanner docker.io/opentripplanner/opentripplanner:latest --load --serve
+docker run -it --rm -p 8080:8080 -v "/$(pwd)/berlin:/var/opentripplanner" docker.io/opentripplanner/opentripplanner:latest --load --serve
 ```
 
 Now open [http://localhost:8080](http://localhost:8080) to see your running OTP instance.


### PR DESCRIPTION
### Summary

This PR fixes the commands given in the Container-Image documentation section.
The -v parameter does not accept relative paths, so we need to use pwd to get a absolute path.

### Issue
#4853

`closes #4853`

### Unit tests

No code changes, so no unit tests added

### Documentation

Fixed an existing documentation
