### PR TITLE
Speed test profiles

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -14,36 +14,52 @@ jobs:
       matrix:
         include:
 
+          # Profiles
+          #
+          # The profile variable is used to filter out some locations when the speed test is run
+          # on a branch during development.
+          #
+          #  - locations with the 'core' profile are always run (even when on a branch)
+          #  - locations with the 'extended' profile are only run after merging to dev-2.x
+
           - location: germany # all of Germany (500k stops, 200k patterns) but no OSM
             iterations: 1
             jfr-delay: "50s"
+            profile: core
 
           - location: norway
             iterations: 4
             jfr-delay: "35s"
-
-          - location: baden-wuerttemberg # German state of Baden-Württemberg: https://en.wikipedia.org/wiki/Baden-W%C3%BCrttemberg
-            iterations: 1
-            jfr-delay: "50s"
+            profile: core
 
           - location: skanetrafiken
             iterations: 1
             jfr-delay: "50s"
+            profile: core
+
+          - location: baden-wuerttemberg # German state of Baden-Württemberg: https://en.wikipedia.org/wiki/Baden-W%C3%BCrttemberg
+            iterations: 1
+            jfr-delay: "50s"
+            profile: extended
 
           - location: switzerland
             iterations: 1
             jfr-delay: "50s"
+            profile: extended
 
           - location: washington-state
             iterations: 1
             jfr-delay: "20s"
+            profile: extended
 
     steps:
       - uses: actions/checkout@v3.1.0
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: actions/setup-java@v3
         with:
           java-version: 17
@@ -51,21 +67,25 @@ jobs:
         timeout-minutes: 5
 
       - name: Set up Maven
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: stCarolas/setup-maven@v.4.5
         with:
           maven-version: 3.8.2
 
       - name: Build jar
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         env:
           MAVEN_OPTS: "-Dmaven.repo.local=/home/lenni/.m2/repository/"
         run: mvn -DskipTests --batch-mode package -P prettierSkip
 
       - name: Build graph
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         run: |
           cp target/otp-*-SNAPSHOT-shaded.jar otp.jar
           java -Xmx32G -jar otp.jar --build --save test/performance/${{ matrix.location }}/
 
       - name: Run speed test
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         env:
           PERFORMANCE_INFLUX_DB_PASSWORD: ${{ secrets.PERFORMANCE_INFLUX_DB_PASSWORD }}
           SPEEDTEST_LOCATION: ${{ matrix.location }}
@@ -74,12 +94,14 @@ jobs:
           mvn exec:java -Dexec.mainClass="org.opentripplanner.transit.speed_test.SpeedTest" -Dexec.classpathScope=test -Dexec.args="--dir=test/performance/${{ matrix.location }} -p md -n ${{ matrix.iterations }} -i 3 -0" -P prettierSkip
 
       - name: Archive travel results file
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.location }}-travelSearch-results.csv
           path: test/performance/${{ matrix.location }}/travelSearch-results.csv
 
       - name: Archive Flight Recorder instrumentation file
+        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.location }}-flight-recorder

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -38,6 +38,8 @@ jobs:
             jfr-delay: "50s"
             profile: core
 
+          # extended locations that are run only after merging to dev-2.x
+
           - location: baden-wuerttemberg # German state of Baden-Württemberg: https://en.wikipedia.org/wiki/Baden-W%C3%BCrttemberg
             iterations: 1
             jfr-delay: "50s"
@@ -55,12 +57,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: actions/setup-java@v3
         with:
           java-version: 17
@@ -68,25 +70,25 @@ jobs:
         timeout-minutes: 5
 
       - name: Set up Maven
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: stCarolas/setup-maven@v.4.5
         with:
           maven-version: 3.8.2
 
       - name: Build jar
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         env:
           MAVEN_OPTS: "-Dmaven.repo.local=/home/lenni/.m2/repository/"
         run: mvn -DskipTests --batch-mode package -P prettierSkip
 
       - name: Build graph
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         run: |
           cp target/otp-*-SNAPSHOT-shaded.jar otp.jar
           java -Xmx32G -jar otp.jar --build --save test/performance/${{ matrix.location }}/
 
       - name: Run speed test
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         env:
           PERFORMANCE_INFLUX_DB_PASSWORD: ${{ secrets.PERFORMANCE_INFLUX_DB_PASSWORD }}
           SPEEDTEST_LOCATION: ${{ matrix.location }}
@@ -95,14 +97,14 @@ jobs:
           mvn exec:java -Dexec.mainClass="org.opentripplanner.transit.speed_test.SpeedTest" -Dexec.classpathScope=test -Dexec.args="--dir=test/performance/${{ matrix.location }} -p md -n ${{ matrix.iterations }} -i 3 -0" -P prettierSkip
 
       - name: Archive travel results file
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.location }}-travelSearch-results.csv
           path: test/performance/${{ matrix.location }}/travelSearch-results.csv
 
       - name: Archive Flight Recorder instrumentation file
-        if: ${{ matrix.profile }} == 'core' || github.ref == 'refs/heads/dev-2.x'
+        if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.location }}-flight-recorder

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev-2.x
-      - speed-test-profiles
 
 jobs:
   perf-test:

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev-2.x
+      - speed-test-profiles
 
 jobs:
   perf-test:


### PR DESCRIPTION
When developing a performance-critical feature we sometimes run the speed test for every commit on a branch.

However, these days the full suite takes 65 minutes with more locations to come.

Therefore I'm changing the CI config that only Norway, Germany and Skane are run when you're on a branch.

The full suite of locations is run only after merge to dev-2.x.