### PR TITLE
Fix SIRI ET PubSub updater shutdown

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.siri.updater;
 
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
@@ -47,8 +48,9 @@ import uk.org.siri.www.siri.SiriType;
  * This class starts a Google PubSub subscription
  * <p>
  * NOTE: - Path to Google credentials (.json-file) MUST exist in environment-variable
- * "GOOGLE_APPLICATION_CREDENTIALS" as described here: https://cloud.google.com/docs/authentication/getting-started
- * - ServiceAccount need access to create subscription ("editor")
+ * "GOOGLE_APPLICATION_CREDENTIALS" as described here:
+ * https://cloud.google.com/docs/authentication/getting-started - ServiceAccount need access to
+ * create subscription ("editor")
  * <p>
  * <p>
  * <p>
@@ -85,14 +87,14 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   private final java.time.Duration reconnectPeriod;
 
   /**
-   * For larger deployments it sometimes takes more than the default 30 seconds to fetch
-   * data, if so this parameter can be increased.
+   * For larger deployments it sometimes takes more than the default 30 seconds to fetch data, if so
+   * this parameter can be increased.
    */
   private final java.time.Duration initialGetDataTimeout;
 
-  private final SubscriptionAdminClient subscriptionAdminClient;
   private final ProjectSubscriptionName subscriptionName;
   private final ProjectTopicName topic;
+  private Subscriber subscriber;
   private final PushConfig pushConfig;
   private final String configRef;
   private final SiriTimetableSnapshotSource snapshotSource;
@@ -143,22 +145,9 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     this.entityResolver = new EntityResolver(transitService, feedId);
     this.fuzzyTripMatcher =
       config.fuzzyTripMatching() ? SiriFuzzyTripMatcher.of(transitService) : null;
-
-    try {
-      // Google libraries expects credentials json-file either as
-      //   Path is stored in environment variable "GOOGLE_APPLICATION_CREDENTIALS"
-      //   (https://cloud.google.com/docs/authentication/getting-started)
-      // or
-      //   Credentials are provided through "workload identity"
-      //   (https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity)
-
-      subscriptionAdminClient = SubscriptionAdminClient.create();
-
-      addShutdownHook();
-    } catch (IOException e) {
-      throw new RuntimeException(e.getMessage(), e);
-    }
     recordMetrics = TripUpdateMetrics.streaming(config);
+
+    addShutdownHook();
   }
 
   @Override
@@ -167,36 +156,9 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   }
 
   @Override
-  public void run() throws IOException {
-    if (subscriptionAdminClient == null) {
-      throw new RuntimeException(
-        "Unable to initialize Google Pubsub-updater: System.getenv('GOOGLE_APPLICATION_CREDENTIALS') = " +
-        System.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-      );
-    }
-
+  public void run() {
     LOG.info("Creating subscription {}", subscriptionName);
-
-    Subscription subscription = subscriptionAdminClient.createSubscription(
-      Subscription
-        .newBuilder()
-        .setTopic(topic.toString())
-        .setName(subscriptionName.toString())
-        .setPushConfig(pushConfig)
-        .setMessageRetentionDuration(
-          // How long will an unprocessed message be kept - minimum 10 minutes
-          com.google.protobuf.Duration.newBuilder().setSeconds(600).build()
-        )
-        .setExpirationPolicy(
-          ExpirationPolicy
-            .newBuilder()
-            // How long will the subscription exist when no longer in use - minimum 1 day
-            .setTtl(com.google.protobuf.Duration.newBuilder().setSeconds(86400).build())
-            .build()
-        )
-        .build()
-    );
-
+    Subscription subscription = createSubscription();
     LOG.info("Created subscription {}", subscriptionName);
 
     final EstimatedTimetableMessageReceiver receiver = new EstimatedTimetableMessageReceiver();
@@ -230,7 +192,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
       }
     }
 
-    Subscriber subscriber = null;
+    subscriber = null;
 
     while (!otpIsShuttingDown) {
       try {
@@ -257,15 +219,11 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
 
   @Override
   public void teardown() {
-    if (subscriptionAdminClient != null) {
-      LOG.info("Deleting subscription {}", subscriptionName);
-      subscriptionAdminClient.deleteSubscription(subscriptionName);
-      LOG.info(
-        "Subscription deleted {} - time since startup: {}",
-        subscriptionName,
-        DurationUtils.durationToStr(Duration.between(startTime, Instant.now()))
-      );
+    if (subscriber != null) {
+      LOG.info("Stopping SIRI-ET PubSub subscriber  {}", subscriptionName);
+      subscriber.stopAsync();
     }
+    deleteSubscription();
   }
 
   @Override
@@ -287,6 +245,57 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
       // Handling cornercase when instance is being shut down before it has been initialized
       LOG.info("Instance is already shutting down - cleaning up immediately.", e);
       teardown();
+    }
+  }
+
+  private Subscription createSubscription() {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      return subscriptionAdminClient.createSubscription(
+        Subscription
+          .newBuilder()
+          .setTopic(topic.toString())
+          .setName(subscriptionName.toString())
+          .setPushConfig(pushConfig)
+          .setMessageRetentionDuration(
+            // How long will an unprocessed message be kept - minimum 10 minutes
+            com.google.protobuf.Duration.newBuilder().setSeconds(600).build()
+          )
+          .setExpirationPolicy(
+            ExpirationPolicy
+              .newBuilder()
+              // How long will the subscription exist when no longer in use - minimum 1 day
+              .setTtl(com.google.protobuf.Duration.newBuilder().setSeconds(86400).build())
+              .build()
+          )
+          .build()
+      );
+    } catch (IOException e) {
+      // Google libraries expects credentials json-file either as
+      //   Path is stored in environment variable "GOOGLE_APPLICATION_CREDENTIALS"
+      //   (https://cloud.google.com/docs/authentication/getting-started)
+      // or
+      //   Credentials are provided through "workload identity"
+      //   (https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity)
+      throw new RuntimeException(
+        "Unable to initialize Google Pubsub-updater: System.getenv('GOOGLE_APPLICATION_CREDENTIALS') = " +
+        System.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+      );
+    }
+  }
+
+  private void deleteSubscription() {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      LOG.info("Deleting subscription {}", subscriptionName);
+      subscriptionAdminClient.deleteSubscription(subscriptionName);
+      LOG.info(
+        "Subscription deleted {} - time since startup: {}",
+        subscriptionName,
+        DurationUtils.durationToStr(Duration.between(startTime, Instant.now()))
+      );
+    } catch (IOException e) {
+      LOG.error("Could not delete subscription {}", subscriptionName);
+    } catch (NotFoundException nfe) {
+      LOG.info("Subscription {} not found, ignoring deletion request", subscriptionName);
     }
   }
 


### PR DESCRIPTION
### Summary
The SIRI ET PubSub updater does not release resources when it stops, preventing the server from shutting down gracefully.
This PR ensures that:
- the subscriber is properly closed on shutdown by calling Subscriber.stopAsync().
- the SubscriptionAdminClient is invoked inside a try-with-resource block, so that its internal resources are released.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No