### PR TITLE
Fix timeshifting of Flex ~ Walk ~ Flex paths in Raptor

### DIFF
--- a/src/main/java/org/opentripplanner/raptor/path/PathBuilder.java
+++ b/src/main/java/org/opentripplanner/raptor/path/PathBuilder.java
@@ -58,6 +58,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   // paths with the same path tail.
   private PathBuilderLeg<T> head = null;
   private PathBuilderLeg<T> tail = null;
+  private int iterationDepartureTime;
 
   protected PathBuilder(PathBuilder<T> other) {
     this(
@@ -163,6 +164,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   }
 
   public RaptorPath<T> build(int iterationDepartureTime) {
+    this.iterationDepartureTime = iterationDepartureTime;
     updateAggregatedFields();
     return new Path<>(iterationDepartureTime, createPathLegs(costCalculator, slackProvider));
   }
@@ -229,7 +231,8 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   }
 
   private void timeShiftAllStreetLegs() {
-    legsAsStream().forEach(leg -> leg.timeShiftThisAndNextLeg(slackProvider));
+    legsAsStream()
+      .forEach(leg -> leg.timeShiftThisAndNextLeg(slackProvider, iterationDepartureTime));
   }
 
   private void insertConstrainedTransfers() {

--- a/src/main/java/org/opentripplanner/raptor/path/PathBuilder.java
+++ b/src/main/java/org/opentripplanner/raptor/path/PathBuilder.java
@@ -58,11 +58,12 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   // paths with the same path tail.
   private PathBuilderLeg<T> head = null;
   private PathBuilderLeg<T> tail = null;
-  private int iterationDepartureTime;
+  protected final int iterationDepartureTime;
 
   protected PathBuilder(PathBuilder<T> other) {
     this(
       other.slackProvider,
+      other.iterationDepartureTime,
       other.costCalculator,
       other.stopNameResolver,
       other.transferConstraintsSearch
@@ -73,6 +74,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
 
   protected PathBuilder(
     RaptorSlackProvider slackProvider,
+    int iterationDepartureTime,
     @Nullable CostCalculator<T> costCalculator,
     @Nullable RaptorStopNameResolver stopNameResolver,
     @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch
@@ -81,6 +83,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     this.costCalculator = costCalculator;
     this.stopNameResolver = stopNameResolver;
     this.transferConstraintsSearch = transferConstraintsSearch;
+    this.iterationDepartureTime = iterationDepartureTime;
   }
 
   /**
@@ -92,6 +95,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
    */
   public static <T extends RaptorTripSchedule> PathBuilder<T> headPathBuilder(
     RaptorSlackProvider slackProvider,
+    int iterationDepartureTime,
     @Nullable CostCalculator<T> costCalculator,
     @Nullable RaptorStopNameResolver stopNameResolver,
     @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch
@@ -99,6 +103,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     return new HeadPathBuilder<>(
       slackProvider,
       costCalculator,
+      iterationDepartureTime,
       stopNameResolver,
       transferConstraintsSearch
     );
@@ -113,6 +118,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
    */
   public static <T extends RaptorTripSchedule> PathBuilder<T> tailPathBuilder(
     RaptorSlackProvider slackProvider,
+    int iterationDepartureTime,
     @Nullable CostCalculator<T> costCalculator,
     @Nullable RaptorStopNameResolver stopNameResolver,
     @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch
@@ -120,6 +126,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     return new TailPathBuilder<>(
       slackProvider,
       costCalculator,
+      iterationDepartureTime,
       stopNameResolver,
       transferConstraintsSearch
     );
@@ -163,8 +170,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     add(PathBuilderLeg.egress(egress));
   }
 
-  public RaptorPath<T> build(int iterationDepartureTime) {
-    this.iterationDepartureTime = iterationDepartureTime;
+  public RaptorPath<T> build() {
     updateAggregatedFields();
     return new Path<>(iterationDepartureTime, createPathLegs(costCalculator, slackProvider));
   }
@@ -276,10 +282,17 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     private HeadPathBuilder(
       RaptorSlackProvider slackProvider,
       CostCalculator<T> costCalculator,
+      int iterationDepartureTime,
       @Nullable RaptorStopNameResolver stopNameResolver,
       @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch
     ) {
-      super(slackProvider, costCalculator, stopNameResolver, transferConstraintsSearch);
+      super(
+        slackProvider,
+        iterationDepartureTime,
+        costCalculator,
+        stopNameResolver,
+        transferConstraintsSearch
+      );
     }
 
     @Override
@@ -293,10 +306,17 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     private TailPathBuilder(
       RaptorSlackProvider slackProvider,
       CostCalculator<T> costCalculator,
+      int iterationDepartureTime,
       @Nullable RaptorStopNameResolver stopNameResolver,
       @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch
     ) {
-      super(slackProvider, costCalculator, stopNameResolver, transferConstraintsSearch);
+      super(
+        slackProvider,
+        iterationDepartureTime,
+        costCalculator,
+        stopNameResolver,
+        transferConstraintsSearch
+      );
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/raptor/path/PathBuilderLeg.java
+++ b/src/main/java/org/opentripplanner/raptor/path/PathBuilderLeg.java
@@ -253,8 +253,6 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
     return waitTimeBeforeNextLegIncludingSlack() + next.waitTimeBeforeNextLegIncludingSlack();
   }
 
-  public void iterationDepartureTime() {}
-
   static <T extends RaptorTripSchedule> PathBuilderLeg<T> accessLeg(RaptorAccessEgress access) {
     return new PathBuilderLeg<>(new MyAccessLeg(access));
   }
@@ -479,6 +477,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
    *     <li>Normal case: Walk ~ boardSlack ~ transit (access can be time-shifted)</li>
    *     <li>Flex and transit: Flex ~ (transferSlack + boardSlack) ~ transit</li>
    *     <li>Flex, walk and transit: Flex ~ Walk ~ (transferSlack + boardSlack) ~ transit</li>
+   *     <li>Flex, walk and Flex: Flex ~ Walk ~ Flex (will be timeshifted in relation to the iteration departure time)</li>
    * </ol>
    * Flex access may or may not be time-shifted.
    */
@@ -488,6 +487,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
 
     int newToTime;
 
+    // if there is no next transit leg then it's a Flex ~ Transfer/Walk ~ Flex path
     if (nextTransitLeg == null) {
       newToTime = iterationDepartureTime + accessPath.durationInSeconds();
       if (next.isTransfer()) {

--- a/src/main/java/org/opentripplanner/raptor/path/PathBuilderLeg.java
+++ b/src/main/java/org/opentripplanner/raptor/path/PathBuilderLeg.java
@@ -173,6 +173,10 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
    * This method operate on the current leg for access legs and the NEXT leg for transfer and
    * egress. So, if the NEXT leg is a transit or egress leg it is time-shifted. This make it safe to
    * call this method on any leg - just make sure the legs are linked first.
+   * <p>
+   *
+   * The given {@code iterationDepartureTime} is used to time-shift access if the path does not have
+   * any transit legs.
    */
   public void timeShiftThisAndNextLeg(
     RaptorSlackProvider slackProvider,

--- a/src/main/java/org/opentripplanner/raptor/path/PathBuilderLeg.java
+++ b/src/main/java/org/opentripplanner/raptor/path/PathBuilderLeg.java
@@ -498,9 +498,8 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
       if (next.isTransfer()) {
         newToTime -= next.asTransferLeg().transfer.durationInSeconds();
       }
+      newToTime = accessPath.latestArrivalTime(newToTime);
     }
-
-    newToTime = accessPath.latestArrivalTime(newToTime);
 
     if (newToTime == RaptorConstants.TIME_NOT_SET) {
       throw new IllegalStateException("Can not time-shift accessPath: " + accessPath);

--- a/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/DebugStopArrivalsStatistics.java
+++ b/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/DebugStopArrivalsStatistics.java
@@ -44,9 +44,9 @@ class DebugStopArrivalsStatistics {
         "Debug stop arrivals statistics. The number logged are: \n" +
         "  - For each stop the number of arrivals logged with:\n" +
         "    - Avarage number of arrivals for stops visited.\n" +
-        "    - The maximum numbers of arriavels for any stop.\n" +
+        "    - The maximum numbers of arrivals for any stop.\n" +
         "    - The total number of stop arrivals.\n" +
-        "  - The capasity(array length) used.\n" +
+        "  - The capacity(array length) used.\n" +
         "    - The avarage array length for stops visited.\n" +
         "    - The total array length allocated.\n" +
         "  - The number of stops:\n" +

--- a/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -45,6 +45,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
   public RaptorPath<T> mapToPath(final DestinationArrival<T> destinationArrival) {
     var pathBuilder = PathBuilder.headPathBuilder(
       slackProvider,
+      iterationDepartureTime,
       costCalculator,
       stopNameResolver,
       transferConstraintsSearch
@@ -68,7 +69,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
       arrival = arrival.previous();
     }
 
-    return pathBuilder.build(iterationDepartureTime);
+    return pathBuilder.build();
   }
 
   private static BoardAndAlightTimeSearch forwardSearch(boolean useApproximateTimeSearch) {

--- a/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ReversePathMapper.java
+++ b/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ReversePathMapper.java
@@ -52,6 +52,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
   public RaptorPath<T> mapToPath(final DestinationArrival<T> destinationArrival) {
     var pathBuilder = PathBuilder.tailPathBuilder(
       slackProvider,
+      iterationDepartureTime,
       costCalculator,
       stopNameResolver,
       transferConstraintsSearch
@@ -63,7 +64,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
     while (true) {
       if (arrival.arrivedByAccess()) {
         pathBuilder.egress(arrival.accessPath().access());
-        return pathBuilder.build(iterationDepartureTime);
+        return pathBuilder.build();
       } else if (arrival.arrivedByTransit()) {
         var times = tripSearch.find(arrival);
         var transit = arrival.transitPath();

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
@@ -36,6 +36,7 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
   private int transferPriorityCost = TransferConstraint.ZERO_COST;
   private int waitTimeOptimizedCost = TransferWaitTimeCostCalculator.ZERO_COST;
   private int generalizedCost = CostCalculator.ZERO_COST;
+  private int iterationDepartureTime;
 
   public OptimizedPathTail(
     RaptorSlackProvider slackProvider,
@@ -125,6 +126,7 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
 
   @Override
   public OptimizedPath<T> build(int iterationDepartureTime) {
+    this.iterationDepartureTime = iterationDepartureTime;
     return new OptimizedPath<>(
       createPathLegs(costCalculator(), slackProvider()),
       iterationDepartureTime,
@@ -152,7 +154,7 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
   protected void add(PathBuilderLeg<T> newLeg) {
     addHead(newLeg);
     // Keep from- and to- times up to date by time-shifting access, transfer and egress legs.
-    newLeg.timeShiftThisAndNextLeg(slackProvider(), -1000009);
+    newLeg.timeShiftThisAndNextLeg(slackProvider(), iterationDepartureTime);
     addTransferPriorityCost(newLeg);
     addOptimizedWaitTimeCost(newLeg);
     updateGeneralizedCost();

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
@@ -152,7 +152,7 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
   protected void add(PathBuilderLeg<T> newLeg) {
     addHead(newLeg);
     // Keep from- and to- times up to date by time-shifting access, transfer and egress legs.
-    newLeg.timeShiftThisAndNextLeg(slackProvider());
+    newLeg.timeShiftThisAndNextLeg(slackProvider(), -1000009);
     addTransferPriorityCost(newLeg);
     addOptimizedWaitTimeCost(newLeg);
     updateGeneralizedCost();

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
@@ -36,17 +36,17 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
   private int transferPriorityCost = TransferConstraint.ZERO_COST;
   private int waitTimeOptimizedCost = TransferWaitTimeCostCalculator.ZERO_COST;
   private int generalizedCost = CostCalculator.ZERO_COST;
-  private int iterationDepartureTime;
 
   public OptimizedPathTail(
     RaptorSlackProvider slackProvider,
     CostCalculator<T> costCalculator,
+    int iterationDepartureTime,
     TransferWaitTimeCostCalculator waitTimeCostCalculator,
     int[] stopBoardAlightCosts,
     double extraStopBoardAlightCostsFactor,
     RaptorStopNameResolver stopNameResolver
   ) {
-    super(slackProvider, costCalculator, stopNameResolver, null);
+    super(slackProvider, iterationDepartureTime, costCalculator, stopNameResolver, null);
     this.waitTimeCostCalculator = waitTimeCostCalculator;
     this.stopPriorityCostCalculator =
       (stopBoardAlightCosts != null && extraStopBoardAlightCostsFactor > 0.01)
@@ -125,8 +125,7 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
   }
 
   @Override
-  public OptimizedPath<T> build(int iterationDepartureTime) {
-    this.iterationDepartureTime = iterationDepartureTime;
+  public OptimizedPath<T> build() {
     return new OptimizedPath<>(
       createPathLegs(costCalculator(), slackProvider()),
       iterationDepartureTime,

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
@@ -111,9 +111,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
     // Combine transit legs and transfers
     var tails = findBestTransferOption(originalPath, transitLegs, possibleTransfers);
 
-    final int iterationDepartureTime = originalPath.rangeRaptorIterationDepartureTime();
-
-    return tails.stream().map(it -> it.build(iterationDepartureTime)).collect(Collectors.toSet());
+    return tails.stream().map(OptimizedPathTail::build).collect(Collectors.toSet());
   }
 
   private static <T> T last(List<T> list) {
@@ -125,11 +123,13 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
     List<TransitPathLeg<T>> originalTransitLegs,
     List<List<TripToTripTransfer<T>>> possibleTransfers
   ) {
+    final int iterationDepartureTime = originalPath.rangeRaptorIterationDepartureTime();
     // Create a set of tails with the last transit leg in it (one element)
     Set<OptimizedPathTail<T>> tails = Set.of(
       new OptimizedPathTail<>(
         slackProvider,
         costCalculator,
+        iterationDepartureTime,
         waitTimeCostCalculator,
         stopBoardAlightCosts,
         extraStopBoardAlightCostsFactor,

--- a/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
+++ b/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
@@ -116,7 +116,7 @@ public class TestPathBuilder implements RaptorTestConstants {
 
   public RaptorPath<TestTripSchedule> egress(TestAccessEgress transfer) {
     builder.egress(transfer);
-    return builder.build(startTime);
+    return builder.build();
   }
 
   /* private methods */
@@ -130,6 +130,7 @@ public class TestPathBuilder implements RaptorTestConstants {
     this.builder =
       PathBuilder.tailPathBuilder(
         slackProvider,
+        startTime,
         costCalculator,
         RaptorStopNameResolver.nullSafe(null),
         null

--- a/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
@@ -1,0 +1,98 @@
+package org.opentripplanner.raptor.moduletests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
+import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flex;
+import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flexAndWalk;
+import static org.opentripplanner.raptor._data.transit.TestRoute.route;
+import static org.opentripplanner.raptor._data.transit.TestTransfer.transfer;
+import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
+import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_MIN_DURATION;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_MIN_DURATION_REV;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.raptor.RaptorService;
+import org.opentripplanner.raptor._data.RaptorTestConstants;
+import org.opentripplanner.raptor._data.api.PathUtils;
+import org.opentripplanner.raptor._data.transit.TestTransitData;
+import org.opentripplanner.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
+import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+
+/**
+ * FEATURE UNDER TEST
+ * <p>
+ * Raptor should add transit-slack + board-slack after flex access, and transit-slack + alight-slack
+ * before flex egress.
+ */
+public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstants {
+
+  private final TestTransitData data = new TestTransitData();
+  private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
+  private final RaptorService<TestTripSchedule> raptorService = new RaptorService<>(
+    RaptorConfig.defaultConfigForTest()
+  );
+
+  @BeforeEach
+  public void setup() {
+    data
+      .withRoute(
+        // Pattern arrive at stop 2 at 0:03:00
+        route(pattern("R1", STOP_A, STOP_D))
+          .withTimetable(
+            // First trip is too early: It takes 2m to get to the point of boarding:
+            // --> 00:00:00 + flex 30s + slack(1m + 30s) = 00:02:00
+            schedule().departures("0:03:29, 0:05:29"),
+            // This is the trip we expect to board
+            schedule().departures("0:04:00, 0:10:00").arrivals("0, 00:06:00"),
+            // REVERSE SEARCH: The last trip arrives too late: It takes 1m40s to get to the
+            // point of "boarding" in the reverse search:
+            // --> 00:10:00 - (flex 20s + slack(1m + 10s)) = 00:08:30  (arrival time)
+            schedule().arrivals("0:04:51, 0:06:51")
+          )
+      )
+      .withTransfer(RaptorTestConstants.STOP_B, transfer(STOP_C, 300));
+    requestBuilder
+      .searchParams()
+      // Start walking 1m before: 30s walk + 30s board-slack
+      .addAccessPaths(flexAndWalk(STOP_B, D2m, ONE_RIDE, 40_000).openingHours("00:05", "00:10"))
+      // Ends 30s after last stop arrival: 10s alight-slack + 20s walk
+      .addEgressPaths(flex(STOP_C, D2m, ONE_RIDE, 56_000))
+      .earliestDepartureTime(T00_00)
+      .latestArrivalTime(T00_30)
+      // Only one iteration is needed - the access should be time-shifted
+      .searchWindowInSeconds(D10m);
+
+    ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
+  }
+
+  static List<RaptorModuleTestCase> testCases() {
+    var path =
+      "Flex+Walk 2m 1x ~ B ~ BUS R1 0:04 0:06 ~ C ~ Flex 2m 1x " +
+      "[0:00:30 0:09:10 8m40s 2tx $1840]";
+    return RaptorModuleTestCase
+      .of()
+      // TODO - Alight slack is missing
+      .add(TC_MIN_DURATION, "[0:00 0:08:30 8m30s 2tx]")
+      // TODO - Board slack is missing
+      .add(TC_MIN_DURATION_REV, "[0:01:50 0:10 8m10s 2tx]")
+      .add(standard(), PathUtils.withoutCost(path))
+      .add(multiCriteria(), path)
+      .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
+  }
+}

--- a/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
@@ -30,7 +30,9 @@ import org.opentripplanner.raptor.spi.UnknownPathString;
 /**
  * FEATURE UNDER TEST
  * <p>
- * Raptor should be able to timeshift a Flex ~ Walk ~ Flex path.
+ * Raptor should be able to time-shift a Flex ~ Walk ~ Flex path, either to the 
+ * requested departure time (iteration-departure-time) or to the earliest possible 
+ * time within the opening hours.
  */
 public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstants {
 
@@ -46,45 +48,38 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
         // Pattern arrive at stop 2 at 0:03:00
         route(pattern("R1", STOP_A, STOP_D))
           .withTimetable(
-            // First trip is too early: It takes 2m to get to the point of boarding:
-            // --> 00:00:00 + flex 30s + slack(1m + 30s) = 00:02:00
-            schedule().departures("0:03:29, 0:05:29"),
-            // This is the trip we expect to board
-            schedule().departures("0:04:00, 0:10:00").arrivals("0, 00:06:00"),
+            schedule().departures("0:04 0:10").arrivals("0:00 0:06"),
             // REVERSE SEARCH: The last trip arrives too late: It takes 1m40s to get to the
             // point of "boarding" in the reverse search:
             // --> 00:10:00 - (flex 20s + slack(1m + 10s)) = 00:08:30  (arrival time)
             schedule().arrivals("0:04:51, 0:06:51")
           )
       )
-      .withTransfer(RaptorTestConstants.STOP_B, transfer(STOP_C, D5m));
+      .withTransfer(STOP_B, transfer(STOP_C, D5m));
   }
 
   @Nonnull
   private static RaptorRequestBuilder<TestTripSchedule> baseRequestBuilder() {
-    RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
+    var requestBuilder = new RaptorRequestBuilder<TestTripSchedule>();
     requestBuilder
       .searchParams()
       .addEgressPaths(flex(STOP_C, D2m, ONE_RIDE, 56_000))
       .earliestDepartureTime(T00_10)
       .latestArrivalTime(T00_30)
-      // Only one iteration is needed - the access should be time-shifted
       .searchWindowInSeconds(D10m);
     return requestBuilder;
   }
 
   static List<RaptorModuleTestCase> flexOnlyNoWalkTestCases() {
     var path = "Flex 2m 1x ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:15 0:25 10m 1tx $1620]";
+    var stdPathRev = "Flex 2m 1x ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:35 0:45 10m 1tx]";
     var minDurationPath = UnknownPathString.of(D10m, 1);
     return RaptorModuleTestCase
       .of()
       .add(TC_MIN_DURATION, minDurationPath.departureAt(T00_10))
       .add(TC_MIN_DURATION_REV, minDurationPath.arrivalAt(T00_30))
       .add(standard().forwardOnly(), PathUtils.withoutCost(path))
-      .add(
-        standard().reverseOnly(),
-        "Flex 2m 1x ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:35 0:45 10m 1tx]"
-      )
+      .add(standard().reverseOnly(), stdPathRev)
       .add(multiCriteria(), path)
       .build();
   }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
@@ -13,7 +13,6 @@ import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCon
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,13 +29,14 @@ import org.opentripplanner.raptor.spi.UnknownPathString;
 /**
  * FEATURE UNDER TEST
  * <p>
- * Raptor should be able to time-shift a Flex ~ Walk ~ Flex path, either to the 
- * requested departure time (iteration-departure-time) or to the earliest possible 
+ * Raptor should be able to time-shift a Flex ~ Walk ~ Flex path, either to the
+ * requested departure time (iteration-departure-time) or to the earliest possible
  * time within the opening hours.
  */
 public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstants {
 
   private final TestTransitData data = new TestTransitData();
+  private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
   private final RaptorService<TestTripSchedule> raptorService = new RaptorService<>(
     RaptorConfig.defaultConfigForTest()
   );
@@ -45,29 +45,18 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
   public void setup() {
     data
       .withRoute(
-        // Pattern arrive at stop 2 at 0:03:00
-        route(pattern("R1", STOP_A, STOP_D))
-          .withTimetable(
-            schedule().departures("0:04 0:10").arrivals("0:00 0:06"),
-            // REVERSE SEARCH: The last trip arrives too late: It takes 1m40s to get to the
-            // point of "boarding" in the reverse search:
-            // --> 00:10:00 - (flex 20s + slack(1m + 10s)) = 00:08:30  (arrival time)
-            schedule().arrivals("0:04:51, 0:06:51")
-          )
+        // The route is not reached by Raptor, but we need at least one trip schedule for the test-data to be valid.
+        route(pattern("Any", STOP_A, STOP_D))
+          .withTimetable(schedule().departures("0:04 0:10").arrivals("0:00 0:06"))
       )
       .withTransfer(STOP_B, transfer(STOP_C, D5m));
-  }
 
-  @Nonnull
-  private static RaptorRequestBuilder<TestTripSchedule> baseRequestBuilder() {
-    var requestBuilder = new RaptorRequestBuilder<TestTripSchedule>();
     requestBuilder
       .searchParams()
       .addEgressPaths(flex(STOP_C, D2m, ONE_RIDE, 56_000))
       .earliestDepartureTime(T00_10)
       .latestArrivalTime(T00_30)
       .searchWindowInSeconds(D10m);
-    return requestBuilder;
   }
 
   static List<RaptorModuleTestCase> flexOnlyNoWalkTestCases() {
@@ -87,7 +76,6 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
   @ParameterizedTest
   @MethodSource("flexOnlyNoWalkTestCases")
   void flexOnlyNoWalk(RaptorModuleTestCase testCase) {
-    var requestBuilder = baseRequestBuilder();
     requestBuilder.searchParams().addAccessPaths(flex(STOP_B, D2m, ONE_RIDE, 40_000));
 
     var request = testCase.withConfig(requestBuilder);
@@ -98,7 +86,6 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
   @ParameterizedTest
   @MethodSource("flexOnlyNoWalkTestCases")
   void flexOnlyNoWalkWithOpening(RaptorModuleTestCase testCase) {
-    var requestBuilder = baseRequestBuilder();
     requestBuilder.searchParams().addAccessPaths(flex(STOP_B, D2m, ONE_RIDE, 40_000));
 
     var request = testCase.withConfig(requestBuilder);

--- a/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
@@ -3,14 +3,12 @@ package org.opentripplanner.raptor.moduletests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flex;
-import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flexAndWalk;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTransfer.transfer;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_MIN_DURATION;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_MIN_DURATION_REV;
-import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.minDuration;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
@@ -73,50 +71,6 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
       // Only one iteration is needed - the access should be time-shifted
       .searchWindowInSeconds(D10m);
     return requestBuilder;
-  }
-
-  private static List<RaptorModuleTestCase> cases(String path) {
-    return RaptorModuleTestCase
-      .of()
-      .add(minDuration(), path)
-      .add(standard(), path)
-      .add(multiCriteria(), path)
-      .build();
-  }
-
-  static List<RaptorModuleTestCase> openingHoursCases() {
-    var path =
-      "Flex+Walk 2m 1x Open(0:05 0:10) ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:15 0:25 10m 1tx $1620]";
-    return cases(path);
-  }
-
-  @ParameterizedTest
-  @MethodSource("openingHoursCases")
-  void flexWalkOpeningHours(RaptorModuleTestCase testCase) {
-    var requestBuilder = baseRequestBuilder();
-    requestBuilder
-      .searchParams()
-      .addAccessPaths(flexAndWalk(STOP_B, D2m, ONE_RIDE, 40_000).openingHours("00:05", "00:10"));
-
-    var request = testCase.withConfig(requestBuilder);
-    var response = raptorService.route(request, data);
-    assertEquals(testCase.expected(), pathsToString(response));
-  }
-
-  static List<RaptorModuleTestCase> noOpeningHoursCases() {
-    var path = "Flex+Walk 2m 1x ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:15 0:25 10m 1tx $1620]";
-    return cases(path);
-  }
-
-  @ParameterizedTest
-  @MethodSource("noOpeningHoursCases")
-  void flexWalkNoOpeningHours(RaptorModuleTestCase testCase) {
-    var requestBuilder = baseRequestBuilder();
-    requestBuilder.searchParams().addAccessPaths(flexAndWalk(STOP_B, D2m, ONE_RIDE, 40_000));
-
-    var request = testCase.withConfig(requestBuilder);
-    var response = raptorService.route(request, data);
-    assertEquals(testCase.expected(), pathsToString(response));
   }
 
   static List<RaptorModuleTestCase> flexOnlyNoWalkTestCases() {

--- a/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
@@ -8,10 +8,7 @@ import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTransfer.transfer;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
-import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_MIN_DURATION;
-import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_MIN_DURATION_REV;
-import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
-import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_MULTI_CRITERIA;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +16,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
-import org.opentripplanner.raptor._data.api.PathUtils;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
@@ -61,11 +57,9 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
       .withTransfer(RaptorTestConstants.STOP_B, transfer(STOP_C, 300));
     requestBuilder
       .searchParams()
-      // Start walking 1m before: 30s walk + 30s board-slack
       .addAccessPaths(flexAndWalk(STOP_B, D2m, ONE_RIDE, 40_000).openingHours("00:05", "00:10"))
-      // Ends 30s after last stop arrival: 10s alight-slack + 20s walk
       .addEgressPaths(flex(STOP_C, D2m, ONE_RIDE, 56_000))
-      .earliestDepartureTime(T00_00)
+      .earliestDepartureTime(T00_10)
       .latestArrivalTime(T00_30)
       // Only one iteration is needed - the access should be time-shifted
       .searchWindowInSeconds(D10m);
@@ -75,16 +69,8 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
 
   static List<RaptorModuleTestCase> testCases() {
     var path =
-      "Flex+Walk 2m 1x Open(0:05 0:10) ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:05 0:15 10m 1tx $1620]";
-    return RaptorModuleTestCase
-      .of()
-      // TODO - Alight slack is missing
-      .add(TC_MIN_DURATION, "[0:00 0:08:30 8m30s 2tx]")
-      // TODO - Board slack is missing
-      .add(TC_MIN_DURATION_REV, "[0:01:50 0:10 8m10s 2tx]")
-      .add(standard(), PathUtils.withoutCost(path))
-      .add(multiCriteria(), path)
-      .build();
+      "Flex+Walk 2m 1x Open(0:05 0:10) ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:15 0:25 10m 1tx $1620]";
+    return RaptorModuleTestCase.of().add(TC_MULTI_CRITERIA, path).build();
   }
 
   @ParameterizedTest

--- a/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/F04_AccessEgressWithRidesNoTransitTest.java
@@ -75,8 +75,7 @@ public class F04_AccessEgressWithRidesNoTransitTest implements RaptorTestConstan
 
   static List<RaptorModuleTestCase> testCases() {
     var path =
-      "Flex+Walk 2m 1x ~ B ~ BUS R1 0:04 0:06 ~ C ~ Flex 2m 1x " +
-      "[0:00:30 0:09:10 8m40s 2tx $1840]";
+      "Flex+Walk 2m 1x Open(0:05 0:10) ~ B ~ Walk 5m ~ C ~ Flex 2m 1x [0:05 0:15 10m 1tx $1620]";
     return RaptorModuleTestCase
       .of()
       // TODO - Alight slack is missing

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
@@ -60,6 +60,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
   private final OptimizedPathTail<TestTripSchedule> subject = new OptimizedPathTail<>(
     SLACK_PROVIDER,
     BasicPathTestCase.COST_CALCULATOR,
+    0,
     waitTimeCalc,
     stopBoardAlightCost,
     2.0,
@@ -137,7 +138,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
     subject.addTransitAndTransferLeg(t1, tx12);
     subject.access(orgPath.accessLeg().access());
 
-    var path = subject.build(0);
+    var path = subject.build();
 
     // We have replaced the first transfer with a 2 minute walk
     var expPath =

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
@@ -14,6 +14,7 @@ import org.opentripplanner.routing.algorithm.transferoptimization.services.Trans
 
 class OptimizedPathTailTest implements RaptorTestConstants {
 
+  public static final int ITERATION_DEPARTURE_TIME_ZERO = 0;
   private final RaptorPath<TestTripSchedule> orgPath = BasicPathTestCase.basicTripAsPath();
 
   private final RaptorPath<TestTripSchedule> flexPath = BasicPathTestCase.flexTripAsPath();
@@ -60,7 +61,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
   private final OptimizedPathTail<TestTripSchedule> subject = new OptimizedPathTail<>(
     SLACK_PROVIDER,
     BasicPathTestCase.COST_CALCULATOR,
-    0,
+    ITERATION_DEPARTURE_TIME_ZERO,
     waitTimeCalc,
     stopBoardAlightCost,
     2.0,

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelectorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelectorTest.java
@@ -50,6 +50,7 @@ public class TransitPathLegSelectorTest implements RaptorTestConstants {
   private final OptimizedPathTail<TestTripSchedule> pathTail = new OptimizedPathTail<>(
     SLACK_PROVIDER,
     COST_CALCULATOR,
+    0,
     null,
     null,
     0.0,


### PR DESCRIPTION
### Summary

For Raptor Flex ~ Walk ~ Flex are valid paths (even though they don't make an awful lot of sense). Right now these paths throw an exception when they are time shifted.

In collaboration with @t2gran we decided that it's easier to fix the `PathBuilder` rather than complicating Raptor to deal with this special case.

### Issue

Closes #4862 

### Unit tests

Added.