### PR TITLE
Allow timeout exception to propagate to Transmodel GraphQL error handling

### DIFF
--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -1563,8 +1563,6 @@ enum RoutingErrorCode {
   outsideBounds
   "The date specified is outside the range of data currently loaded into the system"
   outsideServicePeriod
-  "The routing request timed out."
-  processingTimeout
   "An unknown error happened during the search. The details have been logged to the server logs"
   systemError
   "The origin and destination are so close to each other, that walking is always better, but no direct mode was specified for the search"

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -20,6 +20,7 @@ import org.opentripplanner.ext.flex.flexpathcalculator.StreetFlexPathCalculator;
 import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
 import org.opentripplanner.ext.flex.template.FlexEgressTemplate;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -113,6 +114,7 @@ public class FlexRouter {
   }
 
   public Collection<Itinerary> createFlexOnlyItineraries() {
+    OTPRequestTimeoutException.checkForTimeout();
     calculateFlexAccessTemplates();
     calculateFlexEgressTemplates();
 
@@ -146,6 +148,7 @@ public class FlexRouter {
   }
 
   public Collection<FlexAccessEgress> createFlexAccesses() {
+    OTPRequestTimeoutException.checkForTimeout();
     calculateFlexAccessTemplates();
 
     return this.flexAccessTemplates.stream()
@@ -154,6 +157,7 @@ public class FlexRouter {
   }
 
   public Collection<FlexAccessEgress> createFlexEgresses() {
+    OTPRequestTimeoutException.checkForTimeout();
     calculateFlexEgressTemplates();
 
     return this.flexEgressTemplates.stream()

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
@@ -36,7 +36,7 @@ public class LegacyGraphQLUtils {
       case NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW -> LegacyGraphQLRoutingErrorCode.NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW;
       case OUTSIDE_BOUNDS -> LegacyGraphQLRoutingErrorCode.OUTSIDE_BOUNDS;
       case OUTSIDE_SERVICE_PERIOD -> LegacyGraphQLRoutingErrorCode.OUTSIDE_SERVICE_PERIOD;
-      case SYSTEM_ERROR, PROCESSING_TIMEOUT -> LegacyGraphQLRoutingErrorCode.SYSTEM_ERROR;
+      case SYSTEM_ERROR -> LegacyGraphQLRoutingErrorCode.SYSTEM_ERROR;
       case WALKING_BETTER_THAN_TRANSIT -> LegacyGraphQLRoutingErrorCode.WALKING_BETTER_THAN_TRANSIT;
     };
   }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.transmodelapi;
 
-import graphql.GraphQLError;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
@@ -9,7 +8,6 @@ import java.util.Map;
 import org.opentripplanner.ext.transmodelapi.mapping.TripRequestMapper;
 import org.opentripplanner.ext.transmodelapi.mapping.ViaRequestMapper;
 import org.opentripplanner.ext.transmodelapi.model.PlanResponse;
-import org.opentripplanner.ext.transmodelapi.support.OTPProcessingTimeoutGraphQLException;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.algorithm.mapping.TripPlanMapper;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -42,23 +40,8 @@ public class TransmodelGraphQLPlanner {
       response.debugOutput = res.getDebugTimingAggregator().finishedRendering();
       response.previousPageCursor = res.getPreviousPageCursor();
       response.nextPageCursor = res.getNextPageCursor();
-    } catch (OTPRequestTimeoutException e) {
-      response.plan = TripPlanMapper.mapTripPlan(request, List.of());
-      response.messages.add(new RoutingError(RoutingErrorCode.PROCESSING_TIMEOUT, null));
-      Locale locale = request == null ? serverContext.defaultLocale() : request.locale();
-      return DataFetcherResult
-        .<PlanResponse>newResult()
-        .data(response)
-        .errors(
-          response.messages
-            .stream()
-            .map(routingError ->
-              (GraphQLError) new OTPProcessingTimeoutGraphQLException(routingError.code.name())
-            )
-            .toList()
-        )
-        .localContext(Map.of("locale", locale))
-        .build();
+    } catch (OTPRequestTimeoutException te) {
+      throw te;
     } catch (RoutingValidationException e) {
       response.plan = TripPlanMapper.mapTripPlan(request, List.of());
       response.messages.addAll(e.getRoutingErrors());

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -323,11 +323,6 @@ public class EnumTypes {
       "The date specified is outside the range of data currently loaded into the system"
     )
     .value(
-      "processingTimeout",
-      RoutingErrorCode.PROCESSING_TIMEOUT,
-      "The routing request timed out."
-    )
-    .value(
       "systemError",
       RoutingErrorCode.SYSTEM_ERROR,
       "An unknown error happened during the search. The details have been logged to the server logs"

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/OtpExecutionResult.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/OtpExecutionResult.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.transmodelapi.support;
 
+import graphql.ErrorClassification;
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
@@ -9,6 +10,8 @@ import org.opentripplanner.framework.application.OTPRequestTimeoutException;
  * execution failed due to a timeout.
  */
 public record OtpExecutionResult(ExecutionResult result, boolean timeout) {
+  private static final String API_PROCESSING_TIMEOUT = "ApiProcessingTimeout";
+
   public static OtpExecutionResult of(ExecutionResult result) {
     return new OtpExecutionResult(result, false);
   }
@@ -17,7 +20,13 @@ public record OtpExecutionResult(ExecutionResult result, boolean timeout) {
     return new OtpExecutionResult(
       ExecutionResult
         .newExecutionResult()
-        .addError(GraphQLError.newError().message(OTPRequestTimeoutException.MESSAGE).build())
+        .addError(
+          GraphQLError
+            .newError()
+            .errorType(ErrorClassification.errorClassification(API_PROCESSING_TIMEOUT))
+            .message(OTPRequestTimeoutException.MESSAGE)
+            .build()
+        )
         .build(),
       true
     );

--- a/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/astar/AStar.java
@@ -19,6 +19,7 @@ import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
 import org.opentripplanner.astar.spi.SearchTerminationStrategy;
 import org.opentripplanner.astar.spi.SkipEdgeStrategy;
 import org.opentripplanner.astar.spi.TraverseVisitor;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,6 +184,7 @@ public class AStar<
   }
 
   private void runSearch() {
+    OTPRequestTimeoutException.checkForTimeout();
     long abortTime = DateUtils.absoluteTimeout(timeout);
 
     /* the core of the A* algorithm */

--- a/src/main/java/org/opentripplanner/framework/application/OTPRequestTimeoutException.java
+++ b/src/main/java/org/opentripplanner/framework/application/OTPRequestTimeoutException.java
@@ -1,10 +1,14 @@
 package org.opentripplanner.framework.application;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * This Exception is used to signal that the current (HTTP) request has timed out.
  */
 public class OTPRequestTimeoutException extends RuntimeException {
 
+  private static final Logger LOG = LoggerFactory.getLogger(OTPRequestTimeoutException.class);
   public static final String MESSAGE = "TIMEOUT! The request is too resource intensive.";
 
   @Override
@@ -13,15 +17,42 @@ public class OTPRequestTimeoutException extends RuntimeException {
   }
 
   /**
-   * The Grizzly web server is configured with a transaction timeout and
-   * will set the interrupt flag on the current thread. OTP does not have many blocking operations
-   * which check the interrupted flag, so instead we need to do the check manually. The check has
-   * a small performance overhead so try to place the check in the beginning of significantly big
-   * finite block of calculations.
+   * The Grizzly web server is configured with a transaction timeout and will set the interrupt
+   * flag on the current thread. OTP does not have many blocking operations which check the
+   * interrupted flag, so instead we need to do the check manually. The check has a small
+   * performance overhead so try to place the check in the beginning of significantly big block of
+   * calculations.
    */
   public static void checkForTimeout() {
+    // We call yield() to allow monitoring thread to interrupt current thread. If this work or not
+    // is hard to document and test, and the result would only apply the environment tested - but
+    // it does not hurt. The logic does not relay on the yield() to work, it only aborts sooner.
+    Thread.yield();
+
     if (Thread.currentThread().isInterrupted()) {
+      logDebug();
       throw new OTPRequestTimeoutException();
+    }
+  }
+
+  /**
+   * This method can be used to investigate where the execution aborts, this is interesting
+   * when debugging this feature. Breakpoint is no very useful, because they interfere with the
+   * timeout logic. To make the code timeout use the
+   * {@link org.opentripplanner.framework.time.TimeUtils#busyWaitOnce(int)} method.
+   */
+  private static void logDebug() {
+    if (LOG.isDebugEnabled()) {
+      var st = Thread.currentThread().getStackTrace();
+      if (st.length > 5) {
+        LOG.debug(
+          "checkForTimeout() - Thread {} is interrupted!\n    {}\n    {}\n    {}",
+          Thread.currentThread().getName(),
+          st[3],
+          st[4],
+          st[5]
+        );
+      }
     }
   }
 }

--- a/src/main/java/org/opentripplanner/framework/time/TimeUtils.java
+++ b/src/main/java/org/opentripplanner/framework/time/TimeUtils.java
@@ -189,7 +189,22 @@ public class TimeUtils {
     }
     BUSY_WAIT_GRACE_PERIOD_TIMEOUT.set(time + 5L * waitMs);
 
-    long waitUntil = time + waitMs;
+    return busyWait(waitMs);
+  }
+
+  /**
+   * Wait (compute) until the given {@code waitMs} is past. The returned long is a very random
+   * number.
+   * <p>
+   * This method does a "busy" wait - it is not affected by a thread interrupt like
+   * {@link Thread#sleep(long)}; Hence do not interfere with timeout logic witch uses the interrupt
+   * flag.
+   * <p>
+   * THIS CODE IS NOT MEANT FOR PRODUCTION!
+   */
+  @SuppressWarnings("unused")
+  public static long busyWait(int waitMs) {
+    long waitUntil = System.currentTimeMillis() + waitMs;
 
     Random rnd = new SecureRandom();
     long value = rnd.nextLong();

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -20,6 +20,7 @@ import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.ext.vehicletostopheuristics.BikeToStopSkipEdgeStrategy;
 import org.opentripplanner.ext.vehicletostopheuristics.VehicleToStopSkipEdgeStrategy;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.WalkPreferences;
@@ -188,6 +189,8 @@ public class NearbyStopFinder {
     RouteRequest request,
     StreetRequest streetRequest
   ) {
+    OTPRequestTimeoutException.checkForTimeout();
+
     List<NearbyStop> stopsFound = createDirectlyConnectedStops(
       originVertices,
       reverseDirection,

--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PagingSearchWindowAdjuster;
@@ -86,6 +87,8 @@ public class RoutingWorker {
   }
 
   public RoutingResponse route() {
+    OTPRequestTimeoutException.checkForTimeout();
+
     // If no direct mode is set, then we set one.
     // See {@link FilterTransitWhenDirectModeIsEmpty}
     var emptyDirectModeHandler = new FilterTransitWhenDirectModeIsEmpty(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.graph_builder.module.NearbyStopFinder;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
@@ -36,6 +37,7 @@ public class AccessEgressRouter {
     boolean fromTarget,
     Duration durationLimit
   ) {
+    OTPRequestTimeoutException.checkForTimeout();
     NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(
       transitService,
       durationLimit,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.opentripplanner.ext.flex.FlexRouter;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -23,6 +24,7 @@ public class DirectFlexRouter {
     if (!StreetMode.FLEXIBLE.equals(request.journey().direct().mode())) {
       return Collections.emptyList();
     }
+    OTPRequestTimeoutException.checkForTimeout();
     try (
       var temporaryVertices = new TemporaryVerticesContainer(
         serverContext.graph(),

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
 import java.util.Collections;
 import java.util.List;
 import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -23,6 +24,7 @@ public class DirectStreetRouter {
     if (request.journey().direct().mode() == StreetMode.NOT_SET) {
       return Collections.emptyList();
     }
+    OTPRequestTimeoutException.checkForTimeout();
 
     RouteRequest directRequest = request.clone();
     try (

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.ext.flex.FlexAccessEgress;
 import org.opentripplanner.ext.flex.FlexRouter;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -28,6 +29,8 @@ public class FlexAccessEgressRouter {
     DataOverlayContext dataOverlayContext,
     boolean isEgress
   ) {
+    OTPRequestTimeoutException.checkForTimeout();
+
     TransitService transitService = serverContext.transitService();
 
     Collection<NearbyStop> accessStops = !isEgress

--- a/src/main/java/org/opentripplanner/routing/api/response/RoutingErrorCode.java
+++ b/src/main/java/org/opentripplanner/routing/api/response/RoutingErrorCode.java
@@ -37,10 +37,5 @@ public enum RoutingErrorCode {
    */
   NO_STOPS_IN_RANGE,
 
-  /**
-   * The routing request timed out.
-   */
-  PROCESSING_TIMEOUT,
-
   SYSTEM_ERROR,
 }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -11,6 +11,7 @@ import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
 import org.opentripplanner.astar.strategy.PathComparator;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.StreetPreferences;
 import org.opentripplanner.routing.error.PathNotFoundException;
@@ -132,6 +133,7 @@ public class GraphPathFinder {
     Set<Vertex> from,
     Set<Vertex> to
   ) {
+    OTPRequestTimeoutException.checkForTimeout();
     Instant reqTime = request.dateTime().truncatedTo(ChronoUnit.SECONDS);
 
     List<GraphPath<State, Edge, Vertex>> paths = getPaths(request, from, to);

--- a/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.service;
 
 import java.time.ZoneId;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.algorithm.RoutingWorker;
 import org.opentripplanner.routing.algorithm.via.ViaRoutingWorker;
 import org.opentripplanner.routing.api.RoutingService;
@@ -28,6 +29,7 @@ public class DefaultRoutingService implements RoutingService {
 
   @Override
   public RoutingResponse route(RouteRequest request) {
+    OTPRequestTimeoutException.checkForTimeout();
     request.validateOriginAndDestination();
     RoutingWorker worker = new RoutingWorker(serverContext, request, timeZone);
     return worker.route();
@@ -35,6 +37,7 @@ public class DefaultRoutingService implements RoutingService {
 
   @Override
   public ViaRoutingResponse route(RouteViaRequest request) {
+    OTPRequestTimeoutException.checkForTimeout();
     var viaRoutingWorker = new ViaRoutingWorker(
       request,
       req ->

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -52,6 +52,8 @@
   <logger name="DATA_IMPORT_ISSUES" level="info" />
 
   <logger name="org.opentripplanner" level="info"/>
+
+  <logger name="org.opentripplanner.framework.application" level="info"/>
   <logger name="org.opentripplanner.graph_builder.module.DirectTransferGenerator" level="info"/>
 
 


### PR DESCRIPTION
### Summary

In the Transmodel API plan query the `OTPProcessingTimeoutGraphQLException` was caught and retuned as a routing-error, this resulted in this error to be reported with HTTP status code 200, and not 422 as wanted. 

The `processingTimeout` is removed from the `RoutingErrorCode` enum (Transmodel API). This is a potensial breaking change if the client use some sort of API code generation, but it should not affect runtime - only compile time. The processing timeout was not added to the Legacy API.


### Issue

No issue for this.


### Unit tests

Code removed, no tests changed.

### Documentation
No

### Changelog
No

### Bumping the serialization version id
No

