### PR TITLE
Changing default value for earlyStartSec

### DIFF
--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -725,7 +725,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
       "type" : "siri-et-updater",
       "url" : "https://example.com/some/path",
       "feedId" : "feed_id",
-      "timeoutSec" : 30,
+      "timeout" : "30s",
       "headers" : {
         "Authorization" : "Some-Token"
       }
@@ -734,7 +734,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
       "type" : "siri-sx-updater",
       "url" : "https://example.com/some/path",
       "feedId" : "feed_id",
-      "timeoutSec" : 30,
+      "timeout" : "30s",
       "headers" : {
         "Key" : "Value"
       }

--- a/docs/examples/entur/router-config.json
+++ b/docs/examples/entur/router-config.json
@@ -107,7 +107,7 @@
     {
       "type": "siri-et-updater",
       "frequency": "20s",
-      "previewIntervalMinutes": 180,
+      "previewInterval": "3h",
       "url": "https://example.com",
       "feedId": "EN",
       "blockReadinessUntilInitialized": true

--- a/docs/sandbox/SiriUpdater.md
+++ b/docs/sandbox/SiriUpdater.md
@@ -34,9 +34,9 @@ To enable the SIRI updater you need to add it to the updaters section of the `ro
 | feedId                         |     `string`    | The ID of the feed to apply the updates to.                                                            | *Required* |               |  2.0  |
 | frequency                      |    `duration`   | How often the updates should be retrieved.                                                             | *Optional* | `"PT1M"`      |  2.0  |
 | fuzzyTripMatching              |    `boolean`    | If the fuzzy trip matcher should be used to match trips.                                               | *Optional* | `false`       |  2.0  |
-| previewIntervalMinutes         |    `integer`    | TODO                                                                                                   | *Optional* | `-1`          |  2.0  |
+| previewInterval                |    `duration`   | TODO                                                                                                   | *Optional* |               |  2.0  |
 | requestorRef                   |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
-| timeoutSec                     |    `integer`    | The HTTP timeout to download the updates.                                                              | *Optional* | `15`          |  2.0  |
+| timeout                        |    `duration`   | The HTTP timeout to download the updates.                                                              | *Optional* | `"PT15S"`     |  2.0  |
 | url                            |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
 | [headers](#u__8__headers)      | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
 
@@ -62,7 +62,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
       "type" : "siri-et-updater",
       "url" : "https://example.com/some/path",
       "feedId" : "feed_id",
-      "timeoutSec" : 30,
+      "timeout" : "30s",
       "headers" : {
         "Authorization" : "Some-Token"
       }
@@ -123,7 +123,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
       "type" : "siri-sx-updater",
       "url" : "https://example.com/some/path",
       "feedId" : "feed_id",
-      "timeoutSec" : 30,
+      "timeout" : "30s",
       "headers" : {
         "Key" : "Value"
       }

--- a/docs/sandbox/SiriUpdater.md
+++ b/docs/sandbox/SiriUpdater.md
@@ -78,20 +78,31 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 <!-- siri-sx-updater BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
 
-| Config Parameter               |       Type      | Summary                                                                                                |  Req./Opt. | Default Value | Since |
-|--------------------------------|:---------------:|--------------------------------------------------------------------------------------------------------|:----------:|---------------|:-----:|
-| type = "siri-sx-updater"       |      `enum`     | The type of the updater.                                                                               | *Required* |               |  1.5  |
-| blockReadinessUntilInitialized |    `boolean`    | Whether catching up with the updates should block the readiness check from returning a 'ready' result. | *Optional* | `false`       |  2.0  |
-| earlyStartSec                  |    `integer`    | TODO                                                                                                   | *Optional* | `-1`          |  2.0  |
-| feedId                         |     `string`    | The ID of the feed to apply the updates to.                                                            | *Required* |               |  2.0  |
-| frequency                      |    `duration`   | How often the updates should be retrieved.                                                             | *Optional* | `"PT1M"`      |  2.0  |
-| requestorRef                   |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
-| timeoutSec                     |    `integer`    | The HTTP timeout to download the updates.                                                              | *Optional* | `15`          |  2.0  |
-| url                            |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
-| [headers](#u__9__headers)      | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
+| Config Parameter                |       Type      | Summary                                                                                                |  Req./Opt. | Default Value | Since |
+|---------------------------------|:---------------:|--------------------------------------------------------------------------------------------------------|:----------:|---------------|:-----:|
+| type = "siri-sx-updater"        |      `enum`     | The type of the updater.                                                                               | *Required* |               |  1.5  |
+| blockReadinessUntilInitialized  |    `boolean`    | Whether catching up with the updates should block the readiness check from returning a 'ready' result. | *Optional* | `false`       |  2.0  |
+| [earlyStart](#u__9__earlyStart) |    `duration`   | This value is subtracted from the actual validity defined in the message.                              | *Optional* | `"PT0S"`      |  2.0  |
+| feedId                          |     `string`    | The ID of the feed to apply the updates to.                                                            | *Required* |               |  2.0  |
+| frequency                       |    `duration`   | How often the updates should be retrieved.                                                             | *Optional* | `"PT1M"`      |  2.0  |
+| requestorRef                    |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
+| timeout                         |    `duration`   | The HTTP timeout to download the updates.                                                              | *Optional* | `"PT15S"`     |  2.0  |
+| url                             |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
+| [headers](#u__9__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
 
 
 ##### Parameter details
+
+<h4 id="u__9__earlyStart">earlyStart</h4>
+
+**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`   
+**Path:** /updaters/[9] 
+
+This value is subtracted from the actual validity defined in the message.
+
+Normally the planed departure time is used, so setting this to 10s will cause the
+SX-message to be included in trip-results 10 seconds before the the planed departure
+time.
 
 <h4 id="u__9__headers">headers</h4>
 

--- a/docs/sandbox/SiriUpdater.md
+++ b/docs/sandbox/SiriUpdater.md
@@ -100,8 +100,8 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 This value is subtracted from the actual validity defined in the message.
 
-Normally the planed departure time is used, so setting this to 10s will cause the
-SX-message to be included in trip-results 10 seconds before the the planed departure
+Normally the planned departure time is used, so setting this to 10s will cause the
+SX-message to be included in trip-results 10 seconds before the the planned departure
 time.
 
 <h4 id="u__9__headers">headers</h4>

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -89,7 +90,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
           transitModel,
           transitAlertService,
           SiriFuzzyTripMatcher.of(transitService),
-          0
+          Duration.ZERO
         );
     }
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.siri;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,7 +46,7 @@ public class SiriAlertsUpdateHandler {
   private final Set<TransitAlert> alerts = new HashSet<>();
   private final TransitAlertService transitAlertService;
   /** How long before the posted start of an event it should be displayed to users */
-  private final long earlyStart;
+  private final Duration earlyStart;
   private final AffectsMapper affectsMapper;
 
   public SiriAlertsUpdateHandler(
@@ -53,7 +54,7 @@ public class SiriAlertsUpdateHandler {
     TransitModel transitModel,
     TransitAlertService transitAlertService,
     SiriFuzzyTripMatcher siriFuzzyTripMatcher,
-    long earlyStart
+    Duration earlyStart
   ) {
     this.feedId = feedId;
     this.transitAlertService = transitAlertService;
@@ -147,7 +148,9 @@ public class SiriAlertsUpdateHandler {
         final long realStart = activePeriod.getStartTime() != null
           ? getEpochSecond(activePeriod.getStartTime())
           : 0;
-        final long start = activePeriod.getStartTime() != null ? realStart - earlyStart : 0;
+        final long start = activePeriod.getStartTime() != null
+          ? realStart - earlyStart.toSeconds()
+          : 0;
 
         final long realEnd = activePeriod.getEndTime() != null
           ? getEpochSecond(activePeriod.getEndTime())

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriHttpUtils.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriHttpUtils.java
@@ -19,7 +19,7 @@ public class SiriHttpUtils extends HttpUtils {
   public static InputStream postData(
     String url,
     String xmlData,
-    int timeout,
+    int timeoutMillis,
     Map<String, String> requestHeaderValues
   ) throws IOException {
     HttpPost httppost = new HttpPost(url);
@@ -32,7 +32,7 @@ public class SiriHttpUtils extends HttpUtils {
       }
     }
 
-    HttpClient httpclient = getClient(timeout, timeout);
+    HttpClient httpclient = getClient(timeoutMillis, timeoutMillis);
 
     HttpResponse response = httpclient.execute(httppost);
     if (response.getStatusLine().getStatusCode() != 200) {
@@ -46,11 +46,11 @@ public class SiriHttpUtils extends HttpUtils {
     return entity.getContent();
   }
 
-  private static HttpClient getClient(int socketTimeout, int connectionTimeout) {
+  private static HttpClient getClient(int socketTimeoutMillis, int connectionTimeoutMillis) {
     return HttpClientBuilder
       .create()
-      .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(socketTimeout).build())
-      .setConnectionTimeToLive(connectionTimeout, TimeUnit.MILLISECONDS)
+      .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(socketTimeoutMillis).build())
+      .setConnectionTimeToLive(connectionTimeoutMillis, TimeUnit.MILLISECONDS)
       .build();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdaterParameters.java
@@ -12,43 +12,14 @@ public record SiriETUpdaterParameters(
   String url,
   Duration frequency,
   String requestorRef,
-  int timeoutSec,
-  int previewIntervalMinutes,
+  Duration timeout,
+  Duration previewInterval,
   boolean fuzzyTripMatching,
-  HttpHeaders headers
+  HttpHeaders httpRequestHeaders
 )
-  implements PollingGraphUpdaterParameters, UrlUpdaterParameters {
+  implements
+    PollingGraphUpdaterParameters, UrlUpdaterParameters, SiriETHttpTripUpdateSource.Parameters {
   public SiriETHttpTripUpdateSource.Parameters sourceParameters() {
-    return new SiriETHttpTripUpdateSource.Parameters() {
-      @Override
-      public String getUrl() {
-        return url;
-      }
-
-      @Override
-      public String getRequestorRef() {
-        return requestorRef;
-      }
-
-      @Override
-      public String getFeedId() {
-        return feedId;
-      }
-
-      @Override
-      public int getTimeoutSec() {
-        return timeoutSec;
-      }
-
-      @Override
-      public int getPreviewIntervalMinutes() {
-        return previewIntervalMinutes;
-      }
-
-      @Override
-      public HttpHeaders httpRequestHeaders() {
-        return headers;
-      }
-    };
+    return this;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHelper.java
@@ -36,13 +36,13 @@ public class SiriHelper {
   }
 
   public static String createETServiceRequestAsXml(String requestorRef) throws JAXBException {
-    Siri request = createETServiceRequest(requestorRef, -1);
+    Siri request = createETServiceRequest(requestorRef, null);
     return SiriXml.toXml(request);
   }
 
-  public static String createETServiceRequestAsXml(String requestorRef, int previewIntervalMillis)
+  public static String createETServiceRequestAsXml(String requestorRef, Duration previewInterval)
     throws JAXBException {
-    Siri request = createETServiceRequest(requestorRef, previewIntervalMillis);
+    Siri request = createETServiceRequest(requestorRef, previewInterval);
     return SiriXml.toXml(request);
   }
 
@@ -78,7 +78,7 @@ public class SiriHelper {
     return request;
   }
 
-  private static Siri createETServiceRequest(String requestorRefValue, int previewIntervalMillis) {
+  private static Siri createETServiceRequest(String requestorRefValue, Duration previewInterval) {
     Siri request = createSiriObject();
 
     ServiceRequest serviceRequest = new ServiceRequest();
@@ -92,8 +92,8 @@ public class SiriHelper {
     etRequest.setRequestTimestamp(ZonedDateTime.now());
     etRequest.setVersion("2.0");
 
-    if (previewIntervalMillis > 0) {
-      etRequest.setPreviewInterval(Duration.ofMillis(previewIntervalMillis));
+    if (previewInterval != null) {
+      etRequest.setPreviewInterval(previewInterval);
     }
 
     MessageQualifierStructure messageIdentifier = new MessageQualifierStructure();

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
 import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.ext.siri.SiriHttpUtils;
+import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.DefaultTransitService;
@@ -32,7 +33,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   private WriteToGraphCallback saveResultOnGraph;
   private ZonedDateTime lastTimestamp = ZonedDateTime.now().minusWeeks(1);
   private String requestorRef;
-  private int timeout;
+  private int timeoutMillis = 0;
   private int retryCount = 0;
 
   public SiriSXUpdater(SiriSXUpdaterParameters config, TransitModel transitModel) {
@@ -47,15 +48,9 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
 
     //Keeping original requestorRef use as base for updated requestorRef to be used in retries
     this.originalRequestorRef = requestorRef;
-
-    int timeoutSec = config.timeoutSec();
-    if (timeoutSec > 0) {
-      this.timeout = 1000 * timeoutSec;
-    }
-
-    blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
-    requestHeaders = config.requestHeaders();
-
+    this.timeoutMillis = DurationUtils.toIntMilliseconds(config.timeout(), 0);
+    this.blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
+    this.requestHeaders = config.requestHeaders();
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
     this.updateHandler =
       new SiriAlertsUpdateHandler(
@@ -133,7 +128,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
       InputStream is = SiriHttpUtils.postData(
         url,
         sxServiceRequest,
-        timeout,
+        timeoutMillis,
         requestHeaders.asMap()
       );
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -63,7 +63,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
         transitModel,
         transitAlertService,
         SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel)),
-        config.earlyStartSec()
+        config.earlyStart()
       );
     LOG.info(
       "Creating real-time alert updater (SIRI SX) running every {} seconds : {}",

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdaterParameters.java
@@ -11,7 +11,7 @@ public record SiriSXUpdaterParameters(
   String requestorRef,
   Duration frequency,
   Duration earlyStart,
-  int timeoutSec,
+  Duration timeout,
   boolean blockReadinessUntilInitialized,
   HttpHeaders requestHeaders
 )

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdaterParameters.java
@@ -10,7 +10,7 @@ public record SiriSXUpdaterParameters(
   String url,
   String requestorRef,
   Duration frequency,
-  int earlyStartSec,
+  Duration earlyStart,
   int timeoutSec,
   boolean blockReadinessUntilInitialized,
   HttpHeaders requestHeaders

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -48,7 +48,13 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
     this.toDateTime = config.getToDateTime();
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
     this.updateHandler =
-      new SiriAlertsUpdateHandler(feedId, transitModel, transitAlertService, fuzzyTripMatcher(), 0);
+      new SiriAlertsUpdateHandler(
+        feedId,
+        transitModel,
+        transitAlertService,
+        fuzzyTripMatcher(),
+        Duration.ZERO
+      );
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/framework/time/DurationUtils.java
+++ b/src/main/java/org/opentripplanner/framework/time/DurationUtils.java
@@ -161,6 +161,13 @@ public class DurationUtils {
     }
   }
 
+  /**
+   * Convert duration to an int with unit milliseconds.
+   */
+  public static int toIntMilliseconds(Duration timeout, int defaultValue) {
+    return timeout == null ? defaultValue : (int) timeout.toMillis();
+  }
+
   private static String msToSecondsStr(String formatSeconds, double timeMs) {
     return String.format(ROOT, formatSeconds, timeMs / 1000.0) + " seconds";
   }

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETUpdaterConfig.java
@@ -27,8 +27,12 @@ public class SiriETUpdaterConfig {
         .summary("How often the updates should be retrieved.")
         .asDuration(Duration.ofMinutes(1)),
       c.of("requestorRef").since(V2_0).summary("The requester reference.").asString(null),
-      c.of("timeoutSec").since(V2_0).summary("The HTTP timeout to download the updates.").asInt(15),
-      c.of("previewIntervalMinutes").since(V2_0).summary("TODO").asInt(-1),
+      c
+        .of("timeout")
+        .since(V2_0)
+        .summary("The HTTP timeout to download the updates.")
+        .asDuration(Duration.ofSeconds(15)),
+      c.of("previewInterval").since(V2_0).summary("TODO").asDuration(null),
       c
         .of("fuzzyTripMatching")
         .since(V2_0)

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
@@ -20,7 +20,7 @@ public class SiriSXUpdaterConfig {
         .since(V2_0)
         .summary("How often the updates should be retrieved.")
         .asDuration(Duration.ofMinutes(1)),
-      c.of("earlyStartSec").since(V2_0).summary("TODO").asInt(-1),
+      c.of("earlyStartSec").since(V2_0).summary("TODO").asInt(0),
       c.of("timeoutSec").since(V2_0).summary("The HTTP timeout to download the updates.").asInt(15),
       c
         .of("blockReadinessUntilInitialized")

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
@@ -26,8 +26,8 @@ public class SiriSXUpdaterConfig {
         .summary("This value is subtracted from the actual validity defined in the message.")
         .description(
           """
-          Normally the planed departure time is used, so setting this to 10s will cause the
-          SX-message to be included in trip-results 10 seconds before the the planed departure
+          Normally the planned departure time is used, so setting this to 10s will cause the
+          SX-message to be included in trip-results 10 seconds before the the planned departure
           time."""
         )
         .asDuration(Duration.ZERO),

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
@@ -31,7 +31,11 @@ public class SiriSXUpdaterConfig {
           time."""
         )
         .asDuration(Duration.ZERO),
-      c.of("timeoutSec").since(V2_0).summary("The HTTP timeout to download the updates.").asInt(15),
+      c
+        .of("timeout")
+        .since(V2_0)
+        .summary("The HTTP timeout to download the updates.")
+        .asDuration(Duration.ofSeconds(15)),
       c
         .of("blockReadinessUntilInitialized")
         .since(V2_0)

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
@@ -20,7 +20,17 @@ public class SiriSXUpdaterConfig {
         .since(V2_0)
         .summary("How often the updates should be retrieved.")
         .asDuration(Duration.ofMinutes(1)),
-      c.of("earlyStartSec").since(V2_0).summary("TODO").asInt(0),
+      c
+        .of("earlyStart")
+        .since(V2_0)
+        .summary("This value is subtracted from the actual validity defined in the message.")
+        .description(
+          """
+          Normally the planed departure time is used, so setting this to 10s will cause the
+          SX-message to be included in trip-results 10 seconds before the the planed departure
+          time."""
+        )
+        .asDuration(Duration.ZERO),
       c.of("timeoutSec").since(V2_0).summary("The HTTP timeout to download the updates.").asInt(15),
       c
         .of("blockReadinessUntilInitialized")

--- a/src/test/java/org/opentripplanner/framework/time/DurationUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/time/DurationUtilsTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.framework.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.framework.time.DurationUtils.toIntMilliseconds;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -84,6 +85,13 @@ public class DurationUtilsTest {
     assertEquals(List.of(Duration.ZERO), DurationUtils.durations("0s"));
     assertEquals(List.of(D9s, D2h, D5m), DurationUtils.durations("9s 2h 5m"));
     assertEquals(List.of(D9s, D2h, D5m), DurationUtils.durations("9s;2h,5m"));
+  }
+
+  @Test
+  public void testToIntMilliseconds() {
+    assertEquals(20, toIntMilliseconds(null, 20));
+    assertEquals(0, toIntMilliseconds(Duration.ZERO, 20));
+    assertEquals(123000, toIntMilliseconds(Duration.ofSeconds(123), -1));
   }
 
   @Test

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -291,7 +291,7 @@
       "type": "siri-et-updater",
       "url": "https://example.com/some/path",
       "feedId": "feed_id",
-      "timeoutSec": 30,
+      "timeout": "30s",
       "headers": {
         "Authorization": "Some-Token"
       }
@@ -301,7 +301,7 @@
       "type": "siri-sx-updater",
       "url": "https://example.com/some/path",
       "feedId": "feed_id",
-      "timeoutSec": 30,
+      "timeout": "30s",
       "headers": {
         "Key": "Value"
       }


### PR DESCRIPTION
Changing default value for `earlyStartSec` for SIRI SX-messages.

This value is [subtracted](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java#L150) from the actual validity defined in the message - causing validity-period to start a second later than defined. When a SX-message's validity is set to start from the planned departure-time, this will cause the message to not be included in trip-results.

I.e.: 
If message starts at 12:00:00, subtracting (-1) will make the message start at 12:00:01

Setting the default value to 0 will let the actual validity provided to be used.