### PR TITLE
Minor performance fixes

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -190,7 +190,7 @@ class StopPatternServiceDateKey {
       return false;
     }
     StopPatternServiceDateKey that = (StopPatternServiceDateKey) thatObject;
-    return (this.stopPattern.equals(that.stopPattern) & this.serviceDate.equals(that.serviceDate));
+    return (this.stopPattern.equals(that.stopPattern) && this.serviceDate.equals(that.serviceDate));
   }
 }
 
@@ -215,6 +215,6 @@ class TripServiceDateKey {
       return false;
     }
     TripServiceDateKey that = (TripServiceDateKey) thatObject;
-    return (this.trip.equals(that.trip) & this.serviceDate.equals(that.serviceDate));
+    return (this.trip.equals(that.trip) && this.serviceDate.equals(that.serviceDate));
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
@@ -86,7 +86,7 @@ public class HslFacilitiesDownloader {
 
     JsonNode rootNode = mapper.readTree(facilitiesString);
 
-    if (!jsonParsePath.equals("")) {
+    if (!jsonParsePath.isEmpty()) {
       String delimiter = "/";
       String[] parseElement = jsonParsePath.split(delimiter);
       for (String s : parseElement) {

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubToVehicleParkingGroupMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubToVehicleParkingGroupMapper.java
@@ -46,7 +46,7 @@ public class HslHubToVehicleParkingGroupMapper {
         .fieldNames()
         .forEachRemaining(lang -> {
           String name = nameNode.path(lang).asText();
-          if (!name.equals("")) {
+          if (!name.isEmpty()) {
             translations.put(lang, nameNode.path(lang).asText());
           }
         });

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
@@ -79,7 +79,7 @@ public class HslHubsDownloader {
 
     JsonNode rootNode = mapper.readTree(hubsString);
 
-    if (!jsonParsePath.equals("")) {
+    if (!jsonParsePath.isEmpty()) {
       String delimiter = "/";
       String[] parseElement = jsonParsePath.split(delimiter);
       for (String s : parseElement) {

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
@@ -84,7 +84,7 @@ public class HslParkToVehicleParkingMapper {
         .fieldNames()
         .forEachRemaining(lang -> {
           String name = nameNode.path(lang).asText();
-          if (!name.equals("")) {
+          if (!name.isEmpty()) {
             translations.put(lang, nameNode.path(lang).asText());
           }
         });

--- a/src/main/java/org/opentripplanner/framework/geometry/GeometryUtils.java
+++ b/src/main/java/org/opentripplanner/framework/geometry/GeometryUtils.java
@@ -249,7 +249,7 @@ public class GeometryUtils {
       int i = 0;
       for (List<LngLatAlt> geoJsonPath : geoJsonMultiLineString.getCoordinates()) {
         org.geojson.LineString geoJsonLineString = new org.geojson.LineString(
-          geoJsonPath.toArray(new LngLatAlt[geoJsonPath.size()])
+          geoJsonPath.toArray(new LngLatAlt[0])
         );
         jtsLineStrings[i++] = (LineString) convertGeoJsonToJtsGeometry(geoJsonLineString);
       }

--- a/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
@@ -87,7 +87,7 @@ public class JsonDataListDownloader<T> {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode rootNode = mapper.readTree(rentalString);
 
-    if (!jsonParsePath.equals("")) {
+    if (!jsonParsePath.isEmpty()) {
       String delimiter = "/";
       String[] parseElement = jsonParsePath.split(delimiter);
       for (String s : parseElement) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
@@ -80,7 +80,7 @@ public class GeometryProcessor {
     if (
       trip.getShapeId() == null ||
       trip.getShapeId().getId() == null ||
-      trip.getShapeId().getId().equals("")
+      trip.getShapeId().getId().isEmpty()
     ) {
       return null;
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
@@ -119,9 +119,7 @@ public class PruneIslands implements GraphBuilderModule {
       areas.add(ae.getArea());
     }
     for (AreaEdgeList a : areas) {
-      for (Vertex v : a.visibilityVertices()) {
-        visibilityVertices.add(v);
-      }
+      visibilityVertices.addAll(a.visibilityVertices());
     }
 
     int removed = 0;

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
@@ -66,9 +66,7 @@ class AreaGroup {
       }
     }
     GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
-    Geometry allPolygons = geometryFactory.createMultiPolygon(
-      allRings.toArray(new Polygon[allRings.size()])
-    );
+    Geometry allPolygons = geometryFactory.createMultiPolygon(allRings.toArray(new Polygon[0]));
     this.union = allPolygons.union();
 
     if (this.union instanceof GeometryCollection coll) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/Ring.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/Ring.java
@@ -115,7 +115,7 @@ public class Ring {
         lrholelist.add(ring);
       }
     }
-    LinearRing[] lrholes = lrholelist.toArray(new LinearRing[lrholelist.size()]);
+    LinearRing[] lrholes = lrholelist.toArray(new LinearRing[0]);
     return factory.createPolygon(shell, lrholes);
   }
 

--- a/src/main/java/org/opentripplanner/inspector/raster/NoThruTrafficEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/raster/NoThruTrafficEdgeRenderer.java
@@ -47,7 +47,7 @@ public class NoThruTrafficEdgeRenderer implements EdgeVertexRenderer {
         label += " car";
         colorIndex += 4;
       }
-      if (!label.equals("")) {
+      if (!label.isEmpty()) {
         label = "No" + label + " thru traffic";
       }
 

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMLevel.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMLevel.java
@@ -69,7 +69,7 @@ public class OSMLevel implements Comparable<OSMLevel> {
     /* get short and long level names by splitting on = character */
     String shortName = "";
     String longName = "";
-    Integer indexEquals = spec.indexOf('=');
+    int indexEquals = spec.indexOf('=');
     if (indexEquals >= 1) {
       shortName = spec.substring(0, indexEquals);
       longName = spec.substring(indexEquals + 1);

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
@@ -336,7 +336,7 @@ public class WayPropertySet {
     }
 
     String units = m.group(2);
-    if (units == null || units.equals("")) units = "kmh";
+    if (units == null || units.isEmpty()) units = "kmh";
 
     // we'll be doing quite a few string comparisons here
     units = units.intern();

--- a/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
@@ -327,7 +327,7 @@ public class CommandLineParameters {
 
     @Override
     public void validate(String name, String value) throws ParameterException {
-      Integer i = Integer.parseInt(value);
+      int i = Integer.parseInt(value);
       if (i <= 0) {
         String msg = String.format("%s must be a positive integer.", name);
         throw new ParameterException(msg);

--- a/src/test/java/org/opentripplanner/astar/model/BinHeapTest.java
+++ b/src/test/java/org/opentripplanner/astar/model/BinHeapTest.java
@@ -73,9 +73,7 @@ public class BinHeapTest {
     // First determine the expected results using a plain old PriorityQueue
     expected = new ArrayList<>(N);
     PriorityQueue<Integer> q = new PriorityQueue<>(N);
-    for (Integer j : input) {
-      q.add(j);
-    }
+    q.addAll(input);
     while (!q.isEmpty()) {
       expected.add(q.remove());
     }


### PR DESCRIPTION
### Summary

Minor performance code cleanup as suggested by Intellij and Sonar.
See the 5 commits:
- Use bulk operation on collections: bulk operations are more efficient
- Fix size of List.toArray() parameter: it used to be a best practice to provide an array with an explicit size in the method List.toArray(). This is not recommended anymore with Java 6+ and now less performant
- Use String.isEmpty() to test empty String: slight performance gain with String.isEmpty()
- Replace wrapper with primitive: performance gain
- Use short-circuit boolean operator: performance gain since only one operand is evaluated

### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No

