### PR TITLE
Constant speed street routing

### DIFF
--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -966,7 +966,7 @@ the local filesystem.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osm/[0]   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeed`
 
 The named set of mapping rules applied when parsing OSM tags. Overrides the value specified in `osmDefaults`.
 
@@ -974,7 +974,7 @@ The named set of mapping rules applied when parsing OSM tags. Overrides the valu
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osmDefaults   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeed`
 
 The named set of mapping rules applied when parsing OSM tags.
 

--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -182,7 +182,7 @@ The driving direction to use in the intersection traversal calculation
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"simple"`   
 **Path:** /routingDefaults   
-**Enum values:** `norway` | `simple`
+**Enum values:** `norway` | `simple` | `constant`
 
 The model that computes the costs of turns.
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -943,8 +943,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
       String label = "way " + way.getId() + " from " + index;
       label = label.intern();
       I18NString name = getNameForWay(way, label);
-
-      float carSpeed = way.getOsmProvider().getWayPropertySet().getCarSpeedForWay(way, back);
+      float carSpeed = way.getOsmProvider().getOsmTagMapper().getCarSpeedForWay(way, back);
 
       StreetEdge street = new StreetEdge(
         startEndpoint,

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/ConstantSpeedMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/ConstantSpeedMapper.java
@@ -1,0 +1,53 @@
+package org.opentripplanner.openstreetmap.tagmapping;
+
+import static org.opentripplanner.openstreetmap.wayproperty.WayPropertiesBuilder.withModes;
+import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
+import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
+import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
+import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
+import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
+
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.opentripplanner.openstreetmap.wayproperty.WayPropertySet;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+
+/**
+ * OSM way properties for optimizing distance (not traveling time) in routing.
+ */
+class ConstantSpeedMapper implements OsmTagMapper {
+
+  private float speed;
+
+  public ConstantSpeedMapper() {
+    super();
+    this.speed = 22.22f; // 80 kmph by default
+  }
+
+  public ConstantSpeedMapper(float speed) {
+    super();
+    this.speed = speed;
+  }
+
+  @Override
+  public void populateProperties(WayPropertySet props) {
+    // Remove informal and private roads
+    props.setProperties("highway=*;informal=yes", withModes(NONE));
+    props.setProperties("highway=service;access=private", withModes(NONE));
+    props.setProperties("highway=trail", withModes(NONE));
+    props.setProperties("highway=service;tunnel=yes;access=destination", withModes(NONE));
+    props.setProperties("highway=service;access=destination", withModes(ALL));
+
+    props.setCarSpeed("highway=*", speed);
+
+    // Read the rest from the default set
+    new DefaultMapper().populateProperties(props);
+  }
+
+  @Override
+  public float getCarSpeedForWay(OSMWithTags way, boolean backward) {
+    /*
+     * Set the same 80 km/h speed for all roads, so that car routing finds shortest path
+     */
+    return speed;
+  }
+}

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapper.java
@@ -22,6 +22,10 @@ public interface OsmTagMapper {
     );
   }
 
+  default float getCarSpeedForWay(OSMWithTags way, boolean backward) {
+    return way.getOsmProvider().getWayPropertySet().getCarSpeedForWay(way, backward);
+  }
+
   default boolean isGeneralNoThroughTraffic(OSMWithTags way) {
     String access = way.getTag("access");
     return doesTagValueDisallowThroughTraffic(access);

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperSource.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperSource.java
@@ -12,7 +12,8 @@ public enum OsmTagMapperSource {
   GERMANY,
   ATLANTA,
   HOUSTON,
-  PORTLAND;
+  PORTLAND,
+  CONSTANTSPEED;
 
   public OsmTagMapper getInstance() {
     return switch (this) {
@@ -24,6 +25,7 @@ public enum OsmTagMapperSource {
       case ATLANTA -> new AtlantaMapper();
       case HOUSTON -> new HoustonMapper();
       case PORTLAND -> new PortlandMapper();
+      case CONSTANTSPEED -> new ConstantSpeedMapper();
     };
   }
 }

--- a/src/main/java/org/opentripplanner/street/search/intersection_model/IntersectionTraversalCalculator.java
+++ b/src/main/java/org/opentripplanner/street/search/intersection_model/IntersectionTraversalCalculator.java
@@ -12,12 +12,12 @@ import org.opentripplanner.street.search.TraverseMode;
  *
  * @author avi
  */
+
 public interface IntersectionTraversalCalculator {
   IntersectionTraversalCalculator DEFAULT = create(
     IntersectionTraversalModel.SIMPLE,
     DrivingDirection.RIGHT
   );
-
   /**
    * Compute the duration of turning onto "to" from "from".
    *
@@ -39,6 +39,7 @@ public interface IntersectionTraversalCalculator {
     return switch (intersectionTraversalModel) {
       case NORWAY -> new NorwayIntersectionTraversalCalculator(drivingDirection);
       case SIMPLE -> new SimpleIntersectionTraversalCalculator(drivingDirection);
+      case CONSTANT -> new ConstantIntersectionTraversalCalculator();
     };
   }
 }

--- a/src/main/java/org/opentripplanner/street/search/intersection_model/IntersectionTraversalModel.java
+++ b/src/main/java/org/opentripplanner/street/search/intersection_model/IntersectionTraversalModel.java
@@ -3,4 +3,5 @@ package org.opentripplanner.street.search.intersection_model;
 public enum IntersectionTraversalModel {
   NORWAY,
   SIMPLE,
+  CONSTANT,
 }

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperTest.java
@@ -37,6 +37,20 @@ public class OsmTagMapperTest {
   }
 
   @Test
+  public void constantSpeedCarRouting() {
+    OsmTagMapper osmTagMapper = new ConstantSpeedMapper(20f);
+
+    var slowWay = new OSMWithTags();
+    slowWay.addTag("highway", "residential");
+    assertEquals(20f, osmTagMapper.getCarSpeedForWay(slowWay, true));
+
+    var fastWay = new OSMWithTags();
+    fastWay.addTag("highway", "motorway");
+    fastWay.addTag("maxspeed", "120 kmph");
+    assertEquals(20f, osmTagMapper.getCarSpeedForWay(fastWay, true));
+  }
+
+  @Test
   public void isBicycleNoThroughTrafficExplicitlyDisallowed() {
     OsmTagMapper osmTagMapper = new DefaultMapper();
     assertTrue(


### PR DESCRIPTION
### Summary

Some minor changes in OSM tag mapping and intersection traversal modules to allow street routing, which finds shortest paths instead of optimising traversal time. This is achieved as follows:
- Car speed is requested via a tag mapper, so that full customisation is possible 
- New OSM tag mapper ignores speed limitation tagging of OSM and uses a single default speed
- The existing ConstantIntersectionTraversalCalculator is now available via configuration


### Unit tests

Unit tests for the new OSM tag mapper included.
