### PR TITLE
Extract IFOPT unique station/platform ID from GlobalID KV pair in DELFI feed

### DIFF
--- a/docs/BoardingLocations.md
+++ b/docs/BoardingLocations.md
@@ -53,6 +53,14 @@ add the following to `build-config.json`:
 
 ```
 
+Your NeTEx transit data feed may have the matching references in a KeyValue instead of the ID. If you want to make use of an additional KeyValue you can specify the key for each NeTEx source. For example, the country wide NeTEx feed in Germany stores it under the key `GlobalID`. To use it add the following to your NeTEx source in `build-config.json`:
+
+```json
+{
+  "codeTagKey": "GlobalID"
+}
+```
+
 ## Multiple stops on the same platform
 
 Some stations have a middle platform with a stop on either side of it. In such a case, you can 

--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -75,6 +75,7 @@ Sections follow that describe particular settings in more depth.
 |    [netex](#lfp_netex)                                                   |   `regexp`  | Patterns for matching NeTEx zip files or directories.                                                                                                          | *Optional* | `"(?i)netex"`                     |  2.0  |
 |    [osm](#lfp_osm)                                                       |   `regexp`  | Pattern for matching Open Street Map input files.                                                                                                              | *Optional* | `"(?i)(\.pbf¦\.osm¦\.osm\.xml)$"` |  2.0  |
 | netexDefaults                                                            |   `object`  | The netexDefaults section allows you to specify default properties for NeTEx files.                                                                            | *Optional* |                                   |  2.2  |
+|    [codeTagKey](#nd_codeTagKey)                                          |   `string`  | Which NeTEx KeyValue should be looked on for the source of matching stops to platforms and stops, in addition to the ID.                                       | *Optional* | `"no key"`                        |  2.3  |
 |    feedId                                                                |   `string`  | This field is used to identify the specific NeTEx feed. It is used instead of the feed_id field in GTFS file feed_info.txt.                                    | *Optional* | `"NETEX"`                         |  2.2  |
 |    [groupFilePattern](#nd_groupFilePattern)                              |   `regexp`  | Pattern for matching group NeTEx files.                                                                                                                        | *Optional* | `"(\w{3})-.*\.xml"`               |  2.0  |
 |    ignoreFareFrame                                                       |  `boolean`  | Ignore contents of the FareFrame                                                                                                                               | *Optional* | `false`                           |  2.3  |
@@ -104,6 +105,7 @@ Sections follow that describe particular settings in more depth.
 |       [stationTransferPreference](#tf_0_stationTransferPreference)       |    `enum`   | Should there be some preference or aversion for transfers at stops that are part of a station. Overrides the value specified in `gtfsDefaults`.                | *Optional* | `"allowed"`                       |  2.3  |
 |    { object }                                                            |   `object`  | Nested object in array. The object type is determined by the parameters.                                                                                       | *Optional* |                                   |  2.2  |
 |       type = "NETEX"                                                     |    `enum`   | The feed input format.                                                                                                                                         | *Required* |                                   |  2.2  |
+|       [codeTagKey](#tf_1_codeTagKey)                                     |   `string`  | Which NeTEx KeyValue should be looked on for the source of matching stops to platforms and stops, in addition to the ID.                                       | *Optional* | `"no key"`                        |  2.3  |
 |       feedId                                                             |   `string`  | This field is used to identify the specific NeTEx feed. It is used instead of the feed_id field in GTFS file feed_info.txt.                                    | *Required* |                                   |  2.2  |
 |       [groupFilePattern](#tf_1_groupFilePattern)                         |   `regexp`  | Pattern for matching group NeTEx files.                                                                                                                        | *Optional* | `"(\w{3})-.*\.xml"`               |  2.0  |
 |       ignoreFareFrame                                                    |  `boolean`  | Ignore contents of the FareFrame                                                                                                                               | *Optional* | `false`                           |  2.3  |
@@ -872,6 +874,15 @@ If the filename contains the given pattern
 it is considered a match. Any legal Java Regular expression is allowed.
 
 
+<h3 id="nd_codeTagKey">codeTagKey</h3>
+
+**Since version:** `2.3` ∙ **Type:** `string` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"no key"`   
+**Path:** /netexDefaults 
+
+Which NeTEx KeyValue should be looked on for the source of matching stops to platforms and stops, in addition to the ID.
+
+[Detailed documentation](BoardingLocations.md)
+
 <h3 id="nd_groupFilePattern">groupFilePattern</h3>
 
 **Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(\w{3})-.*\.xml"`   
@@ -1016,6 +1027,15 @@ Should there be some preference or aversion for transfers at stops that are part
 This parameter sets the generic level of preference. What is the actual cost can be changed
 with the `stopTransferCost` parameter in the router configuration.
 
+
+<h3 id="tf_1_codeTagKey">codeTagKey</h3>
+
+**Since version:** `2.3` ∙ **Type:** `string` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"no key"`   
+**Path:** /transitFeeds/[1] 
+
+Which NeTEx KeyValue should be looked on for the source of matching stops to platforms and stops, in addition to the ID.
+
+[Detailed documentation](BoardingLocations.md)
 
 <h3 id="tf_1_groupFilePattern">groupFilePattern</h3>
 

--- a/src/main/java/org/opentripplanner/netex/NetexBundle.java
+++ b/src/main/java/org/opentripplanner/netex/NetexBundle.java
@@ -45,6 +45,7 @@ public class NetexBundle implements Closeable {
   private final double maxStopToShapeSnapDistance;
   private final boolean noTransfersOnIsolatedStops;
   private final boolean ignoreFareFrame;
+  private final String codeTagKey;
   /** The NeTEx entities loaded from the input files and passed on to the mapper. */
   private NetexEntityIndex index = new NetexEntityIndex();
   /** Report errors to issue store */
@@ -60,7 +61,8 @@ public class NetexBundle implements Closeable {
     Set<String> ferryIdsNotAllowedForBicycle,
     double maxStopToShapeSnapDistance,
     boolean noTransfersOnIsolatedStops,
-    boolean ignoreFareFrame
+    boolean ignoreFareFrame,
+    String codeTagKey
   ) {
     this.feedId = feedId;
     this.source = source;
@@ -69,6 +71,7 @@ public class NetexBundle implements Closeable {
     this.maxStopToShapeSnapDistance = maxStopToShapeSnapDistance;
     this.noTransfersOnIsolatedStops = noTransfersOnIsolatedStops;
     this.ignoreFareFrame = ignoreFareFrame;
+    this.codeTagKey = codeTagKey;
   }
 
   /** load the bundle, map it to the OTP transit model and return */
@@ -93,7 +96,8 @@ public class NetexBundle implements Closeable {
         issueStore,
         ferryIdsNotAllowedForBicycle,
         maxStopToShapeSnapDistance,
-        noTransfersOnIsolatedStops
+        noTransfersOnIsolatedStops,
+        codeTagKey
       );
 
     // Load data

--- a/src/main/java/org/opentripplanner/netex/config/NetexFeedParameters.java
+++ b/src/main/java/org/opentripplanner/netex/config/NetexFeedParameters.java
@@ -13,7 +13,7 @@ import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.graph_builder.model.DataSourceConfig;
 
 /**
- * Parameters to configure the NETEX import. Se the generated build-config documentation or
+ * Parameters to configure the NETEX import. See the generated build-config documentation or
  * the config mapping for documentation.
  */
 public class NetexFeedParameters implements DataSourceConfig {
@@ -49,6 +49,7 @@ public class NetexFeedParameters implements DataSourceConfig {
   private final Set<String> ferryIdsNotAllowedForBicycle;
   private final boolean noTransfersOnIsolatedStops;
   private final boolean ignoreFareFrame;
+  private final String codeTagKey;
 
   private NetexFeedParameters() {
     this.source = null;
@@ -64,6 +65,7 @@ public class NetexFeedParameters implements DataSourceConfig {
     this.ferryIdsNotAllowedForBicycle = FERRY_IDS_NOT_ALLOWED_FOR_BICYCLE;
     this.noTransfersOnIsolatedStops = NO_TRANSFERS_ON_ISOLATED_STOPS;
     this.ignoreFareFrame = IGNORE_FARE_FRAME;
+    this.codeTagKey = "";
   }
 
   private NetexFeedParameters(Builder builder) {
@@ -76,6 +78,7 @@ public class NetexFeedParameters implements DataSourceConfig {
     this.ferryIdsNotAllowedForBicycle = Set.copyOf(builder.ferryIdsNotAllowedForBicycle);
     this.noTransfersOnIsolatedStops = builder.noTransfersOnIsolatedStops;
     this.ignoreFareFrame = builder.ignoreFareFrame;
+    this.codeTagKey = builder.codeTagKey;
   }
 
   public static Builder of() {
@@ -130,6 +133,11 @@ public class NetexFeedParameters implements DataSourceConfig {
     return ignoreFareFrame;
   }
 
+  /** See {@link org.opentripplanner.standalone.config.buildconfig.NetexConfig}. */
+  public String codeTagKey() {
+    return codeTagKey;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -143,7 +151,8 @@ public class NetexFeedParameters implements DataSourceConfig {
       sharedGroupFilePattern.equals(that.sharedGroupFilePattern) &&
       groupFilePattern.equals(that.groupFilePattern) &&
       ignoreFareFrame == that.ignoreFareFrame &&
-      ferryIdsNotAllowedForBicycle.equals(that.ferryIdsNotAllowedForBicycle)
+      ferryIdsNotAllowedForBicycle.equals(that.ferryIdsNotAllowedForBicycle) &&
+      codeTagKey.equals(that.codeTagKey)
     );
   }
 
@@ -157,7 +166,8 @@ public class NetexFeedParameters implements DataSourceConfig {
       sharedGroupFilePattern,
       groupFilePattern,
       ignoreFareFrame,
-      ferryIdsNotAllowedForBicycle
+      ferryIdsNotAllowedForBicycle,
+      codeTagKey
     );
   }
 
@@ -173,6 +183,7 @@ public class NetexFeedParameters implements DataSourceConfig {
       .addStr("ignoreFilePattern", ignoreFilePattern, DEFAULT.ignoreFilePattern)
       .addBoolIfTrue("ignoreFareFrame", ignoreFareFrame)
       .addCol("ferryIdsNotAllowedForBicycle", ferryIdsNotAllowedForBicycle, Set.of())
+      .addStr("codeTagKey", codeTagKey, "")
       .toString();
   }
 
@@ -188,6 +199,7 @@ public class NetexFeedParameters implements DataSourceConfig {
     private final Set<String> ferryIdsNotAllowedForBicycle = new HashSet<>();
     private boolean noTransfersOnIsolatedStops;
     private boolean ignoreFareFrame;
+    private String codeTagKey;
 
     private Builder(NetexFeedParameters original) {
       this.original = original;
@@ -200,6 +212,7 @@ public class NetexFeedParameters implements DataSourceConfig {
       this.ferryIdsNotAllowedForBicycle.addAll(original.ferryIdsNotAllowedForBicycle);
       this.noTransfersOnIsolatedStops = original.noTransfersOnIsolatedStops;
       this.ignoreFareFrame = original.ignoreFareFrame;
+      this.codeTagKey = original.codeTagKey;
     }
 
     public URI source() {
@@ -248,6 +261,11 @@ public class NetexFeedParameters implements DataSourceConfig {
 
     public Builder withIgnoreFareFrame(boolean ignoreFareFrame) {
       this.ignoreFareFrame = ignoreFareFrame;
+      return this;
+    }
+
+    public Builder withcodeTagKey(String codeTagKey) {
+      this.codeTagKey = codeTagKey;
       return this;
     }
 

--- a/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
+++ b/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
@@ -66,7 +66,8 @@ public class NetexConfigure {
       config.ferryIdsNotAllowedForBicycle(),
       buildParams.maxStopToShapeSnapDistance,
       config.noTransfersOnIsolatedStops(),
-      config.ignoreFareFrame()
+      config.ignoreFareFrame(),
+      config.codeTagKey()
     );
   }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -67,6 +67,7 @@ public class NetexMapper {
   private final Set<String> ferryIdsNotAllowedForBicycle;
   private final double maxStopToShapeSnapDistance;
   private final boolean noTransfersOnIsolatedStops;
+  private final String codeTagKey;
 
   /** Map entries that cross reference entities within a group/operator, for example Interchanges. */
   private GroupNetexMapper groupMapper;
@@ -93,7 +94,8 @@ public class NetexMapper {
     DataImportIssueStore issueStore,
     Set<String> ferryIdsNotAllowedForBicycle,
     double maxStopToShapeSnapDistance,
-    boolean noTransfersOnIsolatedStops
+    boolean noTransfersOnIsolatedStops,
+    String codeTagKey
   ) {
     this.transitBuilder = transitBuilder;
     this.deduplicator = deduplicator;
@@ -102,6 +104,7 @@ public class NetexMapper {
     this.ferryIdsNotAllowedForBicycle = ferryIdsNotAllowedForBicycle;
     this.noTransfersOnIsolatedStops = noTransfersOnIsolatedStops;
     this.maxStopToShapeSnapDistance = maxStopToShapeSnapDistance;
+    this.codeTagKey = codeTagKey;
     this.calendarServiceBuilder = new CalendarServiceBuilder(idFactory);
     this.tripCalendarBuilder = new TripCalendarBuilder(this.calendarServiceBuilder, issueStore);
   }
@@ -306,7 +309,8 @@ public class NetexMapper {
       transitBuilder.stopModelBuilder(),
       zoneId,
       issueStore,
-      noTransfersOnIsolatedStops
+      noTransfersOnIsolatedStops,
+      codeTagKey
     );
     for (String stopPlaceId : currentNetexIndex.getStopPlaceById().localKeys()) {
       Collection<StopPlace> stopPlaceAllVersions = currentNetexIndex

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -69,7 +69,8 @@ class StopAndStationMapper {
     StopModelBuilder stopModelBuilder,
     ZoneId defaultTimeZone,
     DataImportIssueStore issueStore,
-    boolean noTransfersOnIsolatedStops
+    boolean noTransfersOnIsolatedStops,
+    String codeTagKey
   ) {
     this.stationMapper =
       new StationMapper(
@@ -77,9 +78,11 @@ class StopAndStationMapper {
         idFactory,
         defaultTimeZone,
         noTransfersOnIsolatedStops,
-        stopModelBuilder.stationById()
+        stopModelBuilder.stationById(),
+        codeTagKey
       );
-    this.quayMapper = new QuayMapper(idFactory, issueStore, stopModelBuilder.regularStopsById());
+    this.quayMapper =
+      new QuayMapper(idFactory, issueStore, stopModelBuilder.regularStopsById(), codeTagKey);
     this.tariffZoneMapper = tariffZoneMapper;
     this.quayIndex = quayIndex;
     this.issueStore = issueStore;

--- a/src/main/java/org/opentripplanner/standalone/config/buildconfig/NetexConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/buildconfig/NetexConfig.java
@@ -31,6 +31,7 @@ public class NetexConfig {
   static NetexFeedParameters mapNetexFeed(NodeAdapter feedNode, NetexFeedParameters original) {
     return mapFilePatternParameters(feedNode, original)
       .withFeedId(readFeedId(feedNode).asString())
+      .withcodeTagKey(feedNode.of("codeTagKey").asString(""))
       .withSource(
         feedNode
           .of("source")
@@ -164,6 +165,17 @@ public class NetexConfig {
           .summary("Ignore contents of the FareFrame")
           .docDefaultValue(base.ignoreFareFrame())
           .asBoolean(base.ignoreFareFrame())
+      )
+      .withcodeTagKey(
+        config
+          .of("codeTagKey")
+          .since(V2_3)
+          .summary(
+            "Which NeTEx KeyValue should be looked on for the source of matching stops to platforms and stops, in addition to the ID."
+          )
+          .description("[Detailed documentation](BoardingLocations.md)")
+          .docDefaultValue("no key")
+          .asString(base.codeTagKey())
       );
   }
 

--- a/src/test/java/org/opentripplanner/netex/NetexEpipBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexEpipBundleSmokeTest.java
@@ -121,6 +121,7 @@ class NetexEpipBundleSmokeTest {
     assertEquals(0, quay.getIndex());
     assertNull(quay.getPlatformCode());
     assertEquals(31, stops.size());
+    assertEquals("de:02000:80026::800091", quay.getCode());
   }
 
   private void assertStations(Collection<Station> stations) {
@@ -134,6 +135,7 @@ class NetexEpipBundleSmokeTest {
     assertEquals("Europe/Berlin", station.getTimezone().toString());
     assertEquals(3, station.getChildStops().size());
     assertEquals(20, stations.size());
+    assertEquals("de:02000:80026", station.getCode());
   }
 
   private void assertTripPatterns(Collection<TripPattern> patterns) {

--- a/src/test/java/org/opentripplanner/netex/NetexNordicBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexNordicBundleSmokeTest.java
@@ -139,6 +139,7 @@ public class NetexNordicBundleSmokeTest {
     assertEquals("EN:NSR:StopPlace:3995", quay.getParentStation().getId().toString());
     assertEquals("L", quay.getPlatformCode());
     assertEquals(16, stops.size());
+    assertEquals(null, quay.getCode());
   }
 
   private void assertStations(Collection<Station> stations) {
@@ -150,6 +151,7 @@ public class NetexNordicBundleSmokeTest {
     assertEquals(59.866297, station.getLat(), 0.000001);
     assertEquals(10.821484, station.getLon(), 0.000001);
     assertEquals(5, stations.size());
+    assertEquals(null, station.getCode());
   }
 
   private void assertTripPatterns(Collection<TripPattern> patterns) {

--- a/src/test/java/org/opentripplanner/netex/config/NetexFeedParametersTest.java
+++ b/src/test/java/org/opentripplanner/netex/config/NetexFeedParametersTest.java
@@ -19,6 +19,7 @@ class NetexFeedParametersTest {
   private static final String GROUP_FILE = "[groupFile]+";
   private static final Set<String> FERRY_IDS = Set.of("Ferry:Id");
   private static final String IGNORE_FILE = "[ignoreFl]+";
+  private static final String CODE_TAG_KEY = "Key";
 
   private final NetexFeedParameters subject = NetexFeedParameters
     .of()
@@ -29,6 +30,7 @@ class NetexFeedParametersTest {
     .withGroupFilePattern(Pattern.compile(GROUP_FILE))
     .withIgnoreFilePattern(Pattern.compile(IGNORE_FILE))
     .addFerryIdsNotAllowedForBicycle(FERRY_IDS)
+    .withcodeTagKey(CODE_TAG_KEY)
     .build();
 
   NetexFeedParametersTest() throws Exception {}
@@ -98,7 +100,8 @@ class NetexFeedParametersTest {
       "sharedGroupFilePattern: '[sharedGoupFil]+', " +
       "groupFilePattern: '[groupFile]+', " +
       "ignoreFilePattern: '[ignoreFl]+', " +
-      "ferryIdsNotAllowedForBicycle: [Ferry:Id]" +
+      "ferryIdsNotAllowedForBicycle: [Ferry:Id], " +
+      "codeTagKey: 'Key'" +
       "}",
       subject.toString()
     );

--- a/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
@@ -105,7 +105,7 @@ class ServiceLinkMapperTest {
     EntityById<RegularStop> stopsById = new EntityById<>();
     issueStore = new DefaultDataImportIssueStore();
 
-    QuayMapper quayMapper = new QuayMapper(ID_FACTORY, issueStore, stopsById);
+    QuayMapper quayMapper = new QuayMapper(ID_FACTORY, issueStore, stopsById, null);
     stopPatternBuilder = StopPattern.create(3);
 
     Station parentStation = Station

--- a/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -156,7 +156,8 @@ public class StopAndStationMapperTest {
       StopModel.of(),
       DEFAULT_TIME_ZONE,
       DataImportIssueStore.NOOP,
-      false
+      false,
+      null
     );
 
     stopMapper.mapParentAndChildStops(stopPlaces);
@@ -226,7 +227,8 @@ public class StopAndStationMapperTest {
       StopModel.of(),
       DEFAULT_TIME_ZONE,
       DataImportIssueStore.NOOP,
-      isolated
+      isolated,
+      null
     );
 
     stopMapper.mapParentAndChildStops(stopPlaces);
@@ -287,7 +289,8 @@ public class StopAndStationMapperTest {
       stopModelBuilder,
       DEFAULT_TIME_ZONE,
       DataImportIssueStore.NOOP,
-      false
+      false,
+      null
     );
   }
 

--- a/src/test/resources/netex/epip/build-config.json
+++ b/src/test/resources/netex/epip/build-config.json
@@ -6,7 +6,8 @@
   "subwayAccessTime": 0,
   "netexDefaults": {
     "groupFilePattern": "(.*)_.*\\.xml",
-    "feedId": "HH"
+    "feedId": "HH",
+    "codeTagKey": "GlobalID"
   },
   "osmDefaults": {
     "osmTagMapping": "germany",


### PR DESCRIPTION
### Summary

Import IFOTP from freeform tag to allow matching german netex locations to OSM locations.

### Issue

The german NeTEx feed stores the unique id of stops as separate value under the key "GlobalID" and uses a derived id as actual id. To match locations for boarding between the netex and OSM dataset this should be imported.

As stop_code and platform_code appear to be unused when import netex data, but considered for matching to OSM, I just put it there for now.

This PR is based on top of #4872 and should only be merged after that.

### Unit tests

Already tested with one transit line from the DELFI feed and local OSM data. Now looking at how to unit test this.

### Documentation

Code documentation has been added.

### Changelog

https://github.com/opentripplanner/OpenTripPlanner/labels/skip%20changelog