### PR TITLE
Add leg.headsign to GTFS GraphQL API

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
@@ -39,6 +39,7 @@ import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.ext.fares.FaresToItineraryMapper;
 import org.opentripplanner.ext.fares.impl.DefaultFareService;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareProduct;
@@ -110,7 +111,7 @@ class GraphQLIntegrationTest {
     var transitModel = new TransitModel(stopModel.build(), DEDUPLICATOR);
 
     final TripPattern pattern = TransitModelForTest.pattern(BUS).build();
-    var trip = TransitModelForTest.trip("123").build();
+    var trip = TransitModelForTest.trip("123").withHeadsign(I18NString.of("Trip Headsign")).build();
     var stopTimes = TransitModelForTest.stopTimesEvery5Minutes(3, trip, T11_00);
     var tripTimes = new TripTimes(trip, stopTimes, DEDUPLICATOR);
     pattern.add(tripTimes);
@@ -149,7 +150,7 @@ class GraphQLIntegrationTest {
       .build();
 
     var busLeg = i1.getTransitLeg(1);
-    ScheduledTransitLeg railLeg = (ScheduledTransitLeg) i1.getTransitLeg(2);
+    var railLeg = (ScheduledTransitLeg) i1.getTransitLeg(2);
 
     var fares = new ItineraryFares();
     fares.addFare(FareType.regular, Money.euros(3.1f));

--- a/src/ext-test/resources/gtfsgraphqlapi/expectations/patterns.json
+++ b/src/ext-test/resources/gtfsgraphqlapi/expectations/patterns.json
@@ -3,7 +3,7 @@
     "patterns" : [
       {
         "code" : "F:BUS",
-        "headsign" : null,
+        "headsign" : "Trip Headsign",
         "trips" : [
           {
             "gtfsId" : "F:123",
@@ -13,6 +13,7 @@
                   "gtfsId" : "F:Stop_0",
                   "name" : "Stop_0"
                 },
+                "headsign" : "Stop headsign at stop 10",
                 "scheduledArrival" : 39600,
                 "scheduledDeparture" : 39600,
                 "stopPosition" : 10,
@@ -25,6 +26,7 @@
                   "gtfsId" : "F:Stop_1",
                   "name" : "Stop_1"
                 },
+                "headsign" : "Stop headsign at stop 20",
                 "scheduledArrival" : 39900,
                 "scheduledDeparture" : 39900,
                 "stopPosition" : 20,
@@ -37,6 +39,7 @@
                   "gtfsId" : "F:Stop_2",
                   "name" : "Stop_2"
                 },
+                "headsign" : "Stop headsign at stop 30",
                 "scheduledArrival" : 40200,
                 "scheduledDeparture" : 40200,
                 "stopPosition" : 30,

--- a/src/ext-test/resources/gtfsgraphqlapi/expectations/plan-extended.json
+++ b/src/ext-test/resources/gtfsgraphqlapi/expectations/plan-extended.json
@@ -27,6 +27,8 @@
               "startTime" : 1580641200000,
               "endTime" : 1580641220000,
               "generalizedCost" : 40,
+              "headsign" : null,
+              "trip" : null,
               "alerts" : [ ],
               "rideHailingEstimate" : null,
               "accessibilityScore" : null
@@ -50,6 +52,10 @@
               "startTime" : 1580641260000,
               "endTime" : 1580642100000,
               "generalizedCost" : 992,
+              "headsign" : "Headsign at boarding (stop index 5)",
+              "trip" : {
+                "tripHeadsign" : "Trip headsign 122"
+              },
               "alerts" : [ ],
               "rideHailingEstimate" : null,
               "accessibilityScore" : null
@@ -73,6 +79,10 @@
               "startTime" : 1580643000000,
               "endTime" : 1580644200000,
               "generalizedCost" : 2040,
+              "headsign" : "Headsign at boarding (stop index 5)",
+              "trip" : {
+                "tripHeadsign" : "Trip headsign 439"
+              },
               "alerts" : [
                 {
                   "id" : "QWxlcnQ6Rjphbi1hbGVydA",
@@ -116,6 +126,8 @@
               "startTime" : 1580644200000,
               "endTime" : 1580644800000,
               "generalizedCost" : 1000,
+              "headsign" : null,
+              "trip" : null,
               "alerts" : [ ],
               "rideHailingEstimate" : {
                 "provider" : {

--- a/src/ext-test/resources/gtfsgraphqlapi/queries/patterns.graphql
+++ b/src/ext-test/resources/gtfsgraphqlapi/queries/patterns.graphql
@@ -9,6 +9,7 @@
                     gtfsId
                     name
                 }
+                headsign
                 scheduledArrival
                 scheduledDeparture
                 stopPosition

--- a/src/ext-test/resources/gtfsgraphqlapi/queries/plan-extended.graphql
+++ b/src/ext-test/resources/gtfsgraphqlapi/queries/plan-extended.graphql
@@ -40,6 +40,10 @@
                 endTime
                 mode
                 generalizedCost
+                headsign
+                trip {
+                    tripHeadsign
+                }
                 alerts {
                     id
                     alertHeaderText

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/LegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/LegImpl.java
@@ -13,6 +13,7 @@ import org.opentripplanner.ext.gtfsgraphqlapi.generated.GraphQLTypes;
 import org.opentripplanner.ext.gtfsgraphqlapi.mapping.NumberMapper;
 import org.opentripplanner.ext.ridehailing.model.RideEstimate;
 import org.opentripplanner.ext.ridehailing.model.RideHailingLeg;
+import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.fare.FareProductUse;
@@ -103,6 +104,12 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
   @Override
   public DataFetcher<Integer> generalizedCost() {
     return environment -> getSource(environment).getGeneralizedCost();
+  }
+
+  @Override
+  public DataFetcher<String> headsign() {
+    return environment ->
+      GraphQLUtils.getTranslation(getSource(environment).getHeadsign(), environment);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/generated/GraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/generated/GraphQLDataFetchers.java
@@ -432,6 +432,8 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<Integer> generalizedCost();
 
+    public DataFetcher<String> headsign();
+
     public DataFetcher<Boolean> interlineWithPreviousLeg();
 
     public DataFetcher<Boolean> intermediatePlace();

--- a/src/ext/resources/gtfsgraphqlapi/schema.graphqls
+++ b/src/ext/resources/gtfsgraphqlapi/schema.graphqls
@@ -1632,7 +1632,15 @@ type Leg {
     Whether the destination of this leg (field `to`) is one of the intermediate places specified in the query.
     """
     intermediatePlace: Boolean
+
+    "The turn-by-turn navigation instructions."
     steps: [step]
+
+    """
+    For transit legs, the headsign that the vehicle shows at the stop where the passenger boards.
+    For non-transit legs, null.
+    """
+    headsign: String
 
     """
     This is used to indicate if boarding this leg is possible only with special arrangements.
@@ -3839,9 +3847,10 @@ type Trip implements Node {
     """List of dates when this trip is in service. Format: YYYYMMDD"""
     activeDates: [String]
     tripShortName: String
+
     """Headsign of the vehicle when running on this trip"""
     tripHeadsign(
-        """If translated headsign is found from gtfs translation.txt and wanted language is not same as
+        """If a translated headsign is found from GTFS translation.txt and wanted language is not same as
         feed's language then returns wanted translation. Otherwise uses name from trip_headsign.txt.
         """
         language: String): String

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -24,6 +24,7 @@ import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
 import org.opentripplanner.ext.ridehailing.model.RideEstimate;
 import org.opentripplanner.ext.ridehailing.model.RideHailingLeg;
 import org.opentripplanner.ext.ridehailing.model.RideHailingProvider;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.time.TimeUtils;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
@@ -411,7 +412,11 @@ public class TestItineraryBuilder implements PlanTestConstants {
 
   /** Create a dummy trip */
   private static Trip trip(String id, Route route) {
-    return TransitModelForTest.trip(id).withRoute(route).build();
+    return TransitModelForTest
+      .trip(id)
+      .withRoute(route)
+      .withHeadsign(I18NString.of("Trip headsign %s".formatted(id)))
+      .build();
   }
 
   private static Place stop(Place source) {
@@ -446,6 +451,9 @@ public class TestItineraryBuilder implements PlanTestConstants {
     fromStopTime.setArrivalTime(start);
     fromStopTime.setDepartureTime(start);
     fromStopTime.setTrip(trip);
+    fromStopTime.setStopHeadsign(
+      I18NString.of("Headsign at boarding (stop index %s)".formatted(fromStopIndex))
+    );
 
     // Duplicate stop time for all stops prior to the last.
     for (int i = 0; i < toStopIndex; i++) {

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
@@ -196,6 +197,7 @@ public class TransitModelForTest {
     var stopTime = TransitModelForTest.stopTime(trip, seq);
     stopTime.setArrivalTime(time);
     stopTime.setDepartureTime(time);
+    stopTime.setStopHeadsign(I18NString.of("Stop headsign at stop %s".formatted(seq)));
     return stopTime;
   }
 


### PR DESCRIPTION
### Summary

@binh-dam-ibigroup has reported that in the GTFS GraphQL API a leg's headsign (as opposed the trip's) is not available, even though the internal model already contains the field and it was previously returned in the REST API.

This PR adds it.

### Unit tests

Added.

### Documentation

Added.