### PR TITLE
Gracefully handle nullable fields in TransitAlert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -889,6 +889,12 @@
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
             <version>1.4.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
@@ -240,10 +240,10 @@ class GraphQLIntegrationTest {
       Locale.ENGLISH,
       context
     );
-    var actualJson = extracted(response);
+    var actualJson = responseBody(response);
     assertEquals(200, response.getStatus());
 
-    Path expectationFile = getPath(path);
+    Path expectationFile = getExpectation(path);
 
     if (!expectationFile.toFile().exists()) {
       Files.writeString(
@@ -307,7 +307,7 @@ class GraphQLIntegrationTest {
    * subdirectories are expected to be in the same directory.
    */
   @Nonnull
-  private static Path getPath(Path path) {
+  private static Path getExpectation(Path path) {
     return path
       .getParent()
       .getParent()
@@ -315,7 +315,7 @@ class GraphQLIntegrationTest {
       .resolve(path.getFileName().toString().replace(".graphql", ".json"));
   }
 
-  private static String extracted(Response response) {
+  private static String responseBody(Response response) {
     if (response instanceof OutboundJaxrsResponse outbound) {
       return (String) outbound.getContext().getEntity();
     }

--- a/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/GraphQLIntegrationTest.java
@@ -36,6 +36,7 @@ import javax.annotation.Nonnull;
 import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.opentripplanner._support.text.I18NStrings;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.ext.fares.FaresToItineraryMapper;
 import org.opentripplanner.ext.fares.impl.DefaultFareService;
@@ -264,12 +265,12 @@ class GraphQLIntegrationTest {
   private static List<TransitAlert> getTransitAlert(EntitySelector.Stop entitySelector) {
     var alertWithoutDescription = TransitAlert
       .of(id("no-description"))
-      .withHeaderText(I18NString.of("Just a header"))
+      .withHeaderText(I18NStrings.TRANSLATED_STRING_1)
       .addEntity(entitySelector);
 
     var alertWithoutHeader = TransitAlert
       .of(id("no-header"))
-      .withDescriptionText(I18NString.of("Just a description"))
+      .withDescriptionText(I18NStrings.TRANSLATED_STRING_2)
       .addEntity(entitySelector);
     var alertWithNothing = TransitAlert
       .of(id("neither-header-nor-description"))

--- a/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/mapping/StreetNoteMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/mapping/StreetNoteMapperTest.java
@@ -25,7 +25,7 @@ class StreetNoteMapperTest {
   void mapRegularAlert() {
     var note = note();
     TransitAlert alert = StreetNoteMapper.mapStreetNoteToAlert(note);
-    assertEquals(TEST_STREET_NOTE_HEADER, alert.headerText().toString(Locale.ROOT));
+    assertEquals(TEST_STREET_NOTE_HEADER, alert.headerText().get().toString(Locale.ROOT));
     assertEquals(TEST_STREET_NOTE_DESCRIPTION, alert.descriptionText().get().toString(Locale.ROOT));
     assertEquals(TEST_STREET_NOTE_URL, alert.url().get().toString(Locale.ROOT));
     assertEquals(START_INSTANCE, alert.getEffectiveStartDate());

--- a/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/mapping/StreetNoteMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/gtfsgraphqlapi/mapping/StreetNoteMapperTest.java
@@ -1,13 +1,13 @@
 package org.opentripplanner.ext.gtfsgraphqlapi.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.street.model.note.StreetNote;
@@ -26,8 +26,8 @@ class StreetNoteMapperTest {
     var note = note();
     TransitAlert alert = StreetNoteMapper.mapStreetNoteToAlert(note);
     assertEquals(TEST_STREET_NOTE_HEADER, alert.headerText().toString(Locale.ROOT));
-    assertEquals(TEST_STREET_NOTE_DESCRIPTION, alert.descriptionText().toString(Locale.ROOT));
-    assertEquals(TEST_STREET_NOTE_URL, alert.url().toString(Locale.ROOT));
+    assertEquals(TEST_STREET_NOTE_DESCRIPTION, alert.descriptionText().get().toString(Locale.ROOT));
+    assertEquals(TEST_STREET_NOTE_URL, alert.url().get().toString(Locale.ROOT));
     assertEquals(START_INSTANCE, alert.getEffectiveStartDate());
     assertEquals(END_INSTANCE, alert.getEffectiveEndDate());
   }
@@ -37,7 +37,7 @@ class StreetNoteMapperTest {
     var note = note();
     note.url = null;
     TransitAlert alert = StreetNoteMapper.mapStreetNoteToAlert(note);
-    assertNull(alert.url());
+    assertEquals(Optional.empty(), alert.url());
   }
 
   @Test

--- a/src/ext-test/resources/gtfsgraphqlapi/expectations/alerts.json
+++ b/src/ext-test/resources/gtfsgraphqlapi/expectations/alerts.json
@@ -1,0 +1,18 @@
+{
+  "data" : {
+    "alerts" : [
+      {
+        "id" : "QWxlcnQ6Rjphbi1hbGVydA",
+        "alertHeaderText" : "A header",
+        "alertDescriptionText" : "A description",
+        "alertUrl" : "https://example.com"
+      },
+      {
+        "id" : "QWxlcnQ6RjpudWxscw",
+        "alertHeaderText" : "Just a header",
+        "alertDescriptionText" : "Just a header",
+        "alertUrl" : null
+      }
+    ]
+  }
+}

--- a/src/ext-test/resources/gtfsgraphqlapi/expectations/alerts.json
+++ b/src/ext-test/resources/gtfsgraphqlapi/expectations/alerts.json
@@ -11,10 +11,23 @@
       },
       {
         "id" : "QWxlcnQ6Rjpuby1oZWFkZXI",
-        "alertHeaderText" : "Just a description",
-        "alertDescriptionText" : "Just a description",
+        "alertHeaderText" : "Second string",
+        "alertDescriptionText" : "Second string",
         "alertUrl" : null,
-        "alertDescriptionTextTranslations" : [ ],
+        "alertDescriptionTextTranslations" : [
+          {
+            "language" : null,
+            "text" : "Second string"
+          },
+          {
+            "language" : "de",
+            "text" : "Zweite Zeichenabfolge"
+          },
+          {
+            "language" : "fi",
+            "text" : "Etkö ole varma, mitä tämä tarkoittaa"
+          }
+        ],
         "alertHeaderTextTranslations" : [ ]
       },
       {
@@ -27,11 +40,24 @@
       },
       {
         "id" : "QWxlcnQ6Rjpuby1kZXNjcmlwdGlvbg",
-        "alertHeaderText" : "Just a header",
-        "alertDescriptionText" : "Just a header",
+        "alertHeaderText" : "First string",
+        "alertDescriptionText" : "First string",
         "alertUrl" : null,
         "alertDescriptionTextTranslations" : [ ],
-        "alertHeaderTextTranslations" : [ ]
+        "alertHeaderTextTranslations" : [
+          {
+            "text" : "First string",
+            "language" : null
+          },
+          {
+            "text" : "Erste Zeichenabfolge",
+            "language" : "de"
+          },
+          {
+            "text" : "Minulla ei ole aavistustakaan kuinka puhua suomea",
+            "language" : "fi"
+          }
+        ]
       }
     ]
   }

--- a/src/ext-test/resources/gtfsgraphqlapi/expectations/alerts.json
+++ b/src/ext-test/resources/gtfsgraphqlapi/expectations/alerts.json
@@ -2,16 +2,36 @@
   "data" : {
     "alerts" : [
       {
+        "id" : "QWxlcnQ6RjpuZWl0aGVyLWhlYWRlci1ub3ItZGVzY3JpcHRpb24",
+        "alertHeaderText" : "",
+        "alertDescriptionText" : "",
+        "alertUrl" : null,
+        "alertDescriptionTextTranslations" : [ ],
+        "alertHeaderTextTranslations" : [ ]
+      },
+      {
+        "id" : "QWxlcnQ6Rjpuby1oZWFkZXI",
+        "alertHeaderText" : "Just a description",
+        "alertDescriptionText" : "Just a description",
+        "alertUrl" : null,
+        "alertDescriptionTextTranslations" : [ ],
+        "alertHeaderTextTranslations" : [ ]
+      },
+      {
         "id" : "QWxlcnQ6Rjphbi1hbGVydA",
         "alertHeaderText" : "A header",
         "alertDescriptionText" : "A description",
-        "alertUrl" : "https://example.com"
+        "alertUrl" : "https://example.com",
+        "alertDescriptionTextTranslations" : [ ],
+        "alertHeaderTextTranslations" : [ ]
       },
       {
-        "id" : "QWxlcnQ6RjpudWxscw",
+        "id" : "QWxlcnQ6Rjpuby1kZXNjcmlwdGlvbg",
         "alertHeaderText" : "Just a header",
         "alertDescriptionText" : "Just a header",
-        "alertUrl" : null
+        "alertUrl" : null,
+        "alertDescriptionTextTranslations" : [ ],
+        "alertHeaderTextTranslations" : [ ]
       }
     ]
   }

--- a/src/ext-test/resources/gtfsgraphqlapi/queries/alerts.graphql
+++ b/src/ext-test/resources/gtfsgraphqlapi/queries/alerts.graphql
@@ -1,0 +1,8 @@
+{
+    alerts {
+        id
+        alertHeaderText
+        alertDescriptionText
+        alertUrl
+    }
+}

--- a/src/ext-test/resources/gtfsgraphqlapi/queries/alerts.graphql
+++ b/src/ext-test/resources/gtfsgraphqlapi/queries/alerts.graphql
@@ -4,5 +4,15 @@
         alertHeaderText
         alertDescriptionText
         alertUrl
+        # these translations are a bit questionable, the above fields are already translated into the
+        # language selected in the request
+        alertDescriptionTextTranslations {
+            language
+            text
+        }
+        alertHeaderTextTranslations {
+            text
+            language
+        }
     }
 }

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/AlertImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/AlertImpl.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opentripplanner.ext.gtfsgraphqlapi.GraphQLRequestContext;
 import org.opentripplanner.ext.gtfsgraphqlapi.generated.GraphQLDataFetchers;
@@ -62,11 +63,14 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
 
   @Override
   public DataFetcher<String> alertDescriptionText() {
-    return environment ->
-      getSource(environment)
+    return environment -> {
+      var alert = getSource(environment);
+      return alert
         .descriptionText()
+        .or(() -> Optional.ofNullable(alert.headerText()))
         .map(t -> t.toString(environment.getLocale()))
-        .orElse(null);
+        .orElse("");
+    };
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/AlertImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/AlertImpl.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opentripplanner.ext.gtfsgraphqlapi.GraphQLRequestContext;
 import org.opentripplanner.ext.gtfsgraphqlapi.generated.GraphQLDataFetchers;
@@ -24,7 +23,6 @@ import org.opentripplanner.ext.gtfsgraphqlapi.model.RouteTypeModel;
 import org.opentripplanner.ext.gtfsgraphqlapi.model.StopOnRouteModel;
 import org.opentripplanner.ext.gtfsgraphqlapi.model.StopOnTripModel;
 import org.opentripplanner.ext.gtfsgraphqlapi.model.UnknownModel;
-import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.TranslatedString;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
@@ -40,6 +38,8 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
 
 public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
+
+  private static final String FALLBACK_EMPTY_STRING = "";
 
   @Override
   public DataFetcher<Agency> agency() {
@@ -67,16 +67,16 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
       var alert = getSource(environment);
       return alert
         .descriptionText()
-        .or(() -> Optional.ofNullable(alert.headerText()))
+        .or(alert::headerText)
         .map(t -> t.toString(environment.getLocale()))
-        .orElse("");
+        .orElse(FALLBACK_EMPTY_STRING);
     };
   }
 
   @Override
   public DataFetcher<Iterable<Map.Entry<String, String>>> alertDescriptionTextTranslations() {
     return environment ->
-      getSource(environment).descriptionText().map(this::getTranslations).orElse(null);
+      getSource(environment).descriptionText().map(this::getTranslations).orElse(List.of());
   }
 
   @Override
@@ -101,16 +101,20 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
 
   @Override
   public DataFetcher<String> alertHeaderText() {
-    return environment ->
-      GraphQLUtils.getTranslation(getSource(environment).headerText(), environment);
+    return environment -> {
+      var alert = getSource(environment);
+      return alert
+        .headerText()
+        .or(alert::descriptionText)
+        .map(h -> h.toString(environment.getLocale()))
+        .orElse(FALLBACK_EMPTY_STRING);
+    };
   }
 
   @Override
   public DataFetcher<Iterable<Map.Entry<String, String>>> alertHeaderTextTranslations() {
-    return environment -> {
-      var text = getSource(environment).headerText();
-      return getTranslations(text);
-    };
+    return environment ->
+      getSource(environment).headerText().map(this::getTranslations).orElse(List.of());
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/AlertImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/gtfsgraphqlapi/datafetchers/AlertImpl.java
@@ -63,15 +63,16 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
   @Override
   public DataFetcher<String> alertDescriptionText() {
     return environment ->
-      getSource(environment).descriptionText().toString(environment.getLocale());
+      getSource(environment)
+        .descriptionText()
+        .map(t -> t.toString(environment.getLocale()))
+        .orElse(null);
   }
 
   @Override
   public DataFetcher<Iterable<Map.Entry<String, String>>> alertDescriptionTextTranslations() {
-    return environment -> {
-      var text = getSource(environment).descriptionText();
-      return getTranslations(text);
-    };
+    return environment ->
+      getSource(environment).descriptionText().map(this::getTranslations).orElse(null);
   }
 
   @Override
@@ -115,18 +116,13 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
 
   @Override
   public DataFetcher<String> alertUrl() {
-    return environment -> {
-      var alertUrl = getSource(environment).url();
-      return alertUrl == null ? null : alertUrl.toString(environment.getLocale());
-    };
+    return environment ->
+      getSource(environment).url().map(u -> u.toString(environment.getLocale())).orElse(null);
   }
 
   @Override
   public DataFetcher<Iterable<Map.Entry<String, String>>> alertUrlTranslations() {
-    return environment -> {
-      var url = getSource(environment).url();
-      return getTranslations(url);
-    };
+    return environment -> getSource(environment).url().map(this::getTranslations).orElse(List.of());
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -193,16 +193,19 @@ public class PtSituationElementType {
           .name("description")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(multilingualStringType))))
           .description("Description of situation in all different translations available")
-          .dataFetcher(environment -> {
-            I18NString descriptionText = environment.<TransitAlert>getSource().descriptionText();
-            if (descriptionText instanceof TranslatedString translatedString) {
-              return translatedString.getTranslations();
-            } else if (descriptionText != null) {
-              return List.of(new AbstractMap.SimpleEntry<>(null, descriptionText.toString()));
-            } else {
-              return emptyList();
-            }
-          })
+          .dataFetcher(environment ->
+            environment
+              .<TransitAlert>getSource()
+              .descriptionText()
+              .map(descriptionText -> {
+                if (descriptionText instanceof TranslatedString translatedString) {
+                  return translatedString.getTranslations();
+                } else {
+                  return List.of(new AbstractMap.SimpleEntry<>(null, descriptionText.toString()));
+                }
+              })
+              .orElse(emptyList())
+          )
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -186,7 +186,7 @@ public class PtSituationElementType {
                   return List.of(new AbstractMap.SimpleEntry<>(null, headerText.toString()));
                 }
               })
-              .orElse(emptyList())
+              .orElse(List.of())
           )
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -186,7 +186,7 @@ public class PtSituationElementType {
                   return List.of(new AbstractMap.SimpleEntry<>(null, headerText.toString()));
                 }
               })
-              .orElse(List.of())
+              .orElse(emptyList())
           )
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -186,7 +186,7 @@ public class PtSituationElementType {
                   return List.of(new AbstractMap.SimpleEntry<>(null, headerText.toString()));
                 }
               })
-              .orElse(null)
+              .orElse(emptyList())
           )
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -175,16 +175,19 @@ public class PtSituationElementType {
           .name("summary")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(multilingualStringType))))
           .description("Summary of situation in all different translations available")
-          .dataFetcher(environment -> {
-            I18NString headerText = environment.<TransitAlert>getSource().headerText();
-            if (headerText instanceof TranslatedString translatedString) {
-              return translatedString.getTranslations();
-            } else if (headerText != null) {
-              return List.of(new AbstractMap.SimpleEntry<>(null, headerText.toString()));
-            } else {
-              return emptyList();
-            }
-          })
+          .dataFetcher(environment ->
+            environment
+              .<TransitAlert>getSource()
+              .headerText()
+              .map(headerText -> {
+                if (headerText instanceof TranslatedString translatedString) {
+                  return translatedString.getTranslations();
+                } else {
+                  return List.of(new AbstractMap.SimpleEntry<>(null, headerText.toString()));
+                }
+              })
+              .orElse(null)
+          )
           .build()
       )
       .field(

--- a/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
@@ -34,13 +34,8 @@ public class AlertMapper {
       api.alertHeaderText = domain.headerText().toString(locale);
     }
 
-    if (domain.descriptionText() != null) {
-      api.alertDescriptionText = domain.descriptionText().toString(locale);
-    }
-
-    if (domain.url() != null) {
-      api.alertUrl = domain.url().toString(locale);
-    }
+    api.alertDescriptionText = domain.descriptionText().map(t -> t.toString(locale)).orElse(null);
+    api.alertUrl = domain.url().map(u -> u.toString(locale)).orElse(null);
 
     api.effectiveStartDate = ofNullableInstant(domain.getEffectiveStartDate());
     api.effectiveEndDate = ofNullableInstant(domain.getEffectiveEndDate());

--- a/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
@@ -30,10 +30,7 @@ public class AlertMapper {
 
   ApiAlert mapToApi(TransitAlert domain) {
     ApiAlert api = new ApiAlert();
-    if (domain.headerText() != null) {
-      api.alertHeaderText = domain.headerText().toString(locale);
-    }
-
+    api.alertHeaderText = domain.headerText().map(h -> h.toString(locale)).orElse(null);
     api.alertDescriptionText = domain.descriptionText().map(t -> t.toString(locale)).orElse(null);
     api.alertUrl = domain.url().map(u -> u.toString(locale)).orElse(null);
 

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -62,8 +62,8 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
     return new TransitAlertBuilder(id);
   }
 
-  public I18NString headerText() {
-    return headerText;
+  public Optional<I18NString> headerText() {
+    return Optional.ofNullable(headerText);
   }
 
   public Optional<I18NString> descriptionText() {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -65,8 +66,8 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
     return headerText;
   }
 
-  public I18NString descriptionText() {
-    return descriptionText;
+  public Optional<I18NString> descriptionText() {
+    return Optional.ofNullable(descriptionText);
   }
 
   public I18NString detailText() {
@@ -77,9 +78,8 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
     return adviceText;
   }
 
-  @Nullable
-  public I18NString url() {
-    return url;
+  public Optional<I18NString> url() {
+    return Optional.ofNullable(url);
   }
 
   public List<AlertUrl> siriUrls() {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
@@ -36,7 +36,7 @@ public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, Tra
 
   TransitAlertBuilder(TransitAlert original) {
     super(original);
-    this.headerText = original.headerText();
+    this.headerText = original.headerText().orElse(null);
     this.descriptionText = original.descriptionText().orElse(null);
     this.detailText = original.detailText();
     this.adviceText = original.adviceText();

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
@@ -37,10 +37,10 @@ public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, Tra
   TransitAlertBuilder(TransitAlert original) {
     super(original);
     this.headerText = original.headerText();
-    this.descriptionText = original.descriptionText();
+    this.descriptionText = original.descriptionText().orElse(null);
     this.detailText = original.detailText();
     this.adviceText = original.adviceText();
-    this.url = original.url();
+    this.url = original.url().orElse(null);
     this.siriUrls.addAll(original.siriUrls());
     this.type = original.type();
     this.severity = original.severity();

--- a/src/test/java/org/opentripplanner/_support/text/I18NStrings.java
+++ b/src/test/java/org/opentripplanner/_support/text/I18NStrings.java
@@ -1,0 +1,22 @@
+package org.opentripplanner._support.text;
+
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.framework.i18n.TranslatedString;
+
+public class I18NStrings {
+
+  public static final I18NString TRANSLATED_STRING_1 = TranslatedString.getI18NString(
+    "First string",
+    "de",
+    "Erste Zeichenabfolge",
+    "fi",
+    "Minulla ei ole aavistustakaan kuinka puhua suomea"
+  );
+  public static final I18NString TRANSLATED_STRING_2 = TranslatedString.getI18NString(
+    "Second string",
+    "de",
+    "Zweite Zeichenabfolge",
+    "fi",
+    "Etkö ole varma, mitä tämä tarkoittaa"
+  );
+}

--- a/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
+++ b/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.i18n.TranslatedString;
@@ -83,7 +84,7 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setAgencyId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertNull(transitAlert.url());
+    assertEquals(Optional.empty(), transitAlert.url());
   }
 
   @Test
@@ -102,7 +103,7 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals("https://www.opentripplanner.org/", transitAlert.url().toString());
+    assertEquals("https://www.opentripplanner.org/", transitAlert.url().get().toString());
   }
 
   @Test
@@ -135,7 +136,7 @@ public class AlertsUpdateHandlerTest {
     TransitAlert transitAlert = processOneAlert(alert);
 
     List<Entry<String, String>> translations =
-      ((TranslatedString) transitAlert.url()).getTranslations();
+      ((TranslatedString) transitAlert.url().get()).getTranslations();
     assertEquals(2, translations.size());
     assertEquals("en", translations.get(0).getKey());
     assertEquals("https://www.opentripplanner.org/", translations.get(0).getValue());
@@ -196,7 +197,7 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals("Description", transitAlert.descriptionText().toString());
+    assertEquals("Description", transitAlert.descriptionText().get().toString());
   }
 
   @Test
@@ -221,7 +222,7 @@ public class AlertsUpdateHandlerTest {
     TransitAlert transitAlert = processOneAlert(alert);
 
     List<Entry<String, String>> translations =
-      ((TranslatedString) transitAlert.descriptionText()).getTranslations();
+      ((TranslatedString) transitAlert.descriptionText().get()).getTranslations();
     assertEquals(2, translations.size());
     assertEquals("en", translations.get(0).getKey());
     assertEquals("Description", translations.get(0).getValue());

--- a/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
+++ b/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
@@ -157,7 +157,7 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals("Title", transitAlert.headerText().toString());
+    assertEquals("Title", transitAlert.headerText().get().toString());
   }
 
   @Test
@@ -176,7 +176,7 @@ public class AlertsUpdateHandlerTest {
     TransitAlert transitAlert = processOneAlert(alert);
 
     List<Entry<String, String>> translations =
-      ((TranslatedString) transitAlert.headerText()).getTranslations();
+      ((TranslatedString) transitAlert.headerText().get()).getTranslations();
     assertEquals(2, translations.size());
     assertEquals("en", translations.get(0).getKey());
     assertEquals("Title", translations.get(0).getValue());


### PR DESCRIPTION
### Summary

The return value of `TransitAlert#descriptionText` was producing NPE's in the GTFS GraphQL API so I made it and `url` return an explicit `Optional` so that call sites are forced to deal with this fact.

Since the API schema requires `descriptionText` to be non-null (which isn't the case for the GTFS-RT spec) I used some fallback logic so that it always returns a string.

If we don't want the fallback logic we will have to modify the schema. Let's discuss this at the dev meeting.

### Unit tests

Test added.