### PR TITLE
Build a Docker image that support multiple architectures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,7 @@
                                 <architecture>arm64</architecture>
                                 <os>linux</os>
                             </platform>
+                        </platforms>
                     </from>
                     <to>
                         <image>${env.CONTAINER_REPO}</image>

--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,30 @@
                             <port>8081</port>
                         </ports>
                     </container>
+                    <from>
+                        <platforms>
+                            <platform>
+                                <architecture>amd64</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>arm64</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>arm</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>ppc64le</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>s390x</architecture>
+                                <os>linux</os>
+                            </platform>
+                        </platforms>
+                    </from>
                     <to>
                         <image>${env.CONTAINER_REPO}</image>
                         <auth>

--- a/pom.xml
+++ b/pom.xml
@@ -475,19 +475,6 @@
                                 <architecture>arm64</architecture>
                                 <os>linux</os>
                             </platform>
-                            <platform>
-                                <architecture>arm</architecture>
-                                <os>linux</os>
-                            </platform>
-                            <platform>
-                                <architecture>ppc64le</architecture>
-                                <os>linux</os>
-                            </platform>
-                            <platform>
-                                <architecture>s390x</architecture>
-                                <os>linux</os>
-                            </platform>
-                        </platforms>
                     </from>
                     <to>
                         <image>${env.CONTAINER_REPO}</image>


### PR DESCRIPTION
Closes #4914

This PR add support for building Docker image for the following architectures:
- x86-64 (amd64)
~- ARMv7 32-bit (arm32v7)~
- ARMv8 64-bit (arm64v8)
~- IBM POWER8 (ppc64le)~
~- IBM z Systems (s390x)~