### PR TITLE
Add validation for scheduled transit leg reference

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.model.plan.legreference;
 
+import javax.annotation.Nullable;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -7,5 +8,6 @@ import org.opentripplanner.transit.service.TransitService;
  * Marker interface for various types of leg references
  */
 public interface LegReference {
+  @Nullable
   Leg getLeg(TransitService transitService);
 }

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model.plan.legreference;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
@@ -16,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A reference which can be used to rebuild an exact copy of a {@link ScheduledTransitLeg} using the
- * {@Link RoutingService}
+ * {@link org.opentripplanner.routing.api.RoutingService}
  */
 public record ScheduledTransitLegReference(
   FeedScopedId tripId,
@@ -36,6 +37,7 @@ public record ScheduledTransitLegReference(
    * In this case the method returns null.
    */
   @Override
+  @Nullable
   public ScheduledTransitLeg getLeg(TransitService transitService) {
     Trip trip = transitService.getTripForId(tripId);
     if (trip == null) {

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -11,6 +11,8 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.service.TransitService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A reference which can be used to rebuild an exact copy of a {@link ScheduledTransitLeg} using the
@@ -23,30 +25,70 @@ public record ScheduledTransitLegReference(
   int toStopPositionInPattern
 )
   implements LegReference {
+  private static final Logger LOG = LoggerFactory.getLogger(ScheduledTransitLegReference.class);
+
+  /**
+   * Reconstruct a scheduled transit leg from this scheduled transit leg reference.
+   * Since the transit model could have been modified between the time the reference is created
+   * and the time the transit leg is reconstructed (either because new planned data have been
+   * rolled out, or because a realtime update has modified a trip),
+   * it may not be possible to reconstruct the leg.
+   * In this case the method returns null.
+   */
   @Override
   public ScheduledTransitLeg getLeg(TransitService transitService) {
     Trip trip = transitService.getTripForId(tripId);
-
     if (trip == null) {
+      LOG.info("Invalid transit leg reference: trip {} not found", tripId);
       return null;
     }
 
     TripPattern tripPattern = transitService.getPatternForTrip(trip, serviceDate);
-
-    // no matching pattern found anywhere
     if (tripPattern == null) {
+      LOG.info(
+        "Invalid transit leg reference: trip pattern not found for trip {} and service date {} ",
+        tripId,
+        serviceDate
+      );
+      return null;
+    }
+
+    int numStops = tripPattern.numberOfStops();
+    if (fromStopPositionInPattern >= numStops || toStopPositionInPattern >= numStops) {
+      LOG.info(
+        "Invalid transit leg reference: boarding stop {} or alighting stop {} is out of range" +
+        " in trip {} and service date {} ({} stops in trip pattern) ",
+        fromStopPositionInPattern,
+        toStopPositionInPattern,
+        tripId,
+        serviceDate,
+        numStops
+      );
       return null;
     }
 
     Timetable timetable = transitService.getTimetableForTripPattern(tripPattern, serviceDate);
-
     TripTimes tripTimes = timetable.getTripTimes(trip);
+
+    if (tripTimes == null) {
+      LOG.info(
+        "Invalid transit leg reference: trip times not found for trip {} and service date {} ",
+        tripId,
+        serviceDate
+      );
+      return null;
+    }
 
     if (
       !transitService
         .getServiceCodesRunningForDate(serviceDate)
         .contains(tripTimes.getServiceCode())
     ) {
+      LOG.info(
+        "Invalid transit leg reference: the trip {} does not run on service date {} ",
+        tripId,
+        serviceDate
+      );
       return null;
     }
 

--- a/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -29,7 +29,7 @@ class ScheduledTransitLegReferenceTest {
 
   private static final int SERVICE_CODE = 555;
   private static final LocalDate SERVICE_DATE = LocalDate.of(2023, 1, 1);
-  public static final int NUMBER_OF_STOPS = 3;
+  private static final int NUMBER_OF_STOPS = 3;
   private static TransitService transitService;
   private static FeedScopedId tripId;
 

--- a/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -1,0 +1,128 @@
+package org.opentripplanner.model.plan.legreference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.model.Timetable;
+import org.opentripplanner.model.calendar.CalendarServiceData;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.ScheduledTransitLeg;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
+
+class ScheduledTransitLegReferenceTest {
+
+  private static final int SERVICE_CODE = 555;
+  private static final LocalDate SERVICE_DATE = LocalDate.of(2023, 1, 1);
+  public static final int NUMBER_OF_STOPS = 3;
+  private static TransitService transitService;
+  private static FeedScopedId tripId;
+
+  @BeforeAll
+  static void buildTransitService() {
+    // build transit data
+    TripPattern tripPattern = TransitModelForTest
+      .tripPattern("1", TransitModelForTest.route(id("1")).build())
+      .withStopPattern(TransitModelForTest.stopPattern(NUMBER_OF_STOPS))
+      .build();
+    Timetable timetable = tripPattern.getScheduledTimetable();
+    Trip trip = TransitModelForTest.trip("1").build();
+    tripId = trip.getId();
+    TripTimes tripTimes = new TripTimes(
+      trip,
+      TransitModelForTest.stopTimesEvery5Minutes(5, trip, PlanTestConstants.T11_00),
+      new Deduplicator()
+    );
+    tripTimes.setServiceCode(SERVICE_CODE);
+    timetable.addTripTimes(tripTimes);
+
+    // build transit model
+    TransitModel transitModel = new TransitModel(StopModel.of().build(), new Deduplicator());
+    transitModel.addTripPattern(tripPattern.getId(), tripPattern);
+    transitModel.getServiceCodes().put(tripPattern.getId(), SERVICE_CODE);
+    CalendarServiceData calendarServiceData = new CalendarServiceData();
+    calendarServiceData.putServiceDatesForServiceId(tripPattern.getId(), List.of(SERVICE_DATE));
+    transitModel.updateCalendarServiceData(true, calendarServiceData, DataImportIssueStore.NOOP);
+    transitModel.index();
+
+    // build transit service
+    transitService = new DefaultTransitService(transitModel);
+  }
+
+  @Test
+  void getLegFromReference() {
+    int boardAtStop = 0;
+    int alightAtStop = 1;
+    ScheduledTransitLegReference scheduledTransitLegReference = new ScheduledTransitLegReference(
+      tripId,
+      SERVICE_DATE,
+      boardAtStop,
+      alightAtStop
+    );
+    ScheduledTransitLeg leg = scheduledTransitLegReference.getLeg(transitService);
+    assertNotNull(leg);
+    assertEquals(tripId, leg.getTrip().getId());
+    assertEquals(SERVICE_DATE, leg.getServiceDate());
+    assertEquals(boardAtStop, leg.getBoardStopPosInPattern());
+    assertEquals(alightAtStop, leg.getAlightStopPosInPattern());
+  }
+
+  @Test
+  void getLegFromReferenceUnknownTrip() {
+    ScheduledTransitLegReference scheduledTransitLegReference = new ScheduledTransitLegReference(
+      FeedScopedId.ofNullable("XXX", "YYY"),
+      SERVICE_DATE,
+      0,
+      1
+    );
+    assertNull(scheduledTransitLegReference.getLeg(transitService));
+  }
+
+  @Test
+  void getLegFromReferenceInvalidServiceDate() {
+    ScheduledTransitLegReference scheduledTransitLegReference = new ScheduledTransitLegReference(
+      tripId,
+      LocalDate.EPOCH,
+      0,
+      1
+    );
+    assertNull(scheduledTransitLegReference.getLeg(transitService));
+  }
+
+  @Test
+  void getLegFromReferenceInvalidBoardingStop() {
+    ScheduledTransitLegReference scheduledTransitLegReference = new ScheduledTransitLegReference(
+      tripId,
+      SERVICE_DATE,
+      NUMBER_OF_STOPS,
+      1
+    );
+    assertNull(scheduledTransitLegReference.getLeg(transitService));
+  }
+
+  @Test
+  void getLegFromReferenceInvalidAlightingStop() {
+    ScheduledTransitLegReference scheduledTransitLegReference = new ScheduledTransitLegReference(
+      tripId,
+      SERVICE_DATE,
+      0,
+      NUMBER_OF_STOPS
+    );
+    assertNull(scheduledTransitLegReference.getLeg(transitService));
+  }
+}


### PR DESCRIPTION
### Summary

When requesting a leg by reference in the Transmodel API:

```
query ($id: ID!) {
  leg(
    id: $id
  ) 
{
...
}
```

 the request may fail with the following exception:
```

Exception while fetching data (/leg) : Cannot invoke "org.opentripplanner.transit.model.timetable.TripTimes.getServiceCode()" because "tripTimes" is null
java.lang.NullPointerException: Cannot invoke "org.opentripplanner.transit.model.timetable.TripTimes.getServiceCode()" because "tripTimes" is null
	at org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference.getLeg(ScheduledTransitLegReference.java:48)
	at org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference.getLeg(ScheduledTransitLegReference.java:19)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraphQLSchema.lambda$create$56(TransmodelGraphQLSchema.java:1607)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:67)
```
or this exception:

```

	Exception while fetching data (/leg) : Index 12 out of bounds for length 12
java.lang.ArrayIndexOutOfBoundsException: Index 12 out of bounds for length 12
	at org.opentripplanner.transit.model.timetable.TripTimes.getScheduledArrivalTime(TripTimes.java:229)
	at org.opentripplanner.transit.model.timetable.TripTimes.getArrivalTime(TripTimes.java:250)
	at org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference.getLeg(ScheduledTransitLegReference.java:57)
	at org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference.getLeg(ScheduledTransitLegReference.java:19)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraphQLSchema.lambda$create$56(TransmodelGraphQLSchema.java:1607)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:67)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:122)
	at jdk.internal.reflect.GeneratedMethodAccessor263.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146)
```

Root cause: The transit model may have been modified between the time the transit leg reference is created and the time the transit leg is reconstructed, in which case the leg may not be valid anymore (removed trip, removed stops, ...). This would cause such exceptions.

This PR extends the validation logic to cover more error cases and adds log messages to facilitate further analysis.


### Issue

No

### Unit tests

Added unit tests

### Documentation

No

