### PR TITLE
Log results of Siri-ET updates

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
@@ -39,6 +39,10 @@ public class TimetableHelperTest {
   private static final FeedScopedId SCOPED_STOP_ID = new FeedScopedId(FEED_ID, STOP_ID);
   private static final FeedScopedId SCOPED_AGENCY_ID = new FeedScopedId(FEED_ID, AGENCY_ID);
   private static final FeedScopedId SCOPED_LINE_ID = new FeedScopedId(FEED_ID, LINE_ID);
+  private static final ZonedDateTime START_OF_SERVICE = ZonedDateTime.of(
+    LocalDateTime.of(2022, 12, 9, 0, 0),
+    ZoneId.of("CET")
+  );
 
   private TripTimes tripTimes;
 
@@ -74,7 +78,6 @@ public class TimetableHelperTest {
   @Test
   public void testApplyUpdates_MapPredictionInaccurate_EstimatedCall() {
     // Arrange
-    var startOfService = ZonedDateTime.of(LocalDateTime.of(2022, 12, 9, 0, 0), ZoneId.of("CET"));
 
     CallWrapper estimatedCall = TestCall
       .of()
@@ -85,7 +88,7 @@ public class TimetableHelperTest {
       .build();
 
     // Act
-    TimetableHelper.applyUpdates(startOfService, tripTimes, 0, false, false, estimatedCall, null);
+    TimetableHelper.applyUpdates(START_OF_SERVICE, tripTimes, 0, false, false, estimatedCall, null);
 
     // Assert
     assertStatuses(0, OccupancyStatus.MANY_SEATS_AVAILABLE, false, false, true);
@@ -94,7 +97,6 @@ public class TimetableHelperTest {
   @Test
   public void testApplyUpdates_CancellationPriorityOverPredictionInaccurate_EstimatedCall() {
     // Arrange
-    var startOfService = ZonedDateTime.of(LocalDateTime.of(2022, 12, 9, 0, 0), ZoneId.of("CET"));
 
     CallWrapper estimatedCall = TestCall
       .of()
@@ -105,7 +107,7 @@ public class TimetableHelperTest {
       .build();
 
     // Act
-    TimetableHelper.applyUpdates(startOfService, tripTimes, 0, false, false, estimatedCall, null);
+    TimetableHelper.applyUpdates(START_OF_SERVICE, tripTimes, 0, false, false, estimatedCall, null);
 
     // Assert
 
@@ -115,9 +117,8 @@ public class TimetableHelperTest {
   @Test
   public void testApplyUpdates_CancellationPriorityOverPredictionInaccurate_RecordedCall() {
     // Arrange
-    var startOfService = ZonedDateTime.of(LocalDateTime.of(2022, 12, 9, 0, 0), ZoneId.of("CET"));
 
-    ZonedDateTime actualTime = startOfService.plus(Duration.ofHours(1));
+    ZonedDateTime actualTime = START_OF_SERVICE.plus(Duration.ofHours(1));
     CallWrapper recordedCall = TestCall
       .of()
       .withStopPointRef(STOP_ID)
@@ -128,7 +129,7 @@ public class TimetableHelperTest {
       .build();
 
     // Act
-    TimetableHelper.applyUpdates(startOfService, tripTimes, 0, false, false, recordedCall, null);
+    TimetableHelper.applyUpdates(START_OF_SERVICE, tripTimes, 0, false, false, recordedCall, null);
 
     // Assert
 
@@ -138,7 +139,6 @@ public class TimetableHelperTest {
   @Test
   public void testApplyUpdates_PredictionInaccuratePriorityOverRecorded() {
     // Arrange
-    var startOfService = ZonedDateTime.of(LocalDateTime.of(2022, 12, 9, 0, 0), ZoneId.of("CET"));
 
     CallWrapper recordedCall = TestCall
       .of()
@@ -146,11 +146,11 @@ public class TimetableHelperTest {
       .withPredictionInaccurate(true)
       .withOccupancy(OccupancyEnumeration.FULL)
       .withCancellation(false)
-      .withActualDepartureTime(startOfService.plus(Duration.ofHours(1)))
+      .withActualDepartureTime(START_OF_SERVICE.plus(Duration.ofHours(1)))
       .build();
 
     // Act
-    TimetableHelper.applyUpdates(startOfService, tripTimes, 0, false, false, recordedCall, null);
+    TimetableHelper.applyUpdates(START_OF_SERVICE, tripTimes, 0, false, false, recordedCall, null);
 
     // Assert
     assertStatuses(0, OccupancyStatus.FULL, false, false, true);
@@ -159,7 +159,6 @@ public class TimetableHelperTest {
   @Test
   public void testApplyUpdates_ActualTimeResultsInRecorded() {
     // Arrange
-    var startOfService = ZonedDateTime.of(LocalDateTime.of(2022, 12, 9, 0, 0), ZoneId.of("CET"));
 
     CallWrapper recordedCall = TestCall
       .of()
@@ -167,11 +166,11 @@ public class TimetableHelperTest {
       .withPredictionInaccurate(false)
       .withOccupancy(OccupancyEnumeration.STANDING_AVAILABLE)
       .withCancellation(false)
-      .withActualDepartureTime(startOfService.plus(Duration.ofHours(1)))
+      .withActualDepartureTime(START_OF_SERVICE.plus(Duration.ofHours(1)))
       .build();
 
     // Act
-    TimetableHelper.applyUpdates(startOfService, tripTimes, 0, false, false, recordedCall, null);
+    TimetableHelper.applyUpdates(START_OF_SERVICE, tripTimes, 0, false, false, recordedCall, null);
 
     // Assert
     assertStatuses(0, OccupancyStatus.STANDING_ROOM_ONLY, false, true, false);
@@ -180,12 +179,11 @@ public class TimetableHelperTest {
   @Test
   public void testApplyUpdates_JourneyDefaultValues() {
     // Arrange
-    var startOfService = ZonedDateTime.of(LocalDateTime.of(2022, 12, 9, 0, 0), ZoneId.of("CET"));
     CallWrapper recordedCall = TestCall.of().withStopPointRef(STOP_ID).build();
 
     // Act
     TimetableHelper.applyUpdates(
-      startOfService,
+      START_OF_SERVICE,
       tripTimes,
       0,
       false,

--- a/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -195,37 +194,6 @@ public class TimetableHelperTest {
 
     // Assert
     assertStatuses(0, OccupancyStatus.STANDING_ROOM_ONLY, false, false, true);
-  }
-
-  /**
-   * In the UK profile the arrival time is optional, so we use the departure time as the fallback.
-   */
-  @Test
-  public void applyUpdateWithoutArrivalTime() {
-    // Arrange
-    final ZonedDateTime aimedDepartureTime = START_OF_SERVICE.plusHours(1);
-    CallWrapper recordedCall = TestCall
-      .of()
-      .withStopPointRef(STOP_ID)
-      .withExpectedDepartureTime(aimedDepartureTime)
-      .build();
-
-    // Act
-    TimetableHelper.applyUpdates(
-      START_OF_SERVICE,
-      tripTimes,
-      0,
-      true,
-      recordedCall,
-      OccupancyEnumeration.STANDING_AVAILABLE
-    );
-
-    // Assert
-    var arrivalTime = LocalTime.ofSecondOfDay(tripTimes.getArrivalTime(0));
-    var departureTime = LocalTime.ofSecondOfDay(tripTimes.getDepartureTime(0));
-
-    assertEquals(aimedDepartureTime.toLocalTime(), arrivalTime);
-    assertEquals(aimedDepartureTime.toLocalTime(), departureTime);
   }
 
   private void assertStatuses(

--- a/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -194,6 +195,37 @@ public class TimetableHelperTest {
 
     // Assert
     assertStatuses(0, OccupancyStatus.STANDING_ROOM_ONLY, false, false, true);
+  }
+
+  /**
+   * In the UK profile the arrival time is optional, so we use the departure time as the fallback.
+   */
+  @Test
+  public void applyUpdateWithoutArrivalTime() {
+    // Arrange
+    final ZonedDateTime aimedDepartureTime = START_OF_SERVICE.plusHours(1);
+    CallWrapper recordedCall = TestCall
+      .of()
+      .withStopPointRef(STOP_ID)
+      .withExpectedDepartureTime(aimedDepartureTime)
+      .build();
+
+    // Act
+    TimetableHelper.applyUpdates(
+      START_OF_SERVICE,
+      tripTimes,
+      0,
+      true,
+      recordedCall,
+      OccupancyEnumeration.STANDING_AVAILABLE
+    );
+
+    // Assert
+    var arrivalTime = LocalTime.ofSecondOfDay(tripTimes.getArrivalTime(0));
+    var departureTime = LocalTime.ofSecondOfDay(tripTimes.getDepartureTime(0));
+
+    assertEquals(aimedDepartureTime.toLocalTime(), arrivalTime);
+    assertEquals(aimedDepartureTime.toLocalTime(), departureTime);
   }
 
   private void assertStatuses(

--- a/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
@@ -4,11 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -41,7 +41,7 @@ public class TimetableHelperTest {
   private static final FeedScopedId SCOPED_LINE_ID = new FeedScopedId(FEED_ID, LINE_ID);
   private static final ZonedDateTime START_OF_SERVICE = ZonedDateTime.of(
     LocalDateTime.of(2022, 12, 9, 0, 0),
-    ZoneId.of("CET")
+    ZoneIds.CET
   );
 
   private TripTimes tripTimes;

--- a/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/TimetableHelperTest.java
@@ -23,7 +23,7 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import uk.org.siri.siri20.OccupancyEnumeration;
 
-public class TimeTableHelperTest {
+public class TimetableHelperTest {
 
   private static final String FEED_ID = "FEED_ID";
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -64,7 +64,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
    * messages.
    */
   private final SiriTripPatternCache tripPatternCache;
-  private final ZoneId timeZone;
+  private final TransitModel transitModel;
 
   private final TransitService transitService;
   private final TransitLayerUpdater transitLayerUpdater;
@@ -92,7 +92,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     TimetableSnapshotSourceParameters parameters,
     TransitModel transitModel
   ) {
-    this.timeZone = transitModel.getTimeZone();
+    this.transitModel = transitModel;
     this.transitService = new DefaultTransitService(transitModel);
     this.transitLayerUpdater = transitModel.getTransitLayerUpdater();
     this.maxSnapshotFrequency = parameters.maxSnapshotFrequencyMs();
@@ -135,13 +135,11 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
   /**
    * Method to apply a trip update list to the most recent version of the timetable snapshot.
    *
-   * @param transitModel transitModel to update (needed for adding/changing stop patterns)
    * @param fullDataset  true iff the list with updates represent all updates that are active right
    *                     now, i.e. all previous updates should be disregarded
    * @param updates      SIRI VehicleMonitoringDeliveries that should be applied atomically
    */
   public UpdateResult applyEstimatedTimetable(
-    TransitModel transitModel,
     @Nullable SiriFuzzyTripMatcher fuzzyTripMatcher,
     EntityResolver entityResolver,
     String feedId,
@@ -339,7 +337,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       pattern,
       estimatedVehicleJourney,
       serviceDate,
-      timeZone,
+      transitModel.getTimeZone(),
       entityResolver
     )
       .build();
@@ -449,7 +447,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
   }
 
   private boolean purgeExpiredData() {
-    final LocalDate today = LocalDate.now(timeZone);
+    final LocalDate today = LocalDate.now(transitModel.getTimeZone());
     final LocalDate previously = today.minusDays(2); // Just to be safe...
 
     if (lastPurgeDate != null && lastPurgeDate.compareTo(previously) > 0) {

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -382,7 +382,6 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
 
         var f = saveResultOnGraph.execute((graph, transitModel) -> {
           var results = snapshotSource.applyEstimatedTimetable(
-            transitModel,
             fuzzyTripMatcher,
             entityResolver,
             feedId,

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -9,7 +9,7 @@ import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
-import org.opentripplanner.updater.ResultLogger;
+import org.opentripplanner.updater.spi.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.opentripplanner.updater.trip.metrics.TripUpdateMetrics;

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -102,7 +102,6 @@ public class SiriETUpdater extends PollingGraphUpdater {
         if (etds != null) {
           saveResultOnGraph.execute((graph, transitModel) -> {
             var result = snapshotSource.applyEstimatedTimetable(
-              transitModel,
               fuzzyTripMatcher,
               entityResolver,
               feedId,

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -9,6 +9,7 @@ import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
+import org.opentripplanner.updater.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.opentripplanner.updater.trip.metrics.TripUpdateMetrics;
@@ -108,6 +109,7 @@ public class SiriETUpdater extends PollingGraphUpdater {
               fullDataset,
               etds
             );
+            ResultLogger.logUpdateResult(feedId, "siri-et", result);
             recordMetrics.accept(result);
             if (markPrimed) primed = true;
           });

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -124,7 +124,6 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
 
       super.saveResultOnGraph.execute((graph, transitModel) -> {
         snapshotSource.applyEstimatedTimetable(
-          transitModel,
           fuzzyTripMatcher(),
           entityResolver(),
           feedId,
@@ -150,7 +149,6 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
         try {
           long t1 = System.currentTimeMillis();
           var result = snapshotSource.applyEstimatedTimetable(
-            transitModel,
             fuzzyTripMatcher(),
             entityResolver(),
             feedId,

--- a/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
+++ b/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
@@ -14,11 +14,7 @@ public class ResultLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger(ResultLogger.class);
 
-  public static void logUpdateResult(
-    String feedId,
-    String type,
-    UpdateResult updateResult
-  ) {
+  public static void logUpdateResult(String feedId, String type, UpdateResult updateResult) {
     var totalUpdates = updateResult.successful() + updateResult.failed();
     if (totalUpdates > 0) {
       LOG.info(

--- a/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
+++ b/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
@@ -17,9 +17,9 @@ public class ResultLogger {
   public static void logUpdateResult(
     String feedId,
     String type,
-    int totalUpdates,
     UpdateResult updateResult
   ) {
+    var totalUpdates = updateResult.successful() + updateResult.failed();
     if (totalUpdates > 0) {
       LOG.info(
         "[feedId: {}, type={}] {} of {} update messages were applied successfully (success rate: {}%)",

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -332,18 +332,17 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     var updateResult = UpdateResult.ofResults(results);
 
     if (fullDataset) {
-      logUpdateResult(feedId, updates.size(), failuresByRelationship, updateResult);
+      logUpdateResult(feedId, failuresByRelationship, updateResult);
     }
     return updateResult;
   }
 
   private static void logUpdateResult(
     String feedId,
-    int updates,
     Map<TripDescriptor.ScheduleRelationship, Integer> failuresByRelationship,
     UpdateResult updateResult
   ) {
-    ResultLogger.logUpdateResult(feedId, "trip-updates", updates, updateResult);
+    ResultLogger.logUpdateResult(feedId, "trip-updates", updateResult);
 
     if (!failuresByRelationship.isEmpty()) {
       LOG.info("[feedId: {}] Failures by scheduleRelationship {}", feedId, failuresByRelationship);

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -342,7 +342,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     Map<TripDescriptor.ScheduleRelationship, Integer> failuresByRelationship,
     UpdateResult updateResult
   ) {
-    ResultLogger.logUpdateResult(feedId, "trip-updates", updateResult);
+    ResultLogger.logUpdateResult(feedId, "gtfs-rt-trip-updates", updateResult);
 
     if (!failuresByRelationship.isEmpty()) {
       LOG.info("[feedId: {}] Failures by scheduleRelationship {}", feedId, failuresByRelationship);

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
@@ -137,7 +137,6 @@ public class VehiclePositionPatternMatcher {
     ResultLogger.logUpdateResult(
       feedId,
       "vehicle-positions",
-      vehiclePositions.size(),
       updateResult
     );
 

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
@@ -134,11 +134,7 @@ public class VehiclePositionPatternMatcher {
       .toList();
     // needs to be put into a new list so the types are correct
     var updateResult = UpdateResult.ofResults(new ArrayList<>(results));
-    ResultLogger.logUpdateResult(
-      feedId,
-      "vehicle-positions",
-      updateResult
-    );
+    ResultLogger.logUpdateResult(feedId, "gtfs-rt-vehicle-positions", updateResult);
 
     return updateResult;
   }


### PR DESCRIPTION
### Summary

~I used the Siri-ET updater on a UK feed and noticed that it doesn't have arrival times in the middle of the trip (just the last stop). Therefore I'm using the departure time as a fallback when the arrival time doesn't exist.~

~Right now there is already code for that, but it's only applied to the first or last stop.~

~@lassetyr Will this change cause problems in Norway?~

This now does some very light refactoring and adds logging of the results to the Siri-ET updater.

### Issue

Closes #5031