### PR TITLE
Preemptively make a GraphQL FareProduct an interface

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
@@ -19,7 +19,6 @@ import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
-import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.ItineraryFares;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
@@ -218,7 +217,7 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
       .toList();
 
     assertEquals(1, fareProducts.size());
-    var fp = (FareProduct) fareProducts.get(0);
+    var fp = fareProducts.get(0);
     assertEquals(expectedFare, fp.price());
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
@@ -10,7 +10,6 @@ import static org.opentripplanner.transit.model.basic.Money.USD;
 import static org.opentripplanner.transit.model.basic.Money.usDollars;
 
 import java.util.Collection;
-import java.util.Currency;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +19,7 @@ import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
+import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.ItineraryFares;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
@@ -218,7 +218,7 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
       .toList();
 
     assertEquals(1, fareProducts.size());
-    var fp = fareProducts.get(0);
+    var fp = (FareProduct) fareProducts.get(0);
     assertEquals(expectedFare, fp.price());
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -53,8 +53,6 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
         .getItineraryProducts()
         .stream()
         .filter(fp -> fp.name().equals(type.name()))
-        .filter(FareProduct.class::isInstance)
-        .map(FareProduct.class::cast)
         .map(FareProduct::price)
         .toList();
       assertEquals(List.of(expected), prices);

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -53,6 +53,8 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
         .getItineraryProducts()
         .stream()
         .filter(fp -> fp.name().equals(type.name()))
+        .filter(FareProduct.class::isInstance)
+        .map(FareProduct.class::cast)
         .map(FareProduct::price)
         .toList();
       assertEquals(List.of(expected), prices);

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.fares.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.COMM_TRANS_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.KC_METRO_AGENCY_ID;
@@ -72,7 +73,7 @@ public class OrcaFareServiceTest {
   private static void calculateFare(List<Leg> legs, FareType fareType, Money expectedPrice) {
     ItineraryFares fare = new ItineraryFares();
     orcaFareService.populateFare(fare, USD, fareType, legs, null);
-    Assertions.assertEquals(expectedPrice, fare.getFare(fareType));
+    assertEquals(expectedPrice, fare.getFare(fareType));
   }
 
   private static void assertLegFareEquals(

--- a/src/ext-test/resources/legacygraphqlapi/expectations/plan-fares.json
+++ b/src/ext-test/resources/legacygraphqlapi/expectations/plan-fares.json
@@ -3,10 +3,6 @@
     "plan" : {
       "itineraries" : [
         {
-          "startTime" : 1580641200000,
-          "endTime" : 1580644800000,
-          "generalizedCost" : 4072,
-          "accessibilityScore" : 0.5,
           "legs" : [
             {
               "mode" : "WALK",
@@ -27,8 +23,7 @@
               "startTime" : 1580641200000,
               "endTime" : 1580641220000,
               "generalizedCost" : 40,
-              "fareProducts" : [ ],
-              "accessibilityScore" : null
+              "fareProducts" : [ ]
             },
             {
               "mode" : "BUS",
@@ -55,6 +50,7 @@
                   "product" : {
                     "id" : "F:day-pass",
                     "name" : "day-pass",
+                    "__typename" : "DefaultFareProduct",
                     "price" : {
                       "currency" : {
                         "digits" : 2,
@@ -77,6 +73,7 @@
                   "product" : {
                     "id" : "F:AB",
                     "name" : "regular",
+                    "__typename" : "DefaultFareProduct",
                     "price" : {
                       "currency" : {
                         "digits" : 2,
@@ -93,6 +90,7 @@
                   "product" : {
                     "id" : "F:single-ticket",
                     "name" : "single-ticket",
+                    "__typename" : "DefaultFareProduct",
                     "price" : {
                       "currency" : {
                         "digits" : 2,
@@ -110,8 +108,7 @@
                     }
                   }
                 }
-              ],
-              "accessibilityScore" : null
+              ]
             },
             {
               "mode" : "RAIL",
@@ -138,6 +135,7 @@
                   "product" : {
                     "id" : "F:day-pass",
                     "name" : "day-pass",
+                    "__typename" : "DefaultFareProduct",
                     "price" : {
                       "currency" : {
                         "digits" : 2,
@@ -160,6 +158,7 @@
                   "product" : {
                     "id" : "F:single-ticket",
                     "name" : "single-ticket",
+                    "__typename" : "DefaultFareProduct",
                     "price" : {
                       "currency" : {
                         "digits" : 2,
@@ -177,8 +176,7 @@
                     }
                   }
                 }
-              ],
-              "accessibilityScore" : null
+              ]
             },
             {
               "mode" : "CAR",
@@ -199,8 +197,7 @@
               "startTime" : 1580644200000,
               "endTime" : 1580644800000,
               "generalizedCost" : 1000,
-              "fareProducts" : [ ],
-              "accessibilityScore" : null
+              "fareProducts" : [ ]
             }
           ],
           "fares" : [

--- a/src/ext-test/resources/legacygraphqlapi/expectations/plan-fares.json
+++ b/src/ext-test/resources/legacygraphqlapi/expectations/plan-fares.json
@@ -1,0 +1,229 @@
+{
+  "data" : {
+    "plan" : {
+      "itineraries" : [
+        {
+          "startTime" : 1580641200000,
+          "endTime" : 1580644800000,
+          "generalizedCost" : 4072,
+          "accessibilityScore" : 0.5,
+          "legs" : [
+            {
+              "mode" : "WALK",
+              "from" : {
+                "name" : "A",
+                "lat" : 5.0,
+                "lon" : 8.0,
+                "departureTime" : 1580641200000,
+                "arrivalTime" : 1580641200000
+              },
+              "to" : {
+                "name" : "B",
+                "lat" : 6.0,
+                "lon" : 8.5,
+                "departureTime" : 1580641220000,
+                "arrivalTime" : 1580641220000
+              },
+              "startTime" : 1580641200000,
+              "endTime" : 1580641220000,
+              "generalizedCost" : 40,
+              "fareProducts" : [ ],
+              "accessibilityScore" : null
+            },
+            {
+              "mode" : "BUS",
+              "from" : {
+                "name" : "B",
+                "lat" : 6.0,
+                "lon" : 8.5,
+                "departureTime" : 1580641260000,
+                "arrivalTime" : 1580641260000
+              },
+              "to" : {
+                "name" : "C",
+                "lat" : 7.0,
+                "lon" : 9.0,
+                "departureTime" : 1580642100000,
+                "arrivalTime" : 1580642100000
+              },
+              "startTime" : 1580641260000,
+              "endTime" : 1580642100000,
+              "generalizedCost" : 992,
+              "fareProducts" : [
+                {
+                  "id" : "5d8f889c-42cb-3bcc-89d5-480b995c78c8",
+                  "product" : {
+                    "id" : "F:day-pass",
+                    "name" : "day-pass",
+                    "price" : {
+                      "currency" : {
+                        "digits" : 2,
+                        "code" : "EUR"
+                      },
+                      "amount" : 10.0
+                    },
+                    "riderCategory" : {
+                      "id" : "F:senior-citizens",
+                      "name" : "Senior citizens"
+                    },
+                    "medium" : {
+                      "id" : "F:oyster",
+                      "name" : "TfL Oyster Card"
+                    }
+                  }
+                },
+                {
+                  "id" : "6bd27c98-c0ee-3f62-b606-bbacf2e1f41b",
+                  "product" : {
+                    "id" : "F:AB",
+                    "name" : "regular",
+                    "price" : {
+                      "currency" : {
+                        "digits" : 2,
+                        "code" : "EUR"
+                      },
+                      "amount" : 3.1
+                    },
+                    "riderCategory" : null,
+                    "medium" : null
+                  }
+                },
+                {
+                  "id" : "09bb5f2b-6af9-3355-8b5d-5e93a27ce280",
+                  "product" : {
+                    "id" : "F:single-ticket",
+                    "name" : "single-ticket",
+                    "price" : {
+                      "currency" : {
+                        "digits" : 2,
+                        "code" : "EUR"
+                      },
+                      "amount" : 10.0
+                    },
+                    "riderCategory" : {
+                      "id" : "F:senior-citizens",
+                      "name" : "Senior citizens"
+                    },
+                    "medium" : {
+                      "id" : "F:oyster",
+                      "name" : "TfL Oyster Card"
+                    }
+                  }
+                }
+              ],
+              "accessibilityScore" : null
+            },
+            {
+              "mode" : "RAIL",
+              "from" : {
+                "name" : "C",
+                "lat" : 7.0,
+                "lon" : 9.0,
+                "departureTime" : 1580643000000,
+                "arrivalTime" : 1580643000000
+              },
+              "to" : {
+                "name" : "D",
+                "lat" : 8.0,
+                "lon" : 9.5,
+                "departureTime" : 1580644200000,
+                "arrivalTime" : 1580644200000
+              },
+              "startTime" : 1580643000000,
+              "endTime" : 1580644200000,
+              "generalizedCost" : 2040,
+              "fareProducts" : [
+                {
+                  "id" : "5d8f889c-42cb-3bcc-89d5-480b995c78c8",
+                  "product" : {
+                    "id" : "F:day-pass",
+                    "name" : "day-pass",
+                    "price" : {
+                      "currency" : {
+                        "digits" : 2,
+                        "code" : "EUR"
+                      },
+                      "amount" : 10.0
+                    },
+                    "riderCategory" : {
+                      "id" : "F:senior-citizens",
+                      "name" : "Senior citizens"
+                    },
+                    "medium" : {
+                      "id" : "F:oyster",
+                      "name" : "TfL Oyster Card"
+                    }
+                  }
+                },
+                {
+                  "id" : "46190ddd-93b0-3136-adb7-a18394f8b0ef",
+                  "product" : {
+                    "id" : "F:single-ticket",
+                    "name" : "single-ticket",
+                    "price" : {
+                      "currency" : {
+                        "digits" : 2,
+                        "code" : "EUR"
+                      },
+                      "amount" : 10.0
+                    },
+                    "riderCategory" : {
+                      "id" : "F:senior-citizens",
+                      "name" : "Senior citizens"
+                    },
+                    "medium" : {
+                      "id" : "F:oyster",
+                      "name" : "TfL Oyster Card"
+                    }
+                  }
+                }
+              ],
+              "accessibilityScore" : null
+            },
+            {
+              "mode" : "CAR",
+              "from" : {
+                "name" : "D",
+                "lat" : 8.0,
+                "lon" : 9.5,
+                "departureTime" : 1580644200000,
+                "arrivalTime" : 1580644200000
+              },
+              "to" : {
+                "name" : "E",
+                "lat" : 9.0,
+                "lon" : 10.0,
+                "departureTime" : 1580644800000,
+                "arrivalTime" : 1580644800000
+              },
+              "startTime" : 1580644200000,
+              "endTime" : 1580644800000,
+              "generalizedCost" : 1000,
+              "fareProducts" : [ ],
+              "accessibilityScore" : null
+            }
+          ],
+          "fares" : [
+            {
+              "type" : "regular",
+              "cents" : 310,
+              "currency" : "EUR",
+              "components" : [
+                {
+                  "currency" : "EUR",
+                  "cents" : 310,
+                  "fareId" : "F:AB",
+                  "routes" : [
+                    {
+                      "gtfsId" : "F:BUS"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/ext-test/resources/legacygraphqlapi/expectations/plan.json
+++ b/src/ext-test/resources/legacygraphqlapi/expectations/plan.json
@@ -29,7 +29,6 @@
               "generalizedCost" : 40,
               "alerts" : [ ],
               "rideHailingEstimate" : null,
-              "fareProducts" : [ ],
               "accessibilityScore" : null
             },
             {
@@ -53,68 +52,6 @@
               "generalizedCost" : 992,
               "alerts" : [ ],
               "rideHailingEstimate" : null,
-              "fareProducts" : [
-                {
-                  "id" : "5d8f889c-42cb-3bcc-89d5-480b995c78c8",
-                  "product" : {
-                    "id" : "F:day-pass",
-                    "name" : "day-pass",
-                    "price" : {
-                      "currency" : {
-                        "digits" : 2,
-                        "code" : "EUR"
-                      },
-                      "amount" : 10.0
-                    },
-                    "riderCategory" : {
-                      "id" : "F:senior-citizens",
-                      "name" : "Senior citizens"
-                    },
-                    "medium" : {
-                      "id" : "F:oyster",
-                      "name" : "TfL Oyster Card"
-                    }
-                  }
-                },
-                {
-                  "id" : "6bd27c98-c0ee-3f62-b606-bbacf2e1f41b",
-                  "product" : {
-                    "id" : "F:AB",
-                    "name" : "regular",
-                    "price" : {
-                      "currency" : {
-                        "digits" : 2,
-                        "code" : "EUR"
-                      },
-                      "amount" : 3.1
-                    },
-                    "riderCategory" : null,
-                    "medium" : null
-                  }
-                },
-                {
-                  "id" : "09bb5f2b-6af9-3355-8b5d-5e93a27ce280",
-                  "product" : {
-                    "id" : "F:single-ticket",
-                    "name" : "single-ticket",
-                    "price" : {
-                      "currency" : {
-                        "digits" : 2,
-                        "code" : "EUR"
-                      },
-                      "amount" : 10.0
-                    },
-                    "riderCategory" : {
-                      "id" : "F:senior-citizens",
-                      "name" : "Senior citizens"
-                    },
-                    "medium" : {
-                      "id" : "F:oyster",
-                      "name" : "TfL Oyster Card"
-                    }
-                  }
-                }
-              ],
               "accessibilityScore" : null
             },
             {
@@ -158,52 +95,6 @@
                 }
               ],
               "rideHailingEstimate" : null,
-              "fareProducts" : [
-                {
-                  "id" : "5d8f889c-42cb-3bcc-89d5-480b995c78c8",
-                  "product" : {
-                    "id" : "F:day-pass",
-                    "name" : "day-pass",
-                    "price" : {
-                      "currency" : {
-                        "digits" : 2,
-                        "code" : "EUR"
-                      },
-                      "amount" : 10.0
-                    },
-                    "riderCategory" : {
-                      "id" : "F:senior-citizens",
-                      "name" : "Senior citizens"
-                    },
-                    "medium" : {
-                      "id" : "F:oyster",
-                      "name" : "TfL Oyster Card"
-                    }
-                  }
-                },
-                {
-                  "id" : "46190ddd-93b0-3136-adb7-a18394f8b0ef",
-                  "product" : {
-                    "id" : "F:single-ticket",
-                    "name" : "single-ticket",
-                    "price" : {
-                      "currency" : {
-                        "digits" : 2,
-                        "code" : "EUR"
-                      },
-                      "amount" : 10.0
-                    },
-                    "riderCategory" : {
-                      "id" : "F:senior-citizens",
-                      "name" : "Senior citizens"
-                    },
-                    "medium" : {
-                      "id" : "F:oyster",
-                      "name" : "TfL Oyster Card"
-                    }
-                  }
-                }
-              ],
               "accessibilityScore" : null
             },
             {
@@ -247,7 +138,6 @@
                 },
                 "arrival" : "PT10M"
               },
-              "fareProducts" : [ ],
               "accessibilityScore" : null
             }
           ],

--- a/src/ext-test/resources/legacygraphqlapi/expectations/plan.json
+++ b/src/ext-test/resources/legacygraphqlapi/expectations/plan.json
@@ -140,25 +140,6 @@
               },
               "accessibilityScore" : null
             }
-          ],
-          "fares" : [
-            {
-              "type" : "regular",
-              "cents" : 310,
-              "currency" : "EUR",
-              "components" : [
-                {
-                  "currency" : "EUR",
-                  "cents" : 310,
-                  "fareId" : "F:AB",
-                  "routes" : [
-                    {
-                      "gtfsId" : "F:BUS"
-                    }
-                  ]
-                }
-              ]
-            }
           ]
         }
       ]

--- a/src/ext-test/resources/legacygraphqlapi/queries/plan-fares.graphql
+++ b/src/ext-test/resources/legacygraphqlapi/queries/plan-fares.graphql
@@ -40,45 +40,29 @@
                 endTime
                 mode
                 generalizedCost
-                alerts {
+                fareProducts {
                     id
-                    alertHeaderText
-                    alertDescriptionText
-                    alertEffect
-                    alertCause
-                    alertSeverityLevel
-                    alertUrl
-                    effectiveStartDate
-                    effectiveEndDate
-                    entities {
-                        ... on Stop {
-                            name
-                            gtfsId
-                            lat
-                            lon
-                        }
-                    }
-                }
-                rideHailingEstimate {
-                    provider {
+                    product {
                         id
-                    }
-                    productName
-                    minPrice {
-                        currency {
-                            code
-                            digits
+                        name
+                        ... on DefaultFareProduct {
+                            price {
+                                currency {
+                                    digits
+                                    code
+                                }
+                                amount
+                            }
                         }
-                        amount
-                    }
-                    maxPrice {
-                        currency {
-                            code
-                            digits
+                        riderCategory {
+                            id
+                            name
                         }
-                        amount
+                        medium {
+                            id
+                            name
+                        }
                     }
-                    arrival
                 }
                 accessibilityScore
             }

--- a/src/ext-test/resources/legacygraphqlapi/queries/plan-fares.graphql
+++ b/src/ext-test/resources/legacygraphqlapi/queries/plan-fares.graphql
@@ -1,25 +1,12 @@
 {
     plan(
-        fromPlace: "from",
-        toPlace: "to",
+        from: { lat: 52.3092, lon: 13.0291 }
+        to: { lat: 52.5147, lon: 13.3927 }
         date: "2023-02-15",
         time: "11:37",
-        parking: {
-            unpreferredCost: 555,
-            preferred: [{ not: [{tags: ["a", "b", "c"]}] }],
-            filters: [{ select: [{tags:["e"]}] }]
-        },
-        transportModes: [
-            {
-                mode: CAR,
-                qualifier: HAIL
-            }
-        ]) {
+        transportModes: [{ mode: TRANSIT }]
+    ) {
         itineraries {
-            startTime
-            endTime
-            generalizedCost
-            accessibilityScore
             legs {
                 mode
                 from {
@@ -45,6 +32,7 @@
                     product {
                         id
                         name
+                        __typename
                         ... on DefaultFareProduct {
                             price {
                                 currency {
@@ -64,7 +52,6 @@
                         }
                     }
                 }
-                accessibilityScore
             }
             fares {
                 type

--- a/src/ext-test/resources/legacygraphqlapi/queries/plan.graphql
+++ b/src/ext-test/resources/legacygraphqlapi/queries/plan.graphql
@@ -1,7 +1,7 @@
 {
     plan(
-        fromPlace: "from",
-        toPlace: "to",
+        from: { lat: 52.3092, lon: 13.0291 }
+        to: { lat: 52.5147, lon: 13.3927 }
         date: "2023-02-15",
         time: "11:37",
         parking: {
@@ -81,19 +81,6 @@
                     arrival
                 }
                 accessibilityScore
-            }
-            fares {
-                type
-                cents
-                currency
-                components {
-                    currency
-                    cents
-                    fareId
-                    routes {
-                       gtfsId
-                    }
-                }
             }
         }
     }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -40,8 +40,9 @@ import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLCarPar
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLContactInfoImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLCoordinatesImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLCurrencyImpl;
+import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLDefaultFareProductImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLDepartureRowImpl;
-import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLFareProductImpl;
+import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLFareProductTypeResolver;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLFareProductUseImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLFeedImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLGeometryImpl;
@@ -172,7 +173,8 @@ class LegacyGraphQLIndex {
         .type(typeWiring.build(LegacyGraphQLMoneyImpl.class))
         .type(typeWiring.build(LegacyGraphQLCurrencyImpl.class))
         .type(typeWiring.build(LegacyGraphQLFareProductUseImpl.class))
-        .type(typeWiring.build(LegacyGraphQLFareProductImpl.class))
+        .type("FareProduct", type -> type.typeResolver(new LegacyGraphQLFareProductTypeResolver()))
+        .type(typeWiring.build(LegacyGraphQLDefaultFareProductImpl.class))
         .build();
       SchemaGenerator schemaGenerator = new SchemaGenerator();
       return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLDefaultFareProductImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLDefaultFareProductImpl.java
@@ -8,8 +8,8 @@ import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.RiderCategory;
 import org.opentripplanner.transit.model.basic.Money;
 
-public class LegacyGraphQLFareProductImpl
-  implements LegacyGraphQLDataFetchers.LegacyGraphQLFareProduct {
+public class LegacyGraphQLDefaultFareProductImpl
+  implements LegacyGraphQLDataFetchers.LegacyGraphQLDefaultFareProduct {
 
   @Override
   public DataFetcher<String> id() {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLFareProductTypeResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLFareProductTypeResolver.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
+
+import graphql.TypeResolutionEnvironment;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.TypeResolver;
+import org.opentripplanner.model.fare.FareProduct;
+
+public class LegacyGraphQLFareProductTypeResolver implements TypeResolver {
+
+  @Override
+  public GraphQLObjectType getType(TypeResolutionEnvironment environment) {
+    Object o = environment.getObject();
+    GraphQLSchema schema = environment.getSchema();
+
+    if (o instanceof FareProduct) {
+      return schema.getObjectType("DefaultFareProduct");
+    }
+    return null;
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -292,6 +292,18 @@ public class LegacyGraphQLDataFetchers {
     public DataFetcher<Integer> digits();
   }
 
+  public interface LegacyGraphQLDefaultFareProduct {
+    public DataFetcher<String> id();
+
+    public DataFetcher<FareMedium> medium();
+
+    public DataFetcher<String> name();
+
+    public DataFetcher<Money> price();
+
+    public DataFetcher<RiderCategory> riderCategory();
+  }
+
   /**
    * Departure row is a location, which lists departures of a certain pattern from a
    * stop. Departure rows are identified with the pattern, so querying departure rows
@@ -311,6 +323,20 @@ public class LegacyGraphQLDataFetchers {
     public DataFetcher<Iterable<TripTimeOnDate>> stoptimes();
   }
 
+  public interface LegacyGraphQLDiscountedFareProduct {
+    public DataFetcher<Money> discountedPrice();
+
+    public DataFetcher<Money> fullPrice();
+
+    public DataFetcher<String> id();
+
+    public DataFetcher<FareMedium> medium();
+
+    public DataFetcher<String> name();
+
+    public DataFetcher<RiderCategory> riderCategory();
+  }
+
   /** A 'medium' that a fare product applies to, for example cash, 'Oyster Card' or 'DB Navigator App'. */
   public interface LegacyGraphQLFareMedium {
     public DataFetcher<String> id();
@@ -319,16 +345,22 @@ public class LegacyGraphQLDataFetchers {
   }
 
   /** A fare product (a ticket) to be bought by a passenger */
-  public interface LegacyGraphQLFareProduct {
-    public DataFetcher<String> id();
+  public interface LegacyGraphQLFareProduct extends TypeResolver {
+    public default DataFetcher<String> id() {
+      return null;
+    }
 
-    public DataFetcher<FareMedium> medium();
+    public default DataFetcher<FareMedium> medium() {
+      return null;
+    }
 
-    public DataFetcher<String> name();
+    public default DataFetcher<String> name() {
+      return null;
+    }
 
-    public DataFetcher<Money> price();
-
-    public DataFetcher<RiderCategory> riderCategory();
+    public default DataFetcher<RiderCategory> riderCategory() {
+      return null;
+    }
   }
 
   /** A container for both a fare product (a ticket) and its relationship to the itinerary. */

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -292,6 +292,10 @@ public class LegacyGraphQLDataFetchers {
     public DataFetcher<Integer> digits();
   }
 
+  /**
+   * The standard case of a fare product: it only has a single price to be paid by the passenger
+   * and no discounts are applied.
+   */
   public interface LegacyGraphQLDefaultFareProduct {
     public DataFetcher<String> id();
 
@@ -321,20 +325,6 @@ public class LegacyGraphQLDataFetchers {
     public DataFetcher<Object> stop();
 
     public DataFetcher<Iterable<TripTimeOnDate>> stoptimes();
-  }
-
-  public interface LegacyGraphQLDiscountedFareProduct {
-    public DataFetcher<Money> discountedPrice();
-
-    public DataFetcher<Money> fullPrice();
-
-    public DataFetcher<String> id();
-
-    public DataFetcher<FareMedium> medium();
-
-    public DataFetcher<String> name();
-
-    public DataFetcher<RiderCategory> riderCategory();
   }
 
   /** A 'medium' that a fare product applies to, for example cash, 'Oyster Card' or 'DB Navigator App'. */

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1325,7 +1325,31 @@ type FareProductUse {
 }
 
 "A fare product (a ticket) to be bought by a passenger"
-type FareProduct {
+interface FareProduct {
+    "Identifier for the fare product."
+    id: String!
+
+    """
+    Human readable name of the product, for example example "Day pass" or "Single ticket".
+    """
+    name: String!
+
+    "The category of riders this product applies to, for example students or pensioners."
+    riderCategory: RiderCategory
+
+    """
+    The 'medium' that this product applies to, for example "Oyster Card" or "Berlin Ticket App".
+
+    This communicates to riders that a specific way of buying or keeping this product is required.
+    """
+    medium: FareMedium
+}
+
+"""
+The standard case of a fare product: it only has a single price to be paid by the passenger
+and no discounts are applied.
+"""
+type DefaultFareProduct implements FareProduct {
     "Identifier for the fare product."
     id: String!
 

--- a/src/main/java/org/opentripplanner/model/fare/FareProduct.java
+++ b/src/main/java/org/opentripplanner/model/fare/FareProduct.java
@@ -47,10 +47,10 @@ public record FareProduct(
     var builder = ToStringBuilder
       .of(FareProduct.class)
       .addStr("id", id.toString())
-      .addObj("amount", price);
-    builder.addDuration("duration", validity);
-    builder.addObj("category", category);
-    builder.addObj("medium", medium);
+      .addObj("amount", price)
+      .addDuration("duration", validity)
+      .addObj("category", category)
+      .addObj("medium", medium);
 
     return builder.toString();
   }

--- a/src/main/java/org/opentripplanner/model/fare/ItineraryFares.java
+++ b/src/main/java/org/opentripplanner/model/fare/ItineraryFares.java
@@ -84,7 +84,6 @@ public class ItineraryFares {
    * <p>
    * @deprecated It only exists for backwards-compatibility.
    * Use {@link ItineraryFares#addFareProduct(Leg, FareProduct)},
-   * {@link ItineraryFares#addLegProducts(Collection)} or
    * {@link ItineraryFares#addItineraryProducts(Collection)} instead.
    */
   @Deprecated
@@ -99,7 +98,6 @@ public class ItineraryFares {
    * @deprecated Only exitst for backwards compatibility.
    * Use @{link {@link ItineraryFares#addItineraryProducts(Collection)}},
    * {@link ItineraryFares#addFareProduct(Leg, FareProduct)} or
-   * {@link ItineraryFares#addLegProducts(Collection)} instead.
    */
   @Deprecated
   public void addFareComponent(FareType fareType, List<FareComponent> components) {

--- a/src/main/java/org/opentripplanner/routing/core/FareComponent.java
+++ b/src/main/java/org/opentripplanner/routing/core/FareComponent.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.core;
 
 import java.util.List;
+import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -10,7 +11,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  * FareComponent is a sequence of routes for a particular fare.
  * </p>
  * @deprecated Because it exists only for backwards compatibility, and you should use the Fares V2
- * type, namely {@link org.opentripplanner.model.fare.FareProduct}.
+ * type, namely {@link FareProduct}.
  */
 @Deprecated
 public record FareComponent(FeedScopedId fareId, Money price, List<Leg> legs) {

--- a/src/main/java/org/opentripplanner/routing/core/FareType.java
+++ b/src/main/java/org/opentripplanner/routing/core/FareType.java
@@ -1,10 +1,11 @@
 package org.opentripplanner.routing.core;
 
 import java.io.Serializable;
+import org.opentripplanner.model.fare.FareProduct;
 
 /**
  * @deprecated Because it exists only for backwards compatibility, and you should use the Fares V2
- * type, namely {@link org.opentripplanner.model.fare.FareProduct}.
+ * type, namely {@link FareProduct}.
  */
 @Deprecated
 public enum FareType implements Serializable {


### PR DESCRIPTION
### Summary

After adding an improved API for fares in #4935 @daniel-heppner-ibigroup has tried it out and has requested there to be a change which accommodates a use case that is important for IBI customers: a discounted transfer ticket where a passenger pays a reduced fare. (We had originally debated that but decided not to do it.)

Since the debate how exactly it needs to be modeled has not been finished yet, I would like to pre-emptively make the `FareProduct` an interface so we don't need to rush to decide the correct type structure..

:bomb: This is a breaking API change :bomb: 

### Issue

Relates to #4935

### Unit tests

Tests updated.

### Documentation

API docs are automatically updated.