### PR TITLE
Replace Mockito with concrete implementations where not used in test

### DIFF
--- a/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
-import org.mockito.Mockito;
 import org.opentripplanner.framework.i18n.LocalizedStringFormat;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.StreetTraversalPermission;
@@ -21,9 +21,7 @@ import org.opentripplanner.street.model.vertex.Vertex;
 
 class MissingElevationHandlerTest {
 
-  private static final DefaultDataImportIssueStore issueStore = Mockito.mock(
-    DefaultDataImportIssueStore.class
-  );
+  private static final DataImportIssueStore issueStore = DefaultDataImportIssueStore.NOOP;
 
   private Graph graph;
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -8,11 +8,11 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.mockito.Mockito;
 import org.opentripplanner.model.Frequency;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.test.support.VariableSource;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -24,7 +24,12 @@ import org.opentripplanner.transit.model.timetable.TripTimes;
 class TripPatternForDateTest {
 
   private static final RegularStop STOP = TransitModelForTest.stopForTest("TEST:STOP", 0, 0);
-  private static final TripTimes tripTimes = Mockito.mock(TripTimes.class);
+  private static final Route ROUTE = TransitModelForTest.route("1").build();
+  private static final TripTimes tripTimes = new TripTimes(
+    TransitModelForTest.trip("1").withRoute(ROUTE).build(),
+    List.of(new StopTime()),
+    new Deduplicator()
+  );
 
   static Stream<Arguments> testCases = Stream
     .of(List.of(new FrequencyEntry(new Frequency(), tripTimes)), List.of())
@@ -33,14 +38,12 @@ class TripPatternForDateTest {
   @ParameterizedTest(name = "trip with frequencies {0} should be correctly filtered")
   @VariableSource("testCases")
   void shouldExcludeAndIncludeBasedOnFrequency(List<FrequencyEntry> freqs) {
-    Route route = TransitModelForTest.route("1").build();
-
     var stopTime = new StopTime();
     stopTime.setStop(STOP);
     StopPattern stopPattern = new StopPattern(List.of(stopTime));
     RoutingTripPattern tripPattern = TripPattern
       .of(TransitModelForTest.id("P1"))
-      .withRoute(route)
+      .withRoute(ROUTE)
       .withStopPattern(stopPattern)
       .build()
       .getRoutingTripPattern();

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 import org.opentripplanner.ext.transmodelapi.model.TransmodelTransportSubmode;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
@@ -703,7 +702,11 @@ public class RouteRequestTransitDataProviderFilterTest {
       .build()
       .getRoutingTripPattern();
 
-    TripTimes tripTimes = Mockito.mock(TripTimes.class);
+    TripTimes tripTimes = new TripTimes(
+      TransitModelForTest.trip("1").withRoute(route).build(),
+      List.of(new StopTime()),
+      new Deduplicator()
+    );
 
     return new TripPatternForDate(tripPattern, List.of(tripTimes), List.of(), LocalDate.now());
   }

--- a/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
+++ b/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
@@ -3,8 +3,6 @@ package org.opentripplanner.updater.alert;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import com.google.transit.realtime.GtfsRealtime;
 import com.google.transit.realtime.GtfsRealtime.Alert;
 import com.google.transit.realtime.GtfsRealtime.Alert.Cause;
@@ -14,25 +12,25 @@ import com.google.transit.realtime.GtfsRealtime.TranslatedString.Translation;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.opentripplanner.framework.i18n.TranslatedString;
 import org.opentripplanner.routing.alertpatch.AlertCause;
 import org.opentripplanner.routing.alertpatch.AlertEffect;
 import org.opentripplanner.routing.alertpatch.AlertSeverity;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class AlertsUpdateHandlerTest {
 
   private AlertsUpdateHandler handler;
 
-  private final FakeTransitAlertService service = Mockito.spy(FakeTransitAlertService.class);
+  private final TransitAlertService service = new TransitAlertServiceImpl(new TransitModel());
 
   @BeforeEach
   public void setUp() {
@@ -536,27 +534,5 @@ public class AlertsUpdateHandlerTest {
     Collection<TransitAlert> alerts = service.getAllAlerts();
     assertEquals(1, alerts.size());
     return alerts.iterator().next();
-  }
-
-  abstract static class FakeTransitAlertService implements TransitAlertService {
-
-    private Multimap<EntitySelector, TransitAlert> alerts = HashMultimap.create();
-
-    @Override
-    public void setAlerts(Collection<TransitAlert> alerts) {
-      Multimap<EntitySelector, TransitAlert> newAlerts = HashMultimap.create();
-      for (TransitAlert alert : alerts) {
-        for (EntitySelector entity : alert.entities()) {
-          newAlerts.put(entity, alert);
-        }
-      }
-
-      this.alerts = newAlerts;
-    }
-
-    @Override
-    public Collection<TransitAlert> getAllAlerts() {
-      return new HashSet<>(alerts.values());
-    }
   }
 }


### PR DESCRIPTION
### Summary

Mockito is used in couple of tests, where it is used just for an incomplete implementation of an interface. Replace those with concrete classes. Three classes remain, where we actually use functionality from Mockito.