### PR TITLE
Rename FeedScopeId.parseId to FeedScopedId.parse

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -176,8 +176,7 @@ public class LuceneIndex implements Serializable {
 
   public Stream<StopLocationsGroup> queryStopLocationGroups(String query, boolean autocomplete) {
     return matchingDocuments(StopLocationsGroup.class, query, autocomplete)
-      .map(document -> transitService.getStopLocationsGroup(FeedScopedId.parse(document.get(ID)))
-      );
+      .map(document -> transitService.getStopLocationsGroup(FeedScopedId.parse(document.get(ID))));
   }
 
   public Stream<StreetVertex> queryStreetVertices(String query, boolean autocomplete) {

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -171,12 +171,12 @@ public class LuceneIndex implements Serializable {
 
   public Stream<StopLocation> queryStopLocations(String query, boolean autocomplete) {
     return matchingDocuments(StopLocation.class, query, autocomplete)
-      .map(document -> transitService.getStopLocation(FeedScopedId.parseId(document.get(ID))));
+      .map(document -> transitService.getStopLocation(FeedScopedId.parse(document.get(ID))));
   }
 
   public Stream<StopLocationsGroup> queryStopLocationGroups(String query, boolean autocomplete) {
     return matchingDocuments(StopLocationsGroup.class, query, autocomplete)
-      .map(document -> transitService.getStopLocationsGroup(FeedScopedId.parseId(document.get(ID)))
+      .map(document -> transitService.getStopLocationsGroup(FeedScopedId.parse(document.get(ID)))
       );
   }
 
@@ -199,7 +199,7 @@ public class LuceneIndex implements Serializable {
   }
 
   private static StopCluster toStopCluster(Document document) {
-    var id = FeedScopedId.parseId(document.get(ID));
+    var id = FeedScopedId.parse(document.get(ID));
     var name = document.get(NAME);
     var code = document.get(CODE);
     var lat = document.getField(LAT).numericValue().doubleValue();

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/QueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/QueryTypeImpl.java
@@ -81,7 +81,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
   @Override
   public DataFetcher<Agency> agency() {
     return environment -> {
-      FeedScopedId id = FeedScopedId.parseId(
+      FeedScopedId id = FeedScopedId.parse(
         new GraphQLTypes.GraphQLQueryTypeAgencyArgs(environment.getArguments()).getGraphQLId()
       );
 
@@ -262,7 +262,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
 
       return new GtfsRealtimeFuzzyTripMatcher(transitService)
         .getTrip(
-          transitService.getRouteForId(FeedScopedId.parseId(args.getGraphQLRoute())),
+          transitService.getRouteForId(FeedScopedId.parse(args.getGraphQLRoute())),
           DIRECTION_MAPPER.map(args.getGraphQLDirection()),
           args.getGraphQLTime(),
           ServiceDateUtils.parseString(args.getGraphQLDate())
@@ -292,7 +292,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
             ? filterByIds
               .getGraphQLStops()
               .stream()
-              .map(FeedScopedId::parseId)
+              .map(FeedScopedId::parse)
               .collect(Collectors.toList())
             : null;
         filterByRoutes =
@@ -300,7 +300,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
             ? filterByIds
               .getGraphQLRoutes()
               .stream()
-              .map(FeedScopedId::parseId)
+              .map(FeedScopedId::parse)
               .collect(Collectors.toList())
             : null;
         filterByBikeRentalStations = filterByIds.getGraphQLBikeRentalStations();
@@ -365,11 +365,11 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
 
       switch (type) {
         case "Agency":
-          return transitService.getAgencyForId(FeedScopedId.parseId(id));
+          return transitService.getAgencyForId(FeedScopedId.parse(id));
         case "Alert":
           return null; //TODO
         case "BikePark":
-          var bikeParkId = FeedScopedId.parseId(id);
+          var bikeParkId = FeedScopedId.parse(id);
           return vehicleParkingService == null
             ? null
             : vehicleParkingService
@@ -380,17 +380,17 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         case "BikeRentalStation":
           return vehicleRentalStationService == null
             ? null
-            : vehicleRentalStationService.getVehicleRentalPlace(FeedScopedId.parseId(id));
+            : vehicleRentalStationService.getVehicleRentalPlace(FeedScopedId.parse(id));
         case "VehicleRentalStation":
           return vehicleRentalStationService == null
             ? null
-            : vehicleRentalStationService.getVehicleRentalStation(FeedScopedId.parseId(id));
+            : vehicleRentalStationService.getVehicleRentalStation(FeedScopedId.parse(id));
         case "RentalVehicle":
           return vehicleRentalStationService == null
             ? null
-            : vehicleRentalStationService.getVehicleRentalVehicle(FeedScopedId.parseId(id));
+            : vehicleRentalStationService.getVehicleRentalVehicle(FeedScopedId.parse(id));
         case "CarPark":
-          var carParkId = FeedScopedId.parseId(id);
+          var carParkId = FeedScopedId.parse(id);
           return vehicleParkingService == null
             ? null
             : vehicleParkingService
@@ -403,7 +403,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         case "DepartureRow":
           return PatternAtStop.fromId(transitService, id);
         case "Pattern":
-          return transitService.getTripPatternForId(FeedScopedId.parseId(id));
+          return transitService.getTripPatternForId(FeedScopedId.parse(id));
         case "placeAtDistance":
           {
             String[] parts = id.split(";");
@@ -422,15 +422,15 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
             return new PlaceAtDistance(place, Double.parseDouble(parts[0]));
           }
         case "Route":
-          return transitService.getRouteForId(FeedScopedId.parseId(id));
+          return transitService.getRouteForId(FeedScopedId.parse(id));
         case "Stop":
-          return transitService.getRegularStop(FeedScopedId.parseId(id));
+          return transitService.getRegularStop(FeedScopedId.parse(id));
         case "Stoptime":
           return null; //TODO
         case "stopAtDistance":
           {
             String[] parts = id.split(";");
-            var stop = transitService.getRegularStop(FeedScopedId.parseId(parts[1]));
+            var stop = transitService.getRegularStop(FeedScopedId.parse(parts[1]));
 
             // TODO: Add geometry
             return new NearbyStop(stop, Integer.parseInt(parts[0]), null, null);
@@ -438,10 +438,10 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         case "TicketType":
           return null; //TODO
         case "Trip":
-          var scopedId = FeedScopedId.parseId(id);
+          var scopedId = FeedScopedId.parse(id);
           return transitService.getTripForId(scopedId);
         case "VehicleParking":
-          var vehicleParkingId = FeedScopedId.parseId(id);
+          var vehicleParkingId = FeedScopedId.parse(id);
           return vehicleParkingService == null
             ? null
             : vehicleParkingService
@@ -460,7 +460,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
     return environment ->
       getTransitService(environment)
         .getTripPatternForId(
-          FeedScopedId.parseId(
+          FeedScopedId.parse(
             new GraphQLTypes.GraphQLQueryTypePatternArgs(environment.getArguments()).getGraphQLId()
           )
         );
@@ -553,7 +553,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
     return environment ->
       getTransitService(environment)
         .getRouteForId(
-          FeedScopedId.parseId(
+          FeedScopedId.parse(
             new GraphQLTypes.GraphQLQueryTypeRouteArgs(environment.getArguments()).getGraphQLId()
           )
         );
@@ -570,7 +570,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         return args
           .getGraphQLIds()
           .stream()
-          .map(FeedScopedId::parseId)
+          .map(FeedScopedId::parse)
           .map(transitService::getRouteForId)
           .collect(Collectors.toList());
       }
@@ -613,7 +613,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
     return environment ->
       getTransitService(environment)
         .getStationById(
-          FeedScopedId.parseId(
+          FeedScopedId.parse(
             new GraphQLTypes.GraphQLQueryTypeStationArgs(environment.getArguments()).getGraphQLId()
           )
         );
@@ -630,7 +630,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         return args
           .getGraphQLIds()
           .stream()
-          .map(FeedScopedId::parseId)
+          .map(FeedScopedId::parse)
           .map(transitService::getStationById)
           .collect(Collectors.toList());
       }
@@ -654,7 +654,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
     return environment ->
       getTransitService(environment)
         .getRegularStop(
-          FeedScopedId.parseId(
+          FeedScopedId.parse(
             new GraphQLTypes.GraphQLQueryTypeStopArgs(environment.getArguments()).getGraphQLId()
           )
         );
@@ -671,7 +671,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         return args
           .getGraphQLIds()
           .stream()
-          .map(FeedScopedId::parseId)
+          .map(FeedScopedId::parse)
           .map(transitService::getRegularStop)
           .collect(Collectors.toList());
       }
@@ -764,7 +764,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
     return environment ->
       getTransitService(environment)
         .getTripForId(
-          FeedScopedId.parseId(
+          FeedScopedId.parse(
             new GraphQLTypes.GraphQLQueryTypeTripArgs(environment.getArguments()).getGraphQLId()
           )
         );
@@ -795,7 +795,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         .<GraphQLRequestContext>getContext()
         .vehicleParkingService();
 
-      var vehicleParkingId = FeedScopedId.parseId(args.getGraphQLId());
+      var vehicleParkingId = FeedScopedId.parse(args.getGraphQLId());
       return vehicleParkingService
         .getVehicleParkings()
         .filter(vehicleParking -> vehicleParking.getId().equals(vehicleParkingId))

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/StopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/StopImpl.java
@@ -259,7 +259,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
             environment.getArguments()
           );
           TripPattern pattern = transitService.getTripPatternForId(
-            FeedScopedId.parseId(args.getGraphQLId())
+            FeedScopedId.parse(args.getGraphQLId())
           );
 
           if (pattern == null) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapper.java
@@ -54,7 +54,7 @@ public class TransitIdMapper {
     if (fixedFeedId != null) {
       return new FeedScopedId(fixedFeedId, id);
     }
-    return FeedScopedId.parseId(id);
+    return FeedScopedId.parse(id);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
+++ b/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
@@ -67,7 +67,7 @@ public class LocationStringParser {
       lat = Double.parseDouble(matcher.group(1));
       lon = Double.parseDouble(matcher.group(4));
     } else if (FeedScopedId.isValidString(place)) {
-      placeId = FeedScopedId.parseId(place);
+      placeId = FeedScopedId.parse(place);
     }
     return new GenericLocation(label, placeId, lat, lon);
   }

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -101,7 +101,7 @@ public class LegReferenceSerializer {
   static LegReference readScheduledTransitLeg(ObjectInputStream objectInputStream)
     throws IOException {
     return new ScheduledTransitLegReference(
-      FeedScopedId.parseId(objectInputStream.readUTF()),
+      FeedScopedId.parse(objectInputStream.readUTF()),
       LocalDate.parse(objectInputStream.readUTF(), LENIENT_ISO_LOCAL_DATE),
       objectInputStream.readInt(),
       objectInputStream.readInt()

--- a/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
@@ -32,7 +32,7 @@ public class TransitRequest implements Cloneable, Serializable {
 
   public void setBannedTripsFromString(String ids) {
     if (!ids.isEmpty()) {
-      this.bannedTrips = FeedScopedId.parseListOfIds(ids);
+      this.bannedTrips = FeedScopedId.parseList(ids);
     }
   }
 
@@ -55,7 +55,7 @@ public class TransitRequest implements Cloneable, Serializable {
   @Deprecated
   public void setPreferredAgenciesFromString(String s) {
     if (!s.isEmpty()) {
-      preferredAgencies = FeedScopedId.parseListOfIds(s);
+      preferredAgencies = FeedScopedId.parseList(s);
     }
   }
 
@@ -74,7 +74,7 @@ public class TransitRequest implements Cloneable, Serializable {
 
   public void setUnpreferredAgenciesFromString(String s) {
     if (!s.isEmpty()) {
-      unpreferredAgencies = FeedScopedId.parseListOfIds(s);
+      unpreferredAgencies = FeedScopedId.parseList(s);
     }
   }
 
@@ -92,7 +92,7 @@ public class TransitRequest implements Cloneable, Serializable {
   @Deprecated
   public void setPreferredRoutesFromString(String s) {
     if (!s.isEmpty()) {
-      preferredRoutes = List.copyOf(FeedScopedId.parseListOfIds(s));
+      preferredRoutes = List.copyOf(FeedScopedId.parseList(s));
     } else {
       preferredRoutes = List.of();
     }
@@ -113,7 +113,7 @@ public class TransitRequest implements Cloneable, Serializable {
 
   public void setUnpreferredRoutesFromString(String s) {
     if (!s.isEmpty()) {
-      unpreferredRoutes = List.copyOf(FeedScopedId.parseListOfIds(s));
+      unpreferredRoutes = List.copyOf(FeedScopedId.parseList(s));
     } else {
       unpreferredRoutes = List.of();
     }

--- a/src/main/java/org/opentripplanner/routing/api/request/request/filter/SelectRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/request/filter/SelectRequest.java
@@ -159,7 +159,7 @@ public class SelectRequest implements Serializable {
 
     public Builder withAgenciesFromString(String s) {
       if (!s.isEmpty()) {
-        this.agencies = FeedScopedId.parseListOfIds(s);
+        this.agencies = FeedScopedId.parseList(s);
       }
       return this;
     }
@@ -171,7 +171,7 @@ public class SelectRequest implements Serializable {
 
     public Builder withRoutesFromString(String s) {
       if (!s.isEmpty()) {
-        this.routes = FeedScopedId.parseListOfIds(s);
+        this.routes = FeedScopedId.parseList(s);
       }
       return this;
     }

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
@@ -40,10 +40,10 @@ public class PatternAtStop {
   public static PatternAtStop fromId(TransitService transitService, String id) {
     String[] parts = id.split(";", 2);
     Base64.Decoder decoder = Base64.getDecoder();
-    FeedScopedId stopId = FeedScopedId.parseId(
+    FeedScopedId stopId = FeedScopedId.parse(
       new String(decoder.decode(parts[0]), StandardCharsets.UTF_8)
     );
-    FeedScopedId patternId = FeedScopedId.parseId(
+    FeedScopedId patternId = FeedScopedId.parse(
       new String(decoder.decode(parts[1]), StandardCharsets.UTF_8)
     );
     return new PatternAtStop(

--- a/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
+++ b/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
@@ -400,13 +400,13 @@ public class ParameterBuilder {
   /* Custom OTP types */
 
   public FeedScopedId asFeedScopedId(FeedScopedId defaultValue) {
-    return exist() ? FeedScopedId.parseId(ofType(FEED_SCOPED_ID).asText()) : defaultValue;
+    return exist() ? FeedScopedId.parse(ofType(FEED_SCOPED_ID).asText()) : defaultValue;
   }
 
   public List<FeedScopedId> asFeedScopedIds(List<FeedScopedId> defaultValues) {
     setInfoOptional(defaultValues);
     info.withArray(FEED_SCOPED_ID);
-    return buildAndListSimpleArrayElements(defaultValues, it -> FeedScopedId.parseId(it.asText()));
+    return buildAndListSimpleArrayElements(defaultValues, it -> FeedScopedId.parse(it.asText()));
   }
 
   public CostLinearFunction asCostLinearFunction(CostLinearFunction defaultValue) {

--- a/src/main/java/org/opentripplanner/transit/model/framework/FeedScopedId.java
+++ b/src/main/java/org/opentripplanner/transit/model/framework/FeedScopedId.java
@@ -1,9 +1,7 @@
-/* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.transit.model.framework;
 
 import static org.opentripplanner.framework.lang.StringUtils.assertHasValue;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +18,6 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
    */
   private static final char ID_SEPARATOR = ':';
 
-  @Serial
   private final String feedId;
 
   private final String id;
@@ -46,7 +43,7 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
    * @return an id object
    * @throws IllegalArgumentException if the id cannot be parsed
    */
-  public static FeedScopedId parseId(String value) throws IllegalArgumentException {
+  public static FeedScopedId parse(String value) throws IllegalArgumentException {
     if (value == null || value.isEmpty()) {
       return null;
     }
@@ -73,7 +70,7 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
    * Parses a string consisting of concatenated FeedScopedIds to a List
    */
   public static List<FeedScopedId> parseListOfIds(String s) {
-    return Arrays.stream(s.split(",")).map(FeedScopedId::parseId).collect(Collectors.toList());
+    return Arrays.stream(s.split(",")).map(FeedScopedId::parse).collect(Collectors.toList());
   }
 
   public String getFeedId() {

--- a/src/main/java/org/opentripplanner/transit/model/framework/FeedScopedId.java
+++ b/src/main/java/org/opentripplanner/transit/model/framework/FeedScopedId.java
@@ -55,6 +55,13 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     }
   }
 
+  /**
+   * Parses a string consisting of concatenated FeedScopedIds to a List
+   */
+  public static List<FeedScopedId> parseList(String s) {
+    return Arrays.stream(s.split(",")).map(FeedScopedId::parse).collect(Collectors.toList());
+  }
+
   public static boolean isValidString(String value) throws IllegalArgumentException {
     return value != null && value.indexOf(ID_SEPARATOR) > -1;
   }
@@ -64,13 +71,6 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
    */
   public static String concatenateId(String feedId, String id) {
     return feedId + ID_SEPARATOR + id;
-  }
-
-  /**
-   * Parses a string consisting of concatenated FeedScopedIds to a List
-   */
-  public static List<FeedScopedId> parseListOfIds(String s) {
-    return Arrays.stream(s.split(",")).map(FeedScopedId::parse).collect(Collectors.toList());
   }
 
   public String getFeedId() {

--- a/src/test/java/org/opentripplanner/routing/algorithm/FilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/FilterTest.java
@@ -721,7 +721,7 @@ public class FilterTest {
       .addSelect(
         SelectRequest
           .of()
-          .withGroupOfRoutes(List.of(FeedScopedId.parseId("F:" + GROUP_OF_Routes_ID_1)))
+          .withGroupOfRoutes(List.of(FeedScopedId.parse("F:" + GROUP_OF_Routes_ID_1)))
           .build()
       )
       .build();
@@ -759,7 +759,7 @@ public class FilterTest {
       .addNot(
         SelectRequest
           .of()
-          .withGroupOfRoutes(List.of(FeedScopedId.parseId("F:" + GROUP_OF_Routes_ID_1)))
+          .withGroupOfRoutes(List.of(FeedScopedId.parse("F:" + GROUP_OF_Routes_ID_1)))
           .build()
       )
       .build();

--- a/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
@@ -32,9 +32,7 @@ class RouteTest {
     .withName("operator name")
     .build();
 
-  private static final Branding BRANDING = Branding
-    .of(FeedScopedId.parse("x:brandingId"))
-    .build();
+  private static final Branding BRANDING = Branding.of(FeedScopedId.parse("x:brandingId")).build();
   private static final String COLOR = "color";
   private static final String TEXT_COLOR = "text color";
   private static final int GTFS_TYPE = 0;

--- a/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
@@ -28,12 +28,12 @@ class RouteTest {
   private static final String NETEX_SUBMODE_NAME = "submode";
   private static final SubMode NETEX_SUBMODE = SubMode.of(NETEX_SUBMODE_NAME);
   private static final Operator OPERATOR = Operator
-    .of(FeedScopedId.parseId("x:operatorId"))
+    .of(FeedScopedId.parse("x:operatorId"))
     .withName("operator name")
     .build();
 
   private static final Branding BRANDING = Branding
-    .of(FeedScopedId.parseId("x:brandingId"))
+    .of(FeedScopedId.parse("x:brandingId"))
     .build();
   private static final String COLOR = "color";
   private static final String TEXT_COLOR = "text color";
@@ -111,7 +111,7 @@ class RouteTest {
           .copy()
           .withOperator(
             Operator
-              .of(FeedScopedId.parseId("x:otherOperatorId"))
+              .of(FeedScopedId.parse("x:otherOperatorId"))
               .withName("other operator name")
               .build()
           )
@@ -123,7 +123,7 @@ class RouteTest {
       subject.sameAs(
         subject
           .copy()
-          .withBranding(Branding.of(FeedScopedId.parseId("x:otherBrandingId")).build())
+          .withBranding(Branding.of(FeedScopedId.parse("x:otherBrandingId")).build())
           .build()
       )
     );

--- a/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
@@ -32,11 +32,11 @@ class TripTest {
   private static final SubMode NETEX_SUBMODE = SubMode.of(NETEX_SUBMODE_NAME);
   private static final String NETEX_INTERNAL_PLANNING_CODE = "internalPlanningCode";
   private static final Operator OPERATOR = Operator
-    .of(FeedScopedId.parseId("x:operatorId"))
+    .of(FeedScopedId.parse("x:operatorId"))
     .withName("operator name")
     .build();
-  private static final FeedScopedId SERVICE_ID = FeedScopedId.parseId("x:serviceId");
-  private static final FeedScopedId SHAPE_ID = FeedScopedId.parseId("x:shapeId");
+  private static final FeedScopedId SERVICE_ID = FeedScopedId.parse("x:serviceId");
+  private static final FeedScopedId SHAPE_ID = FeedScopedId.parse("x:shapeId");
   private static final Trip subject = Trip
     .of(TransitModelForTest.id(ID))
     .withShortName(SHORT_NAME)
@@ -127,7 +127,7 @@ class TripTest {
           .copy()
           .withOperator(
             Operator
-              .of(FeedScopedId.parseId("x:otherOperatorId"))
+              .of(FeedScopedId.parse("x:otherOperatorId"))
               .withName("other operator name")
               .build()
           )
@@ -135,10 +135,10 @@ class TripTest {
       )
     );
     assertFalse(
-      subject.sameAs(subject.copy().withServiceId(FeedScopedId.parseId("x:otherServiceId")).build())
+      subject.sameAs(subject.copy().withServiceId(FeedScopedId.parse("x:otherServiceId")).build())
     );
     assertFalse(
-      subject.sameAs(subject.copy().withShapeId(FeedScopedId.parseId("x:otherShapeId")).build())
+      subject.sameAs(subject.copy().withShapeId(FeedScopedId.parse("x:otherShapeId")).build())
     );
   }
 }


### PR DESCRIPTION
### Summary

This renames the static parsing methods in `FeedScopedId` so that the word "id" doesn't show up too many times when reading the code.