### PR TITLE
Use structured log markers for realtime update results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,7 +606,6 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>7.3</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- dependency injection -->

--- a/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
+++ b/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.updater.spi;
 
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+
 import java.util.stream.Collectors;
 import org.opentripplanner.framework.lang.DoubleUtils;
 import org.opentripplanner.model.UpdateError;
@@ -18,7 +20,7 @@ public class ResultLogger {
     var totalUpdates = updateResult.successful() + updateResult.failed();
     if (totalUpdates > 0) {
       LOG.info(
-        "[feedId: {}, type={}] {} of {} update messages were applied successfully (success rate: {}%)",
+        "[feedId={}, type={}] {} of {} update messages were applied successfully (success rate: {}%)",
         feedId,
         type,
         updateResult.successful(),
@@ -34,16 +36,16 @@ public class ResultLogger {
           var value = errorIndex.get(key);
           var tripIds = value.stream().map(UpdateError::debugId).collect(Collectors.toSet());
           LOG.error(
-            "[feedId: {}, type={}] {} failures of type {}: {}",
-            feedId,
-            type,
+            "[{} {}] {} failures of {}: {}",
+            keyValue("feedId", feedId),
+            keyValue("type", type),
             value.size(),
-            key,
+            keyValue("errorType", key),
             tripIds
           );
         });
     } else {
-      LOG.info("[feedId: {}, type={}] Feed did not contain any updates", feedId, type);
+      LOG.info("[feedId={}, type={}] Feed did not contain any updates", feedId, type);
     }
   }
 }

--- a/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
+++ b/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
@@ -35,7 +35,7 @@ public class ResultLogger {
         .forEach(key -> {
           var value = errorIndex.get(key);
           var tripIds = value.stream().map(UpdateError::debugId).collect(Collectors.toSet());
-          LOG.error(
+          LOG.warn(
             "[{} {}] {} failures of {}: {}",
             keyValue("feedId", feedId),
             keyValue("type", type),


### PR DESCRIPTION
### Summary

In a previous PR #5023 I added JSON-formatted logging. This one actually uses that capability to its full power by adding so-called `StructuredMarkers` to logs statements.

This achieves that the (pretty-printed) log messages about the realtime updates in JSON look like this:

```
{
  "@timestamp": "2023-04-18T22:59:58.514710284+02:00",
  "level": "ERROR",
  "logger_name": "org.opentripplanner.updater.spi.ResultLogger",
  "thread_name": "GraphUpdater-2",
  "message": "[feedId=MARTA type=gtfs-rt-trip-updates] 4 failures of errorType=NEGATIVE_DWELL_TIME: [MARTA:7675658{stopIndex=11}, MARTA:7700115{stopIndex=0}, MARTA:7819768{stopIndex=0}, MARTA:7674698{stopIndex=18}]",
  "feedId": "MARTA",
  "type": "gtfs-rt-trip-updates",
  "errorType": "NEGATIVE_DWELL_TIME"
}
```

This allows you to filter out the messages for the types of error that you deem harmless, for example `NO_TRIP_FOR_CANCELLATION_FOUND`. 