### PR TITLE
Reduce log severity for non-optimized transfers

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/OptimizeTransferService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/OptimizeTransferService.java
@@ -84,7 +84,7 @@ public class OptimizeTransferService<T extends RaptorTripSchedule> {
     try {
       return optimizePathDomainService.findBestTransitPath(path);
     } catch (RuntimeException e) {
-      OPTIMIZATION_FAILED_LOG.error(
+      OPTIMIZATION_FAILED_LOG.warn(
         "Unable to optimize transfers in path. Details: {}, path: {}",
         e.getMessage(),
         path,


### PR DESCRIPTION
### Summary

OTP may fail to optimize transfers due to code or data issues:

```
Unable to optimize transfers in path. Details: No value present, path: Walk 7s ~ 37439 ~ BUS 100 @12123 13:03 13:11 ~ 73210 ~ BUS 120 @12013 13:12 13:35 ~ 76169 ~ Walk 1s ~ 76168 ~ BUS 121 @12521 14:10 14:31 ~ 6675 ~ Walk 38m24s [13:02:53 15:09:24 2h6m31s 2tx $29759]
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.orElseThrow(Optional.java:377)
	at org.opentripplanner.routing.algorithm.transferoptimization.services.TransferGenerator.findMinimumToStopTime(TransferGenerator.java:243)
	at org.opentripplanner.routing.algorithm.transferoptimization.services.TransferGenerator.findAllPossibleTransfers(TransferGenerator.java:71)
	at org.opentripplanner.routing.algorithm.transferoptimization.services.OptimizePathDomainService.findBestTransitPath(OptimizePathDomainService.java:108)
	at org.opentripplanner.routing.algorithm.transferoptimization.OptimizeTransferService.optimize(OptimizeTransferService.java:85)
	at org.opentripplanner.routing.algorithm.transferoptimization.OptimizeTransferService.optimize(OptimizeTransferService.java:53)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.route(TransitRouter.java:154)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.routeAndCleanupAfter(TransitRouter.java:92)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.route(TransitRouter.java:85)
	at org.opentripplanner.routing.algorithm.RoutingWorker.routeTransit(RoutingWorker.java:258)
	at org.opentripplanner.routing.algorithm.RoutingWorker.route(RoutingWorker.java:124)
	at org.opentripplanner.routing.service.DefaultRoutingService.route(DefaultRoutingService.java:32)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraphQLPlanner.plan(TransmodelGraphQLPlanner.java:37)
	at org.opentripplanner.ext.transmodelapi.model.plan.TripQuery.lambda$create$0(TripQuery.java:566)
```


In this case OTP falls back to non-optimized transfers and return a valid, if not optimal, response.
This should be logged at WARNING level, not ERROR level.

### Issue
No

### Unit tests

:white_check_mark: 

### Documentation

No
