### PR TITLE
Fix handling of null start time in Transmodel API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -322,8 +322,9 @@ public class QuayType {
             JourneyWhiteListed whiteListed = new JourneyWhiteListed(environment);
             Collection<TransitMode> transitModes = environment.getArgument("whiteListedModes");
 
-            Instant startTime = environment.containsArgument("startTime")
-              ? Instant.ofEpochMilli(environment.getArgument("startTime"))
+            Integer startTimeInput = environment.getArgument("startTime");
+            Instant startTime = startTimeInput != null
+              ? Instant.ofEpochMilli(startTimeInput)
               : Instant.now();
 
             return StopPlaceType


### PR DESCRIPTION
### Summary

When querying estimated calls with a null start time: 

```
query quayEstimatedCalls {
  quay(
    id: "NSR:Quay:101521",
  ) {
    description
    id
    name
    publicCode
    estimatedCalls(
      startTime: null
    ) {
      aimedDepartureTime
      date
      expectedDepartureTime
      realtime
      cancellation
      quay {
        id
        __typename
      }
      __typename
    }
    __typename
  }
}
```

the query fails with an exception:

```
Exception while fetching data (/quay/estimatedCalls) : Cannot invoke "java.lang.Long.longValue()" because the return value of "graphql.schema.DataFetchingEnvironment.getArgument(String)" is null
java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "graphql.schema.DataFetchingEnvironment.getArgument(String)" is null
	at org.opentripplanner.ext.transmodelapi.model.stop.QuayType.lambda$create$11(QuayType.java:326)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.ExecutionStrategy.completeValueForObject(ExecutionStrategy.java:702)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:484)
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:435)
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$1(ExecutionStrategy.java:215)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2168)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:214)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:67)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:122)
```

This PR fixes null value handling for this parameter.

### Issue
No

### Unit tests

:white_check_mark: 

### Documentation

No
