### PR TITLE
JSON logging

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,0 +1,65 @@
+# Logging
+
+OTP uses [logback](http://logback.qos.ch/) and [slj4j](http://www.slf4j.org/) as a logging framework.
+Logging is configured in the `logback.xml` file inside the OTP jar file. See these frameworks for
+more documentation on log configuration.
+
+For developers, starting OTP using the `InteractiveOtpMain` is an easy way to configure debug
+logging.
+
+Some loggers useful for debugging.
+
+- `TRANSFERS_EXPORT`: Dump transfers to _transfers-debug.csv_ file.
+- `DATA_IMPORT_ISSUES`: Write issues to debug lag as well as to the issue report.
+- `REQ_LOG`: Router request log. Enable with `requestLogFile` config parameter in build config.
+- `org.opentripplanner.raptor.RaptorService`: Debug Raptor request and response
+
+## Format
+
+By default, OTP logs in plain text to the console. However, it is possible also log in JSON format.
+
+To enable it, set the Java property `otp.logging.format` to one of these values:
+
+- `plain`: regular plain text logging (default, no need to configure it)
+- `json`: Logstash-encoded JSON format understood by many log ingestion tools (Datadog, Loggly, Loki...)
+
+### Complete example
+
+```
+java -Dotp.logging.format=json -jar otp.jar --load --serve data
+```
+
+### Further customization
+
+If you want to customize the exact log output even further, then you can adapt `logback.xml` to 
+your needs. For example, Entur has their own custom log format configured as follows:
+
+```xml
+<!-- Entur's custom log format  -->
+<appender name="entur" class="ch.qos.logback.core.ConsoleAppender">
+  <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+     <providers>
+        <!-- provides the timestamp <timestamp/> -->
+        <!-- provides the version <version/> -->
+        <!-- provides the fields in the configured pattern -->
+        <pattern>
+           <!-- the pattern that defines what to include -->
+           <pattern>
+           {
+             "serviceContext": {
+               "service": "otp2"
+             },
+             "message": "%message\n%ex{full}",
+             "severity": "%level",
+             "reportLocation": {
+               "filePath": "%logger",
+               "lineNumber": "%line",
+               "functionName": "%method"
+              }
+            }
+            </pattern>
+        </pattern>
+     </providers>
+  </encoder>
+</appender>
+```

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -31,8 +31,14 @@ java -Dotp.logging.format=json -jar otp.jar --load --serve data
 
 ### Further customization
 
-If you want to customize the exact log output even further, then you can adapt `logback.xml` to 
-your needs. For example, Entur has their own custom log format configured as follows:
+If you want to customize the exact log output even further you can use your own logback configuration 
+by starting OTP with the following parameter:
+
+```
+java -Dlogback.configurationFile=/path/to/logback.xml -jar otp.jar --load --serve data
+```
+
+For example, Entur has their own custom log format configured as follows:
 
 ```xml
 <!-- Entur's custom log format  -->

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -16,7 +16,7 @@ Some loggers useful for debugging.
 
 ## Format
 
-By default, OTP logs in plain text to the console. However, it is possible also log in JSON format.
+By default, OTP logs in plain text to the console. However, it is possible to also log in JSON format.
 
 To enable it, set the Java property `otp.logging.format` to one of these values:
 

--- a/docs/Troubleshooting-Routing.md
+++ b/docs/Troubleshooting-Routing.md
@@ -168,27 +168,14 @@ OTP users in Helsinki have documented their best practices for coding railway pl
 OpenStreetMap. These guidelines are
 available [in the OSM Wiki.](https://wiki.openstreetmap.org/wiki/Digitransit#Editing_railway_platforms)
 
-## Debug logging
-
-OTP use [logback](http://logback.qos.ch/) and [slj4j](http://www.slf4j.org/) as a logging framework.
-Logging is configured in the _logback.xml_ file inside the OTP jar file. See these frameworks for
-more documentation on log configuration.
-
-For developers, starting OTP using the `InteractiveOtpMain` is an easy way to configure debug
-logging.
-
-Some useful loggers
-
-- `TRANSFERS_EXPORT` Dump transfers to _transfers-debug.csv_ file.
-- `DATA_IMPORT_ISSUES` Write issues to debug lag as well as to the issue report.
-- `REQ_LOG` Router request log. Enable with `requestLogFile` config parameter in build config.
-- `org.opentripplanner.raptor.RaptorService` Debug Raptor request and response
 
 ### Transit search
 
 The Raptor implementation support instrumentation of ACCEPT, REJECT, and DROP events for
 stop-arrivals and trip boardings. Use the SpeedTest to pass in a set of stops and/or a specific path
 to debug. This is useful when debugging why you do (not) get a particular result.
+
+Read the [logging page](Logging.md) for more information.
 
 ### GTFS Transfers.txt and NeTEx Interchange import
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,12 +55,13 @@ nav:
         - Introduction: 'Configuration.md'
         - Build: 'BuildConfiguration.md'
         - "Boarding Locations": 'BoardingLocations.md'
+        - "Street Graph Pruning": 'IslandPruning.md'
         - Router: 'RouterConfiguration.md'
         - Accessibility: 'Accessibility.md'
         - "Route Request": 'RouteRequest.md'
         - "Realtime Updaters" : 'UpdaterConfig.md'
         - "Routing Modes" : "RoutingModes.md"
-        - "Street Graph Pruning": 'IslandPruning.md'
+        - "Logging" : "Logging.md"
     - Preparing OSM Data: 'Preparing-OSM.md'
     - Netex and SIRI: 'Netex-Norway.md'
     - Security: 'Security.md'

--- a/pom.xml
+++ b/pom.xml
@@ -602,6 +602,13 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
         </dependency>
+        <!-- JSON-formatted logging -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>7.3</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- dependency injection -->
         <dependency>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,9 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+
+  <!-- by default we use the plain log format -->
+  <variable name="format" value="${otp.logging.format:-plain}" />
 
   <!--
     This suppresses the meta-log entries about Logback configuration (how Java).
     This is a stopgap measure.
-    The right solution is to make sure there are not logback.xml files from our dependency libraries on the classpath.
+    The right solution is to make sure there are no logback.xml files from our dependency libraries on the classpath.
    -->
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
@@ -11,16 +15,62 @@
        for logging and debug log messages will never make it to slf4j. -->
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
-  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="plain" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <!-- print out file and line number in parenthesis, which Eclipse and IDEA will link -->
       <pattern>%d{HH:mm:ss.SSS} %level \(%F:%L\) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <!-- Entur's custom log format  -->
+  <appender name="entur" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <providers>
+        <!-- provides the timestamp <timestamp/> -->
+        <!-- provides the version <version/> -->
+        <!-- provides the fields in the configured pattern -->
+        <pattern>
+          <!-- the pattern that defines what to include -->
+          <pattern>
+            {
+              "serviceContext": {
+                "service": "otp2"
+              },
+              "message": "%message\n%ex{full}",
+              "severity": "%level",
+              "reportLocation": {
+                "filePath": "%logger",
+                "lineNumber": "%line",
+                "functionName": "%method"
+              }
+            }
+          </pattern>
+        </pattern>
+      </providers>
+    </encoder>
+  </appender>
+
+  <!-- JSON format in the standard Logstash format understood by many log parsing tools  -->
+  <appender name="json" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <providers>
+        <timestamp/>
+        <mdc/>
+        <context/>
+        <logLevel/>
+        <loggerName/>
+        <threadName/>
+        <message/>
+        <logstashMarkers/>
+        <arguments/>
+        <stackTrace/>
+      </providers>
+    </encoder>
+  </appender>
+
   <!-- Change this to debug to let more messages through. -->
   <root level="info">
-    <appender-ref ref="stdout" />
+    <appender-ref ref="${format}" />
   </root>
 
   <!-- OTP LOGGERS -->

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -22,33 +22,6 @@
     </encoder>
   </appender>
 
-  <!-- Entur's custom log format  -->
-  <appender name="entur" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-      <providers>
-        <!-- provides the timestamp <timestamp/> -->
-        <!-- provides the version <version/> -->
-        <!-- provides the fields in the configured pattern -->
-        <pattern>
-          <!-- the pattern that defines what to include -->
-          <pattern>
-            {
-              "serviceContext": {
-                "service": "otp2"
-              },
-              "message": "%message\n%ex{full}",
-              "severity": "%level",
-              "reportLocation": {
-                "filePath": "%logger",
-                "lineNumber": "%line",
-                "functionName": "%method"
-              }
-            }
-          </pattern>
-        </pattern>
-      </providers>
-    </encoder>
-  </appender>
 
   <!-- JSON format in the standard Logstash format understood by many log parsing tools  -->
   <appender name="json" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
### Summary

This allows users of OTP to switch to JSON-formatted logs by setting an command line parameter like this:

```
java -Dotp.logging.format=json -jar otp.jar --load --serve data
```

A (pretty-printed) example of a log message looks like this:

```
{
  "@timestamp": "2023-04-03T13:28:08.058026697+02:00",
  "level": "INFO",
  "logger_name": "org.opentripplanner.routing.graph.SerializedGraphObject",
  "thread_name": "main",
  "message": "Reading graph from 'tampere/graph.obj'"
}
```

I've also included Entur's configuration in this PR. We can discuss if this is necessary as you may have more customization needs that you don't want to upstream.

### Issue

Closes #5015 

### Documentation

Added.

cc @derhuerst @hbruch 