### PR TITLE
Allow OTP to start when unexpected enum values is encountered in config.

### DIFF
--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -52,7 +52,7 @@ A full list of them can be found in the [RouteRequest](RouteRequest.md).
 |       [minWindow](#transit_dynamicSearchWindow_minWindow)                                 |       `duration`      | The constant minimum duration for a raptor-search-window.                                         | *Optional* | `"PT40M"`     |  2.2  |
 |       [stepMinutes](#transit_dynamicSearchWindow_stepMinutes)                             |       `integer`       | Used to set the steps the search-window is rounded to.                                            | *Optional* | `10`          |  2.1  |
 |    [pagingSearchWindowAdjustments](#transit_pagingSearchWindowAdjustments)                |      `duration[]`     | The provided array of durations is used to increase the search-window for the next/previous page. | *Optional* |               |   na  |
-|    [stopTransferCost](#transit_stopTransferCost)                                          | `enum map of integer` | Use this to set a stop transfer cost for the given transfer priority                              | *Optional* |               |   na  |
+|    [stopTransferCost](#transit_stopTransferCost)                                          | `enum map of integer` | Use this to set a stop transfer cost for the given transfer priority                              | *Optional* |               |  2.0  |
 | transmodelApi                                                                             |        `object`       | Configuration for the Transmodel GraphQL API.                                                     | *Optional* |               |   na  |
 |    [hideFeedId](#transmodelApi_hideFeedId)                                                |       `boolean`       | Hide the FeedId in all API output, and add it to input.                                           | *Optional* | `false`       |   na  |
 |    [tracingHeaderTags](#transmodelApi_tracingHeaderTags)                                  |       `string[]`      | Used to group requests when monitoring OTP.                                                       | *Optional* |               |   na  |
@@ -325,7 +325,7 @@ for more info."
 
 <h3 id="transit_stopTransferCost">stopTransferCost</h3>
 
-**Since version:** `na` ∙ **Type:** `enum map of integer` ∙ **Cardinality:** `Optional`   
+**Since version:** `2.0` ∙ **Type:** `enum map of integer` ∙ **Cardinality:** `Optional`   
 **Path:** /transit   
 **Enum keys:** `discouraged` | `allowed` | `recommended` | `preferred`
 

--- a/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V1
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
-import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_3;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
@@ -649,7 +648,7 @@ Netex data is also often supplied in a ZIP file.
     transferRequests = TransferRequestConfig.map(root, "transferRequests");
 
     if (logUnusedParams && LOG.isWarnEnabled()) {
-      root.logAllUnusedParameters(LOG::warn);
+      root.logAllWarnings(LOG::warn);
     }
   }
 

--- a/src/main/java/org/opentripplanner/standalone/config/OtpConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/OtpConfig.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.standalone.config;
 
-import static org.opentripplanner.standalone.config.framework.json.OtpVersion.NA;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -62,10 +62,14 @@ public class OtpConfig {
         .description(CONFIG_VERSION_DESCRIPTION)
         .asString(null);
     this.otpFeatures =
-      root.of("otpFeatures").since(NA).summary("TODO").asEnumMap(OTPFeature.class, Boolean.class);
+      root
+        .of("otpFeatures")
+        .since(V2_0)
+        .summary("Turn features on/off.")
+        .asEnumMap(OTPFeature.class, Boolean.class);
 
     if (logUnusedParams && LOG.isWarnEnabled()) {
-      root.logAllUnusedParameters(LOG::warn);
+      root.logAllWarnings(LOG::warn);
     }
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
@@ -114,7 +114,7 @@ number of transit vehicles used in that itinerary.
     this.flexConfig = new FlexConfig(root, "flex");
 
     if (logUnusedParams && LOG.isWarnEnabled()) {
-      root.logAllUnusedParameters(LOG::warn);
+      root.logAllWarnings(LOG::warn);
     }
   }
 

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
@@ -52,6 +52,12 @@ public class NodeAdapter {
    */
   private final Map<String, NodeInfo> parameters = new HashMap<>();
 
+  /**
+   * All warning is collected during the file parsing and printed as one block at the
+   * end.
+   */
+  private final List<String> warnings = new ArrayList<>();
+
   private boolean usedAsRaw = false;
 
   private final int level;
@@ -155,12 +161,15 @@ public class NodeAdapter {
   }
 
   /**
-   * Log unused parameters for the entire configuration file/node tree. Only call this method for the
-   * root adapter, once for each config file read.
+   * Log unused parameters and other warnings for the entire configuration file/node tree. Only
+   * call this method for the root adapter, once for each config file read.
    */
-  public void logAllUnusedParameters(Consumer<String> logger) {
+  public void logAllWarnings(Consumer<String> logger) {
     for (String p : unusedParams()) {
       logger.accept("Unexpected config parameter: '" + p + "' in '" + source + "'");
+    }
+    for (String warning : warnings) {
+      logger.accept(warning);
     }
   }
 
@@ -259,6 +268,16 @@ public class NodeAdapter {
 
   String concatPath(String a, String b) {
     return a + "." + b;
+  }
+
+  /**
+   * Add a warning to the list of warnings logged after parsing a config file is
+   * complete.
+   */
+  public void addWaring(String message, String paramName) {
+    message += " Parameter: " + fullPath(paramName) + ".";
+    message += " Source: " + source + ".";
+    warnings.add(message);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
@@ -53,7 +53,7 @@ public class NodeAdapter {
   private final Map<String, NodeInfo> parameters = new HashMap<>();
 
   /**
-   * All warning is collected during the file parsing and printed as one block at the
+   * All warnings are collected during the file parsing and printed as one block at the
    * end.
    */
   private final List<String> warnings = new ArrayList<>();

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
@@ -274,7 +274,7 @@ public class NodeAdapter {
    * Add a warning to the list of warnings logged after parsing a config file is
    * complete.
    */
-  public void addWaring(String message, String paramName) {
+  public void addWarning(String message, String paramName) {
     message += " Parameter: " + fullPath(paramName) + ".";
     message += " Source: " + source + ".";
     warnings.add(message);

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
@@ -31,7 +31,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -222,12 +221,13 @@ public class ParameterBuilder {
 
   public <T extends Enum<T>> Set<T> asEnumSet(Class<T> enumClass) {
     info.withOptional().withEnumSet(enumClass);
-    List<T> result = buildAndListSimpleArrayElements(
+    List<Optional<T>> optionalList = buildAndListSimpleArrayElements(
       List.of(),
-      it -> parseOptionalEnum(it.asText(), enumClass).orElse(null)
-    )
-      .stream()
-      .filter(Objects::nonNull)
+      it -> parseOptionalEnum(it.asText(), enumClass)
+    );
+    List<T> result = optionalList.stream()
+      .filter(Optional::isPresent)
+      .map(Optional::get)
       .toList();
     return result.isEmpty() ? EnumSet.noneOf(enumClass) : EnumSet.copyOf(result);
   }
@@ -683,6 +683,6 @@ public class ParameterBuilder {
   }
 
   private void warning(String message) {
-    target.addWaring(message, paramName());
+    target.addWarning(message, paramName());
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -197,9 +198,17 @@ public class ParameterBuilder {
     return buildAndListComplexArrayElements(defaultValues, mapper);
   }
 
+  /**
+   * @deprecated Avoid using required enum types, when adding/removing new Enum values
+   *             you potentially break forward/backward compatibility. If the new enum
+   *             value is used in the config, an earlier version of OTP can not read
+   *             the required value.
+   */
+  @Deprecated
   public <T extends Enum<T>> T asEnum(Class<T> enumType) {
     info.withRequired().withEnum(enumType);
-    return parseEnum(build().asText(), enumType);
+    // throws exception if enum value is missing
+    return parseRequiredEnum(build().asText(), enumType);
   }
 
   /** Get optional enum value. Parser is not case sensitive. */
@@ -207,17 +216,19 @@ public class ParameterBuilder {
   public <T extends Enum<T>> T asEnum(T defaultValue) {
     info.withEnum((Class<? extends Enum<?>>) defaultValue.getClass());
     setInfoOptional(defaultValue);
-    // Do not inline the node, calling the build is required.
-    var node = build();
-    return exist() ? parseEnum(node.asText(), (Class<T>) defaultValue.getClass()) : defaultValue;
+    return parseOptionalEnum(build().asText(), (Class<T>) defaultValue.getClass())
+      .orElse(defaultValue);
   }
 
   public <T extends Enum<T>> Set<T> asEnumSet(Class<T> enumClass) {
     info.withOptional().withEnumSet(enumClass);
     List<T> result = buildAndListSimpleArrayElements(
       List.of(),
-      it -> parseEnum(it.asText(), enumClass)
-    );
+      it -> parseOptionalEnum(it.asText(), enumClass).orElse(null)
+    )
+      .stream()
+      .filter(Objects::nonNull)
+      .toList();
     return result.isEmpty() ? EnumSet.noneOf(enumClass) : EnumSet.copyOf(result);
   }
 
@@ -250,9 +261,11 @@ public class ParameterBuilder {
     Iterator<String> it = mapNode.listExistingChildNodes();
     while (it.hasNext()) {
       String name = it.next();
-      E key = parseEnum(name, enumType);
-      var child = mapNode.rawNode(name);
-      result.put(key, parseConfigType(elementType, child));
+      Optional<E> key = parseOptionalEnum(name, enumType);
+      if (key.isPresent()) {
+        var child = mapNode.rawNode(name);
+        result.put(key.get(), parseConfigType(elementType, child));
+      }
     }
     return result;
   }
@@ -550,7 +563,7 @@ public class ParameterBuilder {
     }
   }
 
-  private <E extends Enum<E>> E parseEnum(String value, Class<E> ofType) {
+  private <E extends Enum<E>> E parseRequiredEnum(String value, Class<E> ofType) {
     return EnumMapper
       .mapToEnum(value, ofType)
       .orElseThrow(() -> {
@@ -561,6 +574,20 @@ public class ParameterBuilder {
             )
         );
       });
+  }
+
+  private <E extends Enum<E>> Optional<E> parseOptionalEnum(String value, Class<E> ofType) {
+    Optional<E> enumValue = EnumMapper.mapToEnum(value, ofType);
+    if (enumValue.isEmpty()) {
+      warning(
+        "The enum value '%s' is not legal. Expected one of %s.".formatted(
+            value,
+            List.of(ofType.getEnumConstants())
+          )
+      );
+      return Optional.empty();
+    }
+    return enumValue;
   }
 
   private LocalDate parseRelativeLocalDate(String value, ZoneId zoneId) {
@@ -653,5 +680,9 @@ public class ParameterBuilder {
 
   private OtpAppException error(String message, Exception e) {
     return target.createException(message, paramName(), e);
+  }
+
+  private void warning(String message) {
+    target.addWaring(message, paramName());
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
@@ -225,10 +225,7 @@ public class ParameterBuilder {
       List.of(),
       it -> parseOptionalEnum(it.asText(), enumClass)
     );
-    List<T> result = optionalList.stream()
-      .filter(Optional::isPresent)
-      .map(Optional::get)
-      .toList();
+    List<T> result = optionalList.stream().filter(Optional::isPresent).map(Optional::get).toList();
     return result.isEmpty() ? EnumSet.noneOf(enumClass) : EnumSet.copyOf(result);
   }
 

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/TransitRoutingConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/TransitRoutingConfig.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.standalone.config.routerconfig;
 
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.NA;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
 
@@ -106,7 +107,7 @@ no extra threads are started and the search is done in one thread.
     this.stopTransferCost =
       c
         .of("stopTransferCost")
-        .since(NA)
+        .since(V2_0)
         .summary("Use this to set a stop transfer cost for the given transfer priority")
         .description(
           """

--- a/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
@@ -29,7 +29,7 @@ public class BuildConfigTest {
 
     // Test for unused parameters
     var buf = new StringBuilder();
-    a.logAllUnusedParameters(m -> buf.append("\n").append(m));
+    a.logAllWarnings(m -> buf.append("\n").append(m));
     if (!buf.isEmpty()) {
       fail(buf.toString());
     }

--- a/src/test/java/org/opentripplanner/standalone/config/ExampleConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/ExampleConfigTest.java
@@ -72,7 +72,7 @@ public class ExampleConfigTest {
 
       // Test for unused parameters
       var buf = new StringBuilder();
-      a.logAllUnusedParameters(m -> buf.append("\n").append(m));
+      a.logAllWarnings(m -> buf.append("\n").append(m));
       if (!buf.isEmpty()) {
         fail(buf.toString());
       }

--- a/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
@@ -28,7 +28,7 @@ class RouterConfigTest {
 
     // Test for unused parameters
     var buf = new StringBuilder();
-    a.logAllUnusedParameters(m -> buf.append("\n").append(m));
+    a.logAllWarnings(m -> buf.append("\n").append(m));
     if (!buf.isEmpty()) {
       fail(buf.toString());
     }

--- a/src/test/java/org/opentripplanner/standalone/config/sandbox/DataOverlayConfigMapperTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/sandbox/DataOverlayConfigMapperTest.java
@@ -19,7 +19,7 @@ class DataOverlayConfigMapperTest {
 
     // Test for unused parameters
     var buf = new StringBuilder();
-    a.logAllUnusedParameters(m -> buf.append("\n").append(m));
+    a.logAllWarnings(m -> buf.append("\n").append(m));
     if (!buf.isEmpty()) {
       fail(buf.toString());
     }

--- a/src/test/java/org/opentripplanner/transit/speed_test/options/SpeedTestConfig.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/options/SpeedTestConfig.java
@@ -56,7 +56,7 @@ public class SpeedTestConfig {
     request = mapRouteRequest(adapter.of("routingDefaults").asObject());
     updatersConfig = new UpdatersConfig(adapter);
     ignoreStreetResults = adapter.of("ignoreStreetResults").asBoolean(false);
-    adapter.logAllUnusedParameters(LOG::warn);
+    adapter.logAllWarnings(LOG::warn);
   }
 
   public static SpeedTestConfig config(File dir) {


### PR DESCRIPTION
### Summary

Enum values can be added or deleted; Hence to allow OTP to be forward and backward compatible unknown values must be logged(WARNING) and ignored. The Server should not terminate.

The new log items look like this:
```
13:45:56.208 WARN (NodeAdapter.java:172) The enum value 'Fake' is not legal. Expected one of [APIBikeRental, APIServerInfo, APIGraphInspectorTile, APIUpdaterStatus, ConsiderPatternsForDirectTransfers, DebugClient, FloatingBike, MinimumTransferTimeIsDefinitive, OptimizeTransfers, ParallelRouting, TransferConstraints, ActuatorAPI, AsyncGraphQLFetchers, DataOverlay, FaresV2, FlexRouting, GoogleCloudStorage, RealtimeResolver, ReportApi, SandboxAPIGeocoder, SandboxAPILegacyGraphQLApi, SandboxAPIMapboxVectorTilesApi, SandboxAPIParkAndRideApi, SandboxAPITransmodelApi, SandboxAPITravelTime, TransferAnalyzer, VehicleToStopHeuristics]. Parameter: otpFeatures. Source: otp-config.json.
13:45:56.208 WARN (NodeAdapter.java:169) Unexpected config parameter: 'otpFeatures.Fake:true' in 'otp-config.json'
```
In this case I started OTP with a "Fake" feature.


### Issue

Partially fixes #4980

### Unit tests

Updated

### Documentation

Updated
