### PR TITLE
Fix IBI fare calculators

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/FaresFilterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/FaresFilterTest.java
@@ -20,7 +20,7 @@ import org.opentripplanner.transit.model.basic.Money;
 public class FaresFilterTest implements PlanTestConstants {
 
   @Test
-  public void shouldAddFare() {
+  void shouldAddFare() {
     final int ID = 1;
 
     Itinerary i1 = newItinerary(A, 0)

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/AtlantaFareServiceTest.java
@@ -1,6 +1,9 @@
 package org.opentripplanner.ext.fares.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.ext.fares.impl.AtlantaFareService.COBB_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.AtlantaFareService.GCT_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.AtlantaFareService.MARTA_AGENCY_ID;
@@ -10,7 +13,6 @@ import static org.opentripplanner.transit.model.basic.Money.USD;
 import static org.opentripplanner.transit.model.basic.Money.usDollars;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,6 +22,7 @@ import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
@@ -34,16 +37,20 @@ import org.opentripplanner.transit.model.site.RegularStop;
 public class AtlantaFareServiceTest implements PlanTestConstants {
 
   public static final Money DEFAULT_TEST_RIDE_PRICE = usDollars(3.49f);
+  private static final String FEED_ID = "A";
   private static AtlantaFareService atlFareService;
 
   @BeforeAll
   public static void setUpClass() {
-    Map<FeedScopedId, FareRuleSet> regularFareRules = new HashMap<>();
+    Map<FeedScopedId, FareRuleSet> regularFareRules = Map.of(
+      new FeedScopedId(FEED_ID, "regular"),
+      FareModelForTest.INSIDE_CITY_CENTER_SET
+    );
     atlFareService = new TestAtlantaFareService(regularFareRules.values());
   }
 
   @Test
-  public void fromMartaTransfers() {
+  void fromMartaTransfers() {
     List<Leg> rides = List.of(getLeg(MARTA_AGENCY_ID, 0), getLeg(XPRESS_AGENCY_ID, 1));
     calculateFare(rides, DEFAULT_TEST_RIDE_PRICE);
 
@@ -69,7 +76,7 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
   }
 
   @Test
-  public void fromCobbTransfers() {
+  void fromCobbTransfers() {
     List<Leg> rides = List.of(getLeg(COBB_AGENCY_ID, 0), getLeg(MARTA_AGENCY_ID, 1));
     calculateFare(rides, DEFAULT_TEST_RIDE_PRICE);
 
@@ -98,13 +105,13 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
   }
 
   @Test
-  public void fromGctTransfers() {
+  void fromGctTransfers() {
     List<Leg> rides = List.of(getLeg(GCT_AGENCY_ID, 0), getLeg(MARTA_AGENCY_ID, 1));
     calculateFare(rides, DEFAULT_TEST_RIDE_PRICE);
   }
 
   @Test
-  public void tooManyLegs() {
+  void tooManyLegs() {
     List<Leg> rides = List.of(
       getLeg(MARTA_AGENCY_ID, 0),
       getLeg(MARTA_AGENCY_ID, 1),
@@ -158,7 +165,7 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
   }
 
   @Test
-  public void expiredTransfer() {
+  void expiredTransfer() {
     List<Leg> rides = List.of(
       getLeg(MARTA_AGENCY_ID, 0),
       getLeg(MARTA_AGENCY_ID, 1),
@@ -179,7 +186,7 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
   }
 
   @Test
-  public void useStreetcar() {
+  void useStreetcar() {
     var STREETCAR_PRICE = DEFAULT_TEST_RIDE_PRICE.minus(usDollars(1));
     List<Leg> rides = List.of(
       getLeg(MARTA_AGENCY_ID, 0),
@@ -197,6 +204,18 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
         getLeg(COBB_AGENCY_ID, "101", 2)
       );
     calculateFare(rides, DEFAULT_TEST_RIDE_PRICE.plus(usDollars(1)).plus(STREETCAR_PRICE));
+  }
+
+  @Test
+  void fullItinerary() {
+    var itin = createItinerary(MARTA_AGENCY_ID, "1", 0);
+    var fares = atlFareService.calculateFares(itin);
+    assertNotNull(fares);
+    assertTrue(fares.getLegProducts().isEmpty());
+    var itineraryProducts = fares.getItineraryProducts();
+    assertFalse(itineraryProducts.isEmpty());
+    var fp = itineraryProducts.stream().filter(p -> p.name().equals("regular")).findAny().get();
+    assertEquals(Money.usDollars(3.49f), fp.price());
   }
 
   /**
@@ -230,25 +249,30 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
   }
 
   private static Leg createLeg(String agencyId, String shortName, long startTimeMins) {
+    final var itin = createItinerary(agencyId, shortName, startTimeMins);
+    return itin.getLegs().get(0);
+  }
+
+  private static Itinerary createItinerary(String agencyId, String shortName, long startTimeMins) {
     Agency agency = Agency
-      .of(new FeedScopedId("A", agencyId))
+      .of(new FeedScopedId(FEED_ID, agencyId))
       .withName(agencyId)
       .withTimezone(ZoneIds.NEW_YORK.getId())
       .build();
 
     // Set up stops
     RegularStop firstStop = RegularStop
-      .of(new FeedScopedId("A", "1"))
+      .of(new FeedScopedId(FEED_ID, "1"))
       .withCoordinate(new WgsCoordinate(1, 1))
       .withName(new NonLocalizedString("first stop"))
       .build();
     RegularStop lastStop = RegularStop
-      .of(new FeedScopedId("A", "2"))
+      .of(new FeedScopedId(FEED_ID, "2"))
       .withCoordinate(new WgsCoordinate(1, 2))
       .withName(new NonLocalizedString("last stop"))
       .build();
 
-    FeedScopedId routeFeedScopeId = new FeedScopedId("A", "123");
+    FeedScopedId routeFeedScopeId = new FeedScopedId(FEED_ID, "123");
     Route route = Route
       .of(routeFeedScopeId)
       .withAgency(agency)
@@ -261,8 +285,7 @@ public class AtlantaFareServiceTest implements PlanTestConstants {
     var itin = newItinerary(Place.forStop(firstStop), start)
       .bus(route, 1, start, T11_12, Place.forStop(lastStop))
       .build();
-
-    return itin.getLegs().get(0);
+    return itin;
   }
 
   private static class TestAtlantaFareService extends AtlantaFareService {

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceTest.java
@@ -56,6 +56,14 @@ class DefaultFareServiceTest implements PlanTestConstants {
     var fp = fare.getItineraryProducts().get(0);
     assertEquals(TEN_DOLLARS, fp.price());
     assertEquals("F:regular", fp.id().toString());
+
+    var lp = fare.legProductsFromComponents();
+    assertEquals(1, lp.size());
+    var product = lp.values().iterator().next().product();
+    assertEquals(TEN_DOLLARS, product.price());
+
+    // the leg products from the components and the "true" leg products are different collections
+    assertTrue(fare.getLegProducts().isEmpty());
   }
 
   @Test

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.ext.fares.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -105,7 +104,6 @@ class DefaultFareServiceTest implements PlanTestConstants {
     products = List.copyOf(legProductsFromComponents.get(secondLeg));
     assertEquals(TEN_DOLLARS, products.get(0).product().price());
 
-    assertFalse(fare.getItineraryProducts().isEmpty());
     assertEquals(1, fare.getItineraryProducts().size());
     assertEquals(TWENTY_DOLLARS, fare.getItineraryProducts().get(0).price());
   }

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
@@ -92,7 +92,7 @@ public class HSLFareServiceTest implements PlanTestConstants {
     float ABCD_PRICE = 5.70f;
     float D_PRICE = 2.80f;
 
-    HSLFareServiceImpl hslFareService = new HSLFareServiceImpl();
+    HSLFareService hslFareService = new HSLFareService();
     int fiveMinutes = 60 * 5;
 
     // Fare attributes
@@ -446,7 +446,7 @@ public class HSLFareServiceTest implements PlanTestConstants {
 
     FareRuleSet ruleSetAB = new FareRuleSet(fareAttributeAB);
 
-    var service = new HSLFareServiceImpl();
+    var service = new HSLFareService();
     service.addFareRules(FareType.regular, List.of(ruleSetAB));
 
     // outside HSL's fare zones, should return null

--- a/src/ext/java/org/opentripplanner/ext/fares/FaresToItineraryMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/FaresToItineraryMapper.java
@@ -32,7 +32,7 @@ public class FaresToItineraryMapper {
       .forEach(l -> {
         var legInstances = fares.getLegProducts().get(l);
         l.setFareProducts(
-          ListUtils.combine(itineraryInstances, legInstances, legProductsFromComponents.get(l))
+          ListUtils.combine(itineraryInstances, legProductsFromComponents.get(l), legInstances)
         );
       });
   }

--- a/src/ext/java/org/opentripplanner/ext/fares/FaresToItineraryMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/FaresToItineraryMapper.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.ext.fares;
 
+import com.google.common.collect.Multimap;
 import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.model.fare.FareProductUse;
 import org.opentripplanner.model.fare.ItineraryFares;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
 
 /**
@@ -21,13 +23,17 @@ public class FaresToItineraryMapper {
       })
       .toList();
 
+    final Multimap<Leg, FareProductUse> legProductsFromComponents = fares.legProductsFromComponents();
+
     i
       .getLegs()
       .stream()
       .filter(ScheduledTransitLeg.class::isInstance)
       .forEach(l -> {
         var legInstances = fares.getLegProducts().get(l);
-        l.setFareProducts(ListUtils.combine(itineraryInstances, legInstances));
+        l.setFareProducts(
+          ListUtils.combine(itineraryInstances, legInstances, legProductsFromComponents.get(l))
+        );
       });
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
@@ -374,6 +374,12 @@ public class AtlantaFareService extends DefaultFareService {
     addFareRules(FareType.electronicSenior, regularFareRules);
   }
 
+  @Nullable
+  @Override
+  protected Collection<FareRuleSet> fareRulesForFeed(FareType fareType, String feedId) {
+    return fareRulesPerType.get(fareType);
+  }
+
   @Override
   public boolean populateFare(
     ItineraryFares fare,

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
@@ -374,6 +374,10 @@ public class AtlantaFareService extends DefaultFareService {
     addFareRules(FareType.electronicSenior, regularFareRules);
   }
 
+  /**
+   * In the base class only the rules for a specific feed are selected and then passed to the
+   * fare engine, however here we want to explicitly compute fares across feed boundaries.
+   */
   @Nullable
   @Override
   protected Collection<FareRuleSet> fareRulesForFeed(FareType fareType, String feedId) {

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -193,6 +193,9 @@ public class DefaultFareService implements FareService {
     return hasFare ? fare : null;
   }
 
+  /**
+   * For a given fareType and feedId return the applicable fare rule sets.
+   */
   @Nullable
   protected Collection<FareRuleSet> fareRulesForFeed(FareType fareType, String feedId) {
     var fareRulesByTypeAndFeed = fareRulesPerType

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.flex.FlexibleTransitLeg;
+import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.ItineraryFares;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
@@ -140,16 +141,24 @@ public class DefaultFareService implements FareService {
           components.addAll(currentFare.getComponents(fareType));
           fare.addFare(fareType, currentFare.getFare(fareType));
 
-          currentFare.getLegProducts().entries().forEach(entry ->{
-            fare.addFareProduct(entry.getKey(), entry.getValue().product());
-          });
+          currentFare
+            .getLegProducts()
+            .entries()
+            .forEach(entry -> fare.addFareProduct(entry.getKey(), entry.getValue().product()));
 
           fares.add(currentFare.getFare(fareType));
 
-
           // If all the legs are from one feed, consider itinerary products
           if (fareLegs.equals(fareLegsByFeed.get(feedId))) {
-            fare.addItineraryProducts(currentFare.getItineraryProducts());
+            currentFare
+              .getFareTypes()
+              .forEach(type -> {
+                var money = currentFare.getFare(type);
+                var fareProduct = FareProduct
+                  .of(new FeedScopedId(feedId, type.name()), type.name(), money)
+                  .build();
+                fare.addItineraryProducts(List.of(fareProduct));
+              });
           }
         } else {
           legWithoutRulesFound = true;

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
@@ -3,9 +3,7 @@ package org.opentripplanner.ext.fares.impl;
 import com.google.common.collect.Sets;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Currency;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -14,11 +12,8 @@ import java.util.stream.Collectors;
 import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.fares.model.RouteOriginDestination;
-import org.opentripplanner.model.fare.ItineraryFares;
-import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
-import org.opentripplanner.routing.core.FareComponent;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.transit.model.basic.Money;
 import org.slf4j.Logger;
@@ -28,9 +23,9 @@ import org.slf4j.LoggerFactory;
  * This fare service module handles single feed HSL ticket pricing logic.
  */
 
-public class HSLFareServiceImpl extends DefaultFareService {
+public class HSLFareService extends DefaultFareService {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HSLFareServiceImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HSLFareService.class);
   // this is not Float.MAX_VALUE to avoid overflow which would then make debugging harder
   public static final Money MAX_PRICE = Money.euros(999999f);
 

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareServiceFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareServiceFactory.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 
 public class HSLFareServiceFactory extends DefaultFareServiceFactory {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HSLFareServiceImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HSLFareService.class);
 
   @Override
   protected void fillFareRules(
@@ -76,7 +76,7 @@ public class HSLFareServiceFactory extends DefaultFareServiceFactory {
   }
 
   public FareService makeFareService() {
-    HSLFareServiceImpl fareService = new HSLFareServiceImpl();
+    HSLFareService fareService = new HSLFareService();
     fareService.addFareRules(FareType.regular, regularFareRules.values());
     if (LOG.isDebugEnabled()) {
       for (FareRuleSet ruleSet : regularFareRules.values()) {

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -10,6 +10,7 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.model.fare.FareMedium;
@@ -545,6 +546,12 @@ public class OrcaFareService extends DefaultFareService {
       );
       itineraryFares.addFareProduct(leg, transferFareProduct);
     }
+  }
+
+  @Nullable
+  @Override
+  protected Collection<FareRuleSet> fareRulesForFeed(FareType fareType, String feedId) {
+    return fareRulesPerType.get(fareType);
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -548,6 +548,10 @@ public class OrcaFareService extends DefaultFareService {
     }
   }
 
+  /**
+   * In the base class only the rules for a specific feed are selected and then passed to the
+   * fare engine, however here we want to explicitly compute fares across feed boundaries.
+   */
   @Nullable
   @Override
   protected Collection<FareRuleSet> fareRulesForFeed(FareType fareType, String feedId) {

--- a/src/main/java/org/opentripplanner/model/fare/ItineraryFares.java
+++ b/src/main/java/org/opentripplanner/model/fare/ItineraryFares.java
@@ -188,6 +188,12 @@ public class ItineraryFares {
     fareProduct.forEach(fp -> addFareProduct(leg, fp));
   }
 
+  /**
+   * Convert the fare received via the deprecated {@link FareComponent} to leg products. This
+   * inverts the relationship:
+   *   - fare component has several legs
+   *   - leg product is a mapping from leg to a list of fare products
+   */
   @Nonnull
   public Multimap<Leg, FareProductUse> legProductsFromComponents() {
     Multimap<Leg, FareProductUse> legProductsFromComponents = HashMultimap.create();

--- a/src/main/java/org/opentripplanner/model/fare/ItineraryFares.java
+++ b/src/main/java/org/opentripplanner/model/fare/ItineraryFares.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.model.fare;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.lang.Sandbox;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
@@ -102,24 +104,6 @@ public class ItineraryFares {
   @Deprecated
   public void addFareComponent(FareType fareType, List<FareComponent> components) {
     this.components.replaceValues(fareType, components);
-
-    for (var c : components) {
-      var firstLegStartTime = c.legs().get(0).getStartTime();
-      for (var leg : c.legs()) {
-        final FareProduct fareProduct = new FareProduct(
-          c.fareId(),
-          fareType.name(),
-          c.price(),
-          null,
-          null,
-          null
-        );
-        legProducts.put(
-          leg,
-          new FareProductUse(fareProduct.uniqueInstanceId(firstLegStartTime), fareProduct)
-        );
-      }
-    }
   }
 
   /**
@@ -202,5 +186,28 @@ public class ItineraryFares {
    */
   public void addFareProduct(Leg leg, Collection<FareProduct> fareProduct) {
     fareProduct.forEach(fp -> addFareProduct(leg, fp));
+  }
+
+  @Nonnull
+  public Multimap<Leg, FareProductUse> legProductsFromComponents() {
+    Multimap<Leg, FareProductUse> legProductsFromComponents = HashMultimap.create();
+    for (var type : getFareTypes()) {
+      var components = getComponents(type);
+
+      for (var c : components) {
+        var firstLegStartTime = c.legs().get(0).getStartTime();
+        for (var leg : c.legs()) {
+          final FareProduct fareProduct = FareProduct
+            .of(c.fareId(), type.name(), c.price())
+            .build();
+
+          legProductsFromComponents.put(
+            leg,
+            new FareProductUse(fareProduct.uniqueInstanceId(firstLegStartTime), fareProduct)
+          );
+        }
+      }
+    }
+    return legProductsFromComponents;
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -7,6 +7,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:32:24.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -42,29 +57,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              3
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2209,
       "legs": [
@@ -502,6 +495,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:38:09.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -537,29 +545,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2539,
       "legs": [
@@ -955,6 +941,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:40:10.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -990,29 +991,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 1805,
       "legs": [
@@ -1304,6 +1283,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:45:24.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -1339,29 +1333,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              3
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2209,
       "legs": [
@@ -1799,6 +1771,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:54:24.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -1834,29 +1821,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              3
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2209,
       "legs": [
@@ -2294,6 +2259,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:56:10.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -2329,29 +2309,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 1805,
       "legs": [
@@ -3318,6 +3276,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:28:51.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -3353,29 +3326,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2119,
       "legs": [
@@ -3865,6 +3816,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:35:24.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -3900,29 +3866,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2503,
       "legs": [
@@ -4292,6 +4236,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:37:21.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -4327,29 +4286,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2351,
       "legs": [
@@ -4693,6 +4630,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:43:51.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -4728,29 +4680,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2119,
       "legs": [
@@ -5240,6 +5170,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:51:24.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -5275,29 +5220,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2563,
       "legs": [
@@ -5667,6 +5590,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
       "elevationLost": 0.0,
       "endTime": "2009-10-21T23:56:21.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -5702,29 +5640,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2351,
       "legs": [

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
@@ -7,6 +7,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
       "elevationLost": 16.15,
       "endTime": "2009-10-21T23:32:25.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -42,29 +57,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              3
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2282,
       "legs": [
@@ -506,6 +499,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
       "elevationLost": 3.93,
       "endTime": "2009-10-21T23:40:10.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -541,29 +549,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 1803,
       "legs": [
@@ -857,6 +843,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
       "elevationLost": 13.43,
       "endTime": "2009-10-21T23:45:25.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -892,29 +893,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2235,
       "legs": [
@@ -1208,6 +1187,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
       "elevationLost": 16.15,
       "endTime": "2009-10-21T23:45:25.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -1243,29 +1237,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              3
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2282,
       "legs": [
@@ -1707,6 +1679,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
       "elevationLost": 13.43,
       "endTime": "2009-10-21T23:54:25.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -1742,29 +1729,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2235,
       "legs": [
@@ -2058,6 +2023,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
       "elevationLost": 16.15,
       "endTime": "2009-10-21T23:54:25.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -2093,29 +2073,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              3
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2282,
       "legs": [
@@ -3091,6 +3049,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
       "elevationLost": 4.23,
       "endTime": "2009-10-21T23:31:21.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -3126,29 +3099,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2305,
       "legs": [
@@ -3494,6 +3445,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
       "elevationLost": 23.58,
       "endTime": "2009-10-21T23:35:04.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -3529,29 +3495,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2465,
       "legs": [
@@ -3923,6 +3867,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
       "elevationLost": 1.09,
       "endTime": "2009-10-21T23:37:44.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -3958,29 +3917,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2396,
       "legs": [
@@ -4326,6 +4263,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
       "elevationLost": 4.76,
       "endTime": "2009-10-21T23:46:18.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -4361,29 +4313,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2787,
       "legs": [
@@ -4807,6 +4737,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
       "elevationLost": 4.23,
       "endTime": "2009-10-21T23:46:21.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -4842,29 +4787,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2305,
       "legs": [
@@ -5210,6 +5133,21 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
       "elevationLost": 23.58,
       "endTime": "2009-10-21T23:51:04.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -5245,29 +5183,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2525,
       "legs": [

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -235,6 +235,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T18:38:41.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -270,29 +285,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 4281,
       "legs": [
@@ -727,6 +720,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T18:39:22.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -762,29 +770,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2315,
       "legs": [
@@ -1284,6 +1270,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T18:53:55.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -1319,29 +1320,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 4295,
       "legs": [
@@ -1776,6 +1755,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T18:55:32.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -1811,29 +1805,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2385,
       "legs": [
@@ -2333,6 +2305,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T19:08:19.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -2372,49 +2359,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          },
-          {
-            "legIndices": [
-              2
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 3375,
       "legs": [
@@ -3093,6 +3038,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T18:38:40.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -3128,29 +3088,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2895,
       "legs": [
@@ -3588,6 +3526,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T18:54:10.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -3623,29 +3576,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2925,
       "legs": [
@@ -4083,6 +4014,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T19:09:40.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -4118,29 +4064,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2895,
       "legs": [
@@ -4578,6 +4502,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T19:11:51.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -4617,49 +4556,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          },
-          {
-            "legIndices": [
-              2
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 2957,
       "legs": [
@@ -5117,6 +5014,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "elevationLost": 0.0,
       "endTime": "2009-11-17T19:25:05.000+00:00",
       "fare": {
+        "coveringItinerary": [
+          {
+            "amount": {
+              "cents": 200,
+              "currency": {
+                "currency": "USD",
+                "currencyCode": "USD",
+                "defaultFractionDigits": 2,
+                "symbol": "$"
+              }
+            },
+            "id": "prt:regular",
+            "name": "regular"
+          }
+        ],
         "details": {
           "regular": [
             {
@@ -5156,49 +5068,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "symbol": "$"
             }
           }
-        },
-        "legProducts": [
-          {
-            "legIndices": [
-              1
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          },
-          {
-            "legIndices": [
-              2
-            ],
-            "products": [
-              {
-                "amount": {
-                  "cents": 200,
-                  "currency": {
-                    "currency": "USD",
-                    "currencyCode": "USD",
-                    "defaultFractionDigits": 2,
-                    "symbol": "$"
-                  }
-                },
-                "id": "prt:8",
-                "name": "regular"
-              }
-            ]
-          }
-        ]
+        }
       },
       "generalizedCost": 3015,
       "legs": [

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-fares.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-fares.json
@@ -69,6 +69,23 @@
                   }
                 },
                 {
+                  "id" : "6bd27c98-c0ee-3f62-b606-bbacf2e1f41b",
+                  "product" : {
+                    "id" : "F:AB",
+                    "name" : "regular",
+                    "__typename" : "DefaultFareProduct",
+                    "price" : {
+                      "currency" : {
+                        "digits" : 2,
+                        "code" : "EUR"
+                      },
+                      "amount" : 3.1
+                    },
+                    "riderCategory" : null,
+                    "medium" : null
+                  }
+                },
+                {
                   "id" : "09bb5f2b-6af9-3355-8b5d-5e93a27ce280",
                   "product" : {
                     "id" : "F:single-ticket",
@@ -89,23 +106,6 @@
                       "id" : "F:oyster",
                       "name" : "TfL Oyster Card"
                     }
-                  }
-                },
-                {
-                  "id" : "6bd27c98-c0ee-3f62-b606-bbacf2e1f41b",
-                  "product" : {
-                    "id" : "F:AB",
-                    "name" : "regular",
-                    "__typename" : "DefaultFareProduct",
-                    "price" : {
-                      "currency" : {
-                        "digits" : 2,
-                        "code" : "EUR"
-                      },
-                      "amount" : 3.1
-                    },
-                    "riderCategory" : null,
-                    "medium" : null
                   }
                 }
               ]

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-fares.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-fares.json
@@ -69,23 +69,6 @@
                   }
                 },
                 {
-                  "id" : "6bd27c98-c0ee-3f62-b606-bbacf2e1f41b",
-                  "product" : {
-                    "id" : "F:AB",
-                    "name" : "regular",
-                    "__typename" : "DefaultFareProduct",
-                    "price" : {
-                      "currency" : {
-                        "digits" : 2,
-                        "code" : "EUR"
-                      },
-                      "amount" : 3.1
-                    },
-                    "riderCategory" : null,
-                    "medium" : null
-                  }
-                },
-                {
                   "id" : "09bb5f2b-6af9-3355-8b5d-5e93a27ce280",
                   "product" : {
                     "id" : "F:single-ticket",
@@ -106,6 +89,23 @@
                       "id" : "F:oyster",
                       "name" : "TfL Oyster Card"
                     }
+                  }
+                },
+                {
+                  "id" : "6bd27c98-c0ee-3f62-b606-bbacf2e1f41b",
+                  "product" : {
+                    "id" : "F:AB",
+                    "name" : "regular",
+                    "__typename" : "DefaultFareProduct",
+                    "price" : {
+                      "currency" : {
+                        "digits" : 2,
+                        "code" : "EUR"
+                      },
+                      "amount" : 3.1
+                    },
+                    "riderCategory" : null,
+                    "medium" : null
                   }
                 }
               ]


### PR DESCRIPTION
### Summary

https://github.com/opentripplanner/OpenTripPlanner/pull/5284 introduced a regression which broke IBI's fare calculators.

The problem was that leg products were not transferred correctly from the intermediary fares to the eventual result, which is fixed now.

Another problem was that HSL and IBI use different APIs for representing the fares. We hope to address this in #5396 

### Issue

Relates to #5396

### Unit tests

Lots added and adjusted.