### PR TITLE
Fix vertex removal race condition

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
@@ -30,15 +30,11 @@ public class FlexTripEdge extends Edge {
     FlexAccessEgressTemplate flexTemplate,
     FlexPath flexPath
   ) {
-    // Why is this code so dirty? Because we don't want this edge to be added to the edge lists.
-    // The first parameter in Vertex constructor is graph. If it is null, the vertex isn't added to it.
-    super(new Vertex(null, null, 0.0, 0.0) {}, new Vertex(null, null, 0.0, 0.0) {});
+    super(v1, v2, ConnectToGraph.TEMPORARY_EDGE_NOT_CONNECTED_TO_GRAPH);
     this.s1 = s1;
     this.s2 = s2;
     this.trip = trip;
     this.flexTemplate = flexTemplate;
-    this.fromv = v1;
-    this.tov = v2;
     this.flexPath = Objects.requireNonNull(flexPath);
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/GraphCoherencyCheckerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GraphCoherencyCheckerModule.java
@@ -40,16 +40,8 @@ public class GraphCoherencyCheckerModule implements GraphBuilderModule {
           issueStore.add("InvalidEdge", "outgoing edge of %s: from vertex %s does not match", v, e);
           coherent = false;
         }
-        if (e.getToVertex() == null) {
-          issueStore.add("InvalidEdge", "outgoing edge has no to vertex %s", e);
-          coherent = false;
-        }
       }
       for (Edge e : v.getIncoming()) {
-        if (e.getFromVertex() == null) {
-          issueStore.add("InvalidEdge", "incoming edge has no from vertex %s", e);
-          coherent = false;
-        }
         if (e.getToVertex() != v) {
           issueStore.add("InvalidEdge", "incoming edge of %s: to vertex %s does not match", v, e);
           coherent = false;

--- a/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
@@ -152,19 +152,16 @@ public class StreetIndex {
   }
 
   /**
-   * Return the edges whose geometry intersect with the specified envelope. Warning: edges w/o
-   * geometry will not be indexed.
+   * Return the edges whose geometry intersect with the specified envelope. Warning: edges disconnected from the graph
+   * will not be indexed.
    */
   public Collection<Edge> getEdgesForEnvelope(Envelope envelope) {
     return edgeSpatialIndex
       .query(envelope, Scope.PERMANENT)
-      .filter(e -> {
-        if (e.getToVertex() == null || e.getFromVertex() == null) {
-          return false;
-        }
-        Envelope eenv = edgeGeometryOrStraightLine(e).getEnvelopeInternal();
-        return envelope.intersects(eenv);
-      })
+      .filter(e ->
+        e.isReachableFromGraph() &&
+        envelope.intersects(edgeGeometryOrStraightLine(e).getEnvelopeInternal())
+      )
       .toList();
   }
 

--- a/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -249,20 +249,28 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
   }
 
   /**
-   * A static helper method to avoid repeated code for outgoing and incoming lists. Synchronization
+   * A helper method to avoid repeated code for outgoing and incoming lists. Synchronization
    * must be handled by the caller, to avoid passing edge array pointers that may be invalidated.
    */
-  private static Edge[] removeEdge(Edge[] existing, Edge e) {
+  private Edge[] removeEdge(Edge[] existing, Edge e) {
     int nfound = 0;
-    for (int i = 0, j = 0; i < existing.length; i++) {
+    for (int i = 0; i < existing.length; i++) {
       if (existing[i] == e) nfound++;
     }
     if (nfound == 0) {
-      LOG.error("Requested removal of an edge which isn't connected to this vertex.");
+      LOG.debug(
+        "The edge {} has already been removed from this vertex {}, skipping removal",
+        e,
+        this
+      );
       return existing;
     }
     if (nfound > 1) {
-      LOG.error("There are multiple copies of the edge to be removed.)");
+      LOG.warn(
+        "There are multiple copies of the edge {} to be removed from this vertex {}",
+        e,
+        this
+      );
     }
     Edge[] copy = new Edge[existing.length - nfound];
     for (int i = 0, j = 0; i < existing.length; i++) {


### PR DESCRIPTION
### Summary

As detailed in #5128, a race condition can occur when a temporary edge is removed in a thread while another thread uses it for street routing.
This PR ensures that the "from" and "to" vertices connected to an edge are non-nullable and immutable, thus preventing concurrency issues.
- The "fromv" and "tov" fields in the Edge class are made final.
- The FlexTripEdge class is refactored to prevent it from modifying its vertices during construction.
- The Edge.remove() method is refactored so that it does not nullify the reference to vertices during removal.
- The Edge.removeEdge() method is refactored so that multiple calls do not trigger error messages. The method is idempotent, so multiple calls should not be problematic.
- Logic that tested fromv==null and tov==null is refactored

### Issue

partially closes #5128

### Unit tests
:white_check_mark: 

### Documentation
No
