### PR TITLE
Handle CoercingParseValueException

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.api.common;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import graphql.schema.CoercingParseValueException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
@@ -47,7 +48,7 @@ public class OTPExceptionMapper implements ExceptionMapper<Exception> {
         .type("text/plain")
         .build();
     }
-    if (ex instanceof JsonParseException) {
+    if (ex instanceof JsonParseException || ex instanceof CoercingParseValueException) {
       return Response
         .status(Response.Status.BAD_REQUEST)
         .entity(ex.getMessage())


### PR DESCRIPTION
### Summary

When a GraphQL request contains unparseable types (example: unparseable date), the server currently responds with an HTTP status 500 together with the error message:
`graphql.schema.CoercingParseValueException: Expected type XXXX but was YYYY.  `

Similarly to #5121, this PR ensures that the server returns a status 400 in this case.

### Issue

No

### Unit tests
:white_check_mark: 

### Documentation

No

