### PR TITLE
Improve updater log messages

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/ModifiedTripBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/ModifiedTripBuilder.java
@@ -115,18 +115,26 @@ public class ModifiedTripBuilder {
     }
 
     var error = newTimes.validateNonIncreasingTimes();
+    final FeedScopedId id = newTimes.getTrip().getId();
     if (error.isPresent()) {
       var updateError = error.get();
-      final FeedScopedId id = newTimes.getTrip().getId();
       LOG.info(
-        "TripTimes are non-increasing after applying SIRI delay propagation - Trip {}. Stop index {}",
+        "Invalid SIRI-ET data for trip {} - TripTimes are non-increasing after applying SIRI delay propagation at stop index {}",
         id,
         updateError.stopIndex()
       );
       return TripTimesValidationMapper.toResult(id, updateError);
     }
 
-    if (newTimes.getNumStops() != pattern.numberOfStops()) {
+    int numStopsInUpdate = newTimes.getNumStops();
+    int numStopsInPattern = pattern.numberOfStops();
+    if (numStopsInUpdate != numStopsInPattern) {
+      LOG.info(
+        "Invalid SIRI-ET data for trip {} - Inconsistent number of updated stops ({}) and stops in pattern ({})",
+        id,
+        numStopsInUpdate,
+        numStopsInPattern
+      );
       return UpdateError.result(existingTripTimes.getTrip().getId(), TOO_FEW_STOPS);
     }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -341,7 +341,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     )
       .build();
     if (updateResult.isFailure()) {
-      LOG.info("Failed to update TripTimes for trip {}", trip);
       return updateResult.toFailureResult();
     }
 

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
@@ -162,7 +162,7 @@ public class GbfsFeedLoader {
     private boolean fetchData() {
       T newData = GbfsFeedLoader.fetchFeed(url, httpHeaders, implementingClass);
       if (newData == null) {
-        LOG.error("Invalid data for {}", url);
+        LOG.warn("Could not fetch GBFS data for {}. Retrying.", url);
         nextUpdate = getCurrentTimeSeconds();
         return false;
       }


### PR DESCRIPTION
### Summary


1. Fetching data from a vehicle rental feed can fail, for example due to a temporary network error. This is retryable and should be logged at warning level, not error level.
2. The Siri updater logs 2 messages when receiving an invalid real time update. These 2 messages can be combined in one.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No
