### PR TITLE
Min access/egress duration for mode filter

### DIFF
--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -92,6 +92,7 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 |       [intervalRelaxFactor](#rd_if_transitGeneralizedCostLimit_intervalRelaxFactor)                  |        `double`        | How much the filter should be relaxed for itineraries that do not overlap in time.                                                             | *Optional* | `0.4`                    |  2.2  |
 | [maxAccessEgressDurationForMode](#rd_maxAccessEgressDurationForMode)                                 | `enum map of duration` | Limit access/egress per street mode.                                                                                                           | *Optional* |                          |  2.1  |
 | [maxDirectStreetDurationForMode](#rd_maxDirectStreetDurationForMode)                                 | `enum map of duration` | Limit direct route duration per street mode.                                                                                                   | *Optional* |                          |  2.2  |
+| [minAccessEgressDurationForMode](#rd_minAccessEgressDurationForMode)                                 | `enum map of duration` | Minimum limit for access/egress by street mode.                                                                                                | *Optional* |                          |  2.1  |
 | [preferredVehicleParkingTags](#rd_preferredVehicleParkingTags)                                       |       `string[]`       | Vehicle parking facilities that don't have one of these tags will receive an extra cost and will therefore be penalised.                       | *Optional* |                          |  2.3  |
 | [requiredVehicleParkingTags](#rd_requiredVehicleParkingTags)                                         |       `string[]`       | Tags without which a vehicle parking will not be used. If empty, no tags are required.                                                         | *Optional* |                          |  2.1  |
 | [transferOptimization](#rd_transferOptimization)                                                     |        `object`        | Optimize where a transfer between to trip happens.                                                                                             | *Optional* |                          |  2.1  |
@@ -626,6 +627,18 @@ Limit direct route duration per street mode.
 
 Override the settings in `maxDirectStreetDuration` for specific street modes. This is
 done because some street modes searches are much more resource intensive than others.
+
+
+<h3 id="rd_minAccessEgressDurationForMode">minAccessEgressDurationForMode</h3>
+
+**Since version:** `2.1` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`   
+**Path:** /routingDefaults   
+**Enum keys:** `not-set` | `walk` | `bike` | `bike-to-park` | `bike-rental` | `scooter-rental` | `car` | `car-to-park` | `car-pickup` | `car-rental` | `car-hailing` | `flexible`
+
+Minimum limit for access/egress by street mode.
+
+Use this to prevent short access/egress legs with for example FLEX. Be careful,
+do not set a minAccessEgressDuration for WALKING, this will lead to empty results.
 
 
 <h3 id="rd_preferredVehicleParkingTags">preferredVehicleParkingTags</h3>

--- a/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/framework/StreetModeDurationInputTypeTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/framework/StreetModeDurationInputTypeTest.java
@@ -1,0 +1,85 @@
+package org.opentripplanner.ext.transmodelapi.model.framework;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.framework.DurationForEnum;
+
+class StreetModeDurationInputTypeTest {
+
+  public static final DurationForEnum<StreetMode> DEFAULT_DURATION_FOR_STREET_MODE = DurationForEnum
+    .of(StreetMode.class)
+    .withDefault(Duration.ofMinutes(10))
+    .with(StreetMode.WALK, Duration.ofMinutes(20))
+    .build();
+
+  @Test
+  void testMapDurationForStreetMode() {
+    var builder = DEFAULT_DURATION_FOR_STREET_MODE.copyOf();
+    List<Map<String, ?>> input = List.of(
+      Map.of(
+        StreetModeDurationInputType.FIELD_STREET_MODE,
+        StreetMode.WALK,
+        StreetModeDurationInputType.FIELD_DURATION,
+        Duration.ofMinutes(15)
+      ),
+      Map.of(
+        StreetModeDurationInputType.FIELD_STREET_MODE,
+        StreetMode.CAR,
+        StreetModeDurationInputType.FIELD_DURATION,
+        Duration.ofMinutes(5)
+      )
+    );
+
+    StreetModeDurationInputType.mapDurationForStreetMode(
+      builder,
+      DEFAULT_DURATION_FOR_STREET_MODE,
+      input,
+      true
+    );
+
+    assertEquals(
+      "DurationForStreetMode{default:10m, WALK:15m, CAR:5m}",
+      builder.build().toString()
+    );
+  }
+
+  @Test
+  void testMapDurationForStreetModeWithValuesGreaterThenDefault() {
+    var builder = DEFAULT_DURATION_FOR_STREET_MODE.copyOf();
+    List<Map<String, ?>> input = List.of(
+      Map.of(
+        StreetModeDurationInputType.FIELD_STREET_MODE,
+        StreetMode.WALK,
+        StreetModeDurationInputType.FIELD_DURATION,
+        // Add one second to default duration to exceed the limit.
+        DEFAULT_DURATION_FOR_STREET_MODE.valueOf(StreetMode.WALK).plusSeconds(1)
+      )
+    );
+
+    // OK - validation turned off
+    StreetModeDurationInputType.mapDurationForStreetMode(
+      builder,
+      DEFAULT_DURATION_FOR_STREET_MODE,
+      input,
+      false
+    );
+
+    // throw exception when validation is on
+    assertThrows(
+      IllegalArgumentException.class,
+      () ->
+        StreetModeDurationInputType.mapDurationForStreetMode(
+          builder,
+          DEFAULT_DURATION_FOR_STREET_MODE,
+          input,
+          true
+        )
+    );
+  }
+}

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -785,6 +785,8 @@ type QueryType {
     maximumAdditionalTransfers: Int = 5,
     "Maximum number of transfers. Note! The best way to reduce the number of transfers is to set the `transferPenalty` parameter."
     maximumTransfers: Int = 12,
+    "The minimum duration for access/egress for street searches per respective mode. Avoid setting a min duration for mode foot, this may lead to an empty result."
+    minAccessEgressDurationForMode: [StreetModeDurationInput!] = [],
     "The set of access/egress/direct/transit modes to be used for this search. Note that this only works at the Line level. If individual ServiceJourneys have modes that differ from the Line mode, this will NOT be accounted for."
     modes: Modes,
     "The maximum number of trip patterns to return. Note! This reduce the number of trip patterns AFTER the OTP travel search is done in a post-filtering process. There is little/no performance gain in reducing the number of trip patterns returned. See also the trip meta-data on how to implement paging."

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/preferences/StreetPreferencesMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/preferences/StreetPreferencesMapper.java
@@ -12,6 +12,15 @@ public class StreetPreferencesMapper {
     DataFetchingEnvironment environment,
     StreetPreferences defaultPreferences
   ) {
+    street.withMinAccessEgressDuration(builder ->
+      StreetModeDurationInputType.mapDurationForStreetMode(
+        builder,
+        environment,
+        TripQuery.MIN_ACCESS_EGRESS_DURATION_FOR_MODE,
+        defaultPreferences.maxAccessEgressDuration()
+      )
+    );
+
     street.withMaxAccessEgressDuration(builder ->
       StreetModeDurationInputType.mapDurationForStreetModeAndAssertValueIsGreaterThenDefault(
         builder,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
@@ -21,6 +21,7 @@ import org.opentripplanner.routing.core.BicycleOptimizeType;
 
 public class TripQuery {
 
+  public static final String MIN_ACCESS_EGRESS_DURATION_FOR_MODE = "minAccessEgressDurationForMode";
   public static final String MAX_ACCESS_EGRESS_DURATION_FOR_MODE = "maxAccessEgressDurationForMode";
   public static final String MAX_DIRECT_DURATION_FOR_MODE = "maxDirectDurationForMode";
 
@@ -508,6 +509,20 @@ public class TripQuery {
             "FOR SERVER-SIDE TUNING AND IS AVAILABLE HERE FOR TESTING ONLY."
           )
           .type(ItineraryFiltersInputType.create(gqlUtil, preferences.itineraryFilter()))
+          .build()
+      )
+      .argument(
+        GraphQLArgument
+          .newArgument()
+          .name(MIN_ACCESS_EGRESS_DURATION_FOR_MODE)
+          .description(
+            "The minimum duration for access/egress for street searches per respective mode. " +
+            "Avoid setting a min duration for mode foot, this may lead to an empty result."
+          )
+          .type(new GraphQLList(new GraphQLNonNull(durationPerStreetModeType)))
+          .defaultValueLiteral(
+            mapDurationForStreetModeGraphQLValue(preferences.street().minAccessEgressDuration())
+          )
           .build()
       )
       .argument(

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -188,7 +188,7 @@ public class TravelTimeResource {
       routingRequest.arriveBy(),
       traveltimeRequest.maxAccessDuration
     );
-    return new AccessEgressMapper().mapNearbyStops(accessStops, routingRequest.arriveBy());
+    return AccessEgressMapper.mapNearbyStops(accessStops, routingRequest.arriveBy());
   }
 
   private ShortestPathTree<State, Edge, Vertex> getShortestPathTree(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -1,5 +1,9 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.router;
 
+import static org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType.ACCESS;
+import static org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType.EGRESS;
+
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -15,6 +19,7 @@ import org.opentripplanner.raptor.api.path.RaptorPath;
 import org.opentripplanner.raptor.api.response.RaptorResponse;
 import org.opentripplanner.routing.algorithm.mapping.RaptorPathToItineraryMapper;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressRouter;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.FlexAccessEgressRouter;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.DefaultAccessEgress;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
@@ -44,6 +49,7 @@ public class TransitRouter {
   private final DebugTimingAggregator debugTimingAggregator;
   private final ZonedDateTime transitSearchTimeZero;
   private final AdditionalSearchDays additionalSearchDays;
+  private final TemporaryVerticesContainer temporaryVerticesContainer;
 
   private TransitRouter(
     RouteRequest request,
@@ -57,6 +63,7 @@ public class TransitRouter {
     this.transitSearchTimeZero = transitSearchTimeZero;
     this.additionalSearchDays = additionalSearchDays;
     this.debugTimingAggregator = debugTimingAggregator;
+    this.temporaryVerticesContainer = createTemporaryVerticesContainer(request, serverContext);
   }
 
   public static TransitRouterResult route(
@@ -66,26 +73,26 @@ public class TransitRouter {
     AdditionalSearchDays additionalSearchDays,
     DebugTimingAggregator debugTimingAggregator
   ) {
-    var transitRouter = new TransitRouter(
+    TransitRouter transitRouter = new TransitRouter(
       request,
       serverContext,
       transitSearchTimeZero,
       additionalSearchDays,
       debugTimingAggregator
     );
-    try (
-      var temporaryVertices = new TemporaryVerticesContainer(
-        serverContext.graph(),
-        request,
-        request.journey().access().mode(),
-        request.journey().egress().mode()
-      )
-    ) {
-      return transitRouter.route(temporaryVertices);
+
+    return transitRouter.routeAndCleanupAfter();
+  }
+
+  private TransitRouterResult routeAndCleanupAfter() {
+    // try(auto-close):
+    //   Make sure we clean up graph by removing temp-edges from the graph before we exit.
+    try (temporaryVerticesContainer) {
+      return route();
     }
   }
 
-  private TransitRouterResult route(TemporaryVerticesContainer temporaryVertices) {
+  private TransitRouterResult route() {
     if (!request.journey().transit().enabled()) {
       return new TransitRouterResult(List.of(), null);
     }
@@ -104,7 +111,7 @@ public class TransitRouter {
 
     debugTimingAggregator.finishedPatternFiltering();
 
-    var accessEgresses = getAccessEgresses(temporaryVertices);
+    var accessEgresses = fetchAccessEgresses();
 
     debugTimingAggregator.finishedAccessEgress(
       accessEgresses.getAccesses().size(),
@@ -162,22 +169,9 @@ public class TransitRouter {
     return new TransitRouterResult(itineraries, transitResponse.requestUsed().searchParams());
   }
 
-  private AccessEgresses getAccessEgresses(TemporaryVerticesContainer temporaryVertices) {
-    var accessEgressMapper = new AccessEgressMapper();
-    var accessList = new ArrayList<DefaultAccessEgress>();
-    var egressList = new ArrayList<DefaultAccessEgress>();
-
-    var accessCalculator = (Runnable) () -> {
-      debugTimingAggregator.startedAccessCalculating();
-      accessList.addAll(getAccessEgresses(accessEgressMapper, temporaryVertices, false));
-      debugTimingAggregator.finishedAccessCalculating();
-    };
-
-    var egressCalculator = (Runnable) () -> {
-      debugTimingAggregator.startedEgressCalculating();
-      egressList.addAll(getAccessEgresses(accessEgressMapper, temporaryVertices, true));
-      debugTimingAggregator.finishedEgressCalculating();
-    };
+  private AccessEgresses fetchAccessEgresses() {
+    final var asyncAccessList = new ArrayList<DefaultAccessEgress>();
+    final var asyncEgressList = new ArrayList<DefaultAccessEgress>();
 
     if (OTPFeature.ParallelRouting.isOn()) {
       try {
@@ -185,66 +179,80 @@ public class TransitRouter {
         //       log-trace-parameters-propagation and graceful timeout handling here.
         CompletableFuture
           .allOf(
-            CompletableFuture.runAsync(accessCalculator),
-            CompletableFuture.runAsync(egressCalculator)
+            CompletableFuture.runAsync(() -> asyncAccessList.addAll(fetchAccess())),
+            CompletableFuture.runAsync(() -> asyncEgressList.addAll(fetchEgress()))
           )
           .join();
       } catch (CompletionException e) {
         RoutingValidationException.unwrapAndRethrowCompletionException(e);
       }
     } else {
-      accessCalculator.run();
-      egressCalculator.run();
+      asyncAccessList.addAll(fetchAccess());
+      asyncEgressList.addAll(fetchEgress());
     }
 
-    verifyAccessEgress(accessList, egressList);
+    verifyAccessEgress(asyncAccessList, asyncEgressList);
 
-    return new AccessEgresses(accessList, egressList);
+    return new AccessEgresses(asyncAccessList, asyncEgressList);
   }
 
-  private Collection<DefaultAccessEgress> getAccessEgresses(
-    AccessEgressMapper accessEgressMapper,
-    TemporaryVerticesContainer temporaryVertices,
-    boolean isEgress
-  ) {
-    var streetRequest = isEgress ? request.journey().egress() : request.journey().access();
+  private Collection<DefaultAccessEgress> fetchAccess() {
+    debugTimingAggregator.startedAccessCalculating();
+    var list = fetchAccessEgresses(ACCESS);
+    debugTimingAggregator.finishedAccessCalculating();
+    return list;
+  }
+
+  private Collection<DefaultAccessEgress> fetchEgress() {
+    debugTimingAggregator.startedEgressCalculating();
+    var list = fetchAccessEgresses(EGRESS);
+    debugTimingAggregator.finishedEgressCalculating();
+    return list;
+  }
+
+  private Collection<DefaultAccessEgress> fetchAccessEgresses(AccessEgressType type) {
+    var streetRequest = type.isAccess() ? request.journey().access() : request.journey().egress();
 
     // Prepare access/egress lists
     RouteRequest accessRequest = request.clone();
 
-    if (!isEgress) {
+    if (type.isAccess()) {
       accessRequest.journey().rental().setAllowArrivingInRentedVehicleAtDestination(false);
     }
 
+    Duration durationLimit = accessRequest
+      .preferences()
+      .street()
+      .maxAccessEgressDuration()
+      .valueOf(streetRequest.mode());
     var nearbyStops = AccessEgressRouter.streetSearch(
       accessRequest,
-      temporaryVertices,
+      temporaryVerticesContainer,
       serverContext.transitService(),
       streetRequest,
       serverContext.dataOverlayContext(accessRequest),
-      isEgress,
-      accessRequest.preferences().street().maxAccessEgressDuration().valueOf(streetRequest.mode())
+      type.isEgress(),
+      durationLimit
     );
 
-    var isAccess = !isEgress;
     List<DefaultAccessEgress> results = new ArrayList<>(
-      accessEgressMapper.mapNearbyStops(nearbyStops, isEgress)
+      AccessEgressMapper.mapNearbyStops(nearbyStops, type.isEgress())
     );
-    results = timeshiftRideHailing(streetRequest, isAccess, results);
+    results = timeshiftRideHailing(streetRequest, type, results);
 
     // Special handling of flex accesses
     if (OTPFeature.FlexRouting.isOn() && streetRequest.mode() == StreetMode.FLEXIBLE) {
       var flexAccessList = FlexAccessEgressRouter.routeAccessEgress(
         accessRequest,
-        temporaryVertices,
+        temporaryVerticesContainer,
         serverContext,
         additionalSearchDays,
         serverContext.flexConfig(),
         serverContext.dataOverlayContext(accessRequest),
-        isEgress
+        type.isEgress()
       );
 
-      results.addAll(accessEgressMapper.mapFlexAccessEgresses(flexAccessList, isEgress));
+      results.addAll(AccessEgressMapper.mapFlexAccessEgresses(flexAccessList, type.isEgress()));
     }
 
     return results;
@@ -262,20 +270,19 @@ public class TransitRouter {
    */
   private List<DefaultAccessEgress> timeshiftRideHailing(
     StreetRequest streetRequest,
-    boolean isAccess,
-    List<DefaultAccessEgress> results
+    AccessEgressType type,
+    List<DefaultAccessEgress> accessEgressList
   ) {
-    if (streetRequest.mode() == StreetMode.CAR_HAILING) {
-      results =
-        RideHailingAccessShifter.shiftAccesses(
-          isAccess,
-          results,
-          serverContext.rideHailingServices(),
-          request,
-          Instant.now()
-        );
+    if (streetRequest.mode() != StreetMode.CAR_HAILING) {
+      return accessEgressList;
     }
-    return results;
+    return RideHailingAccessShifter.shiftAccesses(
+      type.isAccess(),
+      accessEgressList,
+      serverContext.rideHailingServices(),
+      request,
+      Instant.now()
+    );
   }
 
   private RaptorRoutingRequestTransitData createRequestTransitDataProvider(
@@ -323,5 +330,17 @@ public class TransitRouter {
         List.of(new RoutingError(RoutingErrorCode.NO_TRANSIT_CONNECTION, null))
       );
     }
+  }
+
+  private TemporaryVerticesContainer createTemporaryVerticesContainer(
+    RouteRequest request,
+    OtpServerRequestContext serverContext
+  ) {
+    return new TemporaryVerticesContainer(
+      serverContext.graph(),
+      request,
+      request.journey().access().mode(),
+      request.journey().egress().mode()
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -18,6 +18,7 @@ import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor.api.path.RaptorPath;
 import org.opentripplanner.raptor.api.response.RaptorResponse;
 import org.opentripplanner.routing.algorithm.mapping.RaptorPathToItineraryMapper;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressFilter;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressRouter;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.FlexAccessEgressRouter;
@@ -193,7 +194,12 @@ public class TransitRouter {
 
     verifyAccessEgress(asyncAccessList, asyncEgressList);
 
-    return new AccessEgresses(asyncAccessList, asyncEgressList);
+    // Filter access/egress
+    var accessEgressFilter = new AccessEgressFilter(request);
+    var accessList = accessEgressFilter.filterAccess(asyncAccessList);
+    var egressList = accessEgressFilter.filterEgress(asyncEgressList);
+
+    return new AccessEgresses(accessList, egressList);
   }
 
   private Collection<DefaultAccessEgress> fetchAccess() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressFilter.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
+
+import java.util.Collection;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.DefaultAccessEgress;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+
+/**
+ * This class is responsible for filtering the list of access and egress before
+ * the transit routing is performed.
+ */
+public class AccessEgressFilter {
+
+  private final RouteRequest request;
+
+  public AccessEgressFilter(RouteRequest request) {
+    this.request = request;
+  }
+
+  public Collection<DefaultAccessEgress> filterAccess(Collection<DefaultAccessEgress> list) {
+    return filterMinDurationForMode(list, request.journey().modes().accessMode);
+  }
+
+  public Collection<DefaultAccessEgress> filterEgress(Collection<DefaultAccessEgress> list) {
+    return filterMinDurationForMode(list, request.journey().modes().egressMode);
+  }
+
+  /**
+   * Filter for the preferred street minimum duration.
+   */
+  private Collection<DefaultAccessEgress> filterMinDurationForMode(
+    Collection<DefaultAccessEgress> input,
+    StreetMode streetMode
+  ) {
+    if (input.isEmpty()) {
+      return input;
+    }
+    // The Routing request may only have one access/egress street-mode set, so we can use it to
+    // find the min duration to apply to all access/egress witch is not walking. Walking is the
+    // only mode allowed in combination with other modes(the request mode).
+    var minDurationNotWalking = request
+      .preferences()
+      .street()
+      .minAccessEgressDuration()
+      .valueOf(streetMode);
+
+    if (minDurationNotWalking.isZero()) {
+      return input;
+    }
+
+    return input
+      .stream()
+      .filter(it -> it.isWalkOnly() || it.durationInSeconds() >= minDurationNotWalking.toSeconds())
+      .toList();
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressType.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressType.java
@@ -1,0 +1,18 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
+
+/**
+ * Access and Egress share many features, so instead of duplicating the logic we can make methods
+ * generic and use this "type" explicit differentiate(and not use a boolean flag).
+ */
+public enum AccessEgressType {
+  ACCESS,
+  EGRESS;
+
+  public boolean isAccess() {
+    return this == ACCESS;
+  }
+
+  public boolean isEgress() {
+    return this == EGRESS;
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgress.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgress.java
@@ -60,4 +60,8 @@ public class DefaultAccessEgress implements RaptorAccessEgress {
   public String toString() {
     return asString(true) + (lastState != null ? " (" + lastState + ")" : "");
   }
+
+  public boolean isWalkOnly() {
+    return lastState.containsModeWalkOnly();
+  }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/FlexAccessEgressAdapter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/FlexAccessEgressAdapter.java
@@ -58,6 +58,12 @@ public class FlexAccessEgressAdapter extends DefaultAccessEgress {
   }
 
   @Override
+  public boolean isWalkOnly() {
+    return false;
+  }
+
+
+  @Override
   public String toString() {
     return asString(true);
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
@@ -43,5 +43,4 @@ public class AccessEgressMapper {
       isEgress ? nearbyStop.state.reverse() : nearbyStop.state
     );
   }
-
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
@@ -12,18 +12,7 @@ import org.opentripplanner.transit.model.site.RegularStop;
 
 public class AccessEgressMapper {
 
-  public DefaultAccessEgress mapNearbyStop(NearbyStop nearbyStop, boolean isEgress) {
-    if (!(nearbyStop.stop instanceof RegularStop)) {
-      return null;
-    }
-
-    return new DefaultAccessEgress(
-      nearbyStop.stop.getIndex(),
-      isEgress ? nearbyStop.state.reverse() : nearbyStop.state
-    );
-  }
-
-  public List<DefaultAccessEgress> mapNearbyStops(
+  public static List<DefaultAccessEgress> mapNearbyStops(
     Collection<NearbyStop> accessStops,
     boolean isEgress
   ) {
@@ -34,7 +23,7 @@ public class AccessEgressMapper {
       .collect(Collectors.toList());
   }
 
-  public Collection<DefaultAccessEgress> mapFlexAccessEgresses(
+  public static Collection<DefaultAccessEgress> mapFlexAccessEgresses(
     Collection<FlexAccessEgress> flexAccessEgresses,
     boolean isEgress
   ) {
@@ -43,4 +32,16 @@ public class AccessEgressMapper {
       .map(flexAccessEgress -> new FlexAccessEgressAdapter(flexAccessEgress, isEgress))
       .collect(Collectors.toList());
   }
+
+  private static DefaultAccessEgress mapNearbyStop(NearbyStop nearbyStop, boolean isEgress) {
+    if (!(nearbyStop.stop instanceof RegularStop)) {
+      return null;
+    }
+
+    return new DefaultAccessEgress(
+      nearbyStop.stop.getIndex(),
+      isEgress ? nearbyStop.state.reverse() : nearbyStop.state
+    );
+  }
+
 }

--- a/src/main/java/org/opentripplanner/routing/api/request/framework/DurationForEnum.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/framework/DurationForEnum.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.api.request.framework;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
@@ -73,7 +74,13 @@ public class DurationForEnum<E extends Enum<E>> implements Serializable {
       .addText("default:")
       .addDuration(defaultValue);
 
-    for (Map.Entry<E, Duration> e : valueForEnum.entrySet()) {
+    var sortedEntryList = valueForEnum
+      .entrySet()
+      .stream()
+      .sorted(Comparator.comparingInt(e -> e.getKey().ordinal()))
+      .toList();
+
+    for (Map.Entry<E, Duration> e : sortedEntryList) {
       if (!defaultValue.equals(e.getValue())) {
         builder.addText(", ").addText(e.getKey().name()).addText(":").addDuration(e.getValue());
       }

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
@@ -33,6 +33,7 @@ public final class StreetPreferences implements Serializable {
   private final DrivingDirection drivingDirection;
   private final ElevatorPreferences elevator;
   private final IntersectionTraversalModel intersectionTraversalModel;
+  private final DurationForEnum<StreetMode> minAccessEgressDuration;
   private final DurationForEnum<StreetMode> maxAccessEgressDuration;
   private final DurationForEnum<StreetMode> maxDirectDuration;
   private final Duration routingTimeout;
@@ -42,9 +43,9 @@ public final class StreetPreferences implements Serializable {
     this.drivingDirection = DrivingDirection.RIGHT;
     this.elevator = ElevatorPreferences.DEFAULT;
     this.intersectionTraversalModel = IntersectionTraversalModel.SIMPLE;
-    this.maxAccessEgressDuration =
-      DurationForEnum.of(StreetMode.class).withDefault(ofMinutes(45)).build();
-    this.maxDirectDuration = DurationForEnum.of(StreetMode.class).withDefault(ofHours(4)).build();
+    this.minAccessEgressDuration = durationForStreetModeOf(Duration.ZERO);
+    this.maxAccessEgressDuration = durationForStreetModeOf(ofMinutes(45));
+    this.maxDirectDuration = durationForStreetModeOf(ofHours(4));
     this.routingTimeout = Duration.ofSeconds(5);
   }
 
@@ -53,8 +54,9 @@ public final class StreetPreferences implements Serializable {
     this.drivingDirection = requireNonNull(builder.drivingDirection);
     this.elevator = requireNonNull(builder.elevator);
     this.intersectionTraversalModel = requireNonNull(builder.intersectionTraversalModel);
-    this.maxDirectDuration = requireNonNull(builder.maxDirectDuration);
+    this.minAccessEgressDuration = requireNonNull(builder.minAccessEgressDuration);
     this.maxAccessEgressDuration = requireNonNull(builder.maxAccessEgressDuration);
+    this.maxDirectDuration = requireNonNull(builder.maxDirectDuration);
     this.routingTimeout = requireNonNull(builder.routingTimeout);
   }
 
@@ -86,6 +88,10 @@ public final class StreetPreferences implements Serializable {
     return intersectionTraversalModel;
   }
 
+  public DurationForEnum<StreetMode> minAccessEgressDuration() {
+    return minAccessEgressDuration;
+  }
+
   public DurationForEnum<StreetMode> maxAccessEgressDuration() {
     return maxAccessEgressDuration;
   }
@@ -115,6 +121,7 @@ public final class StreetPreferences implements Serializable {
       elevator.equals(that.elevator) &&
       routingTimeout.equals(that.routingTimeout) &&
       intersectionTraversalModel == that.intersectionTraversalModel &&
+      minAccessEgressDuration.equals(that.minAccessEgressDuration) &&
       maxAccessEgressDuration.equals(that.maxAccessEgressDuration) &&
       maxDirectDuration.equals(that.maxDirectDuration)
     );
@@ -128,6 +135,7 @@ public final class StreetPreferences implements Serializable {
       elevator,
       routingTimeout,
       intersectionTraversalModel,
+      minAccessEgressDuration,
       maxAccessEgressDuration,
       maxDirectDuration
     );
@@ -146,6 +154,7 @@ public final class StreetPreferences implements Serializable {
         intersectionTraversalModel,
         DEFAULT.intersectionTraversalModel
       )
+      .addObj("minAccessEgressDuration", minAccessEgressDuration, DEFAULT.minAccessEgressDuration)
       .addObj("maxAccessEgressDuration", maxAccessEgressDuration, DEFAULT.maxAccessEgressDuration)
       .addObj("maxDirectDuration", maxDirectDuration, DEFAULT.maxDirectDuration)
       .toString();
@@ -158,6 +167,7 @@ public final class StreetPreferences implements Serializable {
     private DrivingDirection drivingDirection;
     private ElevatorPreferences elevator;
     private IntersectionTraversalModel intersectionTraversalModel;
+    private DurationForEnum<StreetMode> minAccessEgressDuration;
     private DurationForEnum<StreetMode> maxAccessEgressDuration;
     private DurationForEnum<StreetMode> maxDirectDuration;
     private Duration routingTimeout;
@@ -168,6 +178,8 @@ public final class StreetPreferences implements Serializable {
       this.drivingDirection = original.drivingDirection;
       this.elevator = original.elevator;
       this.intersectionTraversalModel = original.intersectionTraversalModel;
+
+      this.minAccessEgressDuration = original.minAccessEgressDuration;
       this.maxAccessEgressDuration = original.maxAccessEgressDuration;
       this.maxDirectDuration = original.maxDirectDuration;
       this.routingTimeout = original.routingTimeout;
@@ -195,6 +207,16 @@ public final class StreetPreferences implements Serializable {
     public Builder withIntersectionTraversalModel(IntersectionTraversalModel model) {
       this.intersectionTraversalModel = model;
       return this;
+    }
+
+    public Builder withMinAccessEgressDuration(Consumer<DurationForEnum.Builder<StreetMode>> body) {
+      this.minAccessEgressDuration = this.minAccessEgressDuration.copyOf().apply(body).build();
+      return this;
+    }
+
+    /** Utility method to simplify config parsing */
+    public Builder withMinAccessEgressDuration(Map<StreetMode, Duration> values) {
+      return withMinAccessEgressDuration(b -> b.withValues(values));
     }
 
     public Builder withMaxAccessEgressDuration(Consumer<DurationForEnum.Builder<StreetMode>> body) {
@@ -234,5 +256,9 @@ public final class StreetPreferences implements Serializable {
       var value = new StreetPreferences(this);
       return original.equals(value) ? original : value;
     }
+  }
+
+  private static DurationForEnum<StreetMode> durationForStreetModeOf(Duration defaultValue) {
+    return DurationForEnum.of(StreetMode.class).withDefault(defaultValue).build();
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -513,6 +513,20 @@ ferries, where the check-in process needs to be done in good time before ride.
               .asInt(dftElevator.hopTime())
           );
       })
+      .withMinAccessEgressDuration(
+        // The default value should be ZERO, so it is not configurable
+        c
+          .of("minAccessEgressDurationForMode")
+          .since(V2_1)
+          .summary("Minimum limit for access/egress by street mode.")
+          .description(
+            """
+            Use this to prevent short access/egress legs with for example FLEX. Be careful,
+            do not set a minAccessEgressDuration for WALKING, this will lead to empty results.
+            """
+          )
+          .asEnumMap(StreetMode.class, Duration.class)
+      )
       .withMaxAccessEgressDuration(
         c
           .of("maxAccessEgressDuration")

--- a/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.opentripplanner.astar.spi.AStarState;
@@ -434,6 +435,17 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
       }
     }
     return false;
+  }
+
+  /**
+   * Check all edges is traversed on foot {@code mode=WALK}.
+   * <p>
+   * DO NOT USE THIS IN ROUTING IT WILL NOT PERFORM WELL!
+   */
+  public boolean containsModeWalkOnly() {
+    return Stream
+      .iterate(this, it -> it.backEdge != null, it -> it.backState)
+      .allMatch(it -> it.stateData.currentMode.isWalking());
   }
 
   protected State clone() {

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressFilterTest.java
@@ -1,0 +1,104 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.DefaultAccessEgress;
+import org.opentripplanner.routing.api.request.RequestModes;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.street.search.state.TestStateBuilder;
+
+class AccessEgressFilterTest {
+
+  private static final int LIMIT = 45;
+
+  private static final DefaultAccessEgress CAR_RENTAL_TOO_SHORT = ofCarRental(LIMIT - 1);
+  private static final DefaultAccessEgress CAR_RENTAL_OK = ofCarRental(LIMIT);
+
+  // Walking should not be filtered even if it is below the limit
+  private static final DefaultAccessEgress WALK = ofWalking(LIMIT - 10);
+
+  private static List<Arguments> filterMinDurationTestCase() {
+    return List.of(
+      Arguments.of(List.of(), List.of()),
+      Arguments.of(List.of(WALK), List.of(WALK)),
+      Arguments.of(List.of(CAR_RENTAL_OK), List.of(CAR_RENTAL_OK)),
+      Arguments.of(List.of(), List.of(CAR_RENTAL_TOO_SHORT)),
+      Arguments.of(List.of(WALK, CAR_RENTAL_OK), List.of(WALK, CAR_RENTAL_TOO_SHORT, CAR_RENTAL_OK))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("filterMinDurationTestCase")
+  void filterMinDurationAccessTest(
+    List<DefaultAccessEgress> expected,
+    List<DefaultAccessEgress> input
+  ) {
+    var requestLimitAccess = createRequestWithMinDurationLimitForCar();
+    requestLimitAccess
+      .journey()
+      .setModes(RequestModes.of().withAccessMode(StreetMode.CAR_RENTAL).build());
+
+    var filterAccess = new AccessEgressFilter(requestLimitAccess);
+
+    assertEquals(expected, filterAccess.filterAccess(input));
+    assertEquals(input, filterAccess.filterEgress(input));
+  }
+
+  @ParameterizedTest
+  @MethodSource("filterMinDurationTestCase")
+  void filterMinDurationEgressTest(
+    List<DefaultAccessEgress> expected,
+    List<DefaultAccessEgress> input
+  ) {
+    var requestLimitEgress = createRequestWithMinDurationLimitForCar();
+    requestLimitEgress
+      .journey()
+      .setModes(RequestModes.of().withEgressMode(StreetMode.CAR_RENTAL).build());
+
+    var filterEgress = new AccessEgressFilter(requestLimitEgress);
+
+    assertEquals(input, filterEgress.filterAccess(input));
+    assertEquals(expected, filterEgress.filterEgress(input));
+  }
+
+  private RouteRequest createRequestWithMinDurationLimitForCar() {
+    RouteRequest requestLimitAccess = new RouteRequest();
+    requestLimitAccess.withPreferences(p ->
+      p.withStreet(s ->
+        s.withMinAccessEgressDuration(b -> b.with(StreetMode.CAR_RENTAL, Duration.ofSeconds(LIMIT)))
+      )
+    );
+    return requestLimitAccess;
+  }
+
+  @Test
+  void filterEgress() {}
+
+  private static DefaultAccessEgress ofCarRental(int duration) {
+    return ofAccessEgress(
+      duration,
+      TestStateBuilder.ofCarRental().streetEdge().pickUpCar().build()
+    );
+  }
+
+  private static DefaultAccessEgress ofWalking(int duration) {
+    return ofAccessEgress(duration, TestStateBuilder.ofWalking().streetEdge().build());
+  }
+
+  private static DefaultAccessEgress ofAccessEgress(int duration, State state) {
+    return new DefaultAccessEgress(1, state) {
+      @Override
+      public int durationInSeconds() {
+        return duration;
+      }
+    };
+  }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressTypeTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressTypeTest.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class AccessEgressTypeTest {
+
+  @Test
+  void isAccess() {
+    assertTrue(AccessEgressType.ACCESS.isAccess());
+    assertFalse(AccessEgressType.EGRESS.isAccess());
+  }
+
+  @Test
+  void isEgress() {
+    assertTrue(AccessEgressType.EGRESS.isEgress());
+    assertFalse(AccessEgressType.ACCESS.isEgress());
+  }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgressTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgressTest.java
@@ -21,4 +21,15 @@ class DefaultAccessEgressTest {
     var access = new DefaultAccessEgress(0, state);
     assertFalse(access.getLastState().containsModeCar());
   }
+
+  @Test
+  void containsModeWalkOnly() {
+    var stateWalk = TestStateBuilder.ofWalking().build();
+    var subject = new DefaultAccessEgress(0, stateWalk);
+    assertTrue(subject.isWalkOnly());
+
+    var carRentalState = TestStateBuilder.ofCarRental().streetEdge().pickUpCar().build();
+    subject = new DefaultAccessEgress(0, carRentalState);
+    assertFalse(subject.isWalkOnly());
+  }
 }

--- a/src/test/java/org/opentripplanner/routing/api/request/framework/DurationForEnumTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/framework/DurationForEnumTest.java
@@ -29,6 +29,20 @@ class DurationForEnumTest {
   @Test
   void testToString() {
     assertEquals("DurationForStreetMode{default:7s, WALK:3s}", subject.toString());
+
+    // Assert modes are in order of the enum ordinal
+    assertEquals(
+      "DurationForStreetMode{default:7s, BIKE:3s, SCOOTER_RENTAL:1s, CAR:4s, FLEXIBLE:2s}",
+      DurationForEnum
+        .of(StreetMode.class)
+        .withDefault(DEFAULT)
+        .withValues(Map.of(StreetMode.SCOOTER_RENTAL, Duration.ofSeconds(1)))
+        .withValues(Map.of(StreetMode.CAR, Duration.ofSeconds(4)))
+        .withValues(Map.of(StreetMode.FLEXIBLE, Duration.ofSeconds(2)))
+        .withValues(Map.of(StreetMode.BIKE, Duration.ofSeconds(3)))
+        .build()
+        .toString()
+    );
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
@@ -7,6 +7,7 @@ import static org.opentripplanner.routing.api.request.preference.ImmutablePrefer
 import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.street.search.intersection_model.DrivingDirection;
 import org.opentripplanner.street.search.intersection_model.IntersectionTraversalModel;
 
@@ -17,6 +18,7 @@ class StreetPreferencesTest {
   private static final int ELEVATOR_BOARD_TIME = (int) Duration.ofMinutes(2).toSeconds();
   private static final IntersectionTraversalModel INTERSECTION_TRAVERSAL_MODEL =
     IntersectionTraversalModel.CONSTANT;
+  private static final Duration CAR_MIN_ACCESS_EGRESS = Duration.ofMinutes(1);
   private static final Duration MAX_ACCESS_EGRESS = Duration.ofMinutes(5);
   private static final Duration MAX_DIRECT = Duration.ofMinutes(10);
   public static final Duration ROUTING_TIMEOUT = Duration.ofSeconds(3);
@@ -27,6 +29,7 @@ class StreetPreferencesTest {
     .withTurnReluctance(TURN_RELUCTANCE)
     .withElevator(it -> it.withBoardTime(ELEVATOR_BOARD_TIME))
     .withIntersectionTraversalModel(INTERSECTION_TRAVERSAL_MODEL)
+    .withMinAccessEgressDuration(Map.of(StreetMode.CAR, CAR_MIN_ACCESS_EGRESS))
     .withMaxAccessEgressDuration(MAX_ACCESS_EGRESS, Map.of())
     .withMaxDirectDuration(MAX_DIRECT, Map.of())
     .withRoutingTimeout(ROUTING_TIMEOUT)
@@ -40,6 +43,12 @@ class StreetPreferencesTest {
   @Test
   void intersectionTraversalModel() {
     assertEquals(INTERSECTION_TRAVERSAL_MODEL, subject.intersectionTraversalModel());
+  }
+
+  @Test
+  void minAccessEgressDuration() {
+    assertEquals(Duration.ZERO, subject.minAccessEgressDuration().valueOf(StreetMode.WALK));
+    assertEquals(CAR_MIN_ACCESS_EGRESS, subject.minAccessEgressDuration().valueOf(StreetMode.CAR));
   }
 
   @Test
@@ -92,6 +101,7 @@ class StreetPreferencesTest {
       "routingTimeout: 3s, " +
       "elevator: ElevatorPreferences{boardTime: 2m}, " +
       "intersectionTraversalModel: CONSTANT, " +
+      "minAccessEgressDuration: DurationForStreetMode{default:0s, CAR:1m}, " +
       "maxAccessEgressDuration: DurationForStreetMode{default:5m}, " +
       "maxDirectDuration: DurationForStreetMode{default:10m}" +
       "}",

--- a/src/test/java/org/opentripplanner/street/search/state/StateTest.java
+++ b/src/test/java/org/opentripplanner/street/search/state/StateTest.java
@@ -17,6 +17,9 @@ import static org.opentripplanner.street.model._data.StreetModelForTest.intersec
 import static org.opentripplanner.street.search.TraverseMode.BICYCLE;
 import static org.opentripplanner.street.search.TraverseMode.CAR;
 import static org.opentripplanner.street.search.TraverseMode.WALK;
+import static org.opentripplanner.street.search.state.TestStateBuilder.ofCarRental;
+import static org.opentripplanner.street.search.state.TestStateBuilder.ofDriving;
+import static org.opentripplanner.street.search.state.TestStateBuilder.ofWalking;
 import static org.opentripplanner.street.search.state.VehicleRentalState.BEFORE_RENTING;
 import static org.opentripplanner.street.search.state.VehicleRentalState.HAVE_RENTED;
 import static org.opentripplanner.street.search.state.VehicleRentalState.RENTING_FLOATING;
@@ -95,13 +98,26 @@ class StateTest {
 
   @Test
   void containsDriving() {
-    var state = TestStateBuilder.ofDriving().streetEdge().streetEdge().streetEdge().build();
+    var state = ofDriving().streetEdge().streetEdge().streetEdge().build();
     assertTrue(state.containsModeCar());
   }
 
   @Test
   void walking() {
-    var state = TestStateBuilder.ofWalking().streetEdge().streetEdge().streetEdge().build();
+    var state = ofWalking().streetEdge().streetEdge().streetEdge().build();
     assertFalse(state.containsModeCar());
+  }
+
+  @Test
+  void walkingOnly() {
+    // Walk only
+    assertTrue(ofWalking().streetEdge().build().containsModeWalkOnly(), "One edge");
+    assertTrue(ofWalking().streetEdge().streetEdge().build().containsModeWalkOnly(), "Several edges");
+
+    // Car only
+    assertFalse(ofDriving().streetEdge().build().containsModeWalkOnly(), "One edge");
+    assertFalse(ofDriving().streetEdge().streetEdge().build().containsModeWalkOnly(), "Several edges");
+
+    assertFalse(ofCarRental().streetEdge().pickUpCar().build().containsModeWalkOnly(), "Walk + CAR");
   }
 }

--- a/src/test/java/org/opentripplanner/street/search/state/StateTest.java
+++ b/src/test/java/org/opentripplanner/street/search/state/StateTest.java
@@ -112,12 +112,21 @@ class StateTest {
   void walkingOnly() {
     // Walk only
     assertTrue(ofWalking().streetEdge().build().containsModeWalkOnly(), "One edge");
-    assertTrue(ofWalking().streetEdge().streetEdge().build().containsModeWalkOnly(), "Several edges");
+    assertTrue(
+      ofWalking().streetEdge().streetEdge().build().containsModeWalkOnly(),
+      "Several edges"
+    );
 
     // Car only
     assertFalse(ofDriving().streetEdge().build().containsModeWalkOnly(), "One edge");
-    assertFalse(ofDriving().streetEdge().streetEdge().build().containsModeWalkOnly(), "Several edges");
+    assertFalse(
+      ofDriving().streetEdge().streetEdge().build().containsModeWalkOnly(),
+      "Several edges"
+    );
 
-    assertFalse(ofCarRental().streetEdge().pickUpCar().build().containsModeWalkOnly(), "Walk + CAR");
+    assertFalse(
+      ofCarRental().streetEdge().pickUpCar().build().containsModeWalkOnly(),
+      "Walk + CAR"
+    );
   }
 }

--- a/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
+++ b/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
@@ -2,10 +2,21 @@ package org.opentripplanner.street.search.state;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
+import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
+import org.opentripplanner.service.vehiclerental.street.StreetVehicleRentalLink;
+import org.opentripplanner.service.vehiclerental.street.VehicleRentalEdge;
+import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;
+import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /**
  * Builds up a state chain for use in tests.
@@ -41,6 +52,10 @@ public class TestStateBuilder {
     return new TestStateBuilder(StreetMode.CAR);
   }
 
+  public static TestStateBuilder ofCarRental() {
+    return new TestStateBuilder(StreetMode.CAR_RENTAL);
+  }
+
   /**
    * Traverse a very plain street edge with no special characteristics.
    */
@@ -55,6 +70,52 @@ public class TestStateBuilder {
       throw new IllegalStateException("Only single state transitions are supported.");
     }
     currentState = states[0];
+    return this;
+  }
+
+  /**
+   * Traverse a street edge and switch to Car mode
+   */
+  public TestStateBuilder pickUpCar() {
+    count++;
+
+    var station = new VehicleRentalStation();
+    var stationName = "FooStation";
+    var networkName = "bar";
+    var vehicleType = new RentalVehicleType(
+      new FeedScopedId(networkName, "car"),
+      "car",
+      RentalFormFactor.CAR,
+      RentalVehicleType.PropulsionType.ELECTRIC,
+      100000d
+    );
+    station.id = new FeedScopedId(networkName, stationName);
+    station.name = new NonLocalizedString(stationName);
+    station.latitude = count;
+    station.longitude = count;
+    station.vehiclesAvailable = 10;
+    station.spacesAvailable = 10;
+    station.vehicleTypesAvailable = Map.of(vehicleType, 10);
+    station.vehicleSpacesAvailable = Map.of(vehicleType, 10);
+    station.isRenting = true;
+    station.isReturning = true;
+    station.realTimeData = true;
+
+    VehicleRentalPlaceVertex vertex = new VehicleRentalPlaceVertex(null, station);
+    var link = new StreetVehicleRentalLink((StreetVertex) currentState.vertex, vertex);
+
+    currentState = link.traverse(currentState)[0];
+
+    var edge = new VehicleRentalEdge(vertex, RentalFormFactor.CAR);
+
+    State[] traverse = edge.traverse(currentState);
+    currentState =
+      Arrays
+        .stream(traverse)
+        .filter(it -> it.getNonTransitMode() == TraverseMode.CAR)
+        .findFirst()
+        .get();
+
     return this;
   }
 


### PR DESCRIPTION
### Summary

 - Add `minAccessEgressDurationForMode` filter

This is now configurable and available on the TransmodelAPI and REST(simple version) 

This also include the following refactorings:
 - Cleanup TransitRouter and AccessEgressMapper
 - Sort values in DurationForEnum.toString to make it deterministic
 - Add State.containsModeWalkOnly() and DefaultAccessEgress.isWalkOnly() utility methods
 

Review: Commit by commit reqomended

### Issue
No

### Unit tests
✅ 

### Documentation
✅ 

### Changelog
✅ 

### Bumping the serialization version id
✅ 
