### PR TITLE
Remove ice roads from Finland routing

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
@@ -83,6 +83,11 @@ class FinlandMapper implements OsmTagMapper {
     props.setProperties("highway=service;access=private", withModes(NONE));
     props.setProperties("highway=trail", withModes(NONE));
 
+    // Remove ice/winter roads
+    props.setProperties("highway=*;seasonal=winter", withModes(NONE));
+    props.setProperties("highway=*;ice_road=yes", withModes(NONE));
+    props.setProperties("highway=*;winter_road=yes", withModes(NONE));
+
     // No biking on designated footways/sidewalks
     props.setProperties("highway=footway", withModes(PEDESTRIAN));
     props.setProperties("footway=sidewalk;highway=footway", withModes(PEDESTRIAN));

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapperTest.java
@@ -1,9 +1,12 @@
 package org.opentripplanner.openstreetmap.tagmapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.openstreetmap.model.OSMWay;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.opentripplanner.openstreetmap.wayproperty.WayProperties;
 import org.opentripplanner.openstreetmap.wayproperty.WayPropertySet;
 
 public class FinlandMapperTest {
@@ -189,5 +192,29 @@ public class FinlandMapperTest {
       wps.getDataForWay(wayWithMixinsAndCustomSafety).getWalkSafetyFeatures().forward(),
       epsilon
     );
+  }
+
+  @Test
+  public void testTagMapping() {
+    OSMWithTags way;
+    WayProperties wayData;
+
+    way = new OSMWay();
+    way.addTag("highway", "unclassified");
+    way.addTag("seasonal", "winter");
+    wayData = wps.getDataForWay(way);
+    assertEquals(wayData.getPermission(), NONE);
+
+    way = new OSMWay();
+    way.addTag("highway", "trunk");
+    way.addTag("ice_road", "yes");
+    wayData = wps.getDataForWay(way);
+    assertEquals(wayData.getPermission(), NONE);
+
+    way = new OSMWay();
+    way.addTag("highway", "track");
+    way.addTag("winter_road", "yes");
+    wayData = wps.getDataForWay(way);
+    assertEquals(wayData.getPermission(), NONE);
   }
 }


### PR DESCRIPTION
### Summary

A simple filtering of  ice and winter roads using Finland tag mapping. Ice roads are in use only some months per year, so they should be exluded from the street graph.

At later stage, we might consider implementing a configurable time period for such roads, or perhaps start supporting some OSM tags which limit the time period when the roads are available.
