### PR TITLE
Area vertex linking improvements

### DIFF
--- a/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
  * replacement of the stop linker, #1305.
  */
 public class VertexLinker {
-
   /**
    * if there are two ways and the distances to them differ by less than this value, we link to both
    * of them
@@ -62,7 +61,7 @@ public class VertexLinker {
   private static final double DUPLICATE_WAY_EPSILON_METERS = 0.001;
   private static final int INITIAL_SEARCH_RADIUS_METERS = 100;
   private static final int MAX_SEARCH_RADIUS_METERS = 1000;
-  private static final int MAX_AREA_LINKS = 100; // exit complex area maximally via this many exit points
+  private static final int MAX_AREA_LINKS = 300; // exit complex area maximally via this many exit points
   private static final GeometryFactory GEOMETRY_FACTORY = GeometryUtils.getGeometryFactory();
   /**
    * Spatial index of StreetEdges in the graph.
@@ -340,6 +339,7 @@ public class VertexLinker {
     double length = SphericalDistanceLibrary.length(orig);
 
     IntersectionVertex start = null;
+    Boolean snapped = true;
 
     // if we're very close to one end of the line or the other, or endwise, don't bother to split,
     // cut to the chase and link directly
@@ -363,6 +363,7 @@ public class VertexLinker {
     ) {
       start = (IntersectionVertex) edge.getToVertex();
     } else {
+      snapped = false;
       boolean split = true;
       // if vertex is inside an area, no need to snap to nearest edge and split it
       if (this.addExtraEdgesToAreas && edge instanceof AreaEdge aEdge) {
@@ -386,7 +387,7 @@ public class VertexLinker {
       }
     }
 
-    if (this.addExtraEdgesToAreas && edge instanceof AreaEdge aEdge) {
+    if (this.addExtraEdgesToAreas && edge instanceof AreaEdge aEdge && !snapped) {
       addAreaVertex(start, aEdge.getArea(), scope, tempEdges);
     }
     // TODO Consider moving this code

--- a/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -62,7 +62,8 @@ public class VertexLinker {
   private static final double DUPLICATE_WAY_EPSILON_METERS = 0.001;
   private static final int INITIAL_SEARCH_RADIUS_METERS = 100;
   private static final int MAX_SEARCH_RADIUS_METERS = 1000;
-  private static final int MAX_AREA_LINKS = 300; // exit complex area maximally via this many exit points
+  // exit a complex area maximally via this many exit points
+  private static final int MAX_AREA_LINKS = 300;
   private static final GeometryFactory GEOMETRY_FACTORY = GeometryUtils.getGeometryFactory();
   /**
    * Spatial index of StreetEdges in the graph.

--- a/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
  * replacement of the stop linker, #1305.
  */
 public class VertexLinker {
+
   /**
    * if there are two ways and the distances to them differ by less than this value, we link to both
    * of them

--- a/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -61,6 +61,7 @@ public class VertexLinker {
   private static final double DUPLICATE_WAY_EPSILON_METERS = 0.001;
   private static final int INITIAL_SEARCH_RADIUS_METERS = 100;
   private static final int MAX_SEARCH_RADIUS_METERS = 1000;
+  private static final int MAX_AREA_LINKS = 100; // exit complex area maximally via this many exit points
   private static final GeometryFactory GEOMETRY_FACTORY = GeometryUtils.getGeometryFactory();
   /**
    * Spatial index of StreetEdges in the graph.
@@ -540,7 +541,18 @@ public class VertexLinker {
 
     int added = 0;
 
+    // if area is too complex, consider only part of visibility nodes
+    float skip_ratio = (float) MAX_AREA_LINKS / (float) visibilityVertices.size();
+    int i = 0;
+    float sum_i = 0;
+
     for (IntersectionVertex v : visibilityVertices) {
+      sum_i += skip_ratio;
+      if (Math.floor(sum_i) < i + 1) {
+        continue;
+      }
+      i = (int) Math.floor(sum_i);
+
       LineString newGeometry = GEOMETRY_FACTORY.createLineString(
         new Coordinate[] { nearestPoints[0], v.getCoordinate() }
       );

--- a/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -388,8 +388,10 @@ public class VertexLinker {
       }
     }
 
-    if (this.addExtraEdgesToAreas && edge instanceof AreaEdge aEdge && !snapped) {
-      addAreaVertex(start, aEdge.getArea(), scope, tempEdges);
+    if (this.addExtraEdgesToAreas && edge instanceof AreaEdge aEdge) {
+      if (!snapped || !aEdge.getArea().visibilityVertices.contains(start)) {
+        addAreaVertex(start, aEdge.getArea(), scope, tempEdges);
+      }
     }
     // TODO Consider moving this code
     if (OTPFeature.FlexRouting.isOn()) {

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -276,6 +276,20 @@ public class StreetEdge
     };
   }
 
+  public void setNoThruTraffic(TraverseMode traverseMode) {
+    switch (traverseMode) {
+      case WALK:
+        setWalkNoThruTraffic(true);
+        break;
+      case BICYCLE, SCOOTER:
+        setBicycleNoThruTraffic(true);
+        break;
+      case CAR, FLEX:
+        setMotorVehicleNoThruTraffic(true);
+        break;
+    }
+  }
+
   /**
    * Calculate the speed appropriately given the RouteRequest and traverseMode.
    */

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -82,15 +82,21 @@ public class LinkStopToPlatformTest {
 
     for (int i = 0; i < platform.length; i++) {
       int next_i = (i + 1) % platform.length;
-      edges.add(createAreaEdge(vertices.get(i), vertices.get(next_i), areaEdgeList, "edge " + i));
-      edges.add(
-        createAreaEdge(
-          vertices.get(next_i),
-          vertices.get(i),
-          areaEdgeList,
-          "edge " + String.valueOf(i + platform.length)
-        )
+
+      var edge1 = createAreaEdge(vertices.get(i), vertices.get(next_i), areaEdgeList, "edge " + i);
+      var edge2 = createAreaEdge(
+        vertices.get(next_i),
+        vertices.get(i),
+        areaEdgeList,
+        "edge " + String.valueOf(i + platform.length)
       );
+      edges.add(edge1);
+      edges.add(edge2);
+      // make one corner surrounded by walk nothru edges
+      if (i < 2) {
+        edge1.setWalkNoThruTraffic(true);
+        edge2.setWalkNoThruTraffic(true);
+      }
     }
 
     RegularStop[] transitStops = new RegularStop[stops.length];
@@ -166,6 +172,17 @@ public class LinkStopToPlatformTest {
     // stop links to a new street vertex with 2 edges
     // new vertex connects to all 4 visibility points with 4*2 new edges
     assertEquals(18, graph.getEdges().size());
+
+    // transit stop is connected in one rectangle corner only to walk no thru trafic edges
+    // verify that new area edge connection is also walk no thru
+    // otherwise connection cannot be used to exit the area
+    var noThruEdges = graph
+      .getEdgesOfType(AreaEdge.class)
+      .stream()
+      .filter(a -> a.isWalkNoThruTraffic())
+      .toList();
+    // original platform has 4 nothru edges, now 2 more got added
+    assertEquals(6, noThruEdges.size());
   }
 
   /**

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -171,6 +171,7 @@ public class LinkStopToPlatformTest {
   /**
    * Link stop which is very close to a platform vertex.
    * Linking snaps directly to the vertex.
+   * Connections to other vertices are not created.
    */
   @Test
   public void testLinkStopNearPlatformVertex() {
@@ -190,8 +191,7 @@ public class LinkStopToPlatformTest {
     linkStops(graph);
 
     // stop links to a existing vertex with 2 edges
-    // selected vertex connects to opposite corner with 2 new edges
-    assertEquals(12, graph.getEdges().size());
+    assertEquals(10, graph.getEdges().size());
   }
 
   /**


### PR DESCRIPTION
### Summary

1. Vertex linker now checks access restrictions (no thru traffic) when connecting new vertices with surrounding area edges. Previously there was a bug that walk routing could not exit areas tagged as access=private or access=destination.

2.  Vertex linker no longer connects linked vertex inside an area with all visibility points, if the vertex was snapped  to an existing visibility vertex due to small distance.  Snapped visibility vertex already has the  visibility connections, so there is no need to generate a new set of them. This fixes  extremely slow linking near vertices which have many (sometimes over 100) existing connections. 

3. Vertex linker now has upper limit for visibility point connections.  It is currently defined as class constant just like other linking parameters. It now has the value 300, meaning that routing can exit a complex area via maximally that many exit points.  The are notoriously complex areas in Lund, Sweden, consisting of thousands of vertices, so this may have a positive effect on routing performance.

### Issue

Closes #5203 

### Unit tests

- One test updated to reflect the optimized 'snap point' linking
- A new test which checks that no thru properties are considered in area linking
  