### PR TITLE
Fix walk board cost comparison and add escalatorReluctance to hash

### DIFF
--- a/src/main/java/org/opentripplanner/routing/api/request/preference/WalkPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/WalkPreferences.java
@@ -116,7 +116,7 @@ public final class WalkPreferences implements Serializable {
     return (
       doubleEquals(that.speed, speed) &&
       doubleEquals(that.reluctance, reluctance) &&
-      boardCost == that.boardCost &&
+      boardCost.equals(that.boardCost) &&
       doubleEquals(that.stairsReluctance, stairsReluctance) &&
       doubleEquals(that.stairsTimeFactor, stairsTimeFactor) &&
       doubleEquals(that.safetyFactor, safetyFactor) &&
@@ -132,7 +132,8 @@ public final class WalkPreferences implements Serializable {
       boardCost,
       stairsReluctance,
       stairsTimeFactor,
-      safetyFactor
+      safetyFactor,
+      escalatorReluctance
     );
   }
 

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/ImmutablePreferencesAsserts.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/ImmutablePreferencesAsserts.java
@@ -6,8 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 public class ImmutablePreferencesAsserts {
 
   public static <T> void assertEqualsAndHashCode(T subject, T other, T same) {
+    assertEqualsAndHashCode(subject, same);
+    assertNotEqualsAndHashCode(subject, other);
+  }
+
+  public static <T> void assertEqualsAndHashCode(T subject, T same) {
     assertEquals(subject, same);
     assertEquals(subject.hashCode(), same.hashCode());
+  }
+
+  public static <T> void assertNotEqualsAndHashCode(T subject, T other) {
     assertNotEquals(subject, other);
     assertNotEquals(subject.hashCode(), other.hashCode());
   }

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
@@ -1,11 +1,10 @@
 package org.opentripplanner.routing.api.request.preference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.opentripplanner.routing.api.request.preference.ImmutablePreferencesAsserts.assertEqualsAndHashCode;
+import static org.opentripplanner.routing.api.request.preference.ImmutablePreferencesAsserts.assertNotEqualsAndHashCode;
 
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 class WalkPreferencesTest {
@@ -63,7 +62,7 @@ class WalkPreferencesTest {
   }
 
   @Test
-  void testEqualsAndHashCode() {
+  void testEqualsAndHashCodeWithCopiedPreferences() {
     // Return same object if no value is set
     assertSame(subject, subject.copyOf().build());
     assertSame(TransitPreferences.DEFAULT, TransitPreferences.of().build());
@@ -72,7 +71,10 @@ class WalkPreferencesTest {
     var other = subject.copyOf().withSpeed(10.0).build();
     var copy = other.copyOf().withSpeed(SPEED).build();
     assertEqualsAndHashCode(subject, other, copy);
+  }
 
+  @Test
+  void testEqualsAndHashCodeWithNewlyConstructedPreferences() {
     // Test that nothing breaks while adding wrapper objects for values
     var sameSpeed = 2.3;
     var sameReluctance = 2.51;
@@ -98,8 +100,7 @@ class WalkPreferencesTest {
       .withEscalatorReluctance(sameEscalatorReluctance)
       .withBoardCost(sameBoardCost)
       .build();
-    assertEquals(firstEqual, secondEqual);
-    assertEquals(firstEqual.hashCode(), secondEqual.hashCode());
+    assertEqualsAndHashCode(firstEqual, secondEqual);
 
     // Test that changing speed means preferences are not equal
     var notSameSpeed = sameSpeed + 1;
@@ -112,8 +113,7 @@ class WalkPreferencesTest {
       .withEscalatorReluctance(sameEscalatorReluctance)
       .withBoardCost(sameBoardCost)
       .build();
-    assertNotEquals(firstEqual, differentSpeedPreferences);
-    assertNotEquals(firstEqual.hashCode(), differentSpeedPreferences.hashCode());
+    assertNotEqualsAndHashCode(firstEqual, differentSpeedPreferences);
 
     // Test that changing reluctance means preferences are not equal
     var notSameReluctance = sameReluctance + 1;
@@ -126,8 +126,7 @@ class WalkPreferencesTest {
       .withEscalatorReluctance(sameEscalatorReluctance)
       .withBoardCost(sameBoardCost)
       .build();
-    assertNotEquals(firstEqual, differentReluctancePreferences);
-    assertNotEquals(firstEqual.hashCode(), differentReluctancePreferences.hashCode());
+    assertNotEqualsAndHashCode(firstEqual, differentReluctancePreferences);
 
     // Test that changing stairs reluctance means preferences are not equal
     var notSameStairsReluctance = sameStairsReluctance + 1;
@@ -140,8 +139,7 @@ class WalkPreferencesTest {
       .withEscalatorReluctance(sameEscalatorReluctance)
       .withBoardCost(sameBoardCost)
       .build();
-    assertNotEquals(firstEqual, differentStairsReluctancePreferences);
-    assertNotEquals(firstEqual.hashCode(), differentStairsReluctancePreferences.hashCode());
+    assertNotEqualsAndHashCode(firstEqual, differentStairsReluctancePreferences);
 
     // Test that changing safety factor means preferences are not equal
     var notSameSafetyFactor = sameSafetyFactor + 0.1;
@@ -154,8 +152,7 @@ class WalkPreferencesTest {
       .withEscalatorReluctance(sameEscalatorReluctance)
       .withBoardCost(sameBoardCost)
       .build();
-    assertNotEquals(firstEqual, differentSafetyFactorPreferences);
-    assertNotEquals(firstEqual.hashCode(), differentSafetyFactorPreferences.hashCode());
+    assertNotEqualsAndHashCode(firstEqual, differentSafetyFactorPreferences);
 
     // Test that changing escalator reluctance means preferences are not equal
     var notSameEscalatorReluctance = sameEscalatorReluctance + 1;
@@ -168,8 +165,7 @@ class WalkPreferencesTest {
       .withEscalatorReluctance(notSameEscalatorReluctance)
       .withBoardCost(sameBoardCost)
       .build();
-    assertNotEquals(firstEqual, differentEscalatorReluctancePreferences);
-    assertNotEquals(firstEqual.hashCode(), differentEscalatorReluctancePreferences.hashCode());
+    assertNotEqualsAndHashCode(firstEqual, differentEscalatorReluctancePreferences);
 
     // Test that changing board cost means preferences are not equal
     var notSameBoardCost = sameBoardCost + 1;
@@ -182,8 +178,7 @@ class WalkPreferencesTest {
       .withEscalatorReluctance(sameEscalatorReluctance)
       .withBoardCost(notSameBoardCost)
       .build();
-    assertNotEquals(firstEqual, differentBoardCostPreferences);
-    assertNotEquals(firstEqual.hashCode(), differentBoardCostPreferences.hashCode());
+    assertNotEqualsAndHashCode(firstEqual, differentBoardCostPreferences);
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
@@ -194,11 +194,4 @@ class WalkPreferencesTest {
       subject.toString()
     );
   }
-
-  void assertNotTheSame(Consumer<WalkPreferences.Builder> body) {
-    var copy = subject.copyOf();
-    body.accept(copy);
-    WalkPreferences walk = copy.build();
-    assertNotEquals(subject, walk);
-  }
 }

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
@@ -74,17 +74,116 @@ class WalkPreferencesTest {
     assertEqualsAndHashCode(subject, other, copy);
 
     // Test that nothing breaks while adding wrapper objects for values
-    var copyWithSameValues = subject
-      .copyOf()
-      .withSpeed(subject.speed())
-      .withReluctance(subject.reluctance())
-      .withStairsReluctance(subject.stairsReluctance())
-      .withSafetyFactor(subject.safetyFactor())
-      .withEscalatorReluctance(subject.escalatorReluctance())
-      .withBoardCost(subject.boardCost())
+    var sameSpeed = 2.3;
+    var sameReluctance = 2.51;
+    var sameStairsReluctance = 3.2;
+    var sameSafetyFactor = 0.5;
+    var sameEscalatorReluctance = 2.45;
+    var sameBoardCost = 60;
+    var firstEqual = WalkPreferences
+      .of()
+      .withSpeed(sameSpeed)
+      .withReluctance(sameReluctance)
+      .withStairsReluctance(sameStairsReluctance)
+      .withSafetyFactor(sameSafetyFactor)
+      .withEscalatorReluctance(sameEscalatorReluctance)
+      .withBoardCost(sameBoardCost)
       .build();
-    assertEquals(subject, copyWithSameValues);
-    assertEquals(subject.hashCode(), copyWithSameValues.hashCode());
+    var secondEqual = WalkPreferences
+      .of()
+      .withSpeed(sameSpeed)
+      .withReluctance(sameReluctance)
+      .withStairsReluctance(sameStairsReluctance)
+      .withSafetyFactor(sameSafetyFactor)
+      .withEscalatorReluctance(sameEscalatorReluctance)
+      .withBoardCost(sameBoardCost)
+      .build();
+    assertEquals(firstEqual, secondEqual);
+    assertEquals(firstEqual.hashCode(), secondEqual.hashCode());
+
+    // Test that changing speed means preferences are not equal
+    var notSameSpeed = sameSpeed + 1;
+    var differentSpeedPreferences = WalkPreferences
+      .of()
+      .withSpeed(notSameSpeed)
+      .withReluctance(sameReluctance)
+      .withStairsReluctance(sameStairsReluctance)
+      .withSafetyFactor(sameSafetyFactor)
+      .withEscalatorReluctance(sameEscalatorReluctance)
+      .withBoardCost(sameBoardCost)
+      .build();
+    assertNotEquals(firstEqual, differentSpeedPreferences);
+    assertNotEquals(firstEqual.hashCode(), differentSpeedPreferences.hashCode());
+
+    // Test that changing reluctance means preferences are not equal
+    var notSameReluctance = sameReluctance + 1;
+    var differentReluctancePreferences = WalkPreferences
+      .of()
+      .withSpeed(sameSpeed)
+      .withReluctance(notSameReluctance)
+      .withStairsReluctance(sameStairsReluctance)
+      .withSafetyFactor(sameSafetyFactor)
+      .withEscalatorReluctance(sameEscalatorReluctance)
+      .withBoardCost(sameBoardCost)
+      .build();
+    assertNotEquals(firstEqual, differentReluctancePreferences);
+    assertNotEquals(firstEqual.hashCode(), differentReluctancePreferences.hashCode());
+
+    // Test that changing stairs reluctance means preferences are not equal
+    var notSameStairsReluctance = sameStairsReluctance + 1;
+    var differentStairsReluctancePreferences = WalkPreferences
+      .of()
+      .withSpeed(sameSpeed)
+      .withReluctance(sameReluctance)
+      .withStairsReluctance(notSameStairsReluctance)
+      .withSafetyFactor(sameSafetyFactor)
+      .withEscalatorReluctance(sameEscalatorReluctance)
+      .withBoardCost(sameBoardCost)
+      .build();
+    assertNotEquals(firstEqual, differentStairsReluctancePreferences);
+    assertNotEquals(firstEqual.hashCode(), differentStairsReluctancePreferences.hashCode());
+
+    // Test that changing safety factor means preferences are not equal
+    var notSameSafetyFactor = sameSafetyFactor + 0.1;
+    var differentSafetyFactorPreferences = WalkPreferences
+      .of()
+      .withSpeed(sameSpeed)
+      .withReluctance(sameReluctance)
+      .withStairsReluctance(sameStairsReluctance)
+      .withSafetyFactor(notSameSafetyFactor)
+      .withEscalatorReluctance(sameEscalatorReluctance)
+      .withBoardCost(sameBoardCost)
+      .build();
+    assertNotEquals(firstEqual, differentSafetyFactorPreferences);
+    assertNotEquals(firstEqual.hashCode(), differentSafetyFactorPreferences.hashCode());
+
+    // Test that changing escalator reluctance means preferences are not equal
+    var notSameEscalatorReluctance = sameEscalatorReluctance + 1;
+    var differentEscalatorReluctancePreferences = WalkPreferences
+      .of()
+      .withSpeed(sameSpeed)
+      .withReluctance(sameReluctance)
+      .withStairsReluctance(sameStairsReluctance)
+      .withSafetyFactor(sameSafetyFactor)
+      .withEscalatorReluctance(notSameEscalatorReluctance)
+      .withBoardCost(sameBoardCost)
+      .build();
+    assertNotEquals(firstEqual, differentEscalatorReluctancePreferences);
+    assertNotEquals(firstEqual.hashCode(), differentEscalatorReluctancePreferences.hashCode());
+
+    // Test that changing board cost means preferences are not equal
+    var notSameBoardCost = sameBoardCost + 1;
+    var differentBoardCostPreferences = WalkPreferences
+      .of()
+      .withSpeed(sameSpeed)
+      .withReluctance(sameReluctance)
+      .withStairsReluctance(sameStairsReluctance)
+      .withSafetyFactor(sameSafetyFactor)
+      .withEscalatorReluctance(sameEscalatorReluctance)
+      .withBoardCost(notSameBoardCost)
+      .build();
+    assertNotEquals(firstEqual, differentBoardCostPreferences);
+    assertNotEquals(firstEqual.hashCode(), differentBoardCostPreferences.hashCode());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/WalkPreferencesTest.java
@@ -63,7 +63,7 @@ class WalkPreferencesTest {
   }
 
   @Test
-  void testEqualsAndHAshCode() {
+  void testEqualsAndHashCode() {
     // Return same object if no value is set
     assertSame(subject, subject.copyOf().build());
     assertSame(TransitPreferences.DEFAULT, TransitPreferences.of().build());
@@ -72,10 +72,23 @@ class WalkPreferencesTest {
     var other = subject.copyOf().withSpeed(10.0).build();
     var copy = other.copyOf().withSpeed(SPEED).build();
     assertEqualsAndHashCode(subject, other, copy);
+
+    // Test that nothing breaks while adding wrapper objects for values
+    var copyWithSameValues = subject
+      .copyOf()
+      .withSpeed(subject.speed())
+      .withReluctance(subject.reluctance())
+      .withStairsReluctance(subject.stairsReluctance())
+      .withSafetyFactor(subject.safetyFactor())
+      .withEscalatorReluctance(subject.escalatorReluctance())
+      .withBoardCost(subject.boardCost())
+      .build();
+    assertEquals(subject, copyWithSameValues);
+    assertEquals(subject.hashCode(), copyWithSameValues.hashCode());
   }
 
   @Test
-  void testToSting() {
+  void testToString() {
     assertEquals("WalkPreferences{}", WalkPreferences.DEFAULT.toString());
     assertEquals(
       "WalkPreferences{speed: 1.71, reluctance: 2.5, boardCost: $301, stairsReluctance: 3.0, stairsTimeFactor: 1.31, safetyFactor: 0.51}",


### PR DESCRIPTION
### Summary

Fixes issue with walkBoardCost equal comparison used in transfer cache and adds escalatorReluctance to hash.

### Issue

Closes #5309

### Unit tests

Added

### Documentation
not needed

### Changelog

From title
