### PR TITLE
Retry on failed SIRI-ET Pubsub subscription creation

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -96,7 +96,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   }
 
   @Override
-  protected void runPolling() {
+  protected void runPolling() throws InterruptedException {
     retry.execute(this::updateSiri);
   }
 

--- a/src/main/java/org/opentripplanner/framework/retry/OtpRetry.java
+++ b/src/main/java/org/opentripplanner/framework/retry/OtpRetry.java
@@ -35,7 +35,7 @@ public class OtpRetry {
     this.onRetry = onRetry;
   }
 
-  public void execute(Runnable retryable) {
+  public void execute(Runnable retryable) throws InterruptedException {
     int attempts = 0;
     long sleepTime = initialRetryInterval.toMillis();
     while (true) {
@@ -59,12 +59,7 @@ public class OtpRetry {
           sleepTime
         );
         onRetry.run();
-        try {
-          Thread.sleep(sleepTime);
-        } catch (InterruptedException ex) {
-          Thread.currentThread().interrupt();
-          throw new OtpRetryException(ex);
-        }
+        Thread.sleep(sleepTime);
         sleepTime = sleepTime * backoffMultiplier;
       }
     }

--- a/src/test/java/org/opentripplanner/framework/retry/OtpRetryTest.java
+++ b/src/test/java/org/opentripplanner/framework/retry/OtpRetryTest.java
@@ -28,13 +28,13 @@ class OtpRetryTest {
   }
 
   @Test
-  void testNoInitialFailureNoRetryAttempt() {
+  void testNoInitialFailureNoRetryAttempt() throws InterruptedException {
     otpRetryBuilder.withMaxAttempts(0).build().execute(() -> {});
     assertFalse(hasRetried.isDone());
   }
 
   @Test
-  void testNoInitialFailureOneRetryAttempt() {
+  void testNoInitialFailureOneRetryAttempt() throws InterruptedException {
     otpRetryBuilder.withMaxAttempts(1).build().execute(() -> {});
     assertFalse(hasRetried.isDone());
   }
@@ -83,7 +83,7 @@ class OtpRetryTest {
   }
 
   @Test
-  void testInitialFailureWithRecoveryAndOneRetryAttempt() {
+  void testInitialFailureWithRecoveryAndOneRetryAttempt() throws InterruptedException {
     OtpRetry retry = otpRetryBuilder.withMaxAttempts(1).build();
     retry.execute(() -> {
       if (!hasRetried.isDone()) {


### PR DESCRIPTION
### Summary

During the setup phase of the SIRI-ET Google PubSub updater, a PubSub subscription is created.
This operation may fail and is currently not retried, causing the OTP instance to hang indefinitely:

```
Error while running updater org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdater:
com.google.api.gax.rpc.DeadlineExceededException: io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED: deadline exceeded after 59.857446361s. [closed=[], open=[[buffered_nanos=265252049, buffered_nanos=12074439, remote_addr=pubsub.googleapis.com/108.177.126.95:443]]]
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:94)
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:41)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:86)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:66)
	at com.google.api.gax.grpc.GrpcExceptionCallable$ExceptionTransformingFuture.onFailure(GrpcExceptionCallable.java:97)
	at com.google.api.core.ApiFutures$1.onFailure(ApiFutures.java:84)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1127)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1055)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:807)
	at io.grpc.stub.ClientCalls$GrpcFuture.setException(ClientCalls.java:574)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:544)
	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
	at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
	at com.google.api.gax.grpc.ChannelPool$ReleasingClientCall$1.onClose(ChannelPool.java:541)
	at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:489)
	at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:453)
	at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:486)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:567)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:71)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:735)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:716)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
	Suppressed: com.google.api.gax.rpc.AsyncTaskException: Asynchronous task failed
		at com.google.api.gax.rpc.ApiExceptions.callAndTranslateApiException(ApiExceptions.java:57)
		at com.google.api.gax.rpc.UnaryCallable.call(UnaryCallable.java:112)
		at com.google.cloud.pubsub.v1.SubscriptionAdminClient.createSubscription(SubscriptionAdminClient.java:552)
		at org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdater.createSubscription(SiriETGooglePubsubUpdater.java:266)
		at org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdater.run(SiriETGooglePubsubUpdater.java:158)
		at org.opentripplanner.updater.GraphUpdaterManager.lambda$startUpdaters$0(GraphUpdaterManager.java:104)
		... 3 common frames omitted
Caused by: io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED: deadline exceeded after 59.857446361s. [closed=[], open=[[buffered_nanos=265252049, buffered_nanos=12074439, remote_addr=pubsub.googleapis.com/108.177.126.95:443]]]
	at io.grpc.Status.asRuntimeException(Status.java:539)
	... 17 common frames omitted
```

- This PR adds retry logic to the creation of the subscription.
- In addition, the  custom logic applied for retrying the data initialization step is refactored to make use of the same retry feature (OTPRetry)
- The InterruptedException handling is updated to ensure proper propagation of the OTP shutdown signal.

Note: the operation is retried indefinitely, as in the original implementation. In practice, this updater is likely to be used in a Google Cloud/Kubernetes environment where the Kubernetes liveness probe will eventually time out and kill the hanging pod.


### Issue

No

### Unit tests

Updated unit tests

### Documentation

No
