### PR TITLE
Configure scheduled thread pool for polling updaters

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
+++ b/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
@@ -65,9 +65,16 @@ public class MetricsLogging {
 
     if (transitModel.getUpdaterManager() != null) {
       new ExecutorServiceMetrics(
-        transitModel.getUpdaterManager().getUpdaterPool(),
-        "graphUpdaters",
-        List.of(Tag.of("pool", "graphUpdaters"))
+        transitModel.getUpdaterManager().getPollingUpdaterPool(),
+        "pollingGraphUpdaters",
+        List.of(Tag.of("pool", "pollingGraphUpdaters"))
+      )
+        .bindTo(Metrics.globalRegistry);
+
+      new ExecutorServiceMetrics(
+        transitModel.getUpdaterManager().getNonPollingUpdaterPool(),
+        "nonPollingGraphUpdaters",
+        List.of(Tag.of("pool", "nonPollingGraphUpdaters"))
       )
         .bindTo(Metrics.globalRegistry);
 

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -110,9 +110,7 @@ public class UpdaterConfigurator {
   public static void shutdownGraph(TransitModel transitModel) {
     GraphUpdaterManager updaterManager = transitModel.getUpdaterManager();
     if (updaterManager != null) {
-      LOG.info("Stopping updater manager with {} updaters.", updaterManager.numberOfUpdaters());
       updaterManager.stop();
-      LOG.info("Stopped updater manager");
     }
   }
 

--- a/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/spi/PollingGraphUpdater.java
@@ -33,10 +33,10 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
    * waiting for any realtime data to be applied, we should wait for all of it to be applied, so I
    * removed that.
    */
-  protected boolean primed;
+  protected volatile boolean primed;
 
   /** Shared configuration code for all polling graph updaters. */
-  public PollingGraphUpdater(PollingGraphUpdaterParameters config) {
+  protected PollingGraphUpdater(PollingGraphUpdaterParameters config) {
     this.pollingPeriod = config.frequency();
     this.configRef = config.configRef();
   }
@@ -48,30 +48,13 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
   @Override
   public final void run() {
     try {
-      LOG.info("Polling updater started: {}", this);
-      while (true) {
-        try {
-          // Run concrete polling graph updater's implementation method.
-          runPolling();
-          if (pollingPeriod.toSeconds() <= 0) {
-            // Non-positive polling period values mean to run the updater only once.
-            LOG.info(
-              "As requested in configuration, updater {} has run only once and will now stop.",
-              this.getClass().getSimpleName()
-            );
-            break;
-          }
-        } catch (InterruptedException e) {
-          throw e;
-        } catch (CancellationException e) {
-          LOG.info("OTP is shutting down, the polling updater {} was interrupted", this, e);
-        } catch (Exception e) {
-          LOG.error("Error while running polling updater {}", this, e);
-          // TODO Should we cancel the task? Or after n consecutive failures? cancel();
-        } finally {
-          primed = true;
-        }
-        Thread.sleep(pollingPeriod.toMillis());
+      // Run concrete polling graph updater's implementation method.
+      runPolling();
+      if (runOnlyOnce()) {
+        LOG.info(
+          "As requested in configuration, updater {} has run only once and will now stop.",
+          this.getClass().getSimpleName()
+        );
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -79,7 +62,21 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
         "OTP is shutting down, polling updater {} was interrupted and is stopping.",
         this.getClass().getName()
       );
+    } catch (CancellationException e) {
+      LOG.info("OTP is shutting down, the polling updater {} was interrupted", this, e);
+    } catch (Exception e) {
+      LOG.error("Error while running polling updater {}", this, e);
+      // TODO Should we cancel the task? Or after n consecutive failures? cancel();
+    } finally {
+      primed = true;
     }
+  }
+
+  /**
+   * Non-positive polling period values mean to run the updater only once.
+   */
+  public boolean runOnlyOnce() {
+    return pollingPeriod.toSeconds() <= 0;
   }
 
   /**
@@ -89,6 +86,7 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
    * TODO OTP2 This is really a bit backward. We should just run() the updaters once before scheduling them to poll,
    *           and not bring the router online until they have finished.
    */
+  @Override
   public boolean isPrimed() {
     return primed;
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -81,7 +81,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
       LOG.warn("Unable to setup updater: {}", this, e);
     }
 
-    if (pollingPeriod().toSeconds() <= 0) {
+    if (runOnlyOnce()) {
       LOG.info("Creating vehicle-rental updater running once only (non-polling): {}", source);
     } else {
       LOG.info(

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -73,7 +73,7 @@ class VehicleParkingUpdaterTest {
   }
 
   @Test
-  public void addVehicleParkingTest() {
+  void addVehicleParkingTest() {
     var vehicleParkings = List.of(
       VehicleParkingTestUtil.createParkingWithEntrances("1", 0.0001, 0)
     );
@@ -85,7 +85,7 @@ class VehicleParkingUpdaterTest {
   }
 
   @Test
-  public void updateVehicleParkingTest() {
+  void updateVehicleParkingTest() {
     var vehiclePlaces = VehicleParkingSpaces.builder().bicycleSpaces(1).build();
 
     var vehicleParkings = List.of(
@@ -121,7 +121,7 @@ class VehicleParkingUpdaterTest {
   }
 
   @Test
-  public void deleteVehicleParkingTest() {
+  void deleteVehicleParkingTest() {
     var vehicleParkings = List.of(
       VehicleParkingTestUtil.createParkingWithEntrances("1", 0.0001, 0),
       VehicleParkingTestUtil.createParkingWithEntrances("2", -0.0001, 0)
@@ -141,7 +141,7 @@ class VehicleParkingUpdaterTest {
   }
 
   @Test
-  public void addNotOperatingVehicleParkingTest() {
+  void addNotOperatingVehicleParkingTest() {
     var vehicleParking = VehicleParking.builder().state(VehicleParkingState.CLOSED).build();
 
     when(dataSource.getUpdates()).thenReturn(List.of(vehicleParking));
@@ -152,7 +152,7 @@ class VehicleParkingUpdaterTest {
   }
 
   @Test
-  public void updateNotOperatingVehicleParkingTest() {
+  void updateNotOperatingVehicleParkingTest() {
     var vehiclePlaces = VehicleParkingSpaces.builder().bicycleSpaces(1).build();
 
     var vehicleParking = VehicleParking
@@ -193,7 +193,7 @@ class VehicleParkingUpdaterTest {
   }
 
   @Test
-  public void deleteNotOperatingVehicleParkingTest() {
+  void deleteNotOperatingVehicleParkingTest() {
     var vehicleParking = VehicleParking.builder().state(VehicleParkingState.CLOSED).build();
 
     when(dataSource.getUpdates()).thenReturn(List.of(vehicleParking));
@@ -272,7 +272,7 @@ class VehicleParkingUpdaterTest {
       List.of(vehicleParkingUpdater)
     );
     graphUpdaterManager.startUpdaters();
-    graphUpdaterManager.stop();
+    graphUpdaterManager.stop(false);
   }
 
   private void assertVehicleParkingNotLinked() {

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.util.concurrent.Futures;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.graph.Graph;
@@ -34,7 +36,8 @@ class VehicleRentalUpdaterTest {
     assertFalse(updater.isPrimed());
     var manager = new MockManager(updater);
     manager.startUpdaters();
-    manager.stop();
+    assertTrue(source.hasFailed());
+    manager.stop(false);
     assertTrue(updater.isPrimed());
   }
 
@@ -52,14 +55,25 @@ class VehicleRentalUpdaterTest {
 
   static class FailingDatasource implements VehicleRentalDatasource {
 
+    private final CompletableFuture<Boolean> hasFailed = new CompletableFuture<>();
+
     @Override
     public boolean update() {
+      hasFailed.complete(true);
       throw new RuntimeException("An error occurred while updating the source.");
     }
 
     @Override
     public List<VehicleRentalPlace> getUpdates() {
       return null;
+    }
+
+    private boolean hasFailed() {
+      try {
+        return hasFailed.get(5, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 


### PR DESCRIPTION
### Summary
This PR introduces a scheduled thread pool for polling graph updaters.
This allows for:
* Better controlling the parallelism of polling updaters.
This is important for OTP deployments where a large number of updaters are configured, especially for GBFS updaters that tend to be numerous and frequently updated.
In the current implementation, all updaters are launched at once during OTP startup, which may cause overloading issues. 
*  Replacing custom scheduling logic by standard Java features.

This PR sets the maximum number of parallel polling updater tasks to the number of available cores in the system, but no less than 6 to ensure a reasonable level of parallelism on instances with low core count. This can be made configurable in a subsequent PR if needed.

The behaviour of non-polling updaters (Google PubSub SIRI-ET, Azure SIRI, GTFS MQTT, GTFS websocket, ...) remains unchanged.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation
No