### PR TITLE
Improve street edge thread-safety

### DIFF
--- a/src/main/java/org/opentripplanner/framework/geometry/DirectionUtils.java
+++ b/src/main/java/org/opentripplanner/framework/geometry/DirectionUtils.java
@@ -5,9 +5,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiLineString;
 
-public class DirectionUtils {
-
-  public static DirectionUtils instance;
+public final class DirectionUtils {
 
   private DirectionUtils() {}
 
@@ -15,7 +13,7 @@ public class DirectionUtils {
    * Returns the approximate azimuth from coordinate A to B in decimal degrees clockwise from North,
    * in the range (-180° to +180°). The computation is exact for small delta between A and B.
    */
-  public static synchronized double getAzimuth(Coordinate a, Coordinate b) {
+  public static double getAzimuth(Coordinate a, Coordinate b) {
     double cosLat = Math.cos(Math.toRadians((a.y + b.y) / 2.0));
     double dY = (b.y - a.y); // in degrees, we do not care about the units
     double dX = (b.x - a.x) * cosLat; // same
@@ -31,7 +29,7 @@ public class DirectionUtils {
    *
    * @param geometry a LineString or a MultiLineString
    */
-  public static synchronized double getLastAngle(Geometry geometry) {
+  public static double getLastAngle(Geometry geometry) {
     LineString line;
     if (geometry instanceof MultiLineString) {
       line = (LineString) geometry.getGeometryN(geometry.getNumGeometries() - 1);
@@ -58,7 +56,7 @@ public class DirectionUtils {
    *
    * @param geometry a LineString or a MultiLineString
    */
-  public static synchronized double getFirstAngle(Geometry geometry) {
+  public static double getFirstAngle(Geometry geometry) {
     LineString line;
     if (geometry instanceof MultiLineString) {
       line = (LineString) geometry.getGeometryN(0);

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -19,6 +19,7 @@ import org.opentripplanner.street.model.edge.BoardingLocationToStopLink;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.NamedArea;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.vertex.OsmBoardingLocationVertex;
 import org.opentripplanner.street.model.vertex.StreetVertex;
@@ -185,15 +186,15 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
 
   private StreetEdge linkBoardingLocationToStreetNetwork(StreetVertex from, StreetVertex to) {
     var line = GeometryUtils.makeLineString(List.of(from.getCoordinate(), to.getCoordinate()));
-    return StreetEdge.createStreetEdge(
-      from,
-      to,
-      line,
-      new LocalizedString("name.platform"),
-      SphericalDistanceLibrary.length(line),
-      StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,
-      false
-    );
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(from)
+      .withToVertex(to)
+      .withGeometry(line)
+      .withName(new LocalizedString("name.platform"))
+      .withMeterLength(SphericalDistanceLibrary.length(line))
+      .withPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE)
+      .withBack(false)
+      .buildAndConnect();
   }
 
   private void linkBoardingLocationToStop(

--- a/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
@@ -29,6 +29,7 @@ import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
 import org.opentripplanner.street.model.edge.TemporaryPartialStreetEdge;
+import org.opentripplanner.street.model.edge.TemporaryPartialStreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
@@ -276,35 +277,33 @@ public class StreetIndex {
     double lengthOut = street.getDistanceMeters() * (1 - lengthRatioIn);
 
     if (endVertex) {
-      TemporaryPartialStreetEdge temporaryPartialStreetEdge = TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
-        street,
-        fromv,
-        base,
-        geometries.beginning(),
-        name,
-        lengthIn
-      );
-
-      temporaryPartialStreetEdge.setMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic());
-      temporaryPartialStreetEdge.setBicycleNoThruTraffic(street.isBicycleNoThruTraffic());
-      temporaryPartialStreetEdge.setWalkNoThruTraffic(street.isWalkNoThruTraffic());
-      temporaryPartialStreetEdge.setLink(street.isLink());
-      tempEdges.addEdge(temporaryPartialStreetEdge);
+      TemporaryPartialStreetEdge tpse = new TemporaryPartialStreetEdgeBuilder()
+        .withParentEdge(street)
+        .withFromVertex(fromv)
+        .withToVertex(base)
+        .withGeometry(geometries.beginning())
+        .withName(name)
+        .withMeterLength(lengthIn)
+        .withMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic())
+        .withBicycleNoThruTraffic(street.isBicycleNoThruTraffic())
+        .withWalkNoThruTraffic(street.isWalkNoThruTraffic())
+        .withLink(street.isLink())
+        .buildAndConnect();
+      tempEdges.addEdge(tpse);
     } else {
-      TemporaryPartialStreetEdge temporaryPartialStreetEdge = TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
-        street,
-        base,
-        tov,
-        geometries.ending(),
-        name,
-        lengthOut
-      );
-
-      temporaryPartialStreetEdge.setLink(street.isLink());
-      temporaryPartialStreetEdge.setMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic());
-      temporaryPartialStreetEdge.setBicycleNoThruTraffic(street.isBicycleNoThruTraffic());
-      temporaryPartialStreetEdge.setWalkNoThruTraffic(street.isWalkNoThruTraffic());
-      tempEdges.addEdge(temporaryPartialStreetEdge);
+      TemporaryPartialStreetEdge tpse = new TemporaryPartialStreetEdgeBuilder()
+        .withParentEdge(street)
+        .withFromVertex(base)
+        .withToVertex(tov)
+        .withGeometry(geometries.ending())
+        .withName(name)
+        .withMeterLength(lengthOut)
+        .withLink(street.isLink())
+        .withMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic())
+        .withBicycleNoThruTraffic(street.isBicycleNoThruTraffic())
+        .withWalkNoThruTraffic(street.isWalkNoThruTraffic())
+        .buildAndConnect();
+      tempEdges.addEdge(tpse);
     }
   }
 

--- a/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -21,6 +21,7 @@ import org.opentripplanner.framework.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.index.EdgeSpatialIndex;
 import org.opentripplanner.street.model.edge.AreaEdge;
+import org.opentripplanner.street.model.edge.AreaEdgeBuilder;
 import org.opentripplanner.street.model.edge.AreaEdgeList;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.NamedArea;
@@ -639,42 +640,38 @@ public class VertexLinker {
       // if all joining edges are nothru, then the new edge should be as well
       var incomingNoThruModes = getNoThruModes(to.getIncoming());
       var outgoingNoThruModes = getNoThruModes(to.getIncoming());
-
-      AreaEdge ae = AreaEdge.createAreaEdge(
-        from,
-        to,
-        line,
-        hit.getName(),
-        length,
-        hit.getPermission(),
-        false,
-        ael
-      );
+      AreaEdgeBuilder areaEdgeBuilder = new AreaEdgeBuilder()
+        .withFromVertex(from)
+        .withToVertex(to)
+        .withGeometry(line)
+        .withName(hit.getName())
+        .withMeterLength(length)
+        .withPermission(hit.getPermission())
+        .withBack(false)
+        .withArea(ael);
       for (TraverseMode tm : outgoingNoThruModes) {
-        ae.setNoThruTraffic(tm);
+        areaEdgeBuilder.withNoThruTrafficTraverseMode(tm);
       }
-
+      AreaEdge areaEdge = areaEdgeBuilder.buildAndConnect();
       if (scope != Scope.PERMANENT) {
-        tempEdges.addEdge(ae);
+        tempEdges.addEdge(areaEdge);
       }
 
-      ae =
-        AreaEdge.createAreaEdge(
-          to,
-          from,
-          line.reverse(),
-          hit.getName(),
-          length,
-          hit.getPermission(),
-          true,
-          ael
-        );
+      AreaEdgeBuilder reverseAreaEdgeBuilder = new AreaEdgeBuilder()
+        .withFromVertex(to)
+        .withToVertex(from)
+        .withGeometry(line.reverse())
+        .withName(hit.getName())
+        .withMeterLength(length)
+        .withPermission(hit.getPermission())
+        .withBack(true)
+        .withArea(ael);
       for (TraverseMode tm : incomingNoThruModes) {
-        ae.setNoThruTraffic(tm);
+        reverseAreaEdgeBuilder.withNoThruTrafficTraverseMode(tm);
       }
-
+      AreaEdge reverseAreaEdge = reverseAreaEdgeBuilder.buildAndConnect();
       if (scope != Scope.PERMANENT) {
-        tempEdges.addEdge(ae);
+        tempEdges.addEdge(reverseAreaEdge);
       }
     }
   }

--- a/src/main/java/org/opentripplanner/street/model/edge/AreaEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/AreaEdge.java
@@ -1,69 +1,12 @@
 package org.opentripplanner.street.model.edge;
 
-import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.street.model.vertex.IntersectionVertex;
-
 public class AreaEdge extends StreetEdge {
 
   private final AreaEdgeList area;
 
-  private AreaEdge(
-    IntersectionVertex startEndpoint,
-    IntersectionVertex endEndpoint,
-    LineString geometry,
-    I18NString name,
-    double length,
-    StreetTraversalPermission permissions,
-    boolean back,
-    AreaEdgeList area
-  ) {
-    super(startEndpoint, endEndpoint, geometry, name, length, permissions, back);
-    this.area = area;
-  }
-
-  // constructor without precomputed length
-  private AreaEdge(
-    IntersectionVertex startEndpoint,
-    IntersectionVertex endEndpoint,
-    LineString geometry,
-    I18NString name,
-    StreetTraversalPermission permissions,
-    boolean back,
-    AreaEdgeList area
-  ) {
-    super(startEndpoint, endEndpoint, geometry, name, permissions, back);
-    this.area = area;
-  }
-
-  public static AreaEdge createAreaEdge(
-    IntersectionVertex startEndpoint,
-    IntersectionVertex endEndpoint,
-    LineString geometry,
-    I18NString name,
-    double length,
-    StreetTraversalPermission permissions,
-    boolean back,
-    AreaEdgeList area
-  ) {
-    return connectToGraph(
-      new AreaEdge(startEndpoint, endEndpoint, geometry, name, length, permissions, back, area)
-    );
-  }
-
-  public static AreaEdge createAreaEdge(
-    IntersectionVertex startEndpoint,
-    IntersectionVertex endEndpoint,
-    LineString geometry,
-    I18NString name,
-    StreetTraversalPermission permissions,
-    boolean back,
-    AreaEdgeList area
-  ) {
-    return connectToGraph(
-      new AreaEdge(startEndpoint, endEndpoint, geometry, name, permissions, back, area)
-    );
+  protected AreaEdge(AreaEdgeBuilder builder) {
+    super(builder);
+    this.area = builder.area();
   }
 
   public AreaEdgeList getArea() {

--- a/src/main/java/org/opentripplanner/street/model/edge/AreaEdgeBuilder.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/AreaEdgeBuilder.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.street.model.edge;
+
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
+
+public class AreaEdgeBuilder extends StreetEdgeBuilder<AreaEdgeBuilder> {
+
+  private AreaEdgeList area;
+
+  @Override
+  public AreaEdge buildAndConnect() {
+    return Edge.connectToGraph(new AreaEdge(this));
+  }
+
+  @Override
+  public IntersectionVertex fromVertex() {
+    return (IntersectionVertex) super.fromVertex();
+  }
+
+  @Override
+  public IntersectionVertex toVertex() {
+    return (IntersectionVertex) super.toVertex();
+  }
+
+  public AreaEdgeList area() {
+    return area;
+  }
+
+  public AreaEdgeBuilder withArea(AreaEdgeList area) {
+    this.area = area;
+    return this;
+  }
+}

--- a/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
@@ -19,12 +19,15 @@ import org.opentripplanner.transit.model.basic.Accessibility;
  */
 public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTraversalInformation {
 
+  private static final double DEFAULT_LEVELS = 1;
+  private static final int DEFAULT_TRAVEL_TIME = 0;
+
   private final StreetTraversalPermission permission;
 
   private final Accessibility wheelchairAccessibility;
 
-  private double levels = 1;
-  private int travelTime = 0;
+  private final double levels;
+  private final int travelTime;
 
   private ElevatorHopEdge(
     Vertex from,
@@ -34,7 +37,9 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     double levels,
     int travelTime
   ) {
-    this(from, to, permission, wheelchairAccessibility);
+    super(from, to);
+    this.permission = permission;
+    this.wheelchairAccessibility = wheelchairAccessibility;
     this.levels = levels;
     this.travelTime = travelTime;
   }
@@ -45,9 +50,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     StreetTraversalPermission permission,
     Accessibility wheelchairAccessibility
   ) {
-    super(from, to);
-    this.permission = permission;
-    this.wheelchairAccessibility = wheelchairAccessibility;
+    this(from, to, permission, wheelchairAccessibility, DEFAULT_LEVELS, DEFAULT_TRAVEL_TIME);
   }
 
   public static void bidirectional(
@@ -138,12 +141,12 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     }
 
     s1.incrementWeight(
-      this.travelTime > 0
+      this.travelTime > DEFAULT_TRAVEL_TIME
         ? this.travelTime
         : (preferences.street().elevator().hopCost() * this.levels)
     );
     s1.incrementTimeInSeconds(
-      this.travelTime > 0
+      this.travelTime > DEFAULT_TRAVEL_TIME
         ? this.travelTime
         : (int) (preferences.street().elevator().hopTime() * this.levels)
     );
@@ -162,7 +165,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
 
   @Override
   public double getDistanceMeters() {
-    return 0;
+    return DEFAULT_TRAVEL_TIME;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetEdgeBuilder.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetEdgeBuilder.java
@@ -1,0 +1,232 @@
+package org.opentripplanner.street.model.edge;
+
+import static org.opentripplanner.street.model.edge.StreetEdge.BACK_FLAG_INDEX;
+import static org.opentripplanner.street.model.edge.StreetEdge.BICYCLE_NOTHRUTRAFFIC;
+import static org.opentripplanner.street.model.edge.StreetEdge.CLASS_LINK;
+import static org.opentripplanner.street.model.edge.StreetEdge.HASBOGUSNAME_FLAG_INDEX;
+import static org.opentripplanner.street.model.edge.StreetEdge.MOTOR_VEHICLE_NOTHRUTRAFFIC;
+import static org.opentripplanner.street.model.edge.StreetEdge.ROUNDABOUT_FLAG_INDEX;
+import static org.opentripplanner.street.model.edge.StreetEdge.SLOPEOVERRIDE_FLAG_INDEX;
+import static org.opentripplanner.street.model.edge.StreetEdge.STAIRS_FLAG_INDEX;
+import static org.opentripplanner.street.model.edge.StreetEdge.WALK_NOTHRUTRAFFIC;
+import static org.opentripplanner.street.model.edge.StreetEdge.WHEELCHAIR_ACCESSIBLE_FLAG_INDEX;
+
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.framework.i18n.NonLocalizedString;
+import org.opentripplanner.framework.lang.BitSetUtils;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.search.TraverseMode;
+
+public class StreetEdgeBuilder<B extends StreetEdgeBuilder<B>> {
+
+  // TODO(flamholz): do something smarter with the car speed here.
+  public static final float DEFAULT_CAR_SPEED = 11.2f;
+  public static final float DEFAULT_WALK_SAFETY_FACTOR = 1.0f;
+  private static final float DEFAULT_BICYCLE_SAFETY_FACTOR = 1.0f;
+
+  private StreetVertex from;
+  private StreetVertex to;
+  private LineString geometry;
+  private I18NString name;
+  private int millimeterLength;
+  private StreetTraversalPermission permission;
+  private boolean defaultLength;
+  private float carSpeed;
+  private float walkSafetyFactor;
+  private float bicycleSafetyFactor;
+  private short flags;
+
+  public StreetEdgeBuilder() {
+    this.defaultLength = true;
+    this.walkSafetyFactor = DEFAULT_WALK_SAFETY_FACTOR;
+    this.bicycleSafetyFactor = DEFAULT_BICYCLE_SAFETY_FACTOR;
+    this.carSpeed = DEFAULT_CAR_SPEED;
+    withWheelchairAccessible(true);
+  }
+
+  public StreetEdgeBuilder(StreetEdge original) {
+    this.from = (StreetVertex) original.getFromVertex();
+    this.to = (StreetVertex) original.getToVertex();
+    this.geometry = original.getGeometry();
+    this.name = original.getName();
+    this.millimeterLength = original.getMillimeterLength();
+    this.permission = original.getPermission();
+    this.defaultLength = false;
+    this.carSpeed = original.getCarSpeed();
+    this.walkSafetyFactor = original.getWalkSafetyFactor();
+    this.bicycleSafetyFactor = original.getBicycleSafetyFactor();
+    this.flags = original.getFlags();
+  }
+
+  public StreetEdge buildAndConnect() {
+    return Edge.connectToGraph(new StreetEdge(this));
+  }
+
+  public StreetVertex fromVertex() {
+    return from;
+  }
+
+  public B withFromVertex(StreetVertex from) {
+    this.from = from;
+    return instance();
+  }
+
+  public StreetVertex toVertex() {
+    return to;
+  }
+
+  public B withToVertex(StreetVertex to) {
+    this.to = to;
+    return instance();
+  }
+
+  public LineString geometry() {
+    return geometry;
+  }
+
+  public B withGeometry(LineString geometry) {
+    this.geometry = geometry;
+    return instance();
+  }
+
+  public I18NString name() {
+    return name;
+  }
+
+  public B withName(I18NString name) {
+    this.name = name;
+    return instance();
+  }
+
+  public B withName(String name) {
+    this.name = new NonLocalizedString(name);
+    return instance();
+  }
+
+  public int millimeterLength() {
+    return millimeterLength;
+  }
+
+  public B withMeterLength(double length) {
+    return withMilliMeterLength((int) (length * 1000));
+  }
+
+  public B withMilliMeterLength(int length) {
+    this.millimeterLength = length;
+    this.defaultLength = false;
+    return instance();
+  }
+
+  public boolean hasDefaultLength() {
+    return defaultLength;
+  }
+
+  public StreetTraversalPermission permission() {
+    return permission;
+  }
+
+  public B withPermission(StreetTraversalPermission permission) {
+    this.permission = permission;
+    return instance();
+  }
+
+  public float carSpeed() {
+    return carSpeed;
+  }
+
+  public B withCarSpeed(float carSpeed) {
+    this.carSpeed = carSpeed;
+    return instance();
+  }
+
+  public float walkSafetyFactor() {
+    return walkSafetyFactor;
+  }
+
+  public B withWalkSafetyFactor(float walkSafetyFactor) {
+    this.walkSafetyFactor = walkSafetyFactor;
+    return instance();
+  }
+
+  public float bicycleSafetyFactor() {
+    return bicycleSafetyFactor;
+  }
+
+  public B withBicycleSafetyFactor(float bicycleSafetyFactor) {
+    this.bicycleSafetyFactor = bicycleSafetyFactor;
+    return instance();
+  }
+
+  public short getFlags() {
+    return flags;
+  }
+
+  public B withBack(boolean back) {
+    flags = BitSetUtils.set(flags, BACK_FLAG_INDEX, back);
+    return instance();
+  }
+
+  public B withLink(boolean link) {
+    flags = BitSetUtils.set(flags, CLASS_LINK, link);
+    return instance();
+  }
+
+  public B withBogusName(boolean hasBogusName) {
+    flags = BitSetUtils.set(flags, HASBOGUSNAME_FLAG_INDEX, hasBogusName);
+    return instance();
+  }
+
+  public B withStairs(boolean stairs) {
+    flags = BitSetUtils.set(flags, STAIRS_FLAG_INDEX, stairs);
+    return instance();
+  }
+
+  public B withWheelchairAccessible(boolean wheelchairAccessible) {
+    flags = BitSetUtils.set(flags, WHEELCHAIR_ACCESSIBLE_FLAG_INDEX, wheelchairAccessible);
+    return instance();
+  }
+
+  public B withSlopeOverride(boolean slopeOverride) {
+    flags = BitSetUtils.set(flags, SLOPEOVERRIDE_FLAG_INDEX, slopeOverride);
+    return instance();
+  }
+
+  public B withRoundabout(boolean roundabout) {
+    flags = BitSetUtils.set(flags, ROUNDABOUT_FLAG_INDEX, roundabout);
+    return instance();
+  }
+
+  public B withMotorVehicleNoThruTraffic(boolean motorVehicleNoThruTraffic) {
+    flags = BitSetUtils.set(flags, MOTOR_VEHICLE_NOTHRUTRAFFIC, motorVehicleNoThruTraffic);
+    return instance();
+  }
+
+  public B withBicycleNoThruTraffic(boolean bicycleNoThruTraffic) {
+    flags = BitSetUtils.set(flags, BICYCLE_NOTHRUTRAFFIC, bicycleNoThruTraffic);
+    return instance();
+  }
+
+  public B withWalkNoThruTraffic(boolean walkNoThruTraffic) {
+    flags = BitSetUtils.set(flags, WALK_NOTHRUTRAFFIC, walkNoThruTraffic);
+    return instance();
+  }
+
+  public B withNoThruTrafficTraverseMode(TraverseMode noThruTrafficTraverseMode) {
+    if (noThruTrafficTraverseMode == null) {
+      return instance();
+    }
+    switch (noThruTrafficTraverseMode) {
+      case WALK -> withWalkNoThruTraffic(true);
+      case BICYCLE, SCOOTER -> withBicycleNoThruTraffic(true);
+      case CAR, FLEX -> withMotorVehicleNoThruTraffic(true);
+    }
+    return instance();
+  }
+
+  @SuppressWarnings("unchecked")
+  final B instance() {
+    return (B) this;
+  }
+}

--- a/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdge.java
@@ -2,8 +2,6 @@ package org.opentripplanner.street.model.edge;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.street.model.vertex.StreetVertex;
 
 public final class TemporaryPartialStreetEdge extends StreetEdge implements TemporaryEdge {
 
@@ -21,50 +19,16 @@ public final class TemporaryPartialStreetEdge extends StreetEdge implements Temp
    * is negative, a new length is calculated from the geometry. The elevation data is calculated
    * using the 'parentEdge' and given 'length'.
    */
-  private TemporaryPartialStreetEdge(
-    StreetEdge parentEdge,
-    StreetVertex v1,
-    StreetVertex v2,
-    LineString geometry,
-    I18NString name,
-    double length
-  ) {
-    super(v1, v2, geometry, name, length, parentEdge.getPermission(), false);
-    v1.addRentalRestriction(parentEdge.getFromVertex().rentalRestrictions());
-    v2.addRentalRestriction(parentEdge.getToVertex().rentalRestrictions());
-    this.parentEdge = parentEdge;
+  TemporaryPartialStreetEdge(TemporaryPartialStreetEdgeBuilder builder) {
+    super(builder);
+    builder
+      .fromVertex()
+      .addRentalRestriction(builder.parentEdge().getFromVertex().rentalRestrictions());
+    builder
+      .toVertex()
+      .addRentalRestriction(builder.parentEdge().getToVertex().rentalRestrictions());
+    this.parentEdge = builder.parentEdge();
     this.geometry = super.getGeometry();
-  }
-
-  /**
-   * Create a new partial street edge along the given 'parentEdge' from 'v1' to 'v2'. The length is
-   * calculated using the provided geometry. The elevation data is calculated using the 'parentEdge'
-   * and the calculated 'length'.
-   */
-  private TemporaryPartialStreetEdge(
-    StreetEdge parentEdge,
-    StreetVertex v1,
-    StreetVertex v2,
-    LineString geometry,
-    I18NString name,
-    boolean back
-  ) {
-    super(v1, v2, geometry, name, parentEdge.getPermission(), back);
-    this.parentEdge = parentEdge;
-    this.geometry = super.getGeometry();
-  }
-
-  public static TemporaryPartialStreetEdge createTemporaryPartialStreetEdge(
-    StreetEdge parentEdge,
-    StreetVertex v1,
-    StreetVertex v2,
-    LineString geometry,
-    I18NString name,
-    double length
-  ) {
-    return connectToGraph(
-      new TemporaryPartialStreetEdge(parentEdge, v1, v2, geometry, name, length)
-    );
   }
 
   /**
@@ -143,16 +107,5 @@ public final class TemporaryPartialStreetEdge extends StreetEdge implements Temp
   @Override
   public int getOutAngle() {
     return parentEdge.getInAngle();
-  }
-
-  static TemporaryPartialStreetEdge createTemporaryPartialStreetEdge(
-    StreetEdge parentEdge,
-    StreetVertex v1,
-    StreetVertex v2,
-    LineString geometry,
-    I18NString name,
-    boolean back
-  ) {
-    return connectToGraph(new TemporaryPartialStreetEdge(parentEdge, v1, v2, geometry, name, back));
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeBuilder.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeBuilder.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.street.model.edge;
+
+public class TemporaryPartialStreetEdgeBuilder
+  extends StreetEdgeBuilder<TemporaryPartialStreetEdgeBuilder> {
+
+  private StreetEdge parentEdge;
+
+  @Override
+  public TemporaryPartialStreetEdge buildAndConnect() {
+    return Edge.connectToGraph(new TemporaryPartialStreetEdge(this));
+  }
+
+  public StreetEdge parentEdge() {
+    return parentEdge;
+  }
+
+  public TemporaryPartialStreetEdgeBuilder withParentEdge(StreetEdge parentEdge) {
+    this.parentEdge = parentEdge;
+    withPermission(parentEdge.getPermission());
+    return this;
+  }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -20,6 +20,7 @@ import org.opentripplanner.routing.linking.LinkingDirection;
 import org.opentripplanner.routing.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.AreaEdge;
+import org.opentripplanner.street.model.edge.AreaEdgeBuilder;
 import org.opentripplanner.street.model.edge.AreaEdgeList;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.NamedArea;
@@ -84,25 +85,28 @@ public class LinkStopToPlatformTest {
     namedArea.setOriginalEdges(polygon);
     areaEdgeList.addArea(namedArea);
 
-    ArrayList<AreaEdge> edges = new ArrayList<>();
-
     for (int i = 0; i < platform.length; i++) {
       int next_i = (i + 1) % platform.length;
 
-      var edge1 = createAreaEdge(vertices.get(i), vertices.get(next_i), areaEdgeList, "edge " + i);
-      var edge2 = createAreaEdge(
+      var edgeBuilder1 = createAreaEdge(
+        vertices.get(i),
+        vertices.get(next_i),
+        areaEdgeList,
+        "edge " + i
+      );
+      var edgeBuilder2 = createAreaEdge(
         vertices.get(next_i),
         vertices.get(i),
         areaEdgeList,
         "edge " + String.valueOf(i + platform.length)
       );
-      edges.add(edge1);
-      edges.add(edge2);
       // make one corner surrounded by walk nothru edges
       if (i < 2) {
-        edge1.setWalkNoThruTraffic(true);
-        edge2.setWalkNoThruTraffic(true);
+        edgeBuilder1.withWalkNoThruTraffic(true);
+        edgeBuilder2.withWalkNoThruTraffic(true);
       }
+      edgeBuilder1.buildAndConnect();
+      edgeBuilder2.buildAndConnect();
     }
 
     RegularStop[] transitStops = new RegularStop[stops.length];
@@ -282,7 +286,7 @@ public class LinkStopToPlatformTest {
     }
   }
 
-  private AreaEdge createAreaEdge(
+  private AreaEdgeBuilder createAreaEdge(
     IntersectionVertex v1,
     IntersectionVertex v2,
     AreaEdgeList area,
@@ -292,14 +296,13 @@ public class LinkStopToPlatformTest {
       new Coordinate[] { v1.getCoordinate(), v2.getCoordinate() }
     );
     I18NString name = new LocalizedString(nameString);
-    return AreaEdge.createAreaEdge(
-      v1,
-      v2,
-      line,
-      name,
-      StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,
-      false,
-      area
-    );
+    return new AreaEdgeBuilder()
+      .withFromVertex(v1)
+      .withToVertex(v2)
+      .withGeometry(line)
+      .withName(name)
+      .withPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE)
+      .withBack(false)
+      .withArea(area);
   }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -16,6 +16,7 @@ import org.opentripplanner.graph_builder.module.ned.NEDGridCoverageFactoryImpl;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.OsmVertex;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 
@@ -80,15 +81,15 @@ public class ElevationModuleTest {
     for (int i = 1; i < coordinates.length; ++i) {
       length += SphericalDistanceLibrary.distance(coordinates[i - 1], coordinates[i]);
     }
-    StreetEdge edge = StreetEdge.createStreetEdge(
-      from,
-      to,
-      geometry,
-      "Southwest College St",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    StreetEdge edge = new StreetEdgeBuilder<>()
+      .withFromVertex(from)
+      .withToVertex(to)
+      .withGeometry(geometry)
+      .withName("Southwest College St")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
 
     // create the elevation module
     File cacheDirectory = new File(ElevationModuleTest.class.getResource("ned").getFile());

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.vertex.SplitterVertex;
 import org.opentripplanner.street.model.vertex.StreetVertex;
@@ -49,24 +50,24 @@ public class LinkingTest {
         new Coordinate[] { v0.getCoordinate(), v1.getCoordinate() }
       );
       double dist = SphericalDistanceLibrary.distance(v0.getCoordinate(), v1.getCoordinate());
-      StreetEdge s0 = StreetEdge.createStreetEdge(
-        v0,
-        v1,
-        geom,
-        "test",
-        dist,
-        StreetTraversalPermission.ALL,
-        false
-      );
-      StreetEdge s1 = StreetEdge.createStreetEdge(
-        v1,
-        v0,
-        geom.reverse(),
-        "back",
-        dist,
-        StreetTraversalPermission.ALL,
-        true
-      );
+      StreetEdge s0 = new StreetEdgeBuilder<>()
+        .withFromVertex(v0)
+        .withToVertex(v1)
+        .withGeometry(geom)
+        .withName("test")
+        .withMeterLength(dist)
+        .withPermission(StreetTraversalPermission.ALL)
+        .withBack(false)
+        .buildAndConnect();
+      StreetEdge s1 = new StreetEdgeBuilder<>()
+        .withFromVertex(v1)
+        .withToVertex(v0)
+        .withGeometry(geom.reverse())
+        .withName("back")
+        .withMeterLength(dist)
+        .withPermission(StreetTraversalPermission.ALL)
+        .withBack(true)
+        .buildAndConnect();
 
       // split it but not too close to the end
       double splitVal = Math.random() * 0.95 + 0.025;

--- a/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedStringFormat;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.edge.StreetElevationExtension;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -187,15 +189,15 @@ class MissingElevationHandlerTest {
   }
 
   private StreetEdge edge(IntersectionVertex from, IntersectionVertex to, double length) {
-    return StreetEdge.createStreetEdge(
-      from,
-      to,
-      null,
-      new LocalizedStringFormat("%s%s", from.getName(), to.getName()),
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(from)
+      .withToVertex(to)
+      .withGeometry(null)
+      .withName(new LocalizedStringFormat("%s%s", from.getName(), to.getName()))
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
   }
 
   private void assignElevation(StreetEdge edge, Map<Vertex, Double> elevations) {

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -35,6 +35,7 @@ import org.opentripplanner.routing.services.notes.StreetNotesService;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.note.StreetNote;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
@@ -76,86 +77,86 @@ public class TestHalfEdges {
     br = factory.intersection("br", -74.00, 40.0);
 
     top =
-      StreetEdge.createStreetEdge(
-        tl,
-        tr,
-        GeometryUtils.makeLineString(-74.01, 40.01, -74.0, 40.01),
-        "top",
-        1500,
-        StreetTraversalPermission.ALL,
-        false
-      );
+      new StreetEdgeBuilder<>()
+        .withFromVertex(tl)
+        .withToVertex(tr)
+        .withGeometry(GeometryUtils.makeLineString(-74.01, 40.01, -74.0, 40.01))
+        .withName("top")
+        .withMeterLength(1500)
+        .withPermission(StreetTraversalPermission.ALL)
+        .withBack(false)
+        .buildAndConnect();
     bottom =
-      StreetEdge.createStreetEdge(
-        br,
-        bl,
-        GeometryUtils.makeLineString(-74.01, 40.0, -74.0, 40.0),
-        "bottom",
-        1500,
-        StreetTraversalPermission.ALL,
-        false
-      );
+      new StreetEdgeBuilder<>()
+        .withFromVertex(br)
+        .withToVertex(bl)
+        .withGeometry(GeometryUtils.makeLineString(-74.01, 40.0, -74.0, 40.0))
+        .withName("bottom")
+        .withMeterLength(1500)
+        .withPermission(StreetTraversalPermission.ALL)
+        .withBack(false)
+        .buildAndConnect();
     left =
-      StreetEdge.createStreetEdge(
-        bl,
-        tl,
-        GeometryUtils.makeLineString(-74.01, 40.0, -74.01, 40.01),
-        "left",
-        1500,
-        StreetTraversalPermission.ALL,
-        false
-      );
+      new StreetEdgeBuilder<>()
+        .withFromVertex(bl)
+        .withToVertex(tl)
+        .withGeometry(GeometryUtils.makeLineString(-74.01, 40.0, -74.01, 40.01))
+        .withName("left")
+        .withMeterLength(1500)
+        .withPermission(StreetTraversalPermission.ALL)
+        .withBack(false)
+        .buildAndConnect();
     right =
-      StreetEdge.createStreetEdge(
-        br,
-        tr,
-        GeometryUtils.makeLineString(-74.0, 40.0, -74.0, 40.01),
-        "right",
-        1500,
-        StreetTraversalPermission.PEDESTRIAN,
-        false
-      );
+      new StreetEdgeBuilder<>()
+        .withFromVertex(br)
+        .withToVertex(tr)
+        .withGeometry(GeometryUtils.makeLineString(-74.0, 40.0, -74.0, 40.01))
+        .withName("right")
+        .withMeterLength(1500)
+        .withPermission(StreetTraversalPermission.PEDESTRIAN)
+        .withBack(false)
+        .buildAndConnect();
 
     @SuppressWarnings("unused")
-    StreetEdge topBack = StreetEdge.createStreetEdge(
-      tr,
-      tl,
-      top.getGeometry().reverse(),
-      "topBack",
-      1500,
-      StreetTraversalPermission.ALL,
-      true
-    );
+    StreetEdge topBack = new StreetEdgeBuilder<>()
+      .withFromVertex(tr)
+      .withToVertex(tl)
+      .withGeometry(top.getGeometry().reverse())
+      .withName("topBack")
+      .withMeterLength(1500)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(true)
+      .buildAndConnect();
     @SuppressWarnings("unused")
-    StreetEdge bottomBack = StreetEdge.createStreetEdge(
-      br,
-      bl,
-      bottom.getGeometry().reverse(),
-      "bottomBack",
-      1500,
-      StreetTraversalPermission.ALL,
-      true
-    );
+    StreetEdge bottomBack = new StreetEdgeBuilder<>()
+      .withFromVertex(br)
+      .withToVertex(bl)
+      .withGeometry(bottom.getGeometry().reverse())
+      .withName("bottomBack")
+      .withMeterLength(1500)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(true)
+      .buildAndConnect();
     leftBack =
-      StreetEdge.createStreetEdge(
-        tl,
-        bl,
-        left.getGeometry().reverse(),
-        "leftBack",
-        1500,
-        StreetTraversalPermission.ALL,
-        true
-      );
+      new StreetEdgeBuilder<>()
+        .withFromVertex(tl)
+        .withToVertex(bl)
+        .withGeometry(left.getGeometry().reverse())
+        .withName("leftBack")
+        .withMeterLength(1500)
+        .withPermission(StreetTraversalPermission.ALL)
+        .withBack(true)
+        .buildAndConnect();
     rightBack =
-      StreetEdge.createStreetEdge(
-        tr,
-        br,
-        right.getGeometry().reverse(),
-        "rightBack",
-        1500,
-        StreetTraversalPermission.ALL,
-        true
-      );
+      new StreetEdgeBuilder<>()
+        .withFromVertex(tr)
+        .withToVertex(br)
+        .withGeometry(right.getGeometry().reverse())
+        .withName("rightBack")
+        .withMeterLength(1500)
+        .withPermission(StreetTraversalPermission.ALL)
+        .withBack(true)
+        .buildAndConnect();
 
     var s1 = TransitModelForTest.stopForTest("fleem station", 40.0099999, -74.005);
     var s2 = TransitModelForTest.stopForTest("morx station", 40.0099999, -74.002);

--- a/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -54,13 +54,14 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
             StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE
           );
 
-          street(
+          streetBuilder(
             intersection("D1", 47.500, 19.03),
             intersection("D2", 47.502, 19.03),
             100,
             StreetTraversalPermission.PEDESTRIAN
           )
-            .setWheelchairAccessible(false);
+            .withWheelchairAccessible(false)
+            .buildAndConnect();
 
           street(
             intersection("E1", 47.500, 19.04),

--- a/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
@@ -20,6 +20,7 @@ import org.opentripplanner.street.model.TurnRestrictionType;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.StreetSearchBuilder;
@@ -247,9 +248,16 @@ public class TurnCostTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    StreetEdge pse = StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
-    pse.setCarSpeed(1.0f);
-    return pse;
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(back)
+      .withCarSpeed(1.0f)
+      .buildAndConnect();
   }
 
   private void DisallowTurn(StreetEdge from, StreetEdge to) {

--- a/src/test/java/org/opentripplanner/routing/core/GraphTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/GraphTest.java
@@ -17,6 +17,7 @@ import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.FreeEdge;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
@@ -155,6 +156,14 @@ public class GraphTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, false);
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(false)
+      .buildAndConnect();
   }
 }

--- a/src/test/java/org/opentripplanner/routing/core/TemporaryVerticesContainerTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TemporaryVerticesContainerTest.java
@@ -22,7 +22,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.Edge;
-import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.edge.TemporaryEdge;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TemporaryVertex;
@@ -147,7 +147,15 @@ public class TemporaryVerticesContainerTest {
       new Coordinate[] { v0.getCoordinate(), v1.getCoordinate() }
     );
     double dist = SphericalDistanceLibrary.distance(v0.getCoordinate(), v1.getCoordinate());
-    StreetEdge.createStreetEdge(v0, v1, geom, name, dist, StreetTraversalPermission.ALL, false);
+    new StreetEdgeBuilder<>()
+      .withFromVertex(v0)
+      .withToVertex(v1)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(dist)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
   }
 
   private void assertVertexEdgeIsNotReferencingTemporaryElements(Vertex src, Edge e, Vertex v) {

--- a/src/test/java/org/opentripplanner/routing/core/TurnsTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TurnsTest.java
@@ -9,6 +9,7 @@ import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 
 public class TurnsTest {
@@ -24,29 +25,29 @@ public class TurnsTest {
     IntersectionVertex v1 = StreetModelForTest.intersectionVertex("v1", -0.10, 0);
     IntersectionVertex v2 = StreetModelForTest.intersectionVertex("v2", 0, 0);
 
-    StreetEdge leftEdge = StreetEdge.createStreetEdge(
-      v1,
-      v2,
-      geometry,
-      "morx",
-      10.0,
-      StreetTraversalPermission.ALL,
-      true
-    );
+    StreetEdge leftEdge = new StreetEdgeBuilder<>()
+      .withFromVertex(v1)
+      .withToVertex(v2)
+      .withGeometry(geometry)
+      .withName("morx")
+      .withMeterLength(10.0)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(true)
+      .buildAndConnect();
 
     LineString geometry2 = gf.createLineString(
       new Coordinate[] { new Coordinate(0, 0), new Coordinate(-0.10, 0) }
     );
 
-    StreetEdge rightEdge = StreetEdge.createStreetEdge(
-      v1,
-      v2,
-      geometry2,
-      "fleem",
-      10.0,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    StreetEdge rightEdge = new StreetEdgeBuilder<>()
+      .withFromVertex(v1)
+      .withToVertex(v2)
+      .withGeometry(geometry2)
+      .withName("fleem")
+      .withMeterLength(10.0)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
 
     assertEquals(180, Math.abs(leftEdge.getOutAngle() - rightEdge.getOutAngle()));
   }

--- a/src/test/java/org/opentripplanner/routing/graph/EdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/EdgeTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.Edge;
-import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 
@@ -29,33 +29,33 @@ public class EdgeTest {
     StreetVertex vb = intersectionVertex("B", 10.1, 10.1);
     StreetVertex vc = intersectionVertex("C", 10.2, 10.2);
     StreetVertex vd = intersectionVertex("D", 10.3, 10.3);
-    Edge eab = StreetEdge.createStreetEdge(
-      va,
-      vb,
-      null,
-      "AB",
-      10,
-      StreetTraversalPermission.ALL,
-      false
-    );
-    Edge ebc = StreetEdge.createStreetEdge(
-      vb,
-      vc,
-      null,
-      "BC",
-      10,
-      StreetTraversalPermission.ALL,
-      false
-    );
-    Edge ecd = StreetEdge.createStreetEdge(
-      vc,
-      vd,
-      null,
-      "CD",
-      10,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    Edge eab = new StreetEdgeBuilder<>()
+      .withFromVertex(va)
+      .withToVertex(vb)
+      .withGeometry(null)
+      .withName("AB")
+      .withMeterLength(10)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
+    Edge ebc = new StreetEdgeBuilder<>()
+      .withFromVertex(vb)
+      .withToVertex(vc)
+      .withGeometry(null)
+      .withName("BC")
+      .withMeterLength(10)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
+    Edge ecd = new StreetEdgeBuilder<>()
+      .withFromVertex(vc)
+      .withToVertex(vd)
+      .withGeometry(null)
+      .withName("CD")
+      .withMeterLength(10)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
     // remove an edge that is not connected to this vertex
     va.removeOutgoing(ecd);
     assertEquals(va.getDegreeOut(), 1);

--- a/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
+++ b/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
@@ -1,10 +1,11 @@
 package org.opentripplanner.routing.vehicle_parking;
 
+import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
@@ -44,14 +45,16 @@ public class VehicleParkingTestUtil {
     StreetVertex to,
     StreetTraversalPermission permissions
   ) {
-    StreetEdge.createStreetEdge(
-      from,
-      to,
-      GeometryUtils.makeLineString(from.getLat(), from.getLon(), to.getLat(), to.getLon()),
-      String.format("%s%s street", from.getDefaultName(), to.getDefaultName()),
-      1,
-      permissions,
-      false
-    );
+    new StreetEdgeBuilder<>()
+      .withFromVertex(from)
+      .withToVertex(to)
+      .withGeometry(
+        GeometryUtils.makeLineString(from.getLat(), from.getLon(), to.getLat(), to.getLon())
+      )
+      .withName(String.format("%s%s street", from.getDefaultName(), to.getDefaultName()))
+      .withMeterLength(1)
+      .withPermission(permissions)
+      .withBack(false)
+      .buildAndConnect();
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
+++ b/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
@@ -19,6 +19,7 @@ import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.StreetSearchBuilder;
@@ -199,7 +200,15 @@ public class TurnRestrictionTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(back)
+      .buildAndConnect();
   }
 
   private void DisallowTurn(StreetEdge from, StreetEdge to) {

--- a/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
+++ b/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
@@ -7,6 +7,7 @@ import org.opentripplanner.framework.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.LabelledIntersectionVertex;
 import org.opentripplanner.street.model.vertex.StreetVertex;
@@ -32,7 +33,7 @@ public class StreetModelForTest {
     return streetEdge(vA, vB, meters, StreetTraversalPermission.ALL);
   }
 
-  public static StreetEdge streetEdge(
+  public static StreetEdgeBuilder<?> streetEdgeBuilder(
     StreetVertex vA,
     StreetVertex vB,
     double length,
@@ -46,6 +47,22 @@ public class StreetModelForTest {
     coords[1] = vB.getCoordinate();
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
-    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, false);
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(false);
+  }
+
+  public static StreetEdge streetEdge(
+    StreetVertex vA,
+    StreetVertex vB,
+    double length,
+    StreetTraversalPermission perm
+  ) {
+    return streetEdgeBuilder(vA, vB, length, perm).buildAndConnect();
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/edge/AreaEdgeBuilderTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/AreaEdgeBuilderTest.java
@@ -1,0 +1,40 @@
+package org.opentripplanner.street.model.edge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.framework.geometry.GeometryUtils;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model._data.StreetModelForTest;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+
+class AreaEdgeBuilderTest {
+
+  private static final StreetVertex FROM_VERTEX = StreetModelForTest.V1;
+  private static final StreetVertex TO_VERTEX = StreetModelForTest.V2;
+  private static final StreetTraversalPermission STREET_TRAVERSAL_PERMISSION =
+    StreetTraversalPermission.ALL;
+
+  private static final I18NString NAME = I18NString.of("area-edge-name");
+  private static final LineString GEOMETRY = GeometryUtils
+    .getGeometryFactory()
+    .createLineString(new Coordinate[] { FROM_VERTEX.getCoordinate(), TO_VERTEX.getCoordinate() });
+
+  private static final AreaEdgeList AREA = new AreaEdgeList(null, null);
+
+  @Test
+  void buildAndConnect() {
+    AreaEdge areaEdge = new AreaEdgeBuilder()
+      .withFromVertex(FROM_VERTEX)
+      .withToVertex(TO_VERTEX)
+      .withGeometry(GEOMETRY)
+      .withPermission(STREET_TRAVERSAL_PERMISSION)
+      .withName(NAME)
+      .withArea(AREA)
+      .buildAndConnect();
+    assertEquals(AREA, areaEdge.getArea());
+  }
+}

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeBuilderTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeBuilderTest.java
@@ -1,0 +1,108 @@
+package org.opentripplanner.street.model.edge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.framework.geometry.GeometryUtils;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model._data.StreetModelForTest;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+
+class StreetEdgeBuilderTest {
+
+  private static final StreetVertex FROM_VERTEX = StreetModelForTest.V1;
+  private static final StreetVertex TO_VERTEX = StreetModelForTest.V2;
+  private static final StreetTraversalPermission STREET_TRAVERSAL_PERMISSION =
+    StreetTraversalPermission.ALL;
+
+  private static final I18NString NAME = I18NString.of("street-edge-name");
+
+  private static final double LENGTH = 10.5;
+  private static final LineString GEOMETRY = GeometryUtils
+    .getGeometryFactory()
+    .createLineString(new Coordinate[] { FROM_VERTEX.getCoordinate(), TO_VERTEX.getCoordinate() });
+
+  private static final boolean WHEELCHAIR_ACCESSIBLE = false;
+  private static final boolean BACK = false;
+  private static final boolean STAIRS = true;
+  private static final float CAR_SPEED = 100.1f;
+  private static final float WALK_SAFETY_FACTOR = 0.5f;
+  private static final float BICYCLE_SAFETY_FACTOR = 0.4f;
+  private static final boolean SLOPE_OVERRIDE = false;
+  private static final boolean BOGUS_NAME = true;
+  private static final boolean BICYCLE_NO_THRU_TRAFFIC = true;
+  private static final boolean MOTOR_VEHICLE_NO_THRU_TRAFFIC = true;
+  private static final boolean WALK_NO_THRU_TRAFFIC = true;
+  private static final I18NString NEW_NAME = I18NString.of("street-edge-new-name");
+
+  @Test
+  void buildWithDefaultLength() {
+    StreetEdge streetEdge = new StreetEdgeBuilder<>()
+      .withFromVertex(FROM_VERTEX)
+      .withToVertex(TO_VERTEX)
+      .withGeometry(GEOMETRY)
+      .withName(NAME)
+      .withPermission(STREET_TRAVERSAL_PERMISSION)
+      .buildAndConnect();
+    assertEquals(
+      StreetEdge.defaultMillimeterLength(GEOMETRY) / 1000.0,
+      streetEdge.getDistanceMeters()
+    );
+  }
+
+  @Test
+  void buildWithCustomLength() {
+    StreetEdge streetEdge = buildStreetEdge();
+    assertEquals(NAME, streetEdge.getName());
+    assetAllProperties(streetEdge);
+  }
+
+  @Test
+  void buildFromOriginal() {
+    StreetEdge original = buildStreetEdge();
+    StreetEdge streetEdge = new StreetEdgeBuilder<>(original).withName(NEW_NAME).buildAndConnect();
+    assertEquals(NEW_NAME, streetEdge.getName());
+    assetAllProperties(streetEdge);
+  }
+
+  private static StreetEdge buildStreetEdge() {
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(FROM_VERTEX)
+      .withToVertex(TO_VERTEX)
+      .withMeterLength(LENGTH)
+      .withName(NAME)
+      .withPermission(STREET_TRAVERSAL_PERMISSION)
+      .withCarSpeed(CAR_SPEED)
+      .withWalkSafetyFactor(WALK_SAFETY_FACTOR)
+      .withBicycleSafetyFactor(BICYCLE_SAFETY_FACTOR)
+      .withWheelchairAccessible(WHEELCHAIR_ACCESSIBLE)
+      .withBack(BACK)
+      .withStairs(STAIRS)
+      .withSlopeOverride(SLOPE_OVERRIDE)
+      .withBogusName(BOGUS_NAME)
+      .withWalkNoThruTraffic(WALK_NO_THRU_TRAFFIC)
+      .withBicycleNoThruTraffic(BICYCLE_NO_THRU_TRAFFIC)
+      .withMotorVehicleNoThruTraffic(MOTOR_VEHICLE_NO_THRU_TRAFFIC)
+      .buildAndConnect();
+  }
+
+  private static void assetAllProperties(StreetEdge streetEdge) {
+    assertEquals(FROM_VERTEX, streetEdge.getFromVertex());
+    assertEquals(TO_VERTEX, streetEdge.getToVertex());
+    assertEquals(LENGTH, streetEdge.getDistanceMeters());
+    assertEquals(STREET_TRAVERSAL_PERMISSION, streetEdge.getPermission());
+    assertEquals(WHEELCHAIR_ACCESSIBLE, streetEdge.isWheelchairAccessible());
+    assertEquals(STAIRS, streetEdge.isStairs());
+    assertEquals(CAR_SPEED, streetEdge.getCarSpeed());
+    assertEquals(WALK_SAFETY_FACTOR, streetEdge.getWalkSafetyFactor());
+    assertEquals(BICYCLE_SAFETY_FACTOR, streetEdge.getBicycleSafetyFactor());
+    assertEquals(SLOPE_OVERRIDE, streetEdge.isSlopeOverride());
+    assertEquals(BOGUS_NAME, streetEdge.hasBogusName());
+    assertEquals(WALK_NO_THRU_TRAFFIC, streetEdge.isWalkNoThruTraffic());
+    assertEquals(BICYCLE_NO_THRU_TRAFFIC, streetEdge.isBicycleNoThruTraffic());
+    assertEquals(MOTOR_VEHICLE_NO_THRU_TRAFFIC, streetEdge.isMotorVehicleNoThruTraffic());
+  }
+}

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeCostTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeCostTest.java
@@ -27,15 +27,15 @@ class StreetEdgeCostTest {
   @VariableSource("walkReluctanceCases")
   public void walkReluctance(double walkReluctance, long expectedCost) {
     double length = 100;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "edge",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    var edge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("edge")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withWalk(w -> w.withReluctance(walkReluctance)));
@@ -57,15 +57,15 @@ class StreetEdgeCostTest {
   @VariableSource("bikeReluctanceCases")
   public void bikeReluctance(double bikeReluctance, long expectedCost) {
     double length = 100;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "edge",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    var edge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("edge")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withBike(b -> b.withReluctance(bikeReluctance)));
@@ -88,15 +88,15 @@ class StreetEdgeCostTest {
   @VariableSource("carReluctanceCases")
   public void carReluctance(double carReluctance, long expectedCost) {
     double length = 100;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "edge",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    var edge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("edge")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withCar(c -> c.withReluctance(carReluctance)));
@@ -118,27 +118,27 @@ class StreetEdgeCostTest {
   @VariableSource("stairsCases")
   public void stairsReluctance(double stairsReluctance, long expectedCost) {
     double length = 10;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "stairs",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
-    edge.setStairs(true);
+    var stairsEdge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("stairs")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .withStairs(true)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withWalk(w -> w.withStairsReluctance(stairsReluctance)));
     req.withMode(StreetMode.WALK);
-    var result = traverse(edge, req.build());
+    var result = traverse(stairsEdge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     assertEquals(23, result.getElapsedTimeSeconds());
 
-    edge.setStairs(false);
-    var notStairsResult = traverse(edge, req.build());
+    StreetEdge noStairsEdge = stairsEdge.toBuilder().withStairs(false).buildAndConnect();
+    var notStairsResult = traverse(noStairsEdge, req.build());
     assertEquals(15, (long) notStairsResult.weight);
   }
 
@@ -152,27 +152,27 @@ class StreetEdgeCostTest {
   @VariableSource("bikeStairsCases")
   public void bikeStairsReluctance(double stairsReluctance, long expectedCost) {
     double length = 10;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "stairs",
-      length,
-      StreetTraversalPermission.PEDESTRIAN,
-      false
-    );
-    edge.setStairs(true);
+    var stairsEdge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("stairs")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.PEDESTRIAN)
+      .withBack(false)
+      .withStairs(true)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withBike(b -> b.withStairsReluctance(stairsReluctance)));
     req.withMode(StreetMode.BIKE);
-    var result = traverse(edge, req.build());
+    var result = traverse(stairsEdge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     assertEquals(23, result.getElapsedTimeSeconds());
 
-    edge.setStairs(false);
-    var notStairsResult = traverse(edge, req.build());
+    StreetEdge noStairsEdge = stairsEdge.toBuilder().withStairs(false).buildAndConnect();
+    var notStairsResult = traverse(noStairsEdge, req.build());
     assertEquals(37, (long) notStairsResult.weight);
   }
 
@@ -186,27 +186,27 @@ class StreetEdgeCostTest {
   @VariableSource("walkSafetyCases")
   public void walkSafetyFactor(double walkSafetyFactor, long expectedCost) {
     double length = 10;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "test edge",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
-    edge.setWalkSafetyFactor(2);
+    var safeEdge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("test edge")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .withWalkSafetyFactor(2)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withWalk(w -> w.withSafetyFactor(walkSafetyFactor)));
     req.withMode(StreetMode.WALK);
-    var result = traverse(edge, req.build());
+    var result = traverse(safeEdge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     assertEquals(8, result.getElapsedTimeSeconds());
 
-    edge.setWalkSafetyFactor(1);
-    var defaultSafetyResult = traverse(edge, req.build());
+    StreetEdge lessSafeEdge = safeEdge.toBuilder().withWalkSafetyFactor(1).buildAndConnect();
+    var defaultSafetyResult = traverse(lessSafeEdge, req.build());
     assertEquals(15, (long) defaultSafetyResult.weight);
   }
 

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
 import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdge;
+import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdgeBuilder;
 
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,8 +84,9 @@ public class StreetEdgeTest {
 
   @Test
   public void testTraverseAsPedestrian() {
-    StreetEdge e1 = streetEdge(v1, v2, 100.0, StreetTraversalPermission.ALL);
-    e1.setCarSpeed(10.0f);
+    StreetEdge e1 = streetEdgeBuilder(v1, v2, 100.0, StreetTraversalPermission.ALL)
+      .withCarSpeed(10.0f)
+      .buildAndConnect();
 
     StreetSearchRequest options = StreetSearchRequest
       .copyOf(proto)
@@ -103,8 +105,9 @@ public class StreetEdgeTest {
 
   @Test
   public void testTraverseAsCar() {
-    StreetEdge e1 = streetEdge(v1, v2, 100.0, StreetTraversalPermission.ALL);
-    e1.setCarSpeed(10.0f);
+    StreetEdge e1 = streetEdgeBuilder(v1, v2, 100.0, StreetTraversalPermission.ALL)
+      .withCarSpeed(10.0f)
+      .buildAndConnect();
 
     State s0 = new State(v1, StreetSearchRequest.copyOf(proto).withMode(StreetMode.CAR).build());
     State s1 = e1.traverse(s0)[0];
@@ -321,16 +324,17 @@ public class StreetEdgeTest {
 
     double length = 650.0;
 
-    StreetEdge testStreet = StreetEdge.createStreetEdge(
-      v1,
-      v2,
-      geometry,
-      "Test Lane",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
-    testStreet.setBicycleSafetyFactor(0.74f); // a safe street
+    StreetEdge testStreet = new StreetEdgeBuilder<>()
+      .withFromVertex(v1)
+      .withToVertex(v2)
+      .withGeometry(geometry)
+      .withName("Test Lane")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      // a safe street
+      .withBicycleSafetyFactor(0.74f)
+      .buildAndConnect();
 
     Coordinate[] profile = new Coordinate[] {
       new Coordinate(0, 0), // slope = 0.1

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeWheelchairCostTest.java
@@ -60,15 +60,15 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("slopeCases")
   public void shouldScaleCostWithMaxSlope(double slope, double reluctance, long expectedCost) {
     double length = 1000;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "edge with elevation",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    var edge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("edge with elevation")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
 
     Coordinate[] profile = new Coordinate[] {
       new Coordinate(0, 0),
@@ -113,16 +113,16 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("wheelchairStairsCases")
   public void wheelchairStairsReluctance(double stairsReluctance, long expectedCost) {
     double length = 10;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "stairs",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
-    edge.setStairs(true);
+    var stairEdge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("stairs")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .withStairs(true)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withWheelchair(true);
@@ -143,11 +143,11 @@ class StreetEdgeWheelchairCostTest {
 
     req.withPreferences(pref -> pref.withWalk(w -> w.withReluctance(1.0)));
 
-    var result = traverse(edge, req.build());
+    var result = traverse(stairEdge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
-    edge.setStairs(false);
-    var notStairsResult = traverse(edge, req.build());
+    StreetEdge noStairsEdge = stairEdge.toBuilder().withStairs(false).buildAndConnect();
+    var notStairsResult = traverse(noStairsEdge, req.build());
     assertEquals(7, (long) notStairsResult.weight);
   }
 
@@ -163,16 +163,16 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("inaccessibleStreetCases")
   public void inaccessibleStreet(float inaccessibleStreetReluctance, long expectedCost) {
     double length = 10;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "stairs",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
-    edge.setWheelchairAccessible(false);
+    var edge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("stairs")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .withWheelchairAccessible(false)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withWheelchair(true);
@@ -195,8 +195,8 @@ class StreetEdgeWheelchairCostTest {
     assertEquals(expectedCost, (long) result.weight);
 
     // reluctance should have no effect when the edge is accessible
-    edge.setWheelchairAccessible(true);
-    var accessibleResult = traverse(edge, req.build());
+    StreetEdge accessibleEdge = edge.toBuilder().withWheelchairAccessible(true).buildAndConnect();
+    var accessibleResult = traverse(accessibleEdge, req.build());
     assertEquals(15, (long) accessibleResult.weight);
   }
 
@@ -213,15 +213,15 @@ class StreetEdgeWheelchairCostTest {
   @VariableSource("walkReluctanceCases")
   public void walkReluctance(double walkReluctance, long expectedCost) {
     double length = 10;
-    var edge = StreetEdge.createStreetEdge(
-      V1,
-      V2,
-      null,
-      "stairs",
-      length,
-      StreetTraversalPermission.ALL,
-      false
-    );
+    var edge = new StreetEdgeBuilder<>()
+      .withFromVertex(V1)
+      .withToVertex(V2)
+      .withGeometry(null)
+      .withName("stairs")
+      .withMeterLength(length)
+      .withPermission(StreetTraversalPermission.ALL)
+      .withBack(false)
+      .buildAndConnect();
 
     var req = StreetSearchRequest.of();
     req.withPreferences(p -> p.withWalk(w -> w.withReluctance(walkReluctance)));

--- a/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeBuilderTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeBuilderTest.java
@@ -1,0 +1,43 @@
+package org.opentripplanner.street.model.edge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.framework.geometry.GeometryUtils;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model._data.StreetModelForTest;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+
+class TemporaryPartialStreetEdgeBuilderTest {
+
+  private static final StreetVertex FROM_VERTEX = StreetModelForTest.V1;
+  private static final StreetVertex TO_VERTEX = StreetModelForTest.V2;
+  public static final StreetEdge PARENT_EDGE = StreetModelForTest.streetEdge(
+    StreetModelForTest.V3,
+    StreetModelForTest.V4
+  );
+  private static final StreetTraversalPermission STREET_TRAVERSAL_PERMISSION =
+    StreetTraversalPermission.ALL;
+
+  private static final I18NString NAME = I18NString.of("temporary-partial-street-edge-name");
+  private static final LineString GEOMETRY = GeometryUtils
+    .getGeometryFactory()
+    .createLineString(new Coordinate[] { FROM_VERTEX.getCoordinate(), TO_VERTEX.getCoordinate() });
+
+  @Test
+  void buildAndConnect() {
+    TemporaryPartialStreetEdge tpse = new TemporaryPartialStreetEdgeBuilder()
+      .withFromVertex(FROM_VERTEX)
+      .withToVertex(TO_VERTEX)
+      .withGeometry(GEOMETRY)
+      .withPermission(STREET_TRAVERSAL_PERMISSION)
+      .withName(NAME)
+      .withParentEdge(PARENT_EDGE)
+      .buildAndConnect();
+    assertEquals(PARENT_EDGE, tpse.getParentEdge());
+    assertEquals(GEOMETRY, tpse.getGeometry());
+  }
+}

--- a/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeTest.java
@@ -248,14 +248,14 @@ public class TemporaryPartialStreetEdgeTest {
     String name,
     double length
   ) {
-    return TemporaryPartialStreetEdge.createTemporaryPartialStreetEdge(
-      parentEdge,
-      v1,
-      v2,
-      geometry,
-      new NonLocalizedString(name),
-      length
-    );
+    return new TemporaryPartialStreetEdgeBuilder()
+      .withParentEdge(parentEdge)
+      .withFromVertex(v1)
+      .withToVertex(v2)
+      .withGeometry(geometry)
+      .withName(new NonLocalizedString(name))
+      .withMeterLength(length)
+      .buildAndConnect();
   }
 
   private IntersectionVertex vertex(String label, double lat, double lon) {
@@ -279,6 +279,14 @@ public class TemporaryPartialStreetEdgeTest {
     coords[1] = vB.getCoordinate();
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
-    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, false);
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(false)
+      .buildAndConnect();
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/vertex/BarrierVertexTest.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/BarrierVertexTest.java
@@ -14,6 +14,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
 
@@ -168,6 +169,14 @@ public class BarrierVertexTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(back)
+      .buildAndConnect();
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/vertex/IntersectionVertexTest.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/IntersectionVertexTest.java
@@ -12,6 +12,7 @@ import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 
 public class IntersectionVertexTest {
 
@@ -118,6 +119,14 @@ public class IntersectionVertexTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(back)
+      .buildAndConnect();
   }
 }

--- a/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
@@ -12,6 +12,7 @@ import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.LabelledIntersectionVertex;
 import org.opentripplanner.street.model.vertex.SplitterVertex;
@@ -455,6 +456,14 @@ public class SimpleIntersectionTraversalCalculatorTest {
     LineString geom = GeometryUtils.getGeometryFactory().createLineString(coords);
 
     StreetTraversalPermission perm = StreetTraversalPermission.ALL;
-    return StreetEdge.createStreetEdge(vA, vB, geom, name, length, perm, back);
+    return new StreetEdgeBuilder<>()
+      .withFromVertex(vA)
+      .withToVertex(vB)
+      .withGeometry(geom)
+      .withName(name)
+      .withMeterLength(length)
+      .withPermission(perm)
+      .withBack(back)
+      .buildAndConnect();
   }
 }


### PR DESCRIPTION
### Summary

This PR improves street edge thread-safety by:
1. Making `ElevatorHopEdge` immutable
2.  Make `StreetEdge` `inAngle`/`outAngle` immutable
3. Introducing a builder for `StreetEdge` and its sub-classes, which allows for initializing more properties during construction. 

Street edge construction is also simplified by replacing the various constructors and factory methods by a single builder.

Note:
- The copying of edge properties while splitting an edge (`StreetEdge.copyPropertiesToSplitEdge()`) should also be moved inside the builder for better thread-safety. This requires more refactoring and will be performed in a separate PR.
- Ideally edge alterations performed during graph building (island pruning, safety value normalizer, ...) should also be refactored to achieve complete immutability of the edge classes.

### Issue

No

### Unit tests

Added unit tests

### Documentation
No

