### PR TITLE
Refactor shutdown hook

### DIFF
--- a/src/main/java/org/opentripplanner/framework/application/ApplicationShutdownSupport.java
+++ b/src/main/java/org/opentripplanner/framework/application/ApplicationShutdownSupport.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.framework.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for managing application shutdown.
+ */
+public final class ApplicationShutdownSupport {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationShutdownSupport.class);
+
+  private ApplicationShutdownSupport() {}
+
+  /**
+   * Attempt to add a shutdown hook. If the application is already shutting down, the shutdown hook
+   * will not be added.
+   *
+   * @return true if the shutdown hook is successfully added, false otherwise.
+   */
+  public static boolean addShutdownHook(Thread shutdownHook, String shutdownHookName) {
+    try {
+      LOG.info("Adding shutdown hook {}", shutdownHookName);
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
+      return true;
+    } catch (IllegalStateException e) {
+      LOG.info(
+        "OTP is already shutting down, the shutdown hook {} will not be added",
+        shutdownHookName
+      );
+      return false;
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -6,6 +6,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import org.geotools.referencing.factory.DeferredAuthorityFactory;
 import org.geotools.util.WeakCollectionCleaner;
+import org.opentripplanner.framework.application.ApplicationShutdownSupport;
 import org.opentripplanner.framework.application.OtpAppException;
 import org.opentripplanner.graph_builder.GraphBuilder;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueSummary;
@@ -230,7 +231,7 @@ public class OTPMain {
       },
       "server-shutdown"
     );
-    Runtime.getRuntime().addShutdownHook(hook);
+    ApplicationShutdownSupport.addShutdownHook(hook, hook.getName());
   }
 
   private static void setOtpConfigVersionsOnServerInfo(ConstructApplication app) {

--- a/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
@@ -16,6 +16,7 @@ import org.glassfish.grizzly.ssl.SSLContextConfigurator;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
 import org.glassfish.jersey.server.ContainerFactory;
+import org.opentripplanner.framework.application.ApplicationShutdownSupport;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.slf4j.Logger;
@@ -151,7 +152,7 @@ public class GrizzlyServer {
     // Add shutdown hook to gracefully shut down Grizzly.
     // Signal handling (sun.misc.Signal) is potentially not available on all JVMs.
     Thread shutdownThread = new Thread(httpServer::shutdown, "grizzly-shutdown");
-    Runtime.getRuntime().addShutdownHook(shutdownThread);
+    ApplicationShutdownSupport.addShutdownHook(shutdownThread, shutdownThread.getName());
 
     /* RELINQUISH CONTROL TO THE SERVER THREAD */
     try {


### PR DESCRIPTION
### Summary

When an OTP instance is stopped while it is still performing the startup sequence,  adding a shutdown hook may fail with the following error message:

```
An uncaught error occurred inside OTP: Shutdown in progress
java.lang.IllegalStateException: Shutdown in progress
	at java.base/java.lang.ApplicationShutdownHooks.add(ApplicationShutdownHooks.java:66)
	at java.base/java.lang.Runtime.addShutdownHook(Runtime.java:216)
	at org.opentripplanner.standalone.OTPMain.registerShutdownHookToGracefullyShutDownServer(OTPMain.java:233)
	at org.opentripplanner.standalone.OTPMain.startOtpWebServer(OTPMain.java:192)
	at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:166)
	at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:54)
```
	
This PR handles the case where a shutdown hook is added during shutdown.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No