### PR TITLE
Use a more human-readable value for rental vehicle's name

### DIFF
--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
@@ -73,7 +73,7 @@ public class GbfsFreeVehicleStatusMapper {
   private String getName(GBFSBike vehicle) {
     var typeId = vehicle.getVehicleTypeId();
     if (typeId != null) {
-      var type = vehicleTypes.get(vehicle.getVehicleTypeId());
+      var type = vehicleTypes.get(typeId);
       if (type != null && type.name != null) {
         return type.name;
       } else {

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
@@ -1,7 +1,12 @@
 package org.opentripplanner.updater.vehicle_rental.datasources;
 
+import static java.util.Objects.requireNonNullElse;
+
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.entur.gbfs.v2_3.free_bike_status.GBFSBike;
 import org.entur.gbfs.v2_3.free_bike_status.GBFSRentalUris;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
@@ -14,14 +19,16 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 public class GbfsFreeVehicleStatusMapper {
 
   private final VehicleRentalSystem system;
+
+  @Nonnull
   private final Map<String, RentalVehicleType> vehicleTypes;
 
   public GbfsFreeVehicleStatusMapper(
     VehicleRentalSystem system,
-    Map<String, RentalVehicleType> vehicleTypes
+    @Nullable Map<String, RentalVehicleType> vehicleTypes
   ) {
     this.system = system;
-    this.vehicleTypes = vehicleTypes;
+    this.vehicleTypes = new HashMap<>(requireNonNullElse(vehicleTypes, Map.of()));
   }
 
   public VehicleRentalVehicle mapFreeVehicleStatus(GBFSBike vehicle) {
@@ -33,13 +40,14 @@ public class GbfsFreeVehicleStatusMapper {
       VehicleRentalVehicle rentalVehicle = new VehicleRentalVehicle();
       rentalVehicle.id = new FeedScopedId(system.systemId, vehicle.getBikeId());
       rentalVehicle.system = system;
-      rentalVehicle.name = new NonLocalizedString(vehicle.getBikeId());
+      rentalVehicle.name = new NonLocalizedString(getName(vehicle));
       rentalVehicle.longitude = vehicle.getLon();
       rentalVehicle.latitude = vehicle.getLat();
       rentalVehicle.vehicleType =
-        vehicleTypes == null
-          ? RentalVehicleType.getDefaultType(system.systemId)
-          : vehicleTypes.get(vehicle.getVehicleTypeId());
+        vehicleTypes.getOrDefault(
+          vehicle.getVehicleTypeId(),
+          RentalVehicleType.getDefaultType(system.systemId)
+        );
       rentalVehicle.isReserved = vehicle.getIsReserved() != null ? vehicle.getIsReserved() : false;
       rentalVehicle.isDisabled = vehicle.getIsDisabled() != null ? vehicle.getIsDisabled() : false;
       rentalVehicle.lastReported =
@@ -59,6 +67,20 @@ public class GbfsFreeVehicleStatusMapper {
       return rentalVehicle;
     } else {
       return null;
+    }
+  }
+
+  private String getName(GBFSBike vehicle) {
+    var typeId = vehicle.getVehicleTypeId();
+    if (typeId != null) {
+      var type = vehicleTypes.get(vehicle.getVehicleTypeId());
+      if (type != null && type.name != null) {
+        return type.name;
+      } else {
+        return RentalVehicleType.getDefaultType(system.systemId).name;
+      }
+    } else {
+      return "%s,%s".formatted(vehicle.getLat(), vehicle.getLon());
     }
   }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
@@ -76,11 +76,8 @@ public class GbfsFreeVehicleStatusMapper {
       var type = vehicleTypes.get(typeId);
       if (type != null && type.name != null) {
         return type.name;
-      } else {
-        return RentalVehicleType.getDefaultType(system.systemId).name;
       }
-    } else {
-      return "%s,%s".formatted(vehicle.getLat(), vehicle.getLon());
     }
+    return RentalVehicleType.getDefaultType(system.systemId).name;
   }
 }

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapperTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapperTest.java
@@ -51,7 +51,7 @@ class GbfsFreeVehicleStatusMapperTest {
     bike.setLon(1d);
     var mapped = MAPPER.mapFreeVehicleStatus(bike);
 
-    assertEquals("1.0,1.0", mapped.name.toString());
+    assertEquals("Default vehicle type", mapped.name.toString());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapperTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapperTest.java
@@ -1,0 +1,80 @@
+package org.opentripplanner.updater.vehicle_rental.datasources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.entur.gbfs.v2_3.free_bike_status.GBFSBike;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
+import org.opentripplanner.service.vehiclerental.model.VehicleRentalSystem;
+import org.opentripplanner.street.model.RentalFormFactor;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+class GbfsFreeVehicleStatusMapperTest {
+
+  public static final VehicleRentalSystem SYSTEM = new VehicleRentalSystem(
+    "123",
+    "de",
+    "123",
+    "123",
+    "123",
+    "https://example.com",
+    "https://example.com",
+    null,
+    null,
+    "help@foo.com",
+    "hello@foo.com",
+    "Europe/Berlin",
+    null,
+    null,
+    null
+  );
+  public static final GbfsFreeVehicleStatusMapper MAPPER = new GbfsFreeVehicleStatusMapper(
+    SYSTEM,
+    Map.of(
+      "scooter",
+      new RentalVehicleType(
+        new FeedScopedId("1", "scooter"),
+        "Scooter",
+        RentalFormFactor.SCOOTER,
+        null,
+        null
+      )
+    )
+  );
+
+  @Test
+  void noType() {
+    var bike = new GBFSBike();
+    bike.setBikeId("999999999");
+    bike.setLat(1d);
+    bike.setLon(1d);
+    var mapped = MAPPER.mapFreeVehicleStatus(bike);
+
+    assertEquals("1.0,1.0", mapped.name.toString());
+  }
+
+  @Test
+  void withDefaultType() {
+    var bike = new GBFSBike();
+    bike.setBikeId("999999999");
+    bike.setLat(1d);
+    bike.setLon(1d);
+    bike.setVehicleTypeId("bike");
+    var mapped = MAPPER.mapFreeVehicleStatus(bike);
+
+    assertEquals("Default vehicle type", mapped.name.toString());
+  }
+
+  @Test
+  void withType() {
+    var bike = new GBFSBike();
+    bike.setBikeId("999999999");
+    bike.setLat(1d);
+    bike.setLon(1d);
+    bike.setVehicleTypeId("scooter");
+    var mapped = MAPPER.mapFreeVehicleStatus(bike);
+
+    assertEquals("Scooter", mapped.name.toString());
+  }
+}


### PR DESCRIPTION
### Summary

Freefloating rental vehicles in GBFS don't have a name property but OTP maps the vehicle's id to its name.

This id is often very long, automatically rotated and then ends up in the UI.

In this PR I'm changing the name from the ID to the type of the vehicle (if it exists), otherwise the default one for that feed.

### Unit tests

Added.

cc @derhuerst @hbruch 