### PR TITLE
fix: banned lines filter incorrectly mapped

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/FilterMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/FilterMapper.java
@@ -55,7 +55,7 @@ class FilterMapper {
       (List<String> lines) -> bannedLines.addAll(mapIDsToDomain(lines))
     );
     if (!bannedLines.isEmpty()) {
-      filterRequestBuilder.addSelect(SelectRequest.of().withRoutes(bannedLines).build());
+      filterRequestBuilder.addNot(SelectRequest.of().withRoutes(bannedLines).build());
     }
 
     var selectors = new ArrayList<SelectRequest.Builder>();


### PR DESCRIPTION
### Summary

This PR fixes a regression in the transmodel graphql api that was introduced with mapping to the new filters. banned.lines was incorrectly mapped to a select filter instead of a not filter.

Example in Entur's environment: [shamash query](https://api.entur.io/graphql-explorer/journey-planner-v3?query=%0A%23%20Welcome%20to%20GraphiQL%0A%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%0A%23%20GraphiQL%20is%20an%20in-browser%20IDE%20for%20writing%2C%20validating%2C%20and%0A%23%20testing%20GraphQL%20queries.%0A%23%0A%23%20Type%20queries%20into%20this%20side%20of%20the%20screen%2C%20and%20you%20will%0A%23%20see%20intelligent%20typeaheads%20aware%20of%20the%20current%20GraphQL%20type%20schema%20and%0A%23%20live%20syntax%20and%20validation%20errors%20highlighted%20within%20the%20text.%0A%23%0A%23%20To%20bring%20up%20the%20auto-complete%20at%20any%20point%2C%20just%20press%20Ctrl-Space.%0A%23%0A%23%20Press%20the%20run%20button%20above%2C%20or%20Cmd-Enter%20to%20execute%20the%20query%2C%20and%20the%20result%0A%23%20will%20appear%20in%20the%20pane%20to%20the%20right.%0A%23%0A%23%0A%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%20Example%20query%20for%20planning%20a%20journey%0A%23%23%23%23%20Arguments%0A%7B%0A%20%20trip%28%0A%20%20%20%20from%3A%20%7B%0A%20%20%20%20%20%20place%3A%20%22NSR%3AStopPlace%3A101%22%0A%20%20%20%20%7D%0A%20%20%20%20to%3A%20%7B%0A%20%20%20%20%20%20place%3A%20%22NSR%3AStopPlace%3A59872%22%0A%20%20%20%20%7D%0A%20%20%20%20%23modes%3A%20%7BegressMode%3A%20foot%2C%20accessMode%3A%20foot%2C%20transportModes%3A%20%5B%7BtransportMode%3A%20rail%7D%5D%7D%0A%20%20%20%20searchWindow%3A%20360%0A%20%20%20%20numTripPatterns%3A%2025%0A%20%20%20%20dateTime%3A%20%222023-03-11T21%3A00%3A38.084%2B01%3A00%22%0A%20%20%20%20walkSpeed%3A%201.3%0A%20%20%20%20arriveBy%3A%20false%0A%0A%20%20%20%20banned%3A%20%7Blines%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A17%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A30%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A12%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A54%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A11%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A18%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A31%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A3912%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A23%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A3250%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A3902%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A300%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A100%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A110%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A270%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A3905%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A3140%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A3130%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A390%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22RUT%3ALine%3A400%22%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%20%20%29%0A%0A%23%23%23%23%20Requested%20fields%0A%20%20%7B%0A%20%20%20%20tripPatterns%20%7B%0A%20%20%20%20%20%20expectedStartTime%0A%20%20%20%20%20%20duration%0A%20%20%20%20%20%20walkDistance%0A%20%20%20%20%20%20legs%20%7B%0A%20%20%20%20%20%20%20%20mode%0A%20%20%20%20%20%20%20%20distance%0A%20%20%20%20%20%20%20%20line%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20publicCode%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A).

Trips including banned lines are included. The expected behavior is that there should be no trips using the banned lines.

### Unit tests

The change was manually tested with Norwegian transit data.