### PR TITLE
Catch and log exceptions when generating transfers

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/TransferIndexGenerator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/TransferIndexGenerator.java
@@ -64,16 +64,20 @@ public class TransferIndexGenerator {
         continue;
       }
 
-      findTPoints(tx.getFrom(), ALIGHT)
-        .stream()
-        .filter(TPoint::canAlight)
-        .forEachOrdered(fromPoint -> {
-          for (var toPoint : findTPoints(tx.getTo(), BOARD)) {
-            if (toPoint.canBoard() && !fromPoint.equals(toPoint)) {
-              fromPoint.addTransferConstraints(tx, toPoint, forwardTransfers, reverseTransfers);
+      try {
+        findTPoints(tx.getFrom(), ALIGHT)
+          .stream()
+          .filter(TPoint::canAlight)
+          .forEachOrdered(fromPoint -> {
+            for (var toPoint : findTPoints(tx.getTo(), BOARD)) {
+              if (toPoint.canBoard() && !fromPoint.equals(toPoint)) {
+                fromPoint.addTransferConstraints(tx, toPoint, forwardTransfers, reverseTransfers);
+              }
             }
-          }
-        });
+          });
+      } catch (Exception e) {
+        LOG.error("Unable to generate transfers: {}. Affected transfer: {}", e, tx);
+      }
     }
 
     sortTransfers(forwardTransfers);


### PR DESCRIPTION
### Summary
Ensure that OTP does not crash totally if there is an error while generating transfer constraints

### Unit tests
N/A
### Documentation
N/A
