### PR TITLE
Fix duplicate publishing of speed test data

### DIFF
--- a/src/test/java/org/opentripplanner/transit/speed_test/model/timer/MeterRegistrySetup.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/model/timer/MeterRegistrySetup.java
@@ -82,6 +82,10 @@ class MeterRegistrySetup {
       super(config, clock);
     }
 
+    public void doPublish() {
+      publish();
+    }
+
     @Override
     protected Timer newTimer(
       Id id,

--- a/src/test/java/org/opentripplanner/transit/speed_test/model/timer/SpeedTestTimer.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/model/timer/SpeedTestTimer.java
@@ -119,11 +119,11 @@ public class SpeedTestTimer {
 
   public void finishUp() {
     // close() sends the results to influxdb
-    if (uploadRegistry != null) {
-      if(uploadRegistry instanceof MeterRegistrySetup.CustomInfluxRegistry custom) {
-        custom.doPublish();
-      }
-      uploadRegistry.close();
+    if (
+      uploadRegistry != null &&
+      uploadRegistry instanceof MeterRegistrySetup.CustomInfluxRegistry custom
+    ) {
+      custom.doPublish();
     }
   }
 

--- a/src/test/java/org/opentripplanner/transit/speed_test/model/timer/SpeedTestTimer.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/model/timer/SpeedTestTimer.java
@@ -120,6 +120,9 @@ public class SpeedTestTimer {
   public void finishUp() {
     // close() sends the results to influxdb
     if (uploadRegistry != null) {
+      if(uploadRegistry instanceof MeterRegistrySetup.CustomInfluxRegistry custom) {
+        custom.doPublish();
+      }
       uploadRegistry.close();
     }
   }


### PR DESCRIPTION
### Summary

Version 1.11.1 of micrometer has [changed the behaviour of the `StepRegistry`](https://github.com/micrometer-metrics/micrometer/commit/b0be362f4a5fb2e092fb6ff0c4bc770b7edb7b91) which we use to collect the results of the speed test. This change has resulted in the speed test results being published twice for each run.

![image](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/3cf3edfd-8292-4c9a-bee9-7880b0d527f5)

This PR attempts to work around this problem by allowing our custom micrometer repository to explicitly push to InfluxDB rather than doing it on close.

### Future work

I agree that this isn't a particularly nice solution. In the future I would like to spend some time on rewriting this registry to make it more elegant.