### PR TITLE
Add IBI accessibility score to GraphQL API

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/legacygraphqlapi/GraphQLIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/legacygraphqlapi/GraphQLIntegrationTest.java
@@ -39,6 +39,7 @@ import org.opentripplanner.ext.fares.impl.DefaultFareService;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.routing.alertpatch.AlertCause;
 import org.opentripplanner.routing.alertpatch.AlertEffect;
 import org.opentripplanner.routing.alertpatch.AlertSeverity;
@@ -114,7 +115,11 @@ class GraphQLIntegrationTest {
       .carHail(D10m, E)
       .build();
 
-    var railLeg = i1.getTransitLeg(2);
+    i1.setAccessibilityScore(0.5f);
+
+    ScheduledTransitLeg railLeg = (ScheduledTransitLeg) i1.getTransitLeg(2);
+    railLeg.withAccessibilityScore(.3f);
+
     var alert = TransitAlert
       .of(id("an-alert"))
       .withHeaderText(new NonLocalizedString("A header"))

--- a/src/ext-test/resources/legacygraphqlapi/expectations/plan.json
+++ b/src/ext-test/resources/legacygraphqlapi/expectations/plan.json
@@ -6,6 +6,7 @@
           "startTime" : 1580641200000,
           "endTime" : 1580644800000,
           "generalizedCost" : 4072,
+          "accessibilityScore" : 0.5,
           "legs" : [
             {
               "mode" : "WALK",
@@ -27,7 +28,8 @@
               "endTime" : 1580641220000,
               "generalizedCost" : 40,
               "alerts" : [ ],
-              "rideHailingEstimate" : null
+              "rideHailingEstimate" : null,
+              "accessibilityScore" : null
             },
             {
               "mode" : "BUS",
@@ -49,7 +51,8 @@
               "endTime" : 1580642100000,
               "generalizedCost" : 992,
               "alerts" : [ ],
-              "rideHailingEstimate" : null
+              "rideHailingEstimate" : null,
+              "accessibilityScore" : null
             },
             {
               "mode" : "RAIL",
@@ -91,7 +94,8 @@
                   ]
                 }
               ],
-              "rideHailingEstimate" : null
+              "rideHailingEstimate" : null,
+              "accessibilityScore" : null
             },
             {
               "mode" : "CAR",
@@ -133,7 +137,8 @@
                   "amount" : 2000
                 },
                 "arrival" : "PT10M"
-              }
+              },
+              "accessibilityScore" : null
             }
           ]
         }

--- a/src/ext-test/resources/legacygraphqlapi/queries/plan.graphql
+++ b/src/ext-test/resources/legacygraphqlapi/queries/plan.graphql
@@ -19,6 +19,7 @@
             startTime
             endTime
             generalizedCost
+            accessibilityScore
             legs {
                 mode
                 from {
@@ -79,6 +80,7 @@
                     }
                     arrival
                 }
+                accessibilityScore
             }
         }
     }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLItineraryImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLItineraryImpl.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
+import org.opentripplanner.ext.legacygraphqlapi.mapping.FloatToDoubleMapper;
 import org.opentripplanner.model.SystemNotice;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
@@ -93,6 +94,12 @@ public class LegacyGraphQLItineraryImpl
   @Override
   public DataFetcher<Long> walkTime() {
     return environment -> (long) getSource(environment).getNonTransitDuration().toSeconds();
+  }
+
+  @Override
+  public DataFetcher<Double> accessibilityScore() {
+    return environment ->
+      FloatToDoubleMapper.toDouble(getSource(environment).getAccessibilityScore());
   }
 
   private Itinerary getSource(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -10,6 +10,7 @@ import org.opentripplanner.api.mapping.LocalDateMapper;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes;
+import org.opentripplanner.ext.legacygraphqlapi.mapping.FloatToDoubleMapper;
 import org.opentripplanner.ext.ridehailing.model.RideEstimate;
 import org.opentripplanner.ext.ridehailing.model.RideHailingLeg;
 import org.opentripplanner.model.BookingInfo;
@@ -291,5 +292,10 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
         return res;
       } else return null;
     };
+  }
+
+  @Override
+  public DataFetcher<Double> accessibilityScore() {
+    return environment -> FloatToDoubleMapper.toDouble(getSource(environment).accessibilityScore());
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -274,7 +274,7 @@ public class LegacyGraphQLDataFetchers {
     public DataFetcher<Double> lon();
   }
 
-  /** An amount of money. */
+  /** A currency */
   public interface LegacyGraphQLCurrency {
     public DataFetcher<String> code();
 
@@ -316,6 +316,8 @@ public class LegacyGraphQLDataFetchers {
   }
 
   public interface LegacyGraphQLItinerary {
+    public DataFetcher<Double> accessibilityScore();
+
     public DataFetcher<Boolean> arrivedAtDestinationWithRentedBicycle();
 
     public DataFetcher<Long> duration();
@@ -344,6 +346,8 @@ public class LegacyGraphQLDataFetchers {
   }
 
   public interface LegacyGraphQLLeg {
+    public DataFetcher<Double> accessibilityScore();
+
     public DataFetcher<Agency> agency();
 
     public DataFetcher<Iterable<TransitAlert>> alerts();

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/mapping/FloatToDoubleMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/mapping/FloatToDoubleMapper.java
@@ -1,0 +1,18 @@
+package org.opentripplanner.ext.legacygraphqlapi.mapping;
+
+import javax.annotation.Nullable;
+
+/**
+ * Maps a nullable {@link Float} to a nullable {@link Double}.
+ */
+public class FloatToDoubleMapper {
+
+  @Nullable
+  public static Double toDouble(@Nullable Number input) {
+    if (input != null) {
+      return input.doubleValue();
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1338,6 +1338,15 @@ type Itinerary {
     This make it possible to inspect the itinerary-filter-chain.
     """
     systemNotices: [SystemNotice]!
+
+    """
+    A sandbox features that computes a numeric accessibility score between 0 and 1.
+
+    The closer the value is to 1 the better the wheelchair-accessibility of this itinerary is.
+
+    More information is available at https://docs.opentripplanner.org/en/dev-2.x/sandbox/IBIAccessibilityScore/
+    """
+    accessibilityScore: Float
 }
 
 "A currency"
@@ -1541,6 +1550,15 @@ type Leg {
 
     "Estimate of a hailed ride like Uber."
     rideHailingEstimate: RideHailingEstimate
+
+    """
+    A sandbox features that computes a numeric accessibility score between 0 and 1.
+
+    The closer the value is to 1 the better the wheelchair-accessibility of this leg is.
+
+    More information is available at https://docs.opentripplanner.org/en/dev-2.x/sandbox/IBIAccessibilityScore/
+    """
+    accessibilityScore: Float
 }
 
 """A span of time."""


### PR DESCRIPTION
### Summary

This adds the IBI accessibility score to the GTFS GraphQL API. It's pure sandbox code and therefore only needs a single reviewer.

### Unit tests

Added test fixtures.

### Documentation

Added.

@miles-grant-ibigroup