### PR TITLE
Add areas to documentation example for preparing osm data [ci skip]

### DIFF
--- a/docs/Preparing-OSM.md
+++ b/docs/Preparing-OSM.md
@@ -54,4 +54,4 @@ for accessibility analysis. Here are some example commands:
 Osmosis:** `osmosis --rb input.osm.pbf --tf reject-ways building=* --tf reject-ways waterway=* --tf reject-ways landuse=* --tf reject-ways natural=* --used-node --wb filtered.osm.pbf`
 
 **
-Osmium-Tool:** `osmium tags-filter input.osm.pbf w/highway w/public_transport=platform w/railway=platform w/park_ride=yes r/type=restriction r/type=route -o filtered.osm.pbf -f pbf,add_metadata=false`
+Osmium-Tool:** `osmium tags-filter input.osm.pbf w/highway wa/public_transport=platform wa/railway=platform w/park_ride=yes r/type=restriction r/type=route -o filtered.osm.pbf -f pbf,add_metadata=false`


### PR DESCRIPTION
### Summary

Just update the documentation to include areas when preparing OSM data.
We were following the documentation and ran into an issue, where platforms built as multipolygon areas were missing in our routing graph.
