### PR TITLE
Fix validation of running period for NeTEx flexible lines

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
@@ -223,6 +223,10 @@ public class TripPatternForDate implements Comparable<TripPatternForDate> {
     TripTimes first,
     TripTimes last
   ) {
+    if (first.getTrip().getRoute().getFlexibleLineType() != null) {
+      // do not validate running period for flexible trips
+      return;
+    }
     if (startOfRunningPeriod.isAfter(endOfRunningPeriod)) {
       LOG.warn(
         "Could not construct as start of the running period {} in trip {} is after the end {} in trip {}",


### PR DESCRIPTION
### Summary
As detailed in #5006 , the calculation of the start and end of the transit period is wrong when a flexible line contains both fixed stops and flexible areas.
The construction of TripTimes in this case is necessary since Raptor makes use of flexible lines when they contain at least 2 fixed stops. Moreover these TripTimes are also used to provide flexible trip information in the TransModel API.

This PR relaxes the validation rule of the running period for flexible trips. Flexible trips are identified with Route.getFlexibleLineType() , so this fix covers only flexible lines imported from NeTEx datasets.


### Issue
Partially fixes #5006 

### Unit tests

:white_check_mark: 

### Documentation

No
