### PR TITLE
fix: PageCursor decode of JS "null" (as String)

### DIFF
--- a/src/main/java/org/opentripplanner/framework/lang/StringUtils.java
+++ b/src/main/java/org/opentripplanner/framework/lang/StringUtils.java
@@ -14,6 +14,20 @@ public class StringUtils {
     return text != null && !text.isBlank();
   }
 
+  /** true if the given text is {@code null} or only have white-space characters. */
+  public static boolean hasNoValue(String text) {
+    return text == null || text.isBlank();
+  }
+
+  /**
+   * true if the given text is {@code null}, empty, only white-space or the string {@code "null"}.
+   * This is convenient when parsing untrusted external client requests, and we do not care to
+   * differentiate.
+   * */
+  public static boolean hasNoValueOrNullAsString(String text) {
+    return hasNoValue(text) || "null".equals(text);
+  }
+
   /**
    * Verify String value is NOT {@code null}, empty or only whitespace.
    *

--- a/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorSerializer.java
@@ -11,6 +11,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Base64;
 import javax.annotation.Nullable;
+import org.opentripplanner.framework.lang.StringUtils;
 import org.opentripplanner.model.plan.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ final class PageCursorSerializer {
 
   @Nullable
   public static PageCursor decode(String cursor) {
-    if (cursor == null || cursor.isBlank()) {
+    if (StringUtils.hasNoValueOrNullAsString(cursor)) {
       return null;
     }
     try {
@@ -73,9 +74,9 @@ final class PageCursorSerializer {
     } catch (Exception e) {
       String details = e.getMessage();
       if (details != null && !details.isBlank()) {
-        LOG.error("Unable to decode page cursor: '{}'. Details: {}", cursor, details);
+        LOG.warn("Unable to decode page cursor: '{}'. Details: {}", cursor, details);
       } else {
-        LOG.error("Unable to decode page cursor: '{}'.", cursor);
+        LOG.warn("Unable to decode page cursor: '{}'.", cursor);
       }
       return null;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapper.java
@@ -22,7 +22,7 @@ class OperatorToAgencyMapper {
 
   Operator mapOperator(org.rutebanken.netex.model.Operator source) {
     final String name;
-    if (source.getName() == null || !StringUtils.hasValue(source.getName().getValue())) {
+    if (source.getName() == null || StringUtils.hasNoValue(source.getName().getValue())) {
       issueStore.add("MissingOperatorName", "Missing name for operator %s", source.getId());
       // fall back to NeTEx id when the operator name is missing
       name = source.getId();

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
@@ -294,7 +294,7 @@ public class VehiclePositionPatternMatcher {
 
     var tripId = vehiclePosition.getTrip().getTripId();
 
-    if (!StringUtils.hasValue(tripId)) {
+    if (StringUtils.hasNoValue(tripId)) {
       return Result.failure(UpdateError.noTripId(UpdateError.UpdateErrorType.NO_TRIP_ID));
     }
 

--- a/src/test/java/org/opentripplanner/framework/lang/StringUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/lang/StringUtilsTest.java
@@ -1,22 +1,38 @@
 package org.opentripplanner.framework.lang;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.opentripplanner.test.support.VariableSource;
 
 class StringUtilsTest {
 
+  static final Stream<Arguments> hasValueTestCases = Stream.of(
+    Arguments.of("Text", TRUE),
+    Arguments.of("T", TRUE),
+    Arguments.of(null, FALSE),
+    Arguments.of("", FALSE),
+    Arguments.of("\t\n", FALSE)
+  );
+
+  @ParameterizedTest
+  @VariableSource("hasValueTestCases")
+  void hasValue(String input, Boolean hasValue) {
+    assertEquals(hasValue, StringUtils.hasValue(input));
+    assertEquals(!hasValue, StringUtils.hasNoValue(input));
+    assertEquals(!hasValue, StringUtils.hasNoValueOrNullAsString(input));
+  }
+
   @Test
-  void hasValue() {
-    assertTrue(StringUtils.hasValue("Text"));
-    assertTrue(StringUtils.hasValue(" T "));
-    assertFalse(StringUtils.hasValue(null));
-    assertFalse(StringUtils.hasValue(""));
-    assertFalse(StringUtils.hasValue(" "));
-    assertFalse(StringUtils.hasValue("\n\t"));
+  void hasNoValueOrNullAsString() {
+    assertTrue(StringUtils.hasNoValueOrNullAsString("null"));
   }
 
   @Test


### PR DESCRIPTION
### Summary

A common error in JavaScript is to set a request field to the string `"null"` and not use `null`. This is is logged on the OTP server side, and spam our logs. So I added a smal check for this. 

### Unit tests
✅ 
