### PR TITLE
Fix content type of vector tiles 404

### DIFF
--- a/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
@@ -2,11 +2,14 @@ package org.opentripplanner.framework.io;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.UriInfo;
+import java.nio.charset.StandardCharsets;
+import org.apache.hc.core5.http.ContentType;
 
 public final class HttpUtils {
 
   private HttpUtils() {}
 
+  public static final Object TEXT_PLAIN = ContentType.create("text/plain", StandardCharsets.UTF_8);
   public static final String APPLICATION_X_PROTOBUF = "application/x-protobuf";
 
   private static final String HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";

--- a/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
@@ -2,12 +2,15 @@ package org.opentripplanner.inspector.vector;
 
 import edu.colorado.cires.cmg.mvt.VectorTile;
 import jakarta.ws.rs.core.CacheControl;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import org.apache.hc.core5.http.ContentType;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.api.resource.WebMercatorTile;
+import org.opentripplanner.framework.io.HttpUtils;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 
 /**
@@ -37,6 +40,7 @@ public class VectorTileResponseFactory {
     if (!availableLayerNames.containsAll(requestedLayers)) {
       return Response
         .status(Response.Status.NOT_FOUND)
+        .header(HttpHeaders.CONTENT_TYPE, HttpUtils.TEXT_PLAIN)
         .entity(
           "Could not find vector tile layer(s). Requested layers: %s. Available layers: %s.".formatted(
               requestedLayers,

--- a/src/test/java/org/opentripplanner/inspector/vector/VectorTileResponseFactoryTest.java
+++ b/src/test/java/org/opentripplanner/inspector/vector/VectorTileResponseFactoryTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.inspector.vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Locale;
@@ -62,6 +63,7 @@ class VectorTileResponseFactoryTest {
     var resp = computeResponse(List.of("yellow", "blue"));
 
     assertEquals(404, resp.getStatus());
+    assertEquals("text/plain; charset=UTF-8", resp.getHeaderString(HttpHeaders.CONTENT_TYPE));
     assertEquals(
       "Could not find vector tile layer(s). Requested layers: [yellow, blue]. Available layers: [red, green].",
       resp.getEntity()
@@ -73,6 +75,7 @@ class VectorTileResponseFactoryTest {
     var resp = computeResponse(List.of("red", "blue"));
 
     assertEquals(404, resp.getStatus());
+    assertEquals("text/plain; charset=UTF-8", resp.getHeaderString(HttpHeaders.CONTENT_TYPE));
     assertEquals(
       "Could not find vector tile layer(s). Requested layers: [red, blue]. Available layers: [red, green].",
       resp.getEntity()
@@ -82,7 +85,8 @@ class VectorTileResponseFactoryTest {
   @Test
   void return200WhenAllLayersFound() {
     var resp = computeResponse(List.of("red", "green"));
-
+    // framework will take care of setting it
+    assertEquals(null, resp.getHeaderString(HttpHeaders.CONTENT_TYPE));
     assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
   }
 }


### PR DESCRIPTION
### Summary

When a client requests a vector tile layer that doesn't exist, then OTP returns a 404 with an error message.

However, the content type is set to "application/x-protobuf" causing browsers to not show the error message.

This PR changes this by setting an explicit content type.

cc @hbruch 