### PR TITLE
fix: Catch RoutingValidationException for ViaRoutingResponse

### DIFF
--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -1401,6 +1401,7 @@ enum FilterPlaceType {
 enum InputField {
   dateTime
   from
+  intermediatePlace
   to
 }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -15,6 +15,7 @@ import org.opentripplanner.routing.api.response.RoutingError;
 import org.opentripplanner.routing.api.response.RoutingErrorCode;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.api.response.ViaRoutingResponse;
+import org.opentripplanner.routing.error.RoutingValidationException;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +59,8 @@ public class TransmodelGraphQLPlanner {
     try {
       request = ViaRequestMapper.createRouteViaRequest(environment);
       response = ctx.getRoutingService().route(request);
+    } catch (RoutingValidationException e) {
+      response = new ViaRoutingResponse(Map.of(), List.of(), e.getRoutingErrors());
     } catch (Exception e) {
       LOG.error("System error: " + e.getMessage(), e);
       response =

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -479,6 +479,7 @@ public class EnumTypes {
     .value("dateTime", InputField.DATE_TIME)
     .value("from", InputField.FROM_PLACE)
     .value("to", InputField.TO_PLACE)
+    .value("intermediatePlace", InputField.INTERMEDIATE_PLACE)
     .build();
 
   public static GraphQLEnumType PURCHASE_WHEN = GraphQLEnumType


### PR DESCRIPTION
In viaTrip query, all routing errors resulted in errors in logs and system error in response, including ones we expect, such as `noTransitConnectionInSearchWindow`.

Example request: [shamash](https://api.entur.io/graphql-explorer/journey-planner-v3?query=%7BviaTrip%28from%3A%7Bplace%3A%22NSR%3AStopPlace%3A58927%22%7Dto%3A%7Bplace%3A%22NSR%3AStopPlace%3A58927%22%7DsearchWindow%3A%22PT2H%22%20dateTime%3A%222023-04-27T18%3A04%3A00.000%2B02%3A00%22%20via%3A%5B%7Bplace%3A%22NSR%3AStopPlace%3A222%22%7D%5D%29%7BroutingErrors%7Bdescription%20inputField%20code%7DtripPatternsPerSegment%7BtripPatterns%7BexpectedStartTime%20expectedEndTime%20duration%20walkDistance%20legs%7BexpectedStartTime%20expectedEndTime%20mode%20distance%20line%7Bid%20publicCode%7D%7D%7D%7DtripPatternCombinations%7Bfrom%20to%7D%7D%7D&variables=%7B%22fromPlaceId%22%3A%22NSR%3AStopPlace%3A26638%22%2C%22fromLat%22%3A58.957412%2C%22fromLng%22%3A5.740083%2C%22toLat%22%3A58.963154%2C%22toLng%22%3A5.735651%2C%22toName%22%3A%22Stavanger%20politistasjon%22%2C%22date%22%3A%222023-03-16T16%3A59%3A45.439144Z%22%2C%22transitDate%22%3A%222023-03-16T16%3A55%3A45.439130Z%22%2C%22numberOfTransitPatterns%22%3Anull%2C%22transferPenalty%22%3A300%2C%22arriveBy%22%3Afalse%2C%22loadFootPattern%22%3Afalse%2C%22loadBicyclePattern%22%3Afalse%2C%22searchWindow%22%3A90%2C%22timetableView%22%3Atrue%7D).

Actual response:

```
{
  "data": {
    "viaTrip": {
      "routingErrors": [
        {
          "description": "We're sorry. The trip planner is temporarily unavailable. Please try again later.",
          "inputField": null,
          "code": "systemError"
        }
      ],
      "tripPatternsPerSegment": [],
      "tripPatternCombinations": []
    }
  }
}
``` 

Inspecting the logs I found the following error:

```
org.opentripplanner.routing.error.RoutingValidationException: RoutingError{code: NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW, inputField: INTERMEDIATE_PLACE}
```

The solutions is to handle the RoutingValidationException and providing the actual routing errors to ViaRoutingResponse, which gives the following response instead (tested locally with Norwegian dataset):

```
{
	"data": {
		"viaTrip": {
			"routingErrors": [
				{
					"description": "No trip found. There may be no transit service within the maximum specified distance or at the specified time, or your start or end point might not be safely accessible.",
					"inputField": "intermediatePlace",
					"code": "noTransitConnectionInSearchWindow"
				}
			],
			"tripPatternsPerSegment": [],
			"tripPatternCombinations": []
		}
	}
}
```