### PR TITLE
Add GraphiQL client for transmodel API

### DIFF
--- a/src/client/graphiql/transmodel/index.html
+++ b/src/client/graphiql/transmodel/index.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+
+    <!--
+    This GraphiQL example depends on Promise and fetch, which are available in
+    modern browsers, but can be "polyfilled" for older browsers.
+    GraphiQL itself depends on React DOM.
+    If you do not want to rely on a CDN, you can host these files locally or
+    include them directly in your favored resource bundler.
+  -->
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/react@17/umd/react.development.js"
+      integrity="sha384-xQwCoNcK/7P3Lpv50IZSEbJdpqbToWEODAUyI/RECaRXmOE2apWt7htari8kvKa/"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.development.js"
+      integrity="sha384-E9IgxDsnjKgh0777N3lXen7NwXeTsOpLLJhI01SW7idG046SRqJpsW2rJwsOYk0L"
+      crossorigin="anonymous"
+    ></script>
+
+    <!--
+    These two files can be found in the npm module, however you may wish to
+    copy them directly into your environment, or perhaps include them in your
+    favored resource bundler.
+   -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.css"
+      integrity="sha256-88yn8FJMyGboGs4Bj+Pbb3kWOWXo7jmb+XCRHE+282k="
+      crossorigin="anonymous"
+    />
+    <title>OTP GraphQL Explorer - Transmodel API</title>
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.js"
+      integrity="sha256-s+f7CFAPSUIygFnRC2nfoiEKd3liCUy+snSdYFAoLUc="
+      crossorigin="anonymous"
+    ></script>
+
+    <script>
+      const defaultQuery = `
+# This is an example query for fetching the OTP version and a trip. Change the
+# coordinates to fit your OTP deployment.
+query MyQuery {
+  serverInfo {
+    version
+  }
+  trip(
+    from: {
+      coordinates: {
+        latitude: 58.89053
+        longitude: 5.71654
+      }
+    }
+    to: {
+      coordinates: {
+        latitude: 58.96134
+        longitude: 5.72525
+      }
+    }
+  ) {
+    tripPatterns {
+      expectedStartTime
+      legs {
+        mode
+        line {
+          publicCode
+          name
+        }
+      }
+    }
+  }
+}
+`;
+
+      // Parse the search string to get url parameters.
+      var search = window.location.search;
+      var parameters = {};
+      search
+        .substr(1)
+        .split("&")
+        .forEach(function (entry) {
+          var eq = entry.indexOf("=");
+          if (eq >= 0) {
+            parameters[decodeURIComponent(entry.slice(0, eq))] =
+              decodeURIComponent(entry.slice(eq + 1));
+          }
+        });
+
+      // If variables was provided, try to format it.
+      if (parameters.variables) {
+        try {
+          parameters.variables = JSON.stringify(
+            JSON.parse(parameters.variables),
+            null,
+            2
+          );
+        } catch (e) {
+          // Do nothing, we want to display the invalid JSON as a string, rather
+          // than present an error.
+        }
+      }
+
+      // When the query and variables string is edited, update the URL bar so
+      // that it can be easily shared.
+      function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+      }
+
+      function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+      }
+
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
+
+      function updateURL() {
+        if (parameters["query"] !== defaultQuery) {
+          var newSearch =
+            "?" +
+            Object.keys(parameters)
+              .filter(function (key) {
+                return Boolean(parameters[key]);
+              })
+              .map(function (key) {
+                return (
+                  encodeURIComponent(key) +
+                  "=" +
+                  encodeURIComponent(parameters[key])
+                );
+              })
+              .join("&");
+          history.replaceState(null, null, newSearch);
+        }
+      }
+
+      function graphQLFetcher(graphQLParams) {
+        ``;
+        return fetch("/otp/routers/default/transmodel/index/graphql", {
+          method: "post",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(graphQLParams),
+          credentials: "omit",
+        }).then(function (response) {
+          return response.json().catch(function () {
+            return response.text();
+          });
+        });
+      }
+
+      const header = React.createElement(
+        "a",
+        { className: "graphiql-logo-link" },
+        "OTP GraphQL Explorer"
+      );
+      ReactDOM.render(
+        React.createElement(
+          GraphiQL,
+          {
+            fetcher: graphQLFetcher,
+            defaultVariableEditorOpen: true,
+            query: parameters.query || defaultQuery,
+            variables: parameters.variables,
+            operationName: parameters.operationName,
+            onEditQuery: onEditQuery,
+            onEditVariables: onEditVariables,
+            onEditOperationName: onEditOperationName,
+            defaultEditorToolsVisibility: true,
+          },
+          React.createElement(GraphiQL.Logo, {}, header)
+        ),
+        document.getElementById("graphiql")
+      );
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Summary

This copy the GTFS GraphiQL web page and modify it to fit the Transmodel API.

An enhancment would be to just use one page and have a switch to toggle between GTFS and Transmodel. 

### Issue
No issue available.

### Unit tests
No tests added.


### Documentation
The example is modified to fit with the Transmodel API.

