### PR TITLE
Relax validity check on flex trip with null duration

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexPathDurationsTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexPathDurationsTest.java
@@ -29,7 +29,7 @@ class FlexPathDurationsTest {
     );
     assertThrows(
       IllegalArgumentException.class,
-      () -> new FlexPathDurations(ACCESS_DURATION_SEC, 0, EGRESS_DURATION_SEC, OFFSET)
+      () -> new FlexPathDurations(ACCESS_DURATION_SEC, -1, EGRESS_DURATION_SEC, OFFSET)
     );
     assertThrows(
       IllegalArgumentException.class,

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexPathDurations.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexPathDurations.java
@@ -4,32 +4,33 @@ import org.opentripplanner.framework.time.DurationUtils;
 
 /**
  * This value-object contains the durations for a Flex access or egress path. The path may also
- * contain access and egress "parts" - a walk part in the beginning and/or at the end. It has
- * method for mapping between the flex-trip-times and the router(OTP) time.
+ * contain access and egress "parts" - a walk part in the beginning and/or at the end. It has method
+ * for mapping between the flex-trip-times and the router(OTP) time.
  * <p>
  * If the {@code access/egress} is empty the duration is zero. The flex-trip duration must be at
- * least 1 second. This is just a sanity check, there might be bussiness rules elsewhere
- * restricting this futher.
+ * least 1 second. This is just a sanity check, there might be bussiness rules elsewhere restricting
+ * this futher.
  *
- * @param access The duration of the walking in the beginning of the Flex path. Should be
- *               zero or a positive number. Zero means that the path start with the flex
- *               trip, there is no access.
- * @param trip   The duration of the flex ride. Should be a positive number.
- * @param egress The duration of the walking at the end of the Flex path. Should be zero
- *               or a positive number. Zero means that the path ends after the flex trip,
- *               there is no egress.
- * @param offset The flex trip times is using service-time(noon minus 12 hours) as
- *               "midnight", the {@code offset} is the duration from router midnight
- *               to service-time midnight. This is used to handle day-light-saving-time
- *               adjustments.
+ * @param access The duration of the walking in the beginning of the Flex path. Should be zero or a
+ *               positive number. Zero means that the path start with the flex trip, there is no
+ *               access.
+ * @param trip   The duration of the flex ride. Should be zero or a positive number (zero is a valid
+ *               value since timetables have usually a 1-minute resolution: it is then possible to
+ *               have a 0-second trip between 2 stops).
+ * @param egress The duration of the walking at the end of the Flex path. Should be zero or a
+ *               positive number. Zero means that the path ends after the flex trip, there is no
+ *               egress.
+ * @param offset The flex trip times is using service-time(noon minus 12 hours) as "midnight", the
+ *               {@code offset} is the duration from router midnight to service-time midnight. This
+ *               is used to handle day-light-saving-time adjustments.
  */
 public record FlexPathDurations(int access, int trip, int egress, int offset) {
   public FlexPathDurations {
     if (access < 0) {
       throw new IllegalArgumentException("The access duration must be 0 or a positive number.");
     }
-    if (trip <= 0) {
-      throw new IllegalArgumentException("The trip duration must be a positive number.");
+    if (trip < 0) {
+      throw new IllegalArgumentException("The trip duration must be 0 or a positive number.");
     }
     if (egress < 0) {
       throw new IllegalArgumentException("The egress duration must be 0 or a positive number.");

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPath.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPath.java
@@ -9,8 +9,8 @@ import org.locationtech.jts.geom.LineString;
 public class FlexPath {
 
   private final Supplier<LineString> geometrySupplier;
-  public int distanceMeters;
-  public int durationSeconds;
+  public final int distanceMeters;
+  public final int durationSeconds;
   private LineString geometry;
 
   /**


### PR DESCRIPTION
### Summary

The current validity check on flex trip duration is too strict. It is possible to have flex trips with null duration due to the timetable resolution (usually 1 min): a flex trip between two close stops may appear to take 0 second.

This is observed in our production environment where valid trips are rejected:
```
java.lang.IllegalArgumentException: The trip duration must be a positive number.
	at org.opentripplanner.ext.flex.FlexPathDurations.<init>(FlexPathDurations.java:32)
	at org.opentripplanner.ext.flex.template.FlexAccessTemplate.calculateFlexPathDurations(FlexAccessTemplate.java:133)
	at org.opentripplanner.ext.flex.template.FlexAccessTemplate.lambda$createDirectGraphPath$0(FlexAccessTemplate.java:69)
	at java.base/java.util.Optional.map(Optional.java:260)
	at org.opentripplanner.ext.flex.template.FlexAccessTemplate.createDirectGraphPath(FlexAccessTemplate.java:68)
	at org.opentripplanner.ext.flex.FlexRouter.createFlexOnlyItineraries(FlexRouter.java:131)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.street.DirectFlexRouter.route(DirectFlexRouter.java:66)
	at org.opentripplanner.routing.algorithm.RoutingWorker.routeDirectFlex(RoutingWorker.java:245)
	at org.opentripplanner.routing.algorithm.RoutingWorker.route(RoutingWorker.java:119)
	at org.opentripplanner.routing.service.DefaultRoutingService.route(DefaultRoutingService.java:32)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraphQLPlanner.plan(TransmodelGraphQLPlanner.java:37)
	at org.opentripplanner.ext.transmodelapi.model.plan.TripQuery.lambda$create$0(TripQuery.java:526)
```

This PR relaxes the validity check so that 0s is accepted as a valid flex trip duration.

### Issue
No

### Unit tests

Updated unit tests

### Documentation

No

### Changelog
