### PR TITLE
Fix handling of nullable route names in ORCA fare calculator

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
@@ -33,7 +34,6 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.core.ItineraryFares;
-import org.opentripplanner.test.support.VariableSource;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -446,10 +446,12 @@ public class OrcaFareServiceTest {
     calculateFare(rides, FareType.electronicYouth, 0f);
   }
 
-  static Stream<Arguments> testCases = Arrays.stream(FareType.values()).map(Arguments::of);
+  static Stream<Arguments> allTypes() {
+    return Arrays.stream(FareType.values()).map(Arguments::of);
+  }
 
   @ParameterizedTest
-  @VariableSource("testCases")
+  @MethodSource("allTypes")
   void nullLongName(FareType type) {
     var legs = List.of(
       createLeg(
@@ -460,6 +462,28 @@ public class OrcaFareServiceTest {
         "route1",
         "trip1",
         null,
+        "first stop",
+        "last stop"
+      )
+    );
+
+    var fare = new ItineraryFares();
+    orcaFareService.populateFare(fare, null, type, legs, null);
+    assertNotNull(fare.getFare(type));
+  }
+
+  @ParameterizedTest
+  @MethodSource("allTypes")
+  void nullShortName(FareType type) {
+    var legs = List.of(
+      createLeg(
+        WASHINGTON_STATE_FERRIES_AGENCY_ID,
+        null,
+        0,
+        1,
+        "route1",
+        "trip1",
+        "long name",
         "first stop",
         "last stop"
       )

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.fares.impl;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.COMM_TRANS_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.KC_METRO_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.KITSAP_TRANSIT_AGENCY_ID;
@@ -10,14 +11,20 @@ import static org.opentripplanner.ext.fares.impl.OrcaFareService.WASHINGTON_STAT
 import static org.opentripplanner.model.plan.PlanTestConstants.T11_00;
 import static org.opentripplanner.model.plan.PlanTestConstants.T11_12;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
+import static org.opentripplanner.routing.core.FareType.regular;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
@@ -26,6 +33,7 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.core.ItineraryFares;
+import org.opentripplanner.test.support.VariableSource;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -94,7 +102,7 @@ public class OrcaFareServiceTest {
   @Test
   public void calculateFareForSingleAgency() {
     List<Leg> rides = List.of(getLeg(COMM_TRANS_AGENCY_ID, "400", 0));
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS);
     calculateFare(rides, FareType.senior, 200f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 200f);
@@ -114,7 +122,7 @@ public class OrcaFareServiceTest {
       getLeg(WASHINGTON_STATE_FERRIES_AGENCY_ID, 1),
       getLeg(COMM_TRANS_AGENCY_ID, 2)
     );
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 3);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS * 3);
     calculateFare(
       rides,
       FareType.senior,
@@ -160,7 +168,7 @@ public class OrcaFareServiceTest {
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 120),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 150)
     );
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
     calculateFare(rides, FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 100f + 0f + 0f + 0f + 100f + 0f);
@@ -188,7 +196,7 @@ public class OrcaFareServiceTest {
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 120),
       getLeg(WASHINGTON_STATE_FERRIES_AGENCY_ID, 150, "Fauntleroy-VashonIsland")
     );
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 4 + 610f);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS * 4 + 610f);
     calculateFare(rides, FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 3 + 50f + 305f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(
@@ -218,7 +226,7 @@ public class OrcaFareServiceTest {
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 240),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 270)
     );
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 10);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS * 10);
     calculateFare(rides, FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 10);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(
@@ -261,7 +269,7 @@ public class OrcaFareServiceTest {
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 120),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 149)
     );
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
     calculateFare(rides, FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(
@@ -288,7 +296,7 @@ public class OrcaFareServiceTest {
   @Test
   public void calculateFareForKitsapFastFerryEastAgency() {
     List<Leg> rides = List.of(getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "Kitsap Fast Ferry", "east"));
-    calculateFare(rides, FareType.regular, 200f);
+    calculateFare(rides, regular, 200f);
     calculateFare(rides, FareType.senior, 200f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, DEFAULT_RIDE_PRICE_IN_CENTS);
@@ -305,7 +313,7 @@ public class OrcaFareServiceTest {
     List<Leg> rides = List.of(
       getLeg(WASHINGTON_STATE_FERRIES_AGENCY_ID, 0, "Point Defiance - Tahlequah")
     );
-    calculateFare(rides, FareType.regular, 610f);
+    calculateFare(rides, regular, 610f);
     calculateFare(rides, FareType.senior, 305f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 610f);
@@ -322,7 +330,7 @@ public class OrcaFareServiceTest {
     List<Leg> rides = List.of(
       getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 0, "Roosevelt Station", "Int'l Dist/Chinatown")
     );
-    calculateFare(rides, FareType.regular, 250f);
+    calculateFare(rides, regular, 250f);
     calculateFare(rides, FareType.senior, 100f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 150f);
@@ -334,7 +342,7 @@ public class OrcaFareServiceTest {
       List.of(
         getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 0, "Int'l Dist/Chinatown", "Roosevelt Station")
       );
-    calculateFare(rides, FareType.regular, 250f);
+    calculateFare(rides, regular, 250f);
     calculateFare(rides, FareType.senior, 100f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 150f);
@@ -348,7 +356,7 @@ public class OrcaFareServiceTest {
     List<Leg> rides = List.of(
       getLeg(SOUND_TRANSIT_AGENCY_ID, "S Line", 0, "King Street Station", "Auburn Station")
     );
-    calculateFare(rides, FareType.regular, 425f);
+    calculateFare(rides, regular, 425f);
     calculateFare(rides, FareType.senior, 100f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 150f);
@@ -360,7 +368,7 @@ public class OrcaFareServiceTest {
       List.of(
         getLeg(SOUND_TRANSIT_AGENCY_ID, "N Line", 0, "King Street Station", "Everett Station")
       );
-    calculateFare(rides, FareType.regular, 500f);
+    calculateFare(rides, regular, 500f);
     calculateFare(rides, FareType.senior, 100f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 150f);
@@ -381,7 +389,7 @@ public class OrcaFareServiceTest {
       getLeg(PIERCE_COUNTY_TRANSIT_AGENCY_ID, "594", 120),
       getLeg(KC_METRO_AGENCY_ID, "550", 240)
     );
-    calculateFare(rides, FareType.regular, 975f);
+    calculateFare(rides, regular, 975f);
     calculateFare(rides, FareType.senior, 300f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 450f);
@@ -395,7 +403,7 @@ public class OrcaFareServiceTest {
         getLeg(PIERCE_COUNTY_TRANSIT_AGENCY_ID, "500", 0),
         getLeg(PIERCE_COUNTY_TRANSIT_AGENCY_ID, "501", 60)
       );
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 2);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS * 2);
     calculateFare(rides, FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 2);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, DEFAULT_RIDE_PRICE_IN_CENTS);
@@ -413,7 +421,7 @@ public class OrcaFareServiceTest {
       getLeg(KC_METRO_AGENCY_ID, 60),
       getLeg(KC_METRO_AGENCY_ID, 130)
     );
-    calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 3);
+    calculateFare(rides, regular, DEFAULT_RIDE_PRICE_IN_CENTS * 3);
     calculateFare(rides, FareType.senior, 325f);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 300f);
@@ -429,13 +437,37 @@ public class OrcaFareServiceTest {
       getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 60, "Roosevelt Station", "Angle Lake Station"), // 3.25, should extend transfer
       getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 140, "Int'l Dist/Chinatown", "Angle Lake Station") // 3.00, should be free under extended transfer
     );
-    calculateFare(rides, FareType.regular, 250f + 325f + 300f);
+    calculateFare(rides, regular, 250f + 325f + 300f);
     calculateFare(rides, FareType.senior, 100f * 3);
     calculateFare(rides, FareType.youth, 0f);
     calculateFare(rides, FareType.electronicSpecial, 150f * 2);
     calculateFare(rides, FareType.electronicRegular, 325f); // transfer extended on second leg
     calculateFare(rides, FareType.electronicSenior, 100f * 2);
     calculateFare(rides, FareType.electronicYouth, 0f);
+  }
+
+  static Stream<Arguments> testCases = Arrays.stream(FareType.values()).map(Arguments::of);
+
+  @ParameterizedTest
+  @VariableSource("testCases")
+  void nullLongName(FareType type) {
+    var legs = List.of(
+      createLeg(
+        WASHINGTON_STATE_FERRIES_AGENCY_ID,
+        "1-Line",
+        0,
+        1,
+        "route1",
+        "trip1",
+        null,
+        "first stop",
+        "last stop"
+      )
+    );
+
+    var fare = new ItineraryFares();
+    orcaFareService.populateFare(fare, null, type, legs, null);
+    assertNotNull(fare.getFare(type));
   }
 
   private static Leg getLeg(String agencyId, long startTimeMins) {
@@ -517,7 +549,7 @@ public class OrcaFareServiceTest {
     long startTimeMins,
     String routeId,
     String tripId,
-    String routeLongName,
+    @Nullable String routeLongName,
     String firstStopName,
     String lastStopName
   ) {
@@ -540,11 +572,15 @@ public class OrcaFareServiceTest {
       .build();
 
     FeedScopedId routeFeedScopeId = new FeedScopedId("A", routeId);
+    NonLocalizedString longName = null;
+    if (routeLongName != null) {
+      longName = new NonLocalizedString(routeLongName);
+    }
     Route route = Route
       .of(routeFeedScopeId)
       .withAgency(agency)
       .withShortName(shortName)
-      .withLongName(new NonLocalizedString(routeLongName))
+      .withLongName(longName)
       // TODO: Way to convert from TransitMode to int (GTFS)?
       .withMode(TransitMode.BUS)
       .withGtfsType(transitMode)

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -11,9 +11,7 @@ import static org.opentripplanner.model.plan.PlanTestConstants.T11_00;
 import static org.opentripplanner.model.plan.PlanTestConstants.T11_12;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +93,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareForSingleAgency() {
-    List<Leg> rides = Collections.singletonList(getLeg(COMM_TRANS_AGENCY_ID, "400", 0));
+    List<Leg> rides = List.of(getLeg(COMM_TRANS_AGENCY_ID, "400", 0));
     calculateFare(rides, FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS);
     calculateFare(rides, FareType.senior, 200f);
     calculateFare(rides, FareType.youth, 0f);
@@ -111,7 +109,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareWithNoFreeTransfer() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 0),
       getLeg(WASHINGTON_STATE_FERRIES_AGENCY_ID, 1),
       getLeg(COMM_TRANS_AGENCY_ID, 2)
@@ -138,10 +136,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareByLeg() {
-    List<Leg> rides = Arrays.asList(
-      getLeg(KITSAP_TRANSIT_AGENCY_ID, 0),
-      getLeg(COMM_TRANS_AGENCY_ID, 2)
-    );
+    List<Leg> rides = List.of(getLeg(KITSAP_TRANSIT_AGENCY_ID, 0), getLeg(COMM_TRANS_AGENCY_ID, 2));
     ItineraryFares fares = new ItineraryFares();
     orcaFareService.populateFare(fares, null, FareType.electronicRegular, rides, null);
 
@@ -157,7 +152,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareThatExceedsTwoHourFreeTransferWindow() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 0),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 30),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 60),
@@ -185,7 +180,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareThatIncludesNoFreeTransfers() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 0),
       getLeg(WASHINGTON_STATE_FERRIES_AGENCY_ID, 30, "VashonIsland-Fauntelroy"),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 60),
@@ -211,7 +206,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareThatExceedsTwoHourFreeTransferWindowTwice() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 0),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 30),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 60),
@@ -258,7 +253,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareThatStartsWithACashFare() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(WASHINGTON_STATE_FERRIES_AGENCY_ID, 0),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 30),
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 60),
@@ -292,9 +287,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareForKitsapFastFerryEastAgency() {
-    List<Leg> rides = Collections.singletonList(
-      getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "Kitsap Fast Ferry", "east")
-    );
+    List<Leg> rides = List.of(getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "Kitsap Fast Ferry", "east"));
     calculateFare(rides, FareType.regular, 200f);
     calculateFare(rides, FareType.senior, 200f);
     calculateFare(rides, FareType.youth, 0f);
@@ -309,7 +302,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareForWSFPtToTahlequah() {
-    List<Leg> rides = Collections.singletonList(
+    List<Leg> rides = List.of(
       getLeg(WASHINGTON_STATE_FERRIES_AGENCY_ID, 0, "Point Defiance - Tahlequah")
     );
     calculateFare(rides, FareType.regular, 610f);
@@ -326,7 +319,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateFareForLightRailLeg() {
-    List<Leg> rides = Collections.singletonList(
+    List<Leg> rides = List.of(
       getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 0, "Roosevelt Station", "Int'l Dist/Chinatown")
     );
     calculateFare(rides, FareType.regular, 250f);
@@ -338,7 +331,7 @@ public class OrcaFareServiceTest {
     calculateFare(rides, FareType.electronicYouth, 0f);
     // Ensure that it works in reverse
     rides =
-      Collections.singletonList(
+      List.of(
         getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 0, "Int'l Dist/Chinatown", "Roosevelt Station")
       );
     calculateFare(rides, FareType.regular, 250f);
@@ -352,7 +345,7 @@ public class OrcaFareServiceTest {
 
   @Test
   public void calculateFareForSounderLeg() {
-    List<Leg> rides = Collections.singletonList(
+    List<Leg> rides = List.of(
       getLeg(SOUND_TRANSIT_AGENCY_ID, "S Line", 0, "King Street Station", "Auburn Station")
     );
     calculateFare(rides, FareType.regular, 425f);
@@ -364,7 +357,7 @@ public class OrcaFareServiceTest {
     calculateFare(rides, FareType.electronicYouth, 0f);
     // Ensure that it works in reverse
     rides =
-      Collections.singletonList(
+      List.of(
         getLeg(SOUND_TRANSIT_AGENCY_ID, "N Line", 0, "King Street Station", "Everett Station")
       );
     calculateFare(rides, FareType.regular, 500f);
@@ -383,7 +376,7 @@ public class OrcaFareServiceTest {
    */
   @Test
   public void calculateSoundTransitBusFares() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(COMM_TRANS_AGENCY_ID, "512", 0),
       getLeg(PIERCE_COUNTY_TRANSIT_AGENCY_ID, "594", 120),
       getLeg(KC_METRO_AGENCY_ID, "550", 240)
@@ -398,7 +391,7 @@ public class OrcaFareServiceTest {
 
     // Also make sure that PT's 500 and 501 get regular Pierce fare and not ST's fare
     rides =
-      Arrays.asList(
+      List.of(
         getLeg(PIERCE_COUNTY_TRANSIT_AGENCY_ID, "500", 0),
         getLeg(PIERCE_COUNTY_TRANSIT_AGENCY_ID, "501", 60)
       );
@@ -413,7 +406,7 @@ public class OrcaFareServiceTest {
 
   @Test
   public void calculateCashFreeTransferKCMetro() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(KC_METRO_AGENCY_ID, 0),
       getLeg(KC_METRO_AGENCY_ID, 20),
       getLeg(COMM_TRANS_AGENCY_ID, 45),
@@ -431,7 +424,7 @@ public class OrcaFareServiceTest {
 
   @Test
   public void calculateTransferExtension() {
-    List<Leg> rides = Arrays.asList(
+    List<Leg> rides = List.of(
       getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 0, "Int'l Dist/Chinatown", "Roosevelt Station"), // 2.50
       getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 60, "Roosevelt Station", "Angle Lake Station"), // 3.25, should extend transfer
       getLeg(SOUND_TRANSIT_AGENCY_ID, "1-Line", 140, "Int'l Dist/Chinatown", "Angle Lake Station") // 3.00, should be free under extended transfer

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -125,10 +125,10 @@ public class OrcaFareService extends DefaultFareService {
 
   private static String routeLongNameFallBack(Route route) {
     var longName = route.getLongName();
-    if(longName == null) {
+    if (longName == null) {
       return "";
     } else {
-      return route.getLongName().toString();
+      return longName.toString();
     }
   }
 
@@ -175,15 +175,15 @@ public class OrcaFareService extends DefaultFareService {
    * some cases the route description and short name are needed to define inner agency ride types. For Kitsap, the
    * route data is enough to define the agency, but addition trip id checks are needed to define the fast ferry direction.
    */
-  private static RideType classify(Route routeData, String tripId) {
-    var rideType = getRideType(routeData.getAgency().getId().getId(), routeData);
+  private static RideType classify(Route route, String tripId) {
+    var rideType = getRideType(route.getAgency().getId().getId(), route);
     if (rideType == null) {
       return null;
     }
     if (
       rideType == RideType.KITSAP_TRANSIT &&
-      routeData.getId().getId().equalsIgnoreCase("Kitsap Fast Ferry") &&
-      routeData.getGtfsType() == ROUTE_TYPE_FERRY
+      route.getId().getId().equalsIgnoreCase("Kitsap Fast Ferry") &&
+      route.getGtfsType() == ROUTE_TYPE_FERRY
     ) {
       // Additional trip id checks are required to distinguish Kitsap fast ferry routes.
       if (tripId.contains("east")) {
@@ -191,11 +191,11 @@ public class OrcaFareService extends DefaultFareService {
       } else if (tripId.contains("west")) {
         rideType = RideType.KITSAP_TRANSIT_FAST_FERRY_WESTBOUND;
       }
-    } else if (rideType == RideType.SOUND_TRANSIT && checkShortName(routeData, "1 Line")) {
+    } else if (rideType == RideType.SOUND_TRANSIT && checkShortName(route, "1 Line")) {
       rideType = RideType.SOUND_TRANSIT_LINK;
     } else if (
       rideType == RideType.SOUND_TRANSIT &&
-      (checkShortName(routeData, "S Line") || checkShortName(routeData, "N Line"))
+      (checkShortName(route, "S Line") || checkShortName(route, "N Line"))
     ) {
       rideType = RideType.SOUND_TRANSIT_SOUNDER;
     } else if (rideType == RideType.SOUND_TRANSIT) { //if it isn't Link or Sounder, then...
@@ -300,7 +300,6 @@ public class OrcaFareService extends DefaultFareService {
         FareType.electronicSpecial,
         defaultFare
       );
-      case PIERCE_COUNTY_TRANSIT -> defaultFare;
       default -> defaultFare;
     };
   }

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -12,6 +12,7 @@ import org.opentripplanner.ext.fares.model.FareContainer;
 import org.opentripplanner.ext.fares.model.FareProduct;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.fares.model.RiderCategory;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.core.ItineraryFares;
@@ -88,7 +89,7 @@ public class OrcaFareService extends DefaultFareService {
 
         if (
           route.getGtfsType() == ROUTE_TYPE_FERRY &&
-          route.getLongName().toString().contains("Water Taxi: West Seattle")
+          routeLongNameFallBack(route).contains("Water Taxi: West Seattle")
         ) {
           yield RideType.KC_WATER_TAXI_WEST_SEATTLE;
         } else if (
@@ -120,6 +121,15 @@ public class OrcaFareService extends DefaultFareService {
       case KITSAP_TRANSIT_AGENCY_ID -> RideType.KITSAP_TRANSIT;
       default -> RideType.UNKNOWN;
     };
+  }
+
+  private static String routeLongNameFallBack(Route route) {
+    var longName = route.getLongName();
+    if(longName == null) {
+      return "";
+    } else {
+      return route.getLongName().toString();
+    }
   }
 
   public OrcaFareService(Collection<FareRuleSet> regularFareRules) {
@@ -227,7 +237,7 @@ public class OrcaFareService extends DefaultFareService {
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND -> 2.00f;
       case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> 10.00f;
       case WASHINGTON_STATE_FERRIES -> getWashingtonStateFerriesFare(
-        route.getLongName().toString(),
+        route.getLongName(),
         fareType,
         defaultFare
       );
@@ -286,7 +296,7 @@ public class OrcaFareService extends DefaultFareService {
         EVERETT_TRANSIT,
         SEATTLE_STREET_CAR -> 1.50f;
       case WASHINGTON_STATE_FERRIES -> getWashingtonStateFerriesFare(
-        route.getLongName().toString(),
+        route.getLongName(),
         FareType.electronicSpecial,
         defaultFare
       );
@@ -307,7 +317,7 @@ public class OrcaFareService extends DefaultFareService {
     return switch (rideType) {
       case COMM_TRANS_LOCAL_SWIFT -> 1.25f;
       case COMM_TRANS_COMMUTER_EXPRESS -> 2.00f;
-      case EVERETT_TRANSIT -> 0.50f;
+      case EVERETT_TRANSIT, SKAGIT_TRANSIT -> 0.50f;
       case PIERCE_COUNTY_TRANSIT, SEATTLE_STREET_CAR, KITSAP_TRANSIT -> fareType.equals( // Pierce, Seattle Streetcar, and Kitsap only provide discounted senior fare for orca.
           FareType.electronicSenior
         )
@@ -326,9 +336,9 @@ public class OrcaFareService extends DefaultFareService {
       case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> fareType.equals(FareType.electronicSenior)
         ? 5.00f
         : 10.00f;
-      case SKAGIT_TRANSIT -> 0.50f; // Discount specific to Skagit transit and not Orca.
+      // Discount specific to Skagit transit and not Orca.
       case WASHINGTON_STATE_FERRIES -> getWashingtonStateFerriesFare(
-        route.getLongName().toString(),
+        route.getLongName(),
         fareType,
         defaultFare
       );
@@ -349,16 +359,17 @@ public class OrcaFareService extends DefaultFareService {
    * the default fare.
    */
   private float getWashingtonStateFerriesFare(
-    String routeLongName,
+    I18NString routeLongName,
     FareType fareType,
     float defaultFare
   ) {
-    if (routeLongName == null || routeLongName.isEmpty()) {
+    if (routeLongName == null || routeLongName.toString().isEmpty()) {
       return defaultFare;
     }
-    Map<FareType, Float> fares = OrcaFaresData.washingtonStateFerriesFares.get(
-      routeLongName.replaceAll(" ", "")
-    );
+
+    var longName = routeLongName.toString().replaceAll(" ", "");
+
+    Map<FareType, Float> fares = OrcaFaresData.washingtonStateFerriesFares.get(longName);
     // WSF doesn't support transfers so we only care about cash fares.
     FareType wsfFareType;
     if (fareType == FareType.electronicRegular) {


### PR DESCRIPTION
This fixes a bug in Seattle's ORCA fare calculator where nullable route names where not taken into account.

It is pure sandbox code.