### PR TITLE
Added check for null value of serviceCodesRunning in TripPatternForDateMapper.java

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
@@ -53,6 +53,18 @@ public class TripPatternForDateMapper {
   public TripPatternForDate map(Timetable timetable, LocalDate serviceDate) {
     TIntSet serviceCodesRunning = serviceCodesRunningForDate.get(serviceDate);
 
+    // ServiceCodesRunning is potentially null if the date is not present in the original GTFS.
+    // At that point we can simply return null, as there are no trips running on that date.
+    if (serviceCodesRunning == null) {
+      LOG.debug(
+        "Tried to update TripPattern {}, but no service codes are running for date {}",
+        timetable.getPattern().getId(),
+        serviceDate
+      );
+
+      return null;
+    }
+
     List<TripTimes> times = new ArrayList<>();
 
     // The TripTimes are not sorted by departure time in the source timetable because
@@ -71,6 +83,7 @@ public class TripPatternForDateMapper {
       if (!serviceCodesRunning.contains(tripTimes.getServiceCode())) {
         continue;
       }
+
       if (tripTimes.isDeleted()) {
         continue;
       }


### PR DESCRIPTION
## PR Instructions

When creating a pull request, please follow the format below. For each section, *replace* the
guidance text with your own text, keeping the section heading. If you have nothing to say in a
particular section, you can completely delete the section including its heading to indicate that you
have taken the requested steps. None of these instructions or the guidance text (non-heading text)
should be present in the submitted PR. These sections serve as a checklist: when you have replaced
or deleted all of them, the PR is considered complete. As of 2021, most regular OTP contributors
participate in our twice-weekly conference calls. For all but the simplest and smallest PRs,
participation in these discussions is necessary to facilitate the review and merge process. Other
developers can ask questions and provide immediate feedback on technical design and code style, and
resolve any concerns about long term maintenance and comprehension of new code.

### Summary

Fixes an issue where an NullPointer could be thrown while mapping trip patterns for invalid dates.
This is fixed by checking if the serviceCodesRunning set is not null before trying to check if it includes the current date.

### Issue
[Linked issue](https://github.com/opentripplanner/OpenTripPlanner/issues/5238)
Closes #5238 

### Unit tests

No tests were added / modified. All current tests run successfully. 
Manual verification was done with the given files in #5238 and debugging in IntelliJ, to see if the issue has been solved.

### Documentation
Comments were added where needed.
