### PR TITLE
Add illustrations to fare docs, upgrade GraphiQL

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build GTFS GraphQL API documentation
         run: |
-          npm install -g @magidoc/cli@3.6.4
+          npm install -g @magidoc/cli@4.0.0
           magidoc generate
 
       - name: Deploy compiled HTML to Github pages

--- a/src/client/graphiql/index.html
+++ b/src/client/graphiql/index.html
@@ -22,21 +22,21 @@
     include them directly in your favored resource bundler.
   -->
 
-  <script src="https://cdn.jsdelivr.net/npm/react@17/umd/react.development.js" integrity="sha384-xQwCoNcK/7P3Lpv50IZSEbJdpqbToWEODAUyI/RECaRXmOE2apWt7htari8kvKa/" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.development.js" integrity="sha384-E9IgxDsnjKgh0777N3lXen7NwXeTsOpLLJhI01SW7idG046SRqJpsW2rJwsOYk0L" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.development.js" integrity="sha256-hXNk4rmCMYQXAl+5tLg1XAn3X6RroL6T9SD3afZ1eng=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.development.js" integrity="sha256-bRHakm3eFVwNh3OuDgW7ZGg/H0DU4etihxfdhJkXIoI=" crossorigin="anonymous"></script>
 
   <!--
     These two files can be found in the npm module, however you may wish to
     copy them directly into your environment, or perhaps include them in your
     favored resource bundler.
    -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.css" integrity="sha256-88yn8FJMyGboGs4Bj+Pbb3kWOWXo7jmb+XCRHE+282k=" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphiql@3.0.4/graphiql.min.css" integrity="sha256-wTzfn13a+pLMB5rMeysPPR1hO7x0SwSeQI+cnw7VdbE=" crossorigin="anonymous">
   <title>OTP GraphQL Explorer</title>
 </head>
 
 <body>
 <div id="graphiql">Loading...</div>
-<script src="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.js" integrity="sha256-s+f7CFAPSUIygFnRC2nfoiEKd3liCUy+snSdYFAoLUc=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/graphiql@3.0.4/graphiql.min.js" integrity="sha256-t0BNtgZ2L82dpHhlgKJl4yJ1tbQxcp1N5NkEjR82A7E=" crossorigin="anonymous"></script>
 
 <script>
   const gtfsExampleQuery = `

--- a/src/ext/resources/gtfsgraphqlapi/schema.graphqls
+++ b/src/ext/resources/gtfsgraphqlapi/schema.graphqls
@@ -1330,8 +1330,9 @@ type FareMedium {
 "A container for both a fare product (a ticket) and its relationship to the itinerary."
 type FareProductUse {
     """
-    Identifier local to the itinerary that allows to cross-reference and deduplicate
-    fare products that are applicable for more than one leg.
+    Represents the use of a single instance of a fare product throughout the itinerary. It can
+    be used to cross-reference and de-duplicate fare products that are applicable for more than one
+    leg.
 
     If you want to uniquely identify the fare product itself (not its use) use the product's `id`.
 

--- a/src/ext/resources/gtfsgraphqlapi/schema.graphqls
+++ b/src/ext/resources/gtfsgraphqlapi/schema.graphqls
@@ -1339,19 +1339,19 @@ type FareProductUse {
 
     When a day pass is valid for both legs in the itinerary it will appear for each leg but with the same use-`id`.
 
-    **Illustration*
-    ```
+    **Illustration**
+    ```yaml
     itinerary:
       leg1:
         fareProducts:
-          id: "AAA" // use id not product id
-          products:
+          id: "AAA" // use-id, not product id
+          product:
             id: "day-pass" // product id
             name: "Day Pass"
       leg2:
         fareProducts:
           id: "AAA" // identical to leg1. the passenger needs to buy ONE pass, not two.
-          products:
+          product:
             id: "day-pass"  // product id
             name: "Day Pass"
     ```
@@ -1365,11 +1365,11 @@ type FareProductUse {
     same `product.id` but different use-`id`.
 
     **Illustration**
-    ```
+    ```yaml
     itinerary:
       leg1:
         fareProducts:
-          id: "AAA" // use id, not product id
+          id: "AAA" // use-id, not product id
           product:
             id: "single-ticket" // product id
             name: "Single Ticket"

--- a/src/ext/resources/gtfsgraphqlapi/schema.graphqls
+++ b/src/ext/resources/gtfsgraphqlapi/schema.graphqls
@@ -1331,14 +1331,30 @@ type FareMedium {
 type FareProductUse {
     """
     Identifier local to the itinerary that allows to cross-reference and deduplicate
-    fare products that span more than one leg.
+    fare products that are applicable for more than one leg.
 
     If you want to uniquely identify the fare product itself (not its use) use the product's `id`.
 
     ### Example: Day pass
 
-    When a day pass is valid for all three legs in the itinerary it will appear
-    for each leg but with the same use-`id`.
+    When a day pass is valid for both legs in the itinerary it will appear for each leg but with the same use-`id`.
+
+    **Illustration*
+    ```
+    itinerary:
+      leg1:
+        fareProducts:
+          id: "AAA" // use id not product id
+          products:
+            id: "day-pass" // product id
+            name: "Day Pass"
+      leg2:
+        fareProducts:
+          id: "AAA" // identical to leg1. the passenger needs to buy ONE pass, not two.
+          products:
+            id: "day-pass"  // product id
+            name: "Day Pass"
+    ```
 
     *It is the responsibility of the API consumers to display the day pass as a product for the
     entire itinerary rather than three day passes!*
@@ -1347,6 +1363,24 @@ type FareProductUse {
 
     If you have two legs and need to buy two single tickets they will appear in each leg with the
     same `product.id` but different use-`id`.
+
+    **Illustration**
+    ```
+    itinerary:
+      leg1:
+        fareProducts:
+          id: "AAA" // use id, not product id
+          product:
+            id: "single-ticket" // product id
+            name: "Single Ticket"
+      leg2:
+        fareProducts:
+          id: "BBB" // different to leg1. the passenger needs to buy two single tickets.
+          product:
+            id: "single-ticket"  // product id
+            name: "Single Ticket"
+    ```
+
     """
     id: String!
 

--- a/src/ext/resources/gtfsgraphqlapi/schema.graphqls
+++ b/src/ext/resources/gtfsgraphqlapi/schema.graphqls
@@ -1337,14 +1337,15 @@ type FareProductUse {
 
     ### Example: Day pass
 
-    When a day pass is valid for both legs in the itinerary it will appear for each leg but with the same use-`id`.
+    The day pass is valid for both legs in the itinerary. It is listed as the applicable `product` for each leg,
+    and the same FareProductUse id is shown, indicating that only one pass was used/bought.
 
     **Illustration**
     ```yaml
     itinerary:
       leg1:
         fareProducts:
-          id: "AAA" // use-id, not product id
+          id: "AAA" // id of a FareProductUse instance
           product:
             id: "day-pass" // product id
             name: "Day Pass"
@@ -1369,7 +1370,7 @@ type FareProductUse {
     itinerary:
       leg1:
         fareProducts:
-          id: "AAA" // use-id, not product id
+          id: "AAA" // id of a FareProductUse instance, not product id
           product:
             id: "single-ticket" // product id
             name: "Single Ticket"


### PR DESCRIPTION
### Summary

There has been some confusion when implementing the new fare API so I thought I improve the documentation with illustrative examples of how useId and product id work together. I hope this will make implementation of this, admittedly complex, API a little easier.

I also upgraded GraphiQL and magidoc (HTML doc generator) to the newest version.


