### PR TITLE
Parse NeTEx Resource frame without organisation

### DIFF
--- a/src/main/java/org/opentripplanner/netex/loader/parser/ResourceFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ResourceFrameParser.java
@@ -57,16 +57,18 @@ class ResourceFrameParser extends NetexParser<ResourceFrame_VersionFrameStructur
   /* private methods */
 
   private void parseOrganization(OrganisationsInFrame_RelStructure elements) {
-    for (JAXBElement<?> e : elements.getOrganisation_()) {
-      parseOrganization((Organisation_VersionStructure) e.getValue());
+    if (elements != null) {
+      for (JAXBElement<?> e : elements.getOrganisation_()) {
+        parseOrganization((Organisation_VersionStructure) e.getValue());
+      }
     }
   }
 
   private void parseOrganization(Organisation_VersionStructure element) {
-    if (element instanceof Authority) {
-      authorities.add((Authority) element);
-    } else if (element instanceof Operator) {
-      operators.add((Operator) element);
+    if (element instanceof Authority authority) {
+      authorities.add(authority);
+    } else if (element instanceof Operator operator) {
+      operators.add(operator);
     } else {
       warnOnMissingMapping(LOG, element);
     }

--- a/src/test/java/org/opentripplanner/netex/loader/parser/ResourceFrameParserTest.java
+++ b/src/test/java/org/opentripplanner/netex/loader/parser/ResourceFrameParserTest.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.netex.loader.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.xml.bind.JAXBElement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.netex.index.NetexEntityIndex;
+import org.rutebanken.netex.model.Authority;
+import org.rutebanken.netex.model.DataManagedObjectStructure;
+import org.rutebanken.netex.model.ObjectFactory;
+import org.rutebanken.netex.model.ResourceFrame;
+
+class ResourceFrameParserTest {
+
+  private ResourceFrameParser resourceFrameParser;
+  private ResourceFrame resourceFrame;
+  private ObjectFactory objectFactory;
+  private NetexEntityIndex netexEntityIndex;
+
+  @BeforeEach
+  void setUp() {
+    resourceFrameParser = new ResourceFrameParser();
+    resourceFrame = new ResourceFrame();
+    objectFactory = new ObjectFactory();
+    netexEntityIndex = new NetexEntityIndex();
+  }
+
+  @Test
+  void testResourceFrameWithOrganization() {
+    JAXBElement<? extends DataManagedObjectStructure> organisation = objectFactory.createAuthority(
+      new Authority()
+    );
+    resourceFrame.setOrganisations(objectFactory.createOrganisationsInFrame_RelStructure());
+    resourceFrame.getOrganisations().getOrganisation_().add(organisation);
+    resourceFrameParser.parse(resourceFrame);
+    resourceFrameParser.setResultOnIndex(netexEntityIndex);
+    assertEquals(1, netexEntityIndex.authoritiesById.size());
+  }
+
+  @Test
+  void testResourceFrameWithoutOrganization() {
+    resourceFrameParser.parse(resourceFrame);
+    resourceFrameParser.setResultOnIndex(netexEntityIndex);
+    assertEquals(0, netexEntityIndex.authoritiesById.size());
+  }
+}


### PR DESCRIPTION
### Summary

In the Nordic NeTEx Profile, organisations are optional elements in the ResourceFrame.
Currently the graph builder fails with a NullPointerException if a ResourceFrame does not contain any organisations:

```
An uncaught error occurred inside OTP: java.lang.NullPointerException: Cannot invoke "org.rutebanken.netex.model.OrganisationsInFrame_RelStructure.getOrganisation_()" because "elements" is null
java.lang.RuntimeException: java.lang.NullPointerException: Cannot invoke "org.rutebanken.netex.model.OrganisationsInFrame_RelStructure.getOrganisation_()" because "elements" is null
	at org.opentripplanner.netex.NetexModule.buildGraph(NetexModule.java:107)
	at org.opentripplanner.graph_builder.GraphBuilder.run(GraphBuilder.java:175)
	at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:141)
	at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:55)
Caused by: java.lang.NullPointerException: Cannot invoke "org.rutebanken.netex.model.OrganisationsInFrame_RelStructure.getOrganisation_()" because "elements" is null
	at org.opentripplanner.netex.loader.parser.ResourceFrameParser.parseOrganization(ResourceFrameParser.java:60)
	at org.opentripplanner.netex.loader.parser.ResourceFrameParser.parse(ResourceFrameParser.java:27)
	at org.opentripplanner.netex.loader.parser.ResourceFrameParser.parse(ResourceFrameParser.java:17)
	at org.opentripplanner.netex.loader.parser.NetexDocumentParser.parse(NetexDocumentParser.java:107)
	at org.opentripplanner.netex.loader.parser.NetexDocumentParser.parseCommonFrame(NetexDocumentParser.java:69)
	at org.opentripplanner.netex.loader.parser.NetexDocumentParser.parseFrameList(NetexDocumentParser.java:63)
	at org.opentripplanner.netex.loader.parser.NetexDocumentParser.parse(NetexDocumentParser.java:58)
	at org.opentripplanner.netex.loader.parser.NetexDocumentParser.parseAndPopulateIndex(NetexDocumentParser.java:49)
	at org.opentripplanner.netex.NetexBundle.loadSingeFileEntry(NetexBundle.java:182)
	at org.opentripplanner.netex.NetexBundle.loadFilesThenMapToOtpTransitModel(NetexBundle.java:166)
	at org.opentripplanner.netex.NetexBundle.loadFileEntries(NetexBundle.java:121)
	at org.opentripplanner.netex.NetexBundle.loadBundle(NetexBundle.java:100)
	at org.opentripplanner.netex.NetexModule.buildGraph(NetexModule.java:66)
```
	
	
This PR ensures that the graph builder can parse a ResourceFrame without organisation.

### Issue

No

### Unit tests

Added unit test

### Documentation

No

