### PR TITLE
Map GraphQL UnknowOperationException as bad request

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -5,6 +5,7 @@ import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.analysis.MaxQueryComplexityInstrumentation;
 import graphql.execution.ExecutionStrategy;
+import graphql.execution.UnknownOperationException;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.CoercingParseValueException;
@@ -69,8 +70,8 @@ class TransmodelGraph {
       return ExecutionResultMapper.okResponse(result);
     } catch (OTPRequestTimeoutException te) {
       return ExecutionResultMapper.timeoutResponse();
-    } catch (CoercingParseValueException cpve) {
-      return ExecutionResultMapper.badRequestResponse(cpve.getMessage());
+    } catch (CoercingParseValueException | UnknownOperationException e) {
+      return ExecutionResultMapper.badRequestResponse(e.getMessage());
     } catch (Exception systemError) {
       LOG.error(systemError.getMessage(), systemError);
       return ExecutionResultMapper.systemErrorResponse(systemError.getMessage());


### PR DESCRIPTION
### Summary


When receiving a malformed GraphQL query that refers to an unexisting operation:

`{"query":"{\n  trip(\n    from: {place: \"NSR:StopPlace:58189\"}\n    to: {place: \"NSR:StopPlace:58287\"}\n    numTripPatterns: 5\n  ) {\n    tripPatterns {\n      duration\n      legs {\n        expectedStartTime\n        expectedEndTime\n        mode\n        distance\n        line {\n          id\n          publicCode\n        }\n        fromEstimatedCall {\n          destinationDisplay {\n            frontText\n          }\n        }\n        fromPlace {\n          name\n          quay {\n            publicCode\n          }\n        }\n        toPlace {\n          name\n          quay {\n            publicCode\n          }\n        }\n      }\n    }\n  }\n}\n","variables":null,"operationName":"j"}`


OTP logs an error message:

```
Unknown operation named 'j'.
graphql.execution.UnknownOperationException: Unknown operation named 'j'.
	at graphql.language.NodeUtil.getOperation(NodeUtil.java:84)
	at graphql.execution.Execution.execute(Execution.java:59)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:65)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:122)
```
	
and returns a GraphQL response with HTTP code 500: 	

```
{
    "errors": [
        {
            "message": "Unknown operation named 'j'.",
            "locations": [],
            "extensions": {
                "classification": "InternalServerError"
            }
        }
    ]
}
```


This PR ensures that the API returns an HTTP code 400 - Bad Request with the following GraphQL response:

```
{
    "errors": [
        {
            "message": "Unknown operation named 'j'.",
            "locations": [],
            "extensions": {
                "classification": "BadRequestError"
            }
        }
    ]
}
```
### Issue

No

### Unit tests

:white_check_mark: 

### Documentation
No

### Changelog

No
