### PR TITLE
Exclude OBA's slf4j-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -889,6 +889,12 @@
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
             <version>1.4.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>


### PR DESCRIPTION
### Summary

The latest version of OneBusAway has added a dependency on `slf4j-simple` which produces the following warning when OTP starts up:

```
SLF4J: Class path contains multiple SLF4J providers.
SLF4J: Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@5e0e82ae]
SLF4J: Found provider [org.slf4j.simple.SimpleServiceProvider@6771beb3]
SLF4J: See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual provider is of type [ch.qos.logback.classic.spi.LogbackServiceProvider@5e0e82ae]
```

This PR excludes the dependency so that the warning goes away. I will work with upstream to resolve this there.