### PR TITLE
Avoid changing already non-routable stops when cancelling stops in realtime

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/mapper/PickDropMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/mapper/PickDropMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.siri.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.org.siri.siri20.ArrivalBoardingActivityEnumeration.ALIGHTING;
 import static uk.org.siri.siri20.ArrivalBoardingActivityEnumeration.NO_ALIGHTING;
@@ -181,6 +182,30 @@ class PickDropMapperTest {
     assertTrue(
       testResult.isEmpty(),
       "There is no change in routability - only arrival is cancelled"
+    );
+  }
+
+  @Test
+  public void testCancellationWithNoPlannedBoarding() {
+    var originalPickUpType = PickDrop.NONE;
+    TestCall call = TestCall.of().withCancellation(Boolean.TRUE).build();
+    var testResult = PickDropMapper.mapDropOffType(call, originalPickUpType);
+
+    assertTrue(
+      testResult.isEmpty(),
+      "There is no change in routability - pickup should not be changed"
+    );
+  }
+
+  @Test
+  public void testCancellationWithNoPlannedAlighting() {
+    var originalDropOffType = PickDrop.NONE;
+    TestCall call = TestCall.of().withCancellation(Boolean.TRUE).build();
+    var testResult = PickDropMapper.mapDropOffType(call, originalDropOffType);
+
+    assertTrue(
+      testResult.isEmpty(),
+      "There is no change in routability - dropoff should not be changed"
     );
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/siri/mapper/PickDropMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/mapper/PickDropMapperTest.java
@@ -189,11 +189,23 @@ class PickDropMapperTest {
   public void testCancellationWithNoPlannedBoarding() {
     var originalPickUpType = PickDrop.NONE;
     TestCall call = TestCall.of().withCancellation(Boolean.TRUE).build();
-    var testResult = PickDropMapper.mapDropOffType(call, originalPickUpType);
+    var testResult = PickDropMapper.mapPickUpType(call, originalPickUpType);
 
     assertTrue(
       testResult.isEmpty(),
       "There is no change in routability - pickup should not be changed"
+    );
+  }
+
+  @Test
+  public void testCancellationWithPlannedBoarding() {
+    var originalPickUpType = PickDrop.SCHEDULED;
+    TestCall call = TestCall.of().withCancellation(Boolean.TRUE).build();
+    var testResult = PickDropMapper.mapPickUpType(call, originalPickUpType);
+
+    assertFalse(
+      testResult.isEmpty(),
+      "There is no change in routability - pickup should be changed"
     );
   }
 
@@ -206,6 +218,18 @@ class PickDropMapperTest {
     assertTrue(
       testResult.isEmpty(),
       "There is no change in routability - dropoff should not be changed"
+    );
+  }
+
+  @Test
+  public void testCancellationWithPlannedAlighting() {
+    var originalDropOffType = PickDrop.SCHEDULED;
+    TestCall call = TestCall.of().withCancellation(Boolean.TRUE).build();
+    var testResult = PickDropMapper.mapDropOffType(call, originalDropOffType);
+
+    assertFalse(
+      testResult.isEmpty(),
+      "There is no change in routability - dropoff should be changed"
     );
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/AddedTripBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/AddedTripBuilder.java
@@ -206,7 +206,7 @@ class AddedTripBuilder {
       );
     }
 
-    if (cancellation || stopPattern.isAllStopsCancelled()) {
+    if (cancellation || stopPattern.isAllStopsNonRoutable()) {
       updatedTripTimes.cancelTrip();
     } else {
       updatedTripTimes.setRealTimeState(RealTimeState.ADDED);

--- a/src/ext/java/org/opentripplanner/ext/siri/ModifiedTripBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/ModifiedTripBuilder.java
@@ -96,7 +96,7 @@ public class ModifiedTripBuilder {
 
     StopPattern stopPattern = createStopPattern(pattern, calls, entityResolver);
 
-    if (cancellation || stopPattern.isAllStopsCancelled()) {
+    if (cancellation || stopPattern.isAllStopsNonRoutable()) {
       LOG.debug("Trip is cancelled");
       newTimes.cancelTrip();
       return Result.success(new TripUpdate(pattern.getStopPattern(), newTimes, serviceDate));

--- a/src/ext/java/org/opentripplanner/ext/siri/mapper/PickDropMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/mapper/PickDropMapper.java
@@ -23,10 +23,7 @@ public class PickDropMapper {
    * @return Mapped PickDrop type, empty if routability is not changed.
    */
   public static Optional<PickDrop> mapDropOffType(CallWrapper call, PickDrop currentValue) {
-    if (
-      TRUE.equals(call.isCancellation()) ||
-      call.getArrivalStatus() == CallStatusEnumeration.CANCELLED
-    ) {
+    if (shouldBeCancelled(currentValue, call.isCancellation(), call.getArrivalStatus())) {
       return Optional.of(CANCELLED);
     }
 
@@ -53,10 +50,7 @@ public class PickDropMapper {
    * @return Mapped PickDrop type, empty if routability is not changed.
    */
   public static Optional<PickDrop> mapPickUpType(CallWrapper call, PickDrop currentValue) {
-    if (
-      TRUE.equals(call.isCancellation()) ||
-      call.getDepartureStatus() == CallStatusEnumeration.CANCELLED
-    ) {
+    if (shouldBeCancelled(currentValue, call.isCancellation(), call.getDepartureStatus())) {
       return Optional.of(CANCELLED);
     }
 
@@ -70,5 +64,26 @@ public class PickDropMapper {
       case NO_BOARDING -> Optional.of(NONE);
       case PASS_THRU -> Optional.of(CANCELLED);
     };
+  }
+
+  /**
+   * Considers if PickDrop should be set to CANCELLED.
+   *
+   * If the existing PickDrop is non-routable, the value is not changed.
+   *
+   * @param currentValue The current pick drop value on a stopTime
+   * @param isCallCancellation The incoming call cancellation-flag
+   * @param callStatus The incoming call arrival/departure status
+   * @return
+   */
+  private static boolean shouldBeCancelled(
+    PickDrop currentValue,
+    Boolean isCallCancellation,
+    CallStatusEnumeration callStatus
+  ) {
+    if (currentValue.isNotRoutable()) {
+      return false;
+    }
+    return TRUE.equals(isCallCancellation) || callStatus == CallStatusEnumeration.CANCELLED;
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
@@ -133,7 +133,10 @@ public final class StopPattern implements Serializable {
     return stops.length;
   }
 
-  public boolean isAllStopsCancelled() {
+  /**
+   * Checks that all stops ar non-routable.
+   */
+  public boolean isAllStopsNonRoutable() {
     return (
       Arrays.stream(pickups).allMatch(PickDrop::isNotRoutable) &&
       Arrays.stream(dropoffs).allMatch(PickDrop::isNotRoutable)


### PR DESCRIPTION
### Summary
When a stop is cancelled, the PickDrop is always set to CANCELLED for both boarding and alighting. This causes e.g. trips without boarding to appear on departure-boards.

This PR checks if the existing PickDrop-status is routable before cancelling. If not, the status is kept as-is.

### Issue

closes #5000

### Unit tests

Tests are added to verify new criteria.

