### PR TITLE
Improve Graph updaters shutdown

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -221,12 +221,12 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
       /* commit */
       return addTripToGraphAndBuffer(result.successValue(), journey, entityResolver);
-    } catch (Throwable t) {
+    } catch (Exception e) {
       LOG.warn(
         "{} EstimatedJourney {} failed.",
         shouldAddNewTrip ? "Adding" : "Updating",
         DebugString.of(journey),
-        t
+        e
       );
       return Result.failure(UpdateError.noTripId(UNKNOWN));
     }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -203,7 +203,8 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
 
     int sleepPeriod = 1000;
     int attemptCounter = 1;
-    while (!isPrimed()) { // Retrying until data is initialized successfully
+    boolean otpIsShuttingDown = false;
+    while (!isPrimed() && !otpIsShuttingDown) { // Retrying until data is initialized successfully
       try {
         initializeData(dataInitializationUrl, receiver);
       } catch (Exception e) {
@@ -219,13 +220,17 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
         try {
           Thread.sleep(sleepPeriod);
         } catch (InterruptedException interruptedException) {
-          //Ignore
+          Thread.currentThread().interrupt();
+          otpIsShuttingDown = true;
+          LOG.info(
+            "OTP is shutting down, cancelling initialization of SIRI ET Google PubSub Updater."
+          );
         }
       }
     }
 
     Subscriber subscriber = null;
-    while (true) {
+    while (!otpIsShuttingDown) {
       try {
         subscriber = Subscriber.newBuilder(subscription.getName(), receiver).build();
         subscriber.startAsync().awaitRunning();
@@ -239,7 +244,11 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
       try {
         Thread.sleep(reconnectPeriod.toMillis());
       } catch (InterruptedException e) {
-        e.printStackTrace();
+        Thread.currentThread().interrupt();
+        otpIsShuttingDown = true;
+        LOG.info(
+          "OTP is shutting down, cancelling attempt to reconnect SIRI ET Google PubSub Updater."
+        );
       }
     }
   }
@@ -395,7 +404,10 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
         if (!isPrimed()) {
           try {
             f.get();
-          } catch (InterruptedException | ExecutionException e) {
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          } catch (ExecutionException e) {
             throw new RuntimeException(e);
           }
         }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -370,7 +370,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
               .get(0)
               .getEstimatedVehicleJourneies()
               .size();
-        } catch (Throwable t) {
+        } catch (Exception e) {
           //ignore
         }
         long numberOfUpdates = UPDATE_COUNTER.addAndGet(numberOfUpdatedTrips);

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -86,7 +86,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   }
 
   @Override
-  protected void runPolling() {
+  protected void runPolling() throws InterruptedException {
     try {
       boolean moreData = false;
       do {
@@ -112,11 +112,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
 
       LOG.info("Caught timeout - retry no. {} after {} millis", retryCount, sleepTime);
 
-      try {
-        Thread.sleep(sleepTime);
-      } catch (InterruptedException ex) {
-        //Ignore
-      }
+      Thread.sleep(sleepTime);
 
       // Creating new requestorRef so all data is refreshed
       requestorRef = originalRequestorRef + "-retry-" + retryCount;

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -187,7 +187,8 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   private void initializeData() {
     int sleepPeriod = 1000;
     int attemptCounter = 1;
-    while (true) {
+    boolean otpIsShuttingDown = false;
+    while (!otpIsShuttingDown) {
       try {
         initializeData(dataInitializationUrl, messageConsumer);
         break;
@@ -203,7 +204,9 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
         try {
           Thread.sleep(sleepPeriod);
         } catch (InterruptedException interruptedException) {
-          //Ignore
+          Thread.currentThread().interrupt();
+          otpIsShuttingDown = true;
+          LOG.info("OTP is shutting down, cancelling attempt to initialize Azure SIRI Updater.");
         }
       }
     }
@@ -251,8 +254,9 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
       try {
         // Choosing an arbitrary amount of time to wait until trying again.
         TimeUnit.SECONDS.sleep(5);
-      } catch (InterruptedException e2) {
-        LOG.error("Unable to sleep for period of time");
+      } catch (InterruptedException interruptedException) {
+        Thread.currentThread().interrupt();
+        LOG.info("OTP is shutting down, stopping processing of ServiceBus error messages");
       }
     } else {
       LOG.error(e.getLocalizedMessage(), e);

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -225,6 +225,7 @@ public class OTPMain {
       raptorConfig.shutdown();
       WeakCollectionCleaner.DEFAULT.exit();
       DeferredAuthorityFactory.exit();
+      LOG.info("OTP shutdown: resources released...");
     });
     Runtime.getRuntime().addShutdownHook(hook);
   }

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -218,7 +218,8 @@ public class GraphUpdaterManager implements WriteToGraphCallback, GraphUpdaterSt
     Executors
       .newSingleThreadExecutor()
       .submit(() -> {
-        while (true) {
+        boolean otpIsShuttingDown = false;
+        while (!otpIsShuttingDown) {
           try {
             if (updaterList.stream().allMatch(GraphUpdater::isPrimed)) {
               LOG.info("OTP UPDATERS INITIALIZED - OTP is ready for routing!");
@@ -226,8 +227,12 @@ public class GraphUpdaterManager implements WriteToGraphCallback, GraphUpdaterSt
             }
             //noinspection BusyWait
             Thread.sleep(1000);
-          } catch (Exception e) {
+          } catch (RuntimeException e) {
             LOG.error(e.getMessage(), e);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            otpIsShuttingDown = true;
+            LOG.info("OTP is shutting down, cancelling wait for updaters readiness.");
           }
         }
       });

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -112,6 +112,7 @@ public class UpdaterConfigurator {
     if (updaterManager != null) {
       LOG.info("Stopping updater manager with {} updaters.", updaterManager.numberOfUpdaters());
       updaterManager.stop();
+      LOG.info("Stopped updater manager");
     }
   }
 

--- a/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
@@ -70,8 +70,11 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
         Thread.sleep(pollingPeriodSeconds * 1000);
       }
     } catch (InterruptedException e) {
-      // When updater is interrupted
-      LOG.error("Polling updater {} was interrupted and is stopping.", this.getClass().getName());
+      Thread.currentThread().interrupt();
+      LOG.info(
+        "OTP is shutting down, polling updater {} was interrupted and is stopping.",
+        this.getClass().getName()
+      );
     }
   }
 


### PR DESCRIPTION
### Summary

This PR ensures that graph updaters stop execution gracefully when the OTP server shuts down.
This is particularly important in a cloud environment where OTP instances are routinely started and stopped.

More specifically:
- all updaters should exit their initialization sequence when receiving an interruption signal.
- polling updaters should exit their polling loop when receiving an interruption signal,
- listening updaters that perform retry logic when disconnect should exit their retry loop when receiving an interruption signal.


Additionally:
- log messages during the shutdown sequence are clarified.
- in a couple of places in the code `Throwables` where caught. Now `Exceptions` are caught instead, to prevent hiding memory issues.

### Issue
None
### Unit tests

:white_check_mark: 

### Documentation

No

