### PR TITLE
Configure HTTP connection pooling

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/ridehailing/service/uber/UberService.java
+++ b/src/ext/java/org/opentripplanner/ext/ridehailing/service/uber/UberService.java
@@ -50,6 +50,7 @@ public class UberService extends CachingRideHailingService {
    * be hard to change it, should the need arise.
    */
   private final String wheelchairAccessibleProductId;
+  private final OtpHttpClient otpHttpClient;
 
   public UberService(RideHailingServiceParameters config) {
     this(
@@ -78,6 +79,7 @@ public class UberService extends CachingRideHailingService {
     this.timeEstimateUri = timeEstimateUri;
     this.bannedTypes = bannedTypes;
     this.wheelchairAccessibleProductId = wheelchairAccessibleProductId;
+    this.otpHttpClient = new OtpHttpClient();
   }
 
   @Override
@@ -177,9 +179,7 @@ public class UberService extends CachingRideHailingService {
   }
 
   private <T> T getUberEstimateResponse(URI finalUri, Class<T> clazz) throws IOException {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
-      return otpHttpClient.getAndMapAsJsonObject(finalUri, headers(), MAPPER, clazz);
-    }
+    return otpHttpClient.getAndMapAsJsonObject(finalUri, headers(), MAPPER, clazz);
   }
 
   private boolean filterRides(Ride a, boolean wheelchairAccessible) {

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
@@ -18,6 +18,7 @@ public class SiriHttpLoader {
   private final String url;
   private final Duration timeout;
   private final Duration previewInterval;
+  private final OtpHttpClient otpHttpClient;
 
   public SiriHttpLoader(String url, Duration timeout, HttpHeaders requestHeaders) {
     this(url, timeout, requestHeaders, null);
@@ -33,6 +34,7 @@ public class SiriHttpLoader {
     this.timeout = timeout;
     this.requestHeaders = requestHeaders;
     this.previewInterval = previewInterval;
+    this.otpHttpClient = new OtpHttpClient(timeout, timeout);
   }
 
   /**
@@ -58,7 +60,7 @@ public class SiriHttpLoader {
   }
 
   private Siri fetchFeed(String serviceRequest, RequestTimer requestTimer, String requestorRef) {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient(timeout, timeout)) {
+    try {
       return otpHttpClient.postXmlAndMap(
         url,
         serviceRequest,

--- a/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.smoovebikerental;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
+import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
@@ -32,7 +33,14 @@ public class SmooveBikeRentalDataSource
   private final RentalVehicleType vehicleType;
 
   public SmooveBikeRentalDataSource(SmooveBikeRentalDataSourceParameters config) {
-    super(config.url(), "result", config.httpHeaders());
+    this(config, new OtpHttpClient());
+  }
+
+  public SmooveBikeRentalDataSource(
+    SmooveBikeRentalDataSourceParameters config,
+    OtpHttpClient otpHttpClient
+  ) {
+    super(config.url(), "result", config.httpHeaders(), otpHttpClient);
     networkName = config.getNetwork(DEFAULT_NETWORK_NAME);
     vehicleType = RentalVehicleType.getDefaultType(networkName);
     overloadingAllowed = config.overloadingAllowed();

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
@@ -21,11 +21,12 @@ import org.slf4j.LoggerFactory;
 public class HslFacilitiesDownloader {
 
   private static final Logger log = LoggerFactory.getLogger(HslFacilitiesDownloader.class);
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   private final String jsonParsePath;
   private final BiFunction<JsonNode, Map<FeedScopedId, VehicleParkingGroup>, VehicleParking> facilitiesParser;
   private final String url;
-
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private final OtpHttpClient otpHttpClient;
 
   public HslFacilitiesDownloader(
     String url,
@@ -35,6 +36,7 @@ public class HslFacilitiesDownloader {
     this.url = url;
     this.jsonParsePath = jsonParsePath;
     this.facilitiesParser = facilitiesParser;
+    this.otpHttpClient = new OtpHttpClient();
   }
 
   public List<VehicleParking> downloadFacilities(
@@ -45,7 +47,7 @@ public class HslFacilitiesDownloader {
       return null;
     }
 
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try {
       return otpHttpClient.getAndMap(
         URI.create(url),
         Map.of(),

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
@@ -19,10 +19,12 @@ import org.slf4j.LoggerFactory;
 public class HslHubsDownloader {
 
   private static final Logger log = LoggerFactory.getLogger(HslHubsDownloader.class);
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   private final String jsonParsePath;
   private final Function<JsonNode, Map<FeedScopedId, VehicleParkingGroup>> hubsParser;
   private final String url;
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private final OtpHttpClient otpHttpClient;
 
   public HslHubsDownloader(
     String url,
@@ -32,6 +34,7 @@ public class HslHubsDownloader {
     this.url = url;
     this.jsonParsePath = jsonParsePath;
     this.hubsParser = hubsParser;
+    otpHttpClient = new OtpHttpClient();
   }
 
   public Map<FeedScopedId, VehicleParkingGroup> downloadHubs() {
@@ -39,7 +42,7 @@ public class HslHubsDownloader {
       log.warn("Cannot download updates, because url is null!");
       return null;
     }
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try {
       return otpHttpClient.getAndMap(
         URI.create(url),
         Map.of(),

--- a/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -38,23 +38,24 @@ public class VehicleRentalServiceDirectoryFetcher {
     LOG.info("Fetching list of updaters from {}", parameters.getUrl());
 
     List<GraphUpdater> updaters = new ArrayList<>();
-
+    JsonNode node = null;
     try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
-      JsonNode node = otpHttpClient.getAndMapAsJsonNode(
-        parameters.getUrl(),
-        Map.of(),
-        new ObjectMapper()
+      node = otpHttpClient.getAndMapAsJsonNode(parameters.getUrl(), Map.of(), new ObjectMapper());
+    } catch (OtpHttpClientException e) {
+      LOG.warn("Error fetching list of vehicle rental endpoints from {}", parameters.getUrl(), e);
+    }
+    if (node == null || node.get(parameters.getSourcesName()) == null) {
+      LOG.warn(
+        "Error reading json from {}. Are json tag names configured properly?",
+        parameters.getUrl()
       );
-      JsonNode sources = node.get(parameters.getSourcesName());
+      return updaters;
+    }
 
-      if (sources == null) {
-        LOG.warn(
-          "Error reading json from {}. Are json tag names configured properly?",
-          parameters.getUrl()
-        );
-        return updaters;
-      }
-
+    JsonNode sources = node.get(parameters.getSourcesName());
+    if (!sources.isEmpty()) {
+      int maxHttpConnections = sources.size();
+      OtpHttpClient otpHttpClient = new OtpHttpClient(maxHttpConnections);
       for (JsonNode source : sources) {
         JsonNode network = source.get(parameters.getSourceNetworkName());
         JsonNode updaterUrl = source.get(parameters.getSourceUrlName());
@@ -83,7 +84,8 @@ public class VehicleRentalServiceDirectoryFetcher {
         LOG.info("Fetched updater info for {} at url {}", network, updaterUrl);
 
         var dataSource = VehicleRentalDataSourceFactory.create(
-          vehicleRentalParameters.sourceParameters()
+          vehicleRentalParameters.sourceParameters(),
+          otpHttpClient
         );
         GraphUpdater updater = new VehicleRentalUpdater(
           vehicleRentalParameters,
@@ -93,8 +95,6 @@ public class VehicleRentalServiceDirectoryFetcher {
         );
         updaters.add(updater);
       }
-    } catch (OtpHttpClientException e) {
-      LOG.warn("Error fetching list of vehicle rental endpoints from {}", parameters.getUrl(), e);
     }
 
     LOG.info("{} updaters fetched", updaters.size());

--- a/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
@@ -20,6 +20,7 @@ public class JsonDataListDownloader<T> {
   private final Map<String, String> headers;
   private final Function<JsonNode, T> elementParser;
   private final String url;
+  private final OtpHttpClient otpHttpClient;
 
   public JsonDataListDownloader(
     String url,
@@ -27,10 +28,21 @@ public class JsonDataListDownloader<T> {
     Function<JsonNode, T> elementParser,
     Map<String, String> headers
   ) {
+    this(url, jsonParsePath, elementParser, headers, new OtpHttpClient());
+  }
+
+  public JsonDataListDownloader(
+    String url,
+    String jsonParsePath,
+    Function<JsonNode, T> elementParser,
+    Map<String, String> headers,
+    OtpHttpClient OtpHttpClient
+  ) {
     this.url = url;
     this.jsonParsePath = jsonParsePath;
     this.headers = headers;
     this.elementParser = elementParser;
+    this.otpHttpClient = OtpHttpClient;
   }
 
   public List<T> download() {
@@ -38,7 +50,7 @@ public class JsonDataListDownloader<T> {
       log.warn("Cannot download updates, because url is null!");
       return null;
     }
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try {
       return otpHttpClient.getAndMap(
         URI.create(url),
         headers,

--- a/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -26,6 +26,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
   private final AlertsUpdateHandler updateHandler;
   private final TransitAlertService transitAlertService;
   private final HttpHeaders headers;
+  private final OtpHttpClient otpHttpClient;
   private WriteToGraphCallback saveResultOnGraph;
   private Long lastTimestamp = Long.MIN_VALUE;
 
@@ -49,7 +50,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
     this.updateHandler.setFeedId(config.feedId());
     this.updateHandler.setTransitAlertService(transitAlertService);
     this.updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
-
+    this.otpHttpClient = new OtpHttpClient();
     LOG.info(
       "Creating real-time alert updater running every {} seconds : {}",
       pollingPeriod(),
@@ -73,7 +74,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
 
   @Override
   protected void runPolling() {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try {
       final FeedMessage feed = otpHttpClient.getAndMap(
         URI.create(url),
         this.headers.asMap(),

--- a/src/main/java/org/opentripplanner/updater/spi/GenericJsonDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/spi/GenericJsonDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.spi;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import org.opentripplanner.framework.io.JsonDataListDownloader;
+import org.opentripplanner.framework.io.OtpHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,10 +14,25 @@ public abstract class GenericJsonDataSource<T> implements DataSource<T> {
   private final String url;
   protected List<T> updates = List.of();
 
-  public GenericJsonDataSource(String url, String jsonParsePath, HttpHeaders headers) {
+  protected GenericJsonDataSource(String url, String jsonParsePath, HttpHeaders headers) {
+    this(url, jsonParsePath, headers, new OtpHttpClient());
+  }
+
+  protected GenericJsonDataSource(
+    String url,
+    String jsonParsePath,
+    HttpHeaders headers,
+    OtpHttpClient otpHttpClient
+  ) {
     this.url = url;
     jsonDataListDownloader =
-      new JsonDataListDownloader<>(url, jsonParsePath, this::parseElement, headers.asMap());
+      new JsonDataListDownloader<>(
+        url,
+        jsonParsePath,
+        this::parseElement,
+        headers.asMap(),
+        otpHttpClient
+      );
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
@@ -26,12 +26,14 @@ public class GtfsRealtimeTripUpdateSource {
   private final HttpHeaders headers;
   private boolean fullDataset = true;
   private final ExtensionRegistry registry = ExtensionRegistry.newInstance();
+  private final OtpHttpClient otpHttpClient;
 
   public GtfsRealtimeTripUpdateSource(PollingTripUpdaterParameters config) {
     this.feedId = config.feedId();
     this.url = config.url();
     this.headers = HttpHeaders.of().acceptProtobuf().add(config.headers()).build();
     MfdzRealtimeExtensions.registerAllExtensions(registry);
+    otpHttpClient = new OtpHttpClient();
   }
 
   public List<TripUpdate> getUpdates() {
@@ -39,7 +41,7 @@ public class GtfsRealtimeTripUpdateSource {
     List<FeedEntity> feedEntityList;
     List<TripUpdate> updates = null;
     fullDataset = true;
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try {
       // Decode message
       feedMessage =
         otpHttpClient.getAndMap(

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
@@ -27,19 +27,20 @@ public class GtfsRealtimeHttpVehiclePositionSource {
    * URL to grab GTFS-RT feed from
    */
   private final URI url;
-
   private final HttpHeaders headers;
+  private final OtpHttpClient otpHttpClient;
 
   public GtfsRealtimeHttpVehiclePositionSource(URI url, HttpHeaders headers) {
     this.url = url;
     this.headers = HttpHeaders.of().acceptProtobuf().add(headers).build();
+    this.otpHttpClient = new OtpHttpClient();
   }
 
   /**
    * Parses raw GTFS-RT data into vehicle positions
    */
   public List<VehiclePosition> getPositions() {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try {
       return otpHttpClient.getAndMap(url, headers.asMap(), this::getPositions);
     } catch (OtpHttpClientException e) {
       LOG.warn("Error reading vehicle positions from {}", url, e);

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
@@ -30,13 +30,20 @@ public class GbfsFeedLoader {
   /** One updater per feed type(?) */
   private final Map<GBFSFeedName, GBFSFeedUpdater<?>> feedUpdaters = new HashMap<>();
   private final HttpHeaders httpHeaders;
+  private final OtpHttpClient otpHttpClient;
 
   static {
     objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
   }
 
-  public GbfsFeedLoader(String url, HttpHeaders httpHeaders, String languageCode) {
+  public GbfsFeedLoader(
+    String url,
+    HttpHeaders httpHeaders,
+    String languageCode,
+    OtpHttpClient otpHttpClient
+  ) {
     this.httpHeaders = httpHeaders;
+    this.otpHttpClient = otpHttpClient;
     URI uri;
     try {
       uri = new URI(url);
@@ -90,6 +97,10 @@ public class GbfsFeedLoader {
     }
   }
 
+  GbfsFeedLoader(String url, HttpHeaders httpHeaders, String languageCode) {
+    this(url, httpHeaders, languageCode, new OtpHttpClient());
+  }
+
   /**
    * Checks if any of the feeds should be updated base on the TTL and fetches. Returns true, if any
    * feeds were updated.
@@ -124,7 +135,7 @@ public class GbfsFeedLoader {
   /* private static methods */
 
   private <T> T fetchFeed(URI uri, HttpHeaders httpHeaders, Class<T> clazz) {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try {
       return otpHttpClient.getAndMapAsJsonObject(uri, httpHeaders.asMap(), objectMapper, clazz);
     } catch (OtpHttpClientException e) {
       LOG.warn("Error parsing vehicle rental feed from {}. Details: {}.", uri, e.getMessage(), e);

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
@@ -15,6 +15,7 @@ import org.entur.gbfs.v2_3.system_information.GBFSSystemInformation;
 import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
 import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleTypes;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -36,9 +37,14 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
 
   private GbfsFeedLoader loader;
   private List<GeofencingZone> geofencingZones = List.of();
+  private final OtpHttpClient otpHttpClient;
 
-  public GbfsVehicleRentalDataSource(GbfsVehicleRentalDataSourceParameters parameters) {
+  public GbfsVehicleRentalDataSource(
+    GbfsVehicleRentalDataSourceParameters parameters,
+    OtpHttpClient otpHttpClient
+  ) {
     this.params = parameters;
+    this.otpHttpClient = otpHttpClient;
   }
 
   @Override
@@ -129,7 +135,8 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
 
   @Override
   public void setup() {
-    loader = new GbfsFeedLoader(params.url(), params.httpHeaders(), params.language());
+    loader =
+      new GbfsFeedLoader(params.url(), params.httpHeaders(), params.language(), otpHttpClient);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/VehicleRentalDataSourceFactory.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/VehicleRentalDataSourceFactory.java
@@ -2,20 +2,30 @@ package org.opentripplanner.updater.vehicle_rental.datasources;
 
 import org.opentripplanner.ext.smoovebikerental.SmooveBikeRentalDataSource;
 import org.opentripplanner.ext.smoovebikerental.SmooveBikeRentalDataSourceParameters;
+import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.updater.vehicle_rental.datasources.params.GbfsVehicleRentalDataSourceParameters;
 import org.opentripplanner.updater.vehicle_rental.datasources.params.VehicleRentalDataSourceParameters;
 
 public class VehicleRentalDataSourceFactory {
 
-  public static VehicleRentalDatasource create(VehicleRentalDataSourceParameters source) {
+  public static VehicleRentalDatasource create(
+    VehicleRentalDataSourceParameters source,
+    OtpHttpClient otpHttpClient
+  ) {
     return switch (source.sourceType()) {
       // There used to be a lot more updaters and corresponding config variables here, but since
       // the industry has largely moved towards GBFS, they were removed.
       // See: https://groups.google.com/g/opentripplanner-users/c/0P8UGBJG-zE/m/xaOZnL3OAgAJ
       // If you want to add your provider-specific updater, you can move them into a sandbox module
       // and become the point of contact for the community.
-      case GBFS -> new GbfsVehicleRentalDataSource((GbfsVehicleRentalDataSourceParameters) source);
-      case SMOOVE -> new SmooveBikeRentalDataSource((SmooveBikeRentalDataSourceParameters) source);
+      case GBFS -> new GbfsVehicleRentalDataSource(
+        (GbfsVehicleRentalDataSourceParameters) source,
+        otpHttpClient
+      );
+      case SMOOVE -> new SmooveBikeRentalDataSource(
+        (SmooveBikeRentalDataSourceParameters) source,
+        otpHttpClient
+      );
     };
   }
 }

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
@@ -32,7 +33,8 @@ class GbfsVehicleRentalDataSourceTest {
         null,
         false,
         false
-      )
+      ),
+      new OtpHttpClient()
     );
 
     dataSource.setup();
@@ -122,7 +124,8 @@ class GbfsVehicleRentalDataSourceTest {
         null,
         true,
         false
-      )
+      ),
+      new OtpHttpClient()
     );
 
     dataSource.setup();
@@ -163,7 +166,8 @@ class GbfsVehicleRentalDataSourceTest {
         network,
         false,
         true
-      )
+      ),
+      new OtpHttpClient()
     );
 
     dataSource.setup();


### PR DESCRIPTION
### Summary

This PR enables pooling of Apache HTTP client instances in order to:
1. reduce the overhead of creating HTTP client  instances (CPU and memory intensive)
2. take advantage of HTTP connection pooling

- As a general rule, a client instance is created at construction time in the class that uses it.
- As an exception, GBFS updaters are constructed with a shared client instance. This allows for better pooling when all the GBFS feeds are served by a single feed aggregator (setup used at Entur)
- When an HTTP client instance is used only once (for example when initializing an updater at startup), it is created and disposed in a try-with-resources block (no pooling)

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No
