### PR TITLE
Use correct GTFS sequence number in vehicle position matcher

### DIFF
--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -220,7 +220,7 @@ public class Timetable implements Serializable {
       boolean match = false;
       if (update != null) {
         if (update.hasStopSequence()) {
-          match = update.getStopSequence() == newTimes.getOriginalGtfsStopSequence(i);
+          match = update.getStopSequence() == newTimes.gtfsSequenceOfStopIndex(i);
         } else if (update.hasStopId()) {
           match = pattern.getStop(i).getId().getId().equals(update.getStopId());
         }

--- a/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLeg.java
@@ -92,7 +92,7 @@ public class FrequencyTransitLeg extends ScheduledTransitLeg {
         ServiceDateUtils.toZonedDateTime(serviceDate, zoneId, arrivalTime),
         ServiceDateUtils.toZonedDateTime(serviceDate, zoneId, departureTime),
         i,
-        tripTimes.getOriginalGtfsStopSequence(i)
+        tripTimes.gtfsSequenceOfStopIndex(i)
       );
       visits.add(visit);
     }

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -264,7 +264,7 @@ public class ScheduledTransitLeg implements TransitLeg {
         ServiceDateUtils.toZonedDateTime(serviceDate, zoneId, tripTimes.getArrivalTime(i)),
         ServiceDateUtils.toZonedDateTime(serviceDate, zoneId, tripTimes.getDepartureTime(i)),
         i,
-        tripTimes.getOriginalGtfsStopSequence(i)
+        tripTimes.gtfsSequenceOfStopIndex(i)
       );
       visits.add(visit);
     }
@@ -329,12 +329,12 @@ public class ScheduledTransitLeg implements TransitLeg {
 
   @Override
   public Integer getBoardingGtfsStopSequence() {
-    return tripTimes.getOriginalGtfsStopSequence(boardStopPosInPattern);
+    return tripTimes.gtfsSequenceOfStopIndex(boardStopPosInPattern);
   }
 
   @Override
   public Integer getAlightGtfsStopSequence() {
-    return tripTimes.getOriginalGtfsStopSequence(alightStopPosInPattern);
+    return tripTimes.gtfsSequenceOfStopIndex(alightStopPosInPattern);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -11,6 +11,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.StopTime;
@@ -109,7 +110,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
    */
   private RealTimeState realTimeState = RealTimeState.SCHEDULED;
 
-  public Accessibility wheelchairAccessibility;
+  private Accessibility wheelchairAccessibility;
 
   /**
    * The provided stopTimes are assumed to be pre-filtered, valid, and monotonically increasing. The
@@ -471,8 +472,24 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
   }
 
   /** Just to create uniform getter-syntax across the whole public interface of TripTimes. */
-  public int getOriginalGtfsStopSequence(final int stop) {
+  public int gtfsSequenceOfStopIndex(final int stop) {
     return originalGtfsStopSequence[stop];
+  }
+
+  /**
+   * Returns the 0-based stop sequence of the giving
+   */
+  public OptionalInt stopIndexOfGtfsSequence(int stopSequence) {
+    if (originalGtfsStopSequence == null) {
+      return OptionalInt.empty();
+    }
+    for (int i = 0; i < originalGtfsStopSequence.length; i++) {
+      var sequence = originalGtfsStopSequence[i];
+      if (sequence == stopSequence) {
+        return OptionalInt.of(i);
+      }
+    }
+    return OptionalInt.empty();
   }
 
   /** @return whether or not stopIndex is considered a timepoint in this TripTimes. */

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -471,13 +471,15 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
     timeShift += duration.toSeconds();
   }
 
-  /** Just to create uniform getter-syntax across the whole public interface of TripTimes. */
+  /**
+   * Returns the GTFS sequence number of the given 0-based stop index.
+   */
   public int gtfsSequenceOfStopIndex(final int stop) {
     return originalGtfsStopSequence[stop];
   }
 
   /**
-   * Returns the 0-based stop sequence of the giving
+   * Returns the 0-based stop index of the given GTFS sequence number.
    */
   public OptionalInt stopIndexOfGtfsSequence(int stopSequence) {
     if (originalGtfsStopSequence == null) {

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
@@ -242,8 +242,7 @@ public class VehiclePositionPatternMatcher {
     else if (vehiclePosition.hasCurrentStopSequence()) {
       tripTimes
         .stopIndexOfGtfsSequence(vehiclePosition.getCurrentStopSequence())
-        .stream()
-        .forEach(stopIndex -> {
+        .ifPresent(stopIndex -> {
           if (validStopIndex(stopIndex, stopsOnVehicleTrip)) {
             var stop = stopsOnVehicleTrip.get(stopIndex);
             newPosition.setStop(stop);
@@ -257,7 +256,7 @@ public class VehiclePositionPatternMatcher {
   }
 
   /**
-   * Checks that the current_stop_sequence can actually be found in the pattern.
+   * Checks that the stop index can actually be found in the pattern.
    */
   private static boolean validStopIndex(int stopIndex, List<StopLocation> stopsOnVehicleTrip) {
     return stopIndex < stopsOnVehicleTrip.size() - 1;

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -56,7 +56,7 @@ public class TripTimesTest {
       stopTime.setStop(stop);
       stopTime.setArrivalTime(i * 60);
       stopTime.setDepartureTime(i * 60);
-      stopTime.setStopSequence(i);
+      stopTime.setStopSequence(i * 10);
       stopTimes.add(stopTime);
     }
 
@@ -148,6 +148,19 @@ public class TripTimesTest {
     assertFalse(updatedTripTimesA.isNoDataStop(0));
     assertTrue(updatedTripTimesA.isNoDataStop(1));
     assertFalse(updatedTripTimesA.isNoDataStop(2));
+  }
+
+  @Test
+  void gtfsSequence() {
+    var stopIndex = originalTripTimes.stopIndexOfGtfsSequence(40);
+    assertTrue(stopIndex.isPresent());
+    assertEquals(4, stopIndex.getAsInt());
+  }
+
+  @Test
+  void unknownGtfsSequence() {
+    var stopIndex = originalTripTimes.stopIndexOfGtfsSequence(4);
+    assertTrue(stopIndex.isEmpty());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -152,6 +152,12 @@ public class TripTimesTest {
 
   @Test
   void gtfsSequence() {
+    var stopIndex = originalTripTimes.gtfsSequenceOfStopIndex(2);
+    assertEquals(20, stopIndex);
+  }
+
+  @Test
+  void stopIndexOfGtfsSequence() {
     var stopIndex = originalTripTimes.stopIndexOfGtfsSequence(40);
     assertTrue(stopIndex.isPresent());
     assertEquals(4, stopIndex.getAsInt());

--- a/src/test/java/org/opentripplanner/updater/vehicle_position/VehiclePositionsMatcherTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_position/VehiclePositionsMatcherTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.vehicle_position;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.stopTime;
 
+import com.google.transit.realtime.GtfsRealtime;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
 import java.time.Duration;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner._support.time.ZoneIds;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.service.vehiclepositions.internal.DefaultVehiclePositionService;
 import org.opentripplanner.test.support.VariableSource;
@@ -50,6 +52,9 @@ public class VehiclePositionsMatcherTest {
       .newBuilder()
       .setTrip(TripDescriptor.newBuilder().setTripId(tripId).build())
       .setStopId("stop-1")
+      .setPosition(
+        GtfsRealtime.Position.newBuilder().setLatitude(1).setLongitude(1).setBearing(30).build()
+      )
       .build();
     testVehiclePositions(posWithoutServiceDate);
   }
@@ -101,6 +106,9 @@ public class VehiclePositionsMatcherTest {
       .newBuilder()
       .setTrip(TripDescriptor.newBuilder().setTripId(tripId).build())
       .setCurrentStopSequence(99)
+      .setPosition(
+        GtfsRealtime.Position.newBuilder().setLatitude(1).setLongitude(1).setBearing(30).build()
+      )
       .build();
     testVehiclePositions(posWithInvalidSequence);
   }
@@ -137,7 +145,10 @@ public class VehiclePositionsMatcherTest {
     var vehiclePositions = service.getVehiclePositions(pattern);
     assertEquals(1, vehiclePositions.size());
 
-    assertEquals(tripId, vehiclePositions.get(0).trip().getId().getId());
+    var parsedPos = vehiclePositions.get(0);
+    assertEquals(tripId, parsedPos.trip().getId().getId());
+    assertEquals(new WgsCoordinate(1, 1), parsedPos.coordinates());
+    assertEquals(30, parsedPos.heading());
 
     // if we have an empty list of updates then clear the positions from the previous update
     matcher.applyVehiclePositionUpdates(List.of());
@@ -260,6 +271,9 @@ public class VehiclePositionsMatcherTest {
       .newBuilder()
       .setTrip(TripDescriptor.newBuilder().setTripId(tripId1).setStartDate("20220314").build())
       .setStopId("stop-1")
+      .setPosition(
+        GtfsRealtime.Position.newBuilder().setLatitude(1).setLongitude(1).setBearing(30).build()
+      )
       .build();
   }
 }


### PR DESCRIPTION
### Summary

This is a follow up to #5078 where I realised that the vehicle positon code uses the stop index when it should use the GTFS sequence number.

This PR fixes that, refactors `TripTimes` lightly and improves the documentation.

### Unit tests

Added.

### Documentation

Javadoc improved.