### PR TITLE
Fix concurrent modification exception in vehicle rental service

### DIFF
--- a/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
+++ b/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
@@ -3,9 +3,9 @@ package org.opentripplanner.service.vehiclerental.internal;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
@@ -22,7 +22,7 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
   @Inject
   public DefaultVehicleRentalService() {}
 
-  private final Map<FeedScopedId, VehicleRentalPlace> rentalPlaces = new HashMap<>();
+  private final Map<FeedScopedId, VehicleRentalPlace> rentalPlaces = new ConcurrentHashMap<>();
 
   @Override
   public Collection<VehicleRentalPlace> getVehicleRentalPlaces() {
@@ -39,7 +39,7 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
     return rentalPlaces
       .values()
       .stream()
-      .filter(vehicleRentalPlace -> vehicleRentalPlace instanceof VehicleRentalVehicle)
+      .filter(VehicleRentalVehicle.class::isInstance)
       .map(VehicleRentalVehicle.class::cast)
       .toList();
   }
@@ -47,8 +47,8 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
   @Override
   public VehicleRentalVehicle getVehicleRentalVehicle(FeedScopedId id) {
     VehicleRentalPlace vehicleRentalPlace = rentalPlaces.get(id);
-    return vehicleRentalPlace instanceof VehicleRentalVehicle
-      ? (VehicleRentalVehicle) vehicleRentalPlace
+    return vehicleRentalPlace instanceof VehicleRentalVehicle vehicleRentalVehicle
+      ? vehicleRentalVehicle
       : null;
   }
 
@@ -57,7 +57,7 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
     return rentalPlaces
       .values()
       .stream()
-      .filter(vehicleRentalPlace -> vehicleRentalPlace instanceof VehicleRentalStation)
+      .filter(VehicleRentalStation.class::isInstance)
       .map(VehicleRentalStation.class::cast)
       .toList();
   }
@@ -65,15 +65,13 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
   @Override
   public VehicleRentalStation getVehicleRentalStation(FeedScopedId id) {
     VehicleRentalPlace vehicleRentalPlace = rentalPlaces.get(id);
-    return vehicleRentalPlace instanceof VehicleRentalStation
-      ? (VehicleRentalStation) vehicleRentalPlace
+    return vehicleRentalPlace instanceof VehicleRentalStation vehicleRentalStation
+      ? vehicleRentalStation
       : null;
   }
 
   @Override
   public void addVehicleRentalStation(VehicleRentalPlace vehicleRentalStation) {
-    // Remove old reference first, as adding will be a no-op if already present
-    rentalPlaces.remove(vehicleRentalStation.getId());
     rentalPlaces.put(vehicleRentalStation.getId(), vehicleRentalStation);
   }
 


### PR DESCRIPTION
### Summary

A number of requests fail in our production environment with the following error message:

```
Exception while fetching data (/bikeRentalStations) : null
java.util.ConcurrentModificationException: null
	at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1784)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService.getVehicleRentalStations(DefaultVehicleRentalService.java:62)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraphQLSchema.lambda$create$43(TransmodelGraphQLSchema.java:1350)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:65)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:116)
```

The non-thread-safe  Hashmap used to store vehicle rental places in `DefaultVehicleRentalService` is updated at a high frequency by the GBFS updaters which increases the probability of a collision with read access from the Transmodel API (`/bikeRentalStations)`.
This map is modified only from the GraphWriter thread and read only from the API.

This PR fixes the concurrent modification exception by replacing the HashMap by a ConcurrentHashMap.

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No
