### PR TITLE
Refactor edge constructors

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
@@ -16,12 +16,12 @@ import org.opentripplanner.transit.model.site.StopLocation;
 public class FlexTripEdge extends Edge {
 
   private final FlexTrip trip;
-  public StopLocation s1;
-  public StopLocation s2;
-  public FlexAccessEgressTemplate flexTemplate;
-  public FlexPath flexPath;
+  public final StopLocation s1;
+  public final StopLocation s2;
+  public final FlexAccessEgressTemplate flexTemplate;
+  public final FlexPath flexPath;
 
-  public FlexTripEdge(
+  private FlexTripEdge(
     Vertex v1,
     Vertex v2,
     StopLocation s1,
@@ -30,12 +30,28 @@ public class FlexTripEdge extends Edge {
     FlexAccessEgressTemplate flexTemplate,
     FlexPath flexPath
   ) {
-    super(v1, v2, ConnectToGraph.TEMPORARY_EDGE_NOT_CONNECTED_TO_GRAPH);
+    super(v1, v2);
     this.s1 = s1;
     this.s2 = s2;
     this.trip = trip;
     this.flexTemplate = flexTemplate;
     this.flexPath = Objects.requireNonNull(flexPath);
+  }
+
+  /**
+   * Create a Flex Trip.
+   * Flex trips are not connected to the graph.
+   */
+  public static FlexTripEdge createFlexTripEdge(
+    Vertex v1,
+    Vertex v2,
+    StopLocation s1,
+    StopLocation s2,
+    FlexTrip trip,
+    FlexAccessEgressTemplate flexTemplate,
+    FlexPath flexPath
+  ) {
+    return new FlexTripEdge(v1, v2, s1, s2, trip, flexTemplate, flexPath);
   }
 
   public int getTimeInSeconds() {

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
@@ -150,7 +150,7 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
       return null;
     }
 
-    return new FlexTripEdge(
+    return FlexTripEdge.createFlexTripEdge(
       accessEgress.state.getVertex(),
       flexToVertex,
       accessEgress.stop,

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
@@ -73,7 +73,7 @@ public class FlexEgressTemplate extends FlexAccessEgressTemplate {
       return null;
     }
 
-    return new FlexTripEdge(
+    return FlexTripEdge.createFlexTripEdge(
       flexFromVertex,
       accessEgress.state.getVertex(),
       transferStop,

--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -159,7 +159,7 @@ public class AddTransitModelEntitiesToGraph {
         var platformVertex = stationElementNodes.get(boardingArea.getParentStop());
         boolean wheelchair = boardingArea.getWheelchairAccessibility() == Accessibility.POSSIBLE;
 
-        PathwayEdge.lowCost(
+        PathwayEdge.createLowCostPathwayEdge(
           boardingAreaVertex,
           platformVertex,
           boardingArea.getId(),
@@ -168,7 +168,7 @@ public class AddTransitModelEntitiesToGraph {
           PathwayMode.WALKWAY
         );
 
-        PathwayEdge.lowCost(
+        PathwayEdge.createLowCostPathwayEdge(
           platformVertex,
           boardingAreaVertex,
           boardingArea.getId(),
@@ -198,7 +198,7 @@ public class AddTransitModelEntitiesToGraph {
             .filter(l -> l > 0)
             .orElseGet(() -> distance(fromVertex.getCoordinate(), toVertex.getCoordinate()));
 
-          new PathwayEdge(
+          PathwayEdge.createPathwayEdge(
             fromVertex,
             toVertex,
             pathway.getId(),
@@ -211,7 +211,7 @@ public class AddTransitModelEntitiesToGraph {
             pathway.getPathwayMode()
           );
           if (pathway.isBidirectional()) {
-            new PathwayEdge(
+            PathwayEdge.createPathwayEdge(
               toVertex,
               fromVertex,
               pathway.getId(),
@@ -269,8 +269,18 @@ public class AddTransitModelEntitiesToGraph {
       toLevel.name().toString()
     );
 
-    PathwayEdge.lowCost(fromVertex, fromOffboardVertex, fromVertex.getName(), PathwayMode.ELEVATOR);
-    PathwayEdge.lowCost(toOffboardVertex, toVertex, toVertex.getName(), PathwayMode.ELEVATOR);
+    PathwayEdge.createLowCostPathwayEdge(
+      fromVertex,
+      fromOffboardVertex,
+      fromVertex.getName(),
+      PathwayMode.ELEVATOR
+    );
+    PathwayEdge.createLowCostPathwayEdge(
+      toOffboardVertex,
+      toVertex,
+      toVertex.getName(),
+      PathwayMode.ELEVATOR
+    );
 
     ElevatorOnboardVertex fromOnboardVertex = vertexFactory.elevatorOnboard(
       fromVertex,
@@ -283,11 +293,11 @@ public class AddTransitModelEntitiesToGraph {
       toLevel.name().toString()
     );
 
-    new ElevatorBoardEdge(fromOffboardVertex, fromOnboardVertex);
-    new ElevatorAlightEdge(toOnboardVertex, toOffboardVertex, toLevel.name());
+    ElevatorBoardEdge.createElevatorBoardEdge(fromOffboardVertex, fromOnboardVertex);
+    ElevatorAlightEdge.createElevatorAlightEdge(toOnboardVertex, toOffboardVertex, toLevel.name());
 
     StreetTraversalPermission permission = StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
-    new ElevatorHopEdge(
+    ElevatorHopEdge.createElevatorHopEdge(
       fromOnboardVertex,
       toOnboardVertex,
       permission,
@@ -297,16 +307,25 @@ public class AddTransitModelEntitiesToGraph {
     );
 
     if (pathway.isBidirectional()) {
-      PathwayEdge.lowCost(
+      PathwayEdge.createLowCostPathwayEdge(
         fromOffboardVertex,
         fromVertex,
         fromVertex.getName(),
         PathwayMode.ELEVATOR
       );
-      PathwayEdge.lowCost(toVertex, toOffboardVertex, toVertex.getName(), PathwayMode.ELEVATOR);
-      new ElevatorBoardEdge(toOffboardVertex, toOnboardVertex);
-      new ElevatorAlightEdge(fromOnboardVertex, fromOffboardVertex, fromLevel.name());
-      new ElevatorHopEdge(
+      PathwayEdge.createLowCostPathwayEdge(
+        toVertex,
+        toOffboardVertex,
+        toVertex.getName(),
+        PathwayMode.ELEVATOR
+      );
+      ElevatorBoardEdge.createElevatorBoardEdge(toOffboardVertex, toOnboardVertex);
+      ElevatorAlightEdge.createElevatorAlightEdge(
+        fromOnboardVertex,
+        fromOffboardVertex,
+        fromLevel.name()
+      );
+      ElevatorHopEdge.createElevatorHopEdge(
         toOnboardVertex,
         fromOnboardVertex,
         permission,

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -185,7 +185,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
 
   private StreetEdge linkBoardingLocationToStreetNetwork(StreetVertex from, StreetVertex to) {
     var line = GeometryUtils.makeLineString(List.of(from.getCoordinate(), to.getCoordinate()));
-    return new StreetEdge(
+    return StreetEdge.createStreetEdge(
       from,
       to,
       line,
@@ -201,8 +201,8 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
     String stopCode,
     OsmBoardingLocationVertex boardingLocation
   ) {
-    new BoardingLocationToStopLink(ts, boardingLocation);
-    new BoardingLocationToStopLink(boardingLocation, ts);
+    BoardingLocationToStopLink.createBoardingLocationToStopLink(ts, boardingLocation);
+    BoardingLocationToStopLink.createBoardingLocationToStopLink(boardingLocation, ts);
     LOG.debug(
       "Connected {} ({}) to {} at {}",
       ts,

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -134,8 +134,14 @@ public class StreetLinkerModule implements GraphBuilderModule {
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) ->
             List.of(
-              new StreetTransitStopLink((TransitStopVertex) vertex, streetVertex),
-              new StreetTransitStopLink(streetVertex, (TransitStopVertex) vertex)
+              StreetTransitStopLink.createStreetTransitStopLink(
+                (TransitStopVertex) vertex,
+                streetVertex
+              ),
+              StreetTransitStopLink.createStreetTransitStopLink(
+                streetVertex,
+                (TransitStopVertex) vertex
+              )
             )
         );
       //noinspection Convert2MethodRef
@@ -157,8 +163,14 @@ public class StreetLinkerModule implements GraphBuilderModule {
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) ->
             List.of(
-              new StreetVehicleParkingLink((VehicleParkingEntranceVertex) vertex, streetVertex),
-              new StreetVehicleParkingLink(streetVertex, (VehicleParkingEntranceVertex) vertex)
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                (VehicleParkingEntranceVertex) vertex,
+                streetVertex
+              ),
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                streetVertex,
+                (VehicleParkingEntranceVertex) vertex
+              )
             )
         );
     }
@@ -172,8 +184,14 @@ public class StreetLinkerModule implements GraphBuilderModule {
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) ->
             List.of(
-              new StreetVehicleParkingLink((VehicleParkingEntranceVertex) vertex, streetVertex),
-              new StreetVehicleParkingLink(streetVertex, (VehicleParkingEntranceVertex) vertex)
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                (VehicleParkingEntranceVertex) vertex,
+                streetVertex
+              ),
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                streetVertex,
+                (VehicleParkingEntranceVertex) vertex
+              )
             )
         );
     }
@@ -190,8 +208,14 @@ public class StreetLinkerModule implements GraphBuilderModule {
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) ->
             List.of(
-              new StreetTransitEntranceLink((TransitEntranceVertex) vertex, streetVertex),
-              new StreetTransitEntranceLink(streetVertex, (TransitEntranceVertex) vertex)
+              StreetTransitEntranceLink.createStreetTransitEntranceLink(
+                (TransitEntranceVertex) vertex,
+                streetVertex
+              ),
+              StreetTransitEntranceLink.createStreetTransitEntranceLink(
+                streetVertex,
+                (TransitEntranceVertex) vertex
+              )
             )
         );
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ElevatorProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ElevatorProcessor.java
@@ -161,8 +161,8 @@ class ElevatorProcessor {
       levelName
     );
 
-    new FreeEdge(sourceVertex, offboardVertex);
-    new FreeEdge(offboardVertex, sourceVertex);
+    FreeEdge.createFreeEdge(sourceVertex, offboardVertex);
+    FreeEdge.createFreeEdge(offboardVertex, sourceVertex);
 
     ElevatorOnboardVertex onboardVertex = factory.elevatorOnboard(
       sourceVertex,
@@ -170,8 +170,12 @@ class ElevatorProcessor {
       levelName
     );
 
-    new ElevatorBoardEdge(offboardVertex, onboardVertex);
-    new ElevatorAlightEdge(onboardVertex, offboardVertex, new NonLocalizedString(levelName));
+    ElevatorBoardEdge.createElevatorBoardEdge(offboardVertex, onboardVertex);
+    ElevatorAlightEdge.createElevatorAlightEdge(
+      onboardVertex,
+      offboardVertex,
+      new NonLocalizedString(levelName)
+    );
 
     // accumulate onboard vertices to so they can be connected by hop edges later
     onboardVertices.add(onboardVertex);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -516,7 +516,7 @@ public class OsmModule implements GraphBuilderModule {
     I18NString name = params.edgeNamer().getNameForWay(way, label);
     float carSpeed = way.getOsmProvider().getOsmTagMapper().getCarSpeedForWay(way, back);
 
-    StreetEdge street = new StreetEdge(
+    StreetEdge street = StreetEdge.createStreetEdge(
       startEndpoint,
       endEndpoint,
       geometry,

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -101,7 +101,7 @@ class ParkingProcessor {
       VehicleParkingEntranceVertex parkVertex = vertexFactory.vehicleParkingEntrance(
         vehicleParking
       );
-      new VehicleParkingEdge(parkVertex);
+      VehicleParkingEdge.createVehicleParkingEdge(parkVertex);
     }
 
     LOG.info("Created {} {} P+R nodes.", n, isCarParkAndRide ? "car" : "bike");

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -527,7 +527,7 @@ public class WalkableAreaBuilder {
         endEndpoint.getLabel();
       I18NString name = namer.getNameForWay(areaEntity, label);
 
-      AreaEdge street = new AreaEdge(
+      AreaEdge street = AreaEdge.createAreaEdge(
         startEndpoint,
         endEndpoint,
         line,
@@ -558,7 +558,7 @@ public class WalkableAreaBuilder {
         startEndpoint.getLabel();
       name = namer.getNameForWay(areaEntity, label);
 
-      AreaEdge backStreet = new AreaEdge(
+      AreaEdge backStreet = AreaEdge.createAreaEdge(
         endEndpoint,
         startEndpoint,
         line.reverse(),

--- a/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
@@ -111,18 +111,18 @@ public class StreetIndex {
         edgeLocation = fromv;
 
         if (endVertex) {
-          tempEdges.addEdge(new TemporaryFreeEdge(edgeLocation, location));
+          tempEdges.addEdge(TemporaryFreeEdge.createTemporaryFreeEdge(edgeLocation, location));
         } else {
-          tempEdges.addEdge(new TemporaryFreeEdge(location, edgeLocation));
+          tempEdges.addEdge(TemporaryFreeEdge.createTemporaryFreeEdge(location, edgeLocation));
         }
       } else if (SphericalDistanceLibrary.distance(nearestPoint, tov.getCoordinate()) < 1) {
         // no need to link to area edges caught on-end
         edgeLocation = tov;
 
         if (endVertex) {
-          tempEdges.addEdge(new TemporaryFreeEdge(edgeLocation, location));
+          tempEdges.addEdge(TemporaryFreeEdge.createTemporaryFreeEdge(edgeLocation, location));
         } else {
-          tempEdges.addEdge(new TemporaryFreeEdge(location, edgeLocation));
+          tempEdges.addEdge(TemporaryFreeEdge.createTemporaryFreeEdge(location, edgeLocation));
         }
       } else {
         // creates links from street head -> location -> street tail.
@@ -276,7 +276,7 @@ public class StreetIndex {
     double lengthOut = street.getDistanceMeters() * (1 - lengthRatioIn);
 
     if (endVertex) {
-      TemporaryPartialStreetEdge temporaryPartialStreetEdge = new TemporaryPartialStreetEdge(
+      TemporaryPartialStreetEdge temporaryPartialStreetEdge = TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
         street,
         fromv,
         base,
@@ -291,7 +291,7 @@ public class StreetIndex {
       temporaryPartialStreetEdge.setLink(street.isLink());
       tempEdges.addEdge(temporaryPartialStreetEdge);
     } else {
-      TemporaryPartialStreetEdge temporaryPartialStreetEdge = new TemporaryPartialStreetEdge(
+      TemporaryPartialStreetEdge temporaryPartialStreetEdge = TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
         street,
         base,
         tov,
@@ -364,9 +364,19 @@ public class StreetIndex {
         endVertex ? LinkingDirection.OUTGOING : LinkingDirection.INCOMING,
         endVertex
           ? (vertex, streetVertex) ->
-            List.of(new TemporaryFreeEdge(streetVertex, (TemporaryStreetLocation) vertex))
+            List.of(
+              TemporaryFreeEdge.createTemporaryFreeEdge(
+                streetVertex,
+                (TemporaryStreetLocation) vertex
+              )
+            )
           : (vertex, streetVertex) ->
-            List.of(new TemporaryFreeEdge((TemporaryStreetLocation) vertex, streetVertex))
+            List.of(
+              TemporaryFreeEdge.createTemporaryFreeEdge(
+                (TemporaryStreetLocation) vertex,
+                streetVertex
+              )
+            )
       )
     );
 

--- a/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -640,7 +640,7 @@ public class VertexLinker {
       var incomingNoThruModes = getNoThruModes(to.getIncoming());
       var outgoingNoThruModes = getNoThruModes(to.getIncoming());
 
-      AreaEdge ae = new AreaEdge(
+      AreaEdge ae = AreaEdge.createAreaEdge(
         from,
         to,
         line,
@@ -659,7 +659,7 @@ public class VertexLinker {
       }
 
       ae =
-        new AreaEdge(
+        AreaEdge.createAreaEdge(
           to,
           from,
           line.reverse(),

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingHelper.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingHelper.java
@@ -39,24 +39,24 @@ public class VehicleParkingHelper {
     for (int i = 0; i < vehicleParkingVertices.size(); i++) {
       var currentVertex = vehicleParkingVertices.get(i);
       if (isUsableForParking(currentVertex, currentVertex)) {
-        new VehicleParkingEdge(currentVertex);
+        VehicleParkingEdge.createVehicleParkingEdge(currentVertex);
       }
       for (int j = i + 1; j < vehicleParkingVertices.size(); j++) {
         var nextVertex = vehicleParkingVertices.get(j);
         if (isUsableForParking(currentVertex, nextVertex)) {
-          new VehicleParkingEdge(currentVertex, nextVertex);
-          new VehicleParkingEdge(nextVertex, currentVertex);
+          VehicleParkingEdge.createVehicleParkingEdge(currentVertex, nextVertex);
+          VehicleParkingEdge.createVehicleParkingEdge(nextVertex, currentVertex);
         }
       }
     }
   }
 
   public static void linkToGraph(VehicleParkingEntranceVertex vehicleParkingEntrance) {
-    new StreetVehicleParkingLink(
+    StreetVehicleParkingLink.createStreetVehicleParkingLink(
       vehicleParkingEntrance,
       vehicleParkingEntrance.getParkingEntrance().getVertex()
     );
-    new StreetVehicleParkingLink(
+    StreetVehicleParkingLink.createStreetVehicleParkingLink(
       vehicleParkingEntrance.getParkingEntrance().getVertex(),
       vehicleParkingEntrance
     );

--- a/src/main/java/org/opentripplanner/service/vehiclerental/street/StreetVehicleRentalLink.java
+++ b/src/main/java/org/opentripplanner/service/vehiclerental/street/StreetVehicleRentalLink.java
@@ -14,14 +14,28 @@ public class StreetVehicleRentalLink extends Edge {
 
   private final VehicleRentalPlaceVertex vehicleRentalPlaceVertex;
 
-  public StreetVehicleRentalLink(StreetVertex fromv, VehicleRentalPlaceVertex tov) {
+  private StreetVehicleRentalLink(StreetVertex fromv, VehicleRentalPlaceVertex tov) {
     super(fromv, tov);
     vehicleRentalPlaceVertex = tov;
   }
 
-  public StreetVehicleRentalLink(VehicleRentalPlaceVertex fromv, StreetVertex tov) {
+  private StreetVehicleRentalLink(VehicleRentalPlaceVertex fromv, StreetVertex tov) {
     super(fromv, tov);
     vehicleRentalPlaceVertex = fromv;
+  }
+
+  public static StreetVehicleRentalLink createStreetVehicleRentalLink(
+    StreetVertex fromv,
+    VehicleRentalPlaceVertex tov
+  ) {
+    return connectToGraph(new StreetVehicleRentalLink(fromv, tov));
+  }
+
+  public static StreetVehicleRentalLink createStreetVehicleRentalLink(
+    VehicleRentalPlaceVertex fromv,
+    StreetVertex tov
+  ) {
+    return connectToGraph(new StreetVehicleRentalLink(fromv, tov));
   }
 
   public String toString() {

--- a/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
+++ b/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
@@ -18,11 +18,18 @@ import org.opentripplanner.street.search.state.StateEditor;
  */
 public class VehicleRentalEdge extends Edge {
 
-  public RentalFormFactor formFactor;
+  public final RentalFormFactor formFactor;
 
-  public VehicleRentalEdge(VehicleRentalPlaceVertex vertex, RentalFormFactor formFactor) {
+  private VehicleRentalEdge(VehicleRentalPlaceVertex vertex, RentalFormFactor formFactor) {
     super(vertex, vertex);
     this.formFactor = formFactor;
+  }
+
+  public static VehicleRentalEdge createVehicleRentalEdge(
+    VehicleRentalPlaceVertex vertex,
+    RentalFormFactor formFactor
+  ) {
+    return connectToGraph(new VehicleRentalEdge(vertex, formFactor));
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/edge/AreaEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/AreaEdge.java
@@ -9,7 +9,7 @@ public class AreaEdge extends StreetEdge {
 
   private final AreaEdgeList area;
 
-  public AreaEdge(
+  private AreaEdge(
     IntersectionVertex startEndpoint,
     IntersectionVertex endEndpoint,
     LineString geometry,
@@ -24,7 +24,7 @@ public class AreaEdge extends StreetEdge {
   }
 
   // constructor without precomputed length
-  public AreaEdge(
+  private AreaEdge(
     IntersectionVertex startEndpoint,
     IntersectionVertex endEndpoint,
     LineString geometry,
@@ -35,6 +35,35 @@ public class AreaEdge extends StreetEdge {
   ) {
     super(startEndpoint, endEndpoint, geometry, name, permissions, back);
     this.area = area;
+  }
+
+  public static AreaEdge createAreaEdge(
+    IntersectionVertex startEndpoint,
+    IntersectionVertex endEndpoint,
+    LineString geometry,
+    I18NString name,
+    double length,
+    StreetTraversalPermission permissions,
+    boolean back,
+    AreaEdgeList area
+  ) {
+    return connectToGraph(
+      new AreaEdge(startEndpoint, endEndpoint, geometry, name, length, permissions, back, area)
+    );
+  }
+
+  public static AreaEdge createAreaEdge(
+    IntersectionVertex startEndpoint,
+    IntersectionVertex endEndpoint,
+    LineString geometry,
+    I18NString name,
+    StreetTraversalPermission permissions,
+    boolean back,
+    AreaEdgeList area
+  ) {
+    return connectToGraph(
+      new AreaEdge(startEndpoint, endEndpoint, geometry, name, permissions, back, area)
+    );
   }
 
   public AreaEdgeList getArea() {

--- a/src/main/java/org/opentripplanner/street/model/edge/BoardingLocationToStopLink.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/BoardingLocationToStopLink.java
@@ -12,12 +12,26 @@ import org.opentripplanner.street.model.vertex.TransitStopVertex;
  */
 public class BoardingLocationToStopLink extends StreetTransitEntityLink<TransitStopVertex> {
 
-  public BoardingLocationToStopLink(OsmBoardingLocationVertex fromv, TransitStopVertex tov) {
+  private BoardingLocationToStopLink(OsmBoardingLocationVertex fromv, TransitStopVertex tov) {
     super(fromv, tov, tov.getWheelchairAccessibility());
   }
 
-  public BoardingLocationToStopLink(TransitStopVertex fromv, OsmBoardingLocationVertex tov) {
+  private BoardingLocationToStopLink(TransitStopVertex fromv, OsmBoardingLocationVertex tov) {
     super(fromv, tov, fromv.getWheelchairAccessibility());
+  }
+
+  public static BoardingLocationToStopLink createBoardingLocationToStopLink(
+    OsmBoardingLocationVertex fromv,
+    TransitStopVertex tov
+  ) {
+    return connectToGraph(new BoardingLocationToStopLink(fromv, tov));
+  }
+
+  public static BoardingLocationToStopLink createBoardingLocationToStopLink(
+    TransitStopVertex fromv,
+    OsmBoardingLocationVertex tov
+  ) {
+    return connectToGraph(new BoardingLocationToStopLink(fromv, tov));
   }
 
   protected int getStreetToStopTime() {

--- a/src/main/java/org/opentripplanner/street/model/edge/ElevatorAlightEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/ElevatorAlightEdge.java
@@ -32,7 +32,7 @@ public class ElevatorAlightEdge extends Edge implements BikeWalkableEdge, Elevat
   /**
    * @param level It's a float for future expansion.
    */
-  public ElevatorAlightEdge(
+  private ElevatorAlightEdge(
     ElevatorOnboardVertex from,
     ElevatorOffboardVertex to,
     I18NString level
@@ -45,6 +45,14 @@ public class ElevatorAlightEdge extends Edge implements BikeWalkableEdge, Elevat
     coords[0] = new Coordinate(from.getX(), from.getY());
     coords[1] = new Coordinate(to.getX(), to.getY());
     the_geom = GeometryUtils.getGeometryFactory().createLineString(coords);
+  }
+
+  public static ElevatorAlightEdge createElevatorAlightEdge(
+    ElevatorOnboardVertex from,
+    ElevatorOffboardVertex to,
+    I18NString level
+  ) {
+    return connectToGraph(new ElevatorAlightEdge(from, to, level));
   }
 
   public String toString() {

--- a/src/main/java/org/opentripplanner/street/model/edge/ElevatorBoardEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/ElevatorBoardEdge.java
@@ -25,12 +25,19 @@ public class ElevatorBoardEdge extends Edge implements BikeWalkableEdge, Elevato
    */
   private final LineString geometry;
 
-  public ElevatorBoardEdge(ElevatorOffboardVertex from, ElevatorOnboardVertex to) {
+  private ElevatorBoardEdge(ElevatorOffboardVertex from, ElevatorOnboardVertex to) {
     super(from, to);
     geometry =
       GeometryUtils.makeLineString(
         List.of(new Coordinate(from.getX(), from.getY()), new Coordinate(to.getX(), to.getY()))
       );
+  }
+
+  public static ElevatorBoardEdge createElevatorBoardEdge(
+    ElevatorOffboardVertex from,
+    ElevatorOnboardVertex to
+  ) {
+    return connectToGraph(new ElevatorBoardEdge(from, to));
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
@@ -25,7 +25,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
   private double levels = 1;
   private int travelTime = 0;
 
-  public ElevatorHopEdge(
+  private ElevatorHopEdge(
     Vertex from,
     Vertex to,
     StreetTraversalPermission permission,
@@ -38,7 +38,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     this.travelTime = travelTime;
   }
 
-  public ElevatorHopEdge(
+  private ElevatorHopEdge(
     Vertex from,
     Vertex to,
     StreetTraversalPermission permission,
@@ -57,8 +57,8 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     int levels,
     int travelTime
   ) {
-    new ElevatorHopEdge(from, to, permission, wheelchairBoarding, levels, travelTime);
-    new ElevatorHopEdge(to, from, permission, wheelchairBoarding, levels, travelTime);
+    createElevatorHopEdge(from, to, permission, wheelchairBoarding, levels, travelTime);
+    createElevatorHopEdge(to, from, permission, wheelchairBoarding, levels, travelTime);
   }
 
   public static void bidirectional(
@@ -67,8 +67,30 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     StreetTraversalPermission permission,
     Accessibility wheelchairBoarding
   ) {
-    new ElevatorHopEdge(from, to, permission, wheelchairBoarding);
-    new ElevatorHopEdge(to, from, permission, wheelchairBoarding);
+    createElevatorHopEdge(from, to, permission, wheelchairBoarding);
+    createElevatorHopEdge(to, from, permission, wheelchairBoarding);
+  }
+
+  public static ElevatorHopEdge createElevatorHopEdge(
+    Vertex from,
+    Vertex to,
+    StreetTraversalPermission permission,
+    Accessibility wheelchairAccessibility,
+    double levels,
+    int travelTime
+  ) {
+    return connectToGraph(
+      new ElevatorHopEdge(from, to, permission, wheelchairAccessibility, levels, travelTime)
+    );
+  }
+
+  public static ElevatorHopEdge createElevatorHopEdge(
+    Vertex from,
+    Vertex to,
+    StreetTraversalPermission permission,
+    Accessibility wheelchairAccessibility
+  ) {
+    return connectToGraph(new ElevatorHopEdge(from, to, permission, wheelchairAccessibility));
   }
 
   public StreetTraversalPermission getPermission() {

--- a/src/main/java/org/opentripplanner/street/model/edge/FreeEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/FreeEdge.java
@@ -14,8 +14,12 @@ import org.opentripplanner.street.search.state.StateEditor;
  */
 public class FreeEdge extends Edge {
 
-  public FreeEdge(Vertex from, Vertex to) {
+  protected FreeEdge(Vertex from, Vertex to) {
     super(from, to);
+  }
+
+  public static FreeEdge createFreeEdge(Vertex from, Vertex to) {
+    return connectToGraph(new FreeEdge(from, to));
   }
 
   public String toString() {

--- a/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
@@ -30,7 +30,7 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
   private final boolean wheelchairAccessible;
   private final FeedScopedId id;
 
-  public PathwayEdge(
+  private PathwayEdge(
     Vertex fromv,
     Vertex tov,
     FeedScopedId id,
@@ -54,10 +54,15 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
   }
 
   /**
-   * {@link PathwayEdge#lowCost(Vertex, Vertex, FeedScopedId, I18NString, boolean, PathwayMode)}
+   * {@link PathwayEdge#createLowCostPathwayEdge(Vertex, Vertex, FeedScopedId, I18NString, boolean, PathwayMode)}
    */
-  public static PathwayEdge lowCost(Vertex fromV, Vertex toV, I18NString name, PathwayMode mode) {
-    return PathwayEdge.lowCost(fromV, toV, null, name, true, mode);
+  public static PathwayEdge createLowCostPathwayEdge(
+    Vertex fromV,
+    Vertex toV,
+    I18NString name,
+    PathwayMode mode
+  ) {
+    return PathwayEdge.createLowCostPathwayEdge(fromV, toV, null, name, true, mode);
   }
 
   /**
@@ -65,7 +70,7 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
    * <p>
    * These are for edges which have an implied cost of almost zero just like a FreeEdge has.
    */
-  public static PathwayEdge lowCost(
+  public static PathwayEdge createLowCostPathwayEdge(
     Vertex fromV,
     Vertex toV,
     FeedScopedId id,
@@ -73,7 +78,35 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
     boolean wheelchairAccessible,
     PathwayMode mode
   ) {
-    return new PathwayEdge(fromV, toV, id, name, 0, 0, 0, 0, wheelchairAccessible, mode);
+    return createPathwayEdge(fromV, toV, id, name, 0, 0, 0, 0, wheelchairAccessible, mode);
+  }
+
+  public static PathwayEdge createPathwayEdge(
+    Vertex fromv,
+    Vertex tov,
+    FeedScopedId id,
+    I18NString name,
+    int traversalTime,
+    double distance,
+    int steps,
+    double slope,
+    boolean wheelchairAccessible,
+    PathwayMode mode
+  ) {
+    return connectToGraph(
+      new PathwayEdge(
+        fromv,
+        tov,
+        id,
+        name,
+        traversalTime,
+        distance,
+        steps,
+        slope,
+        wheelchairAccessible,
+        mode
+      )
+    );
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -130,7 +130,7 @@ public class StreetEdge
    */
   private List<TurnRestriction> turnRestrictions = Collections.emptyList();
 
-  public StreetEdge(
+  StreetEdge(
     StreetVertex v1,
     StreetVertex v2,
     LineString geometry,
@@ -188,7 +188,7 @@ public class StreetEdge
   }
 
   //For testing only
-  public StreetEdge(
+  private StreetEdge(
     StreetVertex v1,
     StreetVertex v2,
     LineString geometry,
@@ -200,7 +200,7 @@ public class StreetEdge
     this(v1, v2, geometry, new NonLocalizedString(name), length, permission, back);
   }
 
-  public StreetEdge(
+  StreetEdge(
     StreetVertex v1,
     StreetVertex v2,
     LineString geometry,
@@ -209,6 +209,41 @@ public class StreetEdge
     boolean back
   ) {
     this(v1, v2, geometry, name, SphericalDistanceLibrary.length(geometry), permission, back);
+  }
+
+  public static StreetEdge createStreetEdge(
+    StreetVertex v1,
+    StreetVertex v2,
+    LineString geometry,
+    I18NString name,
+    double length,
+    StreetTraversalPermission permission,
+    boolean back
+  ) {
+    return connectToGraph(new StreetEdge(v1, v2, geometry, name, length, permission, back));
+  }
+
+  public static StreetEdge createStreetEdge(
+    StreetVertex v1,
+    StreetVertex v2,
+    LineString geometry,
+    String name,
+    double length,
+    StreetTraversalPermission permission,
+    boolean back
+  ) {
+    return connectToGraph(new StreetEdge(v1, v2, geometry, name, length, permission, back));
+  }
+
+  public static StreetEdge createStreetEdge(
+    StreetVertex v1,
+    StreetVertex v2,
+    LineString geometry,
+    I18NString name,
+    StreetTraversalPermission permission,
+    boolean back
+  ) {
+    return connectToGraph(new StreetEdge(v1, v2, geometry, name, permission, back));
   }
 
   /**
@@ -774,7 +809,7 @@ public class StreetEdge
   public SplitStreetEdge splitDestructively(SplitterVertex v) {
     SplitLineString geoms = GeometryUtils.splitGeometryAtPoint(getGeometry(), v.getCoordinate());
 
-    StreetEdge e1 = new StreetEdge(
+    StreetEdge e1 = createStreetEdge(
       (StreetVertex) fromv,
       v,
       geoms.beginning(),
@@ -782,7 +817,7 @@ public class StreetEdge
       permission,
       this.isBack()
     );
-    StreetEdge e2 = new StreetEdge(
+    StreetEdge e2 = createStreetEdge(
       v,
       (StreetVertex) tov,
       geoms.ending(),
@@ -858,7 +893,7 @@ public class StreetEdge
 
     if (direction == LinkingDirection.OUTGOING || direction == LinkingDirection.BOTH_WAYS) {
       e1 =
-        new TemporaryPartialStreetEdge(
+        TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
           this,
           (StreetVertex) fromv,
           v,
@@ -871,7 +906,7 @@ public class StreetEdge
     }
     if (direction == LinkingDirection.INCOMING || direction == LinkingDirection.BOTH_WAYS) {
       e2 =
-        new TemporaryPartialStreetEdge(
+        TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
           this,
           v,
           (StreetVertex) tov,
@@ -917,7 +952,14 @@ public class StreetEdge
       double lengthRatio = partial.getLength() / parent.getLength();
       double length = getDistanceMeters() * lengthRatio;
 
-      var tempEdge = new TemporaryPartialStreetEdge(this, from, to, partial, getName(), length);
+      var tempEdge = TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
+        this,
+        from,
+        to,
+        partial,
+        getName(),
+        length
+      );
       copyPropertiesToSplitEdge(tempEdge, start, start + length);
       return Optional.of(tempEdge);
     } else {

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetTransitEntityLink.java
@@ -25,13 +25,21 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
 
   private final Accessibility wheelchairAccessibility;
 
-  public StreetTransitEntityLink(StreetVertex fromv, T tov, Accessibility wheelchairAccessibility) {
+  protected StreetTransitEntityLink(
+    StreetVertex fromv,
+    T tov,
+    Accessibility wheelchairAccessibility
+  ) {
     super(fromv, tov);
     this.transitEntityVertex = tov;
     this.wheelchairAccessibility = wheelchairAccessibility;
   }
 
-  public StreetTransitEntityLink(T fromv, StreetVertex tov, Accessibility wheelchairAccessibility) {
+  protected StreetTransitEntityLink(
+    T fromv,
+    StreetVertex tov,
+    Accessibility wheelchairAccessibility
+  ) {
     super(fromv, tov);
     this.transitEntityVertex = fromv;
     this.wheelchairAccessibility = wheelchairAccessibility;

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetTransitEntranceLink.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetTransitEntranceLink.java
@@ -9,12 +9,26 @@ import org.opentripplanner.street.model.vertex.TransitEntranceVertex;
  */
 public class StreetTransitEntranceLink extends StreetTransitEntityLink<TransitEntranceVertex> {
 
-  public StreetTransitEntranceLink(StreetVertex fromv, TransitEntranceVertex tov) {
+  private StreetTransitEntranceLink(StreetVertex fromv, TransitEntranceVertex tov) {
     super(fromv, tov, tov.getWheelchairAccessibility());
   }
 
-  public StreetTransitEntranceLink(TransitEntranceVertex fromv, StreetVertex tov) {
+  private StreetTransitEntranceLink(TransitEntranceVertex fromv, StreetVertex tov) {
     super(fromv, tov, fromv.getWheelchairAccessibility());
+  }
+
+  public static StreetTransitEntranceLink createStreetTransitEntranceLink(
+    StreetVertex fromv,
+    TransitEntranceVertex tov
+  ) {
+    return connectToGraph(new StreetTransitEntranceLink(fromv, tov));
+  }
+
+  public static StreetTransitEntranceLink createStreetTransitEntranceLink(
+    TransitEntranceVertex fromv,
+    StreetVertex tov
+  ) {
+    return connectToGraph(new StreetTransitEntranceLink(fromv, tov));
   }
 
   public String toString() {

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetTransitStopLink.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetTransitStopLink.java
@@ -9,12 +9,26 @@ import org.opentripplanner.street.model.vertex.TransitStopVertex;
  */
 public class StreetTransitStopLink extends StreetTransitEntityLink<TransitStopVertex> {
 
-  public StreetTransitStopLink(StreetVertex fromv, TransitStopVertex tov) {
+  private StreetTransitStopLink(StreetVertex fromv, TransitStopVertex tov) {
     super(fromv, tov, tov.getWheelchairAccessibility());
   }
 
-  public StreetTransitStopLink(TransitStopVertex fromv, StreetVertex tov) {
+  private StreetTransitStopLink(TransitStopVertex fromv, StreetVertex tov) {
     super(fromv, tov, fromv.getWheelchairAccessibility());
+  }
+
+  public static StreetTransitStopLink createStreetTransitStopLink(
+    StreetVertex fromv,
+    TransitStopVertex tov
+  ) {
+    return connectToGraph(new StreetTransitStopLink(fromv, tov));
+  }
+
+  public static StreetTransitStopLink createStreetTransitStopLink(
+    TransitStopVertex fromv,
+    StreetVertex tov
+  ) {
+    return connectToGraph(new StreetTransitStopLink(fromv, tov));
   }
 
   protected int getStreetToStopTime() {

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetVehicleParkingLink.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetVehicleParkingLink.java
@@ -18,14 +18,28 @@ public class StreetVehicleParkingLink extends Edge {
 
   private final VehicleParkingEntranceVertex vehicleParkingEntranceVertex;
 
-  public StreetVehicleParkingLink(StreetVertex fromv, VehicleParkingEntranceVertex tov) {
+  private StreetVehicleParkingLink(StreetVertex fromv, VehicleParkingEntranceVertex tov) {
     super(fromv, tov);
     vehicleParkingEntranceVertex = tov;
   }
 
-  public StreetVehicleParkingLink(VehicleParkingEntranceVertex fromv, StreetVertex tov) {
+  private StreetVehicleParkingLink(VehicleParkingEntranceVertex fromv, StreetVertex tov) {
     super(fromv, tov);
     vehicleParkingEntranceVertex = fromv;
+  }
+
+  public static StreetVehicleParkingLink createStreetVehicleParkingLink(
+    StreetVertex fromv,
+    VehicleParkingEntranceVertex tov
+  ) {
+    return connectToGraph(new StreetVehicleParkingLink(fromv, tov));
+  }
+
+  public static StreetVehicleParkingLink createStreetVehicleParkingLink(
+    VehicleParkingEntranceVertex fromv,
+    StreetVertex tov
+  ) {
+    return connectToGraph(new StreetVehicleParkingLink(fromv, tov));
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/edge/TemporaryFreeEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/TemporaryFreeEdge.java
@@ -7,18 +7,26 @@ import org.opentripplanner.street.search.state.StateEditor;
 
 public class TemporaryFreeEdge extends FreeEdge implements TemporaryEdge {
 
-  public TemporaryFreeEdge(TemporaryVertex from, Vertex to) {
+  private TemporaryFreeEdge(TemporaryVertex from, Vertex to) {
     super((Vertex) from, to);
     if (from.isEndVertex()) {
       throw new IllegalStateException("A temporary edge is directed away from an end vertex");
     }
   }
 
-  public TemporaryFreeEdge(Vertex from, TemporaryVertex to) {
+  private TemporaryFreeEdge(Vertex from, TemporaryVertex to) {
     super(from, (Vertex) to);
     if (!to.isEndVertex()) {
       throw new IllegalStateException("A temporary edge is directed towards a start vertex");
     }
+  }
+
+  public static TemporaryFreeEdge createTemporaryFreeEdge(TemporaryVertex from, Vertex to) {
+    return connectToGraph(new TemporaryFreeEdge(from, to));
+  }
+
+  public static TemporaryFreeEdge createTemporaryFreeEdge(Vertex from, TemporaryVertex to) {
+    return connectToGraph(new TemporaryFreeEdge(from, to));
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdge.java
@@ -21,7 +21,7 @@ public final class TemporaryPartialStreetEdge extends StreetEdge implements Temp
    * is negative, a new length is calculated from the geometry. The elevation data is calculated
    * using the 'parentEdge' and given 'length'.
    */
-  public TemporaryPartialStreetEdge(
+  private TemporaryPartialStreetEdge(
     StreetEdge parentEdge,
     StreetVertex v1,
     StreetVertex v2,
@@ -41,7 +41,7 @@ public final class TemporaryPartialStreetEdge extends StreetEdge implements Temp
    * calculated using the provided geometry. The elevation data is calculated using the 'parentEdge'
    * and the calculated 'length'.
    */
-  TemporaryPartialStreetEdge(
+  private TemporaryPartialStreetEdge(
     StreetEdge parentEdge,
     StreetVertex v1,
     StreetVertex v2,
@@ -52,6 +52,19 @@ public final class TemporaryPartialStreetEdge extends StreetEdge implements Temp
     super(v1, v2, geometry, name, parentEdge.getPermission(), back);
     this.parentEdge = parentEdge;
     this.geometry = super.getGeometry();
+  }
+
+  public static TemporaryPartialStreetEdge createTemporaryPartialStreetEdge(
+    StreetEdge parentEdge,
+    StreetVertex v1,
+    StreetVertex v2,
+    LineString geometry,
+    I18NString name,
+    double length
+  ) {
+    return connectToGraph(
+      new TemporaryPartialStreetEdge(parentEdge, v1, v2, geometry, name, length)
+    );
   }
 
   /**
@@ -130,5 +143,16 @@ public final class TemporaryPartialStreetEdge extends StreetEdge implements Temp
   @Override
   public int getOutAngle() {
     return parentEdge.getInAngle();
+  }
+
+  static TemporaryPartialStreetEdge createTemporaryPartialStreetEdge(
+    StreetEdge parentEdge,
+    StreetVertex v1,
+    StreetVertex v2,
+    LineString geometry,
+    I18NString name,
+    boolean back
+  ) {
+    return connectToGraph(new TemporaryPartialStreetEdge(parentEdge, v1, v2, geometry, name, back));
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/edge/VehicleParkingEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/VehicleParkingEdge.java
@@ -21,16 +21,31 @@ public class VehicleParkingEdge extends Edge {
 
   private final VehicleParking vehicleParking;
 
-  public VehicleParkingEdge(VehicleParkingEntranceVertex vehicleParkingEntranceVertex) {
+  private VehicleParkingEdge(VehicleParkingEntranceVertex vehicleParkingEntranceVertex) {
     this(vehicleParkingEntranceVertex, vehicleParkingEntranceVertex);
   }
 
-  public VehicleParkingEdge(
+  private VehicleParkingEdge(
     VehicleParkingEntranceVertex fromVehicleParkingEntranceVertex,
     VehicleParkingEntranceVertex toVehicleParkingEntranceVertex
   ) {
     super(fromVehicleParkingEntranceVertex, toVehicleParkingEntranceVertex);
     this.vehicleParking = fromVehicleParkingEntranceVertex.getVehicleParking();
+  }
+
+  public static VehicleParkingEdge createVehicleParkingEdge(
+    VehicleParkingEntranceVertex vehicleParkingEntranceVertex
+  ) {
+    return connectToGraph(new VehicleParkingEdge(vehicleParkingEntranceVertex));
+  }
+
+  public static VehicleParkingEdge createVehicleParkingEdge(
+    VehicleParkingEntranceVertex fromVehicleParkingEntranceVertex,
+    VehicleParkingEntranceVertex toVehicleParkingEntranceVertex
+  ) {
+    return connectToGraph(
+      new VehicleParkingEdge(fromVehicleParkingEntranceVertex, toVehicleParkingEntranceVertex)
+    );
   }
 
   public VehicleParking getVehicleParking() {

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
@@ -186,8 +186,14 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) ->
             List.of(
-              new StreetVehicleParkingLink((VehicleParkingEntranceVertex) vertex, streetVertex),
-              new StreetVehicleParkingLink(streetVertex, (VehicleParkingEntranceVertex) vertex)
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                (VehicleParkingEntranceVertex) vertex,
+                streetVertex
+              ),
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                streetVertex,
+                (VehicleParkingEntranceVertex) vertex
+              )
             )
         );
         disposableEdgeCollections.add(disposableWalkEdges);
@@ -200,8 +206,14 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) ->
             List.of(
-              new StreetVehicleParkingLink((VehicleParkingEntranceVertex) vertex, streetVertex),
-              new StreetVehicleParkingLink(streetVertex, (VehicleParkingEntranceVertex) vertex)
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                (VehicleParkingEntranceVertex) vertex,
+                streetVertex
+              ),
+              StreetVehicleParkingLink.createStreetVehicleParkingLink(
+                streetVertex,
+                (VehicleParkingEntranceVertex) vertex
+              )
             )
         );
         disposableEdgeCollections.add(disposableCarEdges);

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -157,8 +157,14 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
             LinkingDirection.BOTH_WAYS,
             (vertex, streetVertex) ->
               List.of(
-                new StreetVehicleRentalLink((VehicleRentalPlaceVertex) vertex, streetVertex),
-                new StreetVehicleRentalLink(streetVertex, (VehicleRentalPlaceVertex) vertex)
+                StreetVehicleRentalLink.createStreetVehicleRentalLink(
+                  (VehicleRentalPlaceVertex) vertex,
+                  streetVertex
+                ),
+                StreetVehicleRentalLink.createStreetVehicleRentalLink(
+                  streetVertex,
+                  (VehicleRentalPlaceVertex) vertex
+                )
               )
           );
           if (vehicleRentalVertex.getOutgoing().isEmpty()) {
@@ -172,7 +178,9 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
             )
             .collect(Collectors.toSet());
           for (RentalFormFactor formFactor : formFactors) {
-            tempEdges.addEdge(new VehicleRentalEdge(vehicleRentalVertex, formFactor));
+            tempEdges.addEdge(
+              VehicleRentalEdge.createVehicleRentalEdge(vehicleRentalVertex, formFactor)
+            );
           }
           verticesByStation.put(station.getId(), vehicleRentalVertex);
           tempEdgesByStation.put(station.getId(), tempEdges);

--- a/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -340,7 +340,7 @@ public class ConstantsForTests {
 
         VehicleRentalPlaceVertex stationVertex = new VehicleRentalPlaceVertex(station);
         graph.addVertex(stationVertex);
-        new VehicleRentalEdge(stationVertex, vehicleType.formFactor);
+        VehicleRentalEdge.createVehicleRentalEdge(stationVertex, vehicleType.formFactor);
 
         linker.linkVertexPermanently(
           stationVertex,
@@ -348,8 +348,14 @@ public class ConstantsForTests {
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) ->
             List.of(
-              new StreetVehicleRentalLink((VehicleRentalPlaceVertex) vertex, streetVertex),
-              new StreetVehicleRentalLink(streetVertex, (VehicleRentalPlaceVertex) vertex)
+              StreetVehicleRentalLink.createStreetVehicleRentalLink(
+                (VehicleRentalPlaceVertex) vertex,
+                streetVertex
+              ),
+              StreetVehicleRentalLink.createStreetVehicleRentalLink(
+                streetVertex,
+                (VehicleRentalPlaceVertex) vertex
+              )
             )
         );
       }

--- a/src/test/java/org/opentripplanner/astar/AStarTest.java
+++ b/src/test/java/org/opentripplanner/astar/AStarTest.java
@@ -168,7 +168,7 @@ public class AStarTest {
       new NonLocalizedString("near_shilshole_22nd"),
       false
     );
-    new TemporaryConcreteEdge(from, graph.getVertex("shilshole_22nd"));
+    TemporaryConcreteEdge.createTemporaryConcreteEdge(from, graph.getVertex("shilshole_22nd"));
 
     TemporaryStreetLocation to = new TemporaryStreetLocation(
       "near_56th_20th",
@@ -176,7 +176,7 @@ public class AStarTest {
       new NonLocalizedString("near_56th_20th"),
       true
     );
-    new TemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
+    TemporaryConcreteEdge.createTemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
 
     ShortestPathTree<State, Edge, Vertex> tree = StreetSearchBuilder
       .of()
@@ -216,7 +216,7 @@ public class AStarTest {
       new NonLocalizedString("near_shilshole_22nd"),
       false
     );
-    new TemporaryConcreteEdge(from, graph.getVertex("shilshole_22nd"));
+    TemporaryConcreteEdge.createTemporaryConcreteEdge(from, graph.getVertex("shilshole_22nd"));
 
     TemporaryStreetLocation to = new TemporaryStreetLocation(
       "near_56th_20th",
@@ -224,7 +224,7 @@ public class AStarTest {
       new NonLocalizedString("near_56th_20th"),
       true
     );
-    new TemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
+    TemporaryConcreteEdge.createTemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
 
     ShortestPathTree tree = StreetSearchBuilder
       .of()
@@ -297,8 +297,8 @@ public class AStarTest {
       Vertex vA = graph.getVertex(vLabels[i]);
       Vertex vB = graph.getVertex(vLabels[i + 1]);
 
-      new SimpleConcreteEdge(vA, vB);
-      new SimpleConcreteEdge(vB, vA);
+      SimpleConcreteEdge.createSimpleConcreteEdge(vA, vB);
+      SimpleConcreteEdge.createSimpleConcreteEdge(vB, vA);
     }
   }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -261,8 +261,14 @@ public class LinkStopToPlatformTest {
         LinkingDirection.BOTH_WAYS,
         (vertex, streetVertex) ->
           List.of(
-            new StreetTransitStopLink((TransitStopVertex) vertex, streetVertex),
-            new StreetTransitStopLink(streetVertex, (TransitStopVertex) vertex)
+            StreetTransitStopLink.createStreetTransitStopLink(
+              (TransitStopVertex) vertex,
+              streetVertex
+            ),
+            StreetTransitStopLink.createStreetTransitStopLink(
+              streetVertex,
+              (TransitStopVertex) vertex
+            )
           )
       );
     }
@@ -278,7 +284,7 @@ public class LinkStopToPlatformTest {
       new Coordinate[] { v1.getCoordinate(), v2.getCoordinate() }
     );
     I18NString name = new LocalizedString(nameString);
-    return new AreaEdge(
+    return AreaEdge.createAreaEdge(
       v1,
       v2,
       line,

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -80,7 +80,7 @@ public class ElevationModuleTest {
     for (int i = 1; i < coordinates.length; ++i) {
       length += SphericalDistanceLibrary.distance(coordinates[i - 1], coordinates[i]);
     }
-    StreetEdge edge = new StreetEdge(
+    StreetEdge edge = StreetEdge.createStreetEdge(
       from,
       to,
       geometry,

--- a/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
@@ -113,8 +113,14 @@ public class FakeGraph {
         LinkingDirection.BOTH_WAYS,
         (vertex, streetVertex) ->
           List.of(
-            new StreetTransitStopLink((TransitStopVertex) vertex, streetVertex),
-            new StreetTransitStopLink(streetVertex, (TransitStopVertex) vertex)
+            StreetTransitStopLink.createStreetTransitStopLink(
+              (TransitStopVertex) vertex,
+              streetVertex
+            ),
+            StreetTransitStopLink.createStreetTransitStopLink(
+              streetVertex,
+              (TransitStopVertex) vertex
+            )
           )
       );
     }

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -49,7 +49,7 @@ public class LinkingTest {
         new Coordinate[] { v0.getCoordinate(), v1.getCoordinate() }
       );
       double dist = SphericalDistanceLibrary.distance(v0.getCoordinate(), v1.getCoordinate());
-      StreetEdge s0 = new StreetEdge(
+      StreetEdge s0 = StreetEdge.createStreetEdge(
         v0,
         v1,
         geom,
@@ -58,7 +58,7 @@ public class LinkingTest {
         StreetTraversalPermission.ALL,
         false
       );
-      StreetEdge s1 = new StreetEdge(
+      StreetEdge s1 = StreetEdge.createStreetEdge(
         v1,
         v0,
         geom.reverse(),

--- a/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
@@ -186,7 +186,7 @@ class MissingElevationHandlerTest {
   }
 
   private StreetEdge edge(IntersectionVertex from, IntersectionVertex to, double length) {
-    return new StreetEdge(
+    return StreetEdge.createStreetEdge(
       from,
       to,
       null,

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -236,7 +236,15 @@ public class TestItineraryBuilder implements PlanTestConstants {
     var flexPath = new DirectFlexPathCalculator()
       .calculateFlexPath(fromv, tov, template.fromStopIndex, template.toStopIndex);
 
-    var edge = new FlexTripEdge(fromv, tov, lastPlace.stop, to.stop, flexTrip, template, flexPath);
+    var edge = FlexTripEdge.createFlexTripEdge(
+      fromv,
+      tov,
+      lastPlace.stop,
+      to.stop,
+      flexTrip,
+      template,
+      flexPath
+    );
 
     FlexibleTransitLeg leg = new FlexibleTransitLeg(edge, newTime(start), newTime(end), legCost);
 

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -76,7 +76,7 @@ public class TestHalfEdges {
     br = factory.intersection("br", -74.00, 40.0);
 
     top =
-      new StreetEdge(
+      StreetEdge.createStreetEdge(
         tl,
         tr,
         GeometryUtils.makeLineString(-74.01, 40.01, -74.0, 40.01),
@@ -86,7 +86,7 @@ public class TestHalfEdges {
         false
       );
     bottom =
-      new StreetEdge(
+      StreetEdge.createStreetEdge(
         br,
         bl,
         GeometryUtils.makeLineString(-74.01, 40.0, -74.0, 40.0),
@@ -96,7 +96,7 @@ public class TestHalfEdges {
         false
       );
     left =
-      new StreetEdge(
+      StreetEdge.createStreetEdge(
         bl,
         tl,
         GeometryUtils.makeLineString(-74.01, 40.0, -74.01, 40.01),
@@ -106,7 +106,7 @@ public class TestHalfEdges {
         false
       );
     right =
-      new StreetEdge(
+      StreetEdge.createStreetEdge(
         br,
         tr,
         GeometryUtils.makeLineString(-74.0, 40.0, -74.0, 40.01),
@@ -117,7 +117,7 @@ public class TestHalfEdges {
       );
 
     @SuppressWarnings("unused")
-    StreetEdge topBack = new StreetEdge(
+    StreetEdge topBack = StreetEdge.createStreetEdge(
       tr,
       tl,
       top.getGeometry().reverse(),
@@ -127,7 +127,7 @@ public class TestHalfEdges {
       true
     );
     @SuppressWarnings("unused")
-    StreetEdge bottomBack = new StreetEdge(
+    StreetEdge bottomBack = StreetEdge.createStreetEdge(
       br,
       bl,
       bottom.getGeometry().reverse(),
@@ -137,7 +137,7 @@ public class TestHalfEdges {
       true
     );
     leftBack =
-      new StreetEdge(
+      StreetEdge.createStreetEdge(
         tl,
         bl,
         left.getGeometry().reverse(),
@@ -147,7 +147,7 @@ public class TestHalfEdges {
         true
       );
     rightBack =
-      new StreetEdge(
+      StreetEdge.createStreetEdge(
         tr,
         br,
         right.getGeometry().reverse(),

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -114,7 +114,7 @@ public abstract class GraphRoutingTest {
       int length,
       StreetTraversalPermission permissions
     ) {
-      return new StreetEdge(
+      return StreetEdge.createStreetEdge(
         from,
         to,
         GeometryUtils.makeLineString(from.getLat(), from.getLon(), to.getLat(), to.getLon()),
@@ -133,7 +133,7 @@ public abstract class GraphRoutingTest {
       StreetTraversalPermission reversePermissions
     ) {
       return List.of(
-        new StreetEdge(
+        StreetEdge.createStreetEdge(
           from,
           to,
           GeometryUtils.makeLineString(from.getLat(), from.getLon(), to.getLat(), to.getLon()),
@@ -142,7 +142,7 @@ public abstract class GraphRoutingTest {
           forwardPermissions,
           false
         ),
-        new StreetEdge(
+        StreetEdge.createStreetEdge(
           to,
           from,
           GeometryUtils.makeLineString(to.getLat(), to.getLon(), from.getLat(), from.getLon()),
@@ -166,11 +166,17 @@ public abstract class GraphRoutingTest {
         var onboard = vertexFactory.elevatorOnboard(v, boardLabel, boardLabel);
         var offboard = vertexFactory.elevatorOffboard(v, alightLabel, alightLabel);
 
-        new FreeEdge(v, offboard);
-        new FreeEdge(offboard, v);
+        FreeEdge.createFreeEdge(v, offboard);
+        FreeEdge.createFreeEdge(offboard, v);
 
-        edges.add(new ElevatorBoardEdge(offboard, onboard));
-        edges.add(new ElevatorAlightEdge(onboard, offboard, new NonLocalizedString(level)));
+        edges.add(ElevatorBoardEdge.createElevatorBoardEdge(offboard, onboard));
+        edges.add(
+          ElevatorAlightEdge.createElevatorAlightEdge(
+            onboard,
+            offboard,
+            new NonLocalizedString(level)
+          )
+        );
 
         onboardVertices.add(onboard);
       }
@@ -179,8 +185,12 @@ public abstract class GraphRoutingTest {
         var from = onboardVertices.get(i - 1);
         var to = onboardVertices.get(i);
 
-        edges.add(new ElevatorHopEdge(from, to, permission, Accessibility.POSSIBLE));
-        edges.add(new ElevatorHopEdge(to, from, permission, Accessibility.POSSIBLE));
+        edges.add(
+          ElevatorHopEdge.createElevatorHopEdge(from, to, permission, Accessibility.POSSIBLE)
+        );
+        edges.add(
+          ElevatorHopEdge.createElevatorHopEdge(to, from, permission, Accessibility.POSSIBLE)
+        );
       }
 
       return edges;
@@ -239,11 +249,11 @@ public abstract class GraphRoutingTest {
     }
 
     public StreetTransitEntranceLink link(StreetVertex from, TransitEntranceVertex to) {
-      return new StreetTransitEntranceLink(from, to);
+      return StreetTransitEntranceLink.createStreetTransitEntranceLink(from, to);
     }
 
     public StreetTransitEntranceLink link(TransitEntranceVertex from, StreetVertex to) {
-      return new StreetTransitEntranceLink(from, to);
+      return StreetTransitEntranceLink.createStreetTransitEntranceLink(from, to);
     }
 
     public List<StreetTransitEntranceLink> biLink(StreetVertex from, TransitEntranceVertex to) {
@@ -251,11 +261,11 @@ public abstract class GraphRoutingTest {
     }
 
     public StreetTransitStopLink link(StreetVertex from, TransitStopVertex to) {
-      return new StreetTransitStopLink(from, to);
+      return StreetTransitStopLink.createStreetTransitStopLink(from, to);
     }
 
     public StreetTransitStopLink link(TransitStopVertex from, StreetVertex to) {
-      return new StreetTransitStopLink(from, to);
+      return StreetTransitStopLink.createStreetTransitStopLink(from, to);
     }
 
     public List<StreetTransitStopLink> biLink(StreetVertex from, TransitStopVertex to) {
@@ -263,7 +273,7 @@ public abstract class GraphRoutingTest {
     }
 
     public PathwayEdge pathway(Vertex from, Vertex to, int time, int length) {
-      return new PathwayEdge(
+      return PathwayEdge.createPathwayEdge(
         from,
         to,
         null,
@@ -295,11 +305,11 @@ public abstract class GraphRoutingTest {
     }
 
     public TemporaryFreeEdge link(TemporaryVertex from, StreetVertex to) {
-      return new TemporaryFreeEdge(from, to);
+      return TemporaryFreeEdge.createTemporaryFreeEdge(from, to);
     }
 
     public TemporaryFreeEdge link(StreetVertex from, TemporaryVertex to) {
-      return new TemporaryFreeEdge(from, to);
+      return TemporaryFreeEdge.createTemporaryFreeEdge(from, to);
     }
 
     // -- Vehicle rental
@@ -332,7 +342,10 @@ public abstract class GraphRoutingTest {
       var vertex = new VehicleRentalPlaceVertex(
         vehicleRentalStationEntity(id, latitude, longitude, network)
       );
-      new VehicleRentalEdge(vertex, RentalVehicleType.getDefaultType(network).formFactor);
+      VehicleRentalEdge.createVehicleRentalEdge(
+        vertex,
+        RentalVehicleType.getDefaultType(network).formFactor
+      );
       return vertex;
     }
 
@@ -345,11 +358,11 @@ public abstract class GraphRoutingTest {
     }
 
     public StreetVehicleRentalLink link(StreetVertex from, VehicleRentalPlaceVertex to) {
-      return new StreetVehicleRentalLink(from, to);
+      return StreetVehicleRentalLink.createStreetVehicleRentalLink(from, to);
     }
 
     public StreetVehicleRentalLink link(VehicleRentalPlaceVertex from, StreetVertex to) {
-      return new StreetVehicleRentalLink(from, to);
+      return StreetVehicleRentalLink.createStreetVehicleRentalLink(from, to);
     }
 
     public List<StreetVehicleRentalLink> biLink(StreetVertex from, VehicleRentalPlaceVertex to) {
@@ -412,11 +425,11 @@ public abstract class GraphRoutingTest {
     }
 
     public StreetVehicleParkingLink link(StreetVertex from, VehicleParkingEntranceVertex to) {
-      return new StreetVehicleParkingLink(from, to);
+      return StreetVehicleParkingLink.createStreetVehicleParkingLink(from, to);
     }
 
     public StreetVehicleParkingLink link(VehicleParkingEntranceVertex from, StreetVertex to) {
-      return new StreetVehicleParkingLink(from, to);
+      return StreetVehicleParkingLink.createStreetVehicleParkingLink(from, to);
     }
 
     public List<StreetVehicleParkingLink> biLink(

--- a/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
@@ -247,7 +247,7 @@ public class TurnCostTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    StreetEdge pse = new StreetEdge(vA, vB, geom, name, length, perm, back);
+    StreetEdge pse = StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
     pse.setCarSpeed(1.0f);
     return pse;
   }

--- a/src/test/java/org/opentripplanner/routing/core/GraphTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/GraphTest.java
@@ -47,7 +47,8 @@ public class GraphTest {
   public void testAddEdge() {
     Vertex a = new IntersectionVertex("A", 5, 5);
     Vertex b = new IntersectionVertex("B", 6, 6);
-    FreeEdge ee = new FreeEdge(a, b);
+    FreeEdge ee = FreeEdge.createFreeEdge(a, b);
+
     assertNotNull(ee);
   }
 
@@ -60,7 +61,7 @@ public class GraphTest {
     g.addVertex(a);
     g.addVertex(b);
 
-    FreeEdge ee = new FreeEdge(a, b);
+    FreeEdge ee = FreeEdge.createFreeEdge(a, b);
 
     List<Edge> edges = new ArrayList<>(g.getEdges());
     assertEquals(1, edges.size());
@@ -79,10 +80,10 @@ public class GraphTest {
     g.addVertex(c);
 
     Set<Edge> expectedEdges = new HashSet<>(4);
-    expectedEdges.add(new FreeEdge(a, b));
-    expectedEdges.add(new FreeEdge(b, c));
-    expectedEdges.add(new FreeEdge(c, b));
-    expectedEdges.add(new FreeEdge(c, a));
+    expectedEdges.add(FreeEdge.createFreeEdge(a, b));
+    expectedEdges.add(FreeEdge.createFreeEdge(b, c));
+    expectedEdges.add(FreeEdge.createFreeEdge(c, b));
+    expectedEdges.add(FreeEdge.createFreeEdge(c, a));
 
     Set<Edge> edges = new HashSet<>(g.getEdges());
     assertEquals(4, edges.size());
@@ -97,10 +98,10 @@ public class GraphTest {
     Vertex c = new IntersectionVertex("C", 3, 2);
 
     Set<Edge> allEdges = new HashSet<>(4);
-    allEdges.add(new FreeEdge(a, b));
-    allEdges.add(new FreeEdge(b, c));
-    allEdges.add(new FreeEdge(c, b));
-    allEdges.add(new FreeEdge(c, a));
+    allEdges.add(FreeEdge.createFreeEdge(a, b));
+    allEdges.add(FreeEdge.createFreeEdge(b, c));
+    allEdges.add(FreeEdge.createFreeEdge(c, b));
+    allEdges.add(FreeEdge.createFreeEdge(c, a));
 
     Set<StreetEdge> edges = new HashSet<>(g.getStreetEdges());
     assertEquals(0, edges.size());
@@ -154,6 +155,6 @@ public class GraphTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return new StreetEdge(vA, vB, geom, name, length, perm, false);
+    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, false);
   }
 }

--- a/src/test/java/org/opentripplanner/routing/core/TemporaryVerticesContainerTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TemporaryVerticesContainerTest.java
@@ -147,7 +147,7 @@ public class TemporaryVerticesContainerTest {
       new Coordinate[] { v0.getCoordinate(), v1.getCoordinate() }
     );
     double dist = SphericalDistanceLibrary.distance(v0.getCoordinate(), v1.getCoordinate());
-    new StreetEdge(v0, v1, geom, name, dist, StreetTraversalPermission.ALL, false);
+    StreetEdge.createStreetEdge(v0, v1, geom, name, dist, StreetTraversalPermission.ALL, false);
   }
 
   private void assertVertexEdgeIsNotReferencingTemporaryElements(Vertex src, Edge e, Vertex v) {

--- a/src/test/java/org/opentripplanner/routing/core/TurnsTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TurnsTest.java
@@ -23,7 +23,7 @@ public class TurnsTest {
     IntersectionVertex v1 = new IntersectionVertex("v1", -0.10, 0, "v1");
     IntersectionVertex v2 = new IntersectionVertex("v2", 0, 0, "v2");
 
-    StreetEdge leftEdge = new StreetEdge(
+    StreetEdge leftEdge = StreetEdge.createStreetEdge(
       v1,
       v2,
       geometry,
@@ -37,7 +37,7 @@ public class TurnsTest {
       new Coordinate[] { new Coordinate(0, 0), new Coordinate(-0.10, 0) }
     );
 
-    StreetEdge rightEdge = new StreetEdge(
+    StreetEdge rightEdge = StreetEdge.createStreetEdge(
       v1,
       v2,
       geometry2,

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/GeometryProcessorTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/GeometryProcessorTest.java
@@ -88,7 +88,7 @@ public class GeometryProcessorTest {
         stop.getY() - 0.0001
       );
 
-      StreetEdge street1 = new StreetEdge(
+      StreetEdge street1 = StreetEdge.createStreetEdge(
         front,
         back,
         GeometryUtils.makeLineString(
@@ -102,7 +102,7 @@ public class GeometryProcessorTest {
         StreetTraversalPermission.ALL,
         false
       );
-      StreetEdge street2 = new StreetEdge(
+      StreetEdge street2 = StreetEdge.createStreetEdge(
         back,
         front,
         GeometryUtils.makeLineString(

--- a/src/test/java/org/opentripplanner/routing/graph/EdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/EdgeTest.java
@@ -17,7 +17,7 @@ public class EdgeTest {
     Graph graph = new Graph();
     Vertex head = new SimpleConcreteVertex(graph, "head", 47.669457, -122.387577);
     Vertex tail = new SimpleConcreteVertex(graph, "tail", 47.669462, -122.384739);
-    Edge e = new SimpleConcreteEdge(head, tail);
+    Edge e = SimpleConcreteEdge.createSimpleConcreteEdge(head, tail);
 
     assertEquals(head, e.getFromVertex());
     assertEquals(tail, e.getToVertex());
@@ -29,10 +29,33 @@ public class EdgeTest {
     StreetVertex vb = new IntersectionVertex("B", 10.1, 10.1);
     StreetVertex vc = new IntersectionVertex("C", 10.2, 10.2);
     StreetVertex vd = new IntersectionVertex("D", 10.3, 10.3);
-    Edge eab = new StreetEdge(va, vb, null, "AB", 10, StreetTraversalPermission.ALL, false);
-    Edge ebc = new StreetEdge(vb, vc, null, "BC", 10, StreetTraversalPermission.ALL, false);
-    Edge ecd = new StreetEdge(vc, vd, null, "CD", 10, StreetTraversalPermission.ALL, false);
-
+    Edge eab = StreetEdge.createStreetEdge(
+      va,
+      vb,
+      null,
+      "AB",
+      10,
+      StreetTraversalPermission.ALL,
+      false
+    );
+    Edge ebc = StreetEdge.createStreetEdge(
+      vb,
+      vc,
+      null,
+      "BC",
+      10,
+      StreetTraversalPermission.ALL,
+      false
+    );
+    Edge ecd = StreetEdge.createStreetEdge(
+      vc,
+      vd,
+      null,
+      "CD",
+      10,
+      StreetTraversalPermission.ALL,
+      false
+    );
     // remove an edge that is not connected to this vertex
     va.removeOutgoing(ecd);
     assertEquals(va.getDegreeOut(), 1);

--- a/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
@@ -14,8 +14,12 @@ public class SimpleConcreteEdge extends Edge {
   /**
    * Constructor without ID.
    */
-  public SimpleConcreteEdge(Vertex v1, Vertex v2) {
+  private SimpleConcreteEdge(Vertex v1, Vertex v2) {
     super(v1, v2);
+  }
+
+  public static SimpleConcreteEdge createSimpleConcreteEdge(Vertex v1, Vertex v2) {
+    return connectToGraph(new SimpleConcreteEdge(v1, v2));
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
@@ -13,18 +13,26 @@ import org.opentripplanner.street.search.state.StateEditor;
 
 public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
 
-  public TemporaryConcreteEdge(TemporaryVertex v1, Vertex v2) {
+  private TemporaryConcreteEdge(TemporaryVertex v1, Vertex v2) {
     super((Vertex) v1, v2);
     if (v1.isEndVertex()) {
       throw new IllegalStateException("A temporary edge is directed away from an end vertex");
     }
   }
 
-  public TemporaryConcreteEdge(Vertex v1, TemporaryVertex v2) {
+  private TemporaryConcreteEdge(Vertex v1, TemporaryVertex v2) {
     super(v1, (Vertex) v2);
     if (!v2.isEndVertex()) {
       throw new IllegalStateException("A temporary edge is directed towards a start vertex");
     }
+  }
+
+  public static TemporaryConcreteEdge createTemporaryConcreteEdge(TemporaryVertex v1, Vertex v2) {
+    return connectToGraph(new TemporaryConcreteEdge(v1, v2));
+  }
+
+  public static TemporaryConcreteEdge createTemporaryConcreteEdge(Vertex v1, TemporaryVertex v2) {
+    return connectToGraph(new TemporaryConcreteEdge(v1, v2));
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
+++ b/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
@@ -44,7 +44,7 @@ public class VehicleParkingTestUtil {
     StreetVertex to,
     StreetTraversalPermission permissions
   ) {
-    new StreetEdge(
+    StreetEdge.createStreetEdge(
       from,
       to,
       GeometryUtils.makeLineString(from.getLat(), from.getLon(), to.getLat(), to.getLon()),

--- a/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
+++ b/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
@@ -207,7 +207,7 @@ public class TurnRestrictionTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return new StreetEdge(vA, vB, geom, name, length, perm, back);
+    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
   }
 
   private void DisallowTurn(StreetEdge from, StreetEdge to) {

--- a/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
+++ b/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
@@ -44,6 +44,6 @@ public class StreetModelForTest {
     coords[1] = vB.getCoordinate();
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
-    return new StreetEdge(vA, vB, geom, name, length, perm, false);
+    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, false);
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/edge/ElevatorHopEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/ElevatorHopEdgeTest.java
@@ -78,7 +78,12 @@ class ElevatorHopEdgeTest {
   }
 
   private State[] traverse(Accessibility wheelchair, StreetSearchRequest req) {
-    var edge = new ElevatorHopEdge(from, to, StreetTraversalPermission.ALL, wheelchair);
+    var edge = ElevatorHopEdge.createElevatorHopEdge(
+      from,
+      to,
+      StreetTraversalPermission.ALL,
+      wheelchair
+    );
     var state = new State(from, req);
 
     return edge.traverse(state);

--- a/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
@@ -27,7 +27,7 @@ class PathwayEdgeTest {
   void zeroLength() {
     // if elevators have a traversal time and distance of 0 we cannot interpolate the distance
     // from the vertices as they most likely have identical coordinates
-    var edge = new PathwayEdge(
+    var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
       null,
@@ -45,7 +45,7 @@ class PathwayEdgeTest {
 
   @Test
   void zeroLengthWithSteps() {
-    var edge = new PathwayEdge(
+    var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
       null,
@@ -63,7 +63,7 @@ class PathwayEdgeTest {
 
   @Test
   void traversalTime() {
-    var edge = new PathwayEdge(
+    var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
       null,
@@ -83,7 +83,7 @@ class PathwayEdgeTest {
 
   @Test
   void traversalTimeOverridesLength() {
-    var edge = new PathwayEdge(
+    var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
       null,
@@ -105,7 +105,7 @@ class PathwayEdgeTest {
 
   @Test
   void distance() {
-    var edge = new PathwayEdge(
+    var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
       null,
@@ -125,7 +125,7 @@ class PathwayEdgeTest {
 
   @Test
   void wheelchair() {
-    var edge = new PathwayEdge(
+    var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
       null,
@@ -168,7 +168,7 @@ class PathwayEdgeTest {
   @ParameterizedTest(name = "slope of {0} should lead to traversal costs of {1}")
   @VariableSource("slopeCases")
   public void shouldScaleCostWithMaxSlope(double slope, long expectedCost) {
-    var edge = new PathwayEdge(
+    var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
       null,

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeCostTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeCostTest.java
@@ -27,7 +27,15 @@ class StreetEdgeCostTest {
   @VariableSource("walkReluctanceCases")
   public void walkReluctance(double walkReluctance, long expectedCost) {
     double length = 100;
-    var edge = new StreetEdge(V1, V2, null, "edge", length, StreetTraversalPermission.ALL, false);
+    var edge = StreetEdge.createStreetEdge(
+      V1,
+      V2,
+      null,
+      "edge",
+      length,
+      StreetTraversalPermission.ALL,
+      false
+    );
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withWalk(w -> w.withReluctance(walkReluctance)));
@@ -49,7 +57,15 @@ class StreetEdgeCostTest {
   @VariableSource("bikeReluctanceCases")
   public void bikeReluctance(double bikeReluctance, long expectedCost) {
     double length = 100;
-    var edge = new StreetEdge(V1, V2, null, "edge", length, StreetTraversalPermission.ALL, false);
+    var edge = StreetEdge.createStreetEdge(
+      V1,
+      V2,
+      null,
+      "edge",
+      length,
+      StreetTraversalPermission.ALL,
+      false
+    );
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withBike(b -> b.withReluctance(bikeReluctance)));
@@ -72,7 +88,15 @@ class StreetEdgeCostTest {
   @VariableSource("carReluctanceCases")
   public void carReluctance(double carReluctance, long expectedCost) {
     double length = 100;
-    var edge = new StreetEdge(V1, V2, null, "edge", length, StreetTraversalPermission.ALL, false);
+    var edge = StreetEdge.createStreetEdge(
+      V1,
+      V2,
+      null,
+      "edge",
+      length,
+      StreetTraversalPermission.ALL,
+      false
+    );
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withCar(c -> c.withReluctance(carReluctance)));
@@ -94,7 +118,15 @@ class StreetEdgeCostTest {
   @VariableSource("stairsCases")
   public void stairsReluctance(double stairsReluctance, long expectedCost) {
     double length = 10;
-    var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
+    var edge = StreetEdge.createStreetEdge(
+      V1,
+      V2,
+      null,
+      "stairs",
+      length,
+      StreetTraversalPermission.ALL,
+      false
+    );
     edge.setStairs(true);
 
     var req = StreetSearchRequest.of();
@@ -120,7 +152,7 @@ class StreetEdgeCostTest {
   @VariableSource("bikeStairsCases")
   public void bikeStairsReluctance(double stairsReluctance, long expectedCost) {
     double length = 10;
-    var edge = new StreetEdge(
+    var edge = StreetEdge.createStreetEdge(
       V1,
       V2,
       null,
@@ -154,7 +186,7 @@ class StreetEdgeCostTest {
   @VariableSource("walkSafetyCases")
   public void walkSafetyFactor(double walkSafetyFactor, long expectedCost) {
     double length = 10;
-    var edge = new StreetEdge(
+    var edge = StreetEdge.createStreetEdge(
       V1,
       V2,
       null,

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -305,7 +305,7 @@ public class StreetEdgeTest {
 
     double length = 650.0;
 
-    StreetEdge testStreet = new StreetEdge(
+    StreetEdge testStreet = StreetEdge.createStreetEdge(
       v1,
       v2,
       geometry,

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeWheelchairCostTest.java
@@ -60,7 +60,7 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("slopeCases")
   public void shouldScaleCostWithMaxSlope(double slope, double reluctance, long expectedCost) {
     double length = 1000;
-    var edge = new StreetEdge(
+    var edge = StreetEdge.createStreetEdge(
       V1,
       V2,
       null,
@@ -113,7 +113,15 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("wheelchairStairsCases")
   public void wheelchairStairsReluctance(double stairsReluctance, long expectedCost) {
     double length = 10;
-    var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
+    var edge = StreetEdge.createStreetEdge(
+      V1,
+      V2,
+      null,
+      "stairs",
+      length,
+      StreetTraversalPermission.ALL,
+      false
+    );
     edge.setStairs(true);
 
     var req = StreetSearchRequest.of();
@@ -155,7 +163,15 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("inaccessibleStreetCases")
   public void inaccessibleStreet(float inaccessibleStreetReluctance, long expectedCost) {
     double length = 10;
-    var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
+    var edge = StreetEdge.createStreetEdge(
+      V1,
+      V2,
+      null,
+      "stairs",
+      length,
+      StreetTraversalPermission.ALL,
+      false
+    );
     edge.setWheelchairAccessible(false);
 
     var req = StreetSearchRequest.of();
@@ -197,7 +213,15 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("walkReluctanceCases")
   public void walkReluctance(double walkReluctance, long expectedCost) {
     double length = 10;
-    var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
+    var edge = StreetEdge.createStreetEdge(
+      V1,
+      V2,
+      null,
+      "stairs",
+      length,
+      StreetTraversalPermission.ALL,
+      false
+    );
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withWalk(w -> w.withReluctance(walkReluctance)));

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetTransitEntityLinkTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetTransitEntityLinkTest.java
@@ -99,7 +99,7 @@ class StreetTransitEntityLinkTest {
       )
     );
 
-    var edge = new StreetTransitStopLink(from, to);
+    var edge = StreetTransitStopLink.createStreetTransitStopLink(from, to);
     return edge.traverse(new State(from, req.build()));
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetVehicleParkingLinkTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetVehicleParkingLinkTest.java
@@ -71,7 +71,10 @@ class StreetVehicleParkingLinkTest {
     req.withParking(parkingReq);
     req.withPreferences(p -> p.withBike(bike -> bike.withParkCost(0)));
 
-    var edge = new StreetVehicleParkingLink(streetVertex, entranceVertex);
+    var edge = StreetVehicleParkingLink.createStreetVehicleParkingLink(
+      streetVertex,
+      entranceVertex
+    );
 
     var result = traverse(streetVertex, edge, req.build());
     if (shouldTraverse) {

--- a/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeTest.java
@@ -247,7 +247,7 @@ public class TemporaryPartialStreetEdgeTest {
     String name,
     double length
   ) {
-    return new TemporaryPartialStreetEdge(
+    return TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
       parentEdge,
       v1,
       v2,
@@ -278,6 +278,6 @@ public class TemporaryPartialStreetEdgeTest {
     coords[1] = vB.getCoordinate();
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
-    return new StreetEdge(vA, vB, geom, name, length, perm, false);
+    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, false);
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingEdgeTest.java
@@ -154,7 +154,7 @@ class VehicleParkingEdgeTest {
     var vehicleParking = createVehicleParking(bicyclePlaces, carPlaces, availability);
     this.vertex = new VehicleParkingEntranceVertex(vehicleParking.getEntrances().get(0));
 
-    vehicleParkingEdge = new VehicleParkingEdge(vertex);
+    vehicleParkingEdge = VehicleParkingEdge.createVehicleParkingEdge(vertex);
 
     var parking = new VehicleParkingRequest();
     parking.setUseAvailabilityInformation(realtime);

--- a/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingPreferredTagsTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingPreferredTagsTest.java
@@ -83,7 +83,7 @@ class VehicleParkingPreferredTagsTest {
       .build();
 
     var fromV = new VehicleParkingEntranceVertex(entrance);
-    var edge = new VehicleParkingEdge(fromV);
+    var edge = VehicleParkingEdge.createVehicleParkingEdge(fromV);
 
     var parkingReq = new VehicleParkingRequest();
     Collection<VehicleParkingFilter> select = List.of(

--- a/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
@@ -138,7 +138,7 @@ class VehicleRentalEdgeTest {
 
     this.vertex = new VehicleRentalPlaceVertex(station);
 
-    vehicleRentalEdge = new VehicleRentalEdge(vertex, RentalFormFactor.BICYCLE);
+    vehicleRentalEdge = VehicleRentalEdge.createVehicleRentalEdge(vertex, RentalFormFactor.BICYCLE);
 
     var rentalRequest = new VehicleRentalRequest();
     this.request =

--- a/src/test/java/org/opentripplanner/street/model/vertex/BarrierVertexTest.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/BarrierVertexTest.java
@@ -168,6 +168,6 @@ public class BarrierVertexTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return new StreetEdge(vA, vB, geom, name, length, perm, back);
+    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/vertex/IntersectionVertexTest.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/IntersectionVertexTest.java
@@ -117,6 +117,6 @@ public class IntersectionVertexTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return new StreetEdge(vA, vB, geom, name, length, perm, back);
+    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/vertex/TemporaryVertexDisposeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/TemporaryVertexDisposeTest.java
@@ -204,7 +204,7 @@ public class TemporaryVertexDisposeTest {
 
   // Factory method to create an edge
   private static void edge(Vertex a, Vertex b) {
-    new E(a, b);
+    E.createE(a, b);
   }
 
   /* private test helper classes */
@@ -249,6 +249,10 @@ public class TemporaryVertexDisposeTest {
     @Override
     public String toString() {
       return getFromVertex().getLabel() + "->" + getToVertex().getLabel();
+    }
+
+    private static E createE(Vertex from, Vertex to) {
+      return connectToGraph(new E(from, to));
     }
   }
 }

--- a/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
@@ -453,6 +453,6 @@ public class SimpleIntersectionTraversalCalculatorTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return new StreetEdge(vA, vB, geom, name, length, perm, back);
+    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
   }
 }

--- a/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
+++ b/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
@@ -88,11 +88,13 @@ public class TestStateBuilder {
     var station = TestVehicleRentalStationBuilder.of().withVehicleTypeCar().build();
 
     VehicleRentalPlaceVertex vertex = new VehicleRentalPlaceVertex(station);
-    var link = new StreetVehicleRentalLink((StreetVertex) currentState.vertex, vertex);
-
+    var link = StreetVehicleRentalLink.createStreetVehicleRentalLink(
+      (StreetVertex) currentState.vertex,
+      vertex
+    );
     currentState = link.traverse(currentState)[0];
 
-    var edge = new VehicleRentalEdge(vertex, RentalFormFactor.CAR);
+    var edge = VehicleRentalEdge.createVehicleRentalEdge(vertex, RentalFormFactor.CAR);
 
     State[] traverse = edge.traverse(currentState);
     currentState =
@@ -119,16 +121,20 @@ public class TestStateBuilder {
     var from = (StreetVertex) currentState.vertex;
     var link = StreetModelForTest.streetEdge(from, offboard1);
 
-    var boardEdge = new ElevatorBoardEdge(offboard1, onboard1);
+    var boardEdge = ElevatorBoardEdge.createElevatorBoardEdge(offboard1, onboard1);
 
-    var hopEdge = new ElevatorHopEdge(
+    var hopEdge = ElevatorHopEdge.createElevatorHopEdge(
       onboard1,
       onboard2,
       StreetTraversalPermission.PEDESTRIAN,
       Accessibility.POSSIBLE
     );
 
-    var alightEdge = new ElevatorAlightEdge(onboard2, offboard2, new NonLocalizedString("1"));
+    var alightEdge = ElevatorAlightEdge.createElevatorAlightEdge(
+      onboard2,
+      offboard2,
+      new NonLocalizedString("1")
+    );
 
     currentState =
       EdgeTraverser


### PR DESCRIPTION
### Summary

As reported in #5220, the Edge constructor connects the edge to the graph, making it reachable from other threads before the instance is fully constructed.  
This PR ensures that Edge instances are created through factory methods that connect the edge to the graph only after the edge instance is fully constructed.
As an exception, FlexTripEdge instances are not connected to the graph. For consistency FlexTripEdge instances are also constructed with a factory method.

### Issue

Closes #5220

### Unit tests

:white_check_mark: 

### Documentation

No

