### PR TITLE
Bugs related to DST and service date

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.OffsetDateTime;
@@ -24,6 +23,7 @@ import org.opentripplanner.ext.flex.FlexRouter;
 import org.opentripplanner.ext.flex.FlexTest;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.geometry.EncodedPolyline;
+import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.StopTime;
@@ -238,23 +238,20 @@ public class ScheduledDeviatedTripTest extends FlexTest {
     GenericLocation to,
     OtpServerRequestContext serverContext
   ) {
+    var zoneId = ZoneIds.NEW_YORK;
     RouteRequest request = new RouteRequest();
     request.journey().transit().setFilters(List.of(AllowAllTransitFilter.of()));
-    Instant dateTime = LocalDateTime
-      .of(2021, Month.DECEMBER, 16, 12, 0)
-      .atZone(ZoneIds.NEW_YORK)
-      .toInstant();
-    request.setDateTime(dateTime);
+    var dateTime = LocalDateTime.of(2021, Month.DECEMBER, 16, 12, 0).atZone(zoneId);
+    request.setDateTime(dateTime.toInstant());
     request.setFrom(from);
     request.setTo(to);
 
-    var time = dateTime.atZone(ZoneIds.NEW_YORK);
-    var additionalSearchDays = AdditionalSearchDays.defaults(time);
-
+    var transitStartOfTime = ServiceDateUtils.asStartOfService(request.dateTime(), zoneId);
+    var additionalSearchDays = AdditionalSearchDays.defaults(dateTime);
     var result = TransitRouter.route(
       request,
       serverContext,
-      time,
+      transitStartOfTime,
       additionalSearchDays,
       new DebugTimingAggregator()
     );

--- a/src/ext/java/org/opentripplanner/ext/siri/EntityResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/EntityResolver.java
@@ -7,8 +7,6 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Operator;
@@ -160,20 +158,20 @@ public class EntityResolver {
   }
 
   /**
-   * Resolve serviceDate.
-   * For legacy reasons this is provided in originAimedDepartureTime - in lack of alternatives. Even
-   * though the field's name indicates that the timestamp represents the departure from the first
-   * stop, only the Date-part is actually used, and is defined to represent the actual serviceDate.
+   * Resolve serviceDate. For legacy reasons this is provided in originAimedDepartureTime - in lack
+   * of alternatives. Even though the field's name indicates that the timestamp represents the
+   * departure from the first stop, only the Date-part is actually used, and is defined to
+   * represent the actual serviceDate. The time and zone part is ignored.
    */
   public LocalDate resolveServiceDate(ZonedDateTime originAimedDepartureTime) {
-    Optional<ZonedDateTime> localDateOptional = Optional
-      .ofNullable(originAimedDepartureTime)
-      .map(ServiceDateUtils::asStartOfService);
-
-    if (localDateOptional.isPresent()) {
-      return localDateOptional.get().toLocalDate();
+    if (originAimedDepartureTime == null) {
+      return null;
     }
-    return null;
+    // This grab the local-date from timestamp passed into OTP ignoring the time and zone
+    // information. An alternative is to use the transit model zone:
+    // 'originAimedDepartureTime.withZoneSameInstant(transitService.getTimeZone())'
+
+    return originAimedDepartureTime.toLocalDate();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/framework/time/ServiceDateUtils.java
+++ b/src/main/java/org/opentripplanner/framework/time/ServiceDateUtils.java
@@ -9,7 +9,6 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,13 +27,6 @@ public class ServiceDateUtils {
   private static final DateTimeFormatter COMPACT_FORMATTER = DateTimeFormatter.ofPattern(
     "uuuuMMdd"
   );
-
-  /**
-   * Calculate the start of the service day for the given {@link ZonedDateTime}
-   */
-  public static ZonedDateTime asStartOfService(ZonedDateTime date) {
-    return date.truncatedTo(ChronoUnit.HOURS).withHour(12).minusHours(12);
-  }
 
   /**
    * Calculate the start of the service day for the given {@link Instant} at the given

--- a/src/main/java/org/opentripplanner/framework/time/ServiceDateUtils.java
+++ b/src/main/java/org/opentripplanner/framework/time/ServiceDateUtils.java
@@ -54,6 +54,15 @@ public class ServiceDateUtils {
   }
 
   /**
+   * Calculate the service day from start of the service day. On days with daylight saving
+   * time adjustments this may not be the same as {@code startOfService.toLocalDate()}.
+   * Adding 12 hours is necessary.
+   */
+  public static LocalDate asServiceDay(ZonedDateTime startOfService) {
+    return startOfService.plusHours(12).toLocalDate();
+  }
+
+  /**
    * Create a ZonedDateTime based on the service date, time zone and seconds-offset. This
    * method add the offset seconds to the service date start time, which is defined to be NOON - 12
    * hours. This is midnight for most days, except days where the time is adjusted for daylight

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreator.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import org.opentripplanner.framework.time.DurationUtils;
+import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
@@ -43,7 +44,7 @@ class RaptorRoutingRequestTransitDataCreator {
     ZonedDateTime transitSearchTimeZero
   ) {
     this.transitLayer = transitLayer;
-    this.departureDate = transitSearchTimeZero.toLocalDate();
+    this.departureDate = ServiceDateUtils.asServiceDay(transitSearchTimeZero);
     this.transitSearchTimeZero = transitSearchTimeZero;
   }
 

--- a/src/test/java/org/opentripplanner/framework/time/ServiceDateUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/time/ServiceDateUtilsTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.framework.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,6 +97,23 @@ public class ServiceDateUtilsTest {
       "2019-03-30T00:00+01:00[Europe/Paris]",
       asStartOfService(time, ZONE_ID).toString()
     );
+  }
+
+  @Test
+  public void test() {
+    var sd1 = asStartOfService(D2019_03_30, ZONE_ID);
+    var sd2 = asStartOfService(D2019_03_31, ZONE_ID);
+    var sd3 = asStartOfService(D2019_04_01, ZONE_ID);
+
+    assertEquals(D2019_03_30, ServiceDateUtils.asServiceDay(sd1));
+    assertEquals(D2019_03_31, ServiceDateUtils.asServiceDay(sd2));
+    assertEquals(D2019_04_01, ServiceDateUtils.asServiceDay(sd3));
+
+    // When DST adjustment happens the startTime is not on the same date as
+    // the serviceDate
+    assertEquals(sd1.toLocalDate(), ServiceDateUtils.asServiceDay(sd1));
+    assertNotEquals(sd2.toLocalDate(), ServiceDateUtils.asServiceDay(sd2));
+    assertEquals(sd3.toLocalDate(), ServiceDateUtils.asServiceDay(sd3));
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/framework/time/ServiceDateUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/time/ServiceDateUtilsTest.java
@@ -22,7 +22,6 @@ import org.opentripplanner._support.time.ZoneIds;
 public class ServiceDateUtilsTest {
 
   private static final ZoneId ZONE_ID = ZoneIds.PARIS;
-  private static final LocalTime TIME = LocalTime.of(10, 26);
 
   private static final LocalDate D2019_03_30 = LocalDate.of(2019, 3, 30);
   // Daylight Saving Time change from Winter to Summer time on MAR 03 2019 in Europe
@@ -39,27 +38,6 @@ public class ServiceDateUtilsTest {
     LocalTime.MIDNIGHT,
     ZONE_ID
   );
-
-  // Zoned dates in spring around DST switch
-  private static final ZonedDateTime Z1 = ZonedDateTime.of(D2019_03_30, TIME, ZONE_ID);
-  private static final ZonedDateTime Z2 = ZonedDateTime.of(D2019_03_31, TIME, ZONE_ID);
-  private static final ZonedDateTime Z3 = ZonedDateTime.of(D2019_04_01, TIME, ZONE_ID);
-
-  // Zoned dates in fall around DST switch
-  private static final ZonedDateTime Z4 = ZonedDateTime.of(D2019_10_26, TIME, ZONE_ID);
-  private static final ZonedDateTime Z5 = ZonedDateTime.of(D2019_10_27, TIME, ZONE_ID);
-  private static final ZonedDateTime Z6 = ZonedDateTime.of(D2019_10_28, TIME, ZONE_ID);
-
-  @Test
-  public void testAsStartOfServiceWithZonedDatesAroundDST() {
-    // Test Zoned dates around DST
-    assertEquals("2019-03-30T00:00+01:00[Europe/Paris]", asStartOfService(Z1).toString());
-    assertEquals("2019-03-30T23:00+01:00[Europe/Paris]", asStartOfService(Z2).toString());
-    assertEquals("2019-04-01T00:00+02:00[Europe/Paris]", asStartOfService(Z3).toString());
-    assertEquals("2019-10-26T00:00+02:00[Europe/Paris]", asStartOfService(Z4).toString());
-    assertEquals("2019-10-27T01:00+02:00[Europe/Paris]", asStartOfService(Z5).toString());
-    assertEquals("2019-10-28T00:00+01:00[Europe/Paris]", asStartOfService(Z6).toString());
-  }
 
   @Test
   public void testAsStartOfServiceWithLocalDatesAndZoneAroundDST() {


### PR DESCRIPTION
### Summary

This PR fixes 2 errors related to DST adjustments. 

**Fix empty arriveBy search**

When selecting trip-pattern-for-day otp used ended up using the previous day for arrive-by search. This again cased OTP to search an empty set of patterns.


**fix SIRI alerts operatingDay resolving**

In some legacy cases the operatingDay is passed into OTP with time and zoneID. To get
the correct operating day we simply ignore time and zone-id.  The existing code was
wrong for days with DST forward adjustments. This only apply to the SIRI updaters.


### Issue

No issue for this.


### Unit tests

Unit test for the `ServiceDateUtils` is updated, but no module/integration test is added. The plan is to delete this code, and we can not reuse the tests.


### Documentation
No.
