### PR TITLE
Fix filtering by submode

### DIFF
--- a/src/main/java/org/opentripplanner/routing/api/request/request/filter/SelectRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/request/filter/SelectRequest.java
@@ -71,11 +71,25 @@ public class SelectRequest implements Serializable {
     return true;
   }
 
-  public boolean matches(TripTimes tripTimes) {
+  /**
+   * Matches the select clause of a transit filter request.
+   */
+  public boolean matchesSelect(TripTimes tripTimes) {
     var trip = tripTimes.getTrip();
 
     return (
       this.transportModeFilter == null ||
+      this.transportModeFilter.match(trip.getMode(), trip.getNetexSubMode())
+    );
+  }
+
+  /**
+   * Matches the not clause of a transit filter request.
+   */
+  public boolean matchesNot(TripTimes tripTimes) {
+    var trip = tripTimes.getTrip();
+    return (
+      this.transportModeFilter != null &&
       this.transportModeFilter.match(trip.getMode(), trip.getNetexSubMode())
     );
   }

--- a/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequest.java
@@ -86,7 +86,7 @@ public class TransitFilterRequest implements Serializable, TransitFilter {
     if (select.length != 0) {
       var anyMatch = false;
       for (var selectRequest : select) {
-        if (selectRequest.matches(tripTimes)) {
+        if (selectRequest.matchesSelect(tripTimes)) {
           anyMatch = true;
           break;
         }
@@ -97,7 +97,7 @@ public class TransitFilterRequest implements Serializable, TransitFilter {
     }
 
     for (SelectRequest s : not) {
-      if (s.matches(tripTimes)) {
+      if (s.matchesNot(tripTimes)) {
         return false;
       }
     }

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -47,6 +47,13 @@ public class TransitModelForTest {
     .withUrl("https://www.agency.com")
     .build();
 
+  public static final Agency OTHER_AGENCY = Agency
+    .of(id("AX"))
+    .withName("Other Agency Test")
+    .withTimezone(TIME_ZONE_ID)
+    .withUrl("https://www.otheragency.com")
+    .build();
+
   public static FeedScopedId id(String id) {
     return new FeedScopedId(FEED_ID, id);
   }


### PR DESCRIPTION
### Summary

As reported in #5255, filtering by submode does not work in the Transmodel API.
This PR fixes the logic for the special case where an exclusion filter (ex: banned authorities) is used together with a submode filter.

### Issue

Closes #5255 

### Unit tests

Added unit tests.

### Documentation

No

