### PR TITLE
Filter out null, empty and blank elements when mapping feed-scoped ids

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapperTest.java
@@ -1,0 +1,72 @@
+package org.opentripplanner.ext.transmodelapi.mapping;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+class TransitIdMapperTest {
+
+  private static final String FEED_ID = "xxx";
+  private static final String ID = "yyy";
+
+  @Test
+  void testMapValidId() {
+    TransitIdMapper.clearFixedFeedId();
+    FeedScopedId mappedID = TransitIdMapper.mapIDToDomain(FEED_ID + ":" + ID);
+    assertNotNull(mappedID);
+    assertEquals(FEED_ID, mappedID.getFeedId());
+    assertEquals(ID, mappedID.getId());
+  }
+
+  @Test
+  void testMapInvalidId() {
+    TransitIdMapper.clearFixedFeedId();
+    assertThrows(IllegalArgumentException.class, () -> TransitIdMapper.mapIDToDomain("invalid"));
+  }
+
+  @Test
+  void testMapNullId() {
+    assertNull(TransitIdMapper.mapIDToDomain(null));
+  }
+
+  @Test
+  void testMapEmptyId() {
+    assertNull(TransitIdMapper.mapIDToDomain(""));
+  }
+
+  @Test
+  void testMapBlankId() {
+    assertNull(TransitIdMapper.mapIDToDomain(" "));
+  }
+
+  @Test
+  void testMapNullCollectionOfIds() {
+    assertNotNull(TransitIdMapper.mapIDsToDomainNullSafe(null));
+  }
+
+  @Test
+  void testMapEmptyCollectionOfIds() {
+    assertNotNull(TransitIdMapper.mapIDsToDomainNullSafe(Set.of()));
+  }
+
+  @Test
+  void testMapCollectionOfNullIds() {
+    List<FeedScopedId> mappedIds = TransitIdMapper.mapIDsToDomainNullSafe(
+      Arrays.asList(new String[] { null })
+    );
+    assertNotNull(mappedIds);
+    assertTrue(mappedIds.isEmpty());
+  }
+
+  @Test
+  void testMapCollectionOfEmptyIds() {
+    List<FeedScopedId> mappedIds = TransitIdMapper.mapIDsToDomainNullSafe(List.of(""));
+    assertNotNull(mappedIds);
+    assertTrue(mappedIds.isEmpty());
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -3,7 +3,7 @@ package org.opentripplanner.ext.transmodelapi;
 import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 import static org.opentripplanner.ext.transmodelapi.mapping.SeverityMapper.getTransmodelSeverity;
-import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomain;
+import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomainNullSafe;
 import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.FILTER_PLACE_TYPE_ENUM;
 import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.MULTI_MODAL_MODE;
 import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.TRANSPORT_MODE;
@@ -1297,7 +1297,7 @@ public class TransmodelGraphQLSchema {
               .build()
           )
           .dataFetcher(environment -> {
-            List<FeedScopedId> lineIds = mapIDsToDomain(
+            List<FeedScopedId> lineIds = mapIDsToDomainNullSafe(
               environment.getArgumentOrDefault("lines", List.of())
             );
             List<String> privateCodes = environment.getArgumentOrDefault("privateCodes", List.of());

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/FilterMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/FilterMapper.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.ext.transmodelapi.mapping;
 
-import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomain;
+import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomainNullSafe;
 
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
@@ -43,7 +43,7 @@ class FilterMapper {
     var bannedAgencies = new ArrayList<FeedScopedId>();
     callWith.argument(
       "banned.authorities",
-      (Collection<String> authorities) -> bannedAgencies.addAll(mapIDsToDomain(authorities))
+      (Collection<String> authorities) -> bannedAgencies.addAll(mapIDsToDomainNullSafe(authorities))
     );
     if (!bannedAgencies.isEmpty()) {
       filterRequestBuilder.addNot(SelectRequest.of().withAgencies(bannedAgencies).build());
@@ -52,7 +52,7 @@ class FilterMapper {
     var bannedLines = new ArrayList<FeedScopedId>();
     callWith.argument(
       "banned.lines",
-      (List<String> lines) -> bannedLines.addAll(mapIDsToDomain(lines))
+      (List<String> lines) -> bannedLines.addAll(mapIDsToDomainNullSafe(lines))
     );
     if (!bannedLines.isEmpty()) {
       filterRequestBuilder.addNot(SelectRequest.of().withRoutes(bannedLines).build());
@@ -63,7 +63,8 @@ class FilterMapper {
     var whiteListedAgencies = new ArrayList<FeedScopedId>();
     callWith.argument(
       "whiteListed.authorities",
-      (Collection<String> authorities) -> whiteListedAgencies.addAll(mapIDsToDomain(authorities))
+      (Collection<String> authorities) ->
+        whiteListedAgencies.addAll(mapIDsToDomainNullSafe(authorities))
     );
     if (!whiteListedAgencies.isEmpty()) {
       selectors.add(SelectRequest.of().withAgencies(whiteListedAgencies));
@@ -72,7 +73,7 @@ class FilterMapper {
     var whiteListedLines = new ArrayList<FeedScopedId>();
     callWith.argument(
       "whiteListed.lines",
-      (List<String> lines) -> whiteListedLines.addAll(mapIDsToDomain(lines))
+      (List<String> lines) -> whiteListedLines.addAll(mapIDsToDomainNullSafe(lines))
     );
     if (!whiteListedLines.isEmpty()) {
       selectors.add(SelectRequest.of().withRoutes(whiteListedLines));

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/SelectRequestMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/SelectRequestMapper.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.ext.transmodelapi.mapping;
 
-import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomain;
+import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomainNullSafe;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,17 +19,17 @@ class SelectRequestMapper {
 
     if (input.containsKey("lines")) {
       var lines = (List<String>) input.get("lines");
-      selectRequestBuilder.withRoutes(mapIDsToDomain(lines));
+      selectRequestBuilder.withRoutes(mapIDsToDomainNullSafe(lines));
     }
 
     if (input.containsKey("authorities")) {
       var authorities = (List<String>) input.get("authorities");
-      selectRequestBuilder.withAgencies(mapIDsToDomain(authorities));
+      selectRequestBuilder.withAgencies(mapIDsToDomainNullSafe(authorities));
     }
 
     if (input.containsKey("groupOfLines")) {
       var groupOfLines = (List<String>) input.get("groupOfLines");
-      selectRequestBuilder.withGroupOfRoutes(mapIDsToDomain(groupOfLines));
+      selectRequestBuilder.withGroupOfRoutes(mapIDsToDomainNullSafe(groupOfLines));
     }
 
     if (input.containsKey("transportModes")) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapper.java
@@ -1,10 +1,12 @@
 package org.opentripplanner.ext.transmodelapi.mapping;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.opentripplanner.framework.lang.StringUtils;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.slf4j.Logger;
@@ -32,19 +34,17 @@ public class TransitIdMapper {
     return id.toString();
   }
 
-  public static List<FeedScopedId> mapIDsToDomainNullSafe(Collection<String> ids) {
-    return (ids == null) ? List.of() : mapIDsToDomain(ids);
-  }
-
-  public static List<FeedScopedId> mapIDsToDomain(Collection<String> ids) {
+  /**
+   * Maps ids to feed-scoped ids.
+   * Return an empty collection if the collection of ids is null.
+   * If the collection of ids contains null or blank elements, they are ignored.
+   */
+  @Nonnull
+  public static List<FeedScopedId> mapIDsToDomainNullSafe(@Nullable Collection<String> ids) {
     if (ids == null) {
-      return null;
+      return List.of();
     }
-    List<FeedScopedId> list = new ArrayList<>();
-    for (String id : ids) {
-      list.add(mapIDToDomain(id));
-    }
-    return list;
+    return ids.stream().filter(StringUtils::hasValue).map(TransitIdMapper::mapIDToDomain).toList();
   }
 
   public static FeedScopedId mapIDToDomain(String id) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TripRequestMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TripRequestMapper.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.ext.transmodelapi.mapping;
 
-import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomain;
+import static org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper.mapIDsToDomainNullSafe;
 
 import graphql.schema.DataFetchingEnvironment;
 import java.time.Duration;
@@ -66,22 +66,23 @@ public class TripRequestMapper {
     callWith.argument(
       "preferred.authorities",
       (Collection<String> authorities) ->
-        request.journey().transit().setPreferredAgencies(mapIDsToDomain(authorities))
+        request.journey().transit().setPreferredAgencies(mapIDsToDomainNullSafe(authorities))
     );
     callWith.argument(
       "unpreferred.authorities",
       (Collection<String> authorities) ->
-        request.journey().transit().setUnpreferredAgencies(mapIDsToDomain(authorities))
+        request.journey().transit().setUnpreferredAgencies(mapIDsToDomainNullSafe(authorities))
     );
 
     callWith.argument(
       "preferred.lines",
-      (List<String> lines) -> request.journey().transit().setPreferredRoutes(mapIDsToDomain(lines))
+      (List<String> lines) ->
+        request.journey().transit().setPreferredRoutes(mapIDsToDomainNullSafe(lines))
     );
     callWith.argument(
       "unpreferred.lines",
       (List<String> lines) ->
-        request.journey().transit().setUnpreferredRoutes(mapIDsToDomain(lines))
+        request.journey().transit().setUnpreferredRoutes(mapIDsToDomainNullSafe(lines))
     );
 
     callWith.argument(
@@ -103,7 +104,8 @@ public class TripRequestMapper {
     var bannedTrips = new ArrayList<FeedScopedId>();
     callWith.argument(
       "banned.serviceJourneys",
-      (Collection<String> serviceJourneys) -> bannedTrips.addAll(mapIDsToDomain(serviceJourneys))
+      (Collection<String> serviceJourneys) ->
+        bannedTrips.addAll(mapIDsToDomainNullSafe(serviceJourneys))
     );
     if (!bannedTrips.isEmpty()) {
       request.journey().transit().setBannedTrips(bannedTrips);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
@@ -46,8 +46,9 @@ public class JourneyWhiteListed {
       this.authorityIds = Set.of();
       this.lineIds = Set.of();
     } else {
-      this.authorityIds = Set.copyOf(TransitIdMapper.mapIDsToDomain(whiteList.get("authorities")));
-      this.lineIds = Set.copyOf(TransitIdMapper.mapIDsToDomain(whiteList.get("lines")));
+      this.authorityIds =
+        Set.copyOf(TransitIdMapper.mapIDsToDomainNullSafe(whiteList.get("authorities")));
+      this.lineIds = Set.copyOf(TransitIdMapper.mapIDsToDomainNullSafe(whiteList.get("lines")));
     }
   }
 


### PR DESCRIPTION
### Summary

As detailed in #5398, specifying a null id in the list of whitelisted lines for estimated calls causes an exception.
Null values should not be allowed as input parameters in this case.

This PR provides a general fix by filtering out null, empty and blank values when mapping ids to feed-scoped ids.


### Issue

Closes #5398

### Unit tests

Added unit tests

### Documentation

No

