### PR TITLE
Remove deprecation annotation from viaTrip query field

### DIFF
--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -880,7 +880,7 @@ type QueryType {
     via: [ViaLocationInput!]!,
     "Whether the trip must be wheelchair accessible. Supported for the street part to the search, not implemented for the transit yet."
     wheelchairAccessible: Boolean = false
-  ): ViaTrip! @deprecated @timingData
+  ): ViaTrip! @timingData
 }
 
 type RentalVehicle implements PlaceInterface {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/ViaTripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/ViaTripQuery.java
@@ -28,7 +28,6 @@ public class ViaTripQuery {
       .description(
         "Via trip search. Find trip patterns traveling via one or more intermediate (via) locations."
       )
-      .deprecate("This API is under development, expect the contract to change")
       .type(new GraphQLNonNull(viaTripType))
       .withDirective(gqlUtil.timingData)
       .argument(


### PR DESCRIPTION
The viaTrip query field seems to be stable now so the deprecation marking can be removed.