### PR TITLE
Don't expose ports in Docker container image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,10 +459,6 @@
                                 /var/opentripplanner/
                             </volume>
                         </volumes>
-                        <ports>
-                            <port>8080</port>
-                            <port>8081</port>
-                        </ports>
                     </container>
                     <from>
                         <platforms>


### PR DESCRIPTION
### Summary

This PR removes the `<ports>` section from the `<container>` configuration inside `pom.xml` to disable exposing the ports `8080` and `8081`.

If one starts an OpenTripPlanner docker container there should by default be no exposed ports as this enables external access to the service and might open ports in the firewall without the user knowing.

### Issue

Related [issue #5012](https://github.com/opentripplanner/OpenTripPlanner/issues/5012).

Closes #5012 

### Unit tests

I have successfully created a new Docker image after applying my patch by running

```shell
CONTAINER_REGISTRY_USER=p1st CONTAINER_REGISTRY_PASSWORD=**redacted** mvn compile jib:build -Dimage='p1st/opentripplanner:latest'
```

When inspecting it with `docker image inspect p1st/opentripplanner:latest`, the "ExposedPorts" section is missing as expected.

### Documentation

As my commit does not add new code, I think that no extra documentation is required.
