### PR TITLE
Add documentation about flex booking info, cleanup deprecated fields

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -141,15 +141,28 @@ jobs:
           else
             mike deploy --branch $LOCAL_BRANCH --prefix en dev-2.x
           fi
-          git push $REMOTE $LOCAL_BRANCH:$REMOTE_BRANCH
           
-          # commit and push the GraphQL documentation
+          # commit and push the GraphQL documentation if the schema file is newer than the 
+          # compiled output. it's necessary to have this check because the diffs of the magidoc tool
+          # this are quite large and unnecessarily increase the size of the docs repo even when the 
+          # schema hasn't changed.
+          # example commit: https://github.com/opentripplanner/docs/commit/45e6ddf8e4a4
+          
+          SCHEMA_FILE_MODIFIED=`stat -c "%Y" src/ext/resources/legacygraphqlapi/schema.graphqls` 
           git checkout $LOCAL_BRANCH
-          mkdir -p api
-          rsync -r --delete target/magidoc/api/ api/dev-2.x/
-          git add api
-          git commit -am "Add Magidoc GraphQL documentation"
+          DOCS_MODIFIED=`stat -c "%Y" api/dev-2.x/graphql-gtfs/introduction.html` 
+          if [ ${SCHEMA_FILE_MODIFIED} -gt ${DOCS_MODIFIED} ]; then
+            echo "schema.graphqls has been modified, committing updated documentation"
+            mkdir -p api
+            rsync -r --delete target/magidoc/api/ api/dev-2.x/
+            git add api
+            git commit -am "Add Magidoc GraphQL documentation"
+          else
+            echo "schema.graphqls has not been modified, not committing documentation"
+          fi
+          
           git push $REMOTE $LOCAL_BRANCH:$REMOTE_BRANCH
+  
 
   graphql-code-generation:
     if: github.repository_owner == 'opentripplanner'

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -2724,15 +2724,6 @@ type QueryType {
         pageCursor: String
 
         """
-        How easily bad itineraries are filtered from results. Value 0 (default)
-        disables filtering. Itineraries are filtered if they are worse than another
-        one in some respect (e.g. more walking) by more than the percentage of
-        filtering level, which is calculated by dividing 100% by the value of this
-        argument (e.g. `itineraryFiltering = 0.5` → 200% worse itineraries are filtered).
-        """
-        itineraryFiltering: Float
-
-        """
         A multiplier for how bad biking is, compared to being in transit for equal
         lengths of time. Default value: 2.0
         """
@@ -2805,9 +2796,6 @@ type QueryType {
         to the destination at the specified time (true). Default value: false.
         """
         arriveBy: Boolean
-
-        """An ordered list of intermediate locations to be visited."""
-        intermediatePlaces: [InputCoordinates]
 
         """
         List of routes and agencies which are given higher preference when planning the itinerary
@@ -2915,17 +2903,6 @@ type QueryType {
         startTransitStopId: String
 
         """
-        ID of the trip on which the itinerary starts. This argument can be used to
-        plan itineraries when the user is already onboard a vehicle. When using this
-        argument, arguments `time` and `from` should be set based on a vehicle
-        position message received from the vehicle running the specified trip.
-        **Note:** this argument only takes into account the route and estimated
-        travel time of the trip (and therefore arguments `time` and `from` must be
-        used correctly to get meaningful itineraries).
-        """
-        startTransitTripId: String
-
-        """
         When false, return itineraries using canceled trips. Default value: true.
         """
         omitCanceled: Boolean = true
@@ -2949,8 +2926,6 @@ type QueryType {
         """
         allowedTicketTypes: [String]
 
-        """Tuning parameter for the search algorithm, mainly useful for testing."""
-        heuristicStepsPerMainStep: Int
         """
         Which vehicle rental networks can be used. By default, all networks are allowed.
         """
@@ -3035,16 +3010,45 @@ type QueryType {
         Which vehicle rental networks can be used. By default, all networks are allowed.
         """
         allowedBikeRentalNetworks: [String] @deprecated(reason: "Use allowedVehicleRentalNetworks instead")
+
         """
         The maximum time (in seconds) of pre-transit travel when using
         drive-to-transit (park and ride or kiss and ride). Default value: 1800.
         """
+
         maxPreTransitTime: Int @deprecated(reason: "Use walkReluctance or future reluctance parameters for other modes")
         """
         How expensive it is to drive a car when car&parking, increase this value to
         make car driving legs shorter. Default value: 1.
         """
+
         carParkCarLegWeight: Float @deprecated(reason: "Use `carReluctance` instead.")
+
+        """Tuning parameter for the search algorithm, mainly useful for testing."""
+        heuristicStepsPerMainStep: Int @deprecated(reason: "Removed. Doesn't do anything.")
+
+        """
+        How easily bad itineraries are filtered from results. Value 0 (default)
+        disables filtering. Itineraries are filtered if they are worse than another
+        one in some respect (e.g. more walking) by more than the percentage of
+        filtering level, which is calculated by dividing 100% by the value of this
+        argument (e.g. `itineraryFiltering = 0.5` → 200% worse itineraries are filtered).
+        """
+        itineraryFiltering: Float @deprecated(reason: "Removed. Doesn't do anything.")
+
+        """An ordered list of intermediate locations to be visited."""
+        intermediatePlaces: [InputCoordinates] @deprecated(reason: "Not implemented in OTP2.")
+
+        """
+        ID of the trip on which the itinerary starts. This argument can be used to
+        plan itineraries when the user is already onboard a vehicle. When using this
+        argument, arguments `time` and `from` should be set based on a vehicle
+        position message received from the vehicle running the specified trip.
+        **Note:** this argument only takes into account the route and estimated
+        travel time of the trip (and therefore arguments `time` and `from` must be
+        used correctly to get meaningful itineraries).
+        """
+        startTransitTripId: String @deprecated(reason: "Not implemented in OTP2")
     ): Plan @async
 }
 

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -2724,35 +2724,6 @@ type QueryType {
         pageCursor: String
 
         """
-        The maximum distance (in meters) the user is willing to walk per walking
-        section. If the only transport mode allowed is `WALK`, then the value of
-        this argument is ignored.
-        Default: 2000m
-        Maximum value: 15000m
-        **Note:** If this argument has a relatively small value and only some
-        transport modes are allowed (e.g. `WALK` and `RAIL`), it is possible to get
-        an itinerary which has (useless) back and forth public transport legs to
-        avoid walking too long distances.
-
-        DEPRECATED - Use walkReluctance instead
-        """
-        maxWalkDistance: Float @deprecated(reason: "Does nothing. Use walkReluctance instead.")
-
-        """
-        The maximum time (in seconds) of pre-transit travel when using
-        drive-to-transit (park and ride or kiss and ride). Default value: 1800.
-
-        DEPRECATED - Use walkReluctance or future reluctance parameters for other modes
-        """
-        maxPreTransitTime: Int
-
-        """
-        How expensive it is to drive a car when car&parking, increase this value to
-        make car driving legs shorter. Default value: 1.
-        """
-        carParkCarLegWeight: Float
-
-        """
         How easily bad itineraries are filtered from results. Value 0 (default)
         disables filtering. Itineraries are filtered if they are worse than another
         one in some respect (e.g. more walking) by more than the percentage of
@@ -2791,13 +2762,6 @@ type QueryType {
         walkReluctance: Float
 
         """
-        How much more reluctant is the user to walk on streets with car traffic allowed. Default value: 1.0
-
-        Deprecated, use walkSafetyFactor instead.
-        """
-        walkOnStreetReluctance: Float @deprecated(reason: "Use walkSafetyFactor instead")
-
-        """
         How much worse is waiting for a transit vehicle than being on a transit
         vehicle, as a multiplier. The default value treats wait and on-vehicle time
         as the same. It may be tempting to set this higher than walkReluctance (as
@@ -2809,14 +2773,6 @@ type QueryType {
         neighboring stop patterns, this problem could disappear. Default value: 1.0.
         """
         waitReluctance: Float
-
-        """
-        How much less bad is waiting at the beginning of the trip (replaces
-        `waitReluctance` on the first boarding). Default value: 0.4
-
-        Deprecated, not used, the timetable-view replaces this functionality.
-        """
-        waitAtBeginningFactor: Float @deprecated(reason: "Removed in OTP 2")
 
         """
         Max walk speed along streets, in meters per second. Default value: 1.33
@@ -2899,12 +2855,6 @@ type QueryType {
         transferPenalty: Int
 
         """
-        This argument has no use for itinerary planning and will be removed later.
-        ~~When true, do not use goal direction or stop at the target, build a full SPT. Default value: false.~~
-        """
-        batch: Boolean @deprecated(reason: "Removed in OTP 2")
-
-        """
         List of transportation modes that the user is willing to use. Default: `["WALK","TRANSIT"]`
         """
         transportModes: [TransportMode]
@@ -2918,9 +2868,6 @@ type QueryType {
         Debug the itinerary-filter-chain. The filters will mark itineraries as deleted, but does NOT delete them when this is enabled.
         """
         debugItineraryFilter: Boolean
-
-        """Is bike rental allowed? Default value: false"""
-        allowBikeRental: Boolean @deprecated(reason: "Rental is specified by modes")
 
         """
         Whether arriving at the destination with a rented (station) bicycle is allowed without
@@ -2979,22 +2926,6 @@ type QueryType {
         startTransitTripId: String
 
         """
-        No effect on itinerary planning, adjust argument `time` instead to get later departures.
-        ~~The maximum wait time in seconds the user is willing to delay trip start. Only effective in Analyst.~~
-        """
-        claimInitialWait: Long @deprecated(reason: "Removed in OTP 2")
-
-        """
-        **Consider this argument experimental** – setting this argument to true
-        causes timeouts and unoptimal routes in many cases.
-        When true, reverse optimize (find alternative transportation mode, which
-        still arrives to the destination in time) this search on the fly after
-        processing each transit leg, rather than reverse-optimizing the entire path
-        when it's done. Default value: false.
-        """
-        reverseOptimizeOnTheFly: Boolean @deprecated(reason: "Removed in OTP 2")
-
-        """
         When false, return itineraries using canceled trips. Default value: true.
         """
         omitCanceled: Boolean = true
@@ -3003,13 +2934,6 @@ type QueryType {
         When true, realtime updates are ignored during this search. Default value: false
         """
         ignoreRealtimeUpdates: Boolean
-
-        """
-        Only useful for testing and troubleshooting.
-        ~~If true, the remaining weight heuristic is disabled. Currently only
-        implemented for the long distance path service. Default value: false.~~
-        """
-        disableRemainingWeightHeuristic: Boolean @deprecated(reason: "Removed in OTP 2.2")
 
         """
         Two-letter language code (ISO 639-1) used for returned text.
@@ -3027,20 +2951,6 @@ type QueryType {
 
         """Tuning parameter for the search algorithm, mainly useful for testing."""
         heuristicStepsPerMainStep: Int
-
-        """
-        Whether legs should be compacted by performing a reversed search.
-        **Experimental argument, will be removed!**
-        """
-        compactLegsByReversedSearch: Boolean @deprecated(reason: "Removed in OTP 2")
-
-        """
-        Which vehicle rental networks can be used. By default, all networks are allowed.
-
-        Deprecated: Use `allowedVehicleRentalNetworks` instead.
-        """
-        allowedBikeRentalNetworks: [String] @deprecated(reason: "Use allowedVehicleRentalNetworks instead")
-
         """
         Which vehicle rental networks can be used. By default, all networks are allowed.
         """
@@ -3059,6 +2969,82 @@ type QueryType {
 
         "Preferences for vehicle parking"
         parking: VehicleParkingInput
+
+        ## Deprecated fields, none of these have any effect on the routing anymore
+
+        """
+        The maximum distance (in meters) the user is willing to walk per walking
+        section. If the only transport mode allowed is `WALK`, then the value of
+        this argument is ignored.
+        Default: 2000m
+        Maximum value: 15000m
+        **Note:** If this argument has a relatively small value and only some
+        transport modes are allowed (e.g. `WALK` and `RAIL`), it is possible to get
+        an itinerary which has (useless) back and forth public transport legs to
+        avoid walking too long distances.
+        """
+        maxWalkDistance: Float @deprecated(reason: "Does nothing. Use walkReluctance instead.")
+
+        """
+        How much more reluctant is the user to walk on streets with car traffic allowed. Default value: 1.0
+        """
+        walkOnStreetReluctance: Float @deprecated(reason: "Use `walkSafetyFactor` instead")
+
+        """
+        How much less bad is waiting at the beginning of the trip (replaces
+        `waitReluctance` on the first boarding). Default value: 0.4
+        """
+        waitAtBeginningFactor: Float @deprecated(reason: "Removed in OTP 2, the timetable-view replaces this functionality.")
+        """
+        This argument has no use for itinerary planning and will be removed later.
+        When true, do not use goal direction or stop at the target, build a full SPT. Default value: false.
+        """
+        batch: Boolean @deprecated(reason: "Removed in OTP 2")
+
+        """Is bike rental allowed? Default value: false"""
+        allowBikeRental: Boolean @deprecated(reason: "Rental is specified by modes")
+
+        """
+        No effect on itinerary planning, adjust argument `time` instead to get later departures.
+        ~~The maximum wait time in seconds the user is willing to delay trip start. Only effective in Analyst.~~
+        """
+        claimInitialWait: Long @deprecated(reason: "Removed in OTP 2")
+
+        """
+        **Consider this argument experimental** – setting this argument to true
+        causes timeouts and unoptimal routes in many cases.
+        When true, reverse optimize (find alternative transportation mode, which
+        still arrives to the destination in time) this search on the fly after
+        processing each transit leg, rather than reverse-optimizing the entire path
+        when it's done. Default value: false.
+        """
+        reverseOptimizeOnTheFly: Boolean @deprecated(reason: "Removed in OTP 2")
+
+        """
+        If true, the remaining weight heuristic is disabled. Currently only
+        implemented for the long distance path service.
+        """
+        disableRemainingWeightHeuristic: Boolean @deprecated(reason: "Removed in OTP 2.2")
+
+        """
+        Whether legs should be compacted by performing a reversed search.
+        """
+        compactLegsByReversedSearch: Boolean @deprecated(reason: "Removed in OTP 2")
+
+        """
+        Which vehicle rental networks can be used. By default, all networks are allowed.
+        """
+        allowedBikeRentalNetworks: [String] @deprecated(reason: "Use allowedVehicleRentalNetworks instead")
+        """
+        The maximum time (in seconds) of pre-transit travel when using
+        drive-to-transit (park and ride or kiss and ride). Default value: 1800.
+        """
+        maxPreTransitTime: Int @deprecated(reason: "Use walkReluctance or future reluctance parameters for other modes")
+        """
+        How expensive it is to drive a car when car&parking, increase this value to
+        make car driving legs shorter. Default value: 1.
+        """
+        carParkCarLegWeight: Float @deprecated(reason: "Use `carReluctance` instead.")
     ): Plan @async
 }
 

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -3016,14 +3016,12 @@ type QueryType {
         The maximum time (in seconds) of pre-transit travel when using
         drive-to-transit (park and ride or kiss and ride). Default value: 1800.
         """
-
         maxPreTransitTime: Int @deprecated(reason: "Use walkReluctance or future reluctance parameters for other modes")
 
         """
         How expensive it is to drive a car when car&parking, increase this value to
         make car driving legs shorter. Default value: 1.
         """
-
         carParkCarLegWeight: Float @deprecated(reason: "Use `carReluctance` instead.")
 
         """Tuning parameter for the search algorithm, mainly useful for testing."""

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -2970,6 +2970,7 @@ type QueryType {
         `waitReluctance` on the first boarding). Default value: 0.4
         """
         waitAtBeginningFactor: Float @deprecated(reason: "Removed in OTP 2, the timetable-view replaces this functionality.")
+
         """
         This argument has no use for itinerary planning and will be removed later.
         When true, do not use goal direction or stop at the target, build a full SPT. Default value: false.
@@ -3017,6 +3018,7 @@ type QueryType {
         """
 
         maxPreTransitTime: Int @deprecated(reason: "Use walkReluctance or future reluctance parameters for other modes")
+
         """
         How expensive it is to drive a car when car&parking, increase this value to
         make car driving legs shorter. Default value: 1.

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1589,8 +1589,16 @@ type Leg {
     """
     interlineWithPreviousLeg: Boolean
 
+    """
+    Special booking information for the drop off stop of this leg if, for example, it needs
+    to be booked in advance. This could be due to a flexible or on-demand service.
+    """
     dropOffBookingInfo: BookingInfo
 
+    """
+    Special booking information for the pick up stop of this leg if, for example, it needs
+    to be booked in advance. This could be due to a flexible or on-demand service.
+    """
     pickupBookingInfo: BookingInfo
 
     """Applicable alerts for this leg."""
@@ -1992,29 +2000,52 @@ enum PickupDropoffType {
     COORDINATE_WITH_DRIVER
 }
 
+"Contact information for booking an on-demand or flexible service."
 type ContactInfo {
+    "Name of the person to contact"
     contactPerson: String
+    "Phone number to contact"
     phoneNumber: String
+    "Email to contact"
     eMail: String
+    "Fax number to contact"
     faxNumber: String
+    "URL containing general information about the service"
     infoUrl: String
+    "URL to the booking systems of the service"
     bookingUrl: String
+    "Additional notes about the contacting the service provider"
     additionalDetails: String
 }
 
+"Temporal restriction for a booking"
 type BookingTime {
+    "Time of the booking"
     time: String
+    "How many days before the booking"
     daysPrior: Int
 }
 
+"""
+Booking information for a stop time which has special requirements to use, like calling ahead or
+using an app.
+"""
 type BookingInfo {
+    "Contact information for reaching the service provider"
     contactInfo: ContactInfo
+    "When is the earliest time the service can be booked."
     earliestBookingTime: BookingTime
+    "When is the latest time the service can be booked"
     latestBookingTime: BookingTime
+    "Minimum number of seconds before travel to make the request"
     minimumBookingNoticeSeconds: Long
+    "Maximum number of seconds before travel to make the request"
     maximumBookingNoticeSeconds: Long
+    "A general message for those booking the service"
     message: String
+    "A message specific to the pick up"
     pickupMessage: String
+    "A message specific to the drop off"
     dropOffMessage: String
 }
 


### PR DESCRIPTION
### Summary

@miles-grant-ibigroup has pointed out that documentation about the flex fields for special pick up/drop off restrictions was missing so I added it.

Whilst I was working on the schema I also moved the deprecated fields of the `plan` query to the bottom.

It also improves the build pipeline for the static HTML docs so that they are pushed to Github Pages only when the schema has actually changed.