### PR TITLE
Fix staySeated transfers in RealtimeResolver

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolver.java
@@ -3,6 +3,8 @@ package org.opentripplanner.ext.realtimeresolver;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.transit.service.TransitService;
 
 public class RealtimeResolver {
@@ -21,22 +23,51 @@ public class RealtimeResolver {
       var legs = it
         .getLegs()
         .stream()
-        .map(l -> {
-          var ref = l.getLegReference();
+        .map(leg -> {
+          var ref = leg.getLegReference();
           if (ref == null) {
-            return l;
-          }
-
-          var leg = ref.getLeg(transitService);
-          if (leg != null) {
             return leg;
           }
 
-          return l;
+          // Only ScheduledTransitLeg has leg references atm, so this check is just to be future-proof
+          if (!(leg.isScheduledTransitLeg())) {
+            return leg;
+          }
+
+          var realtimeLeg = ref.getLeg(transitService);
+          if (realtimeLeg != null) {
+            return combineReferenceWithOriginal(
+              realtimeLeg.asScheduledTransitLeg(),
+              leg.asScheduledTransitLeg()
+            );
+          }
+          return leg;
         })
         .collect(Collectors.toList());
 
       it.setLegs(legs);
     });
+  }
+
+  private static Leg combineReferenceWithOriginal(
+    ScheduledTransitLeg reference,
+    ScheduledTransitLeg original
+  ) {
+    var leg = new ScheduledTransitLeg(
+      reference.getTripTimes(),
+      reference.getTripPattern(),
+      reference.getBoardStopPosInPattern(),
+      reference.getAlightStopPosInPattern(),
+      reference.getStartTime(),
+      reference.getEndTime(),
+      reference.getServiceDate(),
+      reference.getZoneId(),
+      original.getTransferFromPrevLeg(),
+      original.getTransferToNextLeg(),
+      original.getGeneralizedCost(),
+      original.accessibilityScore()
+    );
+    reference.getTransitAlerts().forEach(leg::addAlert);
+    return leg;
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/network/TripPatternBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/TripPatternBuilder.java
@@ -82,6 +82,11 @@ public final class TripPatternBuilder
     return this;
   }
 
+  public TripPatternBuilder withScheduledTimeTable(Timetable scheduledTimetable) {
+    this.scheduledTimetable = scheduledTimetable;
+    return this;
+  }
+
   public TripPatternBuilder withCreatedByRealtimeUpdater(boolean createdByRealtimeUpdate) {
     this.createdByRealtimeUpdate = createdByRealtimeUpdate;
     return this;


### PR DESCRIPTION
### Summary

This PR fixes an issue where RealtimeResolver will drop the information about constrained transfers like "staySeated". This happens when the `RealtimeResolver` feature is on and a search is done using `ignoreRealtimeUpdates = true`.

This PR simply re-adds the original information that is not available in the response from `ScheduledTransitLegReference.getLeg()`. Other than that it is mostly testing and renaming.


### Unit tests

I added testcases for the specific issue and also for the general functionality of `populateLegsWithRealtime()`. And I removed the old test since it is covered by the new tests.

There's a lot of lines spent on setting up the context for the test cases. I'm a bit new to the codebase, maybe there is an easier way?
