### PR TITLE
Allow multiple FlexibleAreas in a FlexibleStopPlace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.22.0:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -71,11 +71,6 @@ class FlexStopsMapper {
             area
           )
         );
-        LOG.warn(
-          "FlexibleStopPlace {} contains an unsupported area {}. Hail and ride areas are not currently supported.",
-          flexibleStopPlace.getId(),
-          area
-        );
         continue;
       }
 
@@ -158,7 +153,6 @@ class FlexStopsMapper {
           area.getId()
         )
       );
-      LOG.warn("FlexibleArea {}  has an invalid geometry", area.getId(), e);
       return null;
     }
   }

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -79,7 +79,11 @@ class FlexStopsMapper {
       if (shouldAddStopsFromArea(flexibleArea, flexibleStopPlace)) {
         stops.addAll(findStopsInFlexArea(flexibleArea, flexibleAreaGeometry));
       } else {
-        AreaStop areaStop = mapFlexArea(flexibleArea, flexibleAreaGeometry, flexibleStopPlace.getName().getValue());
+        AreaStop areaStop = mapFlexArea(
+          flexibleArea,
+          flexibleAreaGeometry,
+          flexibleStopPlace.getName().getValue()
+        );
         if (areaStop != null) {
           stops.add(areaStop);
         }

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -17,6 +17,7 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.rutebanken.netex.model.FlexibleArea;
 import org.rutebanken.netex.model.FlexibleStopPlace;
+import org.rutebanken.netex.model.KeyListStructure;
 import org.rutebanken.netex.model.KeyValueStructure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +79,7 @@ class FlexStopsMapper {
         continue;
       }
 
-      if (UNRESTRICTED_PUBLIC_TRANSPORT_AREAS_VALUE.equals(getFlexibleAreaType(flexibleArea))) {
+      if (shouldAddStopsFromArea(flexibleArea, flexibleStopPlace)) {
         stops.addAll(findStopsInFlexArea(flexibleArea));
       } else {
         AreaStop areaStop = mapFlexArea(flexibleArea, flexibleStopPlace.getName().getValue());
@@ -166,16 +167,32 @@ class FlexStopsMapper {
     }
   }
 
-  private static String getFlexibleAreaType(FlexibleArea flexibleArea) {
-    String flexibleAreaType = null;
-    if (flexibleArea.getKeyList() != null) {
-      for (KeyValueStructure k : flexibleArea.getKeyList().getKeyValue()) {
+  private boolean shouldAddStopsFromArea(
+    FlexibleArea flexibleArea,
+    FlexibleStopPlace parentStop
+  ) {
+    var flexibleAreaType = getFlexibleStopAreaType(flexibleArea.getKeyList());
+    var parentStopType = getFlexibleStopAreaType(parentStop.getKeyList());
+
+    if (UNRESTRICTED_PUBLIC_TRANSPORT_AREAS_VALUE.equals(flexibleAreaType)) {
+      return true;
+    } else {
+      return (
+        UNRESTRICTED_PUBLIC_TRANSPORT_AREAS_VALUE.equals(parentStopType) && flexibleAreaType == null
+      );
+    }
+  }
+
+  private static String getFlexibleStopAreaType(KeyListStructure keyListStructure) {
+    String flexibleStopAreaType = null;
+    if (keyListStructure != null) {
+      for (KeyValueStructure k : keyListStructure.getKeyValue()) {
         if (k.getKey().equals(FLEXIBLE_STOP_AREA_TYPE_KEY)) {
-          flexibleAreaType = k.getValue();
+          flexibleStopAreaType = k.getValue();
           break;
         }
       }
     }
-    return flexibleAreaType;
+    return flexibleStopAreaType;
   }
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -141,10 +141,6 @@ class FlexStopsMapper {
           area.getId()
         )
       );
-      LOG.warn(
-        "FlexibleArea {} with type UnrestrictedPublicTransportAreas does not contain any regular stop.",
-        area.getId()
-      );
       return List.of();
     }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -74,10 +74,12 @@ class FlexStopsMapper {
         continue;
       }
 
+      Geometry flexibleAreaGeometry = mapGeometry(flexibleArea);
+
       if (shouldAddStopsFromArea(flexibleArea, flexibleStopPlace)) {
-        stops.addAll(findStopsInFlexArea(flexibleArea));
+        stops.addAll(findStopsInFlexArea(flexibleArea, flexibleAreaGeometry));
       } else {
-        AreaStop areaStop = mapFlexArea(flexibleArea, flexibleStopPlace.getName().getValue());
+        AreaStop areaStop = mapFlexArea(flexibleArea, flexibleAreaGeometry, flexibleStopPlace.getName().getValue());
         if (areaStop != null) {
           stops.add(areaStop);
         }
@@ -100,8 +102,7 @@ class FlexStopsMapper {
   /**
    * Allows pickup / drop off along any eligible street inside the area
    */
-  AreaStop mapFlexArea(FlexibleArea area, String backupName) {
-    Geometry geometry = mapGeometry(area);
+  AreaStop mapFlexArea(FlexibleArea area, Geometry geometry, String backupName) {
     if (geometry == null) {
       return null;
     }
@@ -117,8 +118,7 @@ class FlexStopsMapper {
   /**
    * Allows pickup / drop off at any regular Stop inside the area
    */
-  List<RegularStop> findStopsInFlexArea(FlexibleArea area) {
-    Geometry geometry = mapGeometry(area);
+  List<RegularStop> findStopsInFlexArea(FlexibleArea area, Geometry geometry) {
     if (geometry == null) {
       return List.of();
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -167,10 +167,7 @@ class FlexStopsMapper {
     }
   }
 
-  private boolean shouldAddStopsFromArea(
-    FlexibleArea flexibleArea,
-    FlexibleStopPlace parentStop
-  ) {
+  private boolean shouldAddStopsFromArea(FlexibleArea flexibleArea, FlexibleStopPlace parentStop) {
     var flexibleAreaType = getFlexibleStopAreaType(flexibleArea.getKeyList());
     var parentStopType = getFlexibleStopAreaType(parentStop.getKeyList());
 

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -368,10 +368,15 @@ public class NetexMapper {
 
     for (FlexibleStopPlace flexibleStopPlace : flexibleStopPlaces) {
       StopLocation stopLocation = flexStopsMapper.map(flexibleStopPlace);
-      if (stopLocation instanceof AreaStop) {
-        transitBuilder.getAreaStops().add((AreaStop) stopLocation);
+      if (stopLocation instanceof AreaStop areaStop) {
+        transitBuilder.getAreaStops().add(areaStop);
       } else if (stopLocation instanceof GroupStop groupStop) {
         transitBuilder.getGroupStops().add(groupStop);
+        for (var child : groupStop.getLocations()) {
+          if (child instanceof AreaStop areaStop) {
+            transitBuilder.getAreaStops().add(areaStop);
+          }
+        }
       }
     }
   }

--- a/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.basic.SubMode;
@@ -108,7 +108,7 @@ public final class RegularStop
 
   @Override
   @Nonnull
-  public Geometry getGeometry() {
+  public Point getGeometry() {
     return GeometryUtils.getGeometryFactory().createPoint(getCoordinate().asJtsCoordinate());
   }
 

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -226,18 +226,18 @@ class FlexStopsMapperTest {
     var invalidPolygon = List.of(1.0);
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(invalidPolygon);
     flexibleStopPlace.setKeyList(
-            new KeyListStructure()
-                    .withKeyValue(
-                            new KeyValueStructure()
-                                    .withKey("FlexibleStopAreaType")
-                                    .withValue("UnrestrictedPublicTransportAreas")
-                    )
+      new KeyListStructure()
+        .withKeyValue(
+          new KeyValueStructure()
+            .withKey("FlexibleStopAreaType")
+            .withValue("UnrestrictedPublicTransportAreas")
+        )
     );
 
     FlexStopsMapper subject = new FlexStopsMapper(
-            ID_FACTORY,
-            List.of(stop1, stop2),
-            DataImportIssueStore.NOOP
+      ID_FACTORY,
+      List.of(stop1, stop2),
+      DataImportIssueStore.NOOP
     );
 
     GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -166,6 +166,40 @@ class FlexStopsMapperTest {
   }
 
   @Test
+  void testMapGroupStopVariantWithKeyValueOnArea() {
+    RegularStop stop1 = TransitModelForTest.stop("A").withCoordinate(59.6505778, 6.3608759).build();
+    RegularStop stop2 = TransitModelForTest.stop("B").withCoordinate(59.6630333, 6.3697245).build();
+
+    FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(AREA_POS_LIST);
+
+    var area = (FlexibleArea) flexibleStopPlace
+      .getAreas()
+      .getFlexibleAreaOrFlexibleAreaRefOrHailAndRideArea()
+      .get(0);
+    area.withKeyList(
+      new KeyListStructure()
+        .withKeyValue(
+          new KeyValueStructure()
+            .withKey("FlexibleStopAreaType")
+            .withValue("UnrestrictedPublicTransportAreas")
+        )
+    );
+
+    FlexStopsMapper subject = new FlexStopsMapper(
+      ID_FACTORY,
+      List.of(stop1, stop2),
+      DataImportIssueStore.NOOP
+    );
+
+    GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
+
+    assertNotNull(groupStop);
+
+    // Only one of the stops should be inside the polygon
+    assertEquals(1, groupStop.getLocations().size());
+  }
+
+  @Test
   void testMapFlexibleStopPlaceMissingStops() {
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(AREA_POS_LIST);
     flexibleStopPlace.setKeyList(

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -218,6 +218,33 @@ class FlexStopsMapperTest {
     assertNull(groupStop);
   }
 
+  @Test
+  void testMapFlexibleStopPlaceWithInvalidGeometryOnUnrestrictedPublicTransportAreas() {
+    RegularStop stop1 = TransitModelForTest.stop("A").withCoordinate(59.6505778, 6.3608759).build();
+    RegularStop stop2 = TransitModelForTest.stop("B").withCoordinate(59.6630333, 6.3697245).build();
+
+    var invalidPolygon = List.of(1.0);
+    FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(invalidPolygon);
+    flexibleStopPlace.setKeyList(
+            new KeyListStructure()
+                    .withKeyValue(
+                            new KeyValueStructure()
+                                    .withKey("FlexibleStopAreaType")
+                                    .withValue("UnrestrictedPublicTransportAreas")
+                    )
+    );
+
+    FlexStopsMapper subject = new FlexStopsMapper(
+            ID_FACTORY,
+            List.of(stop1, stop2),
+            DataImportIssueStore.NOOP
+    );
+
+    GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
+
+    assertNull(groupStop);
+  }
+
   private FlexibleStopPlace getFlexibleStopPlace(Collection<Double> areaPosList) {
     return new FlexibleStopPlace()
       .withId(FLEXIBLE_STOP_PLACE_ID)


### PR DESCRIPTION
### Summary

Currently only the first FlexibleArea in a NeTEX FlexibleStopPlace is parsed. Modify the code to create a GrupStop if multiple areas exist.
