### PR TITLE
Add validation for missing calls in SIRI update

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
@@ -38,7 +38,7 @@ import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.spi.UpdateError;
 import uk.org.siri.siri20.VehicleModesEnumeration;
 
-public class AddedTripBuilderTest {
+class AddedTripBuilderTest {
 
   private static final Agency AGENCY = TransitModelForTest.AGENCY;
   private static final ZoneId TIME_ZONE = AGENCY.getTimezone();
@@ -105,7 +105,7 @@ public class AddedTripBuilderTest {
   }
 
   @Test
-  public void testAddedTrip() {
+  void testAddedTrip() {
     var addedTrip = new AddedTripBuilder(
       TRANSIT_MODEL,
       ENTITY_RESOLVER,
@@ -370,7 +370,7 @@ public class AddedTripBuilderTest {
   }
 
   @Test
-  public void testAddedTripFailOnMissingServiceId() {
+  void testAddedTripFailOnMissingServiceId() {
     var addedTrip = new AddedTripBuilder(
       TRANSIT_MODEL,
       ENTITY_RESOLVER,
@@ -382,7 +382,7 @@ public class AddedTripBuilderTest {
       null,
       TRANSIT_MODE,
       SUB_MODE,
-      List.of(),
+      getCalls(0),
       false,
       null,
       false,
@@ -400,7 +400,7 @@ public class AddedTripBuilderTest {
   }
 
   @Test
-  public void testAddedTripFailOnNonIncreasingDwellTime() {
+  void testAddedTripFailOnNonIncreasingDwellTime() {
     List<CallWrapper> calls = List.of(
       TestCall
         .of()
@@ -453,6 +453,37 @@ public class AddedTripBuilderTest {
     );
   }
 
+  @Test
+  void testAddedTripFailOnTooFewCalls() {
+    List<CallWrapper> calls = List.of();
+    var addedTrip = new AddedTripBuilder(
+      TRANSIT_MODEL,
+      ENTITY_RESOLVER,
+      AbstractTransitEntity::getId,
+      TRIP_ID,
+      OPERATOR,
+      LINE_REF,
+      REPLACED_ROUTE,
+      SERVICE_DATE,
+      TRANSIT_MODE,
+      SUB_MODE,
+      calls,
+      false,
+      null,
+      false,
+      SHORT_NAME,
+      HEADSIGN
+    )
+      .build();
+
+    assertTrue(addedTrip.isFailure(), "Trip creation should fail");
+    assertEquals(
+      UpdateError.UpdateErrorType.TOO_FEW_STOPS,
+      addedTrip.failureValue().errorType(),
+      "Trip creation should fail with too few stops"
+    );
+  }
+
   @ParameterizedTest
   @CsvSource(
     {
@@ -462,7 +493,7 @@ public class AddedTripBuilderTest {
       "ferry,FERRY,RAIL,",
     }
   )
-  public void testGetTransportMode(
+  void testGetTransportMode(
     String siriMode,
     String internalMode,
     String replacedRouteMode,

--- a/src/ext/java/org/opentripplanner/ext/siri/AddedTripBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/AddedTripBuilder.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.siri;
 import static java.lang.Boolean.TRUE;
 import static org.opentripplanner.ext.siri.mapper.SiriTransportModeMapper.mapTransitMainMode;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_START_DATE;
+import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TOO_FEW_STOPS;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -144,6 +145,10 @@ class AddedTripBuilder {
   }
 
   Result<TripUpdate, UpdateError> build() {
+    if (calls.isEmpty()) {
+      return UpdateError.result(tripId, TOO_FEW_STOPS);
+    }
+
     if (serviceDate == null) {
       return UpdateError.result(tripId, NO_START_DATE);
     }


### PR DESCRIPTION
### Summary

When a SIRI update creates a new trip without estimated calls, the update fails with the following error message:

```
Adding EstimatedJourney EstimatedVehicleJourney{EstimatedVehicleJourneyCode: 'GOA:ServiceJourney:20231003-921967', Operator: GOA:Operator:GOA, VehicleModes: [BUS], Line: GOA:Line:50} failed. java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Objects.java:209)
	at java.base/java.util.ImmutableCollections.listFromArray(ImmutableCollections.java:190)
	at java.base/java.util.List.of(List.java:1047)
	at org.opentripplanner.transit.model.network.StopPattern.getStops(StopPattern.java:174)
	at org.opentripplanner.transit.model.network.TripPattern.getStops(TripPattern.java:199)
	at org.opentripplanner.transit.model.network.RoutingTripPattern.<init>(RoutingTripPattern.java:32)
	at org.opentripplanner.transit.model.network.TripPattern.<init>(TripPattern.java:103)
	at org.opentripplanner.transit.model.network.TripPatternBuilder.buildFromValues(TripPatternBuilder.java:117)
	at org.opentripplanner.transit.model.network.TripPatternBuilder.buildFromValues(TripPatternBuilder.java:17)
	at org.opentripplanner.transit.model.framework.AbstractBuilder.build(AbstractBuilder.java:29)
	at org.opentripplanner.ext.siri.AddedTripBuilder.build(AddedTripBuilder.java:190)
	at org.opentripplanner.ext.siri.SiriTimetableSnapshotSource.apply(SiriTimetableSnapshotSource.java:211)
	at org.opentripplanner.ext.siri.SiriTimetableSnapshotSource.applyEstimatedTimetable(SiriTimetableSnapshotSource.java:169)
	at org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdater.lambda$processSiriData$0(SiriETGooglePubsubUpdater.java:380)
	at org.opentripplanner.updater.GraphUpdaterManager.lambda$execute$1(GraphUpdaterManager.java:192)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
```
	
This PR ensures that the SIRI updater checks earlier in the process if the added trip has no call and reports a validation error.

@lassetyr  should the validation reject as well EstimatedVehicleJourneys with less than 2 calls?


### Issue

No

### Unit tests

Added unit test

### Documentation

No