### PR TITLE
Separating config of projectName for Pubsub topic/subscription

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -128,14 +128,16 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     // set subscriber
     String subscriptionId = System.getenv("HOSTNAME");
     if (subscriptionId == null || subscriptionId.isEmpty()) {
-      subscriptionId = "otp-" + UUID.randomUUID().toString();
+      subscriptionId = "otp-" + UUID.randomUUID();
     }
 
-    String projectName = config.projectName();
+    String subscriptionProjectName = config.subscriptionProjectName();
+    String topicProjectName = config.topicProjectName();
+
     String topicName = config.topicName();
 
-    this.subscriptionName = ProjectSubscriptionName.of(projectName, subscriptionId);
-    this.topic = ProjectTopicName.of(projectName, topicName);
+    this.subscriptionName = ProjectSubscriptionName.of(subscriptionProjectName, subscriptionId);
+    this.topic = ProjectTopicName.of(topicProjectName, topicName);
     this.pushConfig = PushConfig.getDefaultInstance();
     TransitService transitService = new DefaultTransitService(transitModel);
     this.entityResolver = new EntityResolver(transitService, feedId);

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdaterParameters.java
@@ -11,7 +11,9 @@ public record SiriETGooglePubsubUpdaterParameters(
   @Nonnull String configRef,
   @Nullable String feedId,
   String type,
-  String projectName,
+  @Deprecated String projectName,
+  String subscriptionProjectName,
+  String topicProjectName,
   String topicName,
   @Nullable String dataInitializationUrl,
   Duration reconnectPeriod,
@@ -25,7 +27,17 @@ public record SiriETGooglePubsubUpdaterParameters(
 
   public SiriETGooglePubsubUpdaterParameters {
     Objects.requireNonNull(type);
-    Objects.requireNonNull(projectName);
+
+    if (subscriptionProjectName == null && topicProjectName == null) {
+      // New config-parameters not yet in use
+      // TODO: Remove deprecated `projectName` when config is updated
+      Objects.requireNonNull(projectName);
+      subscriptionProjectName = projectName;
+      topicProjectName = projectName;
+    }
+
+    Objects.requireNonNull(subscriptionProjectName);
+    Objects.requireNonNull(topicProjectName);
     Objects.requireNonNull(topicName);
     Objects.requireNonNull(reconnectPeriod);
     Objects.requireNonNull(initialGetDataTimeout);
@@ -40,6 +52,8 @@ public record SiriETGooglePubsubUpdaterParameters(
       .addObj("feedId", feedId, null)
       .addObj("type", type)
       .addObj("projectName", projectName)
+      .addObj("subscriptionProjectName", subscriptionProjectName, projectName)
+      .addObj("topicProjectName", topicProjectName, projectName)
       .addObj("topicName", topicName)
       .addDuration("reconnectPeriod", reconnectPeriod, RECONNECT_PERIOD)
       .addDuration("initialGetDataTimeout", initialGetDataTimeout, INITIAL_GET_DATA_TIMEOUT)

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETGooglePubsubUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETGooglePubsubUpdaterConfig.java
@@ -14,7 +14,9 @@ public class SiriETGooglePubsubUpdaterConfig {
       configRef,
       c.of("feedId").since(NA).summary("TODO").asString(null),
       c.of("type").since(NA).summary("TODO").asString(),
-      c.of("projectName").since(NA).summary("TODO").asString(),
+      c.of("projectName").since(NA).summary("TODO").asString(null), // TODO: Remove (deprecated)
+      c.of("subscriptionProjectName").since(NA).summary("TODO").asString(null), // TODO: Set as required
+      c.of("topicProjectName").since(NA).summary("TODO").asString(null), // TODO: Set as required
       c.of("topicName").since(NA).summary("TODO").asString(),
       c.of("dataInitializationUrl").since(NA).summary("TODO").asString(null),
       c.of("reconnectPeriod").since(NA).summary("TODO").asDuration(RECONNECT_PERIOD),


### PR DESCRIPTION
This PR adds support for specifying separate GCP project names for topic and subscription

Note: will also require a change in `router-config.json` from:
```
    {
          "type": "siri-et-google-pubsub-updater",
          ...
=>        "projectName":"entur-gcp-project", 
          "topicName": "protobuf.estimated_timetables",
          ...
    }
```
to e.g.:
```
    {
          "type": "siri-et-google-pubsub-updater",
          ...
=>        "topicProjectName":"entur-topic-project",
=>        "subscriptionProjectName":"entur-subscription-project",
          "topicName": "protobuf.estimated_timetables",
          ...
    }
```