### PR TITLE
Validate to/from in routing request

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -59,6 +59,9 @@ public class TransmodelGraphQLPlanner {
         )
         .localContext(Map.of("locale", locale))
         .build();
+    } catch (RoutingValidationException e) {
+      response.plan = TripPlanMapper.mapTripPlan(request, List.of());
+      response.messages.addAll(e.getRoutingErrors());
     } catch (Exception e) {
       LOG.error("System error: {}", e.getMessage(), e);
       response.plan = TripPlanMapper.mapTripPlan(request, List.of());

--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -18,6 +18,7 @@ import org.opentripplanner.api.model.error.PlannerError;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
+import org.opentripplanner.routing.error.RoutingValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +94,16 @@ public class PlannerResource extends RoutingResource {
       response.debugOutput = res.getDebugTimingAggregator().finishedRendering();
     } catch (OTPRequestTimeoutException e) {
       response.setError(new PlannerError(Message.PROCESSING_TIMEOUT));
+    } catch (RoutingValidationException e) {
+      if (e.isFromToLocationNotFound()) {
+        response.setError(new PlannerError(Message.GEOCODE_FROM_TO_NOT_FOUND));
+      } else if (e.isFromLocationNotFound()) {
+        response.setError(new PlannerError(Message.GEOCODE_FROM_NOT_FOUND));
+      } else if (e.isToLocationNotFound()) {
+        response.setError(new PlannerError(Message.GEOCODE_TO_NOT_FOUND));
+      } else {
+        response.setError(new PlannerError(Message.SYSTEM_ERROR));
+      }
     } catch (Exception e) {
       LOG.error("System error", e);
       response.setError(new PlannerError(Message.SYSTEM_ERROR));

--- a/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -206,12 +206,15 @@ public class RouteRequest implements Cloneable, Serializable {
   }
 
   /**
-   * Validate that the routing request contains both an origin and a destination.
-   * Origin and destination can be specified either by a reference to a stop place or
-   * by geographical coordinates.
+   * Validate that the routing request contains both an origin and a destination. Origin and
+   * destination can be specified either by a reference to a stop place or by geographical
+   * coordinates. Origin and destination are required in a one-to-one search, but not in a
+   * many-to-one or one-to-many.
+   * TODO - Refactor and make separate requests for one-to-one and the other searches.
+   *
    * @throws RoutingValidationException if either origin or destination is missing.
    */
-  public void validate() {
+  public void validateOriginAndDestination() {
     List<RoutingError> routingErrors = new ArrayList<>(2);
 
     if (from == null || !from.isSpecified()) {

--- a/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -7,6 +7,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 import org.opentripplanner.framework.time.DateUtils;
@@ -16,6 +18,10 @@ import org.opentripplanner.model.plan.pagecursor.PageCursor;
 import org.opentripplanner.model.plan.pagecursor.PageType;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.api.request.request.JourneyRequest;
+import org.opentripplanner.routing.api.response.InputField;
+import org.opentripplanner.routing.api.response.RoutingError;
+import org.opentripplanner.routing.api.response.RoutingErrorCode;
+import org.opentripplanner.routing.error.RoutingValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,6 +203,30 @@ public class RouteRequest implements Cloneable, Serializable {
       return itinerariesSortOrder().isSortedByArrivalTimeAcceding();
     }
     return pageCursor.type == PageType.NEXT_PAGE;
+  }
+
+  /**
+   * Validate that the routing request contains both an origin and a destination.
+   * Origin and destination can be specified either by a reference to a stop place or
+   * by geographical coordinates.
+   * @throws RoutingValidationException if either origin or destination is missing.
+   */
+  public void validate() {
+    List<RoutingError> routingErrors = new ArrayList<>(2);
+
+    if (from == null || !from.isSpecified()) {
+      routingErrors.add(
+        new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.FROM_PLACE)
+      );
+    }
+
+    if (to == null || !to.isSpecified()) {
+      routingErrors.add(new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.TO_PLACE));
+    }
+
+    if (!routingErrors.isEmpty()) {
+      throw new RoutingValidationException(routingErrors);
+    }
   }
 
   public String toString(String sep) {

--- a/src/main/java/org/opentripplanner/routing/error/RoutingValidationException.java
+++ b/src/main/java/org/opentripplanner/routing/error/RoutingValidationException.java
@@ -45,30 +45,26 @@ public class RoutingValidationException extends RuntimeException {
   }
 
   public boolean isFromLocationNotFound() {
-    return (
-      routingErrors != null &&
-      routingErrors
-        .stream()
-        .anyMatch(routingError ->
-          routingError.code == RoutingErrorCode.LOCATION_NOT_FOUND &&
-          routingError.inputField == InputField.FROM_PLACE
-        )
-    );
+    return isLocationNotFound(InputField.FROM_PLACE);
   }
 
   public boolean isToLocationNotFound() {
-    return (
-      routingErrors != null &&
-      routingErrors
-        .stream()
-        .anyMatch(routingError ->
-          routingError.code == RoutingErrorCode.LOCATION_NOT_FOUND &&
-          routingError.inputField == InputField.TO_PLACE
-        )
-    );
+    return isLocationNotFound(InputField.TO_PLACE);
   }
 
   public boolean isFromToLocationNotFound() {
     return isFromLocationNotFound() && isToLocationNotFound();
+  }
+
+  private boolean isLocationNotFound(InputField location) {
+    return (
+      routingErrors != null &&
+      routingErrors
+        .stream()
+        .anyMatch(routingError ->
+          routingError.code == RoutingErrorCode.LOCATION_NOT_FOUND &&
+          routingError.inputField == location
+        )
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/routing/error/RoutingValidationException.java
+++ b/src/main/java/org/opentripplanner/routing/error/RoutingValidationException.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import org.opentripplanner.routing.api.response.InputField;
 import org.opentripplanner.routing.api.response.RoutingError;
+import org.opentripplanner.routing.api.response.RoutingErrorCode;
 
 public class RoutingValidationException extends RuntimeException {
 
@@ -40,5 +42,33 @@ public class RoutingValidationException extends RuntimeException {
   @Override
   public String getMessage() {
     return routingErrors.stream().map(Objects::toString).collect(Collectors.joining("\n"));
+  }
+
+  public boolean isFromLocationNotFound() {
+    return (
+      routingErrors != null &&
+      routingErrors
+        .stream()
+        .anyMatch(routingError ->
+          routingError.code == RoutingErrorCode.LOCATION_NOT_FOUND &&
+          routingError.inputField == InputField.FROM_PLACE
+        )
+    );
+  }
+
+  public boolean isToLocationNotFound() {
+    return (
+      routingErrors != null &&
+      routingErrors
+        .stream()
+        .anyMatch(routingError ->
+          routingError.code == RoutingErrorCode.LOCATION_NOT_FOUND &&
+          routingError.inputField == InputField.TO_PLACE
+        )
+    );
+  }
+
+  public boolean isFromToLocationNotFound() {
+    return isFromLocationNotFound() && isToLocationNotFound();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
@@ -28,6 +28,7 @@ public class DefaultRoutingService implements RoutingService {
 
   @Override
   public RoutingResponse route(RouteRequest request) {
+    request.validate();
     RoutingWorker worker = new RoutingWorker(serverContext, request, timeZone);
     return worker.route();
   }

--- a/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
@@ -28,7 +28,7 @@ public class DefaultRoutingService implements RoutingService {
 
   @Override
   public RoutingResponse route(RouteRequest request) {
-    request.validate();
+    request.validateOriginAndDestination();
     RoutingWorker worker = new RoutingWorker(serverContext, request, timeZone);
     return worker.route();
   }


### PR DESCRIPTION
### Summary

As detailed in #5163, The Transmodel API does not properly report invalid routing requests that do not define the origin or the destination of the search.
This PR adds validation for missing origin or destination in routing requests.
The Transmodel API returns then a specific error message:

```
{
  "data": {
    "trip": {
      "nextPageCursor": null,
      "previousPageCursor": null,
      "tripPatterns": [],
      "routingErrors": [
        {
          "code": "locationNotFound",
          "inputField": "to",
          "description": "Destination is unknown.  Can you be a bit more descriptive?"
        }
      ]
    }
  }
}
```
The REST API returns also a specific error message:

```
	{
    "requestParameters": {
        "date": "04-25-2023",
        "mode": "FLEX_ACCESS,FLEX_EGRESS,TRANSIT",
        "fromPlace": "61.11741770786395,10.451345443725588",
        "time": "2:28pm"
    },
    "error": {
        "id": 450,
        "msg": "Destination is unknown.  Can you be a bit more descriptive?",
        "message": "GEOCODE_TO_NOT_FOUND"
    }
```

### Issue

closes #5163

### Unit tests

Added unit tests.

### Documentation

No