### PR TITLE
Return valid response when stop id is missing in Transmodel query

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -494,6 +494,10 @@ public class StopPlaceType {
     FeedScopedId id,
     DataFetchingEnvironment environment
   ) {
+    if (id == null) {
+      return null;
+    }
+
     TransitService transitService = GqlUtil.getTransitService(environment);
 
     Station station = transitService.getStationById(id);


### PR DESCRIPTION
### Summary

A stop place query where the id is empty:

```
{
  stopPlace(
    id: ""
  ) {
    id
    name
    estimatedCalls(
      startTime: "2023-08-18T09:37:30+0000",
      timeRange: 24000,
      includeCancelledTrips: false,
      numberOfDepartures: 25
    ) {
      realtime
      aimedArrivalTime
      aimedDepartureTime
      expectedArrivalTime
      expectedDepartureTime
      date
      forBoarding
      forAlighting
      destinationDisplay {
        frontText
      }
    }
  }
}
```
returns currently:

```
{
  "errors": [
    {
      "message": "Exception while fetching data (/stopPlace) : Cannot invoke \"Object.hashCode()\" because \"pk\" is null",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "stopPlace"
      ],
      "extensions": {
        "classification": "DataFetchingException"
      }
    }
  ],
  "data": {
    "stopPlace": null
  }
}
```
This PR ensures that the API returns a valid GraphQL response with a null stopPlace:

```
{
  "data": {
    "stopPlace": null
  }
}
```



### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No

