### PR TITLE
Fix logging of stacktraces for polling graph updater

### DIFF
--- a/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
@@ -62,7 +62,7 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
         } catch (InterruptedException e) {
           throw e;
         } catch (Exception e) {
-          LOG.error("Error while running polling updater of type {}", configRef, e);
+          LOG.error("Error while running polling updater {}", this, e);
           // TODO Should we cancel the task? Or after n consecutive failures? cancel();
         } finally {
           primed = true;

--- a/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
@@ -74,6 +74,7 @@ public class GtfsRealtimeTripUpdateSource {
     return updates;
   }
 
+  @Override
   public String toString() {
     return ToStringBuilder
       .of(this.getClass())

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -77,7 +77,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
       // Do any setup if needed
       source.setup();
     } catch (UpdaterConstructionException e) {
-      LOG.warn("Unable to setup updater: {}", parameters.configRef(), e);
+      LOG.warn("Unable to setup updater: {}", this, e);
     }
 
     if (pollingPeriodSeconds() <= 0) {


### PR DESCRIPTION
### Summary

When logging an exception for a polling updater, the call to log4j silently swallowed the exception due to a confusing method call.

By switching to string concatenation the method call correctly interprets the exception as such and logs it accordingly.

### Documentation

I added Javadoc about the reason for this unusual way of logging.

@hbruch 