### PR TITLE
Fix banning of route and agency in GraphQL API

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/legacygraphqlapi/mapping/RouteRequestMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/legacygraphqlapi/mapping/RouteRequestMapperTest.java
@@ -3,14 +3,19 @@ package org.opentripplanner.ext.legacygraphqlapi.mapping;
 import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 import graphql.ExecutionInput;
 import graphql.execution.ExecutionId;
+import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.ext.fares.impl.DefaultFareService;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
@@ -22,6 +27,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graphfinder.GraphFinder;
 import org.opentripplanner.service.vehiclepositions.internal.DefaultVehiclePositionService;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
+import org.opentripplanner.test.support.VariableSource;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 
@@ -49,19 +55,6 @@ class RouteRequestMapperTest implements PlanTestConstants {
 
   @Test
   void parkingFilters() {
-    ExecutionInput executionInput = ExecutionInput
-      .newExecutionInput()
-      .query("")
-      .operationName("plan")
-      .context(context)
-      .locale(Locale.ENGLISH)
-      .build();
-
-    var executionContext = newExecutionContextBuilder()
-      .executionInput(executionInput)
-      .executionId(ExecutionId.from(this.getClass().getName()))
-      .build();
-
     Map<String, Object> arguments = Map.of(
       "parking",
       Map.of(
@@ -81,10 +74,7 @@ class RouteRequestMapperTest implements PlanTestConstants {
       )
     );
 
-    var env = DataFetchingEnvironmentImpl
-      .newDataFetchingEnvironment(executionContext)
-      .arguments(arguments)
-      .build();
+    var env = executionContext(arguments);
 
     var routeRequest = RouteRequestMapper.toRouteRequest(env, context);
 
@@ -100,5 +90,52 @@ class RouteRequestMapperTest implements PlanTestConstants {
       parking.preferred().toString()
     );
     assertEquals(555, parking.unpreferredCost());
+  }
+
+  static Stream<Arguments> banningCases = Stream.of(
+    of(Map.of(), "[TransitFilterRequest{}]"),
+    of(
+      Map.of("routes", "trimet:555"),
+      "[TransitFilterRequest{not: [SelectRequest{transportModes: [], routes: [trimet:555]}]}]"
+    ),
+    of(
+      Map.of("agencies", "trimet:666"),
+      "[TransitFilterRequest{not: [SelectRequest{transportModes: [], agencies: [trimet:666]}]}]"
+    ),
+    of(
+      Map.of("agencies", "trimet:666", "routes", "trimet:444"),
+      "[TransitFilterRequest{not: [SelectRequest{transportModes: [], routes: [trimet:444]}, SelectRequest{transportModes: [], agencies: [trimet:666]}]}]"
+    )
+  );
+
+  @ParameterizedTest
+  @VariableSource("banningCases")
+  void banning(Map<String, Object> banned, String expectedFilters) {
+    Map<String, Object> arguments = Map.of("banned", banned);
+
+    var env = executionContext(arguments);
+    var routeRequest = RouteRequestMapper.toRouteRequest(env, context);
+    assertNotNull(routeRequest);
+
+    assertEquals(expectedFilters, routeRequest.journey().transit().filters().toString());
+  }
+
+  private DataFetchingEnvironment executionContext(Map<String, Object> arguments) {
+    ExecutionInput executionInput = ExecutionInput
+      .newExecutionInput()
+      .query("")
+      .operationName("plan")
+      .context(context)
+      .locale(Locale.ENGLISH)
+      .build();
+
+    var executionContext = newExecutionContextBuilder()
+      .executionInput(executionInput)
+      .executionId(ExecutionId.from(this.getClass().getName()))
+      .build();
+    return DataFetchingEnvironmentImpl
+      .newDataFetchingEnvironment(executionContext)
+      .arguments(arguments)
+      .build();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/mapping/RouteRequestMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/mapping/RouteRequestMapper.java
@@ -171,23 +171,17 @@ public class RouteRequestMapper {
     if (hasArgument(environment, "banned") || hasArgument(environment, "transportModes")) {
       var filterRequestBuilder = TransitFilterRequest.of();
 
-      if (hasArgument(environment, "banned.routes")) {
-        callWith.argument(
-          "banned.routes",
-          s ->
-            filterRequestBuilder.addNot(SelectRequest.of().withRoutesFromString((String) s).build())
-        );
-      }
+      callWith.argument(
+        "banned.routes",
+        s ->
+          filterRequestBuilder.addNot(SelectRequest.of().withRoutesFromString((String) s).build())
+      );
 
-      if (hasArgument(environment, "banned.agencies")) {
-        callWith.argument(
-          "banned.agencies",
-          s ->
-            filterRequestBuilder.addNot(
-              SelectRequest.of().withAgenciesFromString((String) s).build()
-            )
-        );
-      }
+      callWith.argument(
+        "banned.agencies",
+        s ->
+          filterRequestBuilder.addNot(SelectRequest.of().withAgenciesFromString((String) s).build())
+      );
 
       callWith.argument("banned.trips", request.journey().transit()::setBannedTripsFromString);
 

--- a/src/main/java/org/opentripplanner/model/modes/ExcludeAllTransitFilter.java
+++ b/src/main/java/org/opentripplanner/model/modes/ExcludeAllTransitFilter.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.model.modes;
 
 import java.io.Serializable;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -26,5 +27,10 @@ public final class ExcludeAllTransitFilter implements Serializable, TransitFilte
   @Override
   public boolean matchTripTimes(TripTimes trip) {
     return false;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.of(ExcludeAllTransitFilter.class).toString();
   }
 }


### PR DESCRIPTION
### Summary

This fixes an issue where `banned.routes` was not taken into account when constructing the transit filters.

The problem was that `hasArgument("banned.routes")` doesn't work with names with a dot in them. Fortunately, the checks are not needed and can simply be removed as `callWith.argument()` already does the right thing.

### Unit tests

Added.