### PR TITLE
Add documentation for timetable updater config, use duration

### DIFF
--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -613,7 +613,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
   ],
   "timetableUpdates" : {
     "purgeExpiredData" : false,
-    "snapshotFrequency" : "2s"
+    "maxSnapshotFrequency" : "2s"
   },
   "updaters" : [
     {

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -39,6 +39,8 @@ A full list of them can be found in the [RouteRequest](RouteRequest.md).
 | [flex](sandbox/Flex.md)                                                                   |        `object`       | Configuration for flex routing.                                                                   | *Optional* |               |  2.1  |
 | [routingDefaults](RouteRequest.md)                                                        |        `object`       | The default parameters for the routing query.                                                     | *Optional* |               |  2.0  |
 | timetableUpdates                                                                          |        `object`       | Global configuration for timetable updaters.                                                      | *Optional* |               |  2.2  |
+|    [maxSnapshotFrequency](#timetableUpdates_maxSnapshotFrequency)                         |       `duration`      | How long a snapshot should be cached.                                                             | *Optional* | `"PT1S"`      |  2.2  |
+|    purgeExpiredData                                                                       |       `boolean`       | Should expired realtime data be purged from the graph. Apply to GTFS-RT and Siri updates.         | *Optional* | `true`        |  2.2  |
 | [transit](#transit)                                                                       |        `object`       | Configuration for transit searches with RAPTOR.                                                   | *Optional* |               |   na  |
 |    [iterationDepartureStepInSeconds](#transit_iterationDepartureStepInSeconds)            |       `integer`       | Step for departure times between each RangeRaptor iterations.                                     | *Optional* | `60`          |   na  |
 |    [maxNumberOfTransfers](#transit_maxNumberOfTransfers)                                  |       `integer`       | This parameter is used to allocate enough memory space for Raptor.                                | *Optional* | `12`          |   na  |
@@ -143,6 +145,15 @@ search-window.
 
 The search aborts after this duration and any paths found are returned to the client.
 
+
+<h3 id="timetableUpdates_maxSnapshotFrequency">maxSnapshotFrequency</h3>
+
+**Since version:** `2.2` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT1S"`   
+**Path:** /timetableUpdates 
+
+How long a snapshot should be cached.
+
+If a timetable snapshot is requested less than this number of milliseconds after the previous snapshot, then return the same instance. Throttles the potentially resource-consuming task of duplicating a TripPattern → Timetable map and indexing the new Timetables. Applies to GTFS-RT and Siri updates.
 
 <h3 id="transit">transit</h3>
 
@@ -600,6 +611,10 @@ HTTP headers to add to the request. Any header key, value can be inserted.
       "expansionFactor" : 0.25
     }
   ],
+  "timetableUpdates" : {
+    "purgeExpiredData" : false,
+    "snapshotFrequency" : "2s"
+  },
   "updaters" : [
     {
       "type" : "real-time-alerts",

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/UpdatersConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/UpdatersConfig.java
@@ -123,7 +123,7 @@ public class UpdatersConfig implements UpdatersParameters {
           "Throttles the potentially resource-consuming task of duplicating a TripPattern → Timetable map and indexing the new Timetables. " +
           "Applies to GTFS-RT and Siri updates."
         )
-        .asInt(dflt.maxSnapshotFrequencyMs()),
+        .asDuration(dflt.maxSnapshotFrequency()),
       c
         .of("purgeExpiredData")
         .since(V2_2)

--- a/src/main/java/org/opentripplanner/updater/TimetableSnapshotSourceParameters.java
+++ b/src/main/java/org/opentripplanner/updater/TimetableSnapshotSourceParameters.java
@@ -1,24 +1,27 @@
 package org.opentripplanner.updater;
 
+import java.time.Duration;
+
 /**
- * {@link org.opentripplanner.standalone.config.routerconfig.UpdatersConfig#timetableUpdates(org.opentripplanner.standalone.config.framework.json.NodeAdapter)}
+ * {@link
+ * org.opentripplanner.standalone.config.routerconfig.UpdatersConfig#timetableUpdates(org.opentripplanner.standalone.config.framework.json.NodeAdapter)}
  */
 public record TimetableSnapshotSourceParameters(
-  int maxSnapshotFrequencyMs,
+  Duration maxSnapshotFrequency,
   boolean purgeExpiredData
 ) {
   public static final TimetableSnapshotSourceParameters DEFAULT = new TimetableSnapshotSourceParameters(
-    1000,
+    Duration.ofSeconds(1),
     true
   );
 
   /* Factory functions, used instead of a builder - useful in tests. */
 
-  public TimetableSnapshotSourceParameters withMaxSnapshotFrequencyMs(int maxSnapshotFrequencyMs) {
-    return new TimetableSnapshotSourceParameters(maxSnapshotFrequencyMs, this.purgeExpiredData);
+  public TimetableSnapshotSourceParameters withMaxSnapshotFrequency(Duration maxSnapshotFrequency) {
+    return new TimetableSnapshotSourceParameters(maxSnapshotFrequency, this.purgeExpiredData);
   }
 
   public TimetableSnapshotSourceParameters withPurgeExpiredData(boolean purgeExpiredData) {
-    return new TimetableSnapshotSourceParameters(this.maxSnapshotFrequencyMs, purgeExpiredData);
+    return new TimetableSnapshotSourceParameters(this.maxSnapshotFrequency, purgeExpiredData);
   }
 }

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -21,6 +21,7 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
 import de.mfdz.MfdzRealtimeExtensions;
 import java.text.ParseException;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -109,7 +110,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * snapshot, just return the same one. Throttles the potentially resource-consuming task of
    * duplicating a TripPattern → Timetable map and indexing the new Timetables.
    */
-  private final int maxSnapshotFrequencyMs;
+  private final Duration maxSnapshotFrequency;
 
   /**
    * The last committed snapshot that was handed off to a routing thread. This snapshot may be given
@@ -143,8 +144,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   }
 
   /**
-   * Constructor is package local to allow unit-tests to provide their own clock, not using
-   * system time.
+   * Constructor is package local to allow unit-tests to provide their own clock, not using system
+   * time.
    */
   TimetableSnapshotSource(
     TimetableSnapshotSourceParameters parameters,
@@ -156,7 +157,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     this.transitLayerUpdater = transitModel.getTransitLayerUpdater();
     this.deduplicator = transitModel.getDeduplicator();
     this.serviceCodes = transitModel.getServiceCodes();
-    this.maxSnapshotFrequencyMs = parameters.maxSnapshotFrequencyMs();
+    this.maxSnapshotFrequency = parameters.maxSnapshotFrequency();
     this.purgeExpiredData = parameters.purgeExpiredData();
     this.localDateNow = localDateNow;
 
@@ -198,10 +199,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * feed when matching IDs.
    *
    * @param backwardsDelayPropagationType Defines when delays are propagated to previous stops and
-   *                                     if these stops are given the NO_DATA flag.
-   * @param fullDataset true if the list with updates represent all updates that are active right
-   *                    now, i.e. all previous updates should be disregarded
-   * @param updates     GTFS-RT TripUpdate's that should be applied atomically
+   *                                      if these stops are given the NO_DATA flag.
+   * @param fullDataset                   true if the list with updates represent all updates that
+   *                                      are active right now, i.e. all previous updates should be
+   *                                      disregarded
+   * @param updates                       GTFS-RT TripUpdate's that should be applied atomically
    */
   public UpdateResult applyTripUpdates(
     GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
@@ -360,7 +362,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
   private TimetableSnapshot getTimetableSnapshot(final boolean force) {
     final long now = System.currentTimeMillis();
-    if (force || now - lastSnapshotTime > maxSnapshotFrequencyMs) {
+    if (force || now - lastSnapshotTime > maxSnapshotFrequency.toMillis()) {
       if (force || buffer.isDirty()) {
         LOG.debug("Committing {}", buffer);
         snapshot = buffer.commit(transitLayerUpdater, force);
@@ -653,9 +655,9 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * Handle GTFS-RT TripUpdate message containing an ADDED trip.
    *
    * @param stopTimeUpdates GTFS-RT stop time updates
-   * @param tripDescriptor GTFS-RT TripDescriptor
-   * @param stops          the stops of each StopTimeUpdate in the TripUpdate message
-   * @param serviceDate    service date for added trip
+   * @param tripDescriptor  GTFS-RT TripDescriptor
+   * @param stops           the stops of each StopTimeUpdate in the TripUpdate message
+   * @param serviceDate     service date for added trip
    * @return empty Result if successful or one containing an error
    */
   private Result<UpdateSuccess, UpdateError> handleAddedTrip(
@@ -790,11 +792,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   /**
    * Add a (new) trip to the graph and the buffer
    *
-   * @param trip          trip
+   * @param trip              trip
    * @param vehicleDescriptor accessibility information of the vehicle
-   * @param stops         list of stops corresponding to stop time updates
-   * @param serviceDate   service date of trip
-   * @param realTimeState real-time state of new trip
+   * @param stops             list of stops corresponding to stop time updates
+   * @param serviceDate       service date of trip
+   * @param realTimeState     real-time state of new trip
    * @return empty Result if successful or one containing an error
    */
   private Result<UpdateSuccess, UpdateError> addTripToGraphAndBuffer(

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -23,6 +23,7 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeEvent;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
 import de.mfdz.MfdzRealtimeExtensions.StopTimePropertiesExtension.DropOffPickupType;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -112,7 +113,7 @@ public class TimetableSnapshotSourceTest {
   public void testGetSnapshotWithMaxSnapshotFrequencyCleared()
     throws InvalidProtocolBufferException {
     var updater = new TimetableSnapshotSource(
-      TimetableSnapshotSourceParameters.DEFAULT.withMaxSnapshotFrequencyMs(-1),
+      TimetableSnapshotSourceParameters.DEFAULT.withMaxSnapshotFrequency(Duration.ofMillis(-1)),
       transitModel
     );
 
@@ -1130,7 +1131,7 @@ public class TimetableSnapshotSourceTest {
     var updater = new TimetableSnapshotSource(
       TimetableSnapshotSourceParameters.DEFAULT
         .withPurgeExpiredData(purgeExpiredData)
-        .withMaxSnapshotFrequencyMs(maxSnapshotFrequency),
+        .withMaxSnapshotFrequency(Duration.ofMillis(maxSnapshotFrequency)),
       transitModel,
       clock::get
     );

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -86,7 +86,7 @@
       },
       "inaccessibleStreetReluctance": 25,
       "maxSlope": 0.083,
-      "slopeExceededReluctance":  1,
+      "slopeExceededReluctance": 1,
       "stairsReluctance": 100
     }
   },
@@ -182,6 +182,10 @@
       "expansionFactor": 0.25
     }
   ],
+  "timetableUpdates": {
+    "purgeExpiredData": false,
+    "snapshotFrequency": "2s"
+  },
   "updaters": [
     // GTFS-RT service alerts (frequent polling)
     {
@@ -255,7 +259,7 @@
         "Authorization": "A-Token"
       }
     },
-    // Polling for GTFS-RT Vehicle Positions - output can be fetched via trip pattern GraphQL APIss
+    // Polling for GTFS-RT Vehicle Positions - output can be fetched via trip pattern GraphQL API
     {
       "type": "vehicle-positions",
       "url": "https://s3.amazonaws.com/kcm-alerts-realtime-prod/vehiclepositions.pb",

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -184,7 +184,7 @@
   ],
   "timetableUpdates": {
     "purgeExpiredData": false,
-    "snapshotFrequency": "2s"
+    "maxSnapshotFrequency": "2s"
   },
   "updaters": [
     // GTFS-RT service alerts (frequent polling)


### PR DESCRIPTION
### Summary

While I was looking at how to configure Siri, I noticed that there is no documentation for the `timetableUpdates`. This PR adds that and also converts `snapshotFrequency` to a `Duration`.

### Documentation

Autogenerated.