### PR TITLE
Provide default implementation for checkInputs()

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/dataoverlay/EdgeUpdaterModule.java
+++ b/src/ext/java/org/opentripplanner/ext/dataoverlay/EdgeUpdaterModule.java
@@ -44,9 +44,4 @@ public class EdgeUpdaterModule implements GraphBuilderModule {
     // The bindings are needed to build the request context when routing
     graph.dataOverlayParameterBindings = this.parameterBindings;
   }
-
-  @Override
-  public void checkInputs() {
-    //nothing
-  }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
@@ -74,9 +74,4 @@ public class FlexLocationsToStreetEdgesMapper implements GraphBuilderModule {
     }
     LOG.info(progress.completeMessage());
   }
-
-  @Override
-  public void checkInputs() {
-    // No inputs
-  }
 }

--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
@@ -180,11 +180,6 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
     );
   }
 
-  @Override
-  public void checkInputs() {
-    // No inputs
-  }
-
   private static class TransferInfo {
 
     final RegularStop origin;

--- a/src/main/java/org/opentripplanner/graph_builder/issue/report/DataImportIssueReporter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issue/report/DataImportIssueReporter.java
@@ -85,9 +85,6 @@ public class DataImportIssueReporter implements GraphBuilderModule {
     }
   }
 
-  @Override
-  public void checkInputs() {}
-
   /**
    * Delete report if it exists, and return true if successful. Return {@code false} if the {@code
    * reportDirectory} is {@code null} or the directory can NOT be deleted.

--- a/src/main/java/org/opentripplanner/graph_builder/model/GraphBuilderModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/model/GraphBuilderModule.java
@@ -9,5 +9,7 @@ public interface GraphBuilderModule {
   void buildGraph();
 
   /** Check that all inputs to the graphbuilder are valid; throw an exception if not. */
-  void checkInputs();
+  default void checkInputs() {
+    // the vast majority of modules don't have any checks
+  }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -188,11 +188,6 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     );
   }
 
-  @Override
-  public void checkInputs() {
-    // No inputs
-  }
-
   private static Iterable<NearbyStop> findNearbyStops(
     NearbyStopFinder nearbyStopFinder,
     Vertex vertex,

--- a/src/main/java/org/opentripplanner/graph_builder/module/GraphCoherencyCheckerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GraphCoherencyCheckerModule.java
@@ -50,9 +50,4 @@ public class GraphCoherencyCheckerModule implements GraphBuilderModule {
     }
     LOG.info("edge lists and from/to members are {}coherent.", coherent ? "" : "not ");
   }
-
-  @Override
-  public void checkInputs() {
-    //No inputs other than the graph itself
-  }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -94,11 +94,6 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
     LOG.info("Found {} OSM references which match a stop's id or code", successes);
   }
 
-  @Override
-  public void checkInputs() {
-    //no inputs
-  }
-
   private boolean connectVertexToStop(TransitStopVertex ts, StreetIndex index) {
     var stopCode = ts.getStop().getCode();
     var stopId = ts.getStop().getId().getId();

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -77,11 +77,6 @@ public class StreetLinkerModule implements GraphBuilderModule {
     graph.calculateConvexHull();
   }
 
-  @Override
-  public void checkInputs() {
-    //no inputs
-  }
-
   public void linkTransitStops(Graph graph, TransitModel transitModel) {
     List<TransitStopVertex> vertices = graph.getVerticesOfType(TransitStopVertex.class);
     var progress = ProgressTracker.track("Linking transit stops to graph", 5000, vertices.size());

--- a/src/main/java/org/opentripplanner/graph_builder/module/TimeZoneAdjusterModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/TimeZoneAdjusterModule.java
@@ -55,7 +55,4 @@ public class TimeZoneAdjusterModule implements GraphBuilderModule {
           .forEach(frequencyEntry -> frequencyEntry.tripTimes.timeShift(timeShift));
       });
   }
-
-  @Override
-  public void checkInputs() {}
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/TripPatternNamer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/TripPatternNamer.java
@@ -32,9 +32,6 @@ public class TripPatternNamer implements GraphBuilderModule {
     generateUniqueNames(transitModel.getAllTripPatterns());
   }
 
-  @Override
-  public void checkInputs() {}
-
   /**
    * Static method that creates unique human-readable names for a collection of TableTripPatterns.
    * Perhaps this should be in TripPattern, and apply to Frequency patterns as well. TODO: resolve

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModule.java
@@ -50,9 +50,6 @@ public class CalculateWorldEnvelopeModule implements GraphBuilderModule {
     worldEnvelopeRepository.saveEnvelope(envelope);
   }
 
-  @Override
-  public void checkInputs() {}
-
   @SuppressWarnings("Convert2MethodRef")
   static WorldEnvelope build(
     Collection<? extends Vertex> vertices,

--- a/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
@@ -138,11 +138,6 @@ public class PruneIslands implements GraphBuilderModule {
     LOG.info("Removed {} edgeless street vertices", removed);
   }
 
-  @Override
-  public void checkInputs() {
-    //no inputs
-  }
-
   /**
    * island without stops and with less than this number of street vertices will be pruned
    */

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
@@ -96,9 +96,4 @@ public class BusRouteStreetMatcher implements GraphBuilderModule {
     }
     log.info(progress.completeMessage());
   }
-
-  @Override
-  public void checkInputs() {
-    //no file inputs
-  }
 }


### PR DESCRIPTION
### Summary

Right now implementing a `GraphBuilderModule` forces you to add a `checkInputs` method. For 3/4 of the modules this is an empty method that does nothing and only a few have some actual logic .

For this reason I want to add a default implementation (a noop) and only have those few modules implement the method that need it.