### PR TITLE
Validate stop id in Transit leg reference

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -350,7 +350,9 @@ public class ScheduledTransitLeg implements TransitLeg {
       tripTimes.getTrip().getId(),
       serviceDate,
       boardStopPosInPattern,
-      alightStopPosInPattern
+      alightStopPosInPattern,
+      tripPattern.getStops().get(boardStopPosInPattern).getId(),
+      tripPattern.getStops().get(alightStopPosInPattern).getId()
     );
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -26,19 +26,6 @@ public class LegReferenceSerializer {
 
   private static final Logger LOG = LoggerFactory.getLogger(LegReferenceSerializer.class);
 
-  // TODO: This is for backwards compatibility. Change to use ISO_LOCAL_DATE after OTP v2.2 is released
-  private static final DateTimeFormatter LENIENT_ISO_LOCAL_DATE = new DateTimeFormatterBuilder()
-    .appendValue(YEAR, 4)
-    .optionalStart()
-    .appendLiteral('-')
-    .optionalEnd()
-    .appendValue(MONTH_OF_YEAR, 2)
-    .optionalStart()
-    .appendLiteral('-')
-    .optionalEnd()
-    .appendValue(DAY_OF_MONTH, 2)
-    .toFormatter();
-
   /** private constructor to prevent instantiating this utility class */
   private LegReferenceSerializer() {}
 
@@ -93,18 +80,28 @@ public class LegReferenceSerializer {
       out.writeUTF(s.serviceDate().toString());
       out.writeInt(s.fromStopPositionInPattern());
       out.writeInt(s.toStopPositionInPattern());
+      out.writeUTF(s.fromStopId().toString());
+      out.writeUTF(s.toStopId().toString());
     } else {
       throw new IllegalArgumentException("Invalid LegReference type");
     }
   }
 
+  /**
+   * Deserialize a leg reference.
+   * To remain backward-compatible, additional fields (stopId) are read optionally.
+   * TODO: Remove backward-compatible logic after OTP release 2.6
+   *
+   */
   static LegReference readScheduledTransitLeg(ObjectInputStream objectInputStream)
     throws IOException {
     return new ScheduledTransitLegReference(
       FeedScopedId.parse(objectInputStream.readUTF()),
-      LocalDate.parse(objectInputStream.readUTF(), LENIENT_ISO_LOCAL_DATE),
+      LocalDate.parse(objectInputStream.readUTF(), DateTimeFormatter.ISO_LOCAL_DATE),
       objectInputStream.readInt(),
-      objectInputStream.readInt()
+      objectInputStream.readInt(),
+      objectInputStream.available() > 0 ? FeedScopedId.parse(objectInputStream.readUTF()) : null,
+      objectInputStream.available() > 0 ? FeedScopedId.parse(objectInputStream.readUTF()) : null
     );
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -90,7 +90,7 @@ public class LegReferenceSerializer {
   /**
    * Deserialize a leg reference.
    * To remain backward-compatible, additional fields (stopId) are read optionally.
-   * TODO: Remove backward-compatible logic after OTP release 2.6
+   * TODO: Remove backward-compatible logic after OTP release 2.5
    *
    */
   static LegReference readScheduledTransitLeg(ObjectInputStream objectInputStream)

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
@@ -3,40 +3,60 @@ package org.opentripplanner.model.plan.legreference;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * Enum for different types of LegReferences
  */
 enum LegReferenceType {
   SCHEDULED_TRANSIT_LEG_V1(
+    1,
     ScheduledTransitLegReference.class,
-    LegReferenceSerializer::writeScheduledTransitLeg,
-    LegReferenceSerializer::readScheduledTransitLeg
+    LegReferenceSerializer::writeScheduledTransitLegV1,
+    LegReferenceSerializer::readScheduledTransitLegV1
+  ),
+
+  SCHEDULED_TRANSIT_LEG_V2(
+    2,
+    ScheduledTransitLegReference.class,
+    LegReferenceSerializer::writeScheduledTransitLegV2,
+    LegReferenceSerializer::readScheduledTransitLegV2
   );
 
+  private final int version;
   private final Class<? extends LegReference> legReferenceClass;
 
   private final Writer<LegReference> serializer;
   private final Reader<? extends LegReference> deserializer;
 
   LegReferenceType(
+    int version,
     Class<? extends LegReference> legReferenceClass,
     Writer<LegReference> serializer,
     Reader<? extends LegReference> deserializer
   ) {
+    this.version = version;
     this.legReferenceClass = legReferenceClass;
     this.serializer = serializer;
     this.deserializer = deserializer;
   }
 
+  /**
+   * Return the latest LegReferenceType version for a given leg reference class.
+   */
   static LegReferenceType forClass(Class<? extends LegReference> legReferenceClass) {
-    for (var type : LegReferenceType.values()) {
-      if (type.legReferenceClass.equals(legReferenceClass)) {
-        return type;
-      }
-    }
-    return null;
+    Optional<LegReferenceType> latestVersion = Arrays
+      .stream(LegReferenceType.values())
+      .filter(legReferenceType -> legReferenceType.legReferenceClass.equals(legReferenceClass))
+      .reduce((legReferenceType, other) -> {
+        if (legReferenceType.version > other.version) {
+          return legReferenceType;
+        }
+        return other;
+      });
+
+    return latestVersion.orElse(null);
   }
 
   Writer<LegReference> getSerializer() {
@@ -54,6 +74,6 @@ enum LegReferenceType {
 
   @FunctionalInterface
   interface Reader<T> {
-    T read(ObjectInputStream in) throws IOException, ParseException;
+    T read(ObjectInputStream in) throws IOException;
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -9,6 +9,7 @@ import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.service.TransitService;
@@ -23,7 +24,10 @@ public record ScheduledTransitLegReference(
   FeedScopedId tripId,
   LocalDate serviceDate,
   int fromStopPositionInPattern,
-  int toStopPositionInPattern
+  int toStopPositionInPattern,
+  FeedScopedId fromStopId,
+
+  FeedScopedId toStopId
 )
   implements LegReference {
   private static final Logger LOG = LoggerFactory.getLogger(ScheduledTransitLegReference.class);
@@ -35,6 +39,10 @@ public record ScheduledTransitLegReference(
    * rolled out, or because a realtime update has modified a trip),
    * it may not be possible to reconstruct the leg.
    * In this case the method returns null.
+   * The method checks that the referenced stop positions still refer to the same stop ids.
+   * As an exception, the reference is still considered valid if the referenced stop is different
+   * but belongs to the same parent station: this covers for example the case of a last-minute
+   * platform change in a train station that typically does not affect the validity of the leg.
    */
   @Override
   @Nullable
@@ -66,6 +74,18 @@ public record ScheduledTransitLegReference(
         serviceDate,
         numStops
       );
+      return null;
+    }
+
+    if (
+      !matchReferencedStopInPattern(
+        tripPattern,
+        fromStopPositionInPattern,
+        fromStopId,
+        transitService
+      ) ||
+      !matchReferencedStopInPattern(tripPattern, toStopPositionInPattern, toStopId, transitService)
+    ) {
       return null;
     }
 
@@ -122,5 +142,61 @@ public record ScheduledTransitLegReference(
       .addTransitAlertsToLeg(leg, false);
 
     return leg;
+  }
+
+  /**
+   * Return false if the stop id in the reference does not match the actual stop id in the trip
+   * pattern.
+   * Return true in the specific case where the stop ids differ, but belong to the same parent
+   * station.
+   *
+   */
+  private boolean matchReferencedStopInPattern(
+    TripPattern tripPattern,
+    int stopPosition,
+    FeedScopedId stopId,
+    TransitService transitService
+  ) {
+    if (stopId == null) {
+      // this is a legacy reference, skip validation
+      // TODO: remove backward-compatible logic after OTP release 2.6
+      return true;
+    }
+
+    StopLocation stopLocationInPattern = tripPattern.getStops().get(stopPosition);
+    if (stopId.equals(stopLocationInPattern.getId())) {
+      return true;
+    }
+    StopLocation stopLocationInLegReference = transitService.getStopLocation(stopId);
+    if (
+      stopLocationInLegReference == null ||
+      stopLocationInPattern.getParentStation() == null ||
+      !stopLocationInPattern
+        .getParentStation()
+        .equals(stopLocationInLegReference.getParentStation())
+    ) {
+      LOG.info(
+        "Invalid transit leg reference:" +
+        " The referenced stop at position {} with id '{}' does not match" +
+        " the stop id '{}' in trip {} and service date {}",
+        stopPosition,
+        stopId,
+        stopLocationInPattern.getId(),
+        tripId,
+        serviceDate
+      );
+      return false;
+    }
+    LOG.info(
+      "Transit leg reference with modified stop id within the same station: " +
+      "The referenced stop at position {} with id '{}' does not match\" +\n" +
+      "        \" the stop id '{}' in trip {} and service date {}",
+      stopPosition,
+      stopId,
+      stopLocationInPattern.getId(),
+      tripId,
+      serviceDate
+    );
+    return true;
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -159,7 +159,7 @@ public record ScheduledTransitLegReference(
   ) {
     if (stopId == null) {
       // this is a legacy reference, skip validation
-      // TODO: remove backward-compatible logic after OTP release 2.6
+      // TODO: remove backward-compatible logic after OTP release 2.5
       return true;
     }
 

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -1,25 +1,38 @@
 package org.opentripplanner.model.plan.legreference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 class LegReferenceSerializerTest {
 
-  private static final FeedScopedId TRIP_ID = new FeedScopedId("F", "Trip");
+  private static final FeedScopedId TRIP_ID = TransitModelForTest.id("Trip");
   private static final LocalDate SERVICE_DATE = LocalDate.of(2022, 1, 31);
   private static final int FROM_STOP_POS = 1;
+
+  private static final FeedScopedId FROM_STOP_ID = TransitModelForTest.id("Boarding Stop");
   private static final int TO_STOP_POS = 3;
+  private static final FeedScopedId TO_STOP_ID = TransitModelForTest.id("Alighting Stop");
   private static final String ENCODED_TOKEN =
-    "rO0ABXc2ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAAD";
+    "rO0ABXdZABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAADAA9GOkJvYXJkaW5nIFN0b3AAEEY6QWxpZ2h0aW5nIFN0b3A=";
+
   private static final String ENCODED_LEGACY_TOKEN =
-    "rO0ABXc0ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAIMjAyMjAxMzEAAAABAAAAAw==";
+    "rO0ABXc2ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAAD";
 
   @Test
   void testScheduledTransitLegReferenceRoundTrip() {
-    var ref = new ScheduledTransitLegReference(TRIP_ID, SERVICE_DATE, 1, 3);
+    var ref = new ScheduledTransitLegReference(
+      TRIP_ID,
+      SERVICE_DATE,
+      FROM_STOP_POS,
+      TO_STOP_POS,
+      FROM_STOP_ID,
+      TO_STOP_ID
+    );
 
     var out = LegReferenceSerializer.encode(ref);
 
@@ -33,7 +46,7 @@ class LegReferenceSerializerTest {
   @Test
   void testScheduledTransitLegReferenceDeserialize() {
     var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN);
-
+    assertNotNull(ref);
     assertEquals(TRIP_ID, ref.tripId());
     assertEquals(SERVICE_DATE, ref.serviceDate());
     assertEquals(FROM_STOP_POS, ref.fromStopPositionInPattern());

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -17,9 +17,16 @@ class LegReferenceSerializerTest {
   private static final FeedScopedId FROM_STOP_ID = TransitModelForTest.id("Boarding Stop");
   private static final int TO_STOP_POS = 3;
   private static final FeedScopedId TO_STOP_ID = TransitModelForTest.id("Alighting Stop");
+
+  /**
+   * Token based on the latest format, including stop ids.
+   */
   private static final String ENCODED_TOKEN =
     "rO0ABXdZABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAADAA9GOkJvYXJkaW5nIFN0b3AAEEY6QWxpZ2h0aW5nIFN0b3A=";
 
+  /**
+   * Token based on the previous format, without stop ids.
+   */
   private static final String ENCODED_LEGACY_TOKEN =
     "rO0ABXc2ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAAD";
 

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -21,13 +21,13 @@ class LegReferenceSerializerTest {
   /**
    * Token based on the latest format, including stop ids.
    */
-  private static final String ENCODED_TOKEN =
-    "rO0ABXdZABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAADAA9GOkJvYXJkaW5nIFN0b3AAEEY6QWxpZ2h0aW5nIFN0b3A=";
+  private static final String ENCODED_TOKEN_V2 =
+    "rO0ABXdZABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjIABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAADAA9GOkJvYXJkaW5nIFN0b3AAEEY6QWxpZ2h0aW5nIFN0b3A=";
 
   /**
    * Token based on the previous format, without stop ids.
    */
-  private static final String ENCODED_LEGACY_TOKEN =
+  private static final String ENCODED_TOKEN_V1 =
     "rO0ABXc2ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAAD";
 
   @Test
@@ -43,7 +43,7 @@ class LegReferenceSerializerTest {
 
     var out = LegReferenceSerializer.encode(ref);
 
-    assertEquals(ENCODED_TOKEN, out);
+    assertEquals(ENCODED_TOKEN_V2, out);
 
     var ref2 = LegReferenceSerializer.decode(out);
 
@@ -52,7 +52,7 @@ class LegReferenceSerializerTest {
 
   @Test
   void testScheduledTransitLegReferenceDeserialize() {
-    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN);
+    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN_V2);
     assertNotNull(ref);
     assertEquals(TRIP_ID, ref.tripId());
     assertEquals(SERVICE_DATE, ref.serviceDate());
@@ -62,8 +62,8 @@ class LegReferenceSerializerTest {
 
   @Test
   void testScheduledTransitLegReferenceLegacyDeserialize() {
-    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_LEGACY_TOKEN);
-
+    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN_V1);
+    assertNotNull(ref);
     assertEquals(TRIP_ID, ref.tripId());
     assertEquals(SERVICE_DATE, ref.serviceDate());
     assertEquals(FROM_STOP_POS, ref.fromStopPositionInPattern());

--- a/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
@@ -21,6 +21,12 @@ import org.opentripplanner.transit.service.DefaultTransitService;
  */
 class AlternativeLegsTest extends GtfsTest {
 
+  private static final String FEED_ID = "FEED";
+  private static final FeedScopedId STOP_ID_B = new FeedScopedId(FEED_ID, "B");
+  private static final FeedScopedId STOP_ID_C = new FeedScopedId(FEED_ID, "C");
+  private static final FeedScopedId STOP_ID_X = new FeedScopedId(FEED_ID, "X");
+  private static final FeedScopedId STOP_ID_Y = new FeedScopedId(FEED_ID, "Y");
+
   @Override
   public String getFeedName() {
     return "gtfs/simple";
@@ -34,7 +40,9 @@ class AlternativeLegsTest extends GtfsTest {
       new FeedScopedId(this.feedId.getId(), "1.2"),
       LocalDate.parse("2022-04-02"),
       1,
-      2
+      2,
+      STOP_ID_B,
+      STOP_ID_C
     )
       .getLeg(transitService);
 
@@ -70,7 +78,9 @@ class AlternativeLegsTest extends GtfsTest {
       new FeedScopedId(this.feedId.getId(), "2.2"),
       LocalDate.parse("2022-04-02"),
       0,
-      1
+      1,
+      STOP_ID_B,
+      STOP_ID_C
     )
       .getLeg(transitService);
 
@@ -106,7 +116,9 @@ class AlternativeLegsTest extends GtfsTest {
       new FeedScopedId(this.feedId.getId(), "19.1"),
       LocalDate.parse("2022-04-02"),
       1,
-      2
+      2,
+      STOP_ID_X,
+      STOP_ID_Y
     )
       .getLeg(transitService);
 
@@ -137,7 +149,9 @@ class AlternativeLegsTest extends GtfsTest {
       new FeedScopedId(this.feedId.getId(), "19.1"),
       LocalDate.parse("2022-04-02"),
       1,
-      7
+      7,
+      STOP_ID_X,
+      STOP_ID_B
     )
       .getLeg(transitService);
 


### PR DESCRIPTION
### Summary
As detailed in  #5423, transit leg references currently refer to stop position, not stop id: if the trip pattern is changed by a real-time update, the leg reference could point to the wrong physical stop.

This PR verifies that the referenced stop positions still refer to the same stop ids in the actual pattern.
As an exception, the reference is considered valid if the referenced stop is different but belongs to the same parent station: this covers for example the case of a last-minute platform change in a train station that typically does not affect the validity of the leg.

This PR modifies the structure of the serialized leg id by adding new fields, but guarantees that existing (legacy) references will be deserialized successfully.

### Issue
Partially addresses #5423

### Unit tests

Added unit tests

### Documentation

No
