### PR TITLE
Remove name from vertex constructor chain

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev-2.x
+      - vertex-name
 
 jobs:
   perf-test:

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev-2.x
-      - vertex-name
 
 jobs:
   perf-test:

--- a/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
@@ -23,6 +23,7 @@ import org.opentripplanner.ext.flex.FlexRouter;
 import org.opentripplanner.ext.flex.FlexTest;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.geometry.EncodedPolyline;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
 import org.opentripplanner.model.GenericLocation;
@@ -277,7 +278,10 @@ public class ScheduledDeviatedTripTest extends FlexTest {
       stopLocation,
       0,
       List.of(),
-      new State(new StreetLocation(id, new Coordinate(0, 0), id), StreetSearchRequest.of().build())
+      new State(
+        new StreetLocation(id, new Coordinate(0, 0), I18NString.of(id)),
+        StreetSearchRequest.of().build()
+      )
     );
   }
 

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingEntrance.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingEntrance.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.vehicle_parking;
 
 import java.io.Serializable;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
@@ -58,6 +59,7 @@ public class VehicleParkingEntrance implements Serializable {
     return coordinate;
   }
 
+  @Nullable
   public I18NString getName() {
     return name;
   }

--- a/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalPlaceVertex.java
+++ b/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalPlaceVertex.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.service.vehiclerental.street;
 
+import javax.annotation.Nonnull;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
@@ -14,8 +16,14 @@ public class VehicleRentalPlaceVertex extends Vertex {
   private VehicleRentalPlace station;
 
   public VehicleRentalPlaceVertex(VehicleRentalPlace station) {
-    super(station.getLongitude(), station.getLatitude(), station.getName());
+    super(station.getLongitude(), station.getLatitude());
     this.station = station;
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return station.getName();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOffboardVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOffboardVertex.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.street.model.vertex;
 
-import org.opentripplanner.framework.i18n.NonLocalizedString;
+import javax.annotation.Nonnull;
+import org.opentripplanner.framework.i18n.I18NString;
 
 public class ElevatorOffboardVertex extends StreetVertex {
 
@@ -9,7 +10,7 @@ public class ElevatorOffboardVertex extends StreetVertex {
   private final String label;
 
   public ElevatorOffboardVertex(Vertex sourceVertex, String label, String level) {
-    super(sourceVertex.getX(), sourceVertex.getY(), NonLocalizedString.ofNullable(level));
+    super(sourceVertex.getX(), sourceVertex.getY());
     this.level = level;
     this.label = label;
   }
@@ -17,5 +18,11 @@ public class ElevatorOffboardVertex extends StreetVertex {
   @Override
   public VertexLabel getLabel() {
     return VertexLabel.string(LABEL_TEMPLATE.formatted(label, level));
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return NO_NAME;
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOffboardVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOffboardVertex.java
@@ -23,6 +23,6 @@ public class ElevatorOffboardVertex extends StreetVertex {
   @Nonnull
   @Override
   public I18NString getName() {
-    return NO_NAME;
+    return I18NString.of(label);
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOnboardVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOnboardVertex.java
@@ -1,7 +1,8 @@
 package org.opentripplanner.street.model.vertex;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.opentripplanner.framework.i18n.NonLocalizedString;
+import org.opentripplanner.framework.i18n.I18NString;
 
 public class ElevatorOnboardVertex extends StreetVertex {
 
@@ -10,7 +11,7 @@ public class ElevatorOnboardVertex extends StreetVertex {
   private final String label;
 
   public ElevatorOnboardVertex(Vertex sourceVertex, String label, @Nullable String level) {
-    super(sourceVertex.getX(), sourceVertex.getY(), NonLocalizedString.ofNullable(level));
+    super(sourceVertex.getX(), sourceVertex.getY());
     this.level = level;
     this.label = label;
   }
@@ -18,5 +19,11 @@ public class ElevatorOnboardVertex extends StreetVertex {
   @Override
   public VertexLabel getLabel() {
     return VertexLabel.string(LABEL_TEMPLATE.formatted(label, level));
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return NO_NAME;
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOnboardVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/ElevatorOnboardVertex.java
@@ -24,6 +24,6 @@ public class ElevatorOnboardVertex extends StreetVertex {
   @Nonnull
   @Override
   public I18NString getName() {
-    return NO_NAME;
+    return I18NString.of(label);
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/IntersectionVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/IntersectionVertex.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.street.model.vertex;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.lang.BitSetUtils;
 
@@ -22,16 +22,15 @@ public abstract class IntersectionVertex extends StreetVertex {
   protected IntersectionVertex(
     double x,
     double y,
-    @Nullable I18NString name,
     boolean hasHighwayTrafficLight,
     boolean hasCrossingTrafficLight
   ) {
-    super(x, y, name);
+    super(x, y);
     flags = initFlags(hasHighwayTrafficLight, hasCrossingTrafficLight);
   }
 
   protected IntersectionVertex(double x, double y) {
-    this(x, y, null, false, false);
+    this(x, y, false, false);
   }
 
   /**
@@ -72,5 +71,11 @@ public abstract class IntersectionVertex extends StreetVertex {
     flags = BitSetUtils.set(flags, HIGHWAY_TRAFFIC_LIGHT_INDEX, highwayTrafficLight);
     flags = BitSetUtils.set(flags, CROSSING_TRAFFIC_LIGHT_INDEX, crossingTrafficLight);
     return flags;
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return NO_NAME;
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/IntersectionVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/IntersectionVertex.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.street.model.vertex;
 
-import javax.annotation.Nonnull;
-import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.lang.BitSetUtils;
 
 /**
@@ -71,11 +69,5 @@ public abstract class IntersectionVertex extends StreetVertex {
     flags = BitSetUtils.set(flags, HIGHWAY_TRAFFIC_LIGHT_INDEX, highwayTrafficLight);
     flags = BitSetUtils.set(flags, CROSSING_TRAFFIC_LIGHT_INDEX, crossingTrafficLight);
     return flags;
-  }
-
-  @Nonnull
-  @Override
-  public I18NString getName() {
-    return NO_NAME;
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/LabelledIntersectionVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/LabelledIntersectionVertex.java
@@ -16,11 +16,10 @@ public class LabelledIntersectionVertex extends IntersectionVertex {
     @Nonnull String label,
     double x,
     double y,
-    @Nullable I18NString name,
     boolean hasHighwayTrafficLight,
     boolean hasCrossingTrafficLight
   ) {
-    super(x, y, name, hasHighwayTrafficLight, hasCrossingTrafficLight);
+    super(x, y, hasHighwayTrafficLight, hasCrossingTrafficLight);
     this.label = VertexLabel.string(label);
   }
 

--- a/src/main/java/org/opentripplanner/street/model/vertex/LabelledIntersectionVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/LabelledIntersectionVertex.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.street.model.vertex;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 
 /**
@@ -10,7 +9,7 @@ import org.opentripplanner.framework.i18n.I18NString;
  */
 public class LabelledIntersectionVertex extends IntersectionVertex {
 
-  private final VertexLabel label;
+  private final String label;
 
   public LabelledIntersectionVertex(
     @Nonnull String label,
@@ -20,11 +19,17 @@ public class LabelledIntersectionVertex extends IntersectionVertex {
     boolean hasCrossingTrafficLight
   ) {
     super(x, y, hasHighwayTrafficLight, hasCrossingTrafficLight);
-    this.label = VertexLabel.string(label);
+    this.label = label;
   }
 
   @Override
   public VertexLabel getLabel() {
-    return label;
+    return VertexLabel.string(label);
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return I18NString.of(label);
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/OsmBoardingLocationVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/OsmBoardingLocationVertex.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.street.model.vertex;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
@@ -19,6 +21,7 @@ import org.opentripplanner.framework.tostring.ToStringBuilder;
 public class OsmBoardingLocationVertex extends LabelledIntersectionVertex {
 
   public final Set<String> references;
+  private final I18NString name;
 
   public OsmBoardingLocationVertex(
     String label,
@@ -27,8 +30,9 @@ public class OsmBoardingLocationVertex extends LabelledIntersectionVertex {
     @Nullable I18NString name,
     Collection<String> references
   ) {
-    super(label, x, y, name, false, false);
+    super(label, x, y, false, false);
     this.references = Set.copyOf(references);
+    this.name = Objects.requireNonNullElse(name, NO_NAME);
   }
 
   @Override
@@ -38,5 +42,11 @@ public class OsmBoardingLocationVertex extends LabelledIntersectionVertex {
 
   public boolean isConnectedToStreetNetwork() {
     return (getOutgoing().size() + getIncoming().size()) > 0;
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return name;
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/OsmVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/OsmVertex.java
@@ -22,7 +22,7 @@ public class OsmVertex extends IntersectionVertex {
     boolean hasHighwayTrafficLight,
     boolean hasCrossingTrafficLight
   ) {
-    super(x, y, null, hasHighwayTrafficLight, hasCrossingTrafficLight);
+    super(x, y, hasHighwayTrafficLight, hasCrossingTrafficLight);
     this.nodeId = nodeId;
   }
 

--- a/src/main/java/org/opentripplanner/street/model/vertex/OsmVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/OsmVertex.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.street.model.vertex;
 
+import javax.annotation.Nonnull;
+import org.opentripplanner.framework.i18n.I18NString;
+
 /**
  * A vertex coming from OpenStreetMap.
  * <p>
@@ -24,6 +27,12 @@ public class OsmVertex extends IntersectionVertex {
   ) {
     super(x, y, hasHighwayTrafficLight, hasCrossingTrafficLight);
     this.nodeId = nodeId;
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return NO_NAME;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/vertex/SplitterVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/SplitterVertex.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.vertex;
 
+import javax.annotation.Nonnull;
 import org.opentripplanner.framework.i18n.I18NString;
 
 /**
@@ -10,10 +11,12 @@ import org.opentripplanner.framework.i18n.I18NString;
 public class SplitterVertex extends IntersectionVertex {
 
   private final VertexLabel label;
+  private final I18NString name;
 
   public SplitterVertex(String label, double x, double y, I18NString name) {
-    super(x, y, name, false, false);
+    super(x, y, false, false);
     this.label = VertexLabel.string(label);
+    this.name = name;
   }
 
   @Override
@@ -26,5 +29,11 @@ public class SplitterVertex extends IntersectionVertex {
     // splitter vertices don't represent something that exists in the world, so traversing them is
     // always free.
     return true;
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return name;
   }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/StationElementVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/StationElementVertex.java
@@ -8,10 +8,12 @@ import org.opentripplanner.transit.model.site.StationElement;
 public abstract class StationElementVertex extends Vertex {
 
   private final FeedScopedId id;
+  private final I18NString name;
 
   protected StationElementVertex(FeedScopedId id, double x, double y, I18NString name) {
-    super(x, y, name);
+    super(x, y);
     this.id = id;
+    this.name = name;
   }
 
   @Override
@@ -22,4 +24,10 @@ public abstract class StationElementVertex extends Vertex {
   /** Get the corresponding StationElement */
   @Nonnull
   public abstract StationElement getStationElement();
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return name;
+  }
 }

--- a/src/main/java/org/opentripplanner/street/model/vertex/StreetLocation.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/StreetLocation.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.street.model.vertex;
 
+import javax.annotation.Nonnull;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.framework.i18n.NonLocalizedString;
 
 /**
  * Represents a location on a street, somewhere between the two corners. This is used when computing
@@ -11,6 +11,7 @@ import org.opentripplanner.framework.i18n.NonLocalizedString;
  */
 public class StreetLocation extends StreetVertex {
 
+  private final I18NString name;
   private boolean wheelchairAccessible;
 
   private final VertexLabel label;
@@ -18,15 +19,9 @@ public class StreetLocation extends StreetVertex {
   // maybe name should just be pulled from street being split
   public StreetLocation(String id, Coordinate nearestPoint, I18NString name) {
     // calling constructor with null graph means this vertex is temporary
-    super(nearestPoint.x, nearestPoint.y, name);
-    label = VertexLabel.string(id);
-  }
-
-  //For tests only
-  public StreetLocation(String id, Coordinate nearestPoint, String name) {
-    // calling constructor with null graph means this vertex is temporary
-    super(nearestPoint.x, nearestPoint.y, new NonLocalizedString(name));
-    label = VertexLabel.string(id);
+    super(nearestPoint.x, nearestPoint.y);
+    this.label = VertexLabel.string(id);
+    this.name = name;
   }
 
   public boolean isWheelchairAccessible() {
@@ -44,7 +39,13 @@ public class StreetLocation extends StreetVertex {
 
   @Override
   public I18NString getIntersectionName() {
-    return super.getName();
+    return getName();
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return name;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/vertex/StreetVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/StreetVertex.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedString;
 import org.opentripplanner.street.model.edge.Edge;
@@ -27,8 +26,8 @@ public abstract class StreetVertex extends Vertex {
   /** All locations for flex transit, which this vertex is part of */
   private Set<AreaStop> areaStops = EMPTY_SET;
 
-  StreetVertex(double x, double y, @Nullable I18NString streetName) {
-    super(x, y, streetName);
+  StreetVertex(double x, double y) {
+    super(x, y);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertex.java
@@ -3,6 +3,7 @@ package org.opentripplanner.street.model.vertex;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.PathwayEdge;
 import org.opentripplanner.transit.model.basic.Accessibility;

--- a/src/main/java/org/opentripplanner/street/model/vertex/VehicleParkingEntranceVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/VehicleParkingEntranceVertex.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.street.model.vertex;
 
+import javax.annotation.Nonnull;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingEntrance;
 import org.opentripplanner.street.model.edge.StreetVehicleParkingLink;
@@ -16,12 +18,14 @@ public class VehicleParkingEntranceVertex extends Vertex {
   private final VehicleParkingEntrance parkingEntrance;
 
   public VehicleParkingEntranceVertex(VehicleParkingEntrance parkingEntrance) {
-    super(
-      parkingEntrance.getCoordinate().longitude(),
-      parkingEntrance.getCoordinate().latitude(),
-      parkingEntrance.getName()
-    );
+    super(parkingEntrance.getCoordinate().longitude(), parkingEntrance.getCoordinate().latitude());
     this.parkingEntrance = parkingEntrance;
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return NO_NAME;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/vertex/VehicleParkingEntranceVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/VehicleParkingEntranceVertex.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.vertex;
 
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
@@ -25,7 +26,7 @@ public class VehicleParkingEntranceVertex extends Vertex {
   @Nonnull
   @Override
   public I18NString getName() {
-    return NO_NAME;
+    return Objects.requireNonNullElse(parkingEntrance.getName(), NO_NAME);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -144,7 +144,7 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
    * If this vertex is located on only one street, get that street's name in default localization
    */
   public String getDefaultName() {
-    return this.getName().toString();
+    return getName().toString();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -8,9 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.astar.spi.AStarVertex;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
@@ -28,15 +26,11 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serializable, Cloneable {
 
+  public static final I18NString NO_NAME = I18NString.of("(no name provided)");
   private static final Logger LOG = LoggerFactory.getLogger(Vertex.class);
-  private static final I18NString NO_NAME = I18NString.of("(no name provided)");
 
   private final double x;
   private final double y;
-
-  /* Longer human-readable name for the client */
-  @Nonnull
-  private final I18NString name;
 
   private transient Edge[] incoming = new Edge[0];
 
@@ -46,13 +40,8 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
   /* CONSTRUCTORS */
 
   protected Vertex(double x, double y) {
-    this(x, y, NO_NAME);
-  }
-
-  protected Vertex(double x, double y, @Nullable I18NString name) {
     this.x = x;
     this.y = y;
-    this.name = Objects.requireNonNullElse(name, NO_NAME);
   }
 
   /* PUBLIC METHODS */
@@ -145,17 +134,17 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
     return y;
   }
 
-  /** If this vertex is located on only one street, get that street's name */
+  /**
+   * Longer human-readable name for the client
+   */
   @Nonnull
-  public I18NString getName() {
-    return this.name;
-  }
+  public abstract I18NString getName();
 
   /**
    * If this vertex is located on only one street, get that street's name in default localization
    */
   public String getDefaultName() {
-    return this.name.toString();
+    return this.getName().toString();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/street/model/vertex/VertexFactory.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/VertexFactory.java
@@ -62,7 +62,6 @@ public class VertexFactory {
         "area splitter at " + edgeCoordinate,
         edgeCoordinate.x,
         edgeCoordinate.y,
-        null,
         false,
         false
       )
@@ -71,9 +70,7 @@ public class VertexFactory {
 
   @Nonnull
   public IntersectionVertex intersection(String label, double longitude, double latitude) {
-    return addToGraph(
-      new LabelledIntersectionVertex(label, longitude, latitude, I18NString.of(label), false, false)
-    );
+    return addToGraph(new LabelledIntersectionVertex(label, longitude, latitude, false, false));
   }
 
   @Nonnull

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -54,14 +54,7 @@ public class LinkStopToPlatformTest {
 
     for (int i = 0; i < platform.length; i++) {
       Coordinate c = platform[i];
-      var vertex = new LabelledIntersectionVertex(
-        String.valueOf(i),
-        c.x,
-        c.y,
-        I18NString.of("Platform vertex " + i),
-        false,
-        false
-      );
+      var vertex = new LabelledIntersectionVertex(String.valueOf(i), c.x, c.y, false, false);
       graph.addVertex(vertex);
       vertices.add(vertex);
       closedGeom[i] = c;

--- a/src/test/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModuleTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.stop;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -47,6 +49,12 @@ class CalculateWorldEnvelopeModuleTest {
     @Override
     public VertexLabel getLabel() {
       return VertexLabel.string("%s/%s".formatted(getX(), getY()));
+    }
+
+    @Nonnull
+    @Override
+    public I18NString getName() {
+      return I18NString.of(getLabel().toString());
     }
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
+++ b/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
@@ -4,7 +4,6 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.SphericalDistanceLibrary;
-import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
@@ -24,11 +23,11 @@ public class StreetModelForTest {
 
   public static IntersectionVertex intersectionVertex(double lat, double lon) {
     var label = "%s_%s".formatted(lat, lon);
-    return new LabelledIntersectionVertex(label, lat, lon, I18NString.of(label), false, false);
+    return new LabelledIntersectionVertex(label, lat, lon, false, false);
   }
 
   public static IntersectionVertex intersectionVertex(String label, double lat, double lon) {
-    return new LabelledIntersectionVertex(label, lat, lon, I18NString.of(label), false, false);
+    return new LabelledIntersectionVertex(label, lat, lon, false, false);
   }
 
   public static StreetEdge streetEdge(StreetVertex vA, StreetVertex vB) {

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -142,14 +142,7 @@ public class StreetEdgeTest {
    */
   @Test
   public void testTraverseModeSwitchBike() {
-    var vWithTrafficLight = new LabelledIntersectionVertex(
-      "maple_1st",
-      2.0,
-      2.0,
-      null,
-      false,
-      true
-    );
+    var vWithTrafficLight = new LabelledIntersectionVertex("maple_1st", 2.0, 2.0, false, true);
     StreetEdge e0 = streetEdge(v0, vWithTrafficLight, 50.0, StreetTraversalPermission.PEDESTRIAN);
     StreetEdge e1 = streetEdge(
       vWithTrafficLight,
@@ -186,14 +179,7 @@ public class StreetEdgeTest {
    */
   @Test
   public void testTraverseModeSwitchWalk() {
-    var vWithTrafficLight = new LabelledIntersectionVertex(
-      "maple_1st",
-      2.0,
-      2.0,
-      null,
-      false,
-      true
-    );
+    var vWithTrafficLight = new LabelledIntersectionVertex("maple_1st", 2.0, 2.0, false, true);
     StreetEdge e0 = streetEdge(
       v0,
       vWithTrafficLight,

--- a/src/test/java/org/opentripplanner/street/model/vertex/IntersectionVertexTest.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/IntersectionVertexTest.java
@@ -65,7 +65,7 @@ public class IntersectionVertexTest {
     assertEquals(0, iv.getDegreeIn());
     assertEquals(0, iv.getDegreeOut());
 
-    iv = new LabelledIntersectionVertex("vertex", 1.0, 2.0, null, true, false);
+    iv = new LabelledIntersectionVertex("vertex", 1.0, 2.0, true, false);
     assertTrue(iv.hasDrivingTrafficLight());
     assertTrue(iv.hasCyclingTrafficLight());
     assertFalse(iv.hasWalkingTrafficLight());
@@ -87,7 +87,7 @@ public class IntersectionVertexTest {
     assertFalse(iv.hasDrivingTrafficLight());
     assertTrue(iv.inferredFreeFlowing());
 
-    iv = new LabelledIntersectionVertex("vertex", 1.0, 2.0, null, false, true);
+    iv = new LabelledIntersectionVertex("vertex", 1.0, 2.0, false, true);
     iv.addIncoming(fromEdge);
     iv.addOutgoing(straightAheadEdge);
     assertTrue(iv.hasWalkingTrafficLight());

--- a/src/test/java/org/opentripplanner/street/model/vertex/SimpleVertex.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/SimpleVertex.java
@@ -1,14 +1,21 @@
 package org.opentripplanner.street.model.vertex;
 
-import org.opentripplanner.framework.i18n.NonLocalizedString;
+import javax.annotation.Nonnull;
+import org.opentripplanner.framework.i18n.I18NString;
 
 public class SimpleVertex extends StreetVertex {
 
   private final String label;
 
   public SimpleVertex(String label, double lat, double lon) {
-    super(lon, lat, new NonLocalizedString(label));
+    super(lon, lat);
     this.label = label;
+  }
+
+  @Nonnull
+  @Override
+  public I18NString getName() {
+    return I18NString.of(label);
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/street/model/vertex/TemporaryVertexDisposeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/vertex/TemporaryVertexDisposeTest.java
@@ -2,7 +2,9 @@ package org.opentripplanner.street.model.vertex;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.edge.FreeEdge;
 
 public class TemporaryVertexDisposeTest {
@@ -228,6 +230,12 @@ public class TemporaryVertexDisposeTest {
     @Override
     public String toString() {
       return getLabelString();
+    }
+
+    @Nonnull
+    @Override
+    public I18NString getName() {
+      return NO_NAME;
     }
 
     @Override

--- a/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
@@ -433,7 +433,6 @@ public class SimpleIntersectionTraversalCalculatorTest {
       label,
       coord.y,
       coord.x,
-      null,
       hasHighwayLight,
       hasCrossingLight
     );


### PR DESCRIPTION
### Summary

Very few vertices have a name that provides useful information that is not already in the label, yet every instance needs to pass a name into the super constructor.

This is needlessly complex to implement and also wastes some memory.

For this reason I have refactored the `Vertex` base class to not store the name and each subclass is responsible for implementing the method. Most implementations don't provide any additional, useful information that's not already in the label but a handful do.

### Memory savings

The savings are small, but visible: the heap space in the Norway graph is reduced by 20MB, so 0.5%.

