### PR TITLE
Adding minor notes to Container-Image.md doc file

### DIFF
--- a/docs/Container-Image.md
+++ b/docs/Container-Image.md
@@ -24,3 +24,7 @@ docker run -it --rm -p 8080:8080 -v "$(pwd)/berlin:/var/opentripplanner" docker.
 ```
 
 Now open [http://localhost:8080](http://localhost:8080) to see your running OTP instance.
+
+## Additional notes
+Make sure to include the word "gtfs" when naming the gtfs files that you want to use for OTP. Otherwise, graph build will fail.
+When building graph fails (out-of-memory) add an option <b> -e JAVA_OPTS='-Xmx4g' </b> to docker run command

--- a/docs/Container-Image.md
+++ b/docs/Container-Image.md
@@ -26,5 +26,5 @@ docker run -it --rm -p 8080:8080 -v "$(pwd)/berlin:/var/opentripplanner" docker.
 Now open [http://localhost:8080](http://localhost:8080) to see your running OTP instance.
 
 ## Additional notes
-Make sure to include the word "gtfs" when naming the gtfs files that you want to use for OTP. Otherwise, graph build will fail.
-When building graph fails (out-of-memory) add an option <b> -e JAVA_OPTS='-Xmx4g' </b> to docker run command
+Make sure to include the word "gtfs" when naming the gtfs files that you want to use for OTP. Otherwise, graph build will fail.<br/>
+When building graph fails (out-of-memory) add an option <b> -e JAVA_TOOL_OPTIONS='-Xmx4g' </b> to docker run command

--- a/docs/Container-Image.md
+++ b/docs/Container-Image.md
@@ -26,5 +26,7 @@ docker run -it --rm -p 8080:8080 -v "$(pwd)/berlin:/var/opentripplanner" docker.
 Now open [http://localhost:8080](http://localhost:8080) to see your running OTP instance.
 
 ## Additional notes
-Make sure to include the word "gtfs" when naming the gtfs files that you want to use for OTP. Otherwise, graph build will fail.<br/>
-When building graph fails (out-of-memory) add an option <b> -e JAVA_TOOL_OPTIONS='-Xmx4g' </b> to docker run command
+Make sure to include the word "gtfs" when naming the gtfs files that you want to use for OTP. Otherwise, graph build will fail.
+
+If you want to set JVM options you can use the environment variable.
+A full example is `-e JAVA_TOOL_OPTIONS='-Xmx4g'` which you need to add to your docker command.


### PR DESCRIPTION
### Summary

When trying to build graph and start OTP using containers, there were some missing notes that are helpful when build or run fails. This PR addes minor notes to aid the "onboarding".

### Issue

Error messages when building graph were not clear, that the GTFS files should contain the string "gtfs" in their names. Also when using a big osm.pbf file, users are much likely to see out-of-memory message. Adding parameter to use more memory should solve that issue.

### Unit tests

No needed unit tests, as this PR only changes docs.

### Documentation

Changes to Container-Image.md file wihin /docs folder.