### PR TITLE
Remove broken Jersey tracing configuration

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -101,16 +101,12 @@ public class OTPWebApplication extends Application {
   }
 
   /**
-   * Enabling tracing allows us to see how web resource names were matched from the client, in
-   * headers. Disable auto-discovery of features because it's extremely obnoxious to debug and
+   * Disable auto-discovery of features because it's extremely obnoxious to debug and
    * interacts in confusing ways with manually registered features.
    */
   @Override
   public Map<String, Object> getProperties() {
-    Map<String, Object> props = new HashMap<>();
-    props.put(ServerProperties.TRACING, Boolean.TRUE);
-    props.put(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE, Boolean.TRUE);
-    return props;
+    return Map.of(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE, Boolean.TRUE);
   }
 
   /**


### PR DESCRIPTION
### Summary
The Jersey server is configured with the option ServerProperties.TRACING, but the provided value (Boolean.TRUE) is invalid and is ignored.
This results in a warning in the logs at application startup:
`There is no way how to transform value "true" [java.lang.Boolean] to type [java.lang.String].`

The value should be either "OFF" (default), "ON_DEMAND", or "ALL".
The documentation mentions that:

> the feature should not be switched on on production environment.

This PR removes the configuration of this parameter.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No