### PR TITLE
Only log warning in GBFS updater if failed to fetch auto-discovery file

### DIFF
--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
@@ -44,16 +44,15 @@ public class GbfsFeedLoader {
       throw new UpdaterConstructionException("Invalid url " + url);
     }
 
-    if (!url.endsWith("gbfs.json")) {
-      LOG.warn(
-        "GBFS autoconfiguration url {} does not end with gbfs.json. Make sure it follows the specification, if you get any errors using it.",
-        url
-      );
-    }
-
     // Fetch autoconfiguration file
     GBFS data = fetchFeed(uri, httpHeaders, GBFS.class);
     if (data == null) {
+      if (!url.endsWith("gbfs.json")) {
+        LOG.warn(
+          "GBFS autoconfiguration url {} does not end with gbfs.json. Make sure it follows the specification, if you get any errors using it.",
+          url
+        );
+      }
       throw new UpdaterConstructionException(
         "Could not fetch the feed auto-configuration file from " + uri
       );


### PR DESCRIPTION
### Summary

This PR moves a warning that is logged when the GBFS auto-discovery endpoint doesn't follow the naming convention of `gbfs.json`, also if it just lacks the extension `.json`. This naming convention was made optional as of v2.0. The warning just creates noise in the logs. The warning is now only logged if fetching the auto-discovery file fails.
