### PR TITLE
Split maven CI build into two steps to avoid timeouts

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
       - uses: actions/checkout@v3.3.0
@@ -32,7 +33,13 @@ jobs:
           cache: maven
 
       - name: Prepare coverage agent, build and test
-        run: mvn --batch-mode --update-snapshots jacoco:prepare-agent verify jacoco:report -P prettierCheck
+        # these are split into two steps because otherwise maven keeps long-running HTTP connections
+        # to Maven Central open which then hang during the package phase because the Azure (Github Actions)
+        # NAT drops them
+        # https://github.com/actions/runner-images/issues/1499
+        run: |
+          mvn --batch-mode jacoco:prepare-agent test jacoco:report -P prettierCheck
+          mvn --batch-mode package -Dmaven.test.skip -P prettierSkip
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner'
@@ -44,9 +51,10 @@ jobs:
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierCheck -P deployGitHub
+        run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierSkip -P deployGitHub
 
   build-windows:
+    timeout-minutes: 20
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We have had some problems with the CI lately where during the packaging step the build would hang.

My current theory is that this is due to https://github.com/actions/runner-images/issues/1499.

If this is the case then the problem is that Maven keeps long running connections open which the Azure NAT closes.

For this reason I split the build into two steps: one for tests and one for building the jar.

Lets see if that fixes the issues.