### PR TITLE
Fix fare calculation for combined interlined legs

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedLegsFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedLegsFareServiceTest.java
@@ -69,11 +69,11 @@ class CombinedInterlinedLegsFareServiceTest implements PlanTestConstants {
     assertEquals(totalPrice, price);
 
     var firstLeg = itinerary.getTransitLeg(0);
-    var uses = List.copyOf(fare.legProductsFromComponents().get(firstLeg));
+    var uses = fare.legProductsFromComponents().get(firstLeg);
     assertEquals(1, uses.size());
 
     var secondLeg = itinerary.getTransitLeg(1);
-    uses = List.copyOf(fare.legProductsFromComponents().get(secondLeg));
+    uses = fare.legProductsFromComponents().get(secondLeg);
     assertEquals(1, uses.size());
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedLegsFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedLegsFareServiceTest.java
@@ -54,7 +54,7 @@ class CombinedInterlinedLegsFareServiceTest implements PlanTestConstants {
     name = "Itinerary with {3} and combination mode {0} should lead to a fare of {2}"
   )
   @VariableSource("testCases")
-  void modeAlways(CombinationMode mode, Itinerary itinerary, Money expectedPrice, String hint) {
+  void modeAlways(CombinationMode mode, Itinerary itinerary, Money totalPrice, String hint) {
     var service = new CombinedInterlinedLegsFareService(mode);
     service.addFareRules(
       FareType.regular,
@@ -65,7 +65,16 @@ class CombinedInterlinedLegsFareServiceTest implements PlanTestConstants {
     assertNotNull(fare);
 
     var price = fare.getFare(FareType.regular);
+    assertEquals(totalPrice, price);
 
-    assertEquals(expectedPrice, price);
+    var firstLeg = itinerary.getTransitLeg(0);
+    var uses = List.copyOf(fare.legProductsFromComponents().get(firstLeg));
+    assertEquals(1, uses.size());
+
+    var firstProduct = uses.get(0).product();
+
+    var secondLeg = itinerary.getTransitLeg(1);
+    uses = List.copyOf(fare.legProductsFromComponents().get(secondLeg));
+    assertEquals(1, uses.size());
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedTransitLeg.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedTransitLeg.java
@@ -9,6 +9,7 @@ import javax.annotation.Nonnull;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.model.fare.FareProductUse;
+import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.model.plan.TransitLeg;
@@ -115,5 +116,12 @@ class CombinedInterlinedTransitLeg implements TransitLeg {
   @Override
   public List<FareProductUse> fareProducts() {
     return List.of();
+  }
+
+  /**
+   * The two legs that this combined leg originally consisted of.
+   */
+  public List<Leg> originalLegs() {
+    return List.of(first, second);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -259,7 +259,12 @@ public class DefaultFareService implements FareService {
 
       var componentLegs = new ArrayList<Leg>();
       for (int i = start; i <= via; ++i) {
-        componentLegs.add(legs.get(i));
+        final Leg e = legs.get(i);
+        if(e instanceof CombinedInterlinedTransitLeg transitLeg) {
+          componentLegs.addAll(transitLeg.originalLegs());
+        } else {
+          componentLegs.add(e);
+        }
       }
       components.add(
         new FareComponent(fareId, Money.ofFractionalAmount(currency, cost), componentLegs)

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -259,11 +259,16 @@ public class DefaultFareService implements FareService {
 
       var componentLegs = new ArrayList<Leg>();
       for (int i = start; i <= via; ++i) {
-        final Leg e = legs.get(i);
-        if(e instanceof CombinedInterlinedTransitLeg transitLeg) {
-          componentLegs.addAll(transitLeg.originalLegs());
+        final var leg = legs.get(i);
+        // if we have a leg that is combined for the purpose of fare calculation we need to
+        // retrieve the original legs so that the fare products are assigned back to the original
+        // legs that the combined one originally consisted of.
+        // (remember that the combined leg only exists during fare calculation and is thrown away
+        // afterwards to associating fare products with it will result in the API not showing any.)
+        if (leg instanceof CombinedInterlinedTransitLeg combinedLeg) {
+          componentLegs.addAll(combinedLeg.originalLegs());
         } else {
-          componentLegs.add(e);
+          componentLegs.add(leg);
         }
       }
       components.add(
@@ -379,12 +384,13 @@ public class DefaultFareService implements FareService {
 
   /**
    * Returns true if two interlined legs (those with a stay-seated transfer between them) should be
-   * treated as a single leg.
+   * treated as a single leg for the purposes of fare calculation.
    * <p>
    * By default it's disabled since this is unspecified in the GTFS fares spec.
    *
    * @see DefaultFareService#combineInterlinedLegs(List)
    * @see HighestFareInFreeTransferWindowFareService#shouldCombineInterlinedLegs(ScheduledTransitLeg, ScheduledTransitLeg)
+   * @see HSLFareService#shouldCombineInterlinedLegs(ScheduledTransitLeg, ScheduledTransitLeg)
    */
   protected boolean shouldCombineInterlinedLegs(
     ScheduledTransitLeg previousLeg,

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -19,7 +19,6 @@ import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.street.model.note.StreetNote;
 import org.opentripplanner.transit.model.basic.Accessibility;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;


### PR DESCRIPTION
### Summary

This fixes a problem when interlined legs area combined for fare calculation purposes: the fare products are associated to the wrong legs because the combined leg is not "deconstructed" into its parts when returning the results.

@binh-dam-ibigroup: this bugfix is relevant when Houston and SEPTA are going migrate the new Fares API.

### Unit tests

Added.

### Documentation

Javadoc added.