### PR TITLE
Insert escalators into graph after construction

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/EscalatorProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/EscalatorProcessor.java
@@ -29,25 +29,25 @@ class EscalatorProcessor {
 
     for (int i = 0; i < nodes.size() - 1; i++) {
       if (escalatorWay.isForwardEscalator()) {
-        new EscalatorEdge(
+        EscalatorEdge.createEscalatorEdge(
           intersectionNodes.get(nodes.get(i)),
           intersectionNodes.get(nodes.get(i + 1)),
           length
         );
       } else if (escalatorWay.isBackwardEscalator()) {
-        new EscalatorEdge(
+        EscalatorEdge.createEscalatorEdge(
           intersectionNodes.get(nodes.get(i + 1)),
           intersectionNodes.get(nodes.get(i)),
           length
         );
       } else {
-        new EscalatorEdge(
+        EscalatorEdge.createEscalatorEdge(
           intersectionNodes.get(nodes.get(i)),
           intersectionNodes.get(nodes.get(i + 1)),
           length
         );
 
-        new EscalatorEdge(
+        EscalatorEdge.createEscalatorEdge(
           intersectionNodes.get(nodes.get(i + 1)),
           intersectionNodes.get(nodes.get(i)),
           length

--- a/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.edge;
 
+import javax.annotation.Nonnull;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedString;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -13,13 +14,15 @@ public class EscalatorEdge extends Edge {
    * Using the angle of 30 degrees and a speed of 0.5 m/s gives a horizontal component
    * of approx. 0.43 m/s */
   private static final double HORIZONTAL_SPEED = 0.45;
+  private static final LocalizedString NAME = new LocalizedString("name.escalator");
   private final double length;
 
-  public EscalatorEdge(Vertex v1, Vertex v2, double length) {
+  private EscalatorEdge(Vertex v1, Vertex v2, double length) {
     super(v1, v2);
     this.length = length;
   }
 
+  @Nonnull
   @Override
   public State[] traverse(State s0) {
     // Only allow traversal by walking
@@ -40,6 +43,10 @@ public class EscalatorEdge extends Edge {
 
   @Override
   public I18NString getName() {
-    return new LocalizedString("name.escalator");
+    return NAME;
+  }
+
+  public static EscalatorEdge createEscalatorEdge(Vertex from, Vertex to, double length) {
+    return connectToGraph(new EscalatorEdge(from, to, length));
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/edge/ElevatorHopEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/ElevatorHopEdgeTest.java
@@ -28,7 +28,7 @@ class ElevatorHopEdgeTest {
 
   @ParameterizedTest(name = "{0} should be allowed to traverse when requesting onlyAccessible")
   @VariableSource("noTraverse")
-  public void shouldNotTraverse(Accessibility wheelchair) {
+  void shouldNotTraverse(Accessibility wheelchair) {
     var req = StreetSearchRequest.of();
     AccessibilityPreferences feature = AccessibilityPreferences.ofOnlyAccessible();
     req
@@ -63,7 +63,7 @@ class ElevatorHopEdgeTest {
 
   @ParameterizedTest(name = "{0} should allowed to traverse with a cost of {1}")
   @VariableSource("all")
-  public void allowByDefault(Accessibility wheelchair, double expectedCost) {
+  void allowByDefault(Accessibility wheelchair, double expectedCost) {
     var req = StreetSearchRequest.of().build();
     var result = traverse(wheelchair, req)[0];
     assertNotNull(result);

--- a/src/test/java/org/opentripplanner/street/model/edge/EscalatorEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/EscalatorEdgeTest.java
@@ -2,12 +2,12 @@ package org.opentripplanner.street.model.edge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Locale;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner.routing.api.request.StreetMode;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.vertex.SimpleVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
@@ -24,7 +24,7 @@ class EscalatorEdgeTest {
   @ParameterizedTest(name = "escalatorReluctance of {0} should lead to traversal costs of {1}")
   @VariableSource("args")
   void testWalking(double escalatorReluctance, double expectedWeight) {
-    var edge = new EscalatorEdge(from, to, 45);
+    var edge = EscalatorEdge.createEscalatorEdge(from, to, 45);
     var req = StreetSearchRequest
       .of()
       .withPreferences(p -> p.withWalk(w -> w.withEscalatorReluctance(escalatorReluctance)))
@@ -37,7 +37,7 @@ class EscalatorEdgeTest {
 
   @Test
   void testCycling() {
-    var edge = new EscalatorEdge(from, to, 10);
+    var edge = EscalatorEdge.createEscalatorEdge(from, to, 10);
     var req = StreetSearchRequest.of().withMode(StreetMode.BIKE);
     var res = edge.traverse(new State(from, req.build()));
     assertEquals(res.length, 0);
@@ -45,9 +45,16 @@ class EscalatorEdgeTest {
 
   @Test
   void testWheelchair() {
-    var edge = new EscalatorEdge(from, to, 10);
+    var edge = EscalatorEdge.createEscalatorEdge(from, to, 10);
     var req = StreetSearchRequest.of().withMode(StreetMode.WALK).withWheelchair(true);
     var res = edge.traverse(new State(from, req.build()));
     assertEquals(res.length, 0);
+  }
+
+  @Test
+  void name() {
+    var edge = EscalatorEdge.createEscalatorEdge(from, to, 10);
+    assertEquals("Rolltreppe", edge.getName().toString(Locale.GERMANY));
+    assertEquals("escalator", edge.getName().toString(Locale.ENGLISH));
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
@@ -168,7 +168,7 @@ class PathwayEdgeTest {
    */
   @ParameterizedTest(name = "slope of {0} should lead to traversal costs of {1}")
   @VariableSource("slopeCases")
-  public void shouldScaleCostWithMaxSlope(double slope, long expectedCost) {
+  void shouldScaleCostWithMaxSlope(double slope, long expectedCost) {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,


### PR DESCRIPTION
### Summary

While @nurmAV was [adding the new `EscalatorEdge`](https://github.com/opentripplanner/OpenTripPlanner/pull/5046/), @vpaturet also [refactored the edge construction](https://github.com/opentripplanner/OpenTripPlanner/pull/5221) so that you explicitly need to insert an edge into the graph.

These two features were merged at similar times so that now the escalator edges are not added to the graph.

This PR fixes that problem by introducing a factory method in line with all the other edges.