### PR TITLE
Fix fare leg rule mapper, introduce builder

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/GtfsFaresV2ServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/GtfsFaresV2ServiceTest.java
@@ -126,14 +126,19 @@ class GtfsFaresV2ServiceTest implements PlanTestConstants {
 
   GtfsFaresV2Service service = new GtfsFaresV2Service(
     List.of(
-      new FareLegRule(LEG_GROUP1, null, null, null, single),
-      new FareLegRule(LEG_GROUP1, null, null, OUTER_ZONE, singleToOuter),
-      new FareLegRule(LEG_GROUP1, null, OUTER_ZONE, null, singleFromOuter),
-      new FareLegRule(LEG_GROUP1, null, null, null, dayPass),
-      new FareLegRule(LEG_GROUP1, expressNetwork, null, null, expressPass),
-      new FareLegRule(LEG_GROUP1, localNetwork, null, null, localPass),
-      new FareLegRule(LEG_GROUP1, null, INNER_ZONE, OUTER_ZONE, innerToOuterZoneSingle),
-      new FareLegRule("another-leg-group", null, null, null, monthlyPass)
+      FareLegRule.of(single).withLegGroupId(LEG_GROUP1).build(),
+      FareLegRule.of(singleToOuter).withLegGroupId(LEG_GROUP1).withToAreaId(OUTER_ZONE).build(),
+      FareLegRule.of(singleFromOuter).withLegGroupId(LEG_GROUP1).withFromAreaId(OUTER_ZONE).build(),
+      FareLegRule.of(dayPass).withLegGroupId(LEG_GROUP1).build(),
+      FareLegRule.of(expressPass).withLegGroupId(LEG_GROUP1).withNetworkId(expressNetwork).build(),
+      FareLegRule.of(localPass).withLegGroupId(LEG_GROUP1).withNetworkId(localNetwork).build(),
+      FareLegRule
+        .of(innerToOuterZoneSingle)
+        .withLegGroupId(LEG_GROUP1)
+        .withFromAreaId(INNER_ZONE)
+        .withToAreaId(OUTER_ZONE)
+        .build(),
+      FareLegRule.of(monthlyPass).withLegGroupId("another-leg-group").build()
     ),
     List.of(),
     Multimaps.forMap(
@@ -248,10 +253,25 @@ class GtfsFaresV2ServiceTest implements PlanTestConstants {
 
     GtfsFaresV2Service service = new GtfsFaresV2Service(
       List.of(
-        new FareLegRule(LEG_GROUP2, null, INNER_ZONE, INNER_ZONE, freeTransferFromInnerToOuter),
-        new FareLegRule(LEG_GROUP3, null, OUTER_ZONE, OUTER_ZONE, single),
-        new FareLegRule(LEG_GROUP4, null, null, null, freeTransferSingle),
-        new FareLegRule(LEG_GROUP5, null, INNER_ZONE, OUTER_ZONE, singleToOuter)
+        FareLegRule
+          .of(freeTransferFromInnerToOuter)
+          .withLegGroupId(LEG_GROUP2)
+          .withFromAreaId(INNER_ZONE)
+          .withToAreaId(INNER_ZONE)
+          .build(),
+        FareLegRule
+          .of(single)
+          .withLegGroupId(LEG_GROUP3)
+          .withFromAreaId(OUTER_ZONE)
+          .withToAreaId(OUTER_ZONE)
+          .build(),
+        FareLegRule.of(freeTransferSingle).withLegGroupId(LEG_GROUP4).build(),
+        FareLegRule
+          .of(singleToOuter)
+          .withLegGroupId(LEG_GROUP5)
+          .withFromAreaId(INNER_ZONE)
+          .withToAreaId(OUTER_ZONE)
+          .build()
       ),
       List.of(
         new FareTransferRule(LEG_GROUP1, LEG_GROUP1, 1, null, freeTransfer),
@@ -339,36 +359,24 @@ class GtfsFaresV2ServiceTest implements PlanTestConstants {
     );
 
     List<FareLegRule> stopRules = List.of(
-      new FareLegRule(null, null, null, null, new FareDistance.Stops(0, 3), threeStopProduct),
-      new FareLegRule(null, null, null, null, new FareDistance.Stops(5, 10), fiveStopProduct),
-      new FareLegRule(null, null, null, null, new FareDistance.Stops(12, 20), twelveStopProduct)
+      FareLegRule.of(threeStopProduct).withFareDistance(new FareDistance.Stops(0, 3)).build(),
+      FareLegRule.of(fiveStopProduct).withFareDistance(new FareDistance.Stops(5, 10)).build(),
+      FareLegRule.of(twelveStopProduct).withFareDistance(new FareDistance.Stops(12, 20)).build()
     );
 
     List<FareLegRule> distanceRules = List.of(
-      new FareLegRule(
-        null,
-        null,
-        null,
-        null,
-        new LinearDistance(Distance.ofKilometers(7), Distance.ofKilometers(10)),
-        tenKmProduct
-      ),
-      new FareLegRule(
-        null,
-        null,
-        null,
-        null,
-        new LinearDistance(Distance.ofKilometers(3), Distance.ofKilometers(6)),
-        threeKmProduct
-      ),
-      new FareLegRule(
-        null,
-        null,
-        null,
-        null,
-        new LinearDistance(Distance.ofMeters(0), Distance.ofMeters(2000)),
-        twoKmProduct
-      )
+      FareLegRule
+        .of(tenKmProduct)
+        .withFareDistance(new LinearDistance(Distance.ofKilometers(7), Distance.ofKilometers(10)))
+        .build(),
+      FareLegRule
+        .of(threeKmProduct)
+        .withFareDistance(new LinearDistance(Distance.ofKilometers(3), Distance.ofKilometers(6)))
+        .build(),
+      FareLegRule
+        .of(twoKmProduct)
+        .withFareDistance(new LinearDistance(Distance.ofMeters(0), Distance.ofMeters(2000)))
+        .build()
     );
 
     @Test

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/GtfsFaresV2Service.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/GtfsFaresV2Service.java
@@ -46,7 +46,7 @@ public final class GtfsFaresV2Service implements Serializable {
     this.transferRules = fareTransferRules;
     this.networksWithRules = findNetworksWithRules(legRules);
     this.fromAreasWithRules = findAreasWithRules(legRules, FareLegRule::fromAreaId);
-    this.toAreasWithRules = findAreasWithRules(legRules, FareLegRule::toAreadId);
+    this.toAreasWithRules = findAreasWithRules(legRules, FareLegRule::toAreaId);
     this.stopAreas = stopAreas;
   }
 
@@ -152,7 +152,7 @@ public final class GtfsFaresV2Service implements Serializable {
       // if area id is null, the rule applies to all legs UNLESS there is another rule that
       // covers this area
       matchesArea(leg.getFrom().stop, rule.fromAreaId(), fromAreasWithRules) &&
-      matchesArea(leg.getTo().stop, rule.toAreadId(), toAreasWithRules) &&
+      matchesArea(leg.getTo().stop, rule.toAreaId(), toAreasWithRules) &&
       matchesDistance(leg, rule)
     );
   }

--- a/src/ext/java/org/opentripplanner/ext/fares/model/Distance.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/model/Distance.java
@@ -1,7 +1,10 @@
 package org.opentripplanner.ext.fares.model;
 
+import org.opentripplanner.framework.tostring.ValueObjectToStringBuilder;
+
 public class Distance {
 
+  private static final int METERS_PER_KM = 1000;
   private final double meters;
 
   /** Returns a Distance object representing the given number of meters */
@@ -16,12 +19,7 @@ public class Distance {
 
   /** Returns a Distance object representing the given number of kilometers */
   public static Distance ofKilometers(double value) {
-    return new Distance(value * 1000);
-  }
-
-  /** Returns the distance in kilometers */
-  public double toKilometers() {
-    return this.meters / 1000;
+    return new Distance(value * METERS_PER_KM);
   }
 
   /** Returns the distance in meters */
@@ -29,13 +27,21 @@ public class Distance {
     return this.meters;
   }
 
-  /** Returns whether this distance is greater that the given distance */
-  public boolean isAbove(Distance otherDistance) {
-    return this.toMeters() > otherDistance.toMeters();
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof Distance distance) {
+      return distance.meters == this.meters;
+    } else {
+      return false;
+    }
   }
 
-  /** Returns whether this distance is smaller than the given distance */
-  public boolean isBelow(Distance otherDistance) {
-    return this.toMeters() < otherDistance.toMeters();
+  @Override
+  public String toString() {
+    if (meters < METERS_PER_KM) {
+      return ValueObjectToStringBuilder.of().addNum(meters, "m").toString();
+    } else {
+      return ValueObjectToStringBuilder.of().addNum(meters / 1000, "km").toString();
+    }
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRule.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRule.java
@@ -8,20 +8,15 @@ public record FareLegRule(
   @Nullable String legGroupId,
   @Nullable String networkId,
   @Nullable String fromAreaId,
-  @Nullable String toAreadId,
+  @Nullable String toAreaId,
   @Nullable FareDistance fareDistance,
   @Nonnull FareProduct fareProduct
 ) {
-  public FareLegRule(
-    String legGroupId,
-    String networkId,
-    String fromAreaId,
-    String toAreaId,
-    FareProduct fareProduct
-  ) {
-    this(legGroupId, networkId, fromAreaId, toAreaId, null, fareProduct);
-  }
   public String feedId() {
     return fareProduct.id().getFeedId();
+  }
+
+  public static FareLegRuleBuilder of(FareProduct fp) {
+    return new FareLegRuleBuilder(fp);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRuleBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRuleBuilder.java
@@ -1,0 +1,49 @@
+package org.opentripplanner.ext.fares.model;
+
+import org.opentripplanner.model.fare.FareProduct;
+
+/**
+ * Builder for {@link FareLegRule}.
+ */
+public class FareLegRuleBuilder {
+
+  private final FareProduct fareProduct;
+  private String legGroupId;
+  private String networkId;
+  private String fromAreaId;
+  private FareDistance fareDistance = null;
+  private String toAreaId;
+
+  public FareLegRuleBuilder(FareProduct product) {
+    this.fareProduct = product;
+  }
+
+  public FareLegRuleBuilder withLegGroupId(String legGroupId) {
+    this.legGroupId = legGroupId;
+    return this;
+  }
+
+  public FareLegRuleBuilder withNetworkId(String networkId) {
+    this.networkId = networkId;
+    return this;
+  }
+
+  public FareLegRuleBuilder withFromAreaId(String fromAreaId) {
+    this.fromAreaId = fromAreaId;
+    return this;
+  }
+
+  public FareLegRuleBuilder withFareDistance(FareDistance fareDistance) {
+    this.fareDistance = fareDistance;
+    return this;
+  }
+
+  public FareLegRuleBuilder withToAreaId(String toAreaId) {
+    this.toAreaId = toAreaId;
+    return this;
+  }
+
+  public FareLegRule build() {
+    return new FareLegRule(legGroupId, networkId, fromAreaId, toAreaId, fareDistance, fareProduct);
+  }
+}

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -67,7 +67,9 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
       return new ZipStreamDataSourceDecorator(httpsSource);
     } else {
       throw new UnsupportedOperationException(
-        "Only ZIP archives are supported as composite sources for the HTTPS data source"
+        "Only ZIP archives are supported as composite sources for the HTTPS data source. URL: %s".formatted(
+            uri
+          )
       );
     }
   }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -54,7 +54,7 @@ public class OsmModule implements GraphBuilderModule {
   private final VertexGenerator vertexGenerator;
   private final OsmDatabase osmdb;
 
-  public OsmModule(
+  OsmModule(
     Collection<OsmProvider> providers,
     Graph graph,
     DataImportIssueStore issueStore,

--- a/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
@@ -28,14 +28,14 @@ public final class FareLegRuleMapper {
         FareDistance fareDistance = createFareDistance(r);
 
         if (productForRule != null) {
-          return new FareLegRule(
-            r.getLegGroupId(),
-            r.getNetworkId(),
-            r.getFromAreaId(),
-            r.getToAreaId(),
-            fareDistance,
-            productForRule
-          );
+          return FareLegRule
+            .of(productForRule)
+            .withLegGroupId(r.getLegGroupId())
+            .withNetworkId(r.getNetworkId())
+            .withFromAreaId(r.getFromAreaId())
+            .withToAreaId(r.getToAreaId())
+            .withFareDistance(fareDistance)
+            .build();
         } else {
           issueStore.add(
             "UnknownFareProductId",

--- a/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
@@ -51,7 +51,11 @@ public final class FareLegRuleMapper {
   }
 
   private FareDistance createFareDistance(org.onebusaway.gtfs.model.FareLegRule fareLegRule) {
-    return switch (fareLegRule.getDistanceType()) {
+    final Integer distanceType = fareLegRule.getDistanceType();
+    if (distanceType == null) {
+      return null;
+    }
+    return switch (distanceType) {
       case 0 -> new FareDistance.Stops(
         fareLegRule.getMinDistance().intValue(),
         fareLegRule.getMaxDistance().intValue()

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionPatternMatcher.java
@@ -328,7 +328,7 @@ public class VehiclePositionPatternMatcher {
       return UpdateError.result(scopedTripId, NO_SERVICE_ON_DATE);
     }
 
-    // the trip times are only used or mapping the GTFS-RT stop_sequence back to a stop.
+    // the trip times are only used for mapping the GTFS-RT stop_sequence back to a stop.
     // because new trips without trip times are created for realtime-updated ones, we explicitly
     // look at the static trips for the stop_sequence->stop mapping
     var staticTripTimes = getStaticPattern.apply(trip).getScheduledTimetable().getTripTimes(trip);

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
@@ -1,14 +1,71 @@
 package org.opentripplanner.gtfs.mapping;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.FareLegRule;
+import org.onebusaway.gtfs.model.FareProduct;
+import org.opentripplanner.ext.fares.model.Distance;
+import org.opentripplanner.ext.fares.model.FareDistance;
+import org.opentripplanner.ext.fares.model.FareDistance.LinearDistance;
+import org.opentripplanner.ext.fares.model.FareDistance.Stops;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 
 class FareLegRuleMapperTest {
 
-  @Test
-  void emptyDistance() {
+  private record TestCase(
+    Integer distanceType,
+    Double minDistance,
+    Double maxDistance,
+    FareDistance expectedDistance
+  ) {}
+
+  private final List<TestCase> testCases = List.of(
+    new TestCase(0, 1d, 10d, new Stops(1, 10)),
+    new TestCase(
+      1,
+      5000d,
+      10000d,
+      new LinearDistance(Distance.ofKilometers(5), Distance.ofKilometers(10))
+    ),
+    new TestCase(null, null, null, null)
+  );
+
+  @TestFactory
+  Stream<DynamicTest> mapDistance() {
     var mapper = new FareLegRuleMapper(new FareProductMapper(), DataImportIssueStore.NOOP);
-    var fareLegRules = List.of();
+
+    return testCases
+      .stream()
+      .map(tc ->
+        dynamicTest(
+          tc.toString(),
+          () -> {
+            var fp = new FareProduct();
+            fp.setAmount(10);
+            fp.setName("Day pass");
+            fp.setCurrency("EUR");
+            fp.setFareProductId(new AgencyAndId("1", "1"));
+
+            var obaRule = new FareLegRule();
+            obaRule.setFareProduct(fp);
+            obaRule.setDistanceType(tc.distanceType);
+            obaRule.setMinDistance(tc.minDistance);
+            obaRule.setMinDistance(tc.minDistance);
+            obaRule.setMaxDistance(tc.maxDistance);
+
+            var mappedRules = List.copyOf(mapper.map(List.of(obaRule)));
+            assertEquals(1, mappedRules.size());
+
+            var otpRule = mappedRules.get(0);
+            assertEquals(otpRule.fareDistance(), tc.expectedDistance);
+          }
+        )
+      );
   }
 }

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
@@ -1,0 +1,14 @@
+package org.opentripplanner.gtfs.mapping;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+
+class FareLegRuleMapperTest {
+
+  @Test
+  void emptyDistance() {
+    var mapper = new FareLegRuleMapper(new FareProductMapper(), DataImportIssueStore.NOOP);
+    var fareLegRules = List.of();
+  }
+}

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
@@ -56,7 +56,6 @@ class FareLegRuleMapperTest {
             obaRule.setFareProduct(fp);
             obaRule.setDistanceType(tc.distanceType);
             obaRule.setMinDistance(tc.minDistance);
-            obaRule.setMinDistance(tc.minDistance);
             obaRule.setMaxDistance(tc.maxDistance);
 
             var mappedRules = List.copyOf(mapper.map(List.of(obaRule)));

--- a/src/test/java/org/opentripplanner/transit/model/timetable/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/timetable/TripTimesTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 import static org.opentripplanner.transit.model.timetable.ValidationError.ErrorCode.NEGATIVE_DWELL_TIME;
 import static org.opentripplanner.transit.model.timetable.ValidationError.ErrorCode.NEGATIVE_HOP_TIME;
 
@@ -24,24 +25,15 @@ class TripTimesTest {
 
   private static final String TRIP_ID = "testTripId";
 
-  private static final FeedScopedId STOP_A = TransitModelForTest.id("A"); // 0
-  private static final FeedScopedId STOP_B = TransitModelForTest.id("B"); // 1
-  private static final FeedScopedId STOP_C = TransitModelForTest.id("C"); // 2
-  private static final FeedScopedId STOP_D = TransitModelForTest.id("D"); // 3
-  private static final FeedScopedId STOP_E = TransitModelForTest.id("E"); // 4
-  private static final FeedScopedId STOP_F = TransitModelForTest.id("F"); // 5
-  private static final FeedScopedId STOP_G = TransitModelForTest.id("G"); // 6
-  private static final FeedScopedId STOP_H = TransitModelForTest.id("H"); // 7
-
   private static final List<FeedScopedId> stops = List.of(
-    STOP_A,
-    STOP_B,
-    STOP_C,
-    STOP_D,
-    STOP_E,
-    STOP_F,
-    STOP_G,
-    STOP_H
+    id("A"),
+    id("B"),
+    id("C"),
+    id("D"),
+    id("E"),
+    id("F"),
+    id("G"),
+    id("H")
   );
 
   static TripTimes createInitialTripTimes() {
@@ -64,7 +56,7 @@ class TripTimesTest {
   }
 
   @Nested
-  class HeadsignTest {
+  class Headsign {
 
     private static final NonLocalizedString STOP_TEST_DIRECTION = new NonLocalizedString(
       "STOP TEST DIRECTION"
@@ -232,23 +224,27 @@ class TripTimesTest {
     assertFalse(updatedTripTimesA.isNoDataStop(2));
   }
 
-  @Test
-  void gtfsSequence() {
-    var stopIndex = createInitialTripTimes().gtfsSequenceOfStopIndex(2);
-    assertEquals(20, stopIndex);
-  }
+  @Nested
+  class GtfsStopSequence {
 
-  @Test
-  void stopIndexOfGtfsSequence() {
-    var stopIndex = createInitialTripTimes().stopIndexOfGtfsSequence(40);
-    assertTrue(stopIndex.isPresent());
-    assertEquals(4, stopIndex.getAsInt());
-  }
+    @Test
+    void gtfsSequence() {
+      var stopIndex = createInitialTripTimes().gtfsSequenceOfStopIndex(2);
+      assertEquals(20, stopIndex);
+    }
 
-  @Test
-  void unknownGtfsSequence() {
-    var stopIndex = createInitialTripTimes().stopIndexOfGtfsSequence(4);
-    assertTrue(stopIndex.isEmpty());
+    @Test
+    void stopIndexOfGtfsSequence() {
+      var stopIndex = createInitialTripTimes().stopIndexOfGtfsSequence(40);
+      assertTrue(stopIndex.isPresent());
+      assertEquals(4, stopIndex.getAsInt());
+    }
+
+    @Test
+    void unknownGtfsSequence() {
+      var stopIndex = createInitialTripTimes().stopIndexOfGtfsSequence(4);
+      assertTrue(stopIndex.isEmpty());
+    }
   }
 
   @Test


### PR DESCRIPTION
### Summary

The actual core of the PR is quite simple: the `FareLegMapper` was not null-aware and caused an NPE when no distance type was set.

On top of the actual bug fix, I made the following improvements:

- Introduce a builder for `FareLegRule` so that you don't have to pass so many `nulls` to the constructor
- Refactored some tests

### Unit tests

A new unit test was added where I experimented with the `@TestFactory` annotation.

cc @lslangley @drewda 