### PR TITLE
Remove walk leg in a stay seated transfer

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -106,7 +106,7 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
         legs.add(transitLeg);
       }
       // Map transfer leg
-      else if (pathLeg.isTransferLeg()) {
+      else if (pathLeg.isTransferLeg() && !staySeatedInTransferFrom(transitLeg)) {
         legs.addAll(
           mapTransferLeg(
             pathLeg.asTransferLeg(),
@@ -325,5 +325,13 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
 
   private ZonedDateTime createZonedDateTime(int timeInSeconds) {
     return transitSearchTimeZero.plusSeconds(timeInSeconds);
+  }
+
+  private boolean staySeatedInTransferFrom(Leg transitLeg) {
+    return (
+      transitLeg != null &&
+      transitLeg.getTransferToNextLeg() != null &&
+      transitLeg.getTransferToNextLeg().getTransferConstraint().isStaySeated()
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -328,12 +328,16 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
   private ZonedDateTime createZonedDateTime(int timeInSeconds) {
     return transitSearchTimeZero.plusSeconds(timeInSeconds);
   }
-
-  private boolean staySeatedInTransferFrom(Leg transitLeg) {
+  /**
+   * Include transfer leg in itinerary if the path is a "physical" path-leg between two stops, like walk or 
+   * bicycle. Do NOT include it if it represent a stay-seated transfer. See more details in
+   * https://github.com/opentripplanner/OpenTripPlanner/issues/5086.
+   */
+  private boolean includeTransferInItinerary(Leg transitLegBeforeTransfer) {
     return (
-      transitLeg != null &&
-      transitLeg.getTransferToNextLeg() != null &&
-      transitLeg.getTransferToNextLeg().getTransferConstraint().isStaySeated()
+      transitLegBeforeTransfer != null &&
+      transitLegBeforeTransfer.getTransferToNextLeg() != null &&
+      transitLegBeforeTransfer.getTransferToNextLeg().getTransferConstraint().isStaySeated()
     );
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -105,7 +105,9 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
         transitLeg = mapTransitLeg(transitLeg, pathLeg.asTransitLeg());
         legs.add(transitLeg);
       }
-      // Map transfer leg
+      // Map transfer leg but not when there is a stay seated transfer as the transfer leg would be
+      // a walk/bicycle leg between two stops (more details in
+      // https://github.com/opentripplanner/OpenTripPlanner/issues/5086).
       else if (pathLeg.isTransferLeg() && !staySeatedInTransferFrom(transitLeg)) {
         legs.addAll(
           mapTransferLeg(


### PR DESCRIPTION
### Summary

Removes walk between two trips that have a stay seated transfer. OTP1 did not have a walk leg in an interline transfer.

### Issue

closes #5086

### Unit tests

TODO

### Documentation

Not needed

### Changelog

From title
