### PR TITLE
Fix ORCA cross-agency fares

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -75,9 +75,9 @@ public class OrcaFareServiceTest {
    * types.
    */
   private static void calculateFare(List<Leg> legs, FareType fareType, Money expectedPrice) {
-    ItineraryFares fare = new ItineraryFares();
-    orcaFareService.populateFare(fare, USD, fareType, legs, null);
-    assertEquals(expectedPrice, fare.getFare(fareType));
+    var itinerary = new Itinerary(legs);
+    var itineraryFares = orcaFareService.calculateFares(itinerary);
+    assertEquals(expectedPrice, itineraryFares.getFare(fareType));
   }
 
   private static void assertLegFareEquals(
@@ -642,25 +642,27 @@ public class OrcaFareServiceTest {
     String firstStopName,
     String lastStopName
   ) {
+    // Use the agency ID as feed ID to make sure that we have a new feed ID for each different agency
+    // This tests to make sure we are calculating transfers across feeds correctly.
     Agency agency = Agency
-      .of(new FeedScopedId(FEED_ID, agencyId))
+      .of(new FeedScopedId(agencyId, agencyId))
       .withName(agencyId)
       .withTimezone(ZoneIds.NEW_YORK.getId())
       .build();
 
     // Set up stops
     RegularStop firstStop = RegularStop
-      .of(new FeedScopedId(FEED_ID, "1"))
+      .of(new FeedScopedId(agencyId, "1"))
       .withCoordinate(new WgsCoordinate(1, 1))
       .withName(new NonLocalizedString(firstStopName))
       .build();
     RegularStop lastStop = RegularStop
-      .of(new FeedScopedId(FEED_ID, "2"))
+      .of(new FeedScopedId(agencyId, "2"))
       .withCoordinate(new WgsCoordinate(1, 2))
       .withName(new NonLocalizedString(lastStopName))
       .build();
 
-    FeedScopedId routeFeedScopeId = new FeedScopedId(FEED_ID, routeId);
+    FeedScopedId routeFeedScopeId = new FeedScopedId(agencyId, routeId);
     NonLocalizedString longName = null;
     if (routeLongName != null) {
       longName = new NonLocalizedString(routeLongName);

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -90,6 +90,12 @@ public class DefaultFareService implements FareService {
     return fareRulesPerType;
   }
 
+  protected Map<String, List<Leg>> fareLegsByFeed(List<Leg> fareLegs) {
+    return fareLegs
+      .stream()
+      .collect(Collectors.groupingBy(leg -> leg.getAgency().getId().getFeedId()));
+  }
+
   @Override
   public ItineraryFares calculateFares(Itinerary itinerary) {
     var fareLegs = itinerary
@@ -105,9 +111,7 @@ public class DefaultFareService implements FareService {
     if (fareLegs.isEmpty()) {
       return null;
     }
-    var fareLegsByFeed = fareLegs
-      .stream()
-      .collect(Collectors.groupingBy(leg -> leg.getAgency().getId().getFeedId()));
+    var fareLegsByFeed = fareLegsByFeed(fareLegs);
 
     ItineraryFares fare = ItineraryFares.empty();
     boolean hasFare = false;

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -90,6 +90,9 @@ public class DefaultFareService implements FareService {
     return fareRulesPerType;
   }
 
+  /**
+   * Takes a legs and returns a map of their agency's feed id and all corresponding legs.
+   */
   protected Map<String, List<Leg>> fareLegsByFeed(List<Leg> fareLegs) {
     return fareLegs
       .stream()

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -614,6 +614,15 @@ public class OrcaFareService extends DefaultFareService {
   }
 
   /**
+   * Disables functionality grouping legs by their feed.
+   * This ensures we can calculate transfers between agencies/feeds.
+   */
+  @Override
+  protected Map<String, List<Leg>> fareLegsByFeed(List<Leg> fareLegs) {
+    return Map.of(FEED_ID, fareLegs);
+  }
+
+  /**
    * Check if trip falls within the transfer time window.
    */
   private boolean inFreeTransferWindow(


### PR DESCRIPTION
### Summary

The recent changes to fares which grouped legs by their feed ID broke the ORCA fare module's ability to calculate transfers between different agencies. This PR changes the ORCA fare module tests to also test the complexity contained in the super class. Then, it moves the feed grouping logic into an overrideable method which the ORCA module overrides to group all the legs together.  

### Unit tests

The tests are updated and improved to ensure that this bug would be caught in the future, and then they are used to correct the bug. The results have been double checked by testing some trip plans. 