### PR TITLE
Use durations for Raptor search window configuration

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,6 +18,10 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # Fix CI timeouts which is caused by Maven keeping connections open for a very long time
+      # https://github.com/actions/runner-images/issues/1499#issuecomment-718396233
+      MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,10 +18,6 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      # Fix CI timeouts which is caused by Maven keeping connections open for a very long time
-      # https://github.com/actions/runner-images/issues/1499#issuecomment-718396233
-      MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
       - uses: actions/checkout@v3.3.0
@@ -37,7 +33,13 @@ jobs:
           cache: maven
 
       - name: Prepare coverage agent, build and test
-        run: mvn --batch-mode --update-snapshots jacoco:prepare-agent verify jacoco:report -P prettierCheck
+        # these are split into two steps because otherwise maven keeps long-running HTTP connections
+        # to Maven Central open which then hang during the package phase because the Azure (Github Actions)
+        # NAT drops them
+        # https://github.com/actions/runner-images/issues/1499
+        run: |
+          mvn --batch-mode jacoco:prepare-agent test jacoco:report -P prettierCheck
+          mvn --batch-mode package -Dmaven.test.skip -P prettierSkip
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner'
@@ -49,7 +51,7 @@ jobs:
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierCheck -P deployGitHub
+        run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierSkip -P deployGitHub
 
   build-windows:
     timeout-minutes: 20

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
       - uses: actions/checkout@v3.3.0
@@ -47,6 +48,7 @@ jobs:
         run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierCheck -P deployGitHub
 
   build-windows:
+    timeout-minutes: 20
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -46,10 +46,10 @@ A full list of them can be found in the [RouteRequest](RouteRequest.md).
 |    [searchThreadPoolSize](#transit_searchThreadPoolSize)                                  |       `integer`       | Split a travel search in smaller jobs and run them in parallel to improve performance.            | *Optional* | `0`           |   na  |
 |    [transferCacheMaxSize](#transit_transferCacheMaxSize)                                  |       `integer`       | The maximum number of distinct transfers parameters to cache pre-calculated transfers for.        | *Optional* | `25`          |   na  |
 |    [dynamicSearchWindow](#transit_dynamicSearchWindow)                                    |        `object`       | The dynamic search window coefficients used to calculate the EDT, LAT and SW.                     | *Optional* |               |   na  |
-|       [maxWinTimeMinutes](#transit_dynamicSearchWindow_maxWinTimeMinutes)                 |       `integer`       | Upper limit for the search-window calculation.                                                    | *Optional* | `180`         |   na  |
-|       [minTransitTimeCoefficient](#transit_dynamicSearchWindow_minTransitTimeCoefficient) |        `double`       | The coefficient to multiply with `minTransitTime`.                                                | *Optional* | `0.5`         |   na  |
-|       [minWaitTimeCoefficient](#transit_dynamicSearchWindow_minWaitTimeCoefficient)       |        `double`       | The coefficient to multiply with `minWaitTime`.                                                   | *Optional* | `0.5`         |   na  |
-|       [minWinTimeMinutes](#transit_dynamicSearchWindow_minWinTimeMinutes)                 |       `integer`       | The constant minimum number of minutes for a raptor-search-window.                                | *Optional* | `40`          |   na  |
+|       [maxWindow](#transit_dynamicSearchWindow_maxWindow)                                 |       `duration`      | Upper limit for the search-window calculation.                                                    | *Optional* | `"PT3H"`      |  2.1  |
+|       [minTransitTimeCoefficient](#transit_dynamicSearchWindow_minTransitTimeCoefficient) |        `double`       | The coefficient to multiply with `minTransitTime`.                                                | *Optional* | `0.5`         |  2.1  |
+|       [minWaitTimeCoefficient](#transit_dynamicSearchWindow_minWaitTimeCoefficient)       |        `double`       | The coefficient to multiply with `minWaitTime`.                                                   | *Optional* | `0.5`         |  2.1  |
+|       [minWindow](#transit_dynamicSearchWindow_minWindow)                                 |       `duration`      | The constant minimum duration for a raptor-search-window.                                         | *Optional* | `"PT40M"`     |  2.1  |
 |       [stepMinutes](#transit_dynamicSearchWindow_stepMinutes)                             |       `integer`       | Used to set the steps the search-window is rounded to.                                            | *Optional* | `10`          |   na  |
 |    [pagingSearchWindowAdjustments](#transit_pagingSearchWindowAdjustments)                |      `duration[]`     | The provided array of durations is used to increase the search-window for the next/previous page. | *Optional* |               |   na  |
 |    [stopTransferCost](#transit_stopTransferCost)                                          | `enum map of integer` | Use this to set a stop transfer cost for the given transfer priority                              | *Optional* |               |   na  |
@@ -252,9 +252,9 @@ In addition there is an upper bound on the calculation of the search window:
 `maxWinTimeMinutes`.
 
 
-<h3 id="transit_dynamicSearchWindow_maxWinTimeMinutes">maxWinTimeMinutes</h3>
+<h3 id="transit_dynamicSearchWindow_maxWindow">maxWindow</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `180`   
+**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT3H"`   
 **Path:** /transit/dynamicSearchWindow 
 
 Upper limit for the search-window calculation.
@@ -262,15 +262,13 @@ Upper limit for the search-window calculation.
 Long search windows consumes a lot of resources and may take a long time. Use this parameter to
 tune the desired maximum search time.
 
-This is the parameter that affect the response time most, the downside is that a search is only
+This is the parameter that affects the response time most, the downside is that a search is only
 guaranteed to be pareto-optimal within a search-window.
-
-The default is 3 hours. The unit is minutes.
 
 
 <h3 id="transit_dynamicSearchWindow_minTransitTimeCoefficient">minTransitTimeCoefficient</h3>
 
-**Since version:** `na` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`   
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`   
 **Path:** /transit/dynamicSearchWindow 
 
 The coefficient to multiply with `minTransitTime`.
@@ -279,19 +277,19 @@ Use a value between `0.0` and `3.0`. Using `0.0` will eliminate the `minTransitT
 
 <h3 id="transit_dynamicSearchWindow_minWaitTimeCoefficient">minWaitTimeCoefficient</h3>
 
-**Since version:** `na` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`   
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`   
 **Path:** /transit/dynamicSearchWindow 
 
 The coefficient to multiply with `minWaitTime`.
 
 Use a value between `0.0` and `1.0`. Using `0.0` will eliminate the `minWaitTime` from the dynamic raptor-search-window calculation.
 
-<h3 id="transit_dynamicSearchWindow_minWinTimeMinutes">minWinTimeMinutes</h3>
+<h3 id="transit_dynamicSearchWindow_minWindow">minWindow</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `40`   
+**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT40M"`   
 **Path:** /transit/dynamicSearchWindow 
 
-The constant minimum number of minutes for a raptor-search-window. 
+The constant minimum duration for a raptor-search-window. 
 
 Use a value between 20 and 180 minutes in a normal deployment.
 
@@ -482,8 +480,8 @@ Http headers.
     "dynamicSearchWindow" : {
       "minTransitTimeCoefficient" : 0.5,
       "minWaitTimeCoefficient" : 0.5,
-      "minWinTimeMinutes" : 60,
-      "maxWinTimeMinutes" : 300
+      "minWindow" : "1h",
+      "maxWindow" : "5h"
     },
     "stopTransferCost" : {
       "DISCOURAGED" : 1500,

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -45,12 +45,12 @@ A full list of them can be found in the [RouteRequest](RouteRequest.md).
 |    [scheduledTripBinarySearchThreshold](#transit_scheduledTripBinarySearchThreshold)      |       `integer`       | This threshold is used to determine when to perform a binary trip schedule search.                | *Optional* | `50`          |   na  |
 |    [searchThreadPoolSize](#transit_searchThreadPoolSize)                                  |       `integer`       | Split a travel search in smaller jobs and run them in parallel to improve performance.            | *Optional* | `0`           |   na  |
 |    [transferCacheMaxSize](#transit_transferCacheMaxSize)                                  |       `integer`       | The maximum number of distinct transfers parameters to cache pre-calculated transfers for.        | *Optional* | `25`          |   na  |
-|    [dynamicSearchWindow](#transit_dynamicSearchWindow)                                    |        `object`       | The dynamic search window coefficients used to calculate the EDT, LAT and SW.                     | *Optional* |               |   na  |
-|       [maxWindow](#transit_dynamicSearchWindow_maxWindow)                                 |       `duration`      | Upper limit for the search-window calculation.                                                    | *Optional* | `"PT3H"`      |  2.1  |
+|    [dynamicSearchWindow](#transit_dynamicSearchWindow)                                    |        `object`       | The dynamic search window coefficients used to calculate the EDT, LAT and SW.                     | *Optional* |               |  2.1  |
+|       [maxWindow](#transit_dynamicSearchWindow_maxWindow)                                 |       `duration`      | Upper limit for the search-window calculation.                                                    | *Optional* | `"PT3H"`      |  2.2  |
 |       [minTransitTimeCoefficient](#transit_dynamicSearchWindow_minTransitTimeCoefficient) |        `double`       | The coefficient to multiply with `minTransitTime`.                                                | *Optional* | `0.5`         |  2.1  |
 |       [minWaitTimeCoefficient](#transit_dynamicSearchWindow_minWaitTimeCoefficient)       |        `double`       | The coefficient to multiply with `minWaitTime`.                                                   | *Optional* | `0.5`         |  2.1  |
-|       [minWindow](#transit_dynamicSearchWindow_minWindow)                                 |       `duration`      | The constant minimum duration for a raptor-search-window.                                         | *Optional* | `"PT40M"`     |  2.1  |
-|       [stepMinutes](#transit_dynamicSearchWindow_stepMinutes)                             |       `integer`       | Used to set the steps the search-window is rounded to.                                            | *Optional* | `10`          |   na  |
+|       [minWindow](#transit_dynamicSearchWindow_minWindow)                                 |       `duration`      | The constant minimum duration for a raptor-search-window.                                         | *Optional* | `"PT40M"`     |  2.2  |
+|       [stepMinutes](#transit_dynamicSearchWindow_stepMinutes)                             |       `integer`       | Used to set the steps the search-window is rounded to.                                            | *Optional* | `10`          |  2.1  |
 |    [pagingSearchWindowAdjustments](#transit_pagingSearchWindowAdjustments)                |      `duration[]`     | The provided array of durations is used to increase the search-window for the next/previous page. | *Optional* |               |   na  |
 |    [stopTransferCost](#transit_stopTransferCost)                                          | `enum map of integer` | Use this to set a stop transfer cost for the given transfer priority                              | *Optional* |               |   na  |
 | transmodelApi                                                                             |        `object`       | Configuration for the Transmodel GraphQL API.                                                     | *Optional* |               |   na  |
@@ -216,7 +216,7 @@ The maximum number of distinct transfers parameters to cache pre-calculated tran
 
 <h3 id="transit_dynamicSearchWindow">dynamicSearchWindow</h3>
 
-**Since version:** `na` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
+**Since version:** `2.1` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** /transit 
 
 The dynamic search window coefficients used to calculate the EDT, LAT and SW.
@@ -254,7 +254,7 @@ In addition there is an upper bound on the calculation of the search window:
 
 <h3 id="transit_dynamicSearchWindow_maxWindow">maxWindow</h3>
 
-**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT3H"`   
+**Since version:** `2.2` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT3H"`   
 **Path:** /transit/dynamicSearchWindow 
 
 Upper limit for the search-window calculation.
@@ -286,7 +286,7 @@ Use a value between `0.0` and `1.0`. Using `0.0` will eliminate the `minWaitTime
 
 <h3 id="transit_dynamicSearchWindow_minWindow">minWindow</h3>
 
-**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT40M"`   
+**Since version:** `2.2` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT40M"`   
 **Path:** /transit/dynamicSearchWindow 
 
 The constant minimum duration for a raptor-search-window. 
@@ -295,7 +295,7 @@ Use a value between 20 and 180 minutes in a normal deployment.
 
 <h3 id="transit_dynamicSearchWindow_stepMinutes">stepMinutes</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `10`   
+**Since version:** `2.1` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `10`   
 **Path:** /transit/dynamicSearchWindow 
 
 Used to set the steps the search-window is rounded to.

--- a/docs/examples/entur/router-config.json
+++ b/docs/examples/entur/router-config.json
@@ -62,8 +62,8 @@
     "dynamicSearchWindow" : {
       "minTransitTimeCoefficient" : 0.5,
       "minWaitTimeCoefficient" : 0.5,
-      "minWinTimeMinutes" : 60,
-      "maxWinTimeMinutes" : 300
+      "minWindow" : "1h",
+      "maxWindow" : "5h"
     },
     "stopTransferCost" : {
       "DISCOURAGED" : 1500,

--- a/src/main/java/org/opentripplanner/model/plan/PagingSearchWindowAdjuster.java
+++ b/src/main/java/org/opentripplanner/model/plan/PagingSearchWindowAdjuster.java
@@ -24,12 +24,12 @@ public final class PagingSearchWindowAdjuster {
   private final int[] pagingSearchWindowAdjustments;
 
   public PagingSearchWindowAdjuster(
-    int minSearchWindowMinutes,
-    int maxSearchWindowMinutes,
+    Duration minSearchWindow,
+    Duration maxSearchWindow,
     List<Duration> pagingSearchWindowAdjustments
   ) {
-    this.minSearchWindow = Duration.ofMinutes(minSearchWindowMinutes);
-    this.maxSearchWindow = Duration.ofMinutes(maxSearchWindowMinutes);
+    this.minSearchWindow = minSearchWindow;
+    this.maxSearchWindow = maxSearchWindow;
     this.pagingSearchWindowAdjustments =
       pagingSearchWindowAdjustments.stream().mapToInt(d -> (int) d.toMinutes()).toArray();
   }

--- a/src/main/java/org/opentripplanner/raptor/api/request/DynamicSearchWindowCoefficients.java
+++ b/src/main/java/org/opentripplanner/raptor/api/request/DynamicSearchWindowCoefficients.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.raptor.api.request;
 
+import java.time.Duration;
+
 /**
  * The dynamic search window coefficients is used to calculate EDT(earliest-departure-time),
  * LAT(latest-arrival-time) and SW(raptor-search-window) request parameters using heuristics. The
@@ -21,13 +23,13 @@ package org.opentripplanner.raptor.api.request;
  * <p>
  * The 3 coefficients above are:
  * <ol>
- *     <li>{@code C} - {@link #minWinTimeMinutes()}</li>
+ *     <li>{@code C} - {@link #minWindow()}</li>
  *     <li>{@code T} - {@link #minTransitTimeCoefficient()}</li>
  *     <li>{@code W} - {@link #minWaitTimeCoefficient()}</li>
  *     <li>{@code N} - {@link #stepMinutes()}</li>
  * </ol>
  * In addition the this an upper bound on the calculation of the search window:
- * {@link #maxWinTimeMinutes()}.
+ * {@link #maxWindow()}.
  */
 public interface DynamicSearchWindowCoefficients {
   /**
@@ -52,8 +54,8 @@ public interface DynamicSearchWindowCoefficients {
    * {@code C} - The constant minimum number of minutes for a raptor search window. Use a value
    * between 20-180 minutes in a normal deployment.
    */
-  default int minWinTimeMinutes() {
-    return 40;
+  default Duration minWindow() {
+    return Duration.ofMinutes(40);
   }
 
   /**
@@ -66,8 +68,8 @@ public interface DynamicSearchWindowCoefficients {
    * <p>
    * The default is 3 hours. The unit is minutes.
    */
-  default int maxWinTimeMinutes() {
-    return 3 * 60;
+  default Duration maxWindow() {
+    return Duration.ofHours(3);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/RaptorSearchWindowCalculator.java
+++ b/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/RaptorSearchWindowCalculator.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.raptor.rangeraptor.transit;
 
+import java.time.Duration;
 import org.opentripplanner.raptor.api.request.DynamicSearchWindowCoefficients;
 import org.opentripplanner.raptor.api.request.SearchParams;
 
@@ -22,9 +23,9 @@ public class RaptorSearchWindowCalculator {
   private final double minWaitTimeCoefficient;
 
   /** Min search window in seconds */
-  private final int minSearchWinSeconds;
+  private final Duration minSearchWindow;
 
-  private final int maxSearchWinSeconds;
+  private final Duration maxSearchWindow;
   private final int stepSeconds;
 
   private int heuristicMinTransitTime = NOT_SET;
@@ -37,8 +38,8 @@ public class RaptorSearchWindowCalculator {
   public RaptorSearchWindowCalculator(DynamicSearchWindowCoefficients c) {
     this.minTransitTimeCoefficient = c.minTransitTimeCoefficient();
     this.minWaitTimeCoefficient = c.minWaitTimeCoefficient();
-    this.minSearchWinSeconds = c.minWinTimeMinutes() * 60;
-    this.maxSearchWinSeconds = c.maxWinTimeMinutes() * 60;
+    this.minSearchWindow = c.minWindow();
+    this.maxSearchWindow = c.maxWindow();
     this.stepSeconds = c.stepMinutes() * 60;
   }
 
@@ -115,12 +116,12 @@ public class RaptorSearchWindowCalculator {
     // min-travel-time.
     if (params.isEarliestDepartureTimeSet() && params.isLatestArrivalTimeSet()) {
       int travelWindow = params.latestArrivalTime() - params.earliestDepartureTime();
-      // There is no upper limit the the search window when both EDT and LAT is set.
+      // There is no upper limit the search window when both EDT and LAT is set.
       return roundStep(travelWindow - heuristicMinTransitTime);
     } else {
       // Set the search window using the min-travel-time.
       int v = roundStep(
-        minSearchWinSeconds +
+        minSearchWindow.toSeconds() +
         minTransitTimeCoefficient *
         heuristicMinTransitTime +
         minWaitTimeCoefficient *
@@ -128,7 +129,7 @@ public class RaptorSearchWindowCalculator {
       );
 
       // Set an upper bound to the search window
-      return Math.min(maxSearchWinSeconds, v);
+      return (int) Math.min(maxSearchWindow.toSeconds(), v);
     }
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -197,9 +197,7 @@ public class RoutingWorker {
     RouteRequest request
   ) {
     var searchDateTime = ZonedDateTime.ofInstant(request.dateTime(), zoneId);
-    var maxWindow = Duration.ofMinutes(
-      raptorTuningParameters.dynamicSearchWindowCoefficients().maxWinTimeMinutes()
-    );
+    var maxWindow = raptorTuningParameters.dynamicSearchWindowCoefficients().maxWindow();
 
     return new AdditionalSearchDays(
       request.arriveBy(),
@@ -326,8 +324,8 @@ public class RoutingWorker {
   ) {
     var c = raptorTuningParameters.dynamicSearchWindowCoefficients();
     return new PagingSearchWindowAdjuster(
-      c.minWinTimeMinutes(),
-      c.maxWinTimeMinutes(),
+      c.minWindow(),
+      c.maxWindow(),
       transitTuningParameters.pagingSearchWindowAdjustments()
     );
   }

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/TransitRoutingConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/TransitRoutingConfig.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.standalone.config.routerconfig;
 
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.NA;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
 
 import java.time.Duration;
 import java.util.List;
@@ -211,14 +213,14 @@ for more info."
 
     private final double minTransitTimeCoefficient;
     private final double minWaitTimeCoefficient;
-    private final int minWinTimeMinutes;
-    private final int maxWinTimeMinutes;
+    private final Duration minWindow;
+    private final Duration maxWindow;
     private final int stepMinutes;
 
     public DynamicSearchWindowConfig(String parameterName, NodeAdapter root) {
       var dsWin = root
         .of(parameterName)
-        .since(NA)
+        .since(V2_1)
         .summary("The dynamic search window coefficients used to calculate the EDT, LAT and SW.")
         .description(
           """
@@ -259,7 +261,7 @@ In addition there is an upper bound on the calculation of the search window:
       this.minTransitTimeCoefficient =
         dsWin
           .of("minTransitTimeCoefficient")
-          .since(NA)
+          .since(V2_1)
           .summary("The coefficient to multiply with `minTransitTime`.")
           .description(
             "Use a value between `0.0` and `3.0`. Using `0.0` will eliminate the `minTransitTime` " +
@@ -269,41 +271,39 @@ In addition there is an upper bound on the calculation of the search window:
       this.minWaitTimeCoefficient =
         dsWin
           .of("minWaitTimeCoefficient")
-          .since(NA)
+          .since(V2_1)
           .summary("The coefficient to multiply with `minWaitTime`.")
           .description(
             "Use a value between `0.0` and `1.0`. Using `0.0` will eliminate the `minWaitTime` " +
             "from the dynamic raptor-search-window calculation."
           )
           .asDouble(dsWinDft.minWaitTimeCoefficient());
-      this.minWinTimeMinutes =
+      this.minWindow =
         dsWin
-          .of("minWinTimeMinutes")
-          .since(NA)
-          .summary("The constant minimum number of minutes for a raptor-search-window. ")
+          .of("minWindow")
+          .since(V2_2)
+          .summary("The constant minimum duration for a raptor-search-window. ")
           .description("Use a value between 20 and 180 minutes in a normal deployment.")
-          .asInt(dsWinDft.minWinTimeMinutes());
-      this.maxWinTimeMinutes =
+          .asDuration(dsWinDft.minWindow());
+      this.maxWindow =
         dsWin
-          .of("maxWinTimeMinutes")
-          .since(NA)
+          .of("maxWindow")
+          .since(V2_2)
           .summary("Upper limit for the search-window calculation.")
           .description(
             """
 Long search windows consumes a lot of resources and may take a long time. Use this parameter to 
 tune the desired maximum search time.
 
-This is the parameter that affect the response time most, the downside is that a search is only
+This is the parameter that affects the response time most, the downside is that a search is only
 guaranteed to be pareto-optimal within a search-window.
-
-The default is 3 hours. The unit is minutes.
 """
           )
-          .asInt(dsWinDft.maxWinTimeMinutes());
+          .asDuration(dsWinDft.maxWindow());
       this.stepMinutes =
         dsWin
           .of("stepMinutes")
-          .since(NA)
+          .since(V2_1)
           .summary("Used to set the steps the search-window is rounded to.")
           .description(
             """
@@ -330,13 +330,13 @@ coefficient.
     }
 
     @Override
-    public int minWinTimeMinutes() {
-      return minWinTimeMinutes;
+    public Duration minWindow() {
+      return minWindow;
     }
 
     @Override
-    public int maxWinTimeMinutes() {
-      return maxWinTimeMinutes;
+    public Duration maxWindow() {
+      return maxWindow;
     }
 
     @Override

--- a/src/test/java/org/opentripplanner/model/plan/PagingSearchWindowAdjusterTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PagingSearchWindowAdjusterTest.java
@@ -31,8 +31,8 @@ class PagingSearchWindowAdjusterTest {
   private final Instant time = Instant.parse("2022-01-15T12:00:00Z");
 
   private final PagingSearchWindowAdjuster subject = new PagingSearchWindowAdjuster(
-    (int) D10m.toMinutes(),
-    (int) D1d.toMinutes(),
+    D10m,
+    D1d,
     LIST_OF_DURATIONS
   );
 

--- a/src/test/java/org/opentripplanner/raptor/rangeraptor/transit/RaptorSearchWindowCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/raptor/rangeraptor/transit/RaptorSearchWindowCalculatorTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.raptor.rangeraptor.transit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.RaptorConstants;
@@ -25,14 +26,14 @@ public class RaptorSearchWindowCalculatorTest {
 
     /** 10 minutes = 600s */
     @Override
-    public int minWinTimeMinutes() {
-      return 10;
+    public Duration minWindow() {
+      return Duration.ofMinutes(10);
     }
 
     /** Set the max search-window length to 30 minutes (1_800 seconds) */
     @Override
-    public int maxWinTimeMinutes() {
-      return 30;
+    public Duration maxWindow() {
+      return Duration.ofMinutes(30);
     }
 
     /** Round search-window to nearest 1 minute (60 seconds) */

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -92,8 +92,8 @@
     "dynamicSearchWindow": {
       "minTransitTimeCoefficient": 0.5,
       "minWaitTimeCoefficient": 0.5,
-      "minWinTimeMinutes": 60,
-      "maxWinTimeMinutes": 300
+      "minWindow": "1h",
+      "maxWindow": "5h"
     },
     "stopTransferCost": {
       "DISCOURAGED": 1500,

--- a/test/performance/skanetrafiken/speed-test-config.json
+++ b/test/performance/skanetrafiken/speed-test-config.json
@@ -5,7 +5,7 @@
 
   "tuningParameters": {
     "dynamicSearchWindow": {
-      "maxWinTimeMinutes": 1440
+      "maxWindow": "24h"
     },
     "stopTransferCost": {
       "DISCOURAGED": 3000,


### PR DESCRIPTION
### Summary

I believe we talked about this before: we want to start using durations in configuration everywhere rather than number of seconds or minutes.

This PR gets the ball rolling by implementing this for the raptor search window configuration.