### PR TITLE
Fix precedence rules for NeTEx flexible line booking information

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
@@ -2,6 +2,7 @@ package org.opentripplanner.netex.mapping;
 
 import java.time.Duration;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
@@ -44,159 +45,220 @@ public class BookingInfoMapper {
     ServiceJourney serviceJourney,
     FlexibleLine flexibleLine
   ) {
-    if (stopPoint.getBookingArrangements() != null) {
-      return map(stopPoint.getBookingArrangements(), ref("StopPoint", stopPoint));
-    } else if (serviceJourney != null && serviceJourney.getFlexibleServiceProperties() != null) {
-      return map(
-        serviceJourney.getFlexibleServiceProperties(),
-        ref("ServiceJourney", serviceJourney)
-      );
-    } else if (flexibleLine != null) {
-      return map(flexibleLine, ref("FlexibleLine", flexibleLine));
-    }
-    return null;
-  }
-
-  private static BookingTime mapLatestBookingTime(
-    LocalTime latestBookingTime,
-    PurchaseWhenEnumeration purchaseWhen
-  ) {
-    switch (purchaseWhen) {
-      case UNTIL_PREVIOUS_DAY:
-        return new BookingTime(latestBookingTime, 1);
-      case DAY_OF_TRAVEL_ONLY:
-      case ADVANCE_ONLY:
-      case ADVANCE_AND_DAY_OF_TRAVEL:
-        return new BookingTime(latestBookingTime, 0);
-      case TIME_OF_TRAVEL_ONLY:
-        return null;
-      default:
-        throw new IllegalArgumentException("Value not supported: " + purchaseWhen);
-    }
-  }
-
-  private static BookingTime mapEarliestBookingTime(PurchaseWhenEnumeration purchaseWhen) {
-    switch (purchaseWhen) {
-      case UNTIL_PREVIOUS_DAY:
-      case ADVANCE_ONLY:
-      case ADVANCE_AND_DAY_OF_TRAVEL:
-      case TIME_OF_TRAVEL_ONLY:
-        return null;
-      case DAY_OF_TRAVEL_ONLY:
-        return new BookingTime(LocalTime.MIDNIGHT, 0);
-      default:
-        throw new IllegalArgumentException("Value not supported: " + purchaseWhen);
-    }
-  }
-
-  private static String ref(String type, EntityStructure entity) {
-    return type + "(" + entity.getId() + ")";
-  }
-
-  private BookingInfo map(BookingArrangementsStructure bookingArrangements, String entityRef) {
-    return map(
-      bookingArrangements.getBookingContact(),
-      bookingArrangements.getBookingMethods(),
-      bookingArrangements.getLatestBookingTime(),
-      bookingArrangements.getBookWhen(),
-      bookingArrangements.getMinimumBookingPeriod(),
-      bookingArrangements.getBookingNote(),
-      entityRef
-    );
-  }
-
-  private BookingInfo map(FlexibleServiceProperties serviceProperties, String entityRef) {
-    return map(
-      serviceProperties.getBookingContact(),
-      serviceProperties.getBookingMethods(),
-      serviceProperties.getLatestBookingTime(),
-      serviceProperties.getBookWhen(),
-      serviceProperties.getMinimumBookingPeriod(),
-      serviceProperties.getBookingNote(),
-      entityRef
-    );
-  }
-
-  private BookingInfo map(FlexibleLine flexibleLine, String entityRef) {
-    return map(
-      flexibleLine.getBookingContact(),
-      flexibleLine.getBookingMethods(),
-      flexibleLine.getLatestBookingTime(),
-      flexibleLine.getBookWhen(),
-      flexibleLine.getMinimumBookingPeriod(),
-      flexibleLine.getBookingNote(),
-      entityRef
-    );
-  }
-
-  private BookingInfo map(
-    ContactStructure contactStructure,
-    List<BookingMethodEnumeration> bookingMethodEnum,
-    LocalTime latestBookingTime,
-    PurchaseWhenEnumeration bookWhen,
-    Duration minimumBookingPeriod,
-    MultilingualString bookingNote,
-    String entityRef
-  ) {
-    if (contactStructure == null) {
-      return null;
-    }
-
-    ContactInfo contactInfo = ContactInfo
-      .of()
-      .withContactPerson(
-        contactStructure.getContactPerson() != null
-          ? contactStructure.getContactPerson().getValue()
-          : null
-      )
-      .withPhoneNumber(contactStructure.getPhone())
-      .withEMail(contactStructure.getEmail())
-      .withFaxNumber(contactStructure.getFax())
-      .withBookingUrl(contactStructure.getUrl())
-      .withAdditionalDetails(
-        contactStructure.getFurtherDetails() != null
-          ? contactStructure.getFurtherDetails().getValue()
-          : null
-      )
+    return new BookingInfoBuilder()
+      .withFlexibleLine(flexibleLine)
+      .withServiceJourney(serviceJourney)
+      .withStopPoint(stopPoint)
       .build();
+  }
 
-    EnumSet<BookingMethod> bookingMethods = bookingMethodEnum
-      .stream()
-      .map(bm -> BookingMethodMapper.map(entityRef, bm))
-      .filter(Objects::nonNull)
-      .collect(Collectors.toCollection(() -> EnumSet.noneOf(BookingMethod.class)));
+  private class BookingInfoBuilder {
 
-    BookingTime otpEarliestBookingTime = null;
-    BookingTime otpLatestBookingTime = null;
-    Duration minimumBookingNotice = null;
+    private ContactStructure bookingContact;
+    private List<BookingMethodEnumeration> bookingMethods = new ArrayList<>();
+    private LocalTime latestBookingTime;
+    private PurchaseWhenEnumeration bookWhen;
+    private Duration minimumBookingPeriod;
+    private MultilingualString bookingNote;
+    private boolean hasBookingInfo;
+    private String flexibleLineRef;
+    private String serviceJourneyRef;
+    private String stopPointRef;
 
-    if (latestBookingTime != null && bookWhen != null) {
-      otpEarliestBookingTime = mapEarliestBookingTime(bookWhen);
-      otpLatestBookingTime = mapLatestBookingTime(latestBookingTime, bookWhen);
-
-      if (minimumBookingPeriod != null) {
-        issueStore.add(
-          "BookingInfoPeriodIgnored",
-          "MinimumBookingPeriod cannot be set if latestBookingTime is set. " +
-          "MinimumBookingPeriod will be ignored for: %s, entity: %s",
-          contactStructure,
-          entityRef
+    private BookingInfoBuilder withFlexibleLine(FlexibleLine flexibleLine) {
+      if (flexibleLine != null) {
+        this.hasBookingInfo = true;
+        this.flexibleLineRef = ref("FlexibleLine", flexibleLine);
+        setIfNotEmpty(
+          flexibleLine.getBookingContact(),
+          flexibleLine.getBookingMethods(),
+          flexibleLine.getLatestBookingTime(),
+          flexibleLine.getBookWhen(),
+          flexibleLine.getMinimumBookingPeriod(),
+          flexibleLine.getBookingNote()
         );
       }
-    } else if (minimumBookingPeriod != null) {
-      minimumBookingNotice = minimumBookingPeriod;
+      return this;
     }
 
-    return new BookingInfo(
-      contactInfo,
-      bookingMethods,
-      otpEarliestBookingTime,
-      otpLatestBookingTime,
-      minimumBookingNotice,
-      Duration.ZERO,
-      bookingNote != null ? bookingNote.getValue() : null,
-      null,
-      null
-    );
+    private BookingInfoBuilder withServiceJourney(ServiceJourney serviceJourney) {
+      if (serviceJourney != null && serviceJourney.getFlexibleServiceProperties() != null) {
+        this.hasBookingInfo = true;
+        this.serviceJourneyRef = ref("ServiceJourney", serviceJourney);
+        FlexibleServiceProperties flexibleServiceProperties = serviceJourney.getFlexibleServiceProperties();
+        setIfNotEmpty(
+          flexibleServiceProperties.getBookingContact(),
+          flexibleServiceProperties.getBookingMethods(),
+          flexibleServiceProperties.getLatestBookingTime(),
+          flexibleServiceProperties.getBookWhen(),
+          flexibleServiceProperties.getMinimumBookingPeriod(),
+          flexibleServiceProperties.getBookingNote()
+        );
+      }
+      return this;
+    }
+
+    private BookingInfoBuilder withStopPoint(StopPointInJourneyPattern stopPoint) {
+      BookingArrangementsStructure bookingArrangements = stopPoint.getBookingArrangements();
+      if (bookingArrangements != null) {
+        this.hasBookingInfo = true;
+        this.stopPointRef = ref("StopPoint", stopPoint);
+        setIfNotEmpty(
+          bookingArrangements.getBookingContact(),
+          bookingArrangements.getBookingMethods(),
+          bookingArrangements.getLatestBookingTime(),
+          bookingArrangements.getBookWhen(),
+          bookingArrangements.getMinimumBookingPeriod(),
+          bookingArrangements.getBookingNote()
+        );
+      }
+      return this;
+    }
+
+    private BookingInfo build() {
+      if (!hasBookingInfo) {
+        return null;
+      }
+      String entityRefs = flexibleLineRef + '/' + serviceJourneyRef + '/' + stopPointRef;
+      return build(
+        bookingContact,
+        bookingMethods,
+        latestBookingTime,
+        bookWhen,
+        minimumBookingPeriod,
+        bookingNote,
+        entityRefs
+      );
+    }
+
+    private static BookingTime mapLatestBookingTime(
+      LocalTime latestBookingTime,
+      PurchaseWhenEnumeration purchaseWhen
+    ) {
+      return switch (purchaseWhen) {
+        case UNTIL_PREVIOUS_DAY -> new BookingTime(latestBookingTime, 1);
+        case DAY_OF_TRAVEL_ONLY, ADVANCE_ONLY, ADVANCE_AND_DAY_OF_TRAVEL -> new BookingTime(
+          latestBookingTime,
+          0
+        );
+        case TIME_OF_TRAVEL_ONLY -> null;
+        default -> throw new IllegalArgumentException("Value not supported: " + purchaseWhen);
+      };
+    }
+
+    private static BookingTime mapEarliestBookingTime(PurchaseWhenEnumeration purchaseWhen) {
+      return switch (purchaseWhen) {
+        case UNTIL_PREVIOUS_DAY,
+          ADVANCE_ONLY,
+          ADVANCE_AND_DAY_OF_TRAVEL,
+          TIME_OF_TRAVEL_ONLY -> null;
+        case DAY_OF_TRAVEL_ONLY -> new BookingTime(LocalTime.MIDNIGHT, 0);
+        default -> throw new IllegalArgumentException("Value not supported: " + purchaseWhen);
+      };
+    }
+
+    private static String ref(String type, EntityStructure entity) {
+      return type + "(" + entity.getId() + ")";
+    }
+
+    private BookingInfo build(
+      ContactStructure contactStructure,
+      List<BookingMethodEnumeration> bookingMethodEnum,
+      LocalTime latestBookingTime,
+      PurchaseWhenEnumeration bookWhen,
+      Duration minimumBookingPeriod,
+      MultilingualString bookingNote,
+      String entityRefs
+    ) {
+      if (contactStructure == null) {
+        return null;
+      }
+
+      ContactInfo contactInfo = ContactInfo
+        .of()
+        .withContactPerson(
+          contactStructure.getContactPerson() != null
+            ? contactStructure.getContactPerson().getValue()
+            : null
+        )
+        .withPhoneNumber(contactStructure.getPhone())
+        .withEMail(contactStructure.getEmail())
+        .withFaxNumber(contactStructure.getFax())
+        .withBookingUrl(contactStructure.getUrl())
+        .withAdditionalDetails(
+          contactStructure.getFurtherDetails() != null
+            ? contactStructure.getFurtherDetails().getValue()
+            : null
+        )
+        .build();
+
+      EnumSet<BookingMethod> filteredBookingMethods = bookingMethodEnum
+        .stream()
+        .map(bm -> BookingMethodMapper.map(entityRefs, bm))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toCollection(() -> EnumSet.noneOf(BookingMethod.class)));
+
+      BookingTime otpEarliestBookingTime = null;
+      BookingTime otpLatestBookingTime = null;
+      Duration minimumBookingNotice = null;
+
+      if (latestBookingTime != null && bookWhen != null) {
+        otpEarliestBookingTime = mapEarliestBookingTime(bookWhen);
+        otpLatestBookingTime = mapLatestBookingTime(latestBookingTime, bookWhen);
+
+        if (minimumBookingPeriod != null) {
+          issueStore.add(
+            "BookingInfoPeriodIgnored",
+            "MinimumBookingPeriod cannot be set if latestBookingTime is set. " +
+            "MinimumBookingPeriod will be ignored for: %s, entities: %s",
+            contactStructure,
+            entityRefs
+          );
+        }
+      } else if (minimumBookingPeriod != null) {
+        minimumBookingNotice = minimumBookingPeriod;
+      }
+
+      String bookingInfoMessage = bookingNote != null ? bookingNote.getValue() : null;
+      return new BookingInfo(
+        contactInfo,
+        filteredBookingMethods,
+        otpEarliestBookingTime,
+        otpLatestBookingTime,
+        minimumBookingNotice,
+        Duration.ZERO,
+        bookingInfoMessage,
+        null,
+        null
+      );
+    }
+
+    private void setIfNotEmpty(
+      ContactStructure bookingContact,
+      List<BookingMethodEnumeration> bookingMethods,
+      LocalTime latestBookingTime,
+      PurchaseWhenEnumeration bookWhen,
+      Duration minimumBookingPeriod,
+      MultilingualString bookingNote
+    ) {
+      if (bookingContact != null) {
+        this.bookingContact = bookingContact;
+      }
+      if (bookingMethods != null && !bookingMethods.isEmpty()) {
+        this.bookingMethods = bookingMethods;
+      }
+      if (latestBookingTime != null) {
+        this.latestBookingTime = latestBookingTime;
+      }
+      if (bookWhen != null) {
+        this.bookWhen = bookWhen;
+      }
+      if (minimumBookingPeriod != null) {
+        this.minimumBookingPeriod = minimumBookingPeriod;
+      }
+      if (bookingNote != null) {
+        this.bookingNote = bookingNote;
+      }
+    }
   }
 }

--- a/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
@@ -17,7 +17,7 @@ import org.rutebanken.netex.model.PurchaseWhenEnumeration;
 import org.rutebanken.netex.model.ServiceJourney;
 import org.rutebanken.netex.model.StopPointInJourneyPattern;
 
-public class BookingInfoMapperTest {
+class BookingInfoMapperTest {
 
   private static final String STOP_POINT_CONTACT = "StopPoint booking info contact";
   private static final String SERVICE_JOURNEY_CONTACT = "ServiceJourney booking info contact";
@@ -34,7 +34,7 @@ public class BookingInfoMapperTest {
   private final BookingInfoMapper subject = new BookingInfoMapper(DataImportIssueStore.NOOP);
 
   @Test
-  public void testMapBookingInfoPrecedence() {
+  void testMapBookingInfoPrecedence() {
     StopPointInJourneyPattern emptyStopPoint = new StopPointInJourneyPattern();
     ServiceJourney emptyServiceJourney = new ServiceJourney();
 
@@ -79,8 +79,37 @@ public class BookingInfoMapperTest {
     );
   }
 
+  /**
+   * When the contact details are set at the flexible line level, and bookWhen information is
+   * set at StopPoint level, the BookingInfo should contain both contact details and bookWhen
+   * information
+   */
   @Test
-  public void testMapBookingInfo() {
+  void testBookingInfoMergingAndOverriding() {
+    StopPointInJourneyPattern emptyStopPoint = new StopPointInJourneyPattern();
+    ServiceJourney emptyServiceJourney = new ServiceJourney();
+    LocalTime stopPointLatestBookingTime = FIVE_THIRTY;
+
+    StopPointInJourneyPattern stopPoint = new StopPointInJourneyPattern()
+      .withBookingArrangements(
+        new BookingArrangementsStructure()
+          .withLatestBookingTime(stopPointLatestBookingTime)
+          .withBookWhen(PurchaseWhenEnumeration.ADVANCE_AND_DAY_OF_TRAVEL)
+      );
+
+    FlexibleLine flexibleLine = new FlexibleLine()
+      .withBookingContact(
+        new ContactStructure()
+          .withContactPerson(new MultilingualString().withValue(FLEXIBLE_LINE_CONTACT))
+      );
+
+    BookingInfo bookingInfo = subject.map(stopPoint, null, flexibleLine);
+    assertEquals(stopPointLatestBookingTime, bookingInfo.getLatestBookingTime().getTime());
+    assertEquals(FLEXIBLE_LINE_CONTACT, bookingInfo.getContactInfo().getContactPerson());
+  }
+
+  @Test
+  void testMapBookingInfo() {
     ContactStructure contactStructure = new ContactStructure();
     contactStructure.setContactPerson(new MultilingualString().withValue(PERSON));
     contactStructure.setPhone(PHONE);
@@ -101,7 +130,7 @@ public class BookingInfoMapperTest {
   }
 
   @Test
-  public void testMapEarliestLatestBookingTime() {
+  void testMapEarliestLatestBookingTime() {
     ContactStructure contactStructure = new ContactStructure();
     contactStructure.setContactPerson(new MultilingualString().withValue(PERSON));
 
@@ -149,7 +178,7 @@ public class BookingInfoMapperTest {
   }
 
   @Test
-  public void testMapMinimumBookingNotice() {
+  void testMapMinimumBookingNotice() {
     ContactStructure contactStructure = new ContactStructure();
     contactStructure.setContactPerson(new MultilingualString().withValue(PERSON));
 


### PR DESCRIPTION
### Summary
As detailed in #5020, the current algorithm for importing booking information from NeTEx flexible lines does not allow for fine-grained merging of the different booking properties specified at different levels (FlexibleLine, ServiceJourney, StopPointInJourneyPattern).

This PR changes the import logic to make it possible to define common properties at a higher level (for example contact information at the flexible line level), and define more specific properties at lower level.

### Issue
closes #5020 

### Unit tests

Added unit test.

### Documentation

No

