### PR TITLE
Don't crash interline processing if no service data

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
@@ -53,13 +53,19 @@ public class InterlineProcessor {
     this.staySeatedNotAllowed = staySeatedNotAllowed;
     this.maxInterlineDistance = maxInterlineDistance > 0 ? maxInterlineDistance : 200;
     this.issueStore = issueStore;
-    this.transitServiceStart = calendarServiceData.getFirstDate();
+    this.transitServiceStart = calendarServiceData.getFirstDate().orElse(null);
     this.daysInTransitService =
-      (int) ChronoUnit.DAYS.between(transitServiceStart, calendarServiceData.getLastDate()) + 1;
+      calendarServiceData
+        .getLastDate()
+        .map(lastDate -> (int) ChronoUnit.DAYS.between(transitServiceStart, lastDate) + 1)
+        .orElse(0);
     this.calendarServiceData = calendarServiceData;
   }
 
   public List<ConstrainedTransfer> run(Collection<TripPattern> tripPatterns) {
+    if (daysInTransitService == 0) {
+      return List.of();
+    }
     var interlinedTrips = this.getInterlinedTrips(tripPatterns);
     var transfers = interlinedTrips
       .entries()

--- a/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
+++ b/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
@@ -73,20 +73,12 @@ public class CalendarServiceData implements Serializable {
     }
   }
 
-  public LocalDate getFirstDate() {
-    return serviceIdsByDate
-      .keySet()
-      .stream()
-      .min(LocalDate::compareTo)
-      .orElseThrow(() -> new IllegalStateException("No service data is available"));
+  public Optional<LocalDate> getFirstDate() {
+    return serviceIdsByDate.keySet().stream().min(LocalDate::compareTo);
   }
 
-  public LocalDate getLastDate() {
-    return serviceIdsByDate
-      .keySet()
-      .stream()
-      .max(LocalDate::compareTo)
-      .orElseThrow(() -> new IllegalStateException("No service data is available"));
+  public Optional<LocalDate> getLastDate() {
+    return serviceIdsByDate.keySet().stream().max(LocalDate::compareTo);
   }
 
   /* private methods */


### PR DESCRIPTION
### Summary

We have validation at the end of the graph build for when there is no service data configured with a slightly prettier error message.

### Issue

No issue as of yet but the stack trace is:

<details>
03:05:03.302 ERROR [main]  (OTPMain.java:60) An uncaught error occurred inside O
TP: No service data is available
java.lang.IllegalStateException: No service data is available
        at org.opentripplanner.model.calendar.CalendarServiceData.lambda$getFirs
tDate$1(CalendarServiceData.java:92)
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at org.opentripplanner.model.calendar.CalendarServiceData.getFirstDate(C
alendarServiceData.java:91)
        at org.opentripplanner.graph_builder.module.interlining.InterlineProcess
or.<init>(InterlineProcessor.java:59)
        at org.opentripplanner.gtfs.graphbuilder.GtfsModule.buildGraph(GtfsModul
e.java:189)
        at org.opentripplanner.graph_builder.GraphBuilder.run(GraphBuilder.java:
175)
        at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:15
5)
        at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:55)
</details>

while the validation at the end of the graph build outputs:
<details>
13:07:51.403 ERROR [main]  (OTPMain.java:57) The provided transit data have no trips within the configured transit service period. See build config 'transitServiceStart' and 'transitServiceEnd'
org.opentripplanner.framework.application.OtpAppException: The provided transit data have no trips within the configured transit service period. See build config 'transitServiceStart' and 'transitServiceEnd'
	at org.opentripplanner.graph_builder.GraphBuilder.validate(GraphBuilder.java:210)
	at org.opentripplanner.graph_builder.GraphBuilder.run(GraphBuilder.java:180)
	at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:141)
	at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:55)
</details>

### Unit tests

TODO if we decide this is something we want

### Documentation

Not needed

### Changelog

Skip
