### PR TITLE
fix: Log warnings in child nodes

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/NodeAdapter.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.opentripplanner.framework.application.OtpAppException;
 
@@ -168,9 +169,7 @@ public class NodeAdapter {
     for (String p : unusedParams()) {
       logger.accept("Unexpected config parameter: '" + p + "' in '" + source + "'");
     }
-    for (String warning : warnings) {
-      logger.accept(warning);
-    }
+    allWarnings().forEach(logger);
   }
 
   /**
@@ -300,6 +299,14 @@ public class NodeAdapter {
   }
 
   /* private methods */
+
+  private Stream<String> allWarnings() {
+    Stream<String> childrenWarnings = childrenByName
+      .values()
+      .stream()
+      .flatMap(NodeAdapter::allWarnings);
+    return Stream.concat(childrenWarnings, warnings.stream());
+  }
 
   private void addParameterInfo(NodeInfo info) {
     if (parameters.containsKey(info.name())) {

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
@@ -215,7 +215,13 @@ public class ParameterBuilder {
   public <T extends Enum<T>> T asEnum(T defaultValue) {
     info.withEnum((Class<? extends Enum<?>>) defaultValue.getClass());
     setInfoOptional(defaultValue);
-    return parseOptionalEnum(build().asText(), (Class<T>) defaultValue.getClass())
+
+    var node = build();
+
+    if (node.isMissingNode()) {
+      return defaultValue;
+    }
+    return parseOptionalEnum(node.asText(), (Class<T>) defaultValue.getClass())
       .orElse(defaultValue);
   }
 


### PR DESCRIPTION
Warnings in JSON config are not logged if they appear in a child element in the config.


### Issue

I discovered this when testing PR #5106. 

### Unit tests

Updated with a nested config element.


### Documentation
Not relevant.
