### PR TITLE
Remove batch query from Transmodel API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.ext.transmodelapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import graphql.ExecutionResult;
 import graphql.schema.GraphQLSchema;
 import io.micrometer.core.instrument.Tag;
 import jakarta.ws.rs.BadRequestException;
@@ -18,15 +17,10 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
 import java.util.stream.Collectors;
-import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.ext.transmodelapi.support.GraphQLToWebResponseMapper;
@@ -148,58 +142,6 @@ public class TransmodelAPI {
       getTagsFromHeaders(headers)
     );
     return GraphQLToWebResponseMapper.map(result);
-  }
-
-  @POST
-  @Path("/graphql/batch")
-  @Consumes(MediaType.APPLICATION_JSON)
-  public Response getGraphQLBatch(
-    List<HashMap<String, Object>> queries,
-    @HeaderParam("OTPTimeout") @DefaultValue("10000") int timeout,
-    @HeaderParam("OTPMaxResolves") @DefaultValue("1000000") int maxResolves,
-    @Context HttpHeaders headers
-  ) {
-    List<Callable<ExecutionResult>> futures = new ArrayList<>();
-
-    for (Map<String, Object> query : queries) {
-      Map<String, Object> variables;
-      if (query.get("variables") instanceof Map) {
-        variables = (Map) query.get("variables");
-      } else if (
-        query.get("variables") instanceof String && ((String) query.get("variables")).length() > 0
-      ) {
-        try {
-          variables = deserializer.readValue((String) query.get("variables"), Map.class);
-        } catch (IOException e) {
-          throw new BadRequestException("Variables must be a valid json object");
-        }
-      } else {
-        variables = null;
-      }
-      String operationName = (String) query.getOrDefault("operationName", null);
-
-      futures.add(() ->
-        index.executeGraphQL(
-          (String) query.get("query"),
-          serverContext,
-          variables,
-          operationName,
-          maxResolves,
-          getTagsFromHeaders(headers)
-        )
-      );
-    }
-
-    try {
-      List<Future<ExecutionResult>> results = index.threadPool.invokeAll(futures);
-      return Response
-        .status(Response.Status.OK)
-        .entity(GraphQLResponseSerializer.serializeBatch(queries, results))
-        .build();
-    } catch (InterruptedException e) {
-      LOG.error("Batch query interrupted", e);
-      throw new RuntimeException(e);
-    }
   }
 
   private static Iterable<Tag> getTagsFromHeaders(HttpHeaders headers) {


### PR DESCRIPTION
### Summary

As fare as we know, the Transmodel GraphQL batch API is unused. We do not want to maintain this and do not see that there is a use-case for it. So this PR deletes it. If you are using this please let us know! 
