### PR TITLE
Make Money serializable

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/basic/Money.java
+++ b/src/main/java/org/opentripplanner/transit/model/basic/Money.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.model.basic;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -13,7 +14,7 @@ import org.opentripplanner.framework.lang.IntUtils;
 /**
  * Represents an amount of money.
  */
-public class Money implements Comparable<Money> {
+public class Money implements Comparable<Money>, Serializable {
 
   public static final Currency USD = Currency.getInstance("USD");
   public static final Money ZERO_USD = Money.usDollars(0);

--- a/src/test/java/org/opentripplanner/routing/core/MoneyTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/MoneyTest.java
@@ -2,11 +2,12 @@ package org.opentripplanner.routing.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.opentripplanner.transit.model.basic.Locales.NORWEGIAN_BOKMAL;
-import static org.opentripplanner.transit.model.basic.Locales.NORWEGIAN_NYNORSK;
 
+import java.io.Serializable;
 import java.util.Currency;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -85,5 +86,10 @@ class MoneyTest {
     assertTrue(twoDollars.greaterThan(oneDollar));
     assertFalse(oneDollar.greaterThan(oneDollar));
     assertFalse(oneDollar.greaterThan(twoDollars));
+  }
+
+  @Test
+  void serializable() {
+    assertInstanceOf(Serializable.class, oneDollar);
   }
 }


### PR DESCRIPTION
### Summary

@fpurcell has reported (and I have independently also noticed) that when enabling Fares V2 `Money` objects fail serialization because they are not `Serializable`.

This PR fixes that.

### Unit tests

~~I'd love to write one but I'm not sure if it's worth it.~~ Test added.