### PR TITLE
Check service dates instead of service ids for block id transfers

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
@@ -53,10 +53,9 @@ public class InterlineProcessor {
     this.staySeatedNotAllowed = staySeatedNotAllowed;
     this.maxInterlineDistance = maxInterlineDistance > 0 ? maxInterlineDistance : 200;
     this.issueStore = issueStore;
-    this.transitServiceStart = calendarServiceData.getFirstDate().get();
+    this.transitServiceStart = calendarServiceData.getFirstDate();
     this.daysInTransitService =
-      (int) ChronoUnit.DAYS.between(transitServiceStart, calendarServiceData.getLastDate().get()) +
-      1;
+      (int) ChronoUnit.DAYS.between(transitServiceStart, calendarServiceData.getLastDate()) + 1;
     this.calendarServiceData = calendarServiceData;
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
@@ -199,8 +199,8 @@ public class InterlineProcessor {
       );
       return true;
     }
-    TripPattern fromPattern = patternForTripTimes.get(fromTripTimes);
-    TripPattern toPattern = patternForTripTimes.get(toTripTimes);
+    var fromPattern = patternForTripTimes.get(fromTripTimes);
+    var toPattern = patternForTripTimes.get(toTripTimes);
     var fromStop = fromPattern.lastStop();
     var toStop = toPattern.firstStop();
     double teleportationDistance = SphericalDistanceLibrary.fastDistance(

--- a/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
@@ -3,6 +3,9 @@ package org.opentripplanner.graph_builder.module.interlining;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -14,6 +17,7 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.InterliningTeleport;
 import org.opentripplanner.gtfs.mapping.StaySeatedNotAllowed;
 import org.opentripplanner.model.Timetable;
+import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.model.transfer.DefaultTransferService;
 import org.opentripplanner.model.transfer.TransferConstraint;
@@ -33,17 +37,27 @@ public class InterlineProcessor {
   private final int maxInterlineDistance;
   private final DataImportIssueStore issueStore;
   private final List<StaySeatedNotAllowed> staySeatedNotAllowed;
+  private final LocalDate transitServiceStart;
+  private final int daysInTransitService;
+  private final CalendarServiceData calendarServiceData;
+  private final Map<FeedScopedId, BitSet> daysOfServices = new HashMap<>();
 
   public InterlineProcessor(
     DefaultTransferService transferService,
     List<StaySeatedNotAllowed> staySeatedNotAllowed,
     int maxInterlineDistance,
-    DataImportIssueStore issueStore
+    DataImportIssueStore issueStore,
+    CalendarServiceData calendarServiceData
   ) {
     this.transferService = transferService;
     this.staySeatedNotAllowed = staySeatedNotAllowed;
     this.maxInterlineDistance = maxInterlineDistance > 0 ? maxInterlineDistance : 200;
     this.issueStore = issueStore;
+    this.transitServiceStart = calendarServiceData.getFirstDate().get();
+    this.daysInTransitService =
+      (int) ChronoUnit.DAYS.between(transitServiceStart, calendarServiceData.getLastDate().get()) +
+      1;
+    this.calendarServiceData = calendarServiceData;
   }
 
   public List<ConstrainedTransfer> run(Collection<TripPattern> tripPatterns) {
@@ -105,8 +119,8 @@ public class InterlineProcessor {
     /* Record which Pattern each interlined TripTimes belongs to. */
     Map<TripTimes, TripPattern> patternForTripTimes = new HashMap<>();
 
-    /* TripTimes grouped by the block ID and service ID of their trips. Must be a ListMultimap to allow sorting. */
-    ListMultimap<BlockIdAndServiceId, TripTimes> tripTimesForBlock = ArrayListMultimap.create();
+    /* TripTimes grouped by the block ID of their trips. Must be a ListMultimap to allow sorting. */
+    ListMultimap<String, TripTimes> tripTimesForBlockId = ArrayListMultimap.create();
 
     LOG.info("Finding interlining trips based on block IDs.");
     for (TripPattern pattern : tripPatterns) {
@@ -115,7 +129,7 @@ public class InterlineProcessor {
       for (TripTimes tripTimes : timetable.getTripTimes()) {
         Trip trip = tripTimes.getTrip();
         if (StringUtils.hasValue(trip.getGtfsBlockId())) {
-          tripTimesForBlock.put(BlockIdAndServiceId.ofTrip(trip), tripTimes);
+          tripTimesForBlockId.put(trip.getGtfsBlockId(), tripTimes);
           // For space efficiency, only record times that are part of a block.
           patternForTripTimes.put(tripTimes, pattern);
         }
@@ -125,52 +139,39 @@ public class InterlineProcessor {
     // Associate pairs of TripPatterns with lists of trips that continue from one pattern to the other.
     Multimap<TripPatternPair, TripPair> interlines = ArrayListMultimap.create();
 
-    // Sort trips within each block by first departure time, then iterate over trips in this block and service,
-    // linking them. Has no effect on single-trip blocks.
-    SERVICE_BLOCK:for (BlockIdAndServiceId block : tripTimesForBlock.keySet()) {
-      List<TripTimes> blockTripTimes = tripTimesForBlock.get(block);
+    // Sort trips within each block by first departure time, then iterate over trips in this block,
+    // linking them. One from trip can have multiple interline transfers if trip which interlines
+    // with the from trip doesn't operate on every service date of the from trip.
+    for (String blockId : tripTimesForBlockId.keySet()) {
+      List<TripTimes> blockTripTimes = tripTimesForBlockId.get(blockId);
       Collections.sort(blockTripTimes);
-      TripTimes prev = null;
-      for (TripTimes curr : blockTripTimes) {
-        if (prev != null) {
-          if (prev.getDepartureTime(prev.getNumStops() - 1) > curr.getArrivalTime(0)) {
-            LOG.error(
-              "Trip times within block {} are not increasing on service {} after trip {}.",
-              block.blockId(),
-              block.serviceId(),
-              prev.getTrip().getId()
-            );
-            continue SERVICE_BLOCK;
+      for (int i = 0; i < blockTripTimes.size(); i++) {
+        var fromTripTimes = blockTripTimes.get(i);
+        var fromServiceId = fromTripTimes.getTrip().getServiceId();
+        BitSet uncoveredDays = getDaysForService(fromServiceId, true);
+        for (int j = i + 1; j < blockTripTimes.size(); j++) {
+          var toTripTimes = blockTripTimes.get(j);
+          var toServiceId = toTripTimes.getTrip().getServiceId();
+          if (
+            toServiceId.equals(fromServiceId) &&
+            createInterline(fromTripTimes, toTripTimes, blockId, patternForTripTimes, interlines)
+          ) {
+            break;
           }
-          TripPattern prevPattern = patternForTripTimes.get(prev);
-          TripPattern currPattern = patternForTripTimes.get(curr);
-          var fromStop = prevPattern.lastStop();
-          var toStop = currPattern.firstStop();
-          double teleportationDistance = SphericalDistanceLibrary.fastDistance(
-            fromStop.getLat(),
-            fromStop.getLon(),
-            toStop.getLat(),
-            toStop.getLon()
+          BitSet daysForToTripTimes = getDaysForService(
+            toTripTimes.getTrip().getServiceId(),
+            false
           );
-          if (teleportationDistance > maxInterlineDistance) {
-            issueStore.add(
-              new InterliningTeleport(
-                prev.getTrip(),
-                block.blockId(),
-                (int) teleportationDistance,
-                fromStop,
-                toStop
-              )
-            );
-            // Only skip this particular interline edge; there may be other valid ones in the block.
-          } else {
-            interlines.put(
-              new TripPatternPair(prevPattern, currPattern),
-              new TripPair(prev.getTrip(), curr.getTrip())
-            );
+          if (
+            uncoveredDays.intersects(daysForToTripTimes) &&
+            createInterline(fromTripTimes, toTripTimes, blockId, patternForTripTimes, interlines)
+          ) {
+            uncoveredDays.andNot(daysForToTripTimes);
+            if (uncoveredDays.isEmpty()) {
+              break;
+            }
           }
         }
-        prev = curr;
       }
     }
 
@@ -178,13 +179,82 @@ public class InterlineProcessor {
   }
 
   /**
-   * This compound key object is used when grouping interlining trips together by (serviceId,
-   * blockId).
+   * Validates that trip times are continuous and that the transfer stop(s) are not too far away
+   * from each other. Then creates interline between the trips.
+   *
+   * @return true if interline has been created or if there is an issue preventing an interline
+   * creation for certain service dates.
    */
-  private record BlockIdAndServiceId(String blockId, FeedScopedId serviceId) {
-    static BlockIdAndServiceId ofTrip(Trip trip) {
-      return new BlockIdAndServiceId(trip.getGtfsBlockId(), trip.getServiceId());
+  private boolean createInterline(
+    TripTimes fromTripTimes,
+    TripTimes toTripTimes,
+    String blockId,
+    Map<TripTimes, TripPattern> patternForTripTimes,
+    Multimap<TripPatternPair, TripPair> interlines
+  ) {
+    if (
+      fromTripTimes.getDepartureTime(fromTripTimes.getNumStops() - 1) >
+      toTripTimes.getArrivalTime(0)
+    ) {
+      LOG.error(
+        "Trip times within block {} are not increasing on after trip {}.",
+        blockId,
+        fromTripTimes.getTrip().getId()
+      );
+      return true;
     }
+    TripPattern fromPattern = patternForTripTimes.get(fromTripTimes);
+    TripPattern toPattern = patternForTripTimes.get(toTripTimes);
+    var fromStop = fromPattern.lastStop();
+    var toStop = toPattern.firstStop();
+    double teleportationDistance = SphericalDistanceLibrary.fastDistance(
+      fromStop.getLat(),
+      fromStop.getLon(),
+      toStop.getLat(),
+      toStop.getLon()
+    );
+    if (teleportationDistance > maxInterlineDistance) {
+      issueStore.add(
+        new InterliningTeleport(
+          fromTripTimes.getTrip(),
+          blockId,
+          (int) teleportationDistance,
+          fromStop,
+          toStop
+        )
+      );
+      // Only skip this particular interline edge; there may be other valid ones in the block for the
+      // from trip.
+      return false;
+    } else {
+      interlines.put(
+        new TripPatternPair(fromPattern, toPattern),
+        new TripPair(fromTripTimes.getTrip(), toTripTimes.getTrip())
+      );
+      return true;
+    }
+  }
+
+  /**
+   * @param mutable This should be set as true if the {@link BitSet} will be modified as otherwise
+   *                we don't have to create a copy of a cached entity.
+   * @return {@link BitSet} which index starts at the first overall date of the services and the
+   * last index is the last date.
+   */
+  private BitSet getDaysForService(FeedScopedId serviceId, boolean mutable) {
+    BitSet daysForService = this.daysOfServices.get(serviceId);
+    if (daysForService == null) {
+      daysForService = new BitSet(daysInTransitService);
+      var serviceDates = calendarServiceData.getServiceDatesForServiceId(serviceId);
+      if (serviceDates != null) {
+        for (LocalDate serviceDate : serviceDates) {
+          int daysBetween = (int) ChronoUnit.DAYS.between(transitServiceStart, serviceDate);
+          daysForService.set(daysBetween);
+        }
+      }
+      daysOfServices.put(serviceId, daysForService);
+    }
+    return mutable ? (BitSet) daysForService.clone() : daysForService;
   }
 
   private record TripPatternPair(TripPattern from, TripPattern to) {}

--- a/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -180,7 +180,8 @@ public class GtfsModule implements GraphBuilderModule {
             transitModel.getTransferService(),
             builder.getStaySeatedNotAllowed(),
             gtfsBundle.maxInterlineDistance(),
-            issueStore
+            issueStore,
+            calendarServiceData
           )
             .run(otpTransitService.getTripPatterns());
         }

--- a/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
+++ b/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
@@ -73,22 +73,20 @@ public class CalendarServiceData implements Serializable {
     }
   }
 
-  public Optional<LocalDate> getFirstDate() {
-    return serviceDatesByServiceId
-      .values()
+  public LocalDate getFirstDate() {
+    return serviceIdsByDate
+      .keySet()
       .stream()
-      .filter(list -> !list.isEmpty())
-      .map(list -> list.get(0))
-      .min(LocalDate::compareTo);
+      .min(LocalDate::compareTo)
+      .orElseThrow(() -> new IllegalStateException("No service data is available"));
   }
 
-  public Optional<LocalDate> getLastDate() {
-    return serviceDatesByServiceId
-      .values()
+  public LocalDate getLastDate() {
+    return serviceIdsByDate
+      .keySet()
       .stream()
-      .filter(list -> !list.isEmpty())
-      .map(list -> list.get(list.size() - 1))
-      .max(LocalDate::compareTo);
+      .max(LocalDate::compareTo)
+      .orElseThrow(() -> new IllegalStateException("No service data is available"));
   }
 
   /* private methods */

--- a/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
+++ b/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -70,6 +71,24 @@ public class CalendarServiceData implements Serializable {
     for (FeedScopedId serviceId : other.serviceDatesByServiceId.keySet()) {
       putServiceDatesForServiceId(serviceId, other.serviceDatesByServiceId.get(serviceId));
     }
+  }
+
+  public Optional<LocalDate> getFirstDate() {
+    return serviceDatesByServiceId
+      .values()
+      .stream()
+      .filter(list -> !list.isEmpty())
+      .map(list -> list.get(0))
+      .min(LocalDate::compareTo);
+  }
+
+  public Optional<LocalDate> getLastDate() {
+    return serviceDatesByServiceId
+      .values()
+      .stream()
+      .filter(list -> !list.isEmpty())
+      .map(list -> list.get(list.size() - 1))
+      .max(LocalDate::compareTo);
   }
 
   /* private methods */


### PR DESCRIPTION
### Summary

Changes block_id based interline generation to work according to the GTFS specification. This means that we check that trips share the same service date(s) instead of service id. Multiple transfers can be created from one from trip if one to trip doesn't cover all the service dates of the from trip.

### Issue

closes #5099

### Unit tests

Added tests

### Documentation

Not needed

### Changelog

from title
