### PR TITLE
 Add "language" argument to Quay and StopPlace types in transmodel api and deprecate "lang" argument

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/transmodelapi/support/GqlUtilTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/transmodelapi/support/GqlUtilTest.java
@@ -1,0 +1,82 @@
+package org.opentripplanner.ext.transmodelapi.support;
+
+import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import graphql.ExecutionInput;
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class GqlUtilTest {
+
+  static final ExecutionContext executionContext;
+
+  static {
+    ExecutionInput executionInput = ExecutionInput
+      .newExecutionInput()
+      .query("")
+      .locale(Locale.ENGLISH)
+      .build();
+
+    executionContext =
+      newExecutionContextBuilder()
+        .executionInput(executionInput)
+        .executionId(ExecutionId.from("GqlUtilTest"))
+        .build();
+  }
+
+  @Test
+  void testGetLocaleWithLangArgument() {
+    var env = DataFetchingEnvironmentImpl
+      .newDataFetchingEnvironment(executionContext)
+      .locale(Locale.ENGLISH)
+      .arguments(Map.of("lang", "fr"))
+      .build();
+
+    var locale = GqlUtil.getLocale(env);
+
+    assertEquals(Locale.FRENCH, locale);
+  }
+
+  @Test
+  void testGetLocaleWithLanguageArgument() {
+    var env = DataFetchingEnvironmentImpl
+      .newDataFetchingEnvironment(executionContext)
+      .locale(Locale.ENGLISH)
+      .arguments(Map.of("language", "fr"))
+      .build();
+
+    var locale = GqlUtil.getLocale(env);
+
+    assertEquals(Locale.FRENCH, locale);
+  }
+
+  @Test
+  void testGetLocaleWithBothArguments() {
+    var env = DataFetchingEnvironmentImpl
+      .newDataFetchingEnvironment(executionContext)
+      .locale(Locale.ENGLISH)
+      .arguments(Map.of("lang", "de", "language", "fr"))
+      .build();
+
+    var locale = GqlUtil.getLocale(env);
+
+    assertEquals(Locale.GERMAN, locale);
+  }
+
+  @Test
+  void testGetLocaleWithoutArguments() {
+    var env = DataFetchingEnvironmentImpl
+      .newDataFetchingEnvironment(executionContext)
+      .locale(Locale.ENGLISH)
+      .build();
+
+    var locale = GqlUtil.getLocale(env);
+
+    assertEquals(Locale.ENGLISH, locale);
+  }
+}

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -585,7 +585,9 @@ type Quay implements PlaceInterface {
   longitude: Float
   name(
     "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exits, the default name is returned."
-    lang: String
+    lang: String,
+    "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exits, the default name is returned."
+    language: String
   ): String!
   "Public code used to identify this quay within the stop place. For instance a platform code."
   publicCode: String
@@ -1114,8 +1116,10 @@ type StopPlace implements PlaceInterface {
   latitude: Float
   longitude: Float
   name(
-    "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exits, the default name is returned."
-    lang: String
+    "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exist, the default name is returned."
+    lang: String,
+    "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exist, the default name is returned."
+    language: String
   ): String!
   "Returns parent stop for this stop"
   parent: StopPlace

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -67,6 +67,17 @@ public class QuayType {
             GraphQLArgument
               .newArgument()
               .name("lang")
+              .deprecate("Use 'language' instead")
+              .description(
+                "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exits, the default name is returned."
+              )
+              .type(Scalars.GraphQLString)
+              .build()
+          )
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("language")
               .description(
                 "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exits, the default name is returned."
               )
@@ -75,7 +86,7 @@ public class QuayType {
           )
           .dataFetcher(environment -> {
             String lang = environment.getArgument("lang");
-            Locale locale = lang != null ? new Locale(lang) : null;
+            Locale locale = GraphQLUtils.getLocale(environment, lang);
             return (((StopLocation) environment.getSource()).getName().toString(locale));
           })
           .build()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -86,7 +86,9 @@ public class QuayType {
           )
           .dataFetcher(environment -> {
             String lang = environment.getArgument("lang");
-            Locale locale = GraphQLUtils.getLocale(environment, lang);
+            Locale locale = lang != null
+              ? GraphQLUtils.getLocale(environment, lang)
+              : GraphQLUtils.getLocale(environment);
             return (((StopLocation) environment.getSource()).getName().toString(locale));
           })
           .build()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -84,13 +84,12 @@ public class QuayType {
               .type(Scalars.GraphQLString)
               .build()
           )
-          .dataFetcher(environment -> {
-            String lang = environment.getArgument("lang");
-            Locale locale = lang != null
-              ? GraphQLUtils.getLocale(environment, lang)
-              : GraphQLUtils.getLocale(environment);
-            return (((StopLocation) environment.getSource()).getName().toString(locale));
-          })
+          .dataFetcher(environment ->
+            (
+              ((StopLocation) environment.getSource()).getName()
+                .toString(GqlUtil.getLocale(environment))
+            )
+          )
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -87,15 +87,26 @@ public class StopPlaceType {
             GraphQLArgument
               .newArgument()
               .name("lang")
+              .deprecate("Use 'language' instead")
               .description(
-                "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exits, the default name is returned."
+                "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exist, the default name is returned."
+              )
+              .type(Scalars.GraphQLString)
+              .build()
+          )
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("language")
+              .description(
+                "Fetch the name in the language given. The language should be represented as a ISO-639 language code. If the translation does not exist, the default name is returned."
               )
               .type(Scalars.GraphQLString)
               .build()
           )
           .dataFetcher(environment -> {
             String lang = environment.getArgument("lang");
-            Locale locale = lang != null ? new Locale(lang) : null;
+            Locale locale = GraphQLUtils.getLocale(environment, lang);
             return (((MonoOrMultiModalStation) environment.getSource()).getName().toString(locale));
           })
           .build()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -106,7 +106,9 @@ public class StopPlaceType {
           )
           .dataFetcher(environment -> {
             String lang = environment.getArgument("lang");
-            Locale locale = GraphQLUtils.getLocale(environment, lang);
+            Locale locale = lang != null
+              ? GraphQLUtils.getLocale(environment, lang)
+              : GraphQLUtils.getLocale(environment);
             return (((MonoOrMultiModalStation) environment.getSource()).getName().toString(locale));
           })
           .build()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -104,13 +104,12 @@ public class StopPlaceType {
               .type(Scalars.GraphQLString)
               .build()
           )
-          .dataFetcher(environment -> {
-            String lang = environment.getArgument("lang");
-            Locale locale = lang != null
-              ? GraphQLUtils.getLocale(environment, lang)
-              : GraphQLUtils.getLocale(environment);
-            return (((MonoOrMultiModalStation) environment.getSource()).getName().toString(locale));
-          })
+          .dataFetcher(environment ->
+            (
+              ((MonoOrMultiModalStation) environment.getSource()).getName()
+                .toString(GqlUtil.getLocale(environment))
+            )
+          )
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GqlUtil.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GqlUtil.java
@@ -12,6 +12,7 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 import org.opentripplanner.ext.transmodelapi.TransmodelRequestContext;
 import org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper;
 import org.opentripplanner.ext.transmodelapi.model.scalars.DateScalarFactory;
@@ -19,6 +20,7 @@ import org.opentripplanner.ext.transmodelapi.model.scalars.DateTimeScalarFactory
 import org.opentripplanner.ext.transmodelapi.model.scalars.DoubleFunctionScalarFactory;
 import org.opentripplanner.ext.transmodelapi.model.scalars.LocalTimeScalarFactory;
 import org.opentripplanner.ext.transmodelapi.model.scalars.TimeScalarFactory;
+import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.framework.graphql.scalar.DurationScalarFactory;
 import org.opentripplanner.routing.graphfinder.GraphFinder;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
@@ -103,5 +105,15 @@ public class GqlUtil {
 
   public static <T> List<T> listOfNullSafe(T element) {
     return element == null ? List.of() : List.of(element);
+  }
+
+  /**
+   * Helper method to support the deprecated 'lang' argument.
+   */
+  public static Locale getLocale(DataFetchingEnvironment environment) {
+    String lang = environment.getArgument("lang");
+    return lang != null
+      ? GraphQLUtils.getLocale(environment, lang)
+      : GraphQLUtils.getLocale(environment);
   }
 }


### PR DESCRIPTION
Closes #4988 

This PR adds new arguments to StopPlace.name and Quay.name called `language` to replace the `lang` arguments, and marks the latter as deprecated. The datafetcher now uses GraphQLUtils.getLocale with the old argument value as a fallback.

The generated GraphQL schema is missing @deprecated directive on the old 'lang' arguments. This seems intentional: https://github.com/graphql-java/graphql-java/issues/1598, but I guess the generated schema is only used for verifying / testing.

When I run GraphiQL locally, the deprecated arguments can't be seen in the documentation explorer - there's no "Show deprecated" on StopPlace.name or Quay.name. In addition Graphiql doesn't recognize the deprecated argument (shows a squiggly red line). But when I run the query using the deprecated argument, OTP does not complain (as it does when using a non-existing argument).
