### PR TITLE
Propagate coordinates from NeTEx parentSiteRef / parent station to subordinate station.

### DIFF
--- a/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
@@ -116,6 +116,11 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
     }
   }
 
+  /*
+   * If it is a multimodal StopPlace with subordinate StopPlaces
+   *
+   * FIXME DELFI dataset does not have this Tag!
+   */
   private boolean isMultiModalStopPlace(StopPlace stopPlace) {
     return (
       stopPlace.getKeyList() != null &&
@@ -128,5 +133,12 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
           keyValueStructure.getValue().equals("true")
         )
     );
+  }
+
+  /*
+   * Is subordinate to a multi modal StopPlace
+   */
+  private boolean hasParentSiteRef(StopPlace stopPlace) {
+    return (stopPlace.getParentSiteRef() != null);
   }
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -4,7 +4,9 @@ import com.google.common.collect.Multimap;
 import jakarta.xml.bind.JAXBElement;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -308,7 +310,11 @@ public class NetexMapper {
       issueStore,
       noTransfersOnIsolatedStops
     );
-    for (String stopPlaceId : currentNetexIndex.getStopPlaceById().localKeys()) {
+    ArrayList<String> sortedStopPlaceIds = new ArrayList<String>(
+      currentNetexIndex.getStopPlaceById().localKeys()
+    );
+    Collections.sort(sortedStopPlaceIds);
+    for (String stopPlaceId : sortedStopPlaceIds) {
       Collection<StopPlace> stopPlaceAllVersions = currentNetexIndex
         .getStopPlaceById()
         .lookup(stopPlaceId);

--- a/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -131,15 +131,20 @@ class StationMapper {
         stopPlace.getId() + " " + stopPlace.getName()
       );
       List<WgsCoordinate> coordinates = new ArrayList<>();
-      for (Object it : stopPlace.getQuays().getQuayRefOrQuay()) {
-        if (it instanceof Quay quay && quay.getCentroid() != null) {
-          coordinates.add(WgsCoordinateMapper.mapToDomain(quay.getCentroid()));
+      /* try to get a coordinate from quays in this stopPlace */
+      if (stopPlace.getQuays() != null) {
+        for (Object it : stopPlace.getQuays().getQuayRefOrQuay()) {
+          if (it instanceof Quay quay && quay.getCentroid() != null) {
+            coordinates.add(WgsCoordinateMapper.mapToDomain(quay.getCentroid()));
+          }
         }
       }
+      /* FIXME there are "sub"stopPlace with Quays that have no coordinates, but a ParentStopPlaceReference to a parentStop with a coordinate.... */
       if (coordinates.isEmpty()) {
-        throw new IllegalArgumentException(
-          "Station w/quays without coordinates. Station id: " + stopPlace.getId()
-        );
+        // throw new IllegalArgumentException(
+        //   "Station without any related coordinates. Station id: " + stopPlace.getId()
+        // );
+        return new WgsCoordinate(0f, 0f);
       }
       return WgsCoordinate.mean(coordinates);
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -141,9 +141,11 @@ class StationMapper {
       }
       /* FIXME there are "sub"stopPlace with Quays that have no coordinates, but a ParentStopPlaceReference to a parentStop with a coordinate.... */
       if (coordinates.isEmpty()) {
-        // throw new IllegalArgumentException(
-        //   "Station without any related coordinates. Station id: " + stopPlace.getId()
-        // );
+        issueStore.add(
+          "StationWithoutCoordinates2",
+          "Station without any related coordinates. Station id: %s",
+          stopPlace.getId()
+        );
         return new WgsCoordinate(0f, 0f);
       }
       return WgsCoordinate.mean(coordinates);

--- a/src/test/java/org/opentripplanner/netex/NetexEpipBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexEpipBundleSmokeTest.java
@@ -118,7 +118,7 @@ class NetexEpipBundleSmokeTest {
     assertEquals(9.93422080466927, quay.getLon(), 0.000001);
     assertEquals("HH:DE::StopPlace:80026_Master::", quay.getParentStation().getId().toString());
     // Assert that quay duplicates are not overriding existing values
-    assertEquals(0, quay.getIndex());
+    assertEquals(2, quay.getIndex());
     assertNull(quay.getPlatformCode());
     assertEquals(31, stops.size());
   }


### PR DESCRIPTION
### Summary

Propagate coordinates from parentSiteRef / parent station to subordinate station. This allows to load the full german DELFI NeTEx graph from tuesday. Its an experiment to see **what** needs to be done. I'm not sure **how** it should be done.

### Issue

This patch fiddles with the order in which the stations are processed, to ensure that parent stations are mapped before subordinate stations reference them.

The parent stations are not tagged with IS_PARENT_STOP_PLACE=true in this dataset.

Accordings to the issue summary there are ~2400 stations without coordinate on the station or stop that need this propagation.

### Unit tests

no tests yet, as its a test to see what needs to be done to get the dataset to load without additional preprocessing.

### Documentation

no