### PR TITLE
Refactor copy properties from parent edge to split edge

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -39,7 +39,7 @@ import org.opentripplanner.graph_builder.services.ned.ElevationGridCoverageFacto
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
-import org.opentripplanner.street.model.edge.StreetElevationExtension;
+import org.opentripplanner.street.model.edge.StreetElevationExtensionBuilder;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -508,7 +508,12 @@ public class ElevationModule implements GraphBuilderModule {
 
   private void setEdgeElevationProfile(StreetEdge ee, PackedCoordinateSequence elevPCS) {
     try {
-      StreetElevationExtension.addToEdge(ee, elevPCS, false);
+      StreetElevationExtensionBuilder
+        .of(ee)
+        .withElevationProfile(elevPCS)
+        .withComputed(false)
+        .build()
+        .ifPresent(ee::setElevationExtension);
       if (ee.isElevationFlattened()) {
         issueStore.add(new ElevationFlattened(ee));
       }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandler.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandler.java
@@ -10,7 +10,7 @@ import org.opentripplanner.graph_builder.issues.ElevationFlattened;
 import org.opentripplanner.graph_builder.issues.ElevationProfileFailure;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
-import org.opentripplanner.street.model.edge.StreetElevationExtension;
+import org.opentripplanner.street.model.edge.StreetElevationExtensionBuilder;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -253,7 +253,12 @@ class MissingElevationHandler {
     PackedCoordinateSequence profile = new PackedCoordinateSequence.Double(coords);
 
     try {
-      StreetElevationExtension.addToEdge(edge, profile, true);
+      StreetElevationExtensionBuilder
+        .of(edge)
+        .withElevationProfile(profile)
+        .withComputed(true)
+        .build()
+        .ifPresent(edge::setElevationExtension);
 
       if (edge.isElevationFlattened()) {
         issueStore.add(new ElevationFlattened(edge));

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -140,7 +140,7 @@ public class StreetEdge
     this.setWalkSafetyFactor(builder.walkSafetyFactor());
     this.name = builder.name();
     this.setPermission(builder.permission());
-    carSpeed = builder.carSpeed();
+    this.carSpeed = builder.carSpeed();
     LineStringInOutAngles lineStringInOutAngles = LineStringInOutAngles.of(builder.geometry());
     inAngle = lineStringInOutAngles.inAngle();
     outAngle = lineStringInOutAngles.outAngle();
@@ -711,7 +711,7 @@ public class StreetEdge
     StreetEdge e2 = null;
 
     if (direction == LinkingDirection.OUTGOING || direction == LinkingDirection.BOTH_WAYS) {
-      TemporaryPartialStreetEdgeBuilder seb1 = new TemporaryPartialStreetEdgeBuilder()
+      var seb1 = new TemporaryPartialStreetEdgeBuilder()
         .withParentEdge(this)
         .withFromVertex((StreetVertex) fromv)
         .withToVertex(v)
@@ -724,7 +724,7 @@ public class StreetEdge
       tempEdges.addEdge(e1);
     }
     if (direction == LinkingDirection.INCOMING || direction == LinkingDirection.BOTH_WAYS) {
-      TemporaryPartialStreetEdgeBuilder seb2 = new TemporaryPartialStreetEdgeBuilder()
+      var seb2 = new TemporaryPartialStreetEdgeBuilder()
         .withParentEdge(this)
         .withFromVertex(v)
         .withToVertex((StreetVertex) tov)

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetEdgeBuilder.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetEdgeBuilder.java
@@ -37,6 +37,7 @@ public class StreetEdgeBuilder<B extends StreetEdgeBuilder<B>> {
   private float walkSafetyFactor;
   private float bicycleSafetyFactor;
   private short flags;
+  private StreetElevationExtension streetElevationExtension;
 
   public StreetEdgeBuilder() {
     this.defaultLength = true;
@@ -223,6 +224,28 @@ public class StreetEdgeBuilder<B extends StreetEdgeBuilder<B>> {
       case CAR, FLEX -> withMotorVehicleNoThruTraffic(true);
     }
     return instance();
+  }
+
+  public boolean slopeOverride() {
+    return BitSetUtils.get(flags, SLOPEOVERRIDE_FLAG_INDEX);
+  }
+
+  public boolean stairs() {
+    return BitSetUtils.get(flags, STAIRS_FLAG_INDEX);
+  }
+
+  public B withFlags(short flags) {
+    this.flags = flags;
+    return instance();
+  }
+
+  public B withElevationExtension(StreetElevationExtension streetElevationExtension) {
+    this.streetElevationExtension = streetElevationExtension;
+    return instance();
+  }
+
+  public StreetElevationExtension streetElevationExtension() {
+    return streetElevationExtension;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
@@ -1,0 +1,148 @@
+package org.opentripplanner.street.model.edge;
+
+import java.util.Optional;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+import org.opentripplanner.routing.util.ElevationUtils;
+import org.opentripplanner.routing.util.SlopeCosts;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+
+/**
+ * Build an elevation profile for a StreetEdge.
+ */
+public class StreetElevationExtensionBuilder {
+
+  private StreetTraversalPermission permission;
+  private PackedCoordinateSequence elevationProfile;
+
+  private float bicycleSafetyFactor;
+  private double distanceInMeters;
+  private float walkSafetyFactor;
+  private boolean isStairs;
+  private boolean computed;
+  private boolean isSlopeOverride;
+
+  public static StreetElevationExtensionBuilder of(StreetEdge streetEdge) {
+    return new StreetElevationExtensionBuilder()
+      .withComputed(true)
+      .withDistanceInMeters(streetEdge.getDistanceMeters())
+      .withSlopeOverride(streetEdge.isSlopeOverride())
+      .withStairs(streetEdge.isStairs())
+      .withWalkSafetyFactor(streetEdge.getWalkSafetyFactor())
+      .withBicycleSafetyFactor(streetEdge.getBicycleSafetyFactor())
+      .withPermission(streetEdge.getPermission());
+  }
+
+  public static StreetElevationExtensionBuilder of(StreetEdgeBuilder<?> seb) {
+    return new StreetElevationExtensionBuilder()
+      .withComputed(true)
+      .withSlopeOverride(seb.slopeOverride())
+      .withStairs(seb.stairs())
+      .withWalkSafetyFactor(seb.walkSafetyFactor())
+      .withBicycleSafetyFactor(seb.bicycleSafetyFactor())
+      .withPermission(seb.permission());
+  }
+
+  public Optional<StreetElevationExtension> build() {
+    if (elevationProfileHasAtLeastTwoPoints() && (!isSlopeOverride || computed)) {
+      return Optional.of(buildInternal());
+    }
+    return Optional.empty();
+  }
+
+  public StreetElevationExtensionBuilder withPermission(StreetTraversalPermission permission) {
+    this.permission = permission;
+    return this;
+  }
+
+  public StreetElevationExtensionBuilder withElevationProfile(
+    PackedCoordinateSequence parentEdgeElevationProfile
+  ) {
+    this.elevationProfile = parentEdgeElevationProfile;
+    return this;
+  }
+
+  public StreetElevationExtensionBuilder withBicycleSafetyFactor(float bicycleSafetyFactor) {
+    this.bicycleSafetyFactor = bicycleSafetyFactor;
+    return this;
+  }
+
+  public StreetElevationExtensionBuilder withDistanceInMeters(double distanceInMeters) {
+    this.distanceInMeters = distanceInMeters;
+    return this;
+  }
+
+  public StreetElevationExtensionBuilder withWalkSafetyFactor(float walkSafetyFactor) {
+    this.walkSafetyFactor = walkSafetyFactor;
+    return this;
+  }
+
+  public StreetElevationExtensionBuilder withStairs(boolean stairs) {
+    isStairs = stairs;
+    return this;
+  }
+
+  public StreetElevationExtensionBuilder withComputed(boolean computed) {
+    this.computed = computed;
+    return this;
+  }
+
+  public StreetElevationExtensionBuilder withSlopeOverride(boolean slopeOverride) {
+    isSlopeOverride = slopeOverride;
+    return this;
+  }
+
+  private boolean elevationProfileHasAtLeastTwoPoints() {
+    return elevationProfile != null && elevationProfile.size() >= 2;
+  }
+
+  private StreetElevationExtension buildInternal() {
+    boolean slopeLimit = permission.allows(StreetTraversalPermission.CAR);
+    SlopeCosts costs = ElevationUtils.getSlopeCosts(elevationProfile, slopeLimit);
+
+    var effectiveBikeDistanceFactor = costs.slopeSpeedFactor;
+    var effectiveBikeWorkFactor = costs.slopeWorkFactor;
+    var effectiveWalkDistanceFactor = costs.effectiveWalkFactor;
+    var maxSlope = (float) costs.maxSlope;
+    var flattened = costs.flattened;
+
+    float effectiveBicycleSafetyFactor = (float) (
+      bicycleSafetyFactor * costs.lengthMultiplier + costs.slopeSafetyCost / distanceInMeters
+    );
+
+    if (
+      Double.isInfinite(effectiveBicycleSafetyFactor) || Double.isNaN(effectiveBicycleSafetyFactor)
+    ) {
+      throw new IllegalStateException(
+        "Elevation updated bicycleSafetyFactor is " + effectiveBicycleSafetyFactor
+      );
+    }
+
+    float effectiveWalkSafetyFactor = (float) (walkSafetyFactor * effectiveWalkDistanceFactor);
+
+    if (Double.isInfinite(effectiveWalkSafetyFactor) || Double.isNaN(effectiveWalkSafetyFactor)) {
+      throw new IllegalStateException(
+        "Elevation updated walkSafetyFactor is " + effectiveWalkSafetyFactor
+      );
+    }
+
+    if (isStairs) {
+      // Ignore elevation related costs for stairs, RouteRequest#stairsTimeFactor is used instead.
+      effectiveBikeDistanceFactor = 1.0;
+      effectiveWalkDistanceFactor = 1.0;
+    }
+
+    return new StreetElevationExtension(
+      distanceInMeters,
+      computed,
+      elevationProfile,
+      effectiveBicycleSafetyFactor,
+      effectiveBikeDistanceFactor,
+      effectiveBikeWorkFactor,
+      effectiveWalkDistanceFactor,
+      effectiveWalkSafetyFactor,
+      costs.lengthMultiplier,
+      maxSlope,
+      flattened
+    );
+  }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
-import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedStringFormat;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
@@ -17,7 +16,7 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
-import org.opentripplanner.street.model.edge.StreetElevationExtension;
+import org.opentripplanner.street.model.edge.StreetElevationExtensionBuilder;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 
@@ -210,7 +209,12 @@ class MissingElevationHandlerTest {
 
     PackedCoordinateSequence profile = new PackedCoordinateSequence.Double(coords);
 
-    StreetElevationExtension.addToEdge(edge, profile, true);
+    StreetElevationExtensionBuilder
+      .of(edge)
+      .withElevationProfile(profile)
+      .withComputed(true)
+      .build()
+      .ifPresent(edge::setElevationExtension);
   }
 
   private void assertNullElevation(StreetEdge edge) {

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -286,12 +286,16 @@ public class StreetEdgeTest {
       0
     );
     var edge = streetEdge(v0, v1, 50.0, StreetTraversalPermission.ALL);
-    StreetElevationExtension.addToEdge(edge, elevationProfile, false);
-    StreetEdge e0 = edge;
+    StreetElevationExtensionBuilder
+      .of(edge)
+      .withElevationProfile(elevationProfile)
+      .withComputed(false)
+      .build()
+      .ifPresent(edge::setElevationExtension);
 
     assertArrayEquals(
       elevationProfile.toCoordinateArray(),
-      e0.getElevationProfile().toCoordinateArray()
+      edge.getElevationProfile().toCoordinateArray()
     );
   }
 
@@ -328,7 +332,12 @@ public class StreetEdgeTest {
       new Coordinate(length, 0), // slope = -0.1
     };
     PackedCoordinateSequence elev = new PackedCoordinateSequence.Double(profile);
-    StreetElevationExtension.addToEdge(testStreet, elev, false);
+    StreetElevationExtensionBuilder
+      .of(testStreet)
+      .withElevationProfile(elev)
+      .withComputed(false)
+      .build()
+      .ifPresent(testStreet::setElevationExtension);
 
     SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, true);
     double trueLength = costs.lengthMultiplier * length;

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeWheelchairCostTest.java
@@ -75,8 +75,12 @@ class StreetEdgeWheelchairCostTest {
     };
 
     PackedCoordinateSequence elev = new PackedCoordinateSequence.Double(profile);
-    StreetElevationExtension.addToEdge(edge, elev, true);
-
+    StreetElevationExtensionBuilder
+      .of(edge)
+      .withElevationProfile(elev)
+      .withComputed(true)
+      .build()
+      .ifPresent(edge::setElevationExtension);
     assertEquals(slope, edge.getMaxSlope(), 0.0001);
 
     var req = StreetSearchRequest.of();

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilderTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilderTest.java
@@ -1,0 +1,106 @@
+package org.opentripplanner.street.model.edge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+import org.opentripplanner.framework.geometry.GeometryUtils;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model._data.StreetModelForTest;
+
+class StreetElevationExtensionBuilderTest {
+
+  private static final Coordinate[] COORDINATES_ONE_POINT = new Coordinate[] {
+    new Coordinate(0, 0),
+  };
+  private static final PackedCoordinateSequence ELEVATION_PROFILE_ONE_POINT = new PackedCoordinateSequence.Double(
+    COORDINATES_ONE_POINT,
+    2
+  );
+
+  private static final Coordinate[] COORDINATES_TWO_POINTS = new Coordinate[] {
+    new Coordinate(0, 0),
+    new Coordinate(1, 1),
+  };
+  private static final PackedCoordinateSequence ELEVATION_PROFILE_TWO_POINTS = new PackedCoordinateSequence.Double(
+    COORDINATES_TWO_POINTS,
+    2
+  );
+
+  private static final LineString GEOMETRY = GeometryUtils
+    .getGeometryFactory()
+    .createLineString(
+      new Coordinate[] {
+        StreetModelForTest.V1.getCoordinate(),
+        StreetModelForTest.V2.getCoordinate(),
+      }
+    );
+  private StreetEdgeBuilder<?> streetEdgeBuilder;
+
+  @BeforeEach
+  void setup() {
+    streetEdgeBuilder =
+      new StreetEdgeBuilder<>()
+        .withPermission(StreetTraversalPermission.ALL)
+        .withFromVertex(StreetModelForTest.V1)
+        .withToVertex(StreetModelForTest.V2)
+        .withGeometry(GEOMETRY);
+  }
+
+  @Test
+  void testInvalidElevationProfile() {
+    StreetElevationExtensionBuilder seeb = new StreetElevationExtensionBuilder()
+      .withPermission(StreetTraversalPermission.ALL)
+      .withDistanceInMeters(1)
+      .withElevationProfile(ELEVATION_PROFILE_ONE_POINT);
+    assertTrue(seeb.build().isEmpty());
+  }
+
+  @Test
+  void testValidElevationProfile() {
+    StreetElevationExtensionBuilder seeb = new StreetElevationExtensionBuilder()
+      .withPermission(StreetTraversalPermission.ALL)
+      .withDistanceInMeters(1)
+      .withElevationProfile(ELEVATION_PROFILE_TWO_POINTS);
+    Optional<StreetElevationExtension> streetElevationExtension = seeb.build();
+    assertFalse(streetElevationExtension.isEmpty());
+  }
+
+  @Test
+  void testBuildFromStreetEdge() {
+    StreetEdge se = streetEdgeBuilder.buildAndConnect();
+    StreetElevationExtensionBuilder seeb = StreetElevationExtensionBuilder
+      .of(se)
+      .withElevationProfile(ELEVATION_PROFILE_TWO_POINTS);
+    Optional<StreetElevationExtension> streetElevationExtension = seeb.build();
+    assertFalse(streetElevationExtension.isEmpty());
+  }
+
+  @Test
+  void testBuildFromStreetEdgeBuilder() {
+    StreetElevationExtensionBuilder seebFromStreetEdgeBuilder = StreetElevationExtensionBuilder
+      .of(streetEdgeBuilder)
+      .withElevationProfile(ELEVATION_PROFILE_TWO_POINTS)
+      .withDistanceInMeters(1);
+    Optional<StreetElevationExtension> streetElevationExtensionFromStreetEdgeBuilder = seebFromStreetEdgeBuilder.build();
+    assertFalse(streetElevationExtensionFromStreetEdgeBuilder.isEmpty());
+
+    StreetElevationExtensionBuilder seebFromStreetEdge = StreetElevationExtensionBuilder
+      .of(streetEdgeBuilder.buildAndConnect())
+      .withElevationProfile(ELEVATION_PROFILE_TWO_POINTS)
+      .withDistanceInMeters(1);
+    Optional<StreetElevationExtension> streetElevationExtensionFromStreetEdge = seebFromStreetEdge.build();
+
+    assertEquals(
+      streetElevationExtensionFromStreetEdge.orElseThrow().toString(),
+      streetElevationExtensionFromStreetEdge.get().toString(),
+      "Street elevation profiles built from StreetEdge and from StreetEdgeBuilder should be identical"
+    );
+  }
+}


### PR DESCRIPTION
### Summary

When creating a split edge, some properties are copied from the parent edge to the split edge. Currently the copying happens after the split edge is constructed and connected to the graph, leaving a short time window where the split edge is not fully configured but already accessible from other threads.
This PR moves the copying of parent properties in the StreetEdge builder, before the edge is connected to the graph.

Note: only final fields initialized in the constructor are guaranteed to be thread-safe ([JLS 17.5](https://docs.oracle.com/javase/specs/jls/se17/html/jls-17.html#jls-17.5)). Since some of the copied fields are not final, it is still theoretically possible that they become visible from other threads before they are initialized.

### Issue

No

### Unit tests

Added unit tests

### Documentation

No
