### PR TITLE
Add available types and spaces to `VehicleRentalStation`

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehicleRentalStationImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehicleRentalStationImpl.java
@@ -4,7 +4,8 @@ import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
-import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
+import org.opentripplanner.service.vehiclerental.model.RentalVehicleEntityCounts;
+import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStationUris;
 
 public class VehicleRentalStationImpl implements GraphQLDataFetchers.GraphQLVehicleRentalStation {
@@ -96,7 +97,17 @@ public class VehicleRentalStationImpl implements GraphQLDataFetchers.GraphQLVehi
     return environment -> getSource(environment).getVehiclesAvailable();
   }
 
-  private VehicleRentalPlace getSource(DataFetchingEnvironment environment) {
+  @Override
+  public DataFetcher<RentalVehicleEntityCounts> availableVehicles() {
+    return environment -> getSource(environment).getVehicleTypeCounts();
+  }
+
+  @Override
+  public DataFetcher<RentalVehicleEntityCounts> availableSpaces() {
+    return environment -> getSource(environment).getVehicleSpaceCounts();
+  }
+
+  private VehicleRentalStation getSource(DataFetchingEnvironment environment) {
     return environment.getSource();
   }
 }

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -48,7 +48,9 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingState;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle.StopRelationship;
+import org.opentripplanner.service.vehiclerental.model.RentalVehicleEntityCounts;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
+import org.opentripplanner.service.vehiclerental.model.RentalVehicleTypeCount;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStationUris;
@@ -1181,6 +1183,10 @@ public class GraphQLDataFetchers {
     public DataFetcher<String> stationId();
 
     public DataFetcher<Integer> vehiclesAvailable();
+
+    public DataFetcher<RentalVehicleEntityCounts> availableVehicles();
+
+    public DataFetcher<RentalVehicleEntityCounts> availableSpaces();
   }
 
   public interface GraphQLVehicleRentalUris {

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -38,6 +38,8 @@ config:
     BikeRentalStation: org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace#VehicleRentalPlace
     BikeRentalStationUris: org.opentripplanner.service.vehiclerental.model.VehicleRentalStationUris#VehicleRentalStationUris
     VehicleRentalStation: org.opentripplanner.service.vehiclerental.model.VehicleRentalStation#VehicleRentalStation
+    RentalVehicleEntityCounts: org.opentripplanner.service.vehiclerental.model.RentalVehicleEntityCounts#RentalVehicleEntityCounts
+    RentalVehicleTypeCount: org.opentripplanner.service.vehiclerental.model.RentalVehicleTypeCount#RentalVehicleTypeCount
     RentalVehicle: org.opentripplanner.service.vehiclerental.model.VehicleRentalVehicle#VehicleRentalVehicle
     VehicleRentalUris: org.opentripplanner.service.vehiclerental.model.VehicleRentalStationUris#VehicleRentalStationUris
     BikesAllowed: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLBikesAllowed#GraphQLBikesAllowed

--- a/src/main/java/org/opentripplanner/service/vehiclerental/model/RentalVehicleEntityCounts.java
+++ b/src/main/java/org/opentripplanner/service/vehiclerental/model/RentalVehicleEntityCounts.java
@@ -1,0 +1,5 @@
+package org.opentripplanner.service.vehiclerental.model;
+
+import java.util.List;
+
+public record RentalVehicleEntityCounts(int total, List<RentalVehicleTypeCount> byType) {}

--- a/src/main/java/org/opentripplanner/service/vehiclerental/model/RentalVehicleTypeCount.java
+++ b/src/main/java/org/opentripplanner/service/vehiclerental/model/RentalVehicleTypeCount.java
@@ -1,0 +1,3 @@
+package org.opentripplanner.service.vehiclerental.model;
+
+public record RentalVehicleTypeCount(RentalVehicleType vehicleType, int count) {}

--- a/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStation.java
+++ b/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStation.java
@@ -3,6 +3,7 @@ package org.opentripplanner.service.vehiclerental.model;
 import static java.util.Locale.ROOT;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -187,5 +188,36 @@ public class VehicleRentalStation implements VehicleRentalPlace {
       getAvailableDropoffFormFactors(false),
       getAvailablePickupFormFactors(false)
     );
+  }
+
+  /**
+   * @return Counts of available vehicles by type as well as the total number of available vehicles.
+   */
+  public RentalVehicleEntityCounts getVehicleTypeCounts() {
+    return new RentalVehicleEntityCounts(
+      vehiclesAvailable,
+      vehicleRentalTypeMapToList(vehicleTypesAvailable)
+    );
+  }
+
+  /**
+   * @return Counts of available vehicle spaces by type as well as the total number of available
+   * vehicle spaces.
+   */
+  public RentalVehicleEntityCounts getVehicleSpaceCounts() {
+    return new RentalVehicleEntityCounts(
+      spacesAvailable,
+      vehicleRentalTypeMapToList(vehicleSpacesAvailable)
+    );
+  }
+
+  private List<RentalVehicleTypeCount> vehicleRentalTypeMapToList(
+    Map<RentalVehicleType, Integer> vehicleTypeMap
+  ) {
+    return vehicleTypeMap
+      .entrySet()
+      .stream()
+      .map(vtc -> new RentalVehicleTypeCount(vtc.getKey(), vtc.getValue()))
+      .toList();
   }
 }

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -558,7 +558,7 @@ type VehicleRentalStation implements Node & PlaceInterface {
     Number of vehicles currently available on the rental station.
     See field `allowPickupNow` to know if is currently possible to pick up a vehicle.
     """
-    vehiclesAvailable: Int
+    vehiclesAvailable: Int @deprecated(reason: "Use availableVehicles instead, which also contains vehicle types")
 
     """
     Number of free spaces currently available on the rental station.
@@ -567,7 +567,17 @@ type VehicleRentalStation implements Node & PlaceInterface {
     the rental station, even if the vehicle racks don't have any spaces available.
     See field `allowDropoffNow` to know if is currently possible to return a vehicle.
     """
-    spacesAvailable: Int
+    spacesAvailable: Int @deprecated(reason: "Use availableSpaces instead, which also contains the space vehicle types")
+
+    """
+    Number of vehicles currently available on the rental station, grouped by vehicle type.
+    """
+    availableVehicles: RentalVehicleEntityCounts!
+
+    """
+    Number of free spaces currently available on the rental station, grouped by vehicle type.
+    """
+    availableSpaces: RentalVehicleEntityCounts!
 
     """
     If true, values of `vehiclesAvailable` and `spacesAvailable` are updated from a
@@ -615,6 +625,22 @@ type VehicleRentalStation implements Node & PlaceInterface {
     If true, station is on and in service.
     """
     operative: Boolean
+}
+
+type RentalVehicleEntityCounts {
+    """The total number of entities (e.g. vehicles, spaces)."""
+    total: Int!
+
+    """The number of entities by type"""
+    byType: [RentalVehicleTypeCount!]!
+}
+
+type RentalVehicleTypeCount {
+    """The type of the rental vehicle (scooter, bicycle, car...)"""
+    vehicleType: RentalVehicleType!
+
+    """The number of vehicles of this type"""
+    count: Int!
 }
 
 """

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -572,12 +572,12 @@ type VehicleRentalStation implements Node & PlaceInterface {
     """
     Number of vehicles currently available on the rental station, grouped by vehicle type.
     """
-    availableVehicles: RentalVehicleEntityCounts!
+    availableVehicles: RentalVehicleEntityCounts
 
     """
     Number of free spaces currently available on the rental station, grouped by vehicle type.
     """
-    availableSpaces: RentalVehicleEntityCounts!
+    availableSpaces: RentalVehicleEntityCounts
 
     """
     If true, values of `vehiclesAvailable` and `spacesAvailable` are updated from a

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -558,7 +558,7 @@ type VehicleRentalStation implements Node & PlaceInterface {
     Number of vehicles currently available on the rental station.
     See field `allowPickupNow` to know if is currently possible to pick up a vehicle.
     """
-    vehiclesAvailable: Int @deprecated(reason: "Use availableVehicles instead, which also contains vehicle types")
+    vehiclesAvailable: Int @deprecated(reason: "Use `availableVehicles` instead, which also contains vehicle types")
 
     """
     Number of free spaces currently available on the rental station.
@@ -567,7 +567,7 @@ type VehicleRentalStation implements Node & PlaceInterface {
     the rental station, even if the vehicle racks don't have any spaces available.
     See field `allowDropoffNow` to know if is currently possible to return a vehicle.
     """
-    spacesAvailable: Int @deprecated(reason: "Use availableSpaces instead, which also contains the space vehicle types")
+    spacesAvailable: Int @deprecated(reason: "Use `availableSpaces` instead, which also contains the space vehicle types")
 
     """
     Number of vehicles currently available on the rental station, grouped by vehicle type.

--- a/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -73,6 +73,8 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleService;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
+import org.opentripplanner.service.vehiclerental.model.TestVehicleRentalStationBuilder;
+import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.standalone.config.framework.json.JsonSupport;
 import org.opentripplanner.test.support.FilePatternSource;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -241,13 +243,22 @@ class GraphQLIntegrationTest {
       .build();
     realtimeVehicleService.setRealtimeVehicles(pattern, List.of(occypancyVehicle, positionVehicle));
 
+    DefaultVehicleRentalService defaultVehicleRentalService = new DefaultVehicleRentalService();
+    VehicleRentalStation vehicleRentalStation = new TestVehicleRentalStationBuilder()
+      .withVehicles(10)
+      .withSpaces(10)
+      .withVehicleTypeBicycle(5, 7)
+      .withVehicleTypeElectricBicycle(5, 3)
+      .build();
+    defaultVehicleRentalService.addVehicleRentalStation(vehicleRentalStation);
+
     context =
       new GraphQLRequestContext(
         new TestRoutingService(List.of(i1)),
         transitService,
         new DefaultFareService(),
         graph.getVehicleParkingService(),
-        new DefaultVehicleRentalService(),
+        defaultVehicleRentalService,
         realtimeVehicleService,
         GraphFinder.getInstance(graph, transitService::findRegularStop),
         new RouteRequest()

--- a/src/test/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalServiceTest.java
+++ b/src/test/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalServiceTest.java
@@ -17,8 +17,7 @@ class DefaultVehicleRentalServiceTest {
     DefaultVehicleRentalService defaultVehicleRentalService = new DefaultVehicleRentalService();
 
     VehicleRentalStation vehicleRentalStation = new TestVehicleRentalStationBuilder()
-      .withLatitude(1)
-      .withLongitude(1)
+      .withCoordinates(1, 1)
       .build();
     defaultVehicleRentalService.addVehicleRentalStation(vehicleRentalStation);
 

--- a/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
+++ b/src/test/java/org/opentripplanner/street/search/state/TestStateBuilder.java
@@ -117,7 +117,7 @@ public class TestStateBuilder {
   public TestStateBuilder pickUpCarFromStation() {
     return pickUpRentalVehicle(
       RentalFormFactor.CAR,
-      TestVehicleRentalStationBuilder.of().withVehicleTypeCar().build()
+      TestVehicleRentalStationBuilder.of().withVehicleTypeCar(10, 10).build()
     );
   }
 
@@ -138,7 +138,7 @@ public class TestStateBuilder {
   public TestStateBuilder pickUpBikeFromStation() {
     return pickUpRentalVehicle(
       RentalFormFactor.BICYCLE,
-      TestVehicleRentalStationBuilder.of().withVehicleTypeBicycle().build()
+      TestVehicleRentalStationBuilder.of().withVehicleTypeElectricBicycle(10, 10).build()
     );
   }
 

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/vehicle-rental-station.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/vehicle-rental-station.json
@@ -1,0 +1,59 @@
+{
+  "data" : {
+    "vehicleRentalStation" : {
+      "stationId" : "Network-1:FooStation",
+      "name" : "FooStation",
+      "vehiclesAvailable" : 10,
+      "availableVehicles" : {
+        "byType" : [
+          {
+            "vehicleType" : {
+              "formFactor" : "BICYCLE",
+              "propulsionType" : "ELECTRIC"
+            },
+            "count" : 5
+          },
+          {
+            "vehicleType" : {
+              "formFactor" : "BICYCLE",
+              "propulsionType" : "HUMAN"
+            },
+            "count" : 5
+          }
+        ],
+        "total" : 10
+      },
+      "spacesAvailable" : 10,
+      "availableSpaces" : {
+        "byType" : [
+          {
+            "vehicleType" : {
+              "formFactor" : "BICYCLE",
+              "propulsionType" : "ELECTRIC"
+            },
+            "count" : 3
+          },
+          {
+            "vehicleType" : {
+              "formFactor" : "BICYCLE",
+              "propulsionType" : "HUMAN"
+            },
+            "count" : 7
+          }
+        ],
+        "total" : 10
+      },
+      "allowDropoff" : false,
+      "allowPickup" : false,
+      "allowDropoffNow" : false,
+      "allowPickupNow" : false,
+      "network" : "Network-1",
+      "lon" : 18.99,
+      "lat" : 47.51,
+      "capacity" : null,
+      "allowOverloading" : false,
+      "rentalUris" : null,
+      "operative" : false
+    }
+  }
+}

--- a/src/test/resources/org/opentripplanner/apis/gtfs/queries/vehicle-rental-station.graphql
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/queries/vehicle-rental-station.graphql
@@ -1,0 +1,43 @@
+{
+  vehicleRentalStation(id: "Network-1:FooStation") {
+    stationId
+    name
+    vehiclesAvailable
+    availableVehicles {
+      byType {
+        vehicleType {
+          formFactor
+          propulsionType
+        }
+        count
+      }
+      total
+    }
+    spacesAvailable
+    availableSpaces {
+      byType {
+        vehicleType {
+          formFactor
+          propulsionType
+        }
+        count
+      }
+      total
+    }
+    allowDropoff
+    allowPickup
+    allowDropoffNow
+    allowPickupNow
+    network
+    lon
+    lat
+    capacity
+    allowOverloading
+    rentalUris {
+      android
+      ios
+      web
+    }
+    operative
+  }
+}


### PR DESCRIPTION
### Summary

This PR adds `vehicleTypesAvailable` and `vehicleSpacesAvailable` to the `VehicleRentalStation` type. These fields return the count of each vehicle type available for pickup and drop-off, respectively. As an example, this is what the new fields look like in the `vehicleRentalStation` query:

```
...
    "vehicleRentalStation": {
      "stationId": "NYC:cc7b86cf-a2fb-4738-b967-de7b197dc930",
      "name": "Ave A & E 14 St",
      "vehiclesAvailable": 2,
      "vehicleTypesAvailable": [
        {
          "vehicleType": {
            "formFactor": "BICYCLE",
            "propulsionType": "HUMAN"
          },
          "count": 0
        },
        {
          "vehicleType": {
            "formFactor": "BICYCLE",
            "propulsionType": "ELECTRIC_ASSIST"
          },
          "count": 2
        }
      ],
...
```

### Issue

N/A

### Unit tests

- GraphQL integration test added that runs the `vehicleRentalStation` query with the new fields
- Manual testing done with the interactive GraphQL explorer

### Documentation

- Documentation added for new GraphQL fields