### PR TITLE
Handle JsonParseException

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -49,9 +49,7 @@ public class OTPExceptionMapper implements ExceptionMapper<Exception> {
     }
     if (ex instanceof JsonParseException) {
       return Response
-        .status(
-          Response.Status.BAD_REQUEST
-        )
+        .status(Response.Status.BAD_REQUEST)
         .entity(ex.getMessage())
         .type("text/plain")
         .build();

--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.api.common;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
@@ -43,6 +44,15 @@ public class OTPExceptionMapper implements ExceptionMapper<Exception> {
           Response.Status.fromStatusCode(OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY.statusCode())
         )
         .entity("OTP API Processing Timeout")
+        .type("text/plain")
+        .build();
+    }
+    if (ex instanceof JsonParseException) {
+      return Response
+        .status(
+          Response.Status.BAD_REQUEST
+        )
+        .entity(ex.getMessage())
         .type("text/plain")
         .build();
     }


### PR DESCRIPTION
Adds handling of JsonParseException - now returns a `400 Bad Request`. 

This typically occurs when GraphQL-requests contain malformed JSON.

