### PR TITLE
Use different logic in smoove updater to tell if the station is on

### DIFF
--- a/src/ext-test/resources/smoovebikerental/smoove.json
+++ b/src/ext-test/resources/smoovebikerental/smoove.json
@@ -4,7 +4,7 @@
          "name" : "A04 Hamn",
          "operative" : true,
          "coordinates" : "60.167913, 24.952269",
-         "style" : "",
+         "style" : "Station on",
          "avl_bikes" : 1,
          "free_slots" : 11,
          "total_slots" : 12
@@ -13,7 +13,7 @@
          "name" : "B05 Fake",
          "operative" : false,
          "coordinates" : "60, 24",
-         "style" : "",
+         "style" : "Station off",
          "avl_bikes" : 5,
          "free_slots" : 5,
          "total_slots" : 5
@@ -22,7 +22,7 @@
          "name" : "B06 Foo",
          "operative" : true,
          "coordinates" : "61,25",
-         "style" : "",
+         "style" : "Station on",
          "avl_bikes" : 5,
          "free_slots" : 5,
          "total_slots" : 5
@@ -31,7 +31,7 @@
          "name" : "B08 Invalid",
          "operative" : true,
          "coordinates" : "",
-         "style" : "",
+         "style" : "Station on",
          "avl_bikes" : 5,
          "free_slots" : 5,
          "total_slots" : 5
@@ -40,7 +40,7 @@
          "name" : "B09 Full",
          "operative" : true,
          "coordinates" : "60.168913, 24.953269",
-         "style" : "",
+         "style" : "Station on",
          "avl_bikes" : 12,
          "free_slots" : 0,
          "total_slots" : 12

--- a/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
@@ -70,7 +70,7 @@ public class SmooveBikeRentalDataSource
       log.warn("Error parsing bike rental station {}", station.id, e);
       return null;
     }
-    if (!node.path("operative").asText().equals("true")) {
+    if (!node.path("style").asText().equals("Station on")) {
       station.isRenting = false;
       station.isReturning = false;
       station.vehiclesAvailable = 0;


### PR DESCRIPTION
### Summary

Uses `style` field instead of `operative` field to tell if a smoove station is on as unfortunately the `operative` field is always true even though the station is not operative.

### Issue

No issue, minor sandbox change

### Unit tests

Updated test data

### Documentation

Not needed.

### Changelog
Not needed
