### PR TITLE
Fix stop times helper when requesting zero departure

### DIFF
--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -52,6 +52,10 @@ public class StopTimesHelper {
     ArrivalDeparture arrivalDeparture,
     boolean includeCancelledTrips
   ) {
+    if (numberOfDepartures <= 0) {
+      return List.of();
+    }
+
     List<StopTimesInPattern> result = new ArrayList<>();
 
     // Fetch all patterns, including those from realtime sources

--- a/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
@@ -46,7 +46,6 @@ class StopTimesHelperTest {
    */
   @Test
   void stopTimesForStop_zeroRequestedNumberOfDeparture() {
-    // Case 1, should find first departure for each pattern
     var result = StopTimesHelper.stopTimesForStop(
       transitService,
       transitService.getRegularStop(stopId),
@@ -65,7 +64,6 @@ class StopTimesHelperTest {
    */
   @Test
   void stopTimesForStop_oneDeparture() {
-    // Case 1, should find first departure for each pattern
     var result = StopTimesHelper.stopTimesForStop(
       transitService,
       transitService.getRegularStop(stopId),

--- a/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
@@ -42,6 +42,25 @@ class StopTimesHelperTest {
   }
 
   /**
+   * Case 0, requested number of departure = 0
+   */
+  @Test
+  void stopTimesForStop_zeroRequestedNumberOfDeparture() {
+    // Case 1, should find first departure for each pattern
+    var result = StopTimesHelper.stopTimesForStop(
+      transitService,
+      transitService.getRegularStop(stopId),
+      serviceDate.atStartOfDay(transitService.getTimeZone()).toInstant(),
+      Duration.ofHours(24),
+      0,
+      ArrivalDeparture.BOTH,
+      true
+    );
+
+    assertTrue(result.isEmpty());
+  }
+
+  /**
    * Case 1, should find first departure for each pattern when numberOfDepartures is one
    */
   @Test


### PR DESCRIPTION
### Summary
As detailed in #5400, querying estimated calls with a limit on the number of departures set to 0 leads to an exception.
This PR ensures that a valid empty result is returned in this case.

### Issue
Closes #5400

### Unit tests

Added unit test.

### Documentation
No
