### PR TITLE
Cleanup threads and error handling

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.ext.legacygraphqlapi;
 
 import com.google.common.io.Resources;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -86,6 +85,7 @@ import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLservic
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLstepImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLstopAtDistanceImpl;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.concurrent.OtpRequestThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,7 +96,7 @@ class LegacyGraphQLIndex {
   private static final GraphQLSchema indexSchema = buildSchema();
 
   static final ExecutorService threadPool = Executors.newCachedThreadPool(
-    new ThreadFactoryBuilder().setNameFormat("GraphQLExecutor-%d").build()
+    OtpRequestThreadFactory.of("gtfs-api-%d")
   );
 
   protected static GraphQLSchema buildSchema() {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.ext.transmodelapi.support.GraphQLToWebResponseMapper;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.service.TransitModel;
@@ -119,7 +120,7 @@ public class TransmodelAPI {
     } else {
       variables = new HashMap<>();
     }
-    return index.getGraphQLResponse(
+    var result = index.executeGraphQL(
       query,
       serverContext,
       variables,
@@ -127,6 +128,7 @@ public class TransmodelAPI {
       maxResolves,
       getTagsFromHeaders(headers)
     );
+    return GraphQLToWebResponseMapper.map(result);
   }
 
   @POST
@@ -137,7 +139,7 @@ public class TransmodelAPI {
     @HeaderParam("OTPMaxResolves") @DefaultValue("1000000") int maxResolves,
     @Context HttpHeaders headers
   ) {
-    return index.getGraphQLResponse(
+    var result = index.executeGraphQL(
       query,
       serverContext,
       null,
@@ -145,6 +147,7 @@ public class TransmodelAPI {
       maxResolves,
       getTagsFromHeaders(headers)
     );
+    return GraphQLToWebResponseMapper.map(result);
   }
 
   @POST
@@ -176,7 +179,7 @@ public class TransmodelAPI {
       String operationName = (String) query.getOrDefault("operationName", null);
 
       futures.add(() ->
-        index.getGraphQLExecutionResult(
+        index.executeGraphQL(
           (String) query.get("query"),
           serverContext,
           variables,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.transmodelapi;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -21,6 +20,7 @@ import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.ext.actuator.MicrometerGraphQLInstrumentation;
 import org.opentripplanner.ext.transmodelapi.support.OTPProcessingTimeoutGraphQLException;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.concurrent.OtpRequestThreadFactory;
 import org.opentripplanner.framework.http.OtpHttpStatus;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 
@@ -32,9 +32,7 @@ class TransmodelGraph {
 
   TransmodelGraph(GraphQLSchema schema) {
     this.threadPool =
-      Executors.newCachedThreadPool(
-        new ThreadFactoryBuilder().setNameFormat("GraphQLExecutor-%d").build()
-      );
+      Executors.newCachedThreadPool(OtpRequestThreadFactory.of("transmodel-api-%d"));
     this.indexSchema = schema;
   }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -3,25 +3,19 @@ package org.opentripplanner.ext.transmodelapi;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.GraphQLError;
 import graphql.analysis.MaxQueryComplexityInstrumentation;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.GraphQLSchema;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
-import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.ext.actuator.MicrometerGraphQLInstrumentation;
-import org.opentripplanner.ext.transmodelapi.support.OTPProcessingTimeoutGraphQLException;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.concurrent.OtpRequestThreadFactory;
-import org.opentripplanner.framework.http.OtpHttpStatus;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 
 class TransmodelGraph {
@@ -36,7 +30,7 @@ class TransmodelGraph {
     this.indexSchema = schema;
   }
 
-  ExecutionResult getGraphQLExecutionResult(
+  ExecutionResult executeGraphQL(
     String query,
     OtpServerRequestContext serverContext,
     Map<String, Object> variables,
@@ -74,35 +68,5 @@ class TransmodelGraph {
       .variables(variables)
       .build();
     return graphQL.execute(executionInput);
-  }
-
-  Response getGraphQLResponse(
-    String query,
-    OtpServerRequestContext serverContext,
-    Map<String, Object> variables,
-    String operationName,
-    int maxResolves,
-    Iterable<Tag> tracingTags
-  ) {
-    ExecutionResult result = getGraphQLExecutionResult(
-      query,
-      serverContext,
-      variables,
-      operationName,
-      maxResolves,
-      tracingTags
-    );
-    List<GraphQLError> errors = result.getErrors();
-    if (errors.stream().anyMatch(OTPProcessingTimeoutGraphQLException.class::isInstance)) {
-      return Response
-        .status(OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY.statusCode())
-        .entity(GraphQLResponseSerializer.serialize(result))
-        .build();
-    } else {
-      return Response
-        .status(Response.Status.OK)
-        .entity(GraphQLResponseSerializer.serialize(result))
-        .build();
-    }
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GraphQLToWebResponseMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GraphQLToWebResponseMapper.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.ext.transmodelapi.support;
+
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.opentripplanner.api.json.GraphQLResponseSerializer;
+import org.opentripplanner.framework.http.OtpHttpStatus;
+
+/**
+ * Map from a GraphQL ExecutionResult to a web Response
+ */
+public class GraphQLToWebResponseMapper {
+
+  public static Response map(ExecutionResult result) {
+    List<GraphQLError> errors = result.getErrors();
+    if (errors.stream().anyMatch(OTPProcessingTimeoutGraphQLException.class::isInstance)) {
+      return Response
+        .status(OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY.statusCode())
+        .entity(GraphQLResponseSerializer.serialize(result))
+        .build();
+    } else {
+      return Response
+        .status(Response.Status.OK)
+        .entity(GraphQLResponseSerializer.serialize(result))
+        .build();
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/concurrent/OtpRequestThreadFactory.java
+++ b/src/main/java/org/opentripplanner/framework/concurrent/OtpRequestThreadFactory.java
@@ -1,0 +1,39 @@
+package org.opentripplanner.framework.concurrent;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ThreadFactory;
+import javax.annotation.Nonnull;
+
+/**
+ * This thread pool factory should be used to create all threads handling "user" requests in OTP.
+ * It is used to instrument new threads witch enable log information propagation and error handling,
+ * like thread interruption. By "user" we mean users of the query APIs like GTFS GraphQL API,
+ * Transmodel GraphQL API and other http endpoints.
+ * <p>
+ * Real time updaters should NOT use this - we do not want log info propagation and timeout
+ * interrupt handling in these threads. They follow a separate multi-threading strategy.
+ * <p>
+ * The ActuatorAPI is a border-line use-cases for this; It is included because there is no risk
+ * involved and that is the simplest solution.
+ * <p>
+ * We do not apply this to the main grizzly threads either. The factory is used for "child"
+ * threads and the "grizzly" threads are the root parents.
+ */
+public class OtpRequestThreadFactory implements ThreadFactory {
+
+  private final ThreadFactory delegate;
+
+  private OtpRequestThreadFactory(ThreadFactory delegate) {
+    this.delegate = delegate;
+  }
+
+  public static ThreadFactory of(String nameFormat) {
+    var defaultFactory = new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
+    return new OtpRequestThreadFactory(defaultFactory);
+  }
+
+  @Override
+  public Thread newThread(@Nonnull Runnable r) {
+    return delegate.newThread(r);
+  }
+}

--- a/src/main/java/org/opentripplanner/raptor/configure/RaptorConfig.java
+++ b/src/main/java/org/opentripplanner/raptor/configure/RaptorConfig.java
@@ -3,6 +3,7 @@ package org.opentripplanner.raptor.configure;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
+import org.opentripplanner.framework.concurrent.OtpRequestThreadFactory;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequest;
 import org.opentripplanner.raptor.api.request.RaptorTuningParameters;
@@ -125,6 +126,8 @@ public class RaptorConfig<T extends RaptorTripSchedule> {
 
   @Nullable
   private ExecutorService createNewThreadPool(int size) {
-    return size > 0 ? Executors.newFixedThreadPool(size) : null;
+    return size > 0
+      ? Executors.newFixedThreadPool(size, OtpRequestThreadFactory.of("raptor-%d"))
+      : null;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -100,6 +100,8 @@ public class RoutingWorker {
     var routingErrors = Collections.synchronizedSet(new HashSet<RoutingError>());
 
     if (OTPFeature.ParallelRouting.isOn()) {
+      // TODO: This is not using {@link OtpRequestThreadFactory} witch mean we do not get
+      //       log-trace-parameters-propagation and graceful timeout handling here.
       try {
         CompletableFuture
           .allOf(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -178,6 +178,8 @@ public class TransitRouter {
 
     if (OTPFeature.ParallelRouting.isOn()) {
       try {
+        // TODO: This is not using {@link OtpRequestThreadFactory} witch mean we do not get
+        //       log-trace-parameters-propagation and graceful timeout handling here.
         CompletableFuture
           .allOf(
             CompletableFuture.runAsync(accessCalculator),

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -48,6 +48,7 @@ public class OTPMain {
    */
   public static void main(String[] args) {
     try {
+      Thread.currentThread().setName("main");
       CommandLineParameters params = parseAndValidateCmdLine(args);
       OtpStartupInfo.logInfo();
       startOTPServer(params);
@@ -218,14 +219,17 @@ public class OTPMain {
     TransitModel transitModel,
     RaptorConfig<?> raptorConfig
   ) {
-    var hook = new Thread(() -> {
-      LOG.info("OTP shutdown started...");
-      UpdaterConfigurator.shutdownGraph(transitModel);
-      raptorConfig.shutdown();
-      WeakCollectionCleaner.DEFAULT.exit();
-      DeferredAuthorityFactory.exit();
-      LOG.info("OTP shutdown: resources released...");
-    });
+    var hook = new Thread(
+      () -> {
+        LOG.info("OTP shutdown started...");
+        UpdaterConfigurator.shutdownGraph(transitModel);
+        raptorConfig.shutdown();
+        WeakCollectionCleaner.DEFAULT.exit();
+        DeferredAuthorityFactory.exit();
+        LOG.info("OTP shutdown: resources released...");
+      },
+      "server-shutdown"
+    );
     Runtime.getRuntime().addShutdownHook(hook);
   }
 

--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -40,7 +40,10 @@ public class OtpStartupInfo {
     Runtime
       .getRuntime()
       .addShutdownHook(
-        new Thread(() -> LOG.info("OTP SHUTTING DOWN ({})", projectInfo().getVersionString()))
+        new Thread(
+          () -> LOG.info("OTP SHUTTING DOWN ({})", projectInfo().getVersionString()),
+          "server-shutdown-info"
+        )
       );
     LOG.info(NEW_LINE + "{}", info());
   }

--- a/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.standalone.server;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import jakarta.ws.rs.core.Application;
 import java.io.File;
 import java.io.IOException;
@@ -76,6 +77,8 @@ public class GrizzlyServer {
     int nHandlerThreads = getMaxThreads();
     ThreadPoolConfig threadPoolConfig = ThreadPoolConfig
       .defaultConfig()
+      .setPoolName("grizzly")
+      .setThreadFactory(new ThreadFactoryBuilder().setNameFormat("grizzly-%d").build())
       .setCorePoolSize(nHandlerThreads)
       .setMaxPoolSize(nHandlerThreads)
       .setQueueLimit(-1);
@@ -147,7 +150,7 @@ public class GrizzlyServer {
 
     // Add shutdown hook to gracefully shut down Grizzly.
     // Signal handling (sun.misc.Signal) is potentially not available on all JVMs.
-    Thread shutdownThread = new Thread(httpServer::shutdown);
+    Thread shutdownThread = new Thread(httpServer::shutdown, "grizzly-shutdown");
     Runtime.getRuntime().addShutdownHook(shutdownThread);
 
     /* RELINQUISH CONTROL TO THE SERVER THREAD */

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -72,7 +72,7 @@ public class GraphUpdaterManager implements WriteToGraphCallback, GraphUpdaterSt
     this.graph = graph;
     this.transitModel = transitModel;
     // Thread factory used to create new threads, giving them more human-readable names.
-    var threadFactory = new ThreadFactoryBuilder().setNameFormat("GraphUpdater-%d").build();
+    var threadFactory = new ThreadFactoryBuilder().setNameFormat("updater-%d").build();
     this.scheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
     this.updaterPool = Executors.newCachedThreadPool(threadFactory);
 
@@ -216,7 +216,7 @@ public class GraphUpdaterManager implements WriteToGraphCallback, GraphUpdaterSt
    */
   private void reportReadinessForUpdaters() {
     Executors
-      .newSingleThreadExecutor()
+      .newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("updater-ready").build())
       .submit(() -> {
         boolean otpIsShuttingDown = false;
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
   <appender name="plain" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <!-- print out file and line number in parenthesis, which Eclipse and IDEA will link -->
-      <pattern>%d{HH:mm:ss.SSS} %level \(%F:%L\) %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} %level [%thread] \(%F:%L\) %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/src/test/java/org/opentripplanner/OtpArchitectureModules.java
+++ b/src/test/java/org/opentripplanner/OtpArchitectureModules.java
@@ -44,6 +44,7 @@ public interface OtpArchitectureModules {
     FRAMEWORK.subPackage("logging"),
     FRAMEWORK.subPackage("text"),
     FRAMEWORK.subPackage("time"),
-    FRAMEWORK.subPackage("tostring")
+    FRAMEWORK.subPackage("tostring"),
+    FRAMEWORK.subPackage("concurrent")
   );
 }

--- a/src/test/java/org/opentripplanner/raptor/RaptorArchitectureTest.java
+++ b/src/test/java/org/opentripplanner/raptor/RaptorArchitectureTest.java
@@ -216,7 +216,8 @@ public class RaptorArchitectureTest {
         RR_TRANSIT,
         RR_CONTEXT,
         RR_STD_CONFIGURE,
-        RR_MC_CONFIGURE
+        RR_MC_CONFIGURE,
+        FRAMEWORK_UTILS
       )
       .verify();
   }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -13,7 +13,7 @@
   <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <!-- print out file and line number in parenthesis, which Eclipse and IDEA will link -->
-      <pattern>%d{HH:mm:ss.SSS} %level \(%F:%L\) %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} %level [%thread] \(%F:%L\) %msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
### Summary

This PR contains a bit refactoring and small improvements . This is the base for 2 PR coming soon.

Recommend review commit by commit.

- refactor: Set thread names for better debugging and logg messages
- refactor: Extract mapper from GraphQL to Web response
- feature: Limit number of GraphQL errors returned in one request to 25 in the Transmodel API 

### Unit tests
Some, not a lot - but most of this code is infrastructure and will break hard if there is bug.