### PR TITLE
Handle invalid stop sequences for GTFS-RT vehicle positions

### DIFF
--- a/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
@@ -239,7 +239,10 @@ public class VehiclePositionPatternMatcher {
       }
     }
     // but if stop_id isn't there we try current_stop_sequence
-    else if (vehiclePosition.hasCurrentStopSequence()) {
+    else if (
+      vehiclePosition.hasCurrentStopSequence() &&
+      validStopSequence(vehiclePosition, stopsOnVehicleTrip)
+    ) {
       var stop = stopsOnVehicleTrip.get(vehiclePosition.getCurrentStopSequence());
       newPosition.setStop(stop);
     }
@@ -247,6 +250,16 @@ public class VehiclePositionPatternMatcher {
     newPosition.setTrip(trip);
 
     return newPosition.build();
+  }
+
+  /**
+   * Checks that the current_stop_sequence can actually be found in the pattern.
+   */
+  private static boolean validStopSequence(
+    VehiclePosition vehiclePosition,
+    List<StopLocation> stopsOnVehicleTrip
+  ) {
+    return vehiclePosition.getCurrentStopSequence() < stopsOnVehicleTrip.size() - 1;
   }
 
   private record TemporalDistance(LocalDate date, long distance) {}

--- a/src/test/java/org/opentripplanner/updater/vehicle_position/VehiclePositionsMatcherTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_position/VehiclePositionsMatcherTest.java
@@ -52,6 +52,18 @@ public class VehiclePositionsMatcherTest {
     testVehiclePositions(posWithoutServiceDate);
   }
 
+  @Test
+  void invalidStopSequence() {
+    var posWithInvalidSequence = VehiclePosition
+      .newBuilder()
+      .setTrip(TripDescriptor.newBuilder().setTripId(tripId).build())
+      // there are 3 stops in the pattern so a current_stop_sequence of 3 would go off the end of
+      // the trip
+      .setCurrentStopSequence(3)
+      .build();
+    testVehiclePositions(posWithInvalidSequence);
+  }
+
   private void testVehiclePositions(VehiclePosition pos) {
     var service = new DefaultVehiclePositionService();
     var trip = TransitModelForTest.trip(tripId).build();


### PR DESCRIPTION
### Summary

This fixes the case where a GTFS-RT vehicle position source sends no stop id AND an invalid `current_stop_sequence` by validating the sequence before assigning it to a stop.

### Unit tests

Added.