### PR TITLE
Ignore UnrestrictedPublicTransportAreas that do not contain regular stops

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -2,6 +2,7 @@ package org.opentripplanner.netex.mapping;
 
 import java.util.Collection;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -117,6 +118,7 @@ class FlexStopsMapper {
   /**
    * Allows pickup / drop off at any regular Stop inside the area
    */
+  @Nullable
   GroupStop mapStopsInFlexArea(FlexibleStopPlace flexibleStopPlace, FlexibleArea area) {
     GroupStopBuilder result = GroupStop
       .of(idFactory.createId(flexibleStopPlace.getId()))
@@ -133,6 +135,21 @@ class FlexStopsMapper {
       if (geometry.contains(p)) {
         result.addLocation(stop);
       }
+    }
+
+    if (result.stopLocations().isEmpty()) {
+      issueStore.add(
+        Issue.issue(
+          "MissingStopsInUnrestrictedPublicTransportAreas",
+          "FlexibleArea %s with type UnrestrictedPublicTransportAreas does not contain any regular stop.",
+          area.getId()
+        )
+      );
+      LOG.warn(
+        "FlexibleArea {} with type UnrestrictedPublicTransportAreas does not contain any regular stop.",
+        area.getId()
+      );
+      return null;
     }
 
     return result.build();

--- a/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
@@ -30,7 +30,7 @@ public class GroupStop
     this.index = INDEX_COUNTER.getAndIncrement();
     this.name = builder.name();
     this.geometry = builder.geometry();
-    this.centroid = builder.centroid();
+    this.centroid = Objects.requireNonNull(builder.centroid());
     this.stopLocations = builder.stopLocations();
   }
 
@@ -87,11 +87,6 @@ public class GroupStop
   public boolean isPartOfSameStationAs(StopLocation alternativeStop) {
     return false;
   }
-
-  /**
-   * Adds a new location to the location group. This should ONLY be used during the graph build
-   * process.
-   */
 
   /**
    * Returns all the locations belonging to this location group.

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.netex.mapping.MappingSupport.ID_FACTORY;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -92,7 +91,7 @@ class FlexStopsMapperTest {
   );
 
   @Test
-  void mapAreaStop() {
+  void testMapAreaStop() {
     FlexStopsMapper flexStopsMapper = new FlexStopsMapper(
       ID_FACTORY,
       List.of(),
@@ -107,7 +106,7 @@ class FlexStopsMapperTest {
   }
 
   @Test
-  void mapInvalidAreaStop() {
+  void testMapInvalidAreaStop() {
     FlexStopsMapper flexStopsMapper = new FlexStopsMapper(
       ID_FACTORY,
       List.of(),
@@ -122,7 +121,7 @@ class FlexStopsMapperTest {
   }
 
   @Test
-  void mapGroupStop() {
+  void testMapGroupStop() {
     RegularStop stop1 = TransitModelForTest.stop("A").withCoordinate(59.6505778, 6.3608759).build();
     RegularStop stop2 = TransitModelForTest.stop("B").withCoordinate(59.6630333, 6.3697245).build();
 
@@ -144,10 +143,29 @@ class FlexStopsMapperTest {
 
     GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
 
+    assertNotNull(groupStop);
+
     // Only one of the stops should be inside the polygon
     assertEquals(1, groupStop.getLocations().size());
+  }
 
-    assertNotNull(groupStop);
+  @Test
+  void testMapFlexibleStopPlaceMissingStops() {
+    FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(AREA_POS_LIST);
+    flexibleStopPlace.setKeyList(
+      new KeyListStructure()
+        .withKeyValue(
+          new KeyValueStructure()
+            .withKey("FlexibleStopAreaType")
+            .withValue("UnrestrictedPublicTransportAreas")
+        )
+    );
+
+    FlexStopsMapper subject = new FlexStopsMapper(ID_FACTORY, List.of(), DataImportIssueStore.NOOP);
+
+    GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
+
+    assertNull(groupStop);
   }
 
   private FlexibleStopPlace getFlexibleStopPlace(Collection<Double> areaPosList) {


### PR DESCRIPTION
### Summary

This PR fixes #4918: The OTP graph builder should ignore FlexibleStopPlaces of type UnrestrictedPublicTransportAreas when they do not contain any stop.
The FlexibleStopPlace is dropped and an issue is logged in the issue store.
Additionally a null-check is added in the GroupStop constructor to prevent the creation of a GroupStop without a centroid (that triggers NullPointerExceptions downstream in the code)

### Issue

Fixes #4918

### Unit tests

Added unit test

### Documentation
No
