### PR TITLE
Upgrade to Apache HTTP Client 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -931,9 +931,9 @@
             <version>20.2</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.ext.actuator;
 
-import static org.apache.http.HttpHeaders.ACCEPT;
+import static org.apache.hc.core5.http.HttpHeaders.ACCEPT;
 
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.exporter.common.TextFormat;

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import javax.xml.stream.XMLStreamException;
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.hc.core5.net.URIBuilder;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.transit.service.TransitModel;

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import javax.xml.stream.XMLStreamException;
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.hc.core5.net.URIBuilder;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -1,13 +1,13 @@
 package org.opentripplanner.datastore.https;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.http.Header;
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.utils.DateUtils;
+import org.apache.hc.client5.http.utils.DateUtils;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 
@@ -66,9 +66,9 @@ class HttpsDataSourceMetadata {
 
   private static long parseDate(String lastModifiedHeader) {
     if (lastModifiedHeader != null) {
-      Date lastModifiedDate = DateUtils.parseDate(lastModifiedHeader);
+      Instant lastModifiedDate = DateUtils.parseStandardDate(lastModifiedHeader);
       if (lastModifiedDate != null) {
-        return lastModifiedDate.getTime();
+        return lastModifiedDate.toEpochMilli();
       }
     }
     return -1;

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -5,7 +5,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
-import org.apache.http.Header;
+import org.apache.hc.core5.http.Header;
 import org.opentripplanner.datastore.api.CompositeDataSource;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -9,7 +9,7 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.opentripplanner.framework.text.HexString;
 
 public class EtagRequestFilter implements ContainerResponseFilter {

--- a/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.updater.spi;
 
 import java.time.Duration;
+import java.util.concurrent.CancellationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +63,8 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
           }
         } catch (InterruptedException e) {
           throw e;
+        } catch (CancellationException e) {
+          LOG.info("OTP is shutting down, the polling updater {} was interrupted", this, e);
         } catch (Exception e) {
           LOG.error("Error while running polling updater {}", this, e);
           // TODO Should we cancel the task? Or after n consecutive failures? cancel();

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -77,7 +77,7 @@
 
   <logger name="ch.qos.logback" level="warn"/>
   <logger name="com.amazonaws" level="info"/>
-  <logger name="org.apache.http" level="info" />
+  <logger name="org.apache.hc" level="info" />
   <logger name="com.conveyal" level="info"/>
   <logger name="notprivacysafe.graphql" level="off" />
 

--- a/src/test/java/org/opentripplanner/datastore/DataStoreArchitectureTest.java
+++ b/src/test/java/org/opentripplanner/datastore/DataStoreArchitectureTest.java
@@ -23,7 +23,7 @@ public class DataStoreArchitectureTest {
   private static final Package SERVICE = DATASTORE;
 
   private static final Package FRAMEWORK_IO = FRAMEWORK.subPackage("io");
-  private static final Package APACHE_HTTP = Package.of("org.apache.http..");
+  private static final Package APACHE_HTTP = Package.of("org.apache.hc..");
 
   @Test
   void enforceApiPackageDependencies() {

--- a/src/test/java/org/opentripplanner/datastore/https/HttpsDataSourceRepositoryTest.java
+++ b/src/test/java/org/opentripplanner/datastore/https/HttpsDataSourceRepositoryTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import org.apache.http.Header;
+import org.apache.hc.core5.http.Header;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.datastore.api.CompositeDataSource;
 import org.opentripplanner.datastore.api.DataSource;

--- a/src/test/java/org/opentripplanner/datastore/https/HttpsFileDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/datastore/https/HttpsFileDataSourceTest.java
@@ -8,10 +8,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Map;
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.utils.DateUtils;
+import org.apache.hc.client5.http.utils.DateUtils;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.datastore.api.FileType;
 
@@ -55,7 +54,7 @@ class HttpsFileDataSourceTest {
       HttpHeaders.CONTENT_LENGTH,
       "1024",
       HttpHeaders.LAST_MODIFIED,
-      DateUtils.formatDate(Date.from(now))
+      DateUtils.formatStandardDate(Instant.now())
     );
     HttpsDataSourceMetadata metadata = new HttpsDataSourceMetadata(headers);
     HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(

--- a/src/test/java/org/opentripplanner/framework/FrameworkArchitectureTest.java
+++ b/src/test/java/org/opentripplanner/framework/FrameworkArchitectureTest.java
@@ -13,7 +13,7 @@ import org.opentripplanner._support.arch.Package;
 
 public class FrameworkArchitectureTest {
 
-  private static final Package APACHE_HTTP = Package.of("org.apache.http..");
+  private static final Package APACHE_HTTP = Package.of("org.apache.hc..");
   private static final Package GUAVA_COLLECTIONS = Package.of("com.google.common.collect");
 
   private static final Module XML_MODULES = Module.of(


### PR DESCRIPTION
### Summary

This PR upgrades the Apache HTTP client library from v4 to v5.
- The API remains mostly unchanged.
- v5 adds support for HTTP/2.
- v5 uses different Maven coordinates, upgrading will not impact transitive dependencies of other libraries. 

Note: v5 introduces also new default values for connection pooling and TTL. Since the OtpHttpClient is currently not reused, this has no impact.
OtpHttpClient reuse and HTTP connection pooling will be addressed in a separate PR.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No