### PR TITLE
Log unexpected vehicle type in GBFS update

### DIFF
--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationStatusMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationStatusMapper.java
@@ -34,7 +34,7 @@ public class GbfsStationStatusMapper {
     GBFSStation status = statusLookup.get(station.getStationId());
 
     station.vehiclesAvailable =
-      status.getNumBikesAvailable() != null ? status.getNumBikesAvailable().intValue() : 0;
+      status.getNumBikesAvailable() != null ? status.getNumBikesAvailable() : 0;
 
     station.vehicleTypesAvailable =
       status.getVehicleTypesAvailable() != null
@@ -42,21 +42,14 @@ public class GbfsStationStatusMapper {
           .getVehicleTypesAvailable()
           .stream()
           .filter(e -> containsVehicleType(e, status))
-          .collect(
-            Collectors.toMap(
-              e -> vehicleTypes.get(e.getVehicleTypeId()),
-              e -> e.getCount().intValue()
-            )
-          )
+          .collect(Collectors.toMap(e -> vehicleTypes.get(e.getVehicleTypeId()), e -> e.getCount()))
         : Map.of(RentalVehicleType.getDefaultType(station.getNetwork()), station.vehiclesAvailable);
 
     station.vehiclesDisabled =
-      status.getNumBikesDisabled() != null ? status.getNumBikesDisabled().intValue() : 0;
+      status.getNumBikesDisabled() != null ? status.getNumBikesDisabled() : 0;
 
     station.spacesAvailable =
-      status.getNumDocksAvailable() != null
-        ? status.getNumDocksAvailable().intValue()
-        : Integer.MAX_VALUE;
+      status.getNumDocksAvailable() != null ? status.getNumDocksAvailable() : Integer.MAX_VALUE;
 
     station.vehicleSpacesAvailable =
       status.getVehicleDocksAvailable() != null
@@ -67,13 +60,13 @@ public class GbfsStationStatusMapper {
             available
               .getVehicleTypeIds()
               .stream()
-              .map(t -> new VehicleTypeCount(vehicleTypes.get(t), available.getCount().intValue()))
+              .map(t -> new VehicleTypeCount(vehicleTypes.get(t), available.getCount()))
           )
           .collect(Collectors.toMap(VehicleTypeCount::type, VehicleTypeCount::count))
         : Map.of(RentalVehicleType.getDefaultType(station.getNetwork()), station.spacesAvailable);
 
     station.spacesDisabled =
-      status.getNumDocksDisabled() != null ? status.getNumDocksDisabled().intValue() : 0;
+      status.getNumDocksDisabled() != null ? status.getNumDocksDisabled() : 0;
 
     station.isInstalled = status.getIsInstalled() != null ? status.getIsInstalled() : true;
     station.isRenting = status.getIsRenting() != null ? status.getIsRenting() : true;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
@@ -127,16 +127,6 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
     return stations;
   }
 
-  private Map<String, RentalVehicleType> getVehicleTypes(VehicleRentalSystem system) {
-    GBFSVehicleTypes rawVehicleTypes = loader.getFeed(GBFSVehicleTypes.class);
-    if (rawVehicleTypes != null) {
-      GbfsVehicleTypeMapper vehicleTypeMapper = new GbfsVehicleTypeMapper(system.systemId);
-      List<GBFSVehicleType> gbfsVehicleTypes = rawVehicleTypes.getData().getVehicleTypes();
-      return mapVehicleTypes(vehicleTypeMapper, gbfsVehicleTypes);
-    }
-    return Map.of();
-  }
-
   @Override
   public void setup() {
     loader = new GbfsFeedLoader(params.url(), params.httpHeaders(), params.language());
@@ -169,5 +159,15 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
       .map(vehicleTypeMapper::mapRentalVehicleType)
       .distinct()
       .collect(Collectors.toMap(v -> v.id.getId(), Function.identity()));
+  }
+
+  private Map<String, RentalVehicleType> getVehicleTypes(VehicleRentalSystem system) {
+    GBFSVehicleTypes rawVehicleTypes = loader.getFeed(GBFSVehicleTypes.class);
+    if (rawVehicleTypes != null) {
+      GbfsVehicleTypeMapper vehicleTypeMapper = new GbfsVehicleTypeMapper(system.systemId);
+      List<GBFSVehicleType> gbfsVehicleTypes = rawVehicleTypes.getData().getVehicleTypes();
+      return mapVehicleTypes(vehicleTypeMapper, gbfsVehicleTypes);
+    }
+    return Map.of();
   }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
@@ -60,13 +60,7 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
     );
 
     // Get vehicle types
-    Map<String, RentalVehicleType> vehicleTypes = null;
-    GBFSVehicleTypes rawVehicleTypes = loader.getFeed(GBFSVehicleTypes.class);
-    if (rawVehicleTypes != null) {
-      GbfsVehicleTypeMapper vehicleTypeMapper = new GbfsVehicleTypeMapper(system.systemId);
-      List<GBFSVehicleType> gbfsVehicleTypes = rawVehicleTypes.getData().getVehicleTypes();
-      vehicleTypes = mapVehicleTypes(vehicleTypeMapper, gbfsVehicleTypes);
-    }
+    final Map<String, RentalVehicleType> vehicleTypes = getVehicleTypes(system);
 
     List<VehicleRentalPlace> stations = new LinkedList<>();
 
@@ -131,6 +125,16 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
       this.geofencingZones = mapper.mapGeofencingZone(zones);
     }
     return stations;
+  }
+
+  private Map<String, RentalVehicleType> getVehicleTypes(VehicleRentalSystem system) {
+    GBFSVehicleTypes rawVehicleTypes = loader.getFeed(GBFSVehicleTypes.class);
+    if (rawVehicleTypes != null) {
+      GbfsVehicleTypeMapper vehicleTypeMapper = new GbfsVehicleTypeMapper(system.systemId);
+      List<GBFSVehicleType> gbfsVehicleTypes = rawVehicleTypes.getData().getVehicleTypes();
+      return mapVehicleTypes(vehicleTypeMapper, gbfsVehicleTypes);
+    }
+    return Map.of();
   }
 
   @Override


### PR DESCRIPTION
### Summary

As reported in #5174, some GBFS updates fail with a NullPointerException when the status update refers to unexpected vehicle types.
This PR filters out unexpected vehicle types and logs a warning message for facilitating further analysis of this issue.

### Issue

Partially closes #5174 

### Unit tests

:white_check_mark: 

### Documentation

No