### PR TITLE
Improve changelog update stability

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -31,6 +31,7 @@ jobs:
           mv $TEMP_FILE $FILE
           git add $FILE
           git commit -m "Add changelog entry for #${NUMBER} [ci skip]"
+          git pull --rebase origin dev-2.x
           git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x
         env:
           # Use environment variables to prevent injection attack


### PR DESCRIPTION
### Summary

Ran into a problem that a post merge action was unable to update changelog even when rerunning the action. This should fix that issue but should we do this as this problem only occurs rarely?

### Issue

This problem occured in https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4948671568

