### PR TITLE
Fix flexible quay querying in Transmodel API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -317,7 +317,7 @@ public class QuayType {
             );
             Integer timeRangeInput = environment.getArgument("timeRange");
             Duration timeRange = Duration.ofSeconds(timeRangeInput.longValue());
-            RegularStop stop = environment.getSource();
+            StopLocation stop = environment.getSource();
 
             JourneyWhiteListed whiteListed = new JourneyWhiteListed(environment);
             Collection<TransitMode> transitModes = environment.getArgument("whiteListedModes");

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -15,20 +15,18 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collection;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.opentripplanner.ext.transmodelapi.model.EnumTypes;
 import org.opentripplanner.ext.transmodelapi.model.plan.JourneyWhiteListed;
 import org.opentripplanner.ext.transmodelapi.model.scalars.GeoJSONCoordinatesScalar;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
-import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.transit.model.basic.Accessibility;
 import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -184,15 +182,15 @@ public class QuayType {
           .withDirective(gqlUtil.timingData)
           .description("List of lines servicing this quay")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(lineType))))
-          .dataFetcher(environment -> {
-            return GqlUtil
+          .dataFetcher(environment ->
+            GqlUtil
               .getTransitService(environment)
               .getPatternsForStop(environment.getSource(), true)
               .stream()
-              .map(pattern -> pattern.getRoute())
+              .map(TripPattern::getRoute)
               .distinct()
-              .collect(Collectors.toList());
-          })
+              .toList()
+          )
           .build()
       )
       .field(
@@ -202,11 +200,9 @@ public class QuayType {
           .withDirective(gqlUtil.timingData)
           .description("List of journey patterns servicing this quay")
           .type(new GraphQLNonNull(new GraphQLList(journeyPatternType)))
-          .dataFetcher(environment -> {
-            return GqlUtil
-              .getTransitService(environment)
-              .getPatternsForStop(environment.getSource(), true);
-          })
+          .dataFetcher(environment ->
+            GqlUtil.getTransitService(environment).getPatternsForStop(environment.getSource(), true)
+          )
           .build()
       )
       .field(
@@ -343,7 +339,7 @@ public class QuayType {
               .sorted(TripTimeOnDate.compareByDeparture())
               .distinct()
               .limit(numberOfDepartures)
-              .collect(Collectors.toList());
+              .toList();
           })
           .build()
       )
@@ -353,12 +349,12 @@ public class QuayType {
           .name("situations")
           .description("Get all situations active for the quay.")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
-          .dataFetcher(env -> {
-            return GqlUtil
+          .dataFetcher(env ->
+            GqlUtil
               .getTransitService(env)
               .getTransitAlertService()
-              .getStopAlerts(((StopLocation) env.getSource()).getId());
-          })
+              .getStopAlerts(((StopLocation) env.getSource()).getId())
+          )
           .build()
       )
       .field(


### PR DESCRIPTION
### Summary

When querying  a flexible quay in the Transmodel API:

```
query {
  quay(
    id: "SOF:FlexibleStopPlace:ef157b1b-58d7-4431-942d-dc6042f4cae3"
  ) {
    name
    id
    estimatedCalls {
      expectedDepartureTime
      destinationDisplay {
        frontText
      }
      serviceJourney {
        line {
          publicCode
          transportMode
        }
      }
    }
  }
}
```

an exception is thrown:

```
Exception while fetching data (/quays[100689]/estimatedCalls) : class org.opentripplanner.transit.model.site.AreaStop cannot be cast to class org.opentripplanner.transit.model.site.RegularStop (org.opentripplanner.transit.model.site.AreaStop and org.opentripplanner.transit.model.site.RegularStop are in unnamed module of loader 'app')
java.lang.ClassCastException: class org.opentripplanner.transit.model.site.AreaStop cannot be cast to class org.opentripplanner.transit.model.site.RegularStop (org.opentripplanner.transit.model.site.AreaStop and org.opentripplanner.transit.model.site.RegularStop are in unnamed module of loader 'app')
	at org.opentripplanner.ext.transmodelapi.model.stop.QuayType.lambda$create$11(QuayType.java:320)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.ExecutionStrategy.completeValueForObject(ExecutionStrategy.java:702)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:484)
	at graphql.execution.ExecutionStrategy.completeValueForList(ExecutionStrategy.java:586)
	at graphql.execution.ExecutionStrategy.completeValueForList(ExecutionStrategy.java:543)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:469)
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:435)
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$1(ExecutionStrategy.java:215)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2168)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:214)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:67)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:122)
```
	
	
This PR makes it possible to query flexible quays.

### Issue

No.

### Unit tests

:white_check_mark: 

### Documentation

No.

