### PR TITLE
Fix datetime parsing exception

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/scalars/DateTimeScalarFactoryTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/scalars/DateTimeScalarFactoryTest.java
@@ -1,8 +1,11 @@
 package org.opentripplanner.ext.transmodelapi.model.scalars;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner._support.time.ZoneIds.OSLO;
 
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseValueException;
 import graphql.schema.GraphQLScalarType;
 import java.time.Instant;
 import java.util.stream.Stream;
@@ -43,5 +46,11 @@ class DateTimeScalarFactoryTest {
   void parse(String input) {
     var result = subject.getCoercing().parseValue(input);
     assertEquals(EPOCH_MILLIS, result);
+  }
+
+  @Test
+  void parseInvalidInputType() {
+    Coercing<?, ?> coercing = subject.getCoercing();
+    assertThrows(CoercingParseValueException.class, () -> coercing.parseValue(Boolean.TRUE));
   }
 }


### PR DESCRIPTION
### Summary

When an invalid type is provided for a datetime value (example boolean instead of string), the GraphQL DateTime converter fails with the following exception:

```
class java.lang.Boolean cannot be cast to class java.lang.CharSequence (java.lang.Boolean and java.lang.CharSequence are in module java.base of loader 'bootstrap')
java.lang.ClassCastException: class java.lang.Boolean cannot be cast to class java.lang.CharSequence (java.lang.Boolean and java.lang.CharSequence are in module java.base of loader 'bootstrap')
	at org.opentripplanner.ext.transmodelapi.model.scalars.DateTimeScalarFactory$1.parseValue(DateTimeScalarFactory.java:66)
	at org.opentripplanner.ext.transmodelapi.model.scalars.DateTimeScalarFactory$1.parseValue(DateTimeScalarFactory.java:53)
	at graphql.schema.Coercing.parseValue(Coercing.java:129)
	at graphql.execution.ValuesResolverConversion.externalValueToInternalValueForScalar(ValuesResolverConversion.java:538)
	at graphql.execution.ValuesResolverConversion.externalValueToInternalValueImpl(ValuesResolverConversion.java:434)
	at graphql.execution.ValuesResolverConversion.externalValueToInternalValueForVariables(ValuesResolverConversion.java:370)
	at graphql.execution.ValuesResolver.coerceVariableValues(ValuesResolver.java:83)
	at graphql.execution.Execution.execute(Execution.java:68)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:65)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:122)
```
	
	
This PR ensures that a CoercingParseValueException is thrown in this case with a meaningful message sent back to the user:

```
{
  "errors": [
    {
      "message": "Variable 'startTime' has an invalid value: Expected type 'DateTime' but was 'false'.",
      "locations": [
        {
          "line": 1,
          "column": 231
        }
      ],
      "extensions": {
        "classification": "ValidationError"
      }
    }
  ]
}
```
### Issue

No

### Unit tests

Added unit test

### Documentation

No

