### PR TITLE
fix(gbfs updater): prevent IllegalStateException

### DIFF
--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
@@ -69,6 +69,7 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
           .getVehicleTypes()
           .stream()
           .map(vehicleTypeMapper::mapRentalVehicleType)
+          .distinct()
           .collect(Collectors.toMap(v -> v.id.getId(), Function.identity()));
     }
 


### PR DESCRIPTION
### Summary

Some feeds deliver duplicate vehicleType entries. That creates an IllegalStateException because of duplicate keys. This PR fixes the problem by using just unique entries

### Issue

[Issue](https://github.com/opentripplanner/OpenTripPlanner/issues/4954)

`fixes #4954`

