### PR TITLE
Graceful timeout error handling

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
@@ -153,6 +153,7 @@ public class TransmodelAPI {
   @POST
   @Path("/graphql/batch")
   @Consumes(MediaType.APPLICATION_JSON)
+  @Deprecated
   public Response getGraphQLBatch(
     List<HashMap<String, Object>> queries,
     @HeaderParam("OTPTimeout") @DefaultValue("10000") int timeout,
@@ -179,14 +180,16 @@ public class TransmodelAPI {
       String operationName = (String) query.getOrDefault("operationName", null);
 
       futures.add(() ->
-        index.executeGraphQL(
-          (String) query.get("query"),
-          serverContext,
-          variables,
-          operationName,
-          maxResolves,
-          getTagsFromHeaders(headers)
-        )
+        index
+          .executeGraphQL(
+            (String) query.get("query"),
+            serverContext,
+            variables,
+            operationName,
+            maxResolves,
+            getTagsFromHeaders(headers)
+          )
+          .result()
       );
     }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -14,15 +14,15 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.opentripplanner.ext.actuator.MicrometerGraphQLInstrumentation;
+import org.opentripplanner.ext.transmodelapi.support.AbortOnTimeoutExecutionStrategy;
+import org.opentripplanner.ext.transmodelapi.support.OtpExecutionResult;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.concurrent.OtpRequestThreadFactory;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class TransmodelGraph {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TransmodelGraph.class);
   private static final int MAX_ERROR_TO_RETURN = 25;
   private final GraphQLSchema indexSchema;
 
@@ -34,7 +34,7 @@ class TransmodelGraph {
     this.indexSchema = schema;
   }
 
-  ExecutionResult executeGraphQL(
+  OtpExecutionResult executeGraphQL(
     String query,
     OtpServerRequestContext serverContext,
     Map<String, Object> variables,
@@ -43,6 +43,7 @@ class TransmodelGraph {
     Iterable<Tag> tracingTags
   ) {
     Instrumentation instrumentation = new MaxQueryComplexityInstrumentation(maxResolves);
+
     if (OTPFeature.ActuatorAPI.isOn()) {
       instrumentation =
         new ChainedInstrumentation(
@@ -51,7 +52,11 @@ class TransmodelGraph {
         );
     }
 
-    GraphQL graphQL = GraphQL.newGraphQL(indexSchema).instrumentation(instrumentation).build();
+    GraphQL graphQL = GraphQL
+      .newGraphQL(indexSchema)
+      .instrumentation(instrumentation)
+      .queryExecutionStrategy(new AbortOnTimeoutExecutionStrategy())
+      .build();
 
     if (variables == null) {
       variables = new HashMap<>();
@@ -72,9 +77,14 @@ class TransmodelGraph {
       .variables(variables)
       .build();
 
-    var result = graphQL.execute(executionInput);
-    result = limitMaxNumberOfErrors(result);
-    return result;
+    // EXECUTE GRAPHQL QUERY
+    try {
+      var result = graphQL.execute(executionInput);
+      result = limitMaxNumberOfErrors(result);
+      return OtpExecutionResult.of(result);
+    } catch (OTPRequestTimeoutException te) {
+      return OtpExecutionResult.ofTimeout();
+    }
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -52,10 +52,11 @@ class TransmodelGraph {
         );
     }
 
+    var executionStrategy = new AbortOnTimeoutExecutionStrategy();
     GraphQL graphQL = GraphQL
       .newGraphQL(indexSchema)
       .instrumentation(instrumentation)
-      .queryExecutionStrategy(new AbortOnTimeoutExecutionStrategy())
+      .queryExecutionStrategy(executionStrategy)
       .build();
 
     if (variables == null) {
@@ -84,6 +85,8 @@ class TransmodelGraph {
       return OtpExecutionResult.of(result);
     } catch (OTPRequestTimeoutException te) {
       return OtpExecutionResult.ofTimeout();
+    } finally {
+      executionStrategy.tearDown();
     }
   }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/AbortOnTimeoutExecutionStrategy.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/AbortOnTimeoutExecutionStrategy.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.ext.transmodelapi.support;
+
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.ExecutionContext;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
+
+/**
+ * To abort fetching data when a timeout occurs we have to rethrow the time-out-exception.
+ * This will prevent unresolved data-fetchers to be called. The exception is not handled
+ * gracefully.
+ */
+public class AbortOnTimeoutExecutionStrategy extends AsyncExecutionStrategy {
+
+  private final AtomicInteger counter = new AtomicInteger(0);
+
+  @Override
+  protected <T> CompletableFuture<T> handleFetchingException(
+    ExecutionContext executionContext,
+    DataFetchingEnvironment environment,
+    Throwable e
+  ) {
+    if (e instanceof OTPRequestTimeoutException te) {
+      if (counter.incrementAndGet() % 10_000 == 0) {
+        // TODO: Replace this with proper progress tracking
+        System.out.println(counter.get());
+      }
+      throw te;
+    }
+    return super.handleFetchingException(executionContext, environment, e);
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GraphQLToWebResponseMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GraphQLToWebResponseMapper.java
@@ -1,9 +1,6 @@
 package org.opentripplanner.ext.transmodelapi.support;
 
-import graphql.ExecutionResult;
-import graphql.GraphQLError;
 import jakarta.ws.rs.core.Response;
-import java.util.List;
 import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.framework.http.OtpHttpStatus;
 
@@ -12,18 +9,14 @@ import org.opentripplanner.framework.http.OtpHttpStatus;
  */
 public class GraphQLToWebResponseMapper {
 
-  public static Response map(ExecutionResult result) {
-    List<GraphQLError> errors = result.getErrors();
-    if (errors.stream().anyMatch(OTPProcessingTimeoutGraphQLException.class::isInstance)) {
+  public static Response map(OtpExecutionResult result) {
+    if (result.timeout()) {
       return Response
         .status(OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY.statusCode())
-        .entity(GraphQLResponseSerializer.serialize(result))
-        .build();
-    } else {
-      return Response
-        .status(Response.Status.OK)
-        .entity(GraphQLResponseSerializer.serialize(result))
+        .entity(GraphQLResponseSerializer.serialize(result.result()))
         .build();
     }
+    // Default - OK
+    return Response.ok(GraphQLResponseSerializer.serialize(result.result())).build();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/OtpExecutionResult.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/OtpExecutionResult.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.ext.transmodelapi.support;
+
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
+
+/**
+ * Return the GraphQl execution result and a flag to indicate the
+ * execution failed due to a timeout.
+ */
+public record OtpExecutionResult(ExecutionResult result, boolean timeout) {
+  public static OtpExecutionResult of(ExecutionResult result) {
+    return new OtpExecutionResult(result, false);
+  }
+
+  public static OtpExecutionResult ofTimeout() {
+    return new OtpExecutionResult(
+      ExecutionResult
+        .newExecutionResult()
+        .addError(GraphQLError.newError().message(OTPRequestTimeoutException.MESSAGE).build())
+        .build(),
+      true
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -40,9 +40,7 @@ public class OTPExceptionMapper implements ExceptionMapper<Exception> {
     }
     if (ex instanceof OTPRequestTimeoutException) {
       return Response
-        .status(
-          Response.Status.fromStatusCode(OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY.statusCode())
-        )
+        .status(OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY.statusCode())
         .entity("OTP API Processing Timeout")
         .type("text/plain")
         .build();
@@ -59,7 +57,7 @@ public class OTPExceptionMapper implements ExceptionMapper<Exception> {
     LOG.error("Unhandled exception", ex);
     // Return the short form message to the client
     return Response
-      .status(Response.Status.INTERNAL_SERVER_ERROR)
+      .serverError()
       .entity(ex.toString() + " " + ex.getMessage())
       .type("text/plain")
       .build();

--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -16,7 +16,6 @@ import org.opentripplanner.api.mapping.TripPlanMapper;
 import org.opentripplanner.api.mapping.TripSearchMetadataMapper;
 import org.opentripplanner.api.model.error.PlannerError;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
-import org.opentripplanner.framework.http.OtpHttpStatus;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.slf4j.Logger;
@@ -93,18 +92,11 @@ public class PlannerResource extends RoutingResource {
 
       response.debugOutput = res.getDebugTimingAggregator().finishedRendering();
     } catch (OTPRequestTimeoutException e) {
-      PlannerError error = new PlannerError(Message.PROCESSING_TIMEOUT);
-      response.setError(error);
-      return Response
-        .status(OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY.statusCode())
-        .entity(response)
-        .build();
+      response.setError(new PlannerError(Message.PROCESSING_TIMEOUT));
     } catch (Exception e) {
       LOG.error("System error", e);
-      PlannerError error = new PlannerError(Message.SYSTEM_ERROR);
-      response.setError(error);
+      response.setError(new PlannerError(Message.SYSTEM_ERROR));
     }
-
     return Response.ok().entity(response).build();
   }
 }

--- a/src/main/java/org/opentripplanner/framework/application/OTPRequestTimeoutException.java
+++ b/src/main/java/org/opentripplanner/framework/application/OTPRequestTimeoutException.java
@@ -5,9 +5,11 @@ package org.opentripplanner.framework.application;
  */
 public class OTPRequestTimeoutException extends RuntimeException {
 
+  public static final String MESSAGE = "TIMEOUT! The request is too resource intensive.";
+
   @Override
   public String getMessage() {
-    return "TIMEOUT! The request is too resource intensive.";
+    return MESSAGE;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/framework/logging/ProgressTracker.java
+++ b/src/main/java/org/opentripplanner/framework/logging/ProgressTracker.java
@@ -156,6 +156,26 @@ public class ProgressTracker {
     return actionName + " progress tracking started.";
   }
 
+  /**
+   * This method call {@code progressNotification} with the {@link #startMessage()} if it is the
+   * first step, if not it calls the {@link #steps(int, Consumer)}.
+   * <p>
+   * This method is used if you would like to avoid logging the start message - in case
+   * the progress completes before reaching the first {@link #startOrStep(Consumer)}
+   * statement.
+   */
+  public void startOrStep(Consumer<String> progressNotification) {
+    long counter = stepCounter.incrementAndGet();
+    if (counter == 1) {
+      progressNotification.accept(startMessage());
+      return;
+    }
+    if (counter % minBlockSize != 0) {
+      return;
+    }
+    notifyIfQuietPeriodIsOver(counter, progressNotification);
+  }
+
   public void step(Consumer<String> progressNotification) {
     long counter = stepCounter.incrementAndGet();
     if (counter % minBlockSize != 0) {
@@ -191,6 +211,16 @@ public class ProgressTracker {
     }
 
     notifyIfQuietPeriodIsOver(counter, progressNotification);
+  }
+
+  /**
+   * Log complete message if at least one step is performed. This is usually used in combination
+   * with {@link #startOrStep(Consumer)}.
+   */
+  public void completeIfHasSteps(Consumer<String> progressNotification) {
+    if (stepCounter.get() > 0) {
+      progressNotification.accept(completeMessage());
+    }
   }
 
   public String completeMessage() {

--- a/src/main/java/org/opentripplanner/framework/logging/ProgressTracker.java
+++ b/src/main/java/org/opentripplanner/framework/logging/ProgressTracker.java
@@ -157,7 +157,7 @@ public class ProgressTracker {
   }
 
   /**
-   * This method call {@code progressNotification} with the {@link #startMessage()} if it is the
+   * This method calls {@code progressNotification} with the {@link #startMessage()} if it is the
    * first step, if not it calls the {@link #steps(int, Consumer)}.
    * <p>
    * This method is used if you would like to avoid logging the start message - in case

--- a/src/main/java/org/opentripplanner/framework/time/TimeUtils.java
+++ b/src/main/java/org/opentripplanner/framework/time/TimeUtils.java
@@ -1,11 +1,15 @@
 package org.opentripplanner.framework.time;
 
+import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Locale;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -15,8 +19,9 @@ import javax.annotation.Nonnull;
  */
 public class TimeUtils {
 
-  private static final Pattern DAYS_SUFFIX = Pattern.compile("([-+])(\\d+)d");
   public static final Integer ONE_DAY_SECONDS = 24 * 60 * 60;
+  private static final Pattern DAYS_SUFFIX = Pattern.compile("([-+])(\\d+)d");
+  private static final AtomicLong BUSY_WAIT_GRACE_PERIOD_TIMEOUT = new AtomicLong(0);
 
   /** This is a utility class. Do not instantiate this class. It should have only static methods. */
   private TimeUtils() {}
@@ -161,5 +166,40 @@ public class TimeUtils {
    */
   public static ZonedDateTime zonedDateTime(LocalDate date, int seconds, ZoneId zoneId) {
     return RelativeTime.ofSeconds(seconds).toZonedDateTime(date, zoneId);
+  }
+
+  /**
+   * Wait (compute) until the given {@code waitMs} is past. The returned long is a very random
+   * number. If this method is called twice a grace period of 5 times the wait-time is set. All
+   * calls within the grace period will return immediately. This ensures only ONE wait is applied
+   * to a given client request. Wait a bit, then make another request, and you will enter the
+   * busy-wait again.
+   * <p>
+   * This method do a "busy" wait - it is not affected by a thread interrupt like
+   * {@link Thread#sleep(long)}; Hence do not interfere with timeout logic witch uses the interrupt
+   * flag.
+   * <p>
+   * THIS CODE IS NOT MEANT FOR PRODUCTION!
+   */
+  @SuppressWarnings("unused")
+  public static long busyWaitOnce(int waitMs) {
+    long time = System.currentTimeMillis();
+    if (time < BUSY_WAIT_GRACE_PERIOD_TIMEOUT.get()) {
+      return 0;
+    }
+    BUSY_WAIT_GRACE_PERIOD_TIMEOUT.set(time + 5L * waitMs);
+
+    long waitUntil = time + waitMs;
+
+    Random rnd = new SecureRandom();
+    long value = rnd.nextLong();
+
+    // Print wait, this method is for debugging only
+    System.err.printf(Locale.ROOT, "BUSY-WAIT(%.1fs)%n", (waitMs / 1000.0));
+
+    while (System.currentTimeMillis() < waitUntil) {
+      value |= rnd.nextLong();
+    }
+    return value;
   }
 }

--- a/src/main/java/org/opentripplanner/framework/time/TimeUtils.java
+++ b/src/main/java/org/opentripplanner/framework/time/TimeUtils.java
@@ -175,7 +175,7 @@ public class TimeUtils {
    * to a given client request. Wait a bit, then make another request, and you will enter the
    * busy-wait again.
    * <p>
-   * This method do a "busy" wait - it is not affected by a thread interrupt like
+   * This method does a "busy" wait - it is not affected by a thread interrupt like
    * {@link Thread#sleep(long)}; Hence do not interfere with timeout logic witch uses the interrupt
    * flag.
    * <p>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -79,8 +79,6 @@
   <logger name="com.conveyal" level="info"/>
   <logger name="notprivacysafe.graphql" level="off" />
 
-
-
   <!-- Avoid printing info messages about calendars when building graph -->
   <logger name="org.onebusaway.gtfs.impl.calendar.CalendarServiceDataFactoryImpl" level="warn" />
   <!-- Avoid printing ugly warning message when unable to create websocket connection -->

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -77,6 +77,9 @@
   <logger name="com.amazonaws" level="info"/>
   <logger name="org.apache.http" level="info" />
   <logger name="com.conveyal" level="info"/>
+  <logger name="notprivacysafe.graphql" level="off" />
+
+
 
   <!-- Avoid printing info messages about calendars when building graph -->
   <logger name="org.onebusaway.gtfs.impl.calendar.CalendarServiceDataFactoryImpl" level="warn" />


### PR DESCRIPTION
### Summary

#### fix: The Response.Status.fromStatusCode fails with exception if the status code is 422

We want to return HTTP Status code 422, and not 500 for timeouts.
   
#### Refactor: Cleanup error handling in PlannerResource

Handle SYSTEM_ERROR and PROCESSING_TIMEOUT the same way. Timeout and
system-error will show up in the OTP Debug Client.   
   
#### debug: Add a busyWaitOnce() method for manual testing timeouts

The busyWaitOnce() is a method witch make it possible to test timeouts
without interfering with the interrupts.

#### feature: Improve on the GraphQL performance on timeout

The data-fetchers do not abort when a timeout occurs. This commit
improves on the situation and in the end causes the GraphQL instance
to exit with a timeout exception.

The "notprivacysafe.graphql" logger should be turned off to prevent
the TimeOut exception to be logged. The `AbortOnTimeoutExecutionStrategy`
will log the timeout. There might be more than 100 000 pending data-fetchers 
witch all are inerrupted with a timeout, so we use the progress logger:

```
17:51:02.872 INFO [grizzly-0] (AbortOnTimeoutExecutionStrategy.java:42) TIMEOUT! Abort GraphQL query progress tracking started.
17:51:07.402 INFO [grizzly-0] (AbortOnTimeoutExecutionStrategy.java:42) TIMEOUT! Abort GraphQL query progress: 175 000 done
17:51:12.502 INFO [grizzly-0] (AbortOnTimeoutExecutionStrategy.java:42) TIMEOUT! Abort GraphQL query progress: 375 000 done
17:51:14.425 INFO [grizzly-0] (AbortOnTimeoutExecutionStrategy.java:47) TIMEOUT! Abort GraphQL query progress tracking complete. 451 693 done in 12s (35 894 per second). 
```