### PR TITLE
Improve geocoding fuzziness, remove street corners

### DIFF
--- a/docs/sandbox/GeocoderAPI.md
+++ b/docs/sandbox/GeocoderAPI.md
@@ -36,7 +36,6 @@ It supports the following URL parameters:
 | `autocomplete` | Whether we should use the query string to do a prefix match      |
 | `stops`        | Search for stops, either by name or stop code                    |
 | `clusters`     | Search for clusters by their name                                |
-| `corners`      | Search for street corners using at least one of the street names |
 
 #### Stop clusters
 

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -18,7 +17,7 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Alexanderplatz", analyzer);
 
-    System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
+    //System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
         "Alex",

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -1,0 +1,96 @@
+package org.opentripplanner.ext.geocoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.jupiter.api.Test;
+
+class EnglishNgramAnalyzerTest {
+
+  @Test
+  void ngram() throws IOException {
+    var analyzer = new EnglishNGramAnalyzer();
+    List<String> result = analyze("Alexanderplatz", analyzer);
+
+    System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
+    assertEquals(
+      List.of(
+        "Alex",
+        "Alexa",
+        "Alexan",
+        "Alexand",
+        "Alexande",
+        "Alexander",
+        "Alexanderp",
+        "lexa",
+        "lexan",
+        "lexand",
+        "lexande",
+        "lexander",
+        "lexanderp",
+        "lexanderpl",
+        "exan",
+        "exand",
+        "exande",
+        "exander",
+        "exanderp",
+        "exanderpl",
+        "exanderpla",
+        "xand",
+        "xande",
+        "xander",
+        "xanderp",
+        "xanderpl",
+        "xanderpla",
+        "xanderplat",
+        "ande",
+        "ander",
+        "anderp",
+        "anderpl",
+        "anderpla",
+        "anderplat",
+        "anderplatz",
+        "nder",
+        "nderp",
+        "nderpl",
+        "nderpla",
+        "nderplat",
+        "nderplatz",
+        "derp",
+        "derpl",
+        "derpla",
+        "derplat",
+        "derplatz",
+        "erpl",
+        "erpla",
+        "erplat",
+        "erplatz",
+        "rpla",
+        "rplat",
+        "rplatz",
+        "plat",
+        "platz",
+        "latz",
+        "Alexanderplatz"
+      ),
+      result
+    );
+  }
+
+  public List<String> analyze(String text, Analyzer analyzer) throws IOException {
+    List<String> result = new ArrayList<>();
+    TokenStream tokenStream = analyzer.tokenStream("name", text);
+    CharTermAttribute attr = tokenStream.addAttribute(CharTermAttribute.class);
+    tokenStream.reset();
+    while (tokenStream.incrementToken()) {
+      result.add(attr.toString());
+    }
+    return result;
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -9,15 +9,9 @@ import static org.opentripplanner.transit.model.basic.TransitMode.FERRY;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -157,6 +151,8 @@ class LuceneIndexTest {
         "Alexanderplatz",
         "Alexa",
         "alex",
+        "aleyanderplazt",
+        "alexnderplazt",
         "Alexnderplatz",
         "Alexnaderplatz",
         "alexnaderplaz",
@@ -203,13 +199,14 @@ class LuceneIndexTest {
         "points",
         "the five points",
         "five @ points",
+        "five @ the points",
         "five@points",
         "five at points",
         "five&points",
         "five & points",
-        "five and points",
+        "five and the points",
         "points five",
-        "points fife",
+        "points fife"
       }
     )
     void stopClustersWithSpace(String query) {
@@ -218,28 +215,11 @@ class LuceneIndexTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "4456", "445", "#445" })
+    @ValueSource(strings = { "4456", "445" })
     void fuzzyStopCode(String query) {
       var result = index.queryStopClusters(query).toList();
       assertEquals(1, result.size());
       assertEquals(ARTS_CENTER.getName().toString(), result.get(0).name());
-    }
-
-    @Test
-    void analyzer() throws IOException {
-      var x = analyze("#444", new StandardAnalyzer());
-      assertEquals(x, "444");
-    }
-
-    public List<String> analyze(String text, Analyzer analyzer) throws IOException {
-      List<String> result = new ArrayList<String>();
-      TokenStream tokenStream = analyzer.tokenStream("code", text);
-      CharTermAttribute attr = tokenStream.addAttribute(CharTermAttribute.class);
-      tokenStream.reset();
-      while (tokenStream.incrementToken()) {
-        result.add(attr.toString());
-      }
-      return result;
     }
 
     @Test

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -155,6 +155,8 @@ class LuceneIndexTest {
         "alexnderplazt",
         "Alexnderplatz",
         "Alexnaderplatz",
+        "xande",
+        "xanderpla",
         "alexnaderplaz",
         "Alexanderplat",
         "alexanderplat",
@@ -197,6 +199,7 @@ class LuceneIndexTest {
         "five poits",
         "fife",
         "points",
+        "ife points",
         "the five points",
         "five @ points",
         "five @ the points",
@@ -206,7 +209,7 @@ class LuceneIndexTest {
         "five & points",
         "five and the points",
         "points five",
-        "points fife"
+        "points fife",
       }
     )
     void stopClustersWithSpace(String query) {

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -113,7 +113,7 @@ class LuceneIndexTest {
         }
       }
     };
-    index = new LuceneIndex(graph, transitService);
+    index = new LuceneIndex(transitService);
     mapper = new StopClusterMapper(transitService);
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -145,9 +145,24 @@ class LuceneIndexTest {
   @Nested
   class StopClusters {
 
-    @Test
-    void stopClusters() {
-      var result1 = index.queryStopClusters("alex").toList();
+    @ParameterizedTest
+    @ValueSource(
+      strings = {
+        "Alexanderplatz",
+        "alex",
+        "Alexnderplatz",
+        "Alexnaderplatz",
+        "alexnaderplaz",
+        "Alexanderplat",
+        "alexanderplat",
+        "alexand",
+        "alexander platz",
+        "alexander-platz",
+        "alexander",
+      }
+    )
+    void stopClustersWithTypos(String searchTerm) {
+      var result1 = index.queryStopClusters(searchTerm).toList();
       assertEquals(List.of(mapper.map(ALEXANDERPLATZ_STATION)), result1);
     }
 
@@ -167,7 +182,25 @@ class LuceneIndexTest {
     @ParameterizedTest
     @ValueSource(
       strings = {
-        "five", "five ", "five p", "five po", "five poi", "five poin", "five point", "five points",
+        "five",
+        "five ",
+        "five p",
+        "five po",
+        "five poi",
+        "five poin",
+        "five point",
+        "five points",
+        "fife point",
+        "five poits",
+        "fife",
+        "points",
+        "the five points",
+        "five @ points",
+        "five@points",
+        "five at points",
+        "five&points",
+        "five & points",
+        "five and points",
       }
     )
     void stopClustersWithSpace(String query) {

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -28,8 +27,6 @@ import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
 class LuceneIndexTest {
-
-  static Graph graph = new Graph();
 
   // Berlin
   static Station BERLIN_HAUPTBAHNHOF_STATION = station("Hauptbahnhof")

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -13,7 +13,7 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
 
 /**
  * A custom analyzer for stop names. It removes english stop words (at,the...) and splits
- * the input into ing NGrams (https://en.wikipedia.org/wiki/N-gram) so that the middle
+ * the input into NGrams (https://en.wikipedia.org/wiki/N-gram) so that the middle
  * of a stop name can be matched efficiently.
  * <p>
  * For example the query of "exanderpl" will match the stop name "Alexanderplatz".

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.ext.geocoder;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.core.StopFilter;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.en.EnglishPossessiveFilter;
+import org.apache.lucene.analysis.en.PorterStemFilter;
+import org.apache.lucene.analysis.miscellaneous.CapitalizationFilter;
+import org.apache.lucene.analysis.ngram.NGramTokenFilter;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+
+/**
+ * A custom analyzer for stop names. It removes english stop words (at,the...) and splits
+ * the input into ing NGrams (https://en.wikipedia.org/wiki/N-gram) so that the middle
+ * of a stop name can be matched efficiently.
+ * <p>
+ * For example the query of "exanderpl" will match the stop name "Alexanderplatz".
+ */
+class EnglishNGramAnalyzer extends Analyzer {
+
+  @Override
+  protected TokenStreamComponents createComponents(String fieldName) {
+    StandardTokenizer src = new StandardTokenizer();
+    TokenStream result = new EnglishPossessiveFilter(src);
+    result = new LowerCaseFilter(result);
+    result = new StopFilter(result, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
+    result = new PorterStemFilter(result);
+    result = new CapitalizationFilter(result);
+    result = new NGramTokenFilter(result, 4, 10, true);
+    return new TokenStreamComponents(src, result);
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.geocoder;
 
+import static java.util.Map.entry;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -10,9 +12,14 @@ import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene95.Lucene95Codec;
@@ -67,13 +74,31 @@ public class LuceneIndex implements Serializable {
   private final Analyzer analyzer;
   private final SuggestIndexSearcher searcher;
 
+  public static class MyCustomAnalyzer extends Analyzer {
+
+    static final CharArraySet CODE_STOP_WORDS = new CharArraySet(Set.of("#"), true);
+
+    @Override
+    protected TokenStreamComponents createComponents(String fieldName) {
+      StandardTokenizer src = new StandardTokenizer();
+      TokenStream result = new LowerCaseFilter(src);
+      result = new StopFilter(result, CODE_STOP_WORDS);
+      return new TokenStreamComponents(src, result);
+    }
+  }
+
   public LuceneIndex(Graph graph, TransitService transitService) {
     this.graph = graph;
     this.transitService = transitService;
+
     this.analyzer =
       new PerFieldAnalyzerWrapper(
         new StandardAnalyzer(),
-        Map.of(NAME, new EnglishAnalyzer(), SUGGEST, new CompletionAnalyzer(new StandardAnalyzer()))
+        Map.ofEntries(
+          entry(NAME, new EnglishAnalyzer()),
+          entry(SUGGEST, new CompletionAnalyzer(new StandardAnalyzer())),
+          entry(CODE, new MyCustomAnalyzer())
+        )
       );
 
     var directory = new ByteBuffersDirectory();
@@ -304,6 +329,9 @@ public class LuceneIndex implements Serializable {
           new Term(NAME, analyzer.normalize(NAME, searchTerms))
         );
         var codeQuery = new TermQuery(new Term(CODE, analyzer.normalize(CODE, searchTerms)));
+        var prefixCodeQuery = new PrefixQuery(
+          new Term(CODE, analyzer.normalize(CODE, searchTerms))
+        );
         var typeQuery = new TermQuery(
           new Term(TYPE, analyzer.normalize(TYPE, type.getSimpleName()))
         );
@@ -312,6 +340,7 @@ public class LuceneIndex implements Serializable {
           .setMinimumNumberShouldMatch(1)
           .add(typeQuery, Occur.MUST)
           .add(codeQuery, Occur.SHOULD)
+          .add(prefixCodeQuery, Occur.SHOULD)
           .add(nameQuery, Occur.SHOULD)
           .add(fuzzyNameQuery, Occur.SHOULD)
           .add(prefixNameQuery, Occur.SHOULD);

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopScoreDocCollector;
 import org.apache.lucene.search.suggest.document.Completion90PostingsFormat;
 import org.apache.lucene.search.suggest.document.CompletionAnalyzer;
 import org.apache.lucene.search.suggest.document.ContextQuery;

--- a/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
@@ -42,7 +42,7 @@ class StopClusterMapper {
       // if they are very close to each other and have the same name, only one is chosen (at random)
       .filter(
         PredicateUtils.distinctByKey(sl ->
-          new DeduplicationKey(sl.getName(), sl.getCoordinate().roundToApproximate10m())
+          new DeduplicationKey(sl.getName(), sl.getCoordinate().roundToApproximate100m())
         )
       )
       .flatMap(sl -> this.map(sl).stream());

--- a/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
+++ b/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
@@ -146,6 +146,12 @@ public final class WgsCoordinate implements Serializable {
     return new WgsCoordinate(lat, lng);
   }
 
+  public WgsCoordinate roundToApproximate100m() {
+    var lat = DoubleUtils.roundTo3Decimals(latitude);
+    var lng = DoubleUtils.roundTo3Decimals(longitude);
+    return new WgsCoordinate(lat, lng);
+  }
+
   /**
    * Return a string on the form: {@code "(60.12345, 11.12345)"}. Up to 5 digits are used after the
    * period(.), even if the coordinate is specified with a higher precision.

--- a/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
+++ b/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
@@ -146,6 +146,17 @@ public final class WgsCoordinate implements Serializable {
     return new WgsCoordinate(lat, lng);
   }
 
+  /**
+   * Return a new version of this coordinate where latitude/longitude are rounded to 3 decimal
+   * places which at the equator has ~100 meter precision.
+   * <p>
+   * See https://wiki.openstreetmap.org/wiki/Precision_of_coordinates
+   * <p>
+   * This is useful when you want to cache coordinate-based computations but don't need absolute
+   * precision.
+   * <p>
+   * DO NOT USE THIS IN ROUTING (USE AT LEAST 7 DECIMALS)!
+   */
   public WgsCoordinate roundToApproximate100m() {
     var lat = DoubleUtils.roundTo3Decimals(latitude);
     var lng = DoubleUtils.roundTo3Decimals(longitude);

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -438,7 +438,7 @@ public class OSMWithTags {
   }
 
   /**
-   * Is this a public transport boarding location where passengers wait for transti and that can be
+   * Is this a public transport boarding location where passengers wait for transit and that can be
    * linked to a transit stop vertex later on.
    * <p>
    * This intentionally excludes railway=stop and public_transport=stop because these are supposed

--- a/src/test/java/org/opentripplanner/framework/geometry/WgsCoordinateTest.java
+++ b/src/test/java/org/opentripplanner/framework/geometry/WgsCoordinateTest.java
@@ -9,25 +9,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner._support.geometry.Coordinates;
 
 public class WgsCoordinateTest {
 
   @Test
-  public void normalize() {
+  void normalize() {
     WgsCoordinate c = new WgsCoordinate(1.123456789, 2.987654321);
     assertEquals(1.1234568, c.latitude());
     assertEquals(2.9876543, c.longitude());
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     WgsCoordinate c = new WgsCoordinate(1.123456789, 2.987654321);
     assertEquals("(1.12346, 2.98765)", c.toString());
     assertEquals("(1.123, 2.9)", new WgsCoordinate(1.123, 2.9).toString());
   }
 
   @Test
-  public void testCoordinateEquals() {
+  void testCoordinateEquals() {
     WgsCoordinate a = new WgsCoordinate(5.000_000_3, 3.0);
 
     // Test latitude
@@ -50,7 +51,7 @@ public class WgsCoordinateTest {
   }
 
   @Test
-  public void asJtsCoordinate() {
+  void asJtsCoordinate() {
     // Given a well known location in Oslo
     double latitude = 59.9110583;
     double longitude = 10.7502691;
@@ -65,7 +66,7 @@ public class WgsCoordinateTest {
   }
 
   @Test
-  public void mean() {
+  void mean() {
     var c1 = new WgsCoordinate(10.0, 5.0);
     var c2 = new WgsCoordinate(20.0, -5.0);
 
@@ -79,7 +80,7 @@ public class WgsCoordinateTest {
   }
 
   @Test
-  public void validCoordinates() {
+  void validCoordinates() {
     // Edge cases should NOT throw exceptions
     new WgsCoordinate(90d, 1d);
     new WgsCoordinate(-90d, 1d);
@@ -94,13 +95,29 @@ public class WgsCoordinateTest {
   }
 
   @Test
-  public void add() {
+  void add() {
     assertEquals(new WgsCoordinate(12d, 5d), new WgsCoordinate(9d, 1d).add(3d, 4d));
   }
 
   @Test
-  public void testGreenwich() {
+  void testGreenwich() {
     assertEquals(51.48d, WgsCoordinate.GREENWICH.latitude());
     assertEquals(0d, WgsCoordinate.GREENWICH.longitude());
+  }
+
+  @Test
+  void roundingTo10m() {
+    var hamburg = new WgsCoordinate(Coordinates.HAMBURG);
+    var rounded = hamburg.roundToApproximate10m();
+    assertEquals(10.0003, rounded.latitude());
+    assertEquals(53.5566, rounded.longitude());
+  }
+
+  @Test
+  void roundingTo100m() {
+    var hamburg = new WgsCoordinate(Coordinates.HAMBURG);
+    var rounded = hamburg.roundToApproximate100m();
+    assertEquals(10, rounded.latitude());
+    assertEquals(53.557, rounded.longitude());
   }
 }


### PR DESCRIPTION
### Summary

@miles-grant-ibigroup has requested the following changes to the sandbox geocoder:

- Fuzziness is improved through a more elaborate query strategy
- An NGram index is added which allows also matches in the middle of a word so "exanderp" matches "Alexanderplatz"
- The stop clusters, which group stops with the same name, now have a larger radius from 10m to 100m.

#### Feature removal

This PR also removes the street corners from the geocoding index, which improves startup time. @flaktack, who originally added it, [said that he would be fine if it was removed](https://matrix.to/#/!oXNNoHKzbaSOlFzLEt:gitter.im/$qp2RTLCsiGxZVHqGUxe-8CGn4CPMU1tw-WBsJ0NahCE?via=gitter.im&via=matrix.org&via=mafiasi.de).

### Unit tests

Lots added.

### Documentation

Updated.