### PR TITLE
Generate static documentation for GTFS GraphQL API

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -9,6 +9,7 @@ on:
       - master
       - dev-1.x
       - dev-2.x
+      - graphq-docs
   pull_request:
     branches:
       - master
@@ -104,10 +105,19 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r docs/requirements.txt
         
-      - name: Build documentation
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Build main documentation
         if: github.event_name == 'pull_request'
         run: mkdocs build
-        
+
+      - name: Build GTFS GraphQL documentation
+        run: |
+          npm install -g @magidoc/cli
+          magidoc generate
+
       - name: Deploy docs to Github pages
         if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
         run: |

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -9,7 +9,6 @@ on:
       - master
       - dev-1.x
       - dev-2.x
-      - graphq-docs
   pull_request:
     branches:
       - master
@@ -105,41 +104,26 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r docs/requirements.txt
         
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
 
       - name: Build main documentation
         if: github.event_name == 'pull_request'
         run: mkdocs build
 
-      - name: Build GTFS GraphQL documentation
-        run: |
-          npm install -g @magidoc/cli
-          magidoc generate
-          
-          git config --global user.name 'OTP Bot'
-          git config --global user.email 'bot@opentripplanner.org'
-          
-          git fetch origin gh-pages
-          git checkout gh-pages
-          mkdir -p api
-          mv target/magidocs/api/ api/dev-2.x/
-          git add api
-          git commit -am "Add Magidoc documentation"
-          git push
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
-      - name: Deploy docs to Github pages
+      - name: Build GTFS GraphQL API documentation
+        run: |
+          npm install -g @magidoc/cli@3.6.4
+          magidoc generate
+
+      - name: Deploy compiled HTML to Github pages
         if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
         run: |
           git config --global user.name 'OTP Bot'
           git config --global user.email 'bot@opentripplanner.org'
           
-          # mkdocs/mike generates a new sitemap.xml.gz for every commit even if the docs have not changed
-          # this configures the date of the change to be the date when the docs haven been changed last
-          # https://github.com/jimporter/mike/issues/103#issuecomment-1453878471
-          export SOURCE_DATE_EPOCH=`git log -1 --format=%ct docs`
-
           # mike, the versioning plugin for mkdocs, expects there to be a local branch to push to so
           # we are cloning one here and commit to it
           # mike has support for specifing the origin but then it tries to rebase the _local_ gh-pages
@@ -157,6 +141,14 @@ jobs:
           else
             mike deploy --branch $LOCAL_BRANCH --prefix en dev-2.x
           fi
+          git push $REMOTE $LOCAL_BRANCH:$REMOTE_BRANCH
+          
+          # commit and push the GraphQL documentation
+          git checkout $LOCAL_BRANCH
+          mkdir -p api
+          mv target/magidoc/api/ api/dev-2.x/
+          git add api
+          git commit -am "Add Magidoc GraphQL documentation"
           git push $REMOTE $LOCAL_BRANCH:$REMOTE_BRANCH
 
   graphql-code-generation:

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -117,6 +117,17 @@ jobs:
         run: |
           npm install -g @magidoc/cli
           magidoc generate
+          
+          git config --global user.name 'OTP Bot'
+          git config --global user.email 'bot@opentripplanner.org'
+          
+          git fetch origin gh-pages
+          git checkout gh-pages
+          mkdir -p api
+          mv target/magidocs/api/ api/dev-2.x/
+          git add api
+          git commit -am "Add Magidoc documentation"
+          git push
 
       - name: Deploy docs to Github pages
         if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')

--- a/magidoc.mjs
+++ b/magidoc.mjs
@@ -1,0 +1,29 @@
+export default {
+  introspection: {
+    type: 'sdl',
+    paths: ['src/ext/resources/legacygraphqlapi/schema.graphqls'],
+  },
+  website: {
+    template: 'carbon-multi-page',
+    output: 'target/mkdocs/api/graphql-gtfs/v1/',
+    options: {
+      siteRoot: '/api/graphql-gtfs/v1',
+      pages: [{
+        title: 'Introduction',
+        content: `
+# Static documentation
+
+This is the static documentation of the OTP GraphQL GTFS API v1.
+
+Please also check out the interactive API explorer built into every instance and available
+at http://localhost:8080/graphiql 
+`,
+      }],
+      appTitle: 'OTP GTFS GraphQL API v1',
+      queryGenerationFactories: {
+        'Polyline': '<>',
+        'GeoJson': '<>'
+      },
+    }
+  },
+}

--- a/magidoc.mjs
+++ b/magidoc.mjs
@@ -5,18 +5,24 @@ export default {
   },
   website: {
     template: 'carbon-multi-page',
-    output: 'target/magidocs/api/graphql-gtfs/v1/',
+    output: 'target/magidoc/api/graphql-gtfs/v1/',
     options: {
       siteRoot: '/api/dev-2.x/graphql-gtfs/v1',
+      appLogo: 'https://docs.opentripplanner.org/en/dev-2.x/images/otp-logo.svg',
       pages: [{
         title: 'Introduction',
         content: `
-# Static documentation
+# OTP GTFS GraphQL API v1 documentation
 
 This is the static documentation of the OTP GraphQL GTFS API v1.
 
+The GraphQL endpoint of your instance, which you should point your tooling to, is 
+\`http://localhost:8080/otp/routers/default/index/graphql\`
+
 Please also check out the interactive API explorer built into every instance and available
 at http://localhost:8080/graphiql 
+
+![GraphiQL screenshot](https://docs.opentripplanner.org/en/dev-2.x/images/graphiql.png)
 `,
       }],
       appTitle: 'OTP GTFS GraphQL API v1',

--- a/magidoc.mjs
+++ b/magidoc.mjs
@@ -5,9 +5,9 @@ export default {
   },
   website: {
     template: 'carbon-multi-page',
-    output: 'target/mkdocs/api/graphql-gtfs/v1/',
+    output: 'target/magidocs/api/graphql-gtfs/v1/',
     options: {
-      siteRoot: '/api/graphql-gtfs/v1',
+      siteRoot: '/api/dev-2.x/graphql-gtfs/v1',
       pages: [{
         title: 'Introduction',
         content: `


### PR DESCRIPTION
### Summary

This generates a static HTML documentation for the GTFS GraphQL API.

This is useful for IBI customers who want to check out what the API can do without having to set up their own OTP instance.

If you want to check out what it looks like, here is an example: https://leonardehrenfried.github.io/OpenTripPlanner/api/dev-2.x/graphql-gtfs/v1/queries/agencies

![image](https://user-images.githubusercontent.com/151346/234045231-ad48f2fc-9114-464c-873b-a7c90a250d63.png)
