### PR TITLE
Handle missing parent station when collecting SIRI alerts

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -365,8 +365,6 @@ public class EstimatedCallType {
     StopLocation stop = tripTimeOnDate.getStop();
     FeedScopedId stopId = stop.getId();
 
-    FeedScopedId parentStopId = stop.getParentStation().getId();
-
     Collection<TransitAlert> allAlerts = new HashSet<>();
 
     TransitAlertService alertPatchService = transitService.getTransitAlertService();
@@ -386,13 +384,16 @@ public class EstimatedCallType {
     );
     allAlerts.addAll(alertPatchService.getStopAndRouteAlerts(stopId, routeId, stopConditions));
     // StopPlace
-    allAlerts.addAll(alertPatchService.getStopAlerts(parentStopId, stopConditions));
-    allAlerts.addAll(
-      alertPatchService.getStopAndTripAlerts(parentStopId, tripId, serviceDate, stopConditions)
-    );
-    allAlerts.addAll(
-      alertPatchService.getStopAndRouteAlerts(parentStopId, routeId, stopConditions)
-    );
+    if (stop.getParentStation() != null) {
+      FeedScopedId parentStopId = stop.getParentStation().getId();
+      allAlerts.addAll(alertPatchService.getStopAlerts(parentStopId, stopConditions));
+      allAlerts.addAll(
+        alertPatchService.getStopAndTripAlerts(parentStopId, tripId, serviceDate, stopConditions)
+      );
+      allAlerts.addAll(
+        alertPatchService.getStopAndRouteAlerts(parentStopId, routeId, stopConditions)
+      );
+    }
     // Trip
     allAlerts.addAll(alertPatchService.getTripAlerts(tripId, serviceDate));
     // Route


### PR DESCRIPTION
### Summary

A Transmodel query for estimated calls and situations:

```
query getDeparturesForServiceJourney($id: String!, $date: Date) {
  serviceJourney(
    id: $id
  ) {
    estimatedCalls(
      date: $date
    ) {
      quay {
        id
        name
        stopPlace {
          id
        }
      }
        situations {
          situationNumber
        }
    }
  }
}
```
fails if it refers to a FlexibleStopPlace, since  FlexibleStopPlace do not have a parent station:

```
Exception while fetching data (/serviceJourney/estimatedCalls[1]/situations) : Cannot invoke "org.opentripplanner.transit.model.site.Station.getId()" because the return value of "org.opentripplanner.transit.model.site.StopLocation.getParentStation()" is null
java.lang.NullPointerException: Cannot invoke "org.opentripplanner.transit.model.site.Station.getId()" because the return value of "org.opentripplanner.transit.model.site.StopLocation.getParentStation()" is null
	at org.opentripplanner.ext.transmodelapi.model.siri.et.EstimatedCallType.getAllRelevantAlerts(EstimatedCallType.java:368)
	at org.opentripplanner.ext.transmodelapi.model.siri.et.EstimatedCallType.lambda$create$21(EstimatedCallType.java:330)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.ExecutionStrategy.completeValueForObject(ExecutionStrategy.java:702)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:484)
	at graphql.execution.ExecutionStrategy.completeValueForList(ExecutionStrategy.java:586)
	at graphql.execution.ExecutionStrategy.completeValueForList(ExecutionStrategy.java:543)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:469)
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:435)
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$1(ExecutionStrategy.java:215)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2168)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:214)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.ExecutionStrategy.completeValueForObject(ExecutionStrategy.java:702)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:484)
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:435)
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$1(ExecutionStrategy.java:215)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2168)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:214)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:65)
```

This PR ensures that the parent station is ignored if not present when collecting situations/alerts.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No
