### PR TITLE
Make sure the default streetRoutingTimeout is used

### DIFF
--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -679,7 +679,7 @@ type QueryType {
     minimumLatitude: Float!,
     minimumLongitude: Float!
   ): [Quay]! @timingData
-  "Get all quays within the specified walking radius from a location. The returned type has two fields quay and distance"
+  "Get all quays within the specified walking radius from a location. There are no maximum limits for the input parameters, but the query will timeout and return if the parameters are too high."
   quaysByRadius(
     "fetching only nodes after this node (exclusive)"
     after: String,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -705,7 +705,9 @@ public class TransmodelGraphQLSchema {
           .newFieldDefinition()
           .name("quaysByRadius")
           .description(
-            "Get all quays within the specified walking radius from a location. The returned type has two fields quay and distance"
+            "Get all quays within the specified walking radius from a location. There are no maximum " +
+            "limits for the input parameters, but the query will timeout and return if the parameters " +
+            "are too high."
           )
           .withDirective(gqlUtil.timingData)
           .type(

--- a/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/astar/AStar.java
@@ -4,8 +4,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.opentripplanner.astar.model.BinHeap;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
@@ -60,7 +62,7 @@ public class AStar<
     Set<Vertex> toVertices,
     SearchTerminationStrategy<State> terminationStrategy,
     DominanceFunction<State> dominanceFunction,
-    Duration timeout,
+    @Nonnull Duration timeout,
     Collection<State> initialStates
   ) {
     this.heuristic = heuristic;
@@ -70,7 +72,7 @@ public class AStar<
     this.toVertices = toVertices;
     this.arriveBy = arriveBy;
     this.terminationStrategy = terminationStrategy;
-    this.timeout = timeout;
+    this.timeout = Objects.requireNonNull(timeout);
 
     this.spt = new ShortestPathTree<>(dominanceFunction);
 

--- a/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.spi.AStarEdge;
@@ -33,7 +34,6 @@ public abstract class AStarBuilder<
   private Set<Vertex> toVertices;
   private SearchTerminationStrategy<State> terminationStrategy;
   private DominanceFunction<State> dominanceFunction;
-  private Duration timeout;
   private Edge originBackEdge;
   private Collection<State> initialStates;
 
@@ -98,10 +98,8 @@ public abstract class AStarBuilder<
     return builder;
   }
 
-  public Builder setTimeout(Duration timeout) {
-    this.timeout = timeout;
-    return builder;
-  }
+  @Nonnull
+  protected abstract Duration streetRoutingTimeout();
 
   public Builder setOriginBackEdge(Edge originBackEdge) {
     this.originBackEdge = originBackEdge;
@@ -151,7 +149,7 @@ public abstract class AStarBuilder<
       destination,
       terminationStrategy,
       Optional.ofNullable(dominanceFunction).orElseGet(this::createDefaultDominanceFunction),
-      timeout,
+      streetRoutingTimeout(),
       initialStates
     );
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -40,7 +40,6 @@ public class DirectStreetRouter {
       // we could also get a persistent router-scoped GraphPathFinder but there's no setup cost here
       GraphPathFinder gpFinder = new GraphPathFinder(
         serverContext.traverseVisitor(),
-        serverContext.streetRoutingTimeout(),
         serverContext.dataOverlayContext(request)
       );
       List<GraphPath<State, Edge, Vertex>> paths = gpFinder.graphPathFinderEntryPoint(

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.impl;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Iterator;
@@ -54,24 +53,17 @@ public class GraphPathFinder {
   @Nullable
   private final TraverseVisitor<State, Edge> traverseVisitor;
 
-  private final Duration streetRoutingTimeout;
-
   private final DataOverlayContext dataOverlayContext;
 
-  public GraphPathFinder(
-    @Nullable TraverseVisitor<State, Edge> traverseVisitor,
-    Duration streetRoutingTimeout
-  ) {
-    this(traverseVisitor, streetRoutingTimeout, null);
+  public GraphPathFinder(@Nullable TraverseVisitor<State, Edge> traverseVisitor) {
+    this(traverseVisitor, null);
   }
 
   public GraphPathFinder(
     @Nullable TraverseVisitor<State, Edge> traverseVisitor,
-    Duration streetRoutingTimeout,
     @Nullable DataOverlayContext dataOverlayContext
   ) {
     this.traverseVisitor = traverseVisitor;
-    this.streetRoutingTimeout = streetRoutingTimeout;
     this.dataOverlayContext = dataOverlayContext;
   }
 
@@ -100,8 +92,7 @@ public class GraphPathFinder {
       .setStreetRequest(request.journey().direct())
       .setFrom(from)
       .setTo(to)
-      .setDataOverlayContext(dataOverlayContext)
-      .setTimeout(streetRoutingTimeout);
+      .setDataOverlayContext(dataOverlayContext);
 
     // If the search has a traverseVisitor(GraphVisualizer) attached to it, set it as a callback
     // for the AStar search

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.standalone.api;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import java.time.Duration;
 import java.util.Locale;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
@@ -89,8 +88,6 @@ public interface OtpServerRequestContext {
   TransitTuningParameters transitTuningParameters();
 
   RaptorTuningParameters raptorTuningParameters();
-
-  Duration streetRoutingTimeout();
 
   MeterRegistry meterRegistry();
 

--- a/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
  */
 public class RouterConfig implements Serializable {
 
-  private static final Duration DEFAULT_STREET_ROUTING_TIMEOUT = Duration.ofSeconds(5);
   private static final Logger LOG = LoggerFactory.getLogger(RouterConfig.class);
 
   public static final RouterConfig DEFAULT = new RouterConfig(
@@ -43,7 +42,6 @@ public class RouterConfig implements Serializable {
   private final String configVersion;
   private final String requestLogFile;
   private final TransmodelAPIConfig transmodelApi;
-  private final Duration streetRoutingTimeout;
   private final RouteRequest routingRequestDefaults;
   private final TransitRoutingConfig transitConfig;
   private final UpdatersParameters updatersParameters;
@@ -105,13 +103,18 @@ number of transit vehicles used in that itinerary.
           .summary("Configuration for the Transmodel GraphQL API.")
           .asObject()
       );
-    this.streetRoutingTimeout = parseStreetRoutingTimeout(root);
     this.transitConfig = new TransitRoutingConfig("transit", root);
     this.routingRequestDefaults =
       RouteRequestConfig.mapDefaultRouteRequest(root, "routingDefaults");
     this.updatersParameters = new UpdatersConfig(root);
     this.vectorTileLayers = VectorTileConfig.mapVectorTilesParameters(root, "vectorTileLayers");
     this.flexConfig = new FlexConfig(root, "flex");
+
+    this.routingRequestDefaults.withPreferences(p ->
+        p.withStreet(s ->
+          s.withRoutingTimeout(parseStreetRoutingTimeout(root, s.original().routingTimeout()))
+        )
+      );
 
     if (logUnusedParams && LOG.isWarnEnabled()) {
       root.logAllUnusedParameters(LOG::warn);
@@ -137,15 +140,6 @@ number of transit vehicles used in that itinerary.
 
   public String requestLogFile() {
     return requestLogFile;
-  }
-
-  /**
-   * The preferred way to limit the search is to limit the distance for each street mode(WALK, BIKE,
-   * CAR). So the default timeout for a street search is set quite high. This is used to abort the
-   * search if the max distance is not reached within the timeout.
-   */
-  public Duration streetRoutingTimeout() {
-    return streetRoutingTimeout;
   }
 
   public TransmodelAPIConfig transmodelApi() {
@@ -198,7 +192,7 @@ number of transit vehicles used in that itinerary.
    *
    * @since 2.2 - The support for the old format can be removed in version > 2.2.
    */
-  static Duration parseStreetRoutingTimeout(NodeAdapter adapter) {
+  static Duration parseStreetRoutingTimeout(NodeAdapter adapter, Duration defaultValue) {
     return adapter
       .of("streetRoutingTimeout")
       .since(NA)
@@ -219,6 +213,6 @@ search-window.
 The search aborts after this duration and any paths found are returned to the client.
 """
       )
-      .asDuration(DEFAULT_STREET_ROUTING_TIMEOUT);
+      .asDuration(defaultValue);
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -75,9 +75,7 @@ public class ConstructApplication {
 
     // We create the optional GraphVisualizer here, because it would be significant more complex to
     // use Dagger DI to do it - passing in a parameter to enable it or not.
-    var graphVisualizer = cli.visualize
-      ? new GraphVisualizer(graph, config.routerConfig().streetRoutingTimeout())
-      : null;
+    var graphVisualizer = cli.visualize ? new GraphVisualizer(graph) : null;
 
     this.factory =
       DaggerConstructApplicationFactory

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationModule.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationModule.java
@@ -34,7 +34,6 @@ public class ConstructApplicationModule {
     return DefaultServerRequestContext.create(
       routerConfig.transitTuningConfig(),
       routerConfig.routingRequestDefaults(),
-      routerConfig.streetRoutingTimeout(),
       raptorConfig,
       graph,
       transitService,

--- a/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.standalone.server;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import java.time.Duration;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import org.opentripplanner.astar.spi.TraverseVisitor;
@@ -33,7 +32,6 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   private final Graph graph;
   private final TransitService transitService;
   private final TransitRoutingConfig transitRoutingConfig;
-  private final Duration streetRoutingTimeout;
   private final RouteRequest routeRequestDefaults;
   private final MeterRegistry meterRegistry;
   private final RaptorConfig<TripSchedule> raptorConfig;
@@ -53,7 +51,6 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     Graph graph,
     TransitService transitService,
     TransitRoutingConfig transitRoutingConfig,
-    Duration streetRoutingTimeout,
     RouteRequest routeRequestDefaults,
     MeterRegistry meterRegistry,
     RaptorConfig<TripSchedule> raptorConfig,
@@ -69,7 +66,6 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     this.graph = graph;
     this.transitService = transitService;
     this.transitRoutingConfig = transitRoutingConfig;
-    this.streetRoutingTimeout = streetRoutingTimeout;
     this.meterRegistry = meterRegistry;
     this.raptorConfig = raptorConfig;
     this.requestLogger = requestLogger;
@@ -89,7 +85,6 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   public static DefaultServerRequestContext create(
     TransitRoutingConfig transitRoutingConfig,
     RouteRequest routeRequestDefaults,
-    Duration streetRoutingTimeout,
     RaptorConfig<TripSchedule> raptorConfig,
     Graph graph,
     TransitService transitService,
@@ -106,7 +101,6 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
       graph,
       transitService,
       transitRoutingConfig,
-      streetRoutingTimeout,
       routeRequestDefaults,
       meterRegistry,
       raptorConfig,
@@ -181,11 +175,6 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   @Override
   public RaptorTuningParameters raptorTuningParameters() {
     return transitRoutingConfig;
-  }
-
-  @Override
-  public Duration streetRoutingTimeout() {
-    return streetRoutingTimeout;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
+++ b/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.street.search;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.opentripplanner.astar.AStarBuilder;
 import org.opentripplanner.astar.spi.DominanceFunction;
 import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
@@ -61,6 +63,12 @@ public class StreetSearchBuilder extends AStarBuilder<State, Edge, Vertex, Stree
   public StreetSearchBuilder setDataOverlayContext(DataOverlayContext dataOverlayContext) {
     this.dataOverlayContext = dataOverlayContext;
     return this;
+  }
+
+  @Nonnull
+  @Override
+  protected Duration streetRoutingTimeout() {
+    return routeRequest.preferences().street().routingTimeout();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -16,7 +16,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -176,9 +175,6 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
   /* The set of callbacks that display search progress on the showGraph Processing applet. */
   public TraverseVisitor<State, Edge> traverseVisitor;
 
-  /* Needed by the GraphPathFinder */
-  private final Duration streetRoutingTimeout;
-
   public JList<DisplayVertex> nearbyVertices;
 
   private JList<Edge> outgoingEdges;
@@ -249,12 +245,11 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
   protected State lastStateClicked = null;
   private JCheckBox longDistanceModeCheckbox;
 
-  public GraphVisualizer(Graph graph, Duration streetRoutingTimeout) {
+  public GraphVisualizer(Graph graph) {
     super();
     setTitle("GraphVisualizer");
     setExtendedState(JFrame.MAXIMIZED_BOTH);
     this.graph = graph;
-    this.streetRoutingTimeout = streetRoutingTimeout;
   }
 
   public void run() {
@@ -501,7 +496,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
     // if( dontUseGraphicalCallbackCheckBox.isSelected() ){
     // TODO perhaps avoid using a GraphPathFinder and go one level down the call chain directly to a GenericAStar
     // TODO perhaps instead of giving the pathservice a callback, we can just put the visitor in the routing request
-    GraphPathFinder finder = new GraphPathFinder(traverseVisitor, streetRoutingTimeout);
+    GraphPathFinder finder = new GraphPathFinder(traverseVisitor);
 
     long t0 = System.currentTimeMillis();
     // TODO: check options properly intialized (AMB)

--- a/src/test/java/org/opentripplanner/TestServerContext.java
+++ b/src/test/java/org/opentripplanner/TestServerContext.java
@@ -32,7 +32,6 @@ public class TestServerContext {
     DefaultServerRequestContext context = DefaultServerRequestContext.create(
       routerConfig.transitTuningConfig(),
       routerConfig.routingRequestDefaults(),
-      routerConfig.streetRoutingTimeout(),
       new RaptorConfig<>(routerConfig.transitTuningConfig()),
       graph,
       new DefaultTransitService(transitModel),

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModuleTest.java
@@ -12,7 +12,6 @@ import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTR
 import java.io.File;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -377,7 +376,7 @@ public class OpenStreetMapModuleTest {
     Vertex bottomV = graph.getVertex("osm:node:580290955");
     Vertex topV = graph.getVertex("osm:node:559271124");
 
-    GraphPathFinder graphPathFinder = new GraphPathFinder(null, Duration.ofSeconds(3));
+    GraphPathFinder graphPathFinder = new GraphPathFinder(null);
     List<GraphPath<State, Edge, Vertex>> pathList = graphPathFinder.graphPathFinderEntryPoint(
       request,
       Set.of(bottomV),

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.routing.api.request.StreetMode.CAR;
 import static org.opentripplanner.routing.api.request.StreetMode.NOT_SET;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
@@ -66,7 +65,7 @@ public class TestIntermediatePlaces {
       FakeGraph.addPerpendicularRoutes(graph, transitModel);
       FakeGraph.link(graph, transitModel);
       model.index();
-      TestIntermediatePlaces.graphPathFinder = new GraphPathFinder(null, Duration.ofSeconds(3));
+      TestIntermediatePlaces.graphPathFinder = new GraphPathFinder(null);
       timeZone = transitModel.getTimeZone();
 
       graphPathToItineraryMapper =

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
@@ -19,6 +19,7 @@ class StreetPreferencesTest {
     IntersectionTraversalModel.NORWAY;
   private static final Duration MAX_ACCESS_EGRESS = Duration.ofMinutes(5);
   private static final Duration MAX_DIRECT = Duration.ofMinutes(10);
+  public static final Duration ROUTING_TIMEOUT = Duration.ofSeconds(3);
 
   private final StreetPreferences subject = StreetPreferences
     .of()
@@ -28,6 +29,7 @@ class StreetPreferencesTest {
     .withIntersectionTraversalModel(INTERSECTION_TRAVERSAL_MODEL)
     .withMaxAccessEgressDuration(MAX_ACCESS_EGRESS, Map.of())
     .withMaxDirectDuration(MAX_DIRECT, Map.of())
+    .withRoutingTimeout(ROUTING_TIMEOUT)
     .build();
 
   @Test
@@ -61,6 +63,11 @@ class StreetPreferencesTest {
   }
 
   @Test
+  void routingTimeout() {
+    assertEquals(ROUTING_TIMEOUT, subject.routingTimeout());
+  }
+
+  @Test
   void testOfAndCopyOf() {
     // Return same object if no value is set
     assertSame(StreetPreferences.DEFAULT, StreetPreferences.of().build());
@@ -82,6 +89,7 @@ class StreetPreferencesTest {
       "StreetPreferences{" +
       "turnReluctance: 2.0, " +
       "drivingDirection: LEFT, " +
+      "routingTimeout: 3s, " +
       "elevator: ElevatorPreferences{boardTime: 2m}, " +
       "intersectionTraversalModel: NORWAY, " +
       "maxAccessEgressDuration: DurationForStreetMode{default:5m}, " +

--- a/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
@@ -36,22 +36,33 @@ class RouterConfigTest {
 
   @Test
   void parseStreetRoutingTimeout() {
-    var DEFAULT_TIMEOUT = RouterConfig.DEFAULT.streetRoutingTimeout();
+    var DEFAULT_TIMEOUT = RouterConfig.DEFAULT
+      .routingRequestDefaults()
+      .preferences()
+      .street()
+      .routingTimeout();
     NodeAdapter c;
 
     // Fall back to default 5 seconds
     c = createNodeAdaptor("{}");
-    assertEquals(DEFAULT_TIMEOUT, RouterConfig.parseStreetRoutingTimeout(c));
+    assertEquals(DEFAULT_TIMEOUT, RouterConfig.parseStreetRoutingTimeout(c, DEFAULT_TIMEOUT));
 
     // New format: 33 seconds
     c = createNodeAdaptor("{streetRoutingTimeout: '33s'}");
-    assertEquals(Duration.ofSeconds(33), RouterConfig.parseStreetRoutingTimeout(c));
+    assertEquals(
+      Duration.ofSeconds(33),
+      RouterConfig.parseStreetRoutingTimeout(c, DEFAULT_TIMEOUT)
+    );
   }
 
   @Test
   void parseStreetRoutingTimeoutWithIllegalFormat() {
+    Duration defaultTimeout = Duration.ZERO;
     final var c = createNodeAdaptor("{streetRoutingTimeout: 'Hi'}");
-    assertThrows(OtpAppException.class, () -> RouterConfig.parseStreetRoutingTimeout(c));
+    assertThrows(
+      OtpAppException.class,
+      () -> RouterConfig.parseStreetRoutingTimeout(c, defaultTimeout)
+    );
   }
 
   private static NodeAdapter createNodeAdaptor(String jsonText) {

--- a/src/test/java/org/opentripplanner/street/integration/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/street/integration/BarrierRoutingTest.java
@@ -6,7 +6,6 @@ import static org.opentripplanner.routing.api.request.StreetMode.BIKE;
 import static org.opentripplanner.routing.api.request.StreetMode.CAR;
 import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.function.Consumer;
@@ -177,7 +176,7 @@ public class BarrierRoutingTest {
     options.accept(request);
 
     var temporaryVertices = new TemporaryVerticesContainer(graph, request, streetMode, streetMode);
-    var gpf = new GraphPathFinder(null, Duration.ofSeconds(5));
+    var gpf = new GraphPathFinder(null);
     var paths = gpf.graphPathFinderEntryPoint(request, temporaryVertices);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(

--- a/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
 
-import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -82,7 +81,7 @@ public class BicycleRoutingTest {
       request.journey().direct().mode(),
       request.journey().direct().mode()
     );
-    var gpf = new GraphPathFinder(null, Duration.ofSeconds(5));
+    var gpf = new GraphPathFinder(null);
     var paths = gpf.graphPathFinderEntryPoint(request, temporaryVertices);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(

--- a/src/test/java/org/opentripplanner/street/integration/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/street/integration/CarRoutingTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
 
-import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -134,7 +133,7 @@ public class CarRoutingTest {
       StreetMode.CAR,
       StreetMode.CAR
     );
-    var gpf = new GraphPathFinder(null, Duration.ofSeconds(5));
+    var gpf = new GraphPathFinder(null);
     var paths = gpf.graphPathFinderEntryPoint(request, temporaryVertices);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(

--- a/src/test/java/org/opentripplanner/street/integration/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/street/integration/SplitEdgeTurnRestrictionsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
@@ -157,7 +156,7 @@ public class SplitEdgeTurnRestrictionsTest {
       StreetMode.CAR,
       StreetMode.CAR
     );
-    var gpf = new GraphPathFinder(null, Duration.ofSeconds(5));
+    var gpf = new GraphPathFinder(null);
     var paths = gpf.graphPathFinderEntryPoint(request, temporaryVertices);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(

--- a/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -104,7 +104,6 @@ public class SpeedTest {
       DefaultServerRequestContext.create(
         config.transitRoutingParams,
         config.request,
-        null,
         new RaptorConfig<>(config.transitRoutingParams),
         graph,
         new DefaultTransitService(transitModel),


### PR DESCRIPTION
### Summary

OTP have a global street router timeout(`streetRoutingTimeout`) set in router-config. This was not used in all cases. 

To fix this problem I moved the timeout into the street preferences and made it none-nullable. I also now trow an exception if AStar is created with a `null` timeout. I removed the timeout from the call-chain and context - it is now passed in the the AStarBuilder using the request. There are places witch does not use the build-config default request, but create a new request instead - I think this is wrong, but I have not changed it. In those place the timeout will now change from infinite to 5 seconds (code default).


### Unit tests

I added `this.timeout = Objects.requireNonNull(timeout);` in the AStar constructor to prevent a similar error to occur in the future. It is difficult to write a unit-test for this, and a pre-condition is more suited.

