### PR TITLE
Document Siri-SX updaters, use records for config

### DIFF
--- a/doc-templates/SiriUpdater.md
+++ b/doc-templates/SiriUpdater.md
@@ -26,6 +26,10 @@ To enable the SIRI updater you need to add it to the updaters section of the `ro
 
 <!-- INSERT: siri-et-updater -->
 
+### Siri-SX via HTTPS
+
+<!-- INSERT: siri-sx-updater -->
+
 ## Changelog
 
 - Initial version of SIRI updater (October 2019)

--- a/doc-templates/UpdaterConfig.md
+++ b/doc-templates/UpdaterConfig.md
@@ -79,23 +79,8 @@ partial support for both v1 and v2.2 ([list of known GBFS feeds](https://github.
 
 ## Other updaters in sandboxes
 
-### Vehicle parking
-
-Vehicle parking options and configuration is documented in
-its [sandbox documentation](sandbox/VehicleParking.md).
-
-<!-- INSERT: vehicle-parking -->
-
-
-### SIRI SX updater for Azure Service Bus
-
-This is a Sandbox updater, see [sandbox documentation](sandbox/SiriAzureUpdater.md).
-
-<!-- INSERT: siri-azure-sx-updater -->
-
-
-### Vehicle Rental Service Directory configuration
-
-To configure and url for
-the [VehicleRentalServiceDirectory](sandbox/VehicleRentalServiceDirectory.md).
+- [Vehicle parking](sandbox/VehicleParking.md)
+- [Siri over HTTP](sandbox/SiriUpdater.md)
+- [Siri over Azure Message Bus](sandbox/SiriAzureUpdater.md)
+- [VehicleRentalServiceDirectory](sandbox/VehicleRentalServiceDirectory.md)
 

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -707,6 +707,15 @@ HTTP headers to add to the request. Any header key, value can be inserted.
       }
     },
     {
+      "type" : "siri-sx-updater",
+      "url" : "https://example.com/some/path",
+      "feedId" : "feed_id",
+      "timeoutSec" : 30,
+      "headers" : {
+        "Key" : "Value"
+      }
+    },
+    {
       "type" : "siri-azure-sx-updater",
       "topic" : "some_topic",
       "servicebus-url" : "service_bus_url",

--- a/docs/UpdaterConfig.md
+++ b/docs/UpdaterConfig.md
@@ -377,23 +377,8 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 ## Other updaters in sandboxes
 
-### Vehicle parking
-
-Vehicle parking options and configuration is documented in
-its [sandbox documentation](sandbox/VehicleParking.md).
-
-<!-- INSERT: vehicle-parking -->
-
-
-### SIRI SX updater for Azure Service Bus
-
-This is a Sandbox updater, see [sandbox documentation](sandbox/SiriAzureUpdater.md).
-
-<!-- INSERT: siri-azure-sx-updater -->
-
-
-### Vehicle Rental Service Directory configuration
-
-To configure and url for
-the [VehicleRentalServiceDirectory](sandbox/VehicleRentalServiceDirectory.md).
+- [Vehicle parking](sandbox/VehicleParking.md)
+- [Siri over HTTP](sandbox/SiriUpdater.md)
+- [Siri over Azure Message Bus](sandbox/SiriAzureUpdater.md)
+- [VehicleRentalServiceDirectory](sandbox/VehicleRentalServiceDirectory.md)
 

--- a/docs/sandbox/SiriUpdater.md
+++ b/docs/sandbox/SiriUpdater.md
@@ -73,6 +73,56 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 <!-- siri-et-updater END -->
 
+### Siri-SX via HTTPS
+
+<!-- siri-sx-updater BEGIN -->
+<!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
+
+| Config Parameter               |       Type      | Summary                                                                                                |  Req./Opt. | Default Value | Since |
+|--------------------------------|:---------------:|--------------------------------------------------------------------------------------------------------|:----------:|---------------|:-----:|
+| type = "siri-sx-updater"       |      `enum`     | The type of the updater.                                                                               | *Required* |               |  1.5  |
+| blockReadinessUntilInitialized |    `boolean`    | Whether catching up with the updates should block the readiness check from returning a 'ready' result. | *Optional* | `false`       |  2.0  |
+| earlyStartSec                  |    `integer`    | TODO                                                                                                   | *Optional* | `-1`          |  2.0  |
+| feedId                         |     `string`    | The ID of the feed to apply the updates to.                                                            | *Required* |               |  2.0  |
+| frequencySec                   |    `integer`    | How often the updates should be retrieved.                                                             | *Optional* | `60`          |  2.0  |
+| requestorRef                   |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
+| timeoutSec                     |    `integer`    | The HTTP timeout to download the updates.                                                              | *Optional* | `15`          |  2.0  |
+| url                            |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
+| [headers](#u__9__headers)      | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
+
+
+##### Parameter details
+
+<h4 id="u__9__headers">headers</h4>
+
+**Since version:** `2.3` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
+**Path:** /updaters/[9] 
+
+HTTP headers to add to the request. Any header key, value can be inserted.
+
+
+
+##### Example configuration
+
+```JSON
+// router-config.json
+{
+  "updaters" : [
+    {
+      "type" : "siri-sx-updater",
+      "url" : "https://example.com/some/path",
+      "feedId" : "feed_id",
+      "timeoutSec" : 30,
+      "headers" : {
+        "Key" : "Value"
+      }
+    }
+  ]
+}
+```
+
+<!-- siri-sx-updater END -->
+
 ## Changelog
 
 - Initial version of SIRI updater (October 2019)

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -38,8 +38,8 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   public SiriSXUpdater(SiriSXUpdaterParameters config, TransitModel transitModel) {
     super(config);
     // TODO: add options to choose different patch services
-    this.url = config.getUrl();
-    this.requestorRef = config.getRequestorRef();
+    this.url = config.url();
+    this.requestorRef = config.requestorRef();
 
     if (requestorRef == null || requestorRef.isEmpty()) {
       requestorRef = "otp-" + UUID.randomUUID().toString();
@@ -48,7 +48,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
     //Keeping original requestorRef use as base for updated requestorRef to be used in retries
     this.originalRequestorRef = requestorRef;
 
-    int timeoutSec = config.getTimeoutSec();
+    int timeoutSec = config.timeoutSec();
     if (timeoutSec > 0) {
       this.timeout = 1000 * timeoutSec;
     }
@@ -59,11 +59,11 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
     this.updateHandler =
       new SiriAlertsUpdateHandler(
-        config.getFeedId(),
+        config.feedId(),
         transitModel,
         transitAlertService,
         SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel)),
-        config.getEarlyStartSec()
+        config.earlyStartSec()
       );
     LOG.info(
       "Creating real-time alert updater (SIRI SX) running every {} seconds : {}",

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdaterParameters.java
@@ -3,76 +3,15 @@ package org.opentripplanner.ext.siri.updater;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.opentripplanner.updater.spi.PollingGraphUpdaterParameters;
 
-public class SiriSXUpdaterParameters implements PollingGraphUpdaterParameters {
-
-  private final String configRef;
-  private final String feedId;
-  private final String url;
-  private final String requestorRef;
-  private final int frequencySec;
-  private final int earlyStartSec;
-  private final int timeoutSec;
-  private final boolean blockReadinessUntilInitialized;
-
-  private final HttpHeaders requestHeaders;
-
-  public SiriSXUpdaterParameters(
-    String configRef,
-    String feedId,
-    String url,
-    String requestorRef,
-    int frequencySec,
-    int earlyStartSec,
-    int timeoutSec,
-    boolean blockReadinessUntilInitialized,
-    HttpHeaders requestHeaders
-  ) {
-    this.configRef = configRef;
-    this.feedId = feedId;
-    this.url = url;
-    this.requestorRef = requestorRef;
-    this.frequencySec = frequencySec;
-    this.earlyStartSec = earlyStartSec;
-    this.timeoutSec = timeoutSec;
-    this.blockReadinessUntilInitialized = blockReadinessUntilInitialized;
-    this.requestHeaders = requestHeaders;
-  }
-
-  String getFeedId() {
-    return feedId;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  @Override
-  public int frequencySec() {
-    return frequencySec;
-  }
-
-  @Override
-  public String configRef() {
-    return configRef;
-  }
-
-  public String getRequestorRef() {
-    return requestorRef;
-  }
-
-  public int getEarlyStartSec() {
-    return earlyStartSec;
-  }
-
-  public int getTimeoutSec() {
-    return timeoutSec;
-  }
-
-  public boolean blockReadinessUntilInitialized() {
-    return blockReadinessUntilInitialized;
-  }
-
-  public HttpHeaders requestHeaders() {
-    return requestHeaders;
-  }
-}
+public record SiriSXUpdaterParameters(
+  String configRef,
+  String feedId,
+  String url,
+  String requestorRef,
+  int frequencySec,
+  int earlyStartSec,
+  int timeoutSec,
+  boolean blockReadinessUntilInitialized,
+  HttpHeaders requestHeaders
+)
+  implements PollingGraphUpdaterParameters {}

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
@@ -1,9 +1,8 @@
 package org.opentripplanner.standalone.config.routerconfig.updaters;
 
-import static org.opentripplanner.standalone.config.framework.json.OtpVersion.NA;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_3;
 
-import java.util.UUID;
 import org.opentripplanner.ext.siri.updater.SiriSXUpdaterParameters;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
@@ -12,13 +11,23 @@ public class SiriSXUpdaterConfig {
   public static SiriSXUpdaterParameters create(String configRef, NodeAdapter c) {
     return new SiriSXUpdaterParameters(
       configRef,
-      c.of("feedId").since(NA).summary("TODO").asString(null),
-      c.of("url").since(NA).summary("TODO").asString(),
-      c.of("requestorRef").since(NA).summary("TODO").asString("otp-" + UUID.randomUUID()),
-      c.of("frequencySec").since(NA).summary("TODO").asInt(60),
-      c.of("earlyStartSec").since(NA).summary("TODO").asInt(-1),
-      c.of("timeoutSec").since(NA).summary("TODO").asInt(-1),
-      c.of("blockReadinessUntilInitialized").since(NA).summary("TODO").asBoolean(false),
+      c.of("feedId").since(V2_0).summary("The ID of the feed to apply the updates to.").asString(),
+      c.of("url").since(V2_0).summary("The URL to send the HTTP requests to.").asString(),
+      c.of("requestorRef").since(V2_0).summary("The requester reference.").asString(null),
+      c
+        .of("frequencySec")
+        .since(V2_0)
+        .summary("How often the updates should be retrieved.")
+        .asInt(60),
+      c.of("earlyStartSec").since(V2_0).summary("TODO").asInt(-1),
+      c.of("timeoutSec").since(V2_0).summary("The HTTP timeout to download the updates.").asInt(15),
+      c
+        .of("blockReadinessUntilInitialized")
+        .since(V2_0)
+        .summary(
+          "Whether catching up with the updates should block the readiness check from returning a 'ready' result."
+        )
+        .asBoolean(false),
       HttpHeadersConfig.headers(c, V2_3)
     );
   }

--- a/src/test/java/org/opentripplanner/generate/doc/SiriConfigDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/SiriConfigDocTest.java
@@ -29,19 +29,19 @@ public class SiriConfigDocTest {
   private static final File OUT_FILE = new File(DOCS_ROOT, "sandbox/SiriUpdater.md");
 
   private static final String ROUTER_CONFIG_PATH = "standalone/config/" + ROUTER_CONFIG_FILENAME;
-  private static final Set<String> INCLUDE_UPDATERS = Set.of("siri-et-updater");
+  private static final Set<String> INCLUDE_UPDATERS = Set.of("siri-et-updater", "siri-sx-updater");
   private static final SkipNodes SKIP_NODES = SkipNodes.of().build();
   public static final ObjectMapper mapper = new ObjectMapper();
 
   /**
-   * NOTE! This test updates the {@code docs/sandbox/SiriUpdator.md} document based on the latest
+   * NOTE! This test updates the {@code docs/sandbox/SiriUpdater.md} document based on the latest
    * version of the code.
    */
   @Test
   public void updateSiriDoc() {
     NodeAdapter node = readUpdaterConfig();
 
-    // Read and close inout file (same as output file)
+    // Read and close input file (same as output file)
     String template = readFile(TEMPLATE);
     String original = readFile(OUT_FILE);
 

--- a/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
@@ -32,7 +32,8 @@ public class UpdaterConfigDocTest {
   private static final Set<String> SKIP_UPDATERS = Set.of(
     "siri-azure-sx-updater",
     "vehicle-parking",
-    "siri-et-updater"
+    "siri-et-updater",
+    "siri-sx-updater"
   );
   private static final SkipNodes SKIP_NODES = SkipNodes.of().build();
   public static final ObjectMapper mapper = new ObjectMapper();

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -283,6 +283,16 @@
         "Authorization": "Some-Token"
       }
     },
+    // Siri-SX over HTTP
+    {
+      "type": "siri-sx-updater",
+      "url": "https://example.com/some/path",
+      "feedId": "feed_id",
+      "timeoutSec": 30,
+      "headers": {
+        "Key": "Value"
+      }
+    },
     // SIRI SX updater for Azure Service Bus
     {
       "type": "siri-azure-sx-updater",


### PR DESCRIPTION
### Summary

This creates auto-generated documentation for the Siri-SX over HTTP updater.

It also uses a record for the parameters for the updater to reduce the number of lines.