### PR TITLE
Remove pathway id from REST API

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
@@ -246,7 +246,7 @@ class GraphQLIntegrationTest {
   private static WalkStepBuilder walkStep(String name) {
     return WalkStep
       .builder()
-      .withStreetName(new NonLocalizedString(name))
+      .withDirectionText(new NonLocalizedString(name))
       .withStartLocation(WgsCoordinate.GREENWICH)
       .withAngle(10);
   }

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/stepImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/stepImpl.java
@@ -51,7 +51,7 @@ public class stepImpl implements GraphQLDataFetchers.GraphQLStep {
 
   @Override
   public DataFetcher<String> exit() {
-    return environment -> getSource(environment).isExit();
+    return environment -> getSource(environment).getExit();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/stepImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/stepImpl.java
@@ -8,7 +8,6 @@ import org.opentripplanner.ext.gtfsgraphqlapi.generated.GraphQLTypes.GraphQLRela
 import org.opentripplanner.ext.gtfsgraphqlapi.mapping.DirectionMapper;
 import org.opentripplanner.ext.gtfsgraphqlapi.mapping.StreetNoteMapper;
 import org.opentripplanner.model.plan.ElevationProfile.Step;
-import org.opentripplanner.model.plan.RelativeDirection;
 import org.opentripplanner.model.plan.WalkStep;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 
@@ -52,7 +51,7 @@ public class stepImpl implements GraphQLDataFetchers.GraphQLStep {
 
   @Override
   public DataFetcher<String> exit() {
-    return environment -> getSource(environment).getExit();
+    return environment -> getSource(environment).isExit();
   }
 
   @Override
@@ -72,12 +71,12 @@ public class stepImpl implements GraphQLDataFetchers.GraphQLStep {
 
   @Override
   public DataFetcher<Boolean> stayOn() {
-    return environment -> getSource(environment).getStayOn();
+    return environment -> getSource(environment).isStayOn();
   }
 
   @Override
   public DataFetcher<String> streetName() {
-    return environment -> getSource(environment).getStreetName().toString(environment.getLocale());
+    return environment -> getSource(environment).getName().toString(environment.getLocale());
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/stepImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/stepImpl.java
@@ -76,7 +76,8 @@ public class stepImpl implements GraphQLDataFetchers.GraphQLStep {
 
   @Override
   public DataFetcher<String> streetName() {
-    return environment -> getSource(environment).getName().toString(environment.getLocale());
+    return environment ->
+      getSource(environment).getDirectionText().toString(environment.getLocale());
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
@@ -62,7 +62,7 @@ public class PathGuidanceType {
           .name("exit")
           .description("When exiting a highway or traffic circle, the exit name/number.")
           .type(Scalars.GraphQLString)
-          .dataFetcher(environment -> ((WalkStep) environment.getSource()).isExit())
+          .dataFetcher(environment -> ((WalkStep) environment.getSource()).getExit())
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
@@ -41,7 +41,10 @@ public class PathGuidanceType {
           .description("The name of the street.")
           .type(Scalars.GraphQLString)
           .dataFetcher(environment ->
-            GraphQLUtils.getTranslation(((WalkStep) environment.getSource()).getName(), environment)
+            GraphQLUtils.getTranslation(
+              ((WalkStep) environment.getSource()).getDirectionText(),
+              environment
+            )
           )
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
@@ -42,7 +42,7 @@ public class PathGuidanceType {
           .type(Scalars.GraphQLString)
           .dataFetcher(environment ->
             GraphQLUtils.getTranslation(
-              ((WalkStep) environment.getSource()).getStreetName(),
+              ((WalkStep) environment.getSource()).getName(),
               environment
             )
           )
@@ -65,7 +65,7 @@ public class PathGuidanceType {
           .name("exit")
           .description("When exiting a highway or traffic circle, the exit name/number.")
           .type(Scalars.GraphQLString)
-          .dataFetcher(environment -> ((WalkStep) environment.getSource()).getExit())
+          .dataFetcher(environment -> ((WalkStep) environment.getSource()).isExit())
           .build()
       )
       .field(
@@ -74,7 +74,7 @@ public class PathGuidanceType {
           .name("stayOn")
           .description("Indicates whether or not a street changes direction at an intersection.")
           .type(Scalars.GraphQLBoolean)
-          .dataFetcher(environment -> ((WalkStep) environment.getSource()).getStayOn())
+          .dataFetcher(environment -> ((WalkStep) environment.getSource()).isStayOn())
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
@@ -41,10 +41,7 @@ public class PathGuidanceType {
           .description("The name of the street.")
           .type(Scalars.GraphQLString)
           .dataFetcher(environment ->
-            GraphQLUtils.getTranslation(
-              ((WalkStep) environment.getSource()).getName(),
-              environment
-            )
+            GraphQLUtils.getTranslation(((WalkStep) environment.getSource()).getName(), environment)
           )
           .build()
       )

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -90,7 +90,6 @@ public class LegMapper {
     api.headway = domain.getHeadway();
     api.distance = round3Decimals(domain.getDistanceMeters());
     api.generalizedCost = domain.getGeneralizedCost();
-    api.pathway = domain.getPathwayId() != null;
     api.agencyTimeZoneOffset = domain.getAgencyTimeZoneOffset();
 
     if (domain instanceof TransitLeg trLeg) {
@@ -119,12 +118,8 @@ public class LegMapper {
       api.transitLeg = false;
       api.mode = ModeMapper.mapToApi(streetLeg.getMode());
 
-      if (domain.getPathwayId() != null) {
-        api.route = FeedScopedIdMapper.mapToApi(domain.getPathwayId());
-      } else {
         // TODO OTP2 - This should be set to the street name according to the JavaDoc
         api.route = "";
-      }
     }
 
     api.interlineWithPreviousLeg = domain.isInterlinedWithPreviousLeg();

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -118,8 +118,8 @@ public class LegMapper {
       api.transitLeg = false;
       api.mode = ModeMapper.mapToApi(streetLeg.getMode());
 
-        // TODO OTP2 - This should be set to the street name according to the JavaDoc
-        api.route = "";
+      // TODO OTP2 - This should be set to the street name according to the JavaDoc
+      api.route = "";
     }
 
     api.interlineWithPreviousLeg = domain.isInterlinedWithPreviousLeg();

--- a/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
@@ -38,7 +38,7 @@ public class WalkStepMapper {
     api.streetName = domain.getName().toString(locale);
     api.absoluteDirection =
       domain.getAbsoluteDirection().map(AbsoluteDirectionMapper::mapAbsoluteDirection).orElse(null);
-    api.exit = domain.isExit();
+    api.exit = domain.getExit();
     api.stayOn = domain.isStayOn();
     api.area = domain.getArea();
     api.bogusName = domain.getBogusName();

--- a/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
@@ -35,7 +35,7 @@ public class WalkStepMapper {
 
     api.distance = domain.getDistance();
     api.relativeDirection = mapRelativeDirection(domain.getRelativeDirection());
-    api.streetName = domain.getName().toString(locale);
+    api.streetName = domain.getDirectionText().toString(locale);
     api.absoluteDirection =
       domain.getAbsoluteDirection().map(AbsoluteDirectionMapper::mapAbsoluteDirection).orElse(null);
     api.exit = domain.getExit();

--- a/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
@@ -35,11 +35,11 @@ public class WalkStepMapper {
 
     api.distance = domain.getDistance();
     api.relativeDirection = mapRelativeDirection(domain.getRelativeDirection());
-    api.streetName = domain.getStreetName().toString(locale);
+    api.streetName = domain.getName().toString(locale);
     api.absoluteDirection =
       domain.getAbsoluteDirection().map(AbsoluteDirectionMapper::mapAbsoluteDirection).orElse(null);
-    api.exit = domain.getExit();
-    api.stayOn = domain.getStayOn();
+    api.exit = domain.isExit();
+    api.stayOn = domain.isStayOn();
     api.area = domain.getArea();
     api.bogusName = domain.getBogusName();
     if (domain.getStartLocation() != null) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -162,7 +162,6 @@ public class AddTransitModelEntitiesToGraph {
         PathwayEdge.createLowCostPathwayEdge(
           boardingAreaVertex,
           platformVertex,
-          boardingArea.getId(),
           wheelchair,
           PathwayMode.WALKWAY
         );
@@ -170,7 +169,6 @@ public class AddTransitModelEntitiesToGraph {
         PathwayEdge.createLowCostPathwayEdge(
           platformVertex,
           boardingAreaVertex,
-          boardingArea.getId(),
           wheelchair,
           PathwayMode.WALKWAY
         );
@@ -199,7 +197,6 @@ public class AddTransitModelEntitiesToGraph {
           PathwayEdge.createPathwayEdge(
             fromVertex,
             toVertex,
-            pathway.getId(),
             NonLocalizedString.ofNullable(pathway.getSignpostedAs()),
             pathway.getTraversalTime(),
             distance,
@@ -212,7 +209,6 @@ public class AddTransitModelEntitiesToGraph {
             PathwayEdge.createPathwayEdge(
               toVertex,
               fromVertex,
-              pathway.getId(),
               NonLocalizedString.ofNullable(pathway.getReverseSignpostedAs()),
               pathway.getTraversalTime(),
               distance,

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -256,13 +256,6 @@ public interface Leg {
   double getDistanceMeters();
 
   /**
-   * The GTFS pathway id
-   */
-  default FeedScopedId getPathwayId() {
-    return null;
-  }
-
-  /**
    * Get the timezone offset in milliseconds.
    */
   default int getAgencyTimeZoneOffset() {

--- a/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
@@ -12,7 +12,6 @@ import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.model.fare.FareProductUse;
 import org.opentripplanner.street.model.note.StreetNote;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /**
  * One leg of a trip -- that is, a temporally continuous piece of the journey that takes place using
@@ -32,7 +31,6 @@ public class StreetLeg implements Leg {
   private final Set<StreetNote> streetNotes;
   private final ElevationProfile elevationProfile;
 
-  private final FeedScopedId pathwayId;
   private final Boolean walkingBike;
   private final Boolean rentedVehicle;
   private final String vehicleRentalNetwork;
@@ -50,7 +48,6 @@ public class StreetLeg implements Leg {
     this.legGeometry = builder.getGeometry();
     this.walkSteps = builder.getWalkSteps();
     this.streetNotes = Set.copyOf(builder.getStreetNotes());
-    this.pathwayId = builder.getPathwayId();
     this.walkingBike = builder.getWalkingBike();
     this.rentedVehicle = builder.getRentedVehicle();
     this.vehicleRentalNetwork = builder.getVehicleRentalNetwork();
@@ -93,11 +90,6 @@ public class StreetLeg implements Leg {
   @Override
   public double getDistanceMeters() {
     return distanceMeters;
-  }
-
-  @Override
-  public FeedScopedId getPathwayId() {
-    return pathwayId;
   }
 
   @Override
@@ -201,7 +193,6 @@ public class StreetLeg implements Leg {
       .addEnum("mode", mode)
       .addNum("distance", distanceMeters, "m")
       .addNum("cost", generalizedCost)
-      .addObj("gtfsPathwayId", pathwayId)
       .addObj("legGeometry", legGeometry)
       .addObj("legElevation", elevationProfile)
       .addCol("walkSteps", walkSteps)

--- a/src/main/java/org/opentripplanner/model/plan/StreetLegBuilder.java
+++ b/src/main/java/org/opentripplanner/model/plan/StreetLegBuilder.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.street.model.note.StreetNote;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 public class StreetLegBuilder {
 
@@ -21,7 +20,6 @@ public class StreetLegBuilder {
   private LineString geometry;
   private ElevationProfile elevationProfile;
   private List<WalkStep> walkSteps;
-  private FeedScopedId pathwayId;
   private Boolean walkingBike;
   private Boolean rentedVehicle;
   private String vehicleRentalNetwork;
@@ -42,7 +40,6 @@ public class StreetLegBuilder {
       .withGeometry(leg.getLegGeometry())
       .withElevationProfile(leg.getElevationProfile())
       .withWalkSteps(leg.getWalkSteps())
-      .withPathwayId(leg.getPathwayId())
       .withWalkingBike(leg.getWalkingBike())
       .withRentedVehicle(leg.getRentedVehicle())
       .withVehicleRentalNetwork(leg.getVehicleRentalNetwork())
@@ -92,10 +89,6 @@ public class StreetLegBuilder {
 
   public List<WalkStep> getWalkSteps() {
     return walkSteps;
-  }
-
-  public FeedScopedId getPathwayId() {
-    return pathwayId;
   }
 
   public Boolean getWalkingBike() {
@@ -165,11 +158,6 @@ public class StreetLegBuilder {
 
   public StreetLegBuilder withWalkSteps(List<WalkStep> walkSteps) {
     this.walkSteps = walkSteps;
-    return this;
-  }
-
-  public StreetLegBuilder withPathwayId(FeedScopedId pathwayId) {
-    this.pathwayId = pathwayId;
     return this;
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/WalkStep.java
+++ b/src/main/java/org/opentripplanner/model/plan/WalkStep.java
@@ -34,7 +34,7 @@ public final class WalkStep {
   private final WgsCoordinate startLocation;
   private final double distance;
   private final RelativeDirection relativeDirection;
-  private final I18NString streetName;
+  private final I18NString name;
   private final AbsoluteDirection absoluteDirection;
 
   private final Set<StreetNote> streetNotes;
@@ -54,7 +54,7 @@ public final class WalkStep {
     WgsCoordinate startLocation,
     RelativeDirection relativeDirection,
     AbsoluteDirection absoluteDirection,
-    I18NString streetName,
+    I18NString name,
     Set<StreetNote> streetNotes,
     String exit,
     ElevationProfile elevationProfile,
@@ -69,7 +69,7 @@ public final class WalkStep {
     this.distance = distance;
     this.relativeDirection = Objects.requireNonNull(relativeDirection);
     this.absoluteDirection = absoluteDirection;
-    this.streetName = streetName;
+    this.name = name;
     this.streetNotes = Set.copyOf(Objects.requireNonNull(streetNotes));
     this.startLocation = Objects.requireNonNull(startLocation);
     this.bogusName = bogusName;
@@ -107,8 +107,8 @@ public final class WalkStep {
   /**
    * The name of the street.
    */
-  public I18NString getStreetName() {
-    return streetName;
+  public I18NString getName() {
+    return name;
   }
 
   /**
@@ -124,14 +124,14 @@ public final class WalkStep {
   /**
    * When exiting a highway or traffic circle, the exit name/number.
    */
-  public String getExit() {
+  public String isExit() {
     return exit;
   }
 
   /**
    * Indicates whether a street changes direction at an intersection.
    */
-  public Boolean getStayOn() {
+  public Boolean isStayOn() {
     return stayOn;
   }
 
@@ -187,7 +187,7 @@ public final class WalkStep {
       .of(this.getClass())
       .addEnum("absoluteDirection", absoluteDirection)
       .addEnum("relativeDirection", relativeDirection)
-      .addStr("streetName", streetName.toString())
+      .addStr("streetName", name.toString())
       .addNum("distance", distance)
       .toString();
   }

--- a/src/main/java/org/opentripplanner/model/plan/WalkStep.java
+++ b/src/main/java/org/opentripplanner/model/plan/WalkStep.java
@@ -33,7 +33,7 @@ public final class WalkStep {
   private final WgsCoordinate startLocation;
   private final double distance;
   private final RelativeDirection relativeDirection;
-  private final I18NString name;
+  private final I18NString directionText;
   private final AbsoluteDirection absoluteDirection;
 
   private final Set<StreetNote> streetNotes;
@@ -53,7 +53,7 @@ public final class WalkStep {
     WgsCoordinate startLocation,
     RelativeDirection relativeDirection,
     AbsoluteDirection absoluteDirection,
-    I18NString name,
+    I18NString directionText,
     Set<StreetNote> streetNotes,
     String exit,
     ElevationProfile elevationProfile,
@@ -68,7 +68,7 @@ public final class WalkStep {
     this.distance = distance;
     this.relativeDirection = Objects.requireNonNull(relativeDirection);
     this.absoluteDirection = absoluteDirection;
-    this.name = name;
+    this.directionText = directionText;
     this.streetNotes = Set.copyOf(Objects.requireNonNull(streetNotes));
     this.startLocation = Objects.requireNonNull(startLocation);
     this.bogusName = bogusName;
@@ -104,10 +104,13 @@ public final class WalkStep {
   }
 
   /**
-   * The name of the street.
+   * A piece of information that {@link WalkStep#getRelativeDirection()} relates to.
+   * This could be the name of the street ("turn right at Main Street") but also a
+   * station entrance ("enter station at Entrance 4B") or what is on a sign
+   * ("follow signs for Platform 9").
    */
-  public I18NString getName() {
-    return name;
+  public I18NString getDirectionText() {
+    return directionText;
   }
 
   /**
@@ -186,7 +189,7 @@ public final class WalkStep {
       .of(this.getClass())
       .addEnum("absoluteDirection", absoluteDirection)
       .addEnum("relativeDirection", relativeDirection)
-      .addStr("streetName", name.toString())
+      .addStr("streetName", directionText.toString())
       .addNum("distance", distance)
       .toString();
   }

--- a/src/main/java/org/opentripplanner/model/plan/WalkStep.java
+++ b/src/main/java/org/opentripplanner/model/plan/WalkStep.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.lang.DoubleUtils;
-import org.opentripplanner.framework.lang.IntUtils;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.note.StreetNote;
@@ -124,14 +123,14 @@ public final class WalkStep {
   /**
    * When exiting a highway or traffic circle, the exit name/number.
    */
-  public String isExit() {
+  public String getExit() {
     return exit;
   }
 
   /**
    * Indicates whether a street changes direction at an intersection.
    */
-  public Boolean isStayOn() {
+  public boolean isStayOn() {
     return stayOn;
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/WalkStepBuilder.java
+++ b/src/main/java/org/opentripplanner/model/plan/WalkStepBuilder.java
@@ -15,7 +15,7 @@ import org.opentripplanner.street.model.note.StreetNote;
 public class WalkStepBuilder {
 
   private final Set<StreetNote> streetNotes = new HashSet<>();
-  private I18NString streetName;
+  private I18NString directionText;
   private WgsCoordinate startLocation;
   private boolean bogusName = false;
   private double angle;
@@ -34,8 +34,8 @@ public class WalkStepBuilder {
 
   WalkStepBuilder() {}
 
-  public WalkStepBuilder withStreetName(I18NString streetName) {
-    this.streetName = streetName;
+  public WalkStepBuilder withDirectionText(I18NString streetName) {
+    this.directionText = streetName;
     return this;
   }
 
@@ -119,8 +119,8 @@ public class WalkStepBuilder {
   }
 
   @Nullable
-  public String streetNameNoParens() {
-    var str = streetName.toString();
+  public String directionTextNoParens() {
+    var str = directionText.toString();
     if (str == null) {
       return null; //Avoid null reference exceptions with pathways which don't have names
     }
@@ -136,8 +136,8 @@ public class WalkStepBuilder {
     return this;
   }
 
-  public I18NString streetName() {
-    return streetName;
+  public I18NString directionText() {
+    return directionText;
   }
 
   public boolean bogusName() {
@@ -153,7 +153,7 @@ public class WalkStepBuilder {
       startLocation,
       relativeDirection,
       absoluteDirection,
-      streetName,
+      directionText,
       streetNotes,
       exit,
       elevationProfile,

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -30,7 +30,6 @@ import org.opentripplanner.service.vehiclerental.street.VehicleRentalEdge;
 import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;
 import org.opentripplanner.street.model.edge.BoardingLocationToStopLink;
 import org.opentripplanner.street.model.edge.Edge;
-import org.opentripplanner.street.model.edge.PathwayEdge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.VehicleParkingEdge;
 import org.opentripplanner.street.model.note.StreetNote;
@@ -199,17 +198,6 @@ public class GraphPathToItineraryMapper {
     }
 
     return legsStates;
-  }
-
-  /**
-   * TODO: This is mindless. Why is this set on leg, rather than on a walk step? Now only the first pathway is used
-   */
-  private static void setPathwayInfo(StreetLegBuilder leg, List<State> legStates) {
-    for (State legsState : legStates) {
-      if (legsState.getBackEdge() instanceof PathwayEdge pe) {
-        leg.withPathwayId(pe.getId());
-      }
-    }
   }
 
   /**
@@ -420,8 +408,6 @@ public class GraphPathToItineraryMapper {
     }
 
     addStreetNotes(leg, states);
-
-    setPathwayInfo(leg, states);
 
     return leg.build();
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
@@ -266,8 +266,8 @@ public class StatesToWalkStepsMapper {
         WalkStepBuilder twoBack = steps.get(lastIndex - 1);
         WalkStepBuilder lastStep = steps.get(lastIndex);
         boolean isOnSameStreet = lastStep
-          .streetNameNoParens()
-          .equals(threeBack.streetNameNoParens());
+          .directionTextNoParens()
+          .equals(threeBack.directionTextNoParens());
         if (twoBack.distance() < MAX_ZAG_DISTANCE && isOnSameStreet) {
           if (isUTurn(twoBack, lastStep)) {
             steps.remove(lastIndex - 1);
@@ -430,8 +430,8 @@ public class StatesToWalkStepsMapper {
 
   private boolean continueOnSameStreet(Edge edge, String streetNameNoParens) {
     return !(
-      current.streetName().toString() != null &&
-      !(java.util.Objects.equals(current.streetNameNoParens(), streetNameNoParens)) &&
+      current.directionText().toString() != null &&
+      !(java.util.Objects.equals(current.directionTextNoParens(), streetNameNoParens)) &&
       (!current.bogusName() || !edge.hasBogusName())
     );
   }
@@ -510,7 +510,7 @@ public class StatesToWalkStepsMapper {
     // exit != null and uses to <exit>
     // the floor name is the AlightEdge name
     // reset to avoid confusion with 'Elevator on floor 1 to floor 1'
-    step.withStreetName(edge.getName());
+    step.withDirectionText(edge.getName());
 
     step.withRelativeDirection(RelativeDirection.ELEVATOR);
 
@@ -526,7 +526,7 @@ public class StatesToWalkStepsMapper {
   ) {
     addStep(
       createWalkStep(forwardState, backState)
-        .withStreetName(name)
+        .withDirectionText(name)
         .withBogusName(false)
         .withDirections(lastAngle, DirectionUtils.getFirstAngle(edge.getGeometry()), false)
         .withRelativeDirection(direction)
@@ -543,7 +543,7 @@ public class StatesToWalkStepsMapper {
 
     return WalkStep
       .builder()
-      .withStreetName(en.getName())
+      .withDirectionText(en.getName())
       .withStartLocation(new WgsCoordinate(backState.getVertex().getCoordinate()))
       .withBogusName(en.hasBogusName())
       .withAngle(DirectionUtils.getFirstAngle(forwardState.getBackEdge().getGeometry()))

--- a/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.street.model.edge;
 
 import javax.annotation.Nonnull;
-import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
@@ -156,16 +155,6 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
   @Override
   public I18NString getName() {
     return null;
-  }
-
-  @Override
-  public LineString getGeometry() {
-    return null;
-  }
-
-  @Override
-  public double getDistanceMeters() {
-    return 0;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
@@ -14,7 +14,6 @@ import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.StateEditor;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.PathwayMode;
 
 /**
@@ -34,12 +33,10 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
   private final PathwayMode mode;
 
   private final boolean wheelchairAccessible;
-  private final FeedScopedId id;
 
   private PathwayEdge(
     Vertex fromv,
     Vertex tov,
-    FeedScopedId id,
     @Nullable I18NString signpostedAs,
     int traversalTime,
     double distance,
@@ -50,7 +47,6 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
   ) {
     super(fromv, tov);
     this.signpostedAs = signpostedAs;
-    this.id = id;
     this.traversalTime = traversalTime;
     this.steps = steps;
     this.slope = slope;
@@ -60,10 +56,10 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
   }
 
   /**
-   * {@link #createLowCostPathwayEdge(Vertex, Vertex, FeedScopedId, boolean, PathwayMode)}
+   * {@link #createLowCostPathwayEdge(Vertex, Vertex, boolean, PathwayMode)}
    */
   public static PathwayEdge createLowCostPathwayEdge(Vertex fromV, Vertex toV, PathwayMode mode) {
-    return PathwayEdge.createLowCostPathwayEdge(fromV, toV, null, true, mode);
+    return PathwayEdge.createLowCostPathwayEdge(fromV, toV, true, mode);
   }
 
   /**
@@ -74,17 +70,15 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
   public static PathwayEdge createLowCostPathwayEdge(
     Vertex fromV,
     Vertex toV,
-    FeedScopedId id,
     boolean wheelchairAccessible,
     PathwayMode mode
   ) {
-    return createPathwayEdge(fromV, toV, id, null, 0, 0, 0, 0, wheelchairAccessible, mode);
+    return createPathwayEdge(fromV, toV, null, 0, 0, 0, 0, wheelchairAccessible, mode);
   }
 
   public static PathwayEdge createPathwayEdge(
     Vertex fromv,
     Vertex tov,
-    FeedScopedId id,
     I18NString signpostedAs,
     int traversalTime,
     double distance,
@@ -97,7 +91,6 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
       new PathwayEdge(
         fromv,
         tov,
-        id,
         signpostedAs,
         traversalTime,
         distance,
@@ -208,10 +201,6 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
 
   public int getSteps() {
     return steps;
-  }
-
-  public FeedScopedId getId() {
-    return id;
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/model/plan/WalkStepTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/WalkStepTest.java
@@ -15,7 +15,7 @@ public class WalkStepTest {
   @Test
   public void testRelativeDirection() {
     WalkStepBuilder builder = new WalkStepBuilder()
-      .withStreetName(new NonLocalizedString("Any"))
+      .withDirectionText(new NonLocalizedString("Any"))
       .withStartLocation(new WgsCoordinate(3.0, 4.0))
       .withBogusName(false)
       .withAngle(0.0)

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -292,7 +292,6 @@ public abstract class GraphRoutingTest {
       return PathwayEdge.createPathwayEdge(
         from,
         to,
-        null,
         new NonLocalizedString(
           String.format("%s%s pathway", from.getDefaultName(), to.getDefaultName())
         ),

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapperTest.java
@@ -65,7 +65,7 @@ class StatesToWalkStepsMapperTest {
     assertEquals(2, walkSteps.size());
     var step = walkSteps.get(1);
     assertEquals(step.getRelativeDirection(), FOLLOW_SIGNS);
-    assertEquals(sign, step.getStreetName().toString());
+    assertEquals(sign, step.getName().toString());
   }
 
   private static List<WalkStep> buildWalkSteps(TestStateBuilder builder) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapperTest.java
@@ -65,7 +65,7 @@ class StatesToWalkStepsMapperTest {
     assertEquals(2, walkSteps.size());
     var step = walkSteps.get(1);
     assertEquals(step.getRelativeDirection(), FOLLOW_SIGNS);
-    assertEquals(sign, step.getName().toString());
+    assertEquals(sign, step.getDirectionText().toString());
   }
 
   private static List<WalkStep> buildWalkSteps(TestStateBuilder builder) {

--- a/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
-import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -35,7 +34,6 @@ class PathwayEdgeTest {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
-      null,
       new NonLocalizedString("pathway"),
       0,
       0,
@@ -53,7 +51,6 @@ class PathwayEdgeTest {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
-      null,
       new NonLocalizedString("pathway"),
       0,
       0,
@@ -71,7 +68,6 @@ class PathwayEdgeTest {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
-      null,
       new NonLocalizedString("pathway"),
       60,
       0,
@@ -91,7 +87,6 @@ class PathwayEdgeTest {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
-      null,
       new NonLocalizedString("pathway"),
       60,
       1000,
@@ -113,7 +108,6 @@ class PathwayEdgeTest {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
-      null,
       new NonLocalizedString("pathway"),
       0,
       60,
@@ -133,7 +127,6 @@ class PathwayEdgeTest {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
-      null,
       new NonLocalizedString("pathway"),
       0,
       60,
@@ -176,7 +169,6 @@ class PathwayEdgeTest {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       to,
-      null,
       new NonLocalizedString("pathway"),
       60,
       100,
@@ -252,7 +244,6 @@ class PathwayEdgeTest {
       return PathwayEdge.createPathwayEdge(
         from,
         to,
-        id("1"),
         sign,
         60,
         100,

--- a/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
+++ b/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
@@ -176,7 +176,6 @@ public class TestStateBuilder {
     var edge = PathwayEdge.createPathwayEdge(
       from,
       tov,
-      null,
       I18NString.of(s),
       60,
       100,


### PR DESCRIPTION
### Summary

The REST API used to expose the ID of the first pathway on a street leg. This is a strange piece of the API that thankfully didn't make it into the GraphQL API.

Because of this, I'm removing it from the API and also do the associated internal clean up so that we don't needlessly pass the ID around.

Lastly, I renamed a few properties in `WalkStep` so they better reflect their meaning.

@miles-grant-ibigroup has confirmed that IBI is not using this field.