### PR TITLE
Don't return null from StreetEdge#traverse

### DIFF
--- a/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/astar/AStar.java
@@ -140,7 +140,7 @@ public class AStar<
       }
 
       // Iterate over traversal results. When an edge leads nowhere (as indicated by
-      // returning null), the iteration is over.
+      // returning an empty array), the iteration is over.
       var states = edge.traverse(u);
       for (var v : states) {
         // Could be: for (State v : traverseEdge...)

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -386,6 +386,7 @@ public class StreetEdge
   }
 
   @Override
+  @Nonnull
   public State[] traverse(State s0) {
     final StateEditor editor;
 
@@ -396,7 +397,7 @@ public class StreetEdge
       arriveByRental &&
       (tov.rentalTraversalBanned(s0) || hasStartedSearchInNoDropOffZoneAndIsExitingIt(s0))
     ) {
-      return null;
+      return State.empty();
     }
     // if the traversal is banned for the current state because of a GBFS geofencing zone
     // we drop the vehicle and continue walking

--- a/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -144,10 +144,10 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
   }
 
   /**
-   * Convenience method to check if the state array is null or empty.
+   * Convenience method to check if the state array is empty.
    */
   public static boolean isEmpty(State[] s) {
-    return s == null || s.length == 0;
+    return s.length == 0;
   }
 
   /**

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -2,7 +2,7 @@ package org.opentripplanner.street.model.edge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
 import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdge;
@@ -143,7 +143,8 @@ class StreetEdgeGeofencingTest {
 
       var result = restrictedEdge.traverse(editor.makeState());
 
-      assertNull(result);
+      assertTrue(State.isEmpty(result));
+      assertNotNull(result);
     }
 
     @Test
@@ -161,7 +162,9 @@ class StreetEdgeGeofencingTest {
       V2.addRentalRestriction(NO_TRAVERSAL);
       var intialState = initialState(V2, network, true);
       var result = edge.traverse(intialState);
-      assertNull(result);
+
+      assertTrue(State.isEmpty(result));
+      assertNotNull(result);
     }
 
     @Test


### PR DESCRIPTION
### Summary

In #4841 I have overlooked a single statement returning `null` rather than the empty array. This fixes it and updates the tests.

### Unit tests

Adjusted.