### PR TITLE
Log Java version info at startup

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -36,7 +36,7 @@ public class OtpStartupInfo {
   public static void logInfo() {
     // This is good when aggregating logs across multiple load balanced instances of OTP
     // Hint: a regexp filter like "^OTP (START|SHUTTING)" will list nodes going up/down
-    LOG.info("OTP STARTING UP ({})", projectInfo().getVersionString());
+    LOG.info("OTP STARTING UP ({}) using Java {}", projectInfo().getVersionString(), javaVersion());
     Runtime
       .getRuntime()
       .addShutdownHook(
@@ -55,5 +55,9 @@ public class OtpStartupInfo {
 
   private static String line(String text) {
     return text + NEW_LINE;
+  }
+
+  private static String javaVersion() {
+    return System.getProperty("java.version");
   }
 }


### PR DESCRIPTION
### Summary

Add information about the Java version when OTP is starting:

`
OTP STARTING UP (version: 2.5.0-SNAPSHOT, ser.ver.id: 120, commit: 8d5490eb4c38ae7624f3e22df3790f159e250dc8, branch: dev-2.x) using Java 17.0.8
`
### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No

