### PR TITLE
Fix pathway traversal time calculation when none is supplied

### DIFF
--- a/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
@@ -90,10 +90,10 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
 
     if (time == 0) {
       if (distance > 0) {
-        time = (int) (distance * preferences.walk().speed());
+        time = (int) (distance / preferences.walk().speed());
       } else if (isStairs()) {
         // 1 step corresponds to 20cm, doubling that to compensate for elevation;
-        time = (int) (0.4 * Math.abs(steps) * preferences.walk().speed());
+        time = (int) (0.4 * Math.abs(steps) / preferences.walk().speed());
       }
     }
 

--- a/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
@@ -111,7 +111,7 @@ class PathwayEdgeTest {
       null,
       new NonLocalizedString("pathway"),
       0,
-      100,
+      60,
       0,
       0,
       true,
@@ -119,8 +119,8 @@ class PathwayEdgeTest {
     );
 
     var state = assertThatEdgeIsTraversable(edge);
-    assertEquals(133, state.getElapsedTimeSeconds());
-    assertEquals(266, state.getWeight());
+    assertEquals(6, state.getElapsedTimeSeconds());
+    assertEquals(12, state.getWeight());
   }
 
   @Test
@@ -131,7 +131,7 @@ class PathwayEdgeTest {
       null,
       new NonLocalizedString("pathway"),
       0,
-      100,
+      60,
       0,
       0,
       false,
@@ -139,8 +139,8 @@ class PathwayEdgeTest {
     );
 
     var state = assertThatEdgeIsTraversable(edge, true);
-    assertEquals(133, state.getElapsedTimeSeconds());
-    assertEquals(6650.0, state.getWeight());
+    assertEquals(6, state.getElapsedTimeSeconds());
+    assertEquals(300.0, state.getWeight());
   }
 
   static Stream<Arguments> slopeCases = Stream.of(
@@ -194,18 +194,20 @@ class PathwayEdgeTest {
     var req = StreetSearchRequest.of().withWheelchair(wheelchair).withMode(StreetMode.WALK);
 
     req.withPreferences(preferences ->
-      preferences.withWheelchair(
-        WheelchairPreferences
-          .of()
-          .withTripOnlyAccessible()
-          .withStopOnlyAccessible()
-          .withElevatorOnlyAccessible()
-          .withInaccessibleStreetReluctance(25)
-          .withMaxSlope(0.08)
-          .withSlopeExceededReluctance(1)
-          .withStairsReluctance(25)
-          .build()
-      )
+      preferences
+        .withWalk(builder -> builder.withSpeed(10))
+        .withWheelchair(
+          WheelchairPreferences
+            .of()
+            .withTripOnlyAccessible()
+            .withStopOnlyAccessible()
+            .withElevatorOnlyAccessible()
+            .withInaccessibleStreetReluctance(25)
+            .withMaxSlope(0.08)
+            .withSlopeExceededReluctance(1)
+            .withStairsReluctance(25)
+            .build()
+        )
     );
 
     var afterTraversal = edge.traverse(new State(from, req.build()))[0];


### PR DESCRIPTION
### Summary

If `traversal_time` was not specified for a pathway, the distance-based traversal time was calculated using `time = distance * speed` instead of `time = distance / speed`.

This updates the calculation.

### Issue

:x:

### Unit tests

:ballot_box_with_check: - existing tests are updated

### Documentation

No changes.

### Changelog

:ballot_box_with_check: 

### Bumping the serialization version id

:x: