### PR TITLE
Fix board slack list mapping in Transmodel API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/preferences/TransitPreferencesMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/preferences/TransitPreferencesMapper.java
@@ -20,7 +20,7 @@ public class TransitPreferencesMapper {
       callWith.argument("boardSlackDefault", builder::withDefaultSec);
       callWith.argument(
         "boardSlackList",
-        (Integer v) -> TransportModeSlack.mapIntoDomain(builder, v)
+        (Object v) -> TransportModeSlack.mapIntoDomain(builder, v)
       );
     });
     transit.withAlightSlack(builder -> {


### PR DESCRIPTION
### Summary

When specifying a board slack by mode in a Transmodel query:

```
{
  trip(
    from: {
      place: "NSR:StopPlace:58481"
    },
    to: {
      place: "NSR:StopPlace:58482"
    },
    modes: {
      transportModes: {
        transportMode: water
        transportSubModes: localPassengerFerry
      }
    },
    numTripPatterns: 3,

    arriveBy: true,
    boardSlackList: {
      slack: 10
      modes: water
    },
    locale: us,
    timetableView: true
  ) {
    tripPatterns {
      distance
    }
    fromPlace {
      name
      quay {
        estimatedCalls(
          arrivalDeparture: departures,

          whiteListedModes: water,
          numberOfDepartures: 10
        ) {
          actualDepartureTime
          aimedDepartureTime
          date
          expectedDepartureTime
          destinationDisplay {
            frontText
            via
          }
          occupancyStatus
          realtimeState
          stopPositionInPattern
          datedServiceJourney {
            estimatedCalls {
              actualDepartureTime
              aimedDepartureTime
              expectedDepartureTime
              stopPositionInPattern
            }
            journeyPattern {
              directionType
              name
            }
            operatingDay
          }
        }
        stopType
      }
      flexibleArea
    }
    dateTime
    debugOutput {
      totalTime
    }
  }
}
```


an exception is thrown:

```
Exception while fetching data (/trip) : class java.util.Collections$SingletonList cannot be cast to class java.lang.Integer (java.util.Collections$SingletonList and java.lang.Integer are in module java.base of loader 'bootstrap')
java.lang.ClassCastException: class java.util.Collections$SingletonList cannot be cast to class java.lang.Integer (java.util.Collections$SingletonList and java.lang.Integer are in module java.base of loader 'bootstrap')
	at org.opentripplanner.ext.transmodelapi.support.DataFetcherDecorator.call(DataFetcherDecorator.java:46)
	at org.opentripplanner.ext.transmodelapi.support.DataFetcherDecorator.argument(DataFetcherDecorator.java:21)
	at org.opentripplanner.ext.transmodelapi.mapping.preferences.TransitPreferencesMapper.lambda$mapTransitPreferences$1(TransitPreferencesMapper.java:21)
	at org.opentripplanner.routing.api.request.framework.DurationForEnum$Builder.apply(DurationForEnum.java:181)
	at org.opentripplanner.routing.api.request.preference.TransitPreferences$Builder.withBoardSlack(TransitPreferences.java:263)
	at org.opentripplanner.ext.transmodelapi.mapping.preferences.TransitPreferencesMapper.mapTransitPreferences(TransitPreferencesMapper.java:19)
	at org.opentripplanner.ext.transmodelapi.mapping.PreferencesMapper.lambda$mapPreferences$4(PreferencesMapper.java:27)
	at org.opentripplanner.routing.api.request.preference.TransitPreferences$Builder.apply(TransitPreferences.java:326)
	at org.opentripplanner.routing.api.request.preference.RoutingPreferences$Builder.withTransit(RoutingPreferences.java:146)
	at org.opentripplanner.ext.transmodelapi.mapping.PreferencesMapper.mapPreferences(PreferencesMapper.java:27)
	at org.opentripplanner.ext.transmodelapi.mapping.TripRequestMapper.lambda$createRequest$12(TripRequestMapper.java:114)
	at org.opentripplanner.routing.api.request.preference.RoutingPreferences$Builder.apply(RoutingPreferences.java:239)
	at org.opentripplanner.routing.api.request.RouteRequest.withPreferences(RouteRequest.java:104)
	at org.opentripplanner.ext.transmodelapi.mapping.TripRequestMapper.createRequest(TripRequestMapper.java:113)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraphQLPlanner.plan(TransmodelGraphQLPlanner.java:31)
	at org.opentripplanner.ext.transmodelapi.model.plan.TripQuery.lambda$create$0(TripQuery.java:565)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:565)
	at graphql.GraphQL.lambda$parseValidateAndExecute$12(GraphQL.java:484)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:479)
	at graphql.GraphQL.executeAsync(GraphQL.java:438)
	at graphql.GraphQL.execute(GraphQL.java:365)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.executeGraphQL(TransmodelGraph.java:67)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:122)
```

This PR fixes this regression.

### Issue

No

### Unit tests

:white_check_mark: 


### Documentation

No

