### PR TITLE
Add checks for configuring AccessibilityPreferences

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/WheelchairConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/WheelchairConfig.java
@@ -124,6 +124,21 @@ public class WheelchairConfig {
       .since(V2_2)
       .summary("The cost to add when traversing an entity which is know to be inaccessible.")
       .asInt(defaultCosts.inaccessibleCost());
+
+    if (
+      !adapter.exist("onlyConsiderAccessible") &&
+      (adapter.exist("unknownCost") || adapter.exist("inaccessibleCost"))
+    ) {
+      onlyAccessible = false;
+    }
+
+    if (onlyAccessible && (adapter.exist("unknownCost") || adapter.exist("inaccessibleCost"))) {
+      throw new IllegalStateException(
+        "If `onlyConsiderAccessible` is set then `unknownCost` and `inaccessibleCost` may not be set at " +
+        adapter.contextPath()
+      );
+    }
+
     if (onlyAccessible) {
       return AccessibilityPreferences.ofOnlyAccessible();
     } else {

--- a/src/test/java/org/opentripplanner/standalone/config/routerequest/WheelchairConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/routerequest/WheelchairConfigTest.java
@@ -1,0 +1,95 @@
+package org.opentripplanner.standalone.config.routerequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opentripplanner.routing.api.request.preference.AccessibilityPreferences.ofCost;
+import static org.opentripplanner.routing.api.request.preference.AccessibilityPreferences.ofOnlyAccessible;
+import static org.opentripplanner.routing.api.request.preference.WheelchairPreferences.DEFAULT_COSTS;
+import static org.opentripplanner.standalone.config.framework.json.JsonSupport.newNodeAdapterForTest;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.opentripplanner.routing.api.request.preference.AccessibilityPreferences;
+import org.opentripplanner.test.support.VariableSource;
+
+class WheelchairConfigTest {
+
+  static Stream<Arguments> mapAccessibilityPreferencesTestCases = Stream.of(
+    Arguments.of(
+      "default ofOnlyAccessible()",
+      "{}",
+      ofOnlyAccessible(),
+      DEFAULT_COSTS,
+      ofOnlyAccessible()
+    ),
+    Arguments.of("default cost", "{}", ofCost(100, 200), ofCost(100, 200), ofCost(100, 200)),
+    Arguments.of(
+      "onlyConsiderAccessible with default costs",
+      "{\"onlyConsiderAccessible\": true}",
+      DEFAULT_COSTS,
+      DEFAULT_COSTS,
+      ofOnlyAccessible()
+    ),
+    Arguments.of(
+      "Default costs with default ofOnlyAccessible()",
+      "{\"onlyConsiderAccessible\": false}",
+      ofOnlyAccessible(),
+      DEFAULT_COSTS,
+      DEFAULT_COSTS
+    ),
+    Arguments.of(
+      "Only unknownCost set with default ofOnlyAccessible()",
+      "{\"unknownCost\": 100}",
+      ofOnlyAccessible(),
+      DEFAULT_COSTS,
+      ofCost(100, DEFAULT_COSTS.inaccessibleCost())
+    ),
+    Arguments.of(
+      "Only inaccessibleCost set with default ofOnlyAccessible()",
+      "{\"inaccessibleCost\": 100}",
+      ofOnlyAccessible(),
+      DEFAULT_COSTS,
+      ofCost(DEFAULT_COSTS.unknownCost(), 100)
+    ),
+    Arguments.of(
+      "All values set",
+      "{\"unknownCost\": 200, \"inaccessibleCost\": 100, \"onlyConsiderAccessible\": false}",
+      ofOnlyAccessible(),
+      DEFAULT_COSTS,
+      ofCost(200, 100)
+    )
+  );
+
+  @ParameterizedTest(name = "{0}")
+  @VariableSource("mapAccessibilityPreferencesTestCases")
+  void testMapAccessibilityPreferences(
+    String name,
+    String json,
+    AccessibilityPreferences defaultValue,
+    AccessibilityPreferences defaultCost,
+    AccessibilityPreferences expected
+  ) {
+    var nodeAdapter = newNodeAdapterForTest(json);
+    var subject = WheelchairConfig.mapAccessibilityPreferences(
+      nodeAdapter,
+      defaultValue,
+      defaultCost
+    );
+    assertEquals(expected, subject);
+  }
+
+  @Test
+  void testMapAccessibilityWithIncompatibleValues() {
+    var nodeAdapter = newNodeAdapterForTest(
+      "{\"unknownCost\": 200, \"inaccessibleCost\": 100, \"onlyConsiderAccessible\": true}"
+    );
+
+    assertThrows(
+      IllegalStateException.class,
+      () ->
+        WheelchairConfig.mapAccessibilityPreferences(nodeAdapter, ofOnlyAccessible(), DEFAULT_COSTS)
+    );
+  }
+}


### PR DESCRIPTION
### Summary

Checks are added when configuring `AccessibilityPreferences` so that either `onlyConsiderAccessible: true` or `unknownCost`/`inaccessibleCost` may be specified to avoid misconfigurations.

### Issue

#4973 

### Unit tests

:ballot_box_with_check: 

### Documentation

:x:

### Changelog

https://github.com/opentripplanner/OpenTripPlanner/labels/skip%20changelog

### Bumping the serialization version id

:x: 