### PR TITLE
Map CoercingParseValueException

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -7,6 +7,7 @@ import graphql.analysis.MaxQueryComplexityInstrumentation;
 import graphql.execution.ExecutionStrategy;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
+import graphql.schema.CoercingParseValueException;
 import graphql.schema.GraphQLSchema;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
@@ -68,6 +69,8 @@ class TransmodelGraph {
       return ExecutionResultMapper.okResponse(result);
     } catch (OTPRequestTimeoutException te) {
       return ExecutionResultMapper.timeoutResponse();
+    } catch (CoercingParseValueException cpve) {
+      return ExecutionResultMapper.badRequestResponse(cpve.getMessage());
     } catch (Exception systemError) {
       LOG.error(systemError.getMessage(), systemError);
       return ExecutionResultMapper.systemErrorResponse(systemError.getMessage());

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/ExecutionResultMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/ExecutionResultMapper.java
@@ -16,6 +16,10 @@ public class ExecutionResultMapper {
   private static final ErrorClassification API_PROCESSING_TIMEOUT = ErrorClassification.errorClassification(
     "ApiProcessingTimeout"
   );
+  private static final ErrorClassification BAD_REQUEST_ERROR = ErrorClassification.errorClassification(
+    "BadRequestError"
+  );
+
   private static final ErrorClassification INTERNAL_SERVER_ERROR = ErrorClassification.errorClassification(
     "InternalServerError"
   );
@@ -32,6 +36,12 @@ public class ExecutionResultMapper {
       .build();
     var result = ExecutionResult.newExecutionResult().addError(error).build();
     return response(result, OtpHttpStatus.STATUS_UNPROCESSABLE_ENTITY);
+  }
+
+  public static Response badRequestResponse(String message) {
+    var error = GraphQLError.newError().errorType(BAD_REQUEST_ERROR).message(message).build();
+    var result = ExecutionResult.newExecutionResult().addError(error).build();
+    return response(result, Response.Status.BAD_REQUEST);
   }
 
   public static Response systemErrorResponse(String message) {

--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.api.common;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import graphql.schema.CoercingParseValueException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
@@ -46,7 +45,7 @@ public class OTPExceptionMapper implements ExceptionMapper<Exception> {
         .type("text/plain")
         .build();
     }
-    if (ex instanceof JsonParseException || ex instanceof CoercingParseValueException) {
+    if (ex instanceof JsonParseException) {
       return Response
         .status(Response.Status.BAD_REQUEST)
         .entity(ex.getMessage())


### PR DESCRIPTION
### Summary
Since #5192 client errors (bad requests) must be handled in TransmodelGraph, so the fix implemented in #5133 for mapping CoercingParseValueException does not work anymore and the API returns the following response with HTTP code _500 - Internal Server Error:_

```
{
  "errors": [
    {
      "message": "Expected type 'DateTime' but was '2023-08'.",
      "locations": [],
      "extensions": {
        "classification": "InternalServerError"
      }
    }
  ]
}
```

This PR ensures that CoercingParseValueException is mapped to HTTP code _400 - Bad Request_ with the following GraphQL response:

```
{
  "errors": [
    {
      "message": "Expected type 'DateTime' but was '2023-08'.",
      "locations": [],
      "extensions": {
        "classification": "BadRequestError"
      }
    }
  ]
}
```

**Note**: JSON parsing errors (JsonParseException) are caught before entering DataFetchers and are still correctly mapped inside OTPExceptionMapper.

### Issue
No

### Unit tests

:white_check_mark: 

### Documentation

No

