### PR TITLE
Add stay seated test

### DIFF
--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -279,7 +279,7 @@ This is the time/duration in seconds from the earliest-departure-time(EDT) to th
 latest-departure-time(LDT). In case of a reverse search it will be the time from earliest to
 latest arrival time (LAT - EAT).
 
-All optimal travels that depart within the search window is guarantied to be found.
+All optimal travels that depart within the search window is guaranteed to be found.
 
 This is sometimes referred to as the Range Raptor Search Window - but could be used in a none
 Transit search as well; Hence this is named search-window and not raptor-search-window.

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -251,9 +251,9 @@ type Interchange {
   ToServiceJourney: ServiceJourney @deprecated
   fromServiceJourney: ServiceJourney
   guaranteed: Boolean
-  "Maximum time after scheduled departure time the connecting transport is guarantied to wait for the delayed trip. [NOT RESPECTED DURING ROUTING, JUST PASSED THROUGH]"
+  "Maximum time after scheduled departure time the connecting transport is guaranteed to wait for the delayed trip. [NOT RESPECTED DURING ROUTING, JUST PASSED THROUGH]"
   maximumWaitTime: Int
-  "The transfer priority is used to decide where a transfer should happen, at the highest prioritized location. If the guarantied flag is set it take precedence priority. A guarantied ALLOWED transfer is preferred over a PREFERRED none-guarantied transfer."
+  "The transfer priority is used to decide where a transfer should happen, at the highest prioritized location. If the guaranteed flag is set it take precedence priority. A guaranteed ALLOWED transfer is preferred over a PREFERRED none-guaranteed transfer."
   priority: InterchangePriority
   staySeated: Boolean
   toServiceJourney: ServiceJourney

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/InterchangeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/InterchangeType.java
@@ -44,9 +44,9 @@ public class InterchangeType {
           .name("priority")
           .description(
             "The transfer priority is used to decide where a transfer should " +
-            "happen, at the highest prioritized location. If the guarantied " +
-            "flag is set it take precedence priority. A guarantied ALLOWED " +
-            "transfer is preferred over a PREFERRED none-guarantied transfer."
+            "happen, at the highest prioritized location. If the guaranteed " +
+            "flag is set it take precedence priority. A guaranteed ALLOWED " +
+            "transfer is preferred over a PREFERRED none-guaranteed transfer."
           )
           .type(EnumTypes.INTERCHANGE_PRIORITY)
           .dataFetcher(env -> constraint(env).getPriority())
@@ -58,7 +58,7 @@ public class InterchangeType {
           .name("maximumWaitTime")
           .description(
             "Maximum time after scheduled departure time the connecting " +
-            "transport is guarantied to wait for the delayed trip. [NOT " +
+            "transport is guaranteed to wait for the delayed trip. [NOT " +
             "RESPECTED DURING ROUTING, JUST PASSED THROUGH]"
           )
           .type(Scalars.GraphQLInt)

--- a/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
@@ -53,7 +53,7 @@ public class InterlineProcessor {
       .stream()
       .filter(this::staySeatedAllowed)
       .map(p -> {
-        var constraint = TransferConstraint.create();
+        var constraint = TransferConstraint.of();
         constraint.staySeated();
         constraint.priority(TransferPriority.ALLOWED);
 

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -194,7 +194,7 @@ class TransferMapper {
   }
 
   private TransferConstraint mapConstraint(Transfer rhs) {
-    var builder = TransferConstraint.create();
+    var builder = TransferConstraint.of();
 
     builder.guaranteed(rhs.getTransferType() == GUARANTEED);
 

--- a/src/main/java/org/opentripplanner/model/TripStopTimes.java
+++ b/src/main/java/org/opentripplanner/model/TripStopTimes.java
@@ -15,7 +15,7 @@ import org.opentripplanner.transit.model.timetable.Trip;
 /**
  * A multimap from Trip to a sorted list of StopTimes.
  * <p>
- * The list of stop times  for a given trip is guarantied to be sorted.
+ * The list of stop times  for a given trip is guaranteed to be sorted.
  */
 public class TripStopTimes {
 

--- a/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
+++ b/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
@@ -24,7 +24,7 @@ public class TransferConstraint implements Serializable, RaptorTransferConstrain
   /**
    * A regular transfer is a transfer with no constraints.
    */
-  public static final TransferConstraint REGULAR_TRANSFER = create().build();
+  public static final TransferConstraint REGULAR_TRANSFER = of().build();
 
   /**
    * STAY_SEATED is not a priority, but we assign a cost to it to be able to compare it with other
@@ -112,7 +112,7 @@ public class TransferConstraint implements Serializable, RaptorTransferConstrain
     return c == null ? DEFAULT_COST : c.cost();
   }
 
-  public static Builder create() {
+  public static Builder of() {
     return new Builder();
   }
 

--- a/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
+++ b/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
@@ -28,17 +28,17 @@ public class TransferConstraint implements Serializable, RaptorTransferConstrain
 
   /**
    * STAY_SEATED is not a priority, but we assign a cost to it to be able to compare it with other
-   * transfers with a priority and the {@link #GUARANTIED_TRANSFER_COST}.
+   * transfers with a priority and the {@link #GUARANTEED_TRANSFER_COST}.
    */
   private static final int STAY_SEATED_TRANSFER_COST = 10_00;
 
   /**
-   * GUARANTIED is not a priority, but we assign a cost to it to be able to compare it with other
+   * GUARANTEED is not a priority, but we assign a cost to it to be able to compare it with other
    * transfers with a priority. The cost is better than a pure prioritized transfer, but the
-   * priority and GUARANTIED attribute is added together; Hence a (GUARANTIED, RECOMMENDED) transfer
-   * is better than (GUARANTIED, ALLOWED).
+   * priority and GUARANTEED attribute is added together; Hence a (GUARANTEED, RECOMMENDED) transfer
+   * is better than (GUARANTEED, ALLOWED).
    */
-  private static final int GUARANTIED_TRANSFER_COST = 20_00;
+  private static final int GUARANTEED_TRANSFER_COST = 20_00;
 
   /**
    * A cost penalty of 10 points is added to a Transfer which is NOT stay-seated or guaranteed. This
@@ -170,7 +170,7 @@ public class TransferConstraint implements Serializable, RaptorTransferConstrain
   }
 
   /**
-   * Maximum time after scheduled departure time the connecting transport is guarantied to wait for
+   * Maximum time after scheduled departure time the connecting transport is guaranteed to wait for
    * the delayed trip.
    * <p>
    * THIS IS NOT CONSIDERED IN RAPTOR. OTP relies on real-time data for this, so if the "from"
@@ -284,7 +284,7 @@ public class TransferConstraint implements Serializable, RaptorTransferConstrain
       return STAY_SEATED_TRANSFER_COST;
     }
     if (guaranteed) {
-      return GUARANTIED_TRANSFER_COST;
+      return GUARANTEED_TRANSFER_COST;
     }
     return NONE_FACILITATED_COST;
   }

--- a/src/main/java/org/opentripplanner/model/transfer/TransferPriority.java
+++ b/src/main/java/org/opentripplanner/model/transfer/TransferPriority.java
@@ -18,9 +18,9 @@ package org.opentripplanner.model.transfer;
  *     /li>
  * </ol>
  * <p>
- * Note that for {@code transfer_type=1} the guarantied flag is also set causing it to take
- * precedence over the priority. A guarantied ALLOWED transfer is preferred over a PREFERRED
- * none-guarantied transfer.
+ * Note that for {@code transfer_type=1} the guaranteed flag is also set causing it to take
+ * precedence over the priority. A guaranteed ALLOWED transfer is preferred over a PREFERRED
+ * none-guaranteed transfer.
  * <p>
  * Note that {@code transfer_type=2} is not a constraint, just a regular path transfer.
  */

--- a/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
@@ -94,7 +94,7 @@ public class TransferMapper {
   }
 
   private TransferConstraint mapConstraint(ServiceJourneyInterchange it) {
-    var cBuilder = TransferConstraint.create();
+    var cBuilder = TransferConstraint.of();
 
     if (it.isStaySeated() != null) {
       cBuilder.staySeated(it.isStaySeated());

--- a/src/main/java/org/opentripplanner/raptor/api/request/DynamicSearchWindowCoefficients.java
+++ b/src/main/java/org/opentripplanner/raptor/api/request/DynamicSearchWindowCoefficients.java
@@ -64,7 +64,7 @@ public interface DynamicSearchWindowCoefficients {
    * may take a long time. Use this parameter to tune the desired maximum search time.
    * <p>
    * This is the parameter that affect the response time most, the downside is that a search is only
-   * guarantied to be pareto-optimal within a search-window.
+   * guaranteed to be pareto-optimal within a search-window.
    * <p>
    * The default is 3 hours. The unit is minutes.
    */

--- a/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -267,7 +267,7 @@ public class RouteRequest implements Cloneable, Serializable {
    * latest-departure-time(LDT). In case of a reverse search it will be the time from earliest to
    * latest arrival time (LAT - EAT).
    * <p>
-   * All optimal travels that depart within the search window is guarantied to be found.
+   * All optimal travels that depart within the search window is guaranteed to be found.
    * <p>
    * This is sometimes referred to as the Range Raptor Search Window - but could be used in a none
    * Transit search as well; Hence this is named search-window and not raptor-search-window. Do not

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -101,7 +101,7 @@ public class RouteRequestConfig {
   latest-departure-time(LDT). In case of a reverse search it will be the time from earliest to
   latest arrival time (LAT - EAT).
 
-  All optimal travels that depart within the search window is guarantied to be found.
+  All optimal travels that depart within the search window is guaranteed to be found.
 
   This is sometimes referred to as the Range Raptor Search Window - but could be used in a none
   Transit search as well; Hence this is named search-window and not raptor-search-window.

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -363,7 +363,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
       to,
       null,
       null,
-      new ConstrainedTransfer(null, null, null, TransferConstraint.create().staySeated().build())
+      new ConstrainedTransfer(null, null, null, TransferConstraint.of().staySeated().build())
     );
   }
 

--- a/src/test/java/org/opentripplanner/model/transfer/ConstrainedTransferTest.java
+++ b/src/test/java/org/opentripplanner/model/transfer/ConstrainedTransferTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 public class ConstrainedTransferTest {
 
   private static final TransferConstraint NO_CONSTRAINS = TransferConstraint.of().build();
-  private static final TransferConstraint GUARANTIED = TransferConstraint.of().guaranteed().build();
+  private static final TransferConstraint GUARANTEED = TransferConstraint.of().guaranteed().build();
 
   private final ConstrainedTransfer TX_STATION_TO_STATION = noConstTx(STATION_POINT, STATION_POINT);
   private final ConstrainedTransfer TX_STATION_TO_B = noConstTx(STATION_POINT, STOP_POINT_B);
@@ -52,11 +52,11 @@ public class ConstrainedTransferTest {
 
   private final ConstrainedTransfer TX_NO_CONSTRAINS = noConstTx(STOP_POINT_A, STOP_POINT_B);
 
-  private final ConstrainedTransfer TX_GUARANTIED = new ConstrainedTransfer(
+  private final ConstrainedTransfer TX_GUARANTEED = new ConstrainedTransfer(
     null,
     TRIP_POINT_11_1,
     TRIP_POINT_21_3,
-    GUARANTIED
+    GUARANTEED
   );
 
   @Test
@@ -101,7 +101,7 @@ public class ConstrainedTransferTest {
   @Test
   public void noConstraints() {
     assertTrue(TX_NO_CONSTRAINS.noConstraints());
-    assertFalse(TX_GUARANTIED.noConstraints());
+    assertFalse(TX_GUARANTEED.noConstraints());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/model/transfer/ConstrainedTransferTest.java
+++ b/src/test/java/org/opentripplanner/model/transfer/ConstrainedTransferTest.java
@@ -17,11 +17,8 @@ import org.junit.jupiter.api.Test;
 
 public class ConstrainedTransferTest {
 
-  private static final TransferConstraint NO_CONSTRAINS = TransferConstraint.create().build();
-  private static final TransferConstraint GUARANTIED = TransferConstraint
-    .create()
-    .guaranteed()
-    .build();
+  private static final TransferConstraint NO_CONSTRAINS = TransferConstraint.of().build();
+  private static final TransferConstraint GUARANTIED = TransferConstraint.of().guaranteed().build();
 
   private final ConstrainedTransfer TX_STATION_TO_STATION = noConstTx(STATION_POINT, STATION_POINT);
   private final ConstrainedTransfer TX_STATION_TO_B = noConstTx(STATION_POINT, STOP_POINT_B);

--- a/src/test/java/org/opentripplanner/model/transfer/TransferConstraintTest.java
+++ b/src/test/java/org/opentripplanner/model/transfer/TransferConstraintTest.java
@@ -17,25 +17,25 @@ public class TransferConstraintTest {
   private final int MAX_WAIT_TIME_ONE_HOUR = DurationUtils.durationInSeconds("1h");
   private final int D3m = DurationUtils.durationInSeconds("3m");
 
-  private final TransferConstraint NO_CONSTRAINS = TransferConstraint.create().build();
-  private final TransferConstraint RECOMMENDED = TransferConstraint.create().recommended().build();
-  private final TransferConstraint STAY_SEATED = TransferConstraint.create().staySeated().build();
-  private final TransferConstraint GUARANTIED = TransferConstraint.create().guaranteed().build();
-  private final TransferConstraint NOT_ALLOWED = TransferConstraint.create().notAllowed().build();
+  private final TransferConstraint NO_CONSTRAINS = TransferConstraint.of().build();
+  private final TransferConstraint RECOMMENDED = TransferConstraint.of().recommended().build();
+  private final TransferConstraint STAY_SEATED = TransferConstraint.of().staySeated().build();
+  private final TransferConstraint GUARANTIED = TransferConstraint.of().guaranteed().build();
+  private final TransferConstraint NOT_ALLOWED = TransferConstraint.of().notAllowed().build();
   private final TransferConstraint MAX_WAIT_TIME = TransferConstraint
-    .create()
+    .of()
     .guaranteed()
     .maxWaitTime(MAX_WAIT_TIME_ONE_HOUR)
     .build();
   private final TransferConstraint EVERYTHING = TransferConstraint
-    .create()
+    .of()
     .staySeated()
     .guaranteed()
     .preferred()
     .maxWaitTime(MAX_WAIT_TIME_ONE_HOUR)
     .build();
   private final TransferConstraint MIN_TX_TIME = TransferConstraint
-    .create()
+    .of()
     .minTransferTime(D3m)
     .build();
 

--- a/src/test/java/org/opentripplanner/model/transfer/TransferConstraintTest.java
+++ b/src/test/java/org/opentripplanner/model/transfer/TransferConstraintTest.java
@@ -20,7 +20,7 @@ public class TransferConstraintTest {
   private final TransferConstraint NO_CONSTRAINS = TransferConstraint.of().build();
   private final TransferConstraint RECOMMENDED = TransferConstraint.of().recommended().build();
   private final TransferConstraint STAY_SEATED = TransferConstraint.of().staySeated().build();
-  private final TransferConstraint GUARANTIED = TransferConstraint.of().guaranteed().build();
+  private final TransferConstraint GUARANTEED = TransferConstraint.of().guaranteed().build();
   private final TransferConstraint NOT_ALLOWED = TransferConstraint.of().notAllowed().build();
   private final TransferConstraint MAX_WAIT_TIME = TransferConstraint
     .of()
@@ -53,13 +53,13 @@ public class TransferConstraintTest {
 
   @Test
   public void isGuaranteed() {
-    assertTrue(GUARANTIED.isGuaranteed());
+    assertTrue(GUARANTEED.isGuaranteed());
     assertFalse(NO_CONSTRAINS.isGuaranteed());
   }
 
   @Test
   public void isFacilitated() {
-    assertTrue(GUARANTIED.isFacilitated());
+    assertTrue(GUARANTEED.isFacilitated());
     assertTrue(STAY_SEATED.isFacilitated());
     assertFalse(NO_CONSTRAINS.isFacilitated());
     assertFalse(NOT_ALLOWED.isFacilitated());
@@ -68,7 +68,7 @@ public class TransferConstraintTest {
 
   @Test
   public void useInRaptorRouting() {
-    assertTrue(GUARANTIED.includeInRaptorRouting());
+    assertTrue(GUARANTEED.includeInRaptorRouting());
     assertTrue(STAY_SEATED.includeInRaptorRouting());
     assertFalse(NO_CONSTRAINS.includeInRaptorRouting());
     assertTrue(NOT_ALLOWED.includeInRaptorRouting());
@@ -78,7 +78,7 @@ public class TransferConstraintTest {
   @Test
   public void isNotAllowed() {
     assertTrue(NOT_ALLOWED.isNotAllowed());
-    assertFalse(GUARANTIED.isNotAllowed());
+    assertFalse(GUARANTEED.isNotAllowed());
     assertFalse(NO_CONSTRAINS.isNotAllowed());
     assertFalse(MIN_TX_TIME.isNotAllowed());
   }
@@ -99,7 +99,7 @@ public class TransferConstraintTest {
     assertEquals(33_00, NO_CONSTRAINS.cost());
     assertEquals(33_00, MIN_TX_TIME.cost());
     assertEquals(32_00, RECOMMENDED.cost());
-    assertEquals(23_00, GUARANTIED.cost());
+    assertEquals(23_00, GUARANTEED.cost());
     assertEquals(13_00, STAY_SEATED.cost());
     assertEquals(11_00, EVERYTHING.cost());
   }
@@ -108,7 +108,7 @@ public class TransferConstraintTest {
   public void noConstraints() {
     assertTrue(NO_CONSTRAINS.isRegularTransfer());
     assertFalse(STAY_SEATED.isRegularTransfer());
-    assertFalse(GUARANTIED.isRegularTransfer());
+    assertFalse(GUARANTEED.isRegularTransfer());
     assertFalse(RECOMMENDED.isRegularTransfer());
     assertFalse(MAX_WAIT_TIME.isRegularTransfer());
     assertFalse(EVERYTHING.isRegularTransfer());
@@ -127,7 +127,7 @@ public class TransferConstraintTest {
   public void staticPriorityCost() {
     assertEquals(NO_CONSTRAINS.cost(), TransferConstraint.cost(null));
     assertEquals(NO_CONSTRAINS.cost(), TransferConstraint.cost(NO_CONSTRAINS));
-    assertEquals(GUARANTIED.cost(), TransferConstraint.cost(GUARANTIED));
+    assertEquals(GUARANTEED.cost(), TransferConstraint.cost(GUARANTEED));
   }
 
   @Test
@@ -147,7 +147,7 @@ public class TransferConstraintTest {
 
     assertEquals(txMinus, NO_CONSTRAINS.calculateTransferTargetTime(t0, dt, txMinusOp, FORWARD));
     assertEquals(txMinus, RECOMMENDED.calculateTransferTargetTime(t0, dt, txMinusOp, FORWARD));
-    assertEquals(t0, GUARANTIED.calculateTransferTargetTime(t0, dt, txMinusOp, FORWARD));
+    assertEquals(t0, GUARANTEED.calculateTransferTargetTime(t0, dt, txMinusOp, FORWARD));
     assertEquals(t0, STAY_SEATED.calculateTransferTargetTime(t0, dt, txMinusOp, FORWARD));
     assertEquals(t0, EVERYTHING.calculateTransferTargetTime(t0, dt, txMinusOp, FORWARD));
 
@@ -178,7 +178,7 @@ public class TransferConstraintTest {
 
     assertEquals(txMinus, NO_CONSTRAINS.calculateTransferTargetTime(t0, dt, txMinusOp, REVERSE));
     assertEquals(txMinus, RECOMMENDED.calculateTransferTargetTime(t0, dt, txMinusOp, REVERSE));
-    assertEquals(t0, GUARANTIED.calculateTransferTargetTime(t0, dt, txMinusOp, REVERSE));
+    assertEquals(t0, GUARANTEED.calculateTransferTargetTime(t0, dt, txMinusOp, REVERSE));
     assertEquals(t0, STAY_SEATED.calculateTransferTargetTime(t0, dt, txMinusOp, REVERSE));
     assertEquals(t0, EVERYTHING.calculateTransferTargetTime(t0, dt, txMinusOp, REVERSE));
 

--- a/src/test/java/org/opentripplanner/model/transfer/TransferServiceTest.java
+++ b/src/test/java/org/opentripplanner/model/transfer/TransferServiceTest.java
@@ -102,7 +102,7 @@ public class TransferServiceTest {
   }
 
   ConstrainedTransfer transfer(TransferPoint from, TransferPoint to) {
-    var c = TransferConstraint.create().build();
+    var c = TransferConstraint.of().build();
     return new ConstrainedTransfer(null, from, to, c);
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
+++ b/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
@@ -43,15 +43,15 @@ public class TestTransitData
   implements RaptorTransitDataProvider<TestTripSchedule>, RaptorTestConstants {
 
   public static final TransferConstraint TX_GUARANTEED = TransferConstraint
-    .create()
+    .of()
     .guaranteed()
     .build();
   public static final TransferConstraint TX_NOT_ALLOWED = TransferConstraint
-    .create()
+    .of()
     .notAllowed()
     .build();
   public static final TransferConstraint TX_LONG_MIN_TIME = TransferConstraint
-    .create()
+    .of()
     .minTransferTime(3600)
     .build();
 

--- a/src/test/java/org/opentripplanner/raptor/api/path/PathTest.java
+++ b/src/test/java/org/opentripplanner/raptor/api/path/PathTest.java
@@ -176,7 +176,7 @@ public class PathTest implements RaptorTestConstants {
       .times(time("09:10"), time("09:20"))
       .build();
 
-    var tx = TransferConstraint.create().staySeated().build();
+    var tx = TransferConstraint.of().staySeated().build();
     TransitPathLeg<TestTripSchedule> leg2 = new TransitPathLeg<>(
       trip2,
       trip2.departure(0),

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E01_StaySeatedTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E01_StaySeatedTransferTest.java
@@ -26,9 +26,9 @@ import org.opentripplanner.raptor.spi.DefaultSlackProvider;
  * FEATURE UNDER TEST
  * <p>
  * Raptor should return a path if it exists when a transfer is only possible because it is
- * guaranteed/stay-seated. A guaranteed transfer should be able even if there is zero time to do the
- * transfer. In these cases the transfer-slack should be ignored and the connection should be
- * possible.
+ * guaranteed/stay-seated. A stay-seated transfer should be possible even if there is zero time to
+ * do the transfer. In these cases the transfer-slack should be ignored and the connection should
+ * be possible.
  */
 public class E01_StaySeatedTransferTest implements RaptorTestConstants {
 
@@ -75,7 +75,7 @@ public class E01_StaySeatedTransferTest implements RaptorTestConstants {
       .latestArrivalTime(T00_30)
       .timetable(true);
 
-    // Make sure the slack have values which prevent the normal from happening transfer.
+    // Make sure the slack have values which prevent a normal transfer.
     // The test scenario have zero seconds to transfer, so any slack will do.
     data.withSlackProvider(new DefaultSlackProvider(D30s, D20s, D10s));
 

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E01_StaySeatedTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E01_StaySeatedTransferTest.java
@@ -26,7 +26,7 @@ import org.opentripplanner.raptor.spi.DefaultSlackProvider;
  * FEATURE UNDER TEST
  * <p>
  * Raptor should return a path if it exists when a transfer is only possible because it is
- * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do the
+ * guaranteed/stay-seated. A guaranteed transfer should be able even if there is zero time to do the
  * transfer. In these cases the transfer-slack should be ignored and the connection should be
  * possible.
  */

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E01_StaySeatedTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E01_StaySeatedTransferTest.java
@@ -1,0 +1,103 @@
+package org.opentripplanner.raptor.moduletests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor._data.transit.TestRoute.route;
+import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.model.transfer.TransferConstraint;
+import org.opentripplanner.raptor.RaptorService;
+import org.opentripplanner.raptor._data.RaptorTestConstants;
+import org.opentripplanner.raptor._data.api.PathUtils;
+import org.opentripplanner.raptor._data.transit.TestAccessEgress;
+import org.opentripplanner.raptor._data.transit.TestTransitData;
+import org.opentripplanner.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
+import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+import org.opentripplanner.raptor.spi.DefaultSlackProvider;
+
+/**
+ * FEATURE UNDER TEST
+ * <p>
+ * Raptor should return a path if it exists when a transfer is only possible because it is
+ * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do the
+ * transfer. In these cases the transfer-slack should be ignored and the connection should be
+ * possible.
+ */
+public class E01_StaySeatedTransferTest implements RaptorTestConstants {
+
+  private final TestTransitData data = new TestTransitData();
+  private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
+  private final RaptorService<TestTripSchedule> raptorService = new RaptorService<>(
+    RaptorConfig.defaultConfigForTest()
+  );
+
+  /**
+   * Schedule
+   * <pre>
+   * Stop:   1       2       3
+   *   R1: 00:02 - 00:05
+   *   R2:         00:05 - 00:10
+   *</pre>
+   * Access(stop 1) and egress(stop 3) is 30s.
+   */
+  @BeforeEach
+  public void setup() {
+    var r1 = route("R1", STOP_A, STOP_B).withTimetable(schedule("0:02 0:05"));
+    var r2 = route("R2", STOP_B, STOP_C).withTimetable(schedule("0:05 0:10"));
+
+    var tripA = r1.timetable().getTripSchedule(0);
+    var tripB = r2.timetable().getTripSchedule(0);
+
+    data.withRoutes(r1, r2);
+    data.withConstrainedTransfer(
+      tripA,
+      STOP_B,
+      tripB,
+      STOP_B,
+      TransferConstraint.of().staySeated().build()
+    );
+    data.mcCostParamsBuilder().transferCost(100);
+
+    // NOTE! No search-window is set.
+    requestBuilder
+      .searchParams()
+      .constrainedTransfers(true)
+      .addAccessPaths(TestAccessEgress.walk(STOP_A, D30s))
+      .addEgressPaths(TestAccessEgress.walk(STOP_C, D30s))
+      .earliestDepartureTime(T00_00)
+      .latestArrivalTime(T00_30)
+      .timetable(true);
+
+    // Make sure the slack have values which prevent the normal from happening transfer.
+    // The test scenario have zero seconds to transfer, so any slack will do.
+    data.withSlackProvider(new DefaultSlackProvider(D30s, D20s, D10s));
+
+    ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
+  }
+
+  static List<RaptorModuleTestCase> testCases() {
+    // Note! The number of transfers is zero with stay-seated/interlining
+    var path =
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R2 0:05 0:10 ~ C ~ Walk 30s " +
+      "[0:01:10 0:10:40 9m30s 0tx $1230]";
+    return RaptorModuleTestCase
+      .of()
+      .addMinDuration("9m30s", TX_1, T00_00, T00_30)
+      .add(standard(), PathUtils.withoutCost(path))
+      .add(multiCriteria(), path)
+      .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    assertEquals(testCase.expected(), testCase.run(raptorService, data, requestBuilder));
+  }
+}

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedTransferTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.raptor.moduletests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
-import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_REV;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
@@ -20,14 +19,17 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+import org.opentripplanner.raptor.spi.DefaultSlackProvider;
 
 /**
  * FEATURE UNDER TEST
  * <p>
- * Raptor should NOT return a path with a NOT-ALLOWED transfer, instead it should try to find
- * another option.
+ * Raptor should return a path if it exists when a transfer is only possible because it is
+ * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do the
+ * transfer. In these cases the transfer-slack should be ignored and the connection should be
+ * possible.
  */
-public class E02_NotAllowedConstrainedTransferTest implements RaptorTestConstants {
+public class E02_GuaranteedTransferTest implements RaptorTestConstants {
 
   private final TestTransitData data = new TestTransitData();
   private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
@@ -43,29 +45,16 @@ public class E02_NotAllowedConstrainedTransferTest implements RaptorTestConstant
   @BeforeEach
   public void setup() {
     var r1 = route("R1", STOP_A, STOP_B).withTimetable(schedule("0:02 0:05"));
-    var r2 = route("R2", STOP_B, STOP_C)
-      .withTimetable(
-        schedule("0:10 0:15"),
-        // Add another schedule - should not be used even if the not-allowed is
-        // attached to the first one - not-allowed in Raptor apply to the Route.
-        // The trip/timetable search should handle not-allowed on trip level.
-        schedule("0:12 0:17")
-      );
-    var r3 = route("R3", STOP_B, STOP_C).withTimetable(schedule("0:15 0:20"));
+    var r2 = route("R2", STOP_B, STOP_C).withTimetable(schedule("0:05 0:10"));
 
-    var tripR1a = r1.timetable().getTripSchedule(0);
-    var tripR2a = r2.timetable().getTripSchedule(0);
+    var tripA = r1.timetable().getTripSchedule(0);
+    var tripB = r2.timetable().getTripSchedule(0);
 
-    data.withRoutes(r1, r2, r3);
-
-    // Apply not-allowed on the first trip from R1 and R2 - when found this will apply to
-    // the second trip in R2 as well. This is of cause not a correct way to implement the
-    // transit model, a not-allowed transfer should apply to ALL trips if constraint is passed
-    // to raptor.
-    data.withConstrainedTransfer(tripR1a, STOP_B, tripR2a, STOP_B, TestTransitData.TX_NOT_ALLOWED);
+    data.withRoutes(r1, r2);
+    data.withGuaranteedTransfer(tripA, STOP_B, tripB, STOP_B);
     data.mcCostParamsBuilder().transferCost(100);
 
-    // NOTE! No search-window set
+    // NOTE! No search-window is set.
     requestBuilder
       .searchParams()
       .constrainedTransfers(true)
@@ -75,17 +64,21 @@ public class E02_NotAllowedConstrainedTransferTest implements RaptorTestConstant
       .latestArrivalTime(T00_30)
       .timetable(true);
 
+    // Make sure the slack have values which prevent the normal from happening transfer.
+    // The test scenario have zero seconds to transfer, so any slack will do.
+    data.withSlackProvider(new DefaultSlackProvider(D30s, D20s, D10s));
+
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
   static List<RaptorModuleTestCase> testCases() {
     var path =
-      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R3 0:15 0:20 ~ C ~ Walk 30s " +
-      "[0:01:30 0:20:30 19m 1tx $2500]";
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R2 0:05 0:10 ~ C ~ Walk 30s " +
+      "[0:01:10 0:10:40 9m30s 1tx $1230]";
     return RaptorModuleTestCase
       .of()
-      .addMinDuration("9m", TX_1, T00_00, T00_30)
-      .add(standard().not(TC_STANDARD_REV), PathUtils.withoutCost(path))
+      .addMinDuration("9m30s", TX_1, T00_00, T00_30)
+      .add(standard(), PathUtils.withoutCost(path))
       .add(multiCriteria(), path)
       .build();
   }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
@@ -14,6 +14,7 @@ import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.api.PathUtils;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
+import org.opentripplanner.raptor._data.transit.TestTransfer;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
@@ -25,9 +26,9 @@ import org.opentripplanner.raptor.spi.DefaultSlackProvider;
  * FEATURE UNDER TEST
  * <p>
  * Raptor should return a path if it exists when a transfer is only possible because it is
- * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do the
- * transfer. In these cases the transfer-slack should be ignored and the connection should be
- * possible.
+ * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do
+ * the transfer, even with a short walk leg of 30s between the stops. In these cases the walk leg
+ * and the transfer-slack should be ignored and the connection should be possible.
  */
 public class E02_GuaranteedWalkTransferTest implements RaptorTestConstants {
 
@@ -38,20 +39,27 @@ public class E02_GuaranteedWalkTransferTest implements RaptorTestConstants {
   );
 
   /**
-   * Schedule: Stop:   1       2       3 R1: 00:02 - 00:05 R2:         00:05 - 00:10
+   * Schedule
+   * <pre>
+   * Stop:   A       B       C       D
+   *   R1: 00:02 - 00:05
+   *                  ~ walk ~
+   *   R2:                 00:05 - 00:10
+   * </pre>
    * <p>
    * Access(stop 1) and egress(stop 3) is 30s.
    */
   @BeforeEach
   public void setup() {
     var r1 = route("R1", STOP_A, STOP_B).withTimetable(schedule("0:02 0:05"));
-    var r2 = route("R2", STOP_B, STOP_C).withTimetable(schedule("0:05 0:10"));
+    var r2 = route("R2", STOP_C, STOP_D).withTimetable(schedule("0:05 0:10"));
 
     var tripA = r1.timetable().getTripSchedule(0);
     var tripB = r2.timetable().getTripSchedule(0);
 
     data.withRoutes(r1, r2);
-    data.withGuaranteedTransfer(tripA, STOP_B, tripB, STOP_B);
+    data.withGuaranteedTransfer(tripA, STOP_B, tripB, STOP_C);
+    data.withTransfer(STOP_B, TestTransfer.transfer(STOP_C, 30));
     data.mcCostParamsBuilder().transferCost(100);
 
     // NOTE! No search-window is set.
@@ -59,13 +67,13 @@ public class E02_GuaranteedWalkTransferTest implements RaptorTestConstants {
       .searchParams()
       .constrainedTransfers(true)
       .addAccessPaths(TestAccessEgress.walk(STOP_A, D30s))
-      .addEgressPaths(TestAccessEgress.walk(STOP_C, D30s))
+      .addEgressPaths(TestAccessEgress.walk(STOP_D, D30s))
       .earliestDepartureTime(T00_00)
       .latestArrivalTime(T00_30)
       .timetable(true);
 
     // Make sure the slack have values which prevent the normal from happening transfer.
-    // The test scenario have zero seconds to transfer, so any slack will do.
+    // The test scenario have zero seconds to transfer, a 20s walk leg, so any slack will do.
     data.withSlackProvider(new DefaultSlackProvider(D30s, D20s, D10s));
 
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
@@ -73,11 +81,13 @@ public class E02_GuaranteedWalkTransferTest implements RaptorTestConstants {
 
   static List<RaptorModuleTestCase> testCases() {
     var path =
-      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R2 0:05 0:10 ~ C ~ Walk 30s " +
-      "[0:01:10 0:10:40 9m30s 1tx $1230]";
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ Walk 30s ~ C ~ BUS R2 0:05 0:10 ~ D ~ Walk 30s " +
+      "[0:01:10 0:10:40 9m30s 1tx $1260]";
     return RaptorModuleTestCase
       .of()
-      .addMinDuration("9m30s", TX_1, T00_00, T00_30)
+      // BUG! 10 minutes is wrong, it should be 9m30s - Raptor may drop optimal paths,
+      // because of this!
+      .addMinDuration("10m", TX_1, T00_00, T00_30)
       .add(standard(), PathUtils.withoutCost(path))
       .add(multiCriteria(), path)
       .build();

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
@@ -26,9 +26,9 @@ import org.opentripplanner.raptor.spi.DefaultSlackProvider;
  * FEATURE UNDER TEST
  * <p>
  * Raptor should return a path if it exists when a transfer is only possible because it is
- * guaranteed/stay-seated. A guaranteed transfer should be able even if there is zero time to do
- * the transfer, even with a short walk leg of 30s between the stops. In these cases the walk leg
- * and the transfer-slack should be ignored and the connection should be possible.
+ * guaranteed/stay-seated. A guaranteed transfer should be possible even if there is zero time to
+ * do the transfer, even with a short walk leg of 30s between the stops. In these cases the walk
+ * leg and the transfer-slack should be ignored and the connection should be possible.
  */
 public class E02_GuaranteedWalkTransferTest implements RaptorTestConstants {
 
@@ -72,8 +72,8 @@ public class E02_GuaranteedWalkTransferTest implements RaptorTestConstants {
       .latestArrivalTime(T00_30)
       .timetable(true);
 
-    // Make sure the slack have values which prevent the normal from happening transfer.
-    // The test scenario have zero seconds to transfer, a 20s walk leg, so any slack will do.
+    // Make sure the slack have values which prevent a normal transfer.
+    // The test scenario have zero seconds to transfer and a 30s walk leg, so any slack will do.
     data.withSlackProvider(new DefaultSlackProvider(D30s, D20s, D10s));
 
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
@@ -26,7 +26,7 @@ import org.opentripplanner.raptor.spi.DefaultSlackProvider;
  * FEATURE UNDER TEST
  * <p>
  * Raptor should return a path if it exists when a transfer is only possible because it is
- * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do
+ * guaranteed/stay-seated. A guaranteed transfer should be able even if there is zero time to do
  * the transfer, even with a short walk leg of 30s between the stops. In these cases the walk leg
  * and the transfer-slack should be ignored and the connection should be possible.
  */

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E02_GuaranteedWalkTransferTest.java
@@ -29,7 +29,7 @@ import org.opentripplanner.raptor.spi.DefaultSlackProvider;
  * transfer. In these cases the transfer-slack should be ignored and the connection should be
  * possible.
  */
-public class E02_GuaranteedTransferTest implements RaptorTestConstants {
+public class E02_GuaranteedWalkTransferTest implements RaptorTestConstants {
 
   private final TestTransitData data = new TestTransitData();
   private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E03_NotAllowedConstrainedTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E03_NotAllowedConstrainedTransferTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.raptor.moduletests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_REV;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
@@ -19,17 +20,14 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
-import org.opentripplanner.raptor.spi.DefaultSlackProvider;
 
 /**
  * FEATURE UNDER TEST
  * <p>
- * Raptor should return a path if it exists when a transfer is only possible because it is
- * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do the
- * transfer. In these cases the transfer-slack should be ignored and the connection should be
- * possible.
+ * Raptor should NOT return a path with a NOT-ALLOWED transfer, instead it should try to find
+ * another option.
  */
-public class E01_GuaranteedTransferTest implements RaptorTestConstants {
+public class E03_NotAllowedConstrainedTransferTest implements RaptorTestConstants {
 
   private final TestTransitData data = new TestTransitData();
   private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
@@ -45,16 +43,29 @@ public class E01_GuaranteedTransferTest implements RaptorTestConstants {
   @BeforeEach
   public void setup() {
     var r1 = route("R1", STOP_A, STOP_B).withTimetable(schedule("0:02 0:05"));
-    var r2 = route("R2", STOP_B, STOP_C).withTimetable(schedule("0:05 0:10"));
+    var r2 = route("R2", STOP_B, STOP_C)
+      .withTimetable(
+        schedule("0:10 0:15"),
+        // Add another schedule - should not be used even if the not-allowed is
+        // attached to the first one - not-allowed in Raptor apply to the Route.
+        // The trip/timetable search should handle not-allowed on trip level.
+        schedule("0:12 0:17")
+      );
+    var r3 = route("R3", STOP_B, STOP_C).withTimetable(schedule("0:15 0:20"));
 
-    var tripA = r1.timetable().getTripSchedule(0);
-    var tripB = r2.timetable().getTripSchedule(0);
+    var tripR1a = r1.timetable().getTripSchedule(0);
+    var tripR2a = r2.timetable().getTripSchedule(0);
 
-    data.withRoutes(r1, r2);
-    data.withGuaranteedTransfer(tripA, STOP_B, tripB, STOP_B);
+    data.withRoutes(r1, r2, r3);
+
+    // Apply not-allowed on the first trip from R1 and R2 - when found this will apply to
+    // the second trip in R2 as well. This is of cause not a correct way to implement the
+    // transit model, a not-allowed transfer should apply to ALL trips if constraint is passed
+    // to raptor.
+    data.withConstrainedTransfer(tripR1a, STOP_B, tripR2a, STOP_B, TestTransitData.TX_NOT_ALLOWED);
     data.mcCostParamsBuilder().transferCost(100);
 
-    // NOTE! No search-window is set.
+    // NOTE! No search-window set
     requestBuilder
       .searchParams()
       .constrainedTransfers(true)
@@ -64,21 +75,17 @@ public class E01_GuaranteedTransferTest implements RaptorTestConstants {
       .latestArrivalTime(T00_30)
       .timetable(true);
 
-    // Make sure the slack have values which prevent the normal from happening transfer.
-    // The test scenario have zero seconds to transfer, so any slack will do.
-    data.withSlackProvider(new DefaultSlackProvider(D30s, D20s, D10s));
-
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
   static List<RaptorModuleTestCase> testCases() {
     var path =
-      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R2 0:05 0:10 ~ C ~ Walk 30s " +
-      "[0:01:10 0:10:40 9m30s 1tx $1230]";
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R3 0:15 0:20 ~ C ~ Walk 30s " +
+      "[0:01:30 0:20:30 19m 1tx $2500]";
     return RaptorModuleTestCase
       .of()
-      .addMinDuration("9m30s", TX_1, T00_00, T00_30)
-      .add(standard(), PathUtils.withoutCost(path))
+      .addMinDuration("9m", TX_1, T00_00, T00_30)
+      .add(standard().not(TC_STANDARD_REV), PathUtils.withoutCost(path))
       .add(multiCriteria(), path)
       .build();
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearchTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearchTest.java
@@ -37,19 +37,19 @@ public class ConstrainedBoardingSearchTest {
 
   private static final FeedScopedId ID = TransitModelForTest.id("ID");
   private static final TransferConstraint GUARANTEED_CONSTRAINT = TransferConstraint
-    .create()
+    .of()
     .guaranteed()
     .build();
   private static final TransferConstraint NOT_ALLOWED_CONSTRAINT = TransferConstraint
-    .create()
+    .of()
     .notAllowed()
     .build();
   private static final TransferConstraint MIN_TRANSFER_TIME_10_MIN_CONSTRAINT = TransferConstraint
-    .create()
+    .of()
     .minTransferTime(600)
     .build();
   private static final TransferConstraint MIN_TRANSFER_TIME_0_MIN_CONSTRAINT = TransferConstraint
-    .create()
+    .of()
     .minTransferTime(0)
     .build();
   private static final StopTransferPoint STOP_B_TX_POINT = new StopTransferPoint(STOP_B);

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceConstrainedTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceConstrainedTest.java
@@ -23,7 +23,7 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
  * <pre>
  * POSSIBLE TRANSFERS
  * Transfers        B-C 1m     C-D 2m       D-E 3m     E-F 4m      F-G 5m
- * Constraint       ALLOWED  RECOMMENDED  PREFERRED  GUARANTIED  STAY_SEATED
+ * Constraint       ALLOWED  RECOMMENDED  PREFERRED  GUARANTEED  STAY_SEATED
  * Trip 1  A 10:02  B 10:10    C 10:15     D 10:20     E 10:25     F 10:30
  * Trip 2           C 10:13    D 10:18     E 10:24     G 10:30     G 10:36   H 10:40
  * </pre>

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
@@ -20,7 +20,7 @@ public class TestTransferBuilder<T extends RaptorTripSchedule> {
   private final int fromStopIndex;
   private final T toTrip;
   private final int toStopIndex;
-  private final TransferConstraint.Builder constraint = TransferConstraint.create();
+  private final TransferConstraint.Builder constraint = TransferConstraint.of();
 
   private TestTransferBuilder(T fromTrip, int fromStopIndex, T toTrip, int toStopIndex) {
     this.fromTrip = fromTrip;

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGeneratorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGeneratorTest.java
@@ -529,7 +529,7 @@ public class TransferGeneratorTest implements RaptorTestConstants {
     var tripA = l1.getTripSchedule(0);
     var tripB = l2.getTripSchedule(0);
     var constraint = TransferConstraint
-      .create()
+      .of()
       .minTransferTime((int) minTransferTime.getSeconds())
       .build();
     data.withConstrainedTransfer(tripA, STOP_B, tripB, STOP_B, constraint);


### PR DESCRIPTION
### Summary

Add/update Raptor module tests to document StaySeated/Interlining and Guaranteed transfers.

### Issue
This PR is a response to a question raised as part of #5086. 
> Can staySeated/interline transfers with zero time to do the transfer have walking leg with a duration?

Answer: Yes, and the Raptor Module tests now documents this feature. 

### Unit tests
✅  This PR only add tests.
