### PR TITLE
Deduplicate lang string

### DIFF
--- a/src/client/i18n/de.po
+++ b/src/client/i18n/de.po
@@ -106,7 +106,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "ÖPNV und Fahrradverleih"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/de.po
+++ b/src/client/i18n/de.po
@@ -100,13 +100,13 @@ msgstr "ÖPNV und Fahrradverleih"
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:329
 msgid "Rented Scooter"
-msgstr ""
+msgstr "Leihroller"
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr ""
+msgstr "ÖPNV und Leihroller"
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/en.po
+++ b/src/client/i18n/en.po
@@ -108,7 +108,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Transit & Rented Bicycle"
+msgstr "Transit & Rented Scooter"
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/es.po
+++ b/src/client/i18n/es.po
@@ -100,13 +100,13 @@ msgstr "Transporte Público y Alquiler de bicicleta"
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:329
 msgid "Rented Scooter"
-msgstr ""
+msgstr "Patinete de alquiler"
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr ""
+msgstr "Transporte Público y Patinete de alquiler"
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/es.po
+++ b/src/client/i18n/es.po
@@ -90,12 +90,12 @@ msgstr "Bicicleta y Transporte Público"
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:325
 msgid "Rented Bicycle"
-msgstr "Alquiler bicicleta"
+msgstr "Bicicleta de alquiler"
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:327
 msgid "Transit & Rented Bicycle"
-msgstr "Transporte Público y Alquiler de bicicleta"
+msgstr "Transporte Público y Bicicleta de alquiler"
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:329

--- a/src/client/i18n/es.po
+++ b/src/client/i18n/es.po
@@ -106,7 +106,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Transporte Público y Alquiler de bicicleta"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/fr.po
+++ b/src/client/i18n/fr.po
@@ -107,7 +107,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Transports en commun et Vélo Libre Service"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/hu.po
+++ b/src/client/i18n/hu.po
@@ -108,7 +108,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Tömegközlekedés és bérelt kerékpár"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/it.po
+++ b/src/client/i18n/it.po
@@ -113,7 +113,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Bike sharing & Ride"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/no.po
+++ b/src/client/i18n/no.po
@@ -109,7 +109,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Kollektivtransport &amp; Bysykkel"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/pl.po
+++ b/src/client/i18n/pl.po
@@ -106,7 +106,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "kom. publiczną & wypoż. rowerem"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/pt.po
+++ b/src/client/i18n/pt.po
@@ -107,7 +107,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Vários & bicicletas alugadas"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333

--- a/src/client/i18n/sl.po
+++ b/src/client/i18n/sl.po
@@ -107,7 +107,7 @@ msgstr ""
 #: src/client/js/otp/config.js:331
 #, fuzzy
 msgid "Transit & Rented Scooter"
-msgstr "Izposojeno kolo &amp; Javni prevoz"
+msgstr ""
 
 #. Travel by: mode of transport (Used in selection in Travel Options widgets)
 #: src/client/js/otp/config.js:333


### PR DESCRIPTION
### Summary

Make `Transit & Rented Scooter` language string be different from the `Transit & Rented Bicycle` language string for the client UI.

### Issue

I noticed that the strings are the same which is confusing.

I fixed the string (`Bicycle` -> `Scooter`) in English. I don't know the appropriate terms in the other languages and the `Rented Scooter` message itself is empty for all of them, therefore I removed the duplicate translation to enforce fallback to English for now.

Let me know if I did anything wrong. I tried looking through the contributing/developer guidelines, but could not find whether these files are actually intended to be edited or are generated via some tool.