### PR TITLE
Disable nynorsk money tests

### DIFF
--- a/src/test/java/org/opentripplanner/routing/core/MoneyTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/MoneyTest.java
@@ -31,9 +31,9 @@ class MoneyTest {
     of(oneDollar, Locale.GERMANY, "1,00 $"),
     of(Money.euros(1), Locale.GERMANY, "1,00 €"),
     of(oneDollar, NORWEGIAN_BOKMAL, "USD 1,00"),
-    of(oneDollar, NORWEGIAN_NYNORSK, "1.00 USD"),
-    of(hundredNOK, NORWEGIAN_BOKMAL, "kr 100,00"),
-    of(hundredNOK, NORWEGIAN_NYNORSK, "100.00 kr")
+    //of(oneDollar, NORWEGIAN_NYNORSK, "1.00 USD"),
+    of(hundredNOK, NORWEGIAN_BOKMAL, "kr 100,00")
+    //of(hundredNOK, NORWEGIAN_NYNORSK, "100.00 kr")
   );
 
   @ParameterizedTest(name = "{0} with locale {1} should localise to \"{2}\"")


### PR DESCRIPTION
### Summary

The behavior of money formatting for the nynorsk locale has been modified recently (https://bugs.openjdk.org/browse/JDK-8295564), making some tests fail.
This PR temporary disables these tests.

### Issue
No

### Unit tests

:white_check_mark: 

### Documentation

No
