### PR TITLE
Return client error for invalid Transmodel query JSON format

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
@@ -98,21 +98,26 @@ public class TransmodelAPI {
       throw new BadRequestException("No query found in body");
     }
 
-    String query = (String) queryParameters.get("query");
+    if (!(queryParameters.get("query") instanceof String query)) {
+      throw new BadRequestException("Invalid format for query");
+    }
+
     Object queryVariables = queryParameters.getOrDefault("variables", null);
-    String operationName = (String) queryParameters.getOrDefault("operationName", null);
     Map<String, Object> variables;
-    if (queryVariables instanceof Map) {
-      variables = (Map) queryVariables;
-    } else if (queryVariables instanceof String && !((String) queryVariables).isEmpty()) {
+    if (queryVariables instanceof Map queryVariablesAsMap) {
+      variables = queryVariablesAsMap;
+    } else if (
+      queryVariables instanceof String queryVariablesAsString && !queryVariablesAsString.isEmpty()
+    ) {
       try {
-        variables = deserializer.readValue((String) queryVariables, Map.class);
+        variables = deserializer.readValue(queryVariablesAsString, Map.class);
       } catch (IOException e) {
         throw new BadRequestException("Variables must be a valid json object");
       }
     } else {
       variables = new HashMap<>();
     }
+    String operationName = (String) queryParameters.getOrDefault("operationName", null);
     return index.executeGraphQL(
       query,
       serverContext,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -115,7 +116,7 @@ public class TransmodelAPI {
         throw new BadRequestException("Variables must be a valid json object");
       }
     } else {
-      variables = new HashMap<>();
+      variables = Collections.emptyMap();
     }
     String operationName = (String) queryParameters.getOrDefault("operationName", null);
     return index.executeGraphQL(


### PR DESCRIPTION
### Summary

When receiving a GraphQL query in JSON format, the Transmodel API expects the query part to be a valid JSON string.
If the query part contains a structured object instead:
```
{
"query":{"q1":"Query1", "q2":"Query2"}
}
```
the request fails with the following message :

```
java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class java.lang.String (java.util.LinkedHashMap and java.lang.String are in module java.base of loader 'bootstrap') class java.util.LinkedHashMap cannot be cast to class java.lang.String (java.util.LinkedHashMap and java.lang.String are in module java.base of loader 'bootstrap')
```
and returns an error code 500 - Internal Server Error.

This PR ensures that the client receives a meaningful error message and an error code 400 - Bad Request.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation
No

