### PR TITLE
Remove unconnected walking areas from graph

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -305,6 +305,11 @@ public class WalkableAreaBuilder {
 
       if (edgeList.visibilityVertices.size() == 0) {
         issueStore.add(new UnconnectedArea(group));
+        // Area is not connected to graph. Remove it immediately before it causes any trouble.
+        for (Edge edge : edges) {
+          graph.removeEdge(edge);
+        }
+        continue;
       }
 
       createNamedAreas(edgeList, ring, group.areas);


### PR DESCRIPTION
### Summary

Walkable area builder is able to detect unconnected areas, but left them in the graph. Such areas often lack so called visibilityVertices, which are required when linking stops to areas.  The result was that some isolated graph edges got linked with the stop, and island pruning did not discover to relink such stops after removal of the area.

It seems best to remove bad areas as soon as they get detected, instead of adding more complex code to deal with various linking problems. This PR does the required change. 

Attached  is a picture of a ferry platform, which got detached from the graph due to this bug.

![image](https://user-images.githubusercontent.com/13776096/226326163-8e86d552-929b-4d18-ad37-2842cebda44d.png)