### PR TITLE
Improve vehicle rental service directory error handling

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -96,10 +96,6 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
       final InputStream data = HttpUtils.getData(uri, Duration.ofMillis(timeout), rh.asMap());
       final long t2 = System.currentTimeMillis();
 
-      if (data == null) {
-        throw new IOException("Historical endpoint returned no data from url" + url);
-      }
-
       var reader = new InputStreamReader(data);
       var string = CharStreams.toString(reader);
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -102,10 +102,6 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
       final InputStream data = HttpUtils.getData(uri, Duration.ofMillis(timeout), rh.asMap());
       final long t2 = System.currentTimeMillis();
 
-      if (data == null) {
-        throw new IOException("Historical endpoint returned no data from url" + url);
-      }
-
       var reader = new InputStreamReader(data);
       var string = CharStreams.toString(reader);
 

--- a/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/api/VehicleRentalServiceDirectoryFetcherParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/api/VehicleRentalServiceDirectoryFetcherParameters.java
@@ -5,39 +5,14 @@ import org.opentripplanner.updater.spi.HttpHeaders;
 
 public class VehicleRentalServiceDirectoryFetcherParameters {
 
-  /**
-   * Endpoint for the VehicleRentalServiceDirectory
-   * <p>
-   * This is required.
-   */
   private final URI url;
 
-  /**
-   * Json tag name for updater sources
-   * <p>
-   * Optonal, default values is "systems".
-   */
   private final String sourcesName;
 
-  /**
-   * Json tag name for endpoint urls for each source
-   * <p>
-   * Optonal, default values is "url".
-   */
   private final String sourceUrlName;
 
-  /**
-   * Json tag name for the network name for each source
-   * <p>
-   * Optonal, default values is "id".
-   */
   private final String sourceNetworkName;
 
-  /**
-   * Json tag name for http headers
-   * <p>
-   * Optional, default value is null
-   */
   private final HttpHeaders headers;
 
   private final String language;
@@ -58,22 +33,47 @@ public class VehicleRentalServiceDirectoryFetcherParameters {
     this.headers = headers;
   }
 
+  /**
+   * Endpoint for the VehicleRentalServiceDirectory
+   * <p>
+   * This is required.
+   */
   public URI getUrl() {
     return url;
   }
 
+  /**
+   * Json tag name for updater sources
+   * <p>
+   * Optional, default values is "systems".
+   */
   public String getSourcesName() {
     return sourcesName;
   }
 
+  /**
+   * Json tag name for endpoint urls for each source
+   * <p>
+   * Optional, default values is "url".
+   */
   public String getSourceUrlName() {
     return sourceUrlName;
   }
 
+  /**
+   * Json tag name for the network name for each source
+   * <p>
+   * Optional, default values is "id".
+   */
   public String getSourceNetworkName() {
     return sourceNetworkName;
   }
 
+  /**
+   * Json tag name for http headers
+   * <p>
+   * Optional, default value is null
+   */
   public HttpHeaders getHeaders() {
     return headers;
   }

--- a/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
@@ -50,11 +50,18 @@ public class HttpUtils {
   ) throws IOException {
     HttpResponse response = getResponse(new HttpGet(uri), timeout, requestHeaderValues);
     if (response.getStatusLine().getStatusCode() != 200) {
-      return null;
+      throw new IOException(
+        "Service unavailable: " +
+        uri +
+        ". HTTP status code: " +
+        response.getStatusLine().getStatusCode() +
+        " - " +
+        response.getStatusLine().getReasonPhrase()
+      );
     }
     HttpEntity entity = response.getEntity();
     if (entity == null) {
-      return null;
+      throw new IOException("HTTP response message entity is empty for url: " + uri);
     }
     return entity.getContent();
   }

--- a/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -76,9 +76,6 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
   protected void runPolling() {
     try {
       InputStream data = HttpUtils.getData(URI.create(url), this.headers.asMap());
-      if (data == null) {
-        throw new RuntimeException("Failed to get data from url " + url);
-      }
 
       final FeedMessage feed = FeedMessage.PARSER.parseFrom(data);
 


### PR DESCRIPTION
### Summary

Improve error handling and prevent OTP from going down when connecting to external http services.

The fix apply to all updaters using the `HttpUtils.getData()` methods. But, the error observed at Entur does only apply to the `VehicleRentalServiceDirectoryFetcher`. The fix improve the log messages for all Updaters when a remote service is unavailable.

The VehicleRentalServiceDirectoryFetcher went down with a IllegalSateException when the http endpoint failed (`getData(...)` retuned `null`. Instead of returning `null` in some error-cases and throwing IOExceptions in others the HttpUtils is changed to throw an IOException in all cases. This make it more robust, and the checked exception forces the client to handle it.

### Issue
There is no issue for this.

### Unit tests
No tests added.


### Documentation
Small improvement on JavaDoc added, and the `getData(...)` now works as expected from the signature.

### Changelog
No

### Bumping the serialization version id
No
