### PR TITLE
Fix prettier node download for CI

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -23,7 +23,14 @@ jobs:
       - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-          
+
+      # nodejs is needed because the dynamic download of it via the prettier maven plugin often
+      # times out
+      # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
       # Java setup step completes very fast, no need to run in a preconfigured docker container
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -38,7 +45,7 @@ jobs:
         # NAT drops them
         # https://github.com/actions/runner-images/issues/1499
         run: |
-          mvn --batch-mode jacoco:prepare-agent test jacoco:report -P prettierCheck
+          mvn --batch-mode jacoco:prepare-agent test jacoco:report -P prettierCheck -Dprettier.nodePath=node
           mvn --batch-mode package -Dmaven.test.skip -P prettierSkip
 
       - name: Send coverage data to codecov.io


### PR DESCRIPTION
The Maven prettier plugin often fails to download the nodejs binary.

Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439

```
[INFO] argLine set to -javaagent:/home/runner/.m2/repository/org/jacoco/org.jacoco.agent/0.8.8/org.jacoco.agent-0.8.8-runtime.jar=destfile=/home/runner/work/OpenTripPlanner/OpenTripPlanner/target/jacoco.exec
[INFO] 
[INFO] --- prettier-maven-plugin:0.19:check (default) @ otp ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:30 min
[INFO] Finished at: 2023-03-22T13:36:47Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal com.hubspot.maven.plugins:prettier-maven-plugin:0.19:check (default) on project otp: Error downloading node: timeout -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```

This makes the CI sometimes frustrating.

I want to try fixing it by using a preinstalled node binary.