### PR TITLE
Fix issue with null headers in HSL park updater

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdater.java
@@ -60,7 +60,7 @@ public class HslParkUpdater implements DataSource<VehicleParking> {
         parameters.utilizationsUrl(),
         "",
         parkPatchMapper::parseUtilization,
-        null
+        Map.of()
       );
     this.facilitiesFrequencySec = parameters.facilitiesFrequencySec();
   }

--- a/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
@@ -9,7 +9,9 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,26 +25,26 @@ public class JsonDataListDownloader<T> {
   private final OtpHttpClient otpHttpClient;
 
   public JsonDataListDownloader(
-    String url,
-    String jsonParsePath,
-    Function<JsonNode, T> elementParser,
-    Map<String, String> headers
+    @Nonnull String url,
+    @Nonnull String jsonParsePath,
+    @Nonnull Function<JsonNode, T> elementParser,
+    @Nonnull Map<String, String> headers
   ) {
     this(url, jsonParsePath, elementParser, headers, new OtpHttpClient());
   }
 
   public JsonDataListDownloader(
-    String url,
-    String jsonParsePath,
-    Function<JsonNode, T> elementParser,
-    Map<String, String> headers,
-    OtpHttpClient OtpHttpClient
+    @Nonnull String url,
+    @Nonnull String jsonParsePath,
+    @Nonnull Function<JsonNode, T> elementParser,
+    @Nonnull Map<String, String> headers,
+    @Nonnull OtpHttpClient OtpHttpClient
   ) {
-    this.url = url;
-    this.jsonParsePath = jsonParsePath;
-    this.headers = headers;
-    this.elementParser = elementParser;
-    this.otpHttpClient = OtpHttpClient;
+    this.url = Objects.requireNonNull(url);
+    this.jsonParsePath = Objects.requireNonNull(jsonParsePath);
+    this.headers = Objects.requireNonNull(headers);
+    this.elementParser = Objects.requireNonNull(elementParser);
+    this.otpHttpClient = Objects.requireNonNull(OtpHttpClient);
   }
 
   public List<T> download() {


### PR DESCRIPTION
### Summary

HSL park updater failed to start because we now have a check that headers can't be null.

### Issue

Minor sandbox problem, no issue

### Unit tests

Not sure if feasible

### Documentation

Not needed

### Changelog

Not needed
