### PR TITLE
Rename OSM constanspeed tag mapper and derive it from finland tag mapper

### DIFF
--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -965,7 +965,7 @@ the local filesystem.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osm/[0]   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeed`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeedfinland`
 
 The named set of mapping rules applied when parsing OSM tags. Overrides the value specified in `osmDefaults`.
 
@@ -973,7 +973,7 @@ The named set of mapping rules applied when parsing OSM tags. Overrides the valu
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osmDefaults   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeed`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeedfinland`
 
 The named set of mapping rules applied when parsing OSM tags.
 

--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -965,7 +965,7 @@ the local filesystem.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osm/[0]   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeedfinland`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constant-speed-finland`
 
 The named set of mapping rules applied when parsing OSM tags. Overrides the value specified in `osmDefaults`.
 
@@ -973,7 +973,7 @@ The named set of mapping rules applied when parsing OSM tags. Overrides the valu
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osmDefaults   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constantspeedfinland`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston` | `portland` | `constant-speed-finland`
 
 The named set of mapping rules applied when parsing OSM tags.
 

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/ConstantSpeedMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/ConstantSpeedMapper.java
@@ -14,16 +14,16 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
 /**
  * OSM way properties for optimizing distance (not traveling time) in routing.
  */
-class ConstantSpeedMapper implements OsmTagMapper {
+class ConstantSpeedFinlandMapper implements OsmTagMapper {
 
   private float speed;
 
-  public ConstantSpeedMapper() {
+  public ConstantSpeedFinlandMapper() {
     super();
     this.speed = 22.22f; // 80 kmph by default
   }
 
-  public ConstantSpeedMapper(float speed) {
+  public ConstantSpeedFinlandMapper(float speed) {
     super();
     this.speed = speed;
   }

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/ConstantSpeedMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/ConstantSpeedMapper.java
@@ -30,17 +30,9 @@ class ConstantSpeedMapper implements OsmTagMapper {
 
   @Override
   public void populateProperties(WayPropertySet props) {
-    // Remove informal and private roads
-    props.setProperties("highway=*;informal=yes", withModes(NONE));
-    props.setProperties("highway=service;access=private", withModes(NONE));
-    props.setProperties("highway=trail", withModes(NONE));
-    props.setProperties("highway=service;tunnel=yes;access=destination", withModes(NONE));
-    props.setProperties("highway=service;access=destination", withModes(ALL));
-
     props.setCarSpeed("highway=*", speed);
-
     // Read the rest from the default set
-    new DefaultMapper().populateProperties(props);
+    new FinlandMapper().populateProperties(props);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperSource.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperSource.java
@@ -13,7 +13,7 @@ public enum OsmTagMapperSource {
   ATLANTA,
   HOUSTON,
   PORTLAND,
-  CONSTANTSPEEDFINLAND;
+  CONSTANT_SPEED_FINLAND;
 
   public OsmTagMapper getInstance() {
     return switch (this) {
@@ -25,7 +25,7 @@ public enum OsmTagMapperSource {
       case ATLANTA -> new AtlantaMapper();
       case HOUSTON -> new HoustonMapper();
       case PORTLAND -> new PortlandMapper();
-      case CONSTANTSPEEDFINLAND -> new ConstantSpeedFinlandMapper();
+      case CONSTANT_SPEED_FINLAND -> new ConstantSpeedFinlandMapper();
     };
   }
 }

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperSource.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperSource.java
@@ -13,7 +13,7 @@ public enum OsmTagMapperSource {
   ATLANTA,
   HOUSTON,
   PORTLAND,
-  CONSTANTSPEED;
+  CONSTANTSPEEDFINLAND;
 
   public OsmTagMapper getInstance() {
     return switch (this) {
@@ -25,7 +25,7 @@ public enum OsmTagMapperSource {
       case ATLANTA -> new AtlantaMapper();
       case HOUSTON -> new HoustonMapper();
       case PORTLAND -> new PortlandMapper();
-      case CONSTANTSPEED -> new ConstantSpeedMapper();
+      case CONSTANTSPEEDFINLAND -> new ConstantSpeedFinlandMapper();
     };
   }
 }

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/OsmTagMapperTest.java
@@ -38,7 +38,7 @@ public class OsmTagMapperTest {
 
   @Test
   public void constantSpeedCarRouting() {
-    OsmTagMapper osmTagMapper = new ConstantSpeedMapper(20f);
+    OsmTagMapper osmTagMapper = new ConstantSpeedFinlandMapper(20f);
 
     var slowWay = new OSMWithTags();
     slowWay.addTag("highway", "residential");


### PR DESCRIPTION
### Summary

- Default tag mapping is US specific and works badly in Finland, so derive constant speed mapping from Finnish rules
- Rename the tag mapper to reflect that it is now specific to Finland

