### PR TITLE
Fix transferCacheRequests when custom streetRoutingTimeout is set

### DIFF
--- a/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
@@ -29,7 +29,6 @@ import org.opentripplanner.street.search.intersection_model.IntersectionTraversa
 public final class StreetPreferences implements Serializable {
 
   public static StreetPreferences DEFAULT = new StreetPreferences();
-
   private final double turnReluctance;
   private final DrivingDirection drivingDirection;
   private final ElevatorPreferences elevator;

--- a/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.preference.StreetPreferences;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.opentripplanner.standalone.config.routerconfig.TransitRoutingConfig;
 import org.opentripplanner.standalone.config.routerconfig.UpdatersConfig;
@@ -104,11 +105,10 @@ number of transit vehicles used in that itinerary.
           .asObject()
       );
     this.routingRequestDefaults =
-      RouteRequestConfig.mapDefaultRouteRequest(root, "routingDefaults");
-    this.routingRequestDefaults.withPreferences(p ->
-        p.withStreet(s ->
-          s.withRoutingTimeout(parseStreetRoutingTimeout(root, s.original().routingTimeout()))
-        )
+      RouteRequestConfig.mapDefaultRouteRequest(
+        root,
+        "routingDefaults",
+        parseStreetRoutingTimeout(root, StreetPreferences.DEFAULT.routingTimeout())
       );
     this.transitConfig = new TransitRoutingConfig("transit", root, routingRequestDefaults);
     this.updatersParameters = new UpdatersConfig(root);

--- a/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
@@ -105,16 +105,15 @@ number of transit vehicles used in that itinerary.
       );
     this.routingRequestDefaults =
       RouteRequestConfig.mapDefaultRouteRequest(root, "routingDefaults");
-    this.transitConfig = new TransitRoutingConfig("transit", root, routingRequestDefaults);
-    this.updatersParameters = new UpdatersConfig(root);
-    this.vectorTileLayers = VectorTileConfig.mapVectorTilesParameters(root, "vectorTileLayers");
-    this.flexConfig = new FlexConfig(root, "flex");
-
     this.routingRequestDefaults.withPreferences(p ->
         p.withStreet(s ->
           s.withRoutingTimeout(parseStreetRoutingTimeout(root, s.original().routingTimeout()))
         )
       );
+    this.transitConfig = new TransitRoutingConfig("transit", root, routingRequestDefaults);
+    this.updatersParameters = new UpdatersConfig(root);
+    this.vectorTileLayers = VectorTileConfig.mapVectorTilesParameters(root, "vectorTileLayers");
+    this.flexConfig = new FlexConfig(root, "flex");
 
     if (logUnusedParams && LOG.isWarnEnabled()) {
       root.logAllWarnings(LOG::warn);

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -35,14 +35,21 @@ public class RouteRequestConfig {
 
   private static final String WHEELCHAIR_ACCESSIBILITY = "wheelchairAccessibility";
 
-  public static RouteRequest mapDefaultRouteRequest(NodeAdapter root, String parameterName) {
+  public static RouteRequest mapDefaultRouteRequest(
+    NodeAdapter root,
+    String parameterName,
+    Duration streetRoutingTimeout
+  ) {
     var c = root
       .of(parameterName)
       .since(V2_0)
       .summary("The default parameters for the routing query.")
       .description("Most of these are overridable through the various API endpoints.")
       .asObject();
-    return mapRouteRequest(c);
+    var routeRequest = mapRouteRequest(c);
+    routeRequest.withPreferences(p -> p.withStreet(s -> s.withRoutingTimeout(streetRoutingTimeout))
+    );
+    return routeRequest;
   }
 
   public static RouteRequest mapRouteRequest(NodeAdapter c) {

--- a/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
@@ -48,10 +48,37 @@ class RouterConfigTest {
     assertEquals(DEFAULT_TIMEOUT, RouterConfig.parseStreetRoutingTimeout(c, DEFAULT_TIMEOUT));
 
     // New format: 33 seconds
-    c = createNodeAdaptor("{streetRoutingTimeout: '33s'}");
+    c =
+      createNodeAdaptor(
+        """
+      {
+        "streetRoutingTimeout": "33s",
+        "transit": {
+          "transferCacheRequests": [
+            {
+              "mode": "WALK"
+            }
+          ]
+        }
+      }
+      """
+      );
+    var routerConfig = new RouterConfig(c, false);
+
+    final Duration expected = Duration.ofSeconds(33);
     assertEquals(
-      Duration.ofSeconds(33),
-      RouterConfig.parseStreetRoutingTimeout(c, DEFAULT_TIMEOUT)
+      expected,
+      routerConfig.routingRequestDefaults().preferences().street().routingTimeout()
+    );
+    assertEquals(
+      expected,
+      routerConfig
+        .transitTuningConfig()
+        .transferCacheRequests()
+        .get(0)
+        .preferences()
+        .street()
+        .routingTimeout()
     );
   }
 


### PR DESCRIPTION
### Summary

Fixes issue with wrong `streetRoutingTimeout` value being used for initializing cached transfer requests.

### Issue

closes https://github.com/opentripplanner/OpenTripPlanner/issues/5038

### Unit tests

Improved existing test

### Documentation

Not needed

### Changelog

From title
