### PR TITLE
Identify which terminal is the problem when throwing an exception

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopMapper.java
@@ -40,7 +40,9 @@ class StopMapper {
         "Expected type " +
         org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_STOP +
         ", but got " +
-        gtfsStop.getLocationType()
+        gtfsStop.getLocationType() +
+        " from stop " +
+        gtfsStop
       );
     }
 


### PR DESCRIPTION
### Summary

Stop mapper now includes the GTFS stop id  in the exception it throws when expected stop reference is  pointing to a terminal. When the identifier is known, it is easy to find the error in the data (e.g. reference to a terminal in stop_times.txt).



