### PR TITLE
Add example JSON to route request documentation, move configuration to top level in menu

### DIFF
--- a/doc-templates/RouteRequest.md
+++ b/doc-templates/RouteRequest.md
@@ -16,3 +16,7 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 ## Parameter Details
 
 <!-- INSERT: PARAMETERS-DETAILS -->
+
+## Config Example
+
+<!-- INSERT: JSON-EXAMPLE -->

--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -815,3 +815,110 @@ include stairs as a last result.
 
 
 <!-- PARAMETERS-DETAILS END -->
+
+## Config Example
+
+<!-- JSON-EXAMPLE BEGIN -->
+<!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
+
+```JSON
+// router-config.json
+{
+  "routingDefaults" : {
+    "walkSpeed" : 1.3,
+    "bikeSpeed" : 5,
+    "carSpeed" : 40,
+    "numItineraries" : 12,
+    "transferPenalty" : 0,
+    "walkReluctance" : 4.0,
+    "bikeReluctance" : 5.0,
+    "bikeWalkingReluctance" : 10.0,
+    "bikeStairsReluctance" : 150.0,
+    "carReluctance" : 10.0,
+    "stairsReluctance" : 1.65,
+    "turnReluctance" : 1.0,
+    "elevatorBoardTime" : 90,
+    "elevatorBoardCost" : 90,
+    "elevatorHopTime" : 20,
+    "elevatorHopCost" : 20,
+    "vehicleRental" : {
+      "pickupCost" : 120,
+      "dropOffTime" : 30,
+      "dropOffCost" : 30
+    },
+    "bikeParkTime" : 60,
+    "bikeParkCost" : 120,
+    "carDropoffTime" : 120,
+    "waitReluctance" : 1.0,
+    "walkBoardCost" : 600,
+    "bikeBoardCost" : 600,
+    "otherThanPreferredRoutesPenalty" : 300,
+    "transferSlack" : 120,
+    "boardSlackForMode" : {
+      "AIRPLANE" : "35m"
+    },
+    "alightSlackForMode" : {
+      "AIRPLANE" : "15m"
+    },
+    "transitReluctanceForMode" : {
+      "RAIL" : 0.85
+    },
+    "maxAccessEgressDurationForMode" : {
+      "BIKE_RENTAL" : "20m"
+    },
+    "itineraryFilters" : {
+      "transitGeneralizedCostLimit" : {
+        "costLimitFunction" : "900 + 1.5 x",
+        "intervalRelaxFactor" : 0.4
+      },
+      "bikeRentalDistanceRatio" : 0.3,
+      "accessibilityScore" : true,
+      "minBikeParkingDistance" : 300
+    },
+    "carDecelerationSpeed" : 2.9,
+    "carAccelerationSpeed" : 2.9,
+    "ignoreRealtimeUpdates" : false,
+    "geoidElevation" : false,
+    "maxJourneyDuration" : "36h",
+    "unpreferred" : {
+      "agencies" : [
+        "HSL:123"
+      ],
+      "routes" : [
+        "HSL:456"
+      ]
+    },
+    "unpreferredCost" : "600 + 2.0 x",
+    "streetRoutingTimeout" : "5s",
+    "transferOptimization" : {
+      "optimizeTransferWaitTime" : true,
+      "minSafeWaitTimeFactor" : 5.0,
+      "backTravelWaitTimeFactor" : 1.0,
+      "extraStopBoardAlightCostsFactor" : 8.0
+    },
+    "wheelchairAccessibility" : {
+      "trip" : {
+        "onlyConsiderAccessible" : false,
+        "unknownCost" : 600,
+        "inaccessibleCost" : 3600
+      },
+      "stop" : {
+        "onlyConsiderAccessible" : false,
+        "unknownCost" : 600,
+        "inaccessibleCost" : 3600
+      },
+      "elevator" : {
+        "onlyConsiderAccessible" : false,
+        "unknownCost" : 20,
+        "inaccessibleCost" : 3600
+      },
+      "inaccessibleStreetReluctance" : 25,
+      "maxSlope" : 0.083,
+      "slopeExceededReluctance" : 1,
+      "stairsReluctance" : 100
+    }
+  }
+}
+```
+
+<!-- JSON-EXAMPLE END -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,23 +57,24 @@ nav:
     - Getting OTP: 'Getting-OTP.md'
     - Container Image: 'Container-Image.md'
     - System Requirements and Suggestions: 'System-Requirements.md'
-    - Configuration:
-        - Introduction: 'Configuration.md'
-        - Build: 'BuildConfiguration.md'
-        - "Boarding Locations": 'BoardingLocations.md'
-        - "Street Graph Pruning": 'IslandPruning.md'
-        - Router: 'RouterConfiguration.md'
-        - Accessibility: 'Accessibility.md'
-        - "Route Request": 'RouteRequest.md'
-        - "Realtime Updaters" : 'UpdaterConfig.md'
-        - "Routing Modes" : "RoutingModes.md"
-        - "Logging" : "Logging.md"
+
     - Preparing OSM Data: 'Preparing-OSM.md'
     - Netex and SIRI: 'Netex-Norway.md'
     - Security: 'Security.md'
     - Troubleshooting: 'Troubleshooting-Routing.md'
     - Comparing OTP2 to OTP1: 'Version-Comparison.md'
-    - OTP2 Migration Guide: 'OTP2-MigrationGuide.md'  
+    - OTP2 Migration Guide: 'OTP2-MigrationGuide.md'
+- Configuration:
+    - Introduction: 'Configuration.md'
+    - Build: 'BuildConfiguration.md'
+    - "Boarding Locations": 'BoardingLocations.md'
+    - "Street Graph Pruning": 'IslandPruning.md'
+    - Router: 'RouterConfiguration.md'
+    - Accessibility: 'Accessibility.md'
+    - "Route Request": 'RouteRequest.md'
+    - "Realtime Updaters": 'UpdaterConfig.md'
+    - "Routing Modes": "RoutingModes.md"
+    - "Logging": "Logging.md"
 - Development:
     - "Developers' Guide": 'Developers-Guide.md'
     - Interfaces and Data Sources: 'Interfaces-Data-Sources.md'

--- a/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
@@ -7,6 +7,7 @@ import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_3;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
+import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceJsonExample;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersDetails;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersTable;
 import static org.opentripplanner.standalone.config.framework.json.JsonSupport.jsonNodeFromResource;
@@ -17,6 +18,7 @@ import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
+import org.opentripplanner.generate.doc.framework.TemplateUtil;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
@@ -33,16 +35,15 @@ public class RouteRequestDocTest {
     .build();
 
   /**
-   * NOTE! This test updates the {@code docs/Configuration.md} document based on the latest
+   * NOTE! This test updates the {@code docs/RouteRequest.md} document based on the latest
    * version of the code. The following is auto generated:
    * <ul>
    *   <li>The configuration type table</li>
-   *   <li>The list of OTP features</li>
    * </ul>
    */
   @Test
-  public void updateBuildConfigurationDoc() {
-    NodeAdapter node = readBuildConfig();
+  public void updateRouteRequestConfigurationDoc() {
+    NodeAdapter node = readRoutingDefaults();
 
     // Read and close inout file (same as output file)
     String doc = readFile(TEMPLATE);
@@ -51,12 +52,18 @@ public class RouteRequestDocTest {
     doc = replaceParametersTable(doc, getParameterSummaryTable(node));
     doc = replaceParametersDetails(doc, getParameterDetailsList(node));
 
+    var example = TemplateUtil
+      .jsonExampleBuilder(node.rawNode())
+      .wrapInObject("routingDefaults")
+      .build();
+    doc = replaceJsonExample(doc, example, ROUTER_CONFIG_FILENAME);
+
     writeFile(OUT_FILE, doc);
 
     assertFileEquals(original, OUT_FILE);
   }
 
-  private NodeAdapter readBuildConfig() {
+  private NodeAdapter readRoutingDefaults() {
     var json = jsonNodeFromResource(ROUTER_CONFIG_PATH);
     var conf = new RouterConfig(json, ROUTER_CONFIG_PATH, false);
     return conf.asNodeAdapter().child("routingDefaults");

--- a/src/test/java/org/opentripplanner/generate/doc/framework/JsonExampleBuilder.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/JsonExampleBuilder.java
@@ -13,7 +13,7 @@ public class JsonExampleBuilder {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private JsonNode node;
 
-  public JsonExampleBuilder(JsonNode node) {
+  JsonExampleBuilder(JsonNode node) {
     Objects.requireNonNull(node);
     this.node = node;
   }

--- a/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
@@ -27,6 +27,10 @@ public class TemplateUtil {
     return replaceSection(doc, EXAMPLE, jsonExample(root, source));
   }
 
+  public static String replaceJsonExample(String doc, JsonNode json, String source) {
+    return replaceSection(doc, EXAMPLE, jsonExample(json, source));
+  }
+
   public static String replaceSection(String doc, String token, String replacement) {
     var replaceToken = replaceToken(token);
 


### PR DESCRIPTION
### Summary

Adds a JSON example to the route request documentation page.

It also moves the configuration item in the docs menu to the top level. To me this looks a lot less busy and feels quite natural.

![image](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/90898e2a-2073-4d57-bbcf-30d379da4cbb)

### Documentation

Yes.