### PR TITLE
Fix Transmodel GraphQL query with empty quay id

### DIFF
--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -248,6 +248,9 @@ public class StopModel implements Serializable {
   @Nullable
   @SafeVarargs
   private static <V> V getById(FeedScopedId id, Map<FeedScopedId, ? extends V>... maps) {
+    if (id == null) {
+      return null;
+    }
     for (Map<FeedScopedId, ? extends V> map : maps) {
       V v = map.get(id);
       if (v != null) {

--- a/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
+++ b/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.transit.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -131,5 +132,11 @@ class StopModelTest {
     assertEquals(EXP_GROUP_OF_STATION, m.listStopLocationGroups().toString());
     assertEquals(COOR_B, m.getCoordinateById(ID));
     assertFalse(m.hasAreaStops());
+  }
+
+  @Test
+  void testNullStopLocationId() {
+    var m = StopModel.of().build();
+    assertNull(m.getStopLocation(null));
   }
 }


### PR DESCRIPTION
### Summary

As detailed in #5399, requesting a quay with an empty id or an id consisting only of spaces leads to an exception.
This PR ensures that a valid empty result is returned in this case.

### Issue

Closes #5399

### Unit tests

Added unit test

### Documentation
No

