### PR TITLE
Prevent NPE in vehicle position matching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>1.2.1</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <!-- we have to fork the JVM during tests so that the argLine is passed along -->
                     <forkCount>3</forkCount>
@@ -311,6 +318,20 @@
                     </argLine>
                     <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
                     <disableXmlReport>true</disableXmlReport>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                        <printStacktraceOnError>true</printStacktraceOnError>
+                        <printStacktraceOnFailure>true</printStacktraceOnFailure>
+                        <printStdoutOnError>true</printStdoutOnError>
+                        <printStdoutOnFailure>true</printStdoutOnFailure>
+                        <printStdoutOnSuccess>false</printStdoutOnSuccess>
+                        <printStderrOnError>true</printStderrOnError>
+                        <printStderrOnFailure>true</printStderrOnFailure>
+                        <printStderrOnSuccess>false</printStderrOnSuccess>
+                    </statelessTestsetInfoReporter>
                 </configuration>
             </plugin>
             <!-- code coverage report -->

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -19,7 +19,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.Result;
@@ -67,7 +70,8 @@ public class Timetable implements Serializable {
    * Copy constructor: create an un-indexed Timetable with the same TripTimes as the specified
    * timetable.
    */
-  Timetable(Timetable tt, LocalDate serviceDate) {
+  Timetable(Timetable tt, @Nonnull LocalDate serviceDate) {
+    Objects.requireNonNull(serviceDate);
     tripTimes.addAll(tt.tripTimes);
     this.serviceDate = serviceDate;
     this.pattern = tt.pattern;
@@ -106,6 +110,7 @@ public class Timetable implements Serializable {
     return tripTimes.get(tripIndex);
   }
 
+  @Nullable
   public TripTimes getTripTimes(Trip trip) {
     for (TripTimes tt : tripTimes) {
       if (tt.getTrip() == trip) {
@@ -426,6 +431,7 @@ public class Timetable implements Serializable {
    * The ServiceDate for which this (updated) timetable is valid. If null, then it is valid for all
    * dates.
    */
+  @Nullable
   public LocalDate getServiceDate() {
     return serviceDate;
   }

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -27,9 +27,6 @@ import org.opentripplanner.updater.spi.UpdateSuccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// this is only currently in edgetype because that's where Trippattern is.
-// move these classes elsewhere.
-
 /**
  * Part of concurrency control for stoptime updates.
  * <p>
@@ -40,8 +37,6 @@ import org.slf4j.LoggerFactory;
  * <p>
  * At this point, only one writing thread at a time is supported.
  * <p>
- *  TODO OTP2 - Move this to package: org.opentripplanner.model
- *            - after ass Entur NeTEx PRs are merged.
  */
 public class TimetableSnapshot {
 


### PR DESCRIPTION
### Summary

@amy-corson-ibigroup has reported that the vehicle position updater can run into a `NullPointerException` that then stops all further updates.

This PR checks for that condition and returns a clean error so that other updates can continue. However, more research is necessary why this happens in the first place.

### Unit tests

Added.

### Junit reporter changes

We discussed this in a previous dev meeting and we agreed that we want to try a new test reporter for the console, which are the changes in the pom.

It looks like this:

![Screenshot from 2023-06-21 21-46-27](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/54ee0a25-5149-4821-afe3-f61a73ba5151)
