### PR TITLE
Fix SIRI SX retry logic

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETHttpTripUpdateSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETHttpTripUpdateSource.java
@@ -22,6 +22,7 @@ public class SiriETHttpTripUpdateSource implements EstimatedTimetableSource {
   private final String url;
 
   private final SiriHttpLoader siriHttpLoader;
+  private final String requestorRef;
 
   /**
    * True iff the last list with updates represent all updates that are active right now, i.e. all
@@ -34,15 +35,15 @@ public class SiriETHttpTripUpdateSource implements EstimatedTimetableSource {
     this.feedId = parameters.feedId();
     this.url = parameters.url();
 
-    String requestorRef = parameters.requestorRef() == null || parameters.requestorRef().isEmpty()
-      ? "otp-" + UUID.randomUUID()
-      : parameters.requestorRef();
+    requestorRef =
+      parameters.requestorRef() == null || parameters.requestorRef().isEmpty()
+        ? "otp-" + UUID.randomUUID()
+        : parameters.requestorRef();
 
     siriHttpLoader =
       new SiriHttpLoader(
         url,
         parameters.timeout(),
-        requestorRef,
         parameters.httpRequestHeaders(),
         parameters.previewInterval()
       );
@@ -52,7 +53,7 @@ public class SiriETHttpTripUpdateSource implements EstimatedTimetableSource {
   public Siri getUpdates() {
     long t1 = System.currentTimeMillis();
     try {
-      Siri siri = siriHttpLoader.fetchETFeed();
+      Siri siri = siriHttpLoader.fetchETFeed(requestorRef);
 
       if (siri.getServiceDelivery().getResponseTimestamp().isBefore(lastTimestamp)) {
         LOG.info("Newer data has already been processed");

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
@@ -17,28 +17,20 @@ public class SiriHttpLoader {
   private final HttpHeaders requestHeaders;
   private final String url;
   private final Duration timeout;
-  private final String requestorRef;
   private final Duration previewInterval;
 
-  public SiriHttpLoader(
-    String url,
-    Duration timeout,
-    String requestorRef,
-    HttpHeaders requestHeaders
-  ) {
-    this(url, timeout, requestorRef, requestHeaders, null);
+  public SiriHttpLoader(String url, Duration timeout, HttpHeaders requestHeaders) {
+    this(url, timeout, requestHeaders, null);
   }
 
   public SiriHttpLoader(
     String url,
     Duration timeout,
-    String requestorRef,
     HttpHeaders requestHeaders,
     Duration previewInterval
   ) {
     this.url = url;
     this.timeout = timeout;
-    this.requestorRef = requestorRef;
     this.requestHeaders = requestHeaders;
     this.previewInterval = previewInterval;
   }
@@ -46,26 +38,26 @@ public class SiriHttpLoader {
   /**
    * Send a SIRI-SX service request and unmarshal the response as JAXB.
    */
-  public Siri fetchSXFeed() throws JAXBException {
+  public Siri fetchSXFeed(String requestorRef) throws JAXBException {
     RequestTimer requestTimer = new RequestTimer("SX");
     requestTimer.init();
     String sxServiceRequest = SiriHelper.createSXServiceRequestAsXml(requestorRef);
     requestTimer.serviceRequestCreated();
-    return fetchFeed(sxServiceRequest, requestTimer);
+    return fetchFeed(sxServiceRequest, requestTimer, requestorRef);
   }
 
   /**
    * Send a SIRI-ET service request and unmarshal the response as JAXB.
    */
-  public Siri fetchETFeed() throws JAXBException {
+  public Siri fetchETFeed(String requestorRef) throws JAXBException {
     RequestTimer requestTimer = new RequestTimer("ET");
     requestTimer.init();
     String etServiceRequest = SiriHelper.createETServiceRequestAsXml(requestorRef, previewInterval);
     requestTimer.serviceRequestCreated();
-    return fetchFeed(etServiceRequest, requestTimer);
+    return fetchFeed(etServiceRequest, requestTimer, requestorRef);
   }
 
-  private Siri fetchFeed(String serviceRequest, RequestTimer requestTimer) {
+  private Siri fetchFeed(String serviceRequest, RequestTimer requestTimer, String requestorRef) {
     try (OtpHttpClient otpHttpClient = new OtpHttpClient(timeout, timeout)) {
       return otpHttpClient.postXmlAndMap(
         url,

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -53,8 +53,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
         SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel)),
         config.earlyStart()
       );
-    siriHttpLoader =
-      new SiriHttpLoader(url, config.timeout(), requestorRef, config.requestHeaders());
+    siriHttpLoader = new SiriHttpLoader(url, config.timeout(), config.requestHeaders());
 
     LOG.info(
       "Creating real-time alert updater (SIRI SX) running every {} seconds : {}",
@@ -114,7 +113,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   private Siri getUpdates() {
     long t1 = System.currentTimeMillis();
     try {
-      Siri siri = siriHttpLoader.fetchSXFeed();
+      Siri siri = siriHttpLoader.fetchSXFeed(requestorRef);
 
       ServiceDelivery serviceDelivery = siri.getServiceDelivery();
       if (serviceDelivery == null) {


### PR DESCRIPTION
### Summary

This PR fixes a bug in the retry logic of the SIRI SX updater introduced in  #5213:
The SIRI SX updater maintains a session with the SIRI SX server by marking each SIRI request with a unique requestorRef.
The server uses this requestorRef to identify which messages have already been sent to that client and filter them out of the response.
When a network issue causes a request to fail, the session is left in an unknown state and the SIRI SX updater should reset it by sending a new requestorRef.
The ability to send a new requestorRef is broken since #5213.


### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No
