### PR TITLE
Add support for decimal numbers in the constant part of a linear function

### DIFF
--- a/src/test/java/org/opentripplanner/routing/api/request/framework/LinearFunctionSerializationTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/framework/LinearFunctionSerializationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner.framework.time.DurationUtils;
+import org.opentripplanner.test.support.TestTableParser;
 import org.opentripplanner.test.support.VariableSource;
 
 class LinearFunctionSerializationTest {
@@ -20,14 +21,21 @@ class LinearFunctionSerializationTest {
   private static final Duration D1h = Duration.ofSeconds(3600);
 
   @SuppressWarnings("unused")
-  static Stream<Arguments> parseTestCases = Stream.of(
-    Arguments.of("0+0t", "0s", 0.00),
-    Arguments.of("1+0.0111 t", "1s", 0.01),
-    Arguments.of("120 + 0.111 t", "2m", 0.11),
-    Arguments.of("2h3m + 1.111 t", "2h3m", 1.11),
-    Arguments.of("2h3m + 2.111 t", "2h3m", 2.1),
-    Arguments.of("3h + 5.111 t", "3h", 5.1),
-    Arguments.of("7m + 10.1 x", "7m", 10.0)
+  static Stream<Arguments> parseTestCases = TestTableParser.of(
+    """
+    #        INPUT    ||       EXPECTED
+    #                 ||  CONSTANT | COEFFICIENT
+               0+0t   ||       0s  |   0.0
+         1+0.0111 t   ||       1s  |   0.01
+      120 + 0.111 t   ||       2m  |   0.11
+      120 + 0.111 t   ||       2m  |   0.11
+         12.0 + 0 t   ||      12s  |   0.0
+     2h3m + 1.111 t   ||     2h3m  |   1.11
+     2h3m + 2.111 t   ||     2h3m  |   2.1
+       3h + 5.111 t   ||       3h  |   5.1
+        7m + 10.1 x   ||       7m  |  10.0
+      PT7s + 10.1 x   ||       7s  |  10.0
+    """
   );
 
   @ParameterizedTest

--- a/src/test/java/org/opentripplanner/test/support/TestTableParser.java
+++ b/src/test/java/org/opentripplanner/test/support/TestTableParser.java
@@ -45,18 +45,7 @@ public class TestTableParser {
     var result = new Object[args.length];
 
     for (int i = 0; i < args.length; i++) {
-      String arg = args[i].toLowerCase(Locale.ROOT);
-      if (arg.matches("-?\\d+")) {
-        result[i] = Integer.valueOf(arg);
-      } else if (arg.matches("-?\\d*\\.\\d+")) {
-        result[i] = Double.valueOf(arg);
-      } else if (arg.matches("t(rue)?|y(es)?|x")) {
-        result[i] = Boolean.TRUE;
-      } else if (arg.matches("f(alse)?|n(o)?|-")) {
-        result[i] = Boolean.FALSE;
-      } else {
-        result[i] = arg;
-      }
+      result[i] = toValue(args[i]);
     }
     return result;
   }
@@ -64,6 +53,23 @@ public class TestTableParser {
   private static String stripComment(String line) {
     int pos = line.indexOf("#");
     return pos < 0 ? line : (pos == 0 ? "" : line.substring(0, pos).trim());
+  }
+
+  private static Object toValue(String arg) {
+    if (arg.matches("-?\\d+")) {
+      return Integer.valueOf(arg);
+    }
+    if (arg.matches("-?\\d*\\.\\d+")) {
+      return Double.valueOf(arg);
+    }
+    String lcArg = arg.toLowerCase(Locale.ROOT);
+    if (lcArg.matches("t(rue)?|y(es)?|x")) {
+      return Boolean.TRUE;
+    }
+    if (lcArg.matches("f(alse)?|n(o)?|-")) {
+      return Boolean.FALSE;
+    }
+    return arg;
   }
 
   @Test


### PR DESCRIPTION
### Summary

Som of the APIs expose the linear function to configure itinerary filters. Before the #5267 it was allowed to pass in a decimal number in the constant part of this function. In #5267 only a integer and a duration was allowed. This created an issue with existing clients(at Entur). I have now added support for decimal numbers. Support for integer and duration is kept.


### Issue

There is no issue for this fix.


### Unit tests

Unit tests are added for the regression tests.

### Documentation

We do not want people to pass in decimal numbers in the constant part of a linear function, so the doc is NOT changed.

### Changelog
Skip  chanelog, since this fixes a PR merged in the same version(2.4)

### Bumping the serialization version id
No
