### PR TITLE
Take nullable route short name into account in Atlanta fare calculator

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
@@ -61,6 +61,12 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
   }
 
   @Test
+  void nullShortName() {
+    var legs = List.of(getLeg(GCT_AGENCY_ID, null, 1));
+    calculateFare(legs, 349);
+  }
+
+  @Test
   public void fromCobbTransfers() {
     List<Leg> rides = List.of(getLeg(COBB_AGENCY_ID, 0), getLeg(MARTA_AGENCY_ID, 1));
     calculateFare(rides, DEFAULT_RIDE_PRICE_IN_CENTS);
@@ -255,7 +261,12 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
 
     @Override
     protected float getLegPrice(Leg leg, FareType fareType, Collection<FareRuleSet> fareRules) {
-      String routeShortName = leg.getRoute().getShortName().toLowerCase();
+      var routeShortName = leg.getRoute().getShortName();
+      if (routeShortName == null) {
+        return DEFAULT_TEST_RIDE_PRICE;
+      }
+      routeShortName = leg.getRoute().getShortName().toLowerCase();
+
       // Testing, return default test ride price.
       return switch (routeShortName) {
         case "101" -> DEFAULT_TEST_RIDE_PRICE + 1;

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
@@ -10,6 +10,7 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.core.FareType;
@@ -51,7 +52,10 @@ public class AtlantaFareService extends DefaultFareService {
       this.routeNames = Arrays.stream(members).map(String::toLowerCase).collect(Collectors.toSet());
     }
 
-    public boolean routeNamesContains(String s) {
+    public boolean routeNamesContains(@Nullable String s) {
+      if (s == null) {
+        return false;
+      }
       return routeNames.contains(s.toLowerCase());
     }
   }
@@ -194,7 +198,10 @@ public class AtlantaFareService extends DefaultFareService {
 
   private static RideType classify(Leg ride) {
     Route getRoute = ride.getRoute();
-    String shortName = getRoute.getShortName().toLowerCase();
+    String shortName = getRoute.getShortName();
+    if (shortName != null) {
+      shortName = shortName.toLowerCase();
+    }
 
     switch (getRoute.getAgency().getId().getId()) {
       case COBB_AGENCY_ID -> {


### PR DESCRIPTION
Fixes a bug where a route short name of null leads to an NPE.


### Unit tests

Added.