### PR TITLE
Bridge Dagger and Jersey, inject TransitService

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/FaresIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/FaresIntegrationTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.TestOtpModel;
-import org.opentripplanner.TestServerContext;
+import org.opentripplanner.TestServerContextBuilder;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.fare.ItineraryFares;
@@ -37,7 +37,11 @@ public class FaresIntegrationTest {
 
     var feedId = transitModel.getFeedIds().iterator().next();
 
-    var serverContext = TestServerContext.createServerContext(graph, transitModel);
+    var serverContext = TestServerContextBuilder
+      .of()
+      .withGraph(graph)
+      .withTransitModel(transitModel)
+      .serverContext();
 
     var start = LocalDateTime
       .of(2009, Month.AUGUST, 7, 12, 0, 0)
@@ -57,7 +61,11 @@ public class FaresIntegrationTest {
     TransitModel transitModel = model.transitModel();
     var portlandId = transitModel.getFeedIds().iterator().next();
 
-    var serverContext = TestServerContext.createServerContext(graph, transitModel);
+    var serverContext = TestServerContextBuilder
+      .of()
+      .withGraph(graph)
+      .withTransitModel(transitModel)
+      .serverContext();
 
     // from zone 3 to zone 2
     var from = GenericLocation.fromStopId(
@@ -115,7 +123,11 @@ public class FaresIntegrationTest {
     TransitModel transitModel = model.transitModel();
     String feedId = transitModel.getFeedIds().iterator().next();
 
-    var serverContext = TestServerContext.createServerContext(graph, transitModel);
+    var serverContext = TestServerContextBuilder
+      .of()
+      .withGraph(graph)
+      .withTransitModel(transitModel)
+      .serverContext();
 
     Money tenUSD = Money.usDollars(10);
 

--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.TestOtpModel;
-import org.opentripplanner.TestServerContext;
+import org.opentripplanner.TestServerContextBuilder;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.DirectTransferGenerator;
@@ -65,7 +65,13 @@ public class FlexIntegrationTest {
       transitModel,
       List.of(FlexTest.COBB_BUS_30_GTFS, FlexTest.MARTA_BUS_856_GTFS, FlexTest.COBB_FLEX_GTFS)
     );
-    service = TestServerContext.createServerContext(graph, transitModel).routingService();
+    service =
+      TestServerContextBuilder
+        .of()
+        .withGraph(graph)
+        .withTransitModel(transitModel)
+        .serverContext()
+        .routingService();
   }
 
   @Test
@@ -170,7 +176,7 @@ public class FlexIntegrationTest {
 
   @AfterAll
   static void teardown() {
-    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
+    OTPFeature.FlexRouting.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
   }
 
   private static void addGtfsToGraph(Graph graph, TransitModel transitModel, List<File> gtfsFiles) {

--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexTest.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.ext.flex.flexpathcalculator.DirectFlexPathCalculator;
 import org.opentripplanner.framework.application.OTPFeature;
@@ -20,6 +19,7 @@ import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
+// TODO: Using inheritance here is wrong, make this a utility class.
 public abstract class FlexTest {
 
   private static final ResourceLoader RES = ResourceLoader.of(FlexTest.class);
@@ -53,11 +53,11 @@ public abstract class FlexTest {
       graph,
       new ServiceDateInterval(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
     );
-    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
-    module.buildGraph();
-    transitModel.index();
-    graph.index(transitModel.getStopModel());
-    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
+    OTPFeature.FlexRouting.testOn(() -> {
+      module.buildGraph();
+      transitModel.index();
+      graph.index(transitModel.getStopModel());
+    });
     assertTrue(transitModel.hasFlexTrips());
     return new TestOtpModel(graph, transitModel);
   }

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -14,7 +14,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GraphUpdaterStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,8 +64,8 @@ public class ActuatorAPI {
   @GET
   @Path("/health")
   @Produces(MediaType.APPLICATION_JSON)
-  public Response health(@Context OtpServerRequestContext serverContext) {
-    GraphUpdaterStatus updaterStatus = serverContext.transitService().getUpdaterStatus();
+  public Response health(@Context TransitService transitService) {
+    GraphUpdaterStatus updaterStatus = transitService.getUpdaterStatus();
     if (updaterStatus != null) {
       var listUnprimedUpdaters = updaterStatus.listUnprimedUpdaters();
 

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -144,14 +144,17 @@ public class LuceneIndex implements Serializable {
     }
   }
 
-  public static synchronized LuceneIndex forServer(OtpServerRequestContext serverContext) {
+  public static synchronized LuceneIndex forServer(
+    OtpServerRequestContext serverContext,
+    TransitService transitService
+  ) {
     var graph = serverContext.graph();
     var existingIndex = graph.getLuceneIndex();
     if (existingIndex != null) {
       return existingIndex;
     }
 
-    var newIndex = new LuceneIndex(serverContext.transitService());
+    var newIndex = new LuceneIndex(transitService);
     graph.setLuceneIndex(newIndex);
     return newIndex;
   }

--- a/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
+++ b/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
@@ -17,6 +17,7 @@ import org.opentripplanner.routing.graphfinder.GraphFinder;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Created by demory on 7/26/18.
@@ -30,6 +31,7 @@ public class ParkAndRideResource {
 
   public ParkAndRideResource(
     @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService,
     /**
      * @deprecated The support for multiple routers are removed from OTP2.
      * See https://github.com/opentripplanner/OpenTripPlanner/issues/2760
@@ -42,7 +44,7 @@ public class ParkAndRideResource {
     //           - serverContext.graphFinder(). This needs at least a comment!
     //           - This can be replaced with a search done with the StopModel
     //           - if we have a radius search there.
-    this.graphFinder = new DirectGraphFinder(serverContext.transitService()::findRegularStop);
+    this.graphFinder = new DirectGraphFinder(transitService::findRegularStop);
   }
 
   /** Envelopes are in latitude, longitude format */

--- a/src/ext/java/org/opentripplanner/ext/reportapi/configure/ReportFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/configure/ReportFactory.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.ext.reportapi.configure;
+
+import dagger.Subcomponent;
+import org.opentripplanner.ext.reportapi.model.ReportService;
+import org.opentripplanner.framework.di.OtpServerRequest;
+import org.opentripplanner.routing.api.request.RouteRequest;
+
+@OtpServerRequest
+@Subcomponent
+public interface ReportFactory {
+  @OtpServerRequest
+  ReportService reportService();
+
+  @OtpServerRequest
+  RouteRequest defaultRequest();
+
+  @Subcomponent.Builder
+  interface Builder {
+    ReportFactory build();
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
@@ -6,11 +6,11 @@ import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 
 public class GraphReportBuilder {
 
-  public static GraphStats build(OtpServerRequestContext context) {
-    var transitService = context.transitService();
+  public static GraphStats build(OtpServerRequestContext context, TransitService transitService) {
     var graph = context.graph();
     var constrainedTransfers = transitService.getTransferService().listAll();
 

--- a/src/ext/java/org/opentripplanner/ext/reportapi/model/ReportService.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/model/ReportService.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.ext.reportapi.model;
+
+import jakarta.inject.Inject;
+import org.opentripplanner.framework.di.OtpServerRequest;
+import org.opentripplanner.model.transfer.TransferService;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.transit.service.TransitService;
+
+@OtpServerRequest
+public class ReportService {
+
+  private final TransferService transferService;
+  private final TransitService transitService;
+  private final RouteRequest defaultRequest;
+
+  @Inject
+  public ReportService(TransitService transitService, RouteRequest defaultRequest) {
+    this.transferService = transitService.getTransferService();
+    this.transitService = transitService;
+    this.defaultRequest = defaultRequest;
+  }
+
+  public TransferService getTransferService() {
+    return transferService;
+  }
+
+  public TransitService getTransitService() {
+    return transitService;
+  }
+
+  public RouteRequest getDefaultRequest() {
+    return defaultRequest;
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Objects;
+import org.opentripplanner.ext.reportapi.configure.ReportFactory;
 import org.opentripplanner.ext.reportapi.model.BicycleSafetyReport;
 import org.opentripplanner.ext.reportapi.model.CachedValue;
 import org.opentripplanner.ext.reportapi.model.GraphReportBuilder;
@@ -28,7 +30,7 @@ import org.opentripplanner.transit.service.TransitService;
 @Produces(MediaType.TEXT_PLAIN)
 public class ReportResource {
 
-  /** Since the computation is pretty expensive only allow it every 5 minutes */
+  /** Since the computation is pretty expensive, only allow it every 5 minutes */
   private static final CachedValue<GraphStats> cachedStats = new CachedValue<>(
     Duration.ofMinutes(5)
   );
@@ -38,13 +40,16 @@ public class ReportResource {
   private final RouteRequest defaultRequest;
 
   @SuppressWarnings("unused")
-  public ReportResource(
-    @Context OtpServerRequestContext requestContext,
-    @Context TransitService transitService
-  ) {
-    this.transferService = transitService.getTransferService();
-    this.transitService = transitService;
-    this.defaultRequest = requestContext.defaultRouteRequest();
+  public ReportResource(@Context ReportFactory reportFactory) {
+    var rs1 = reportFactory.reportService();
+    var rs2 = reportFactory.reportService();
+
+    System.err.println("ts.re: " + Objects.hashCode(rs1));
+    System.err.println("ts.re: " + Objects.hashCode(rs2));
+
+    this.transitService = rs1.getTransitService();
+    this.transferService = rs2.getTransferService();
+    this.defaultRequest = rs1.getDefaultRequest();
   }
 
   @GET

--- a/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -38,9 +38,12 @@ public class ReportResource {
   private final RouteRequest defaultRequest;
 
   @SuppressWarnings("unused")
-  public ReportResource(@Context OtpServerRequestContext requestContext) {
-    this.transferService = requestContext.transitService().getTransferService();
-    this.transitService = requestContext.transitService();
+  public ReportResource(
+    @Context OtpServerRequestContext requestContext,
+    @Context TransitService transitService
+  ) {
+    this.transferService = transitService.getTransferService();
+    this.transitService = transitService;
     this.defaultRequest = requestContext.defaultRouteRequest();
   }
 
@@ -99,7 +102,7 @@ public class ReportResource {
   public Response stats(@Context OtpServerRequestContext serverRequestContext) {
     return Response
       .status(Response.Status.OK)
-      .entity(cachedStats.get(() -> GraphReportBuilder.build(serverRequestContext)))
+      .entity(cachedStats.get(() -> GraphReportBuilder.build(serverRequestContext, transitService)))
       .type("application/json")
       .build();
   }

--- a/src/ext/java/org/opentripplanner/ext/restapi/resources/PlannerResource.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/resources/PlannerResource.java
@@ -20,6 +20,8 @@ import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.error.RoutingValidationException;
+import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +46,13 @@ public class PlannerResource extends RoutingResource {
   @Deprecated
   @PathParam("ignoreRouterId")
   private String ignoreRouterId;
+
+  public PlannerResource(
+    @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService
+  ) {
+    super(serverContext, transitService);
+  }
 
   // We inject info about the incoming request so we can include the incoming query
   // parameters in the outgoing response. This is a TriMet requirement.

--- a/src/ext/java/org/opentripplanner/ext/restapi/resources/Routers.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/resources/Routers.java
@@ -11,6 +11,7 @@ import org.opentripplanner.ext.restapi.model.ApiRouterInfo;
 import org.opentripplanner.ext.restapi.model.ApiRouterList;
 import org.opentripplanner.routing.error.GraphNotFoundException;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * This REST API endpoint returns some meta-info about a router. OTP2 does no longer support
@@ -29,9 +30,14 @@ import org.opentripplanner.standalone.api.OtpServerRequestContext;
 public class Routers {
 
   private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
 
-  public Routers(@Context OtpServerRequestContext serverContext) {
+  public Routers(
+    @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService
+  ) {
     this.serverContext = serverContext;
+    this.transitService = transitService;
   }
 
   /**
@@ -64,7 +70,7 @@ public class Routers {
       return new ApiRouterInfo(
         "default",
         serverContext.graph(),
-        serverContext.transitService(),
+        transitService,
         serverContext.vehicleRentalService(),
         serverContext.worldEnvelopeService().envelope().orElseThrow()
       );

--- a/src/ext/java/org/opentripplanner/ext/restapi/resources/Routers.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/resources/Routers.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import java.util.Objects;
 import org.opentripplanner.ext.restapi.model.ApiRouterInfo;
 import org.opentripplanner.ext.restapi.model.ApiRouterList;
 import org.opentripplanner.routing.error.GraphNotFoundException;
@@ -36,8 +37,8 @@ public class Routers {
     @Context OtpServerRequestContext serverContext,
     @Context TransitService transitService
   ) {
-    this.serverContext = serverContext;
-    this.transitService = transitService;
+    this.serverContext = Objects.requireNonNull(serverContext);
+    this.transitService = Objects.requireNonNull(transitService);
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/restapi/resources/RoutingResource.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/resources/RoutingResource.java
@@ -13,6 +13,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
@@ -702,8 +703,8 @@ public abstract class RoutingResource {
     @Context OtpServerRequestContext serverContext,
     @Context TransitService transitService
   ) {
-    this.serverContext = serverContext;
-    this.transitService = transitService;
+    this.serverContext = Objects.requireNonNull(serverContext);
+    this.transitService = Objects.requireNonNull(transitService);
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/restapi/resources/RoutingResource.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/resources/RoutingResource.java
@@ -34,6 +34,7 @@ import org.opentripplanner.standalone.config.framework.file.ConfigFileLoader;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.opentripplanner.standalone.config.routerequest.RouteRequestConfig;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +56,18 @@ import org.slf4j.LoggerFactory;
 public abstract class RoutingResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(RoutingResource.class);
+
+  /**
+   * somewhat ugly bug fix: the graphService is only needed here for fetching per-graph time zones.
+   * this should ideally be done when setting the routing context, but at present departure/ arrival
+   * time is stored in the request as an epoch time with the TZ already resolved, and other code
+   * depends on this behavior. (AMB) Alternatively, we could eliminate the separate RouteRequest
+   * objects and just resolve vertices and timezones here right away, but just ignore them in
+   * semantic equality checks.
+   */
+  protected OtpServerRequestContext serverContext;
+
+  protected TransitService transitService;
 
   /**
    * The start location -- either latitude, longitude pair in degrees or a Vertex label. For
@@ -685,16 +698,13 @@ public abstract class RoutingResource {
   @QueryParam("config")
   private String config;
 
-  /**
-   * somewhat ugly bug fix: the graphService is only needed here for fetching per-graph time zones.
-   * this should ideally be done when setting the routing context, but at present departure/ arrival
-   * time is stored in the request as an epoch time with the TZ already resolved, and other code
-   * depends on this behavior. (AMB) Alternatively, we could eliminate the separate RouteRequest
-   * objects and just resolve vertices and timezones here right away, but just ignore them in
-   * semantic equality checks.
-   */
-  @Context
-  protected OtpServerRequestContext serverContext;
+  public RoutingResource(
+    @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService
+  ) {
+    this.serverContext = serverContext;
+    this.transitService = transitService;
+  }
 
   /**
    * Range/sanity check the query parameter fields and build a Request object from them.
@@ -712,7 +722,7 @@ public abstract class RoutingResource {
 
     {
       //FIXME: move into setter method on routing request
-      ZoneId tz = ZoneIdFallback.zoneId(serverContext.transitService().getTimeZone());
+      ZoneId tz = ZoneIdFallback.zoneId(transitService.getTimeZone());
       if (date == null && time != null) { // Time was provided but not date
         LOG.debug("parsing ISO datetime {}", time);
         try {

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -75,6 +75,7 @@ public class TravelTimeResource {
 
   public TravelTimeResource(
     @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService,
     @QueryParam("location") String location,
     @QueryParam("time") String time,
     @QueryParam("cutoff") @DefaultValue("60m") List<String> cutoffs,
@@ -82,7 +83,7 @@ public class TravelTimeResource {
     @QueryParam("arriveBy") @DefaultValue("false") boolean arriveBy
   ) {
     this.graph = serverContext.graph();
-    this.transitService = serverContext.transitService();
+    this.transitService = transitService;
     routingRequest = serverContext.defaultRouteRequest();
     routingRequest.setArriveBy(arriveBy);
 

--- a/src/main/java/org/opentripplanner/api/resource/UpdaterStatusResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/UpdaterStatusResource.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GraphUpdaterStatus;
 
 /**
@@ -18,23 +18,23 @@ import org.opentripplanner.updater.GraphUpdaterStatus;
 @Produces(MediaType.APPLICATION_JSON)
 public class UpdaterStatusResource {
 
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
 
   public UpdaterStatusResource(
-    @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService,
     /**
      * @deprecated The support for multiple routers are removed from OTP2.
      * See https://github.com/opentripplanner/OpenTripPlanner/issues/2760
      */
     @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
   ) {
-    this.serverContext = serverContext;
+    this.transitService = transitService;
   }
 
   /** Return a list of all agencies in the graph. */
   @GET
   public Response getUpdaters() {
-    GraphUpdaterStatus updaterStatus = serverContext.transitService().getUpdaterStatus();
+    GraphUpdaterStatus updaterStatus = transitService.getUpdaterStatus();
     if (updaterStatus == null) {
       return Response.status(Response.Status.NOT_FOUND).entity("No updaters running.").build();
     }
@@ -48,7 +48,7 @@ public class UpdaterStatusResource {
   @GET
   @Path("/{updaterId}")
   public Response getUpdaters(@PathParam("updaterId") int updaterId) {
-    GraphUpdaterStatus updaterStatus = serverContext.transitService().getUpdaterStatus();
+    GraphUpdaterStatus updaterStatus = transitService.getUpdaterStatus();
     if (updaterStatus == null) {
       return Response.status(Response.Status.NOT_FOUND).entity("No updaters running.").build();
     }

--- a/src/main/java/org/opentripplanner/apis/gtfs/GraphQLRequestContext.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/GraphQLRequestContext.java
@@ -21,10 +21,13 @@ public record GraphQLRequestContext(
   GraphFinder graphFinder,
   RouteRequest defaultRouteRequest
 ) {
-  public static GraphQLRequestContext ofServerContext(OtpServerRequestContext context) {
+  public static GraphQLRequestContext ofServerContext(
+    OtpServerRequestContext context,
+    TransitService transitService
+  ) {
     return new GraphQLRequestContext(
       context.routingService(),
-      context.transitService(),
+      transitService,
       context.graph().getFareService(),
       context.graph().getVehicleParkingService(),
       context.vehicleRentalService(),

--- a/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLAPI.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLAPI.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,10 +28,15 @@ public class GtfsGraphQLAPI {
   private static final Logger LOG = LoggerFactory.getLogger(GtfsGraphQLAPI.class);
 
   private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
   private final ObjectMapper deserializer = new ObjectMapper();
 
-  public GtfsGraphQLAPI(@Context OtpServerRequestContext serverContext) {
+  public GtfsGraphQLAPI(
+    @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService
+  ) {
     this.serverContext = serverContext;
+    this.transitService = transitService;
   }
 
   /**
@@ -41,9 +47,10 @@ public class GtfsGraphQLAPI {
 
     public GtfsGraphQLAPIOldPath(
       @Context OtpServerRequestContext serverContext,
+      @Context TransitService transitService,
       @PathParam("ignoreRouterId") String ignore
     ) {
-      super(serverContext);
+      super(serverContext, transitService);
     }
   }
 
@@ -95,7 +102,7 @@ public class GtfsGraphQLAPI {
       maxResolves,
       timeout,
       locale,
-      GraphQLRequestContext.ofServerContext(serverContext)
+      GraphQLRequestContext.ofServerContext(serverContext, transitService)
     );
   }
 
@@ -117,7 +124,7 @@ public class GtfsGraphQLAPI {
       maxResolves,
       timeout,
       locale,
-      GraphQLRequestContext.ofServerContext(serverContext)
+      GraphQLRequestContext.ofServerContext(serverContext, transitService)
     );
   }
 }

--- a/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
@@ -27,6 +27,7 @@ import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +45,13 @@ public class TransmodelAPI {
   private static Collection<String> tracingHeaderTags;
 
   private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
   private final TransmodelGraph index;
   private final ObjectMapper deserializer = new ObjectMapper();
 
   public TransmodelAPI(
     @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService,
     /**
      * @deprecated The support for multiple routers are removed from OTP2.
      * See https://github.com/opentripplanner/OpenTripPlanner/issues/2760
@@ -56,6 +59,7 @@ public class TransmodelAPI {
     @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
   ) {
     this.serverContext = serverContext;
+    this.transitService = transitService;
     this.index = new TransmodelGraph(schema);
   }
 
@@ -122,6 +126,7 @@ public class TransmodelAPI {
     return index.executeGraphQL(
       query,
       serverContext,
+      transitService,
       variables,
       operationName,
       maxResolves,
@@ -140,6 +145,7 @@ public class TransmodelAPI {
     return index.executeGraphQL(
       query,
       serverContext,
+      transitService,
       null,
       null,
       maxResolves,

--- a/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
@@ -25,6 +25,7 @@ import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.concurrent.OtpRequestThreadFactory;
 import org.opentripplanner.framework.lang.ObjectUtils;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ class TransmodelGraph {
   Response executeGraphQL(
     String query,
     OtpServerRequestContext serverContext,
+    TransitService transitService,
     Map<String, Object> variables,
     String operationName,
     int maxResolves,
@@ -54,7 +56,7 @@ class TransmodelGraph {
     try (var executionStrategy = new AbortOnTimeoutExecutionStrategy()) {
       variables = ObjectUtils.ifNotNull(variables, new HashMap<>());
       var instrumentation = createInstrumentation(maxResolves, tracingTags);
-      var transmodelRequestContext = createRequestContext(serverContext);
+      var transmodelRequestContext = createRequestContext(serverContext, transitService);
       var executionInput = createExecutionInput(
         query,
         serverContext,
@@ -92,12 +94,13 @@ class TransmodelGraph {
   }
 
   private static TransmodelRequestContext createRequestContext(
-    OtpServerRequestContext serverContext
+    OtpServerRequestContext serverContext,
+    TransitService transitService
   ) {
     return new TransmodelRequestContext(
       serverContext,
       serverContext.routingService(),
-      serverContext.transitService()
+      transitService
     );
   }
 

--- a/src/main/java/org/opentripplanner/framework/di/OtpServerRequest.java
+++ b/src/main/java/org/opentripplanner/framework/di/OtpServerRequest.java
@@ -1,0 +1,17 @@
+package org.opentripplanner.framework.di;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Scope;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+/**
+ * Tag your Resource @SubComponent (Factory) and the Servies it provides with this annotation.
+ * The annotation is used by dagger to create ONE instance per request(per sub-component).
+ */
+@Documented
+@Retention(RUNTIME)
+@Scope
+public @interface OtpServerRequest {
+}

--- a/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
@@ -7,11 +7,11 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
-import org.apache.hc.core5.http.ContentType;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.api.resource.WebMercatorTile;
 import org.opentripplanner.framework.io.HttpUtils;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Common functionality for creating a vector tile response.
@@ -26,7 +26,8 @@ public class VectorTileResponseFactory {
     List<String> requestedLayers,
     List<LayerParameters<LayerType>> availableLayers,
     LayerBuilderFactory<LayerType> layerBuilderFactory,
-    OtpServerRequestContext context
+    OtpServerRequestContext context,
+    TransitService transitService
   ) {
     VectorTile.Tile.Builder mvtBuilder = VectorTile.Tile.newBuilder();
     Envelope envelope = WebMercatorTile.tile2Envelope(x, y, z);
@@ -58,7 +59,7 @@ public class VectorTileResponseFactory {
       ) {
         cacheMaxSeconds = Math.min(cacheMaxSeconds, layerParameters.cacheMaxSeconds());
         VectorTile.Tile.Layer layer = layerBuilderFactory
-          .createLayerBuilder(layerParameters, locale, context)
+          .createLayerBuilder(layerParameters, locale, context, transitService)
           .build(envelope);
         mvtBuilder.addLayers(layer);
       }
@@ -80,7 +81,8 @@ public class VectorTileResponseFactory {
     LayerBuilder<?> createLayerBuilder(
       LayerParameters<LayerType> layerParameters,
       Locale locale,
-      OtpServerRequestContext context
+      OtpServerRequestContext context,
+      TransitService transitService
     );
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -17,6 +17,7 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.ItineraryFilterPreferences;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 
 public class RouteRequestToFilterChainMapper {
 
@@ -29,6 +30,7 @@ public class RouteRequestToFilterChainMapper {
   public static ItineraryListFilterChain createFilterChain(
     RouteRequest request,
     OtpServerRequestContext context,
+    TransitService transitService,
     Instant earliestDepartureTimeUsed,
     Duration searchWindowUsed,
     boolean removeWalkAllTheWayResults,
@@ -85,8 +87,8 @@ public class RouteRequestToFilterChainMapper {
         params.removeItinerariesWithSameRoutesAndStops()
       )
       .withTransitAlerts(
-        context.transitService().getTransitAlertService(),
-        context.transitService()::getMultiModalStationForStation
+        transitService.getTransitAlertService(),
+        transitService::getMultiModalStationForStation
       )
       .withSearchWindow(earliestDepartureTimeUsed, searchWindowUsed)
       .withPageCursorInputSubscriber(pageCursorInputSubscriber)

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
@@ -13,14 +13,19 @@ import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.search.TemporaryVerticesContainer;
+import org.opentripplanner.transit.service.TransitService;
 
 public class DirectFlexRouter {
 
-  public static List<Itinerary> route(
-    OtpServerRequestContext serverContext,
-    RouteRequest request,
-    AdditionalSearchDays additionalSearchDays
-  ) {
+  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+
+  public DirectFlexRouter(OtpServerRequestContext serverContext, TransitService transitService) {
+    this.serverContext = serverContext;
+    this.transitService = transitService;
+  }
+
+  public List<Itinerary> route(RouteRequest request, AdditionalSearchDays additionalSearchDays) {
     if (!StreetMode.FLEXIBLE.equals(request.journey().direct().mode())) {
       return Collections.emptyList();
     }
@@ -37,7 +42,7 @@ public class DirectFlexRouter {
       Collection<NearbyStop> accessStops = AccessEgressRouter.streetSearch(
         request,
         temporaryVertices,
-        serverContext.transitService(),
+        transitService,
         request.journey().direct(),
         serverContext.dataOverlayContext(request),
         false,
@@ -47,7 +52,7 @@ public class DirectFlexRouter {
       Collection<NearbyStop> egressStops = AccessEgressRouter.streetSearch(
         request,
         temporaryVertices,
-        serverContext.transitService(),
+        transitService,
         request.journey().direct(),
         serverContext.dataOverlayContext(request),
         true,
@@ -57,7 +62,7 @@ public class DirectFlexRouter {
 
       FlexRouter flexRouter = new FlexRouter(
         serverContext.graph(),
-        serverContext.transitService(),
+        transitService,
         serverContext.flexConfig(),
         request.dateTime(),
         request.arriveBy(),

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -12,15 +12,26 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.impl.GraphPathFinder;
+import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TemporaryVerticesContainer;
 import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.transit.service.TransitService;
 
+@HttpRequestScoped
 public class DirectStreetRouter {
 
-  public static List<Itinerary> route(OtpServerRequestContext serverContext, RouteRequest request) {
+  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+
+  public DirectStreetRouter(OtpServerRequestContext serverContext, TransitService transitService) {
+    this.serverContext = serverContext;
+    this.transitService = transitService;
+  }
+
+  public List<Itinerary> route(RouteRequest request) {
     if (request.journey().direct().mode() == StreetMode.NOT_SET) {
       return Collections.emptyList();
     }
@@ -51,7 +62,7 @@ public class DirectStreetRouter {
 
       // Convert the internal GraphPaths to itineraries
       final GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
-        serverContext.transitService().getTimeZone(),
+        transitService.getTimeZone(),
         serverContext.graph().streetNotesService,
         serverContext.graph().ellipsoidToGeoidDifference
       );

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -12,15 +12,15 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.impl.GraphPathFinder;
-import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.standalone.api.OtpServerRequestScope;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TemporaryVerticesContainer;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.transit.service.TransitService;
 
-@HttpRequestScoped
+@OtpServerRequestScope
 public class DirectStreetRouter {
 
   private final OtpServerRequestContext serverContext;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
@@ -24,14 +24,13 @@ public class FlexAccessEgressRouter {
     RouteRequest request,
     TemporaryVerticesContainer verticesContainer,
     OtpServerRequestContext serverContext,
+    TransitService transitService,
     AdditionalSearchDays searchDays,
     FlexConfig config,
     DataOverlayContext dataOverlayContext,
     boolean isEgress
   ) {
     OTPRequestTimeoutException.checkForTimeout();
-
-    TransitService transitService = serverContext.transitService();
 
     Collection<NearbyStop> accessStops = !isEgress
       ? AccessEgressRouter.streetSearch(

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
@@ -51,12 +51,12 @@ import org.opentripplanner.transit.service.TransitService;
  * for the synchronization. Only request scoped components need to be synchronized - they are
  * potentially lazy initialized.
  */
-@HttpRequestScoped
+@OtpServerRequestScope
 public interface OtpServerRequestContext {
   /**
    * A RouteRequest containing default parameters that will be cloned when handling each request.
    */
-  @HttpRequestScoped
+  @OtpServerRequestScope
   RouteRequest defaultRouteRequest();
 
   /**
@@ -68,7 +68,7 @@ public interface OtpServerRequestContext {
 
   Graph graph();
 
-  @HttpRequestScoped
+  @OtpServerRequestScope
   @Deprecated
   TransitService transitService();
 
@@ -78,7 +78,7 @@ public interface OtpServerRequestContext {
    * realtime update that happens during the request will not affect the returned service and will
    * not be visible to the request.
    */
-  @HttpRequestScoped
+  @OtpServerRequestScope
   RoutingService routingService();
 
   /**
@@ -111,7 +111,7 @@ public interface OtpServerRequestContext {
    * Callback which is injected into the {@code DirectStreetRouter}, used to visualize the
    * search.
    */
-  @HttpRequestScoped
+  @OtpServerRequestScope
   TraverseVisitor<State, Edge> traverseVisitor();
 
   default GraphFinder graphFinder() {

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
@@ -69,6 +69,7 @@ public interface OtpServerRequestContext {
   Graph graph();
 
   @HttpRequestScoped
+  @Deprecated
   TransitService transitService();
 
   /**

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestScope.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestScope.java
@@ -14,5 +14,5 @@ import java.lang.annotation.Target;
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)
 @Inherited
-public @interface HttpRequestScoped {
+public @interface OtpServerRequestScope {
 }

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -145,7 +145,7 @@ public class ConstructApplication {
   private Application createApplication() {
     LOG.info("Wiring up and configuring server.");
     setupTransitRoutingServer();
-    return new OTPWebApplication(routerConfig().server(), this::createServerContext);
+    return new OTPWebApplication(routerConfig().server(), this::createServerContext, factory);
   }
 
   private void setupTransitRoutingServer() {
@@ -177,7 +177,7 @@ public class ConstructApplication {
 
     if (OTPFeature.SandboxAPIGeocoder.isOn()) {
       LOG.info("Creating debug client geocoder lucene index");
-      LuceneIndex.forServer(createServerContext());
+      LuceneIndex.forServer(createServerContext(), factory.transitService());
     }
   }
 

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -60,7 +60,7 @@ public class ConstructApplication {
 
   private final CommandLineParameters cli;
   private final GraphBuilderDataSources graphBuilderDataSources;
-  private final ConstructApplicationFactory factory;
+  private final OtpServerFactory factory;
 
   /**
    * Create a new OTP configuration instance for a given directory.
@@ -84,7 +84,7 @@ public class ConstructApplication {
     var graphVisualizer = cli.visualize ? new GraphVisualizer(graph) : null;
 
     this.factory =
-      DaggerConstructApplicationFactory
+      DaggerOtpServerFactory
         .builder()
         .configModel(config)
         .graph(graph)
@@ -97,7 +97,7 @@ public class ConstructApplication {
         .build();
   }
 
-  public ConstructApplicationFactory getFactory() {
+  public OtpServerFactory getFactory() {
     return factory;
   }
 

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -145,7 +145,7 @@ public class ConstructApplication {
   private Application createApplication() {
     LOG.info("Wiring up and configuring server.");
     setupTransitRoutingServer();
-    return new OTPWebApplication(routerConfig().server(), this::createServerContext, factory);
+    return new OTPWebApplication(routerConfig().server(), factory);
   }
 
   private void setupTransitRoutingServer() {

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
@@ -47,7 +47,7 @@ import org.opentripplanner.visualizer.GraphVisualizer;
     RealtimeVehicleRepositoryModule.class,
     VehicleRentalServiceModule.class,
     VehicleRentalRepositoryModule.class,
-    ConstructApplicationModule.class,
+    OtpServerModule.class,
     RideHailingServicesModule.class,
     EmissionsServiceModule.class,
     StopConsolidationServiceModule.class,

--- a/src/main/java/org/opentripplanner/standalone/configure/OtpServerFactory.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OtpServerFactory.java
@@ -54,7 +54,7 @@ import org.opentripplanner.visualizer.GraphVisualizer;
     InteractiveLauncherModule.class,
   }
 )
-public interface ConstructApplicationFactory {
+public interface OtpServerFactory {
   ConfigModel config();
   RaptorConfig<TripSchedule> raptorConfig();
   Graph graph();
@@ -109,6 +109,6 @@ public interface ConstructApplicationFactory {
     @BindsInstance
     Builder emissionsDataModel(EmissionsDataModel emissionsDataModel);
 
-    ConstructApplicationFactory build();
+    OtpServerFactory build();
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/configure/OtpServerFactory.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OtpServerFactory.java
@@ -7,12 +7,14 @@ import javax.annotation.Nullable;
 import org.opentripplanner.ext.emissions.EmissionsDataModel;
 import org.opentripplanner.ext.emissions.EmissionsServiceModule;
 import org.opentripplanner.ext.interactivelauncher.configuration.InteractiveLauncherModule;
+import org.opentripplanner.ext.reportapi.configure.ReportFactory;
 import org.opentripplanner.ext.ridehailing.configure.RideHailingServicesModule;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationRepository;
 import org.opentripplanner.ext.stopconsolidation.configure.StopConsolidationServiceModule;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueSummary;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
@@ -75,6 +77,10 @@ public interface OtpServerFactory {
 
   TransitService transitService();
   OtpServerRequestContext createServerContext();
+
+  RouteRequest defaultRequest();
+
+  ReportFactory.Builder reportFactoryBuilder();
 
   MetricsLogging metricsLogging();
 

--- a/src/main/java/org/opentripplanner/standalone/configure/OtpServerModule.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OtpServerModule.java
@@ -23,7 +23,7 @@ import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.visualizer.GraphVisualizer;
 
 @Module
-public class ConstructApplicationModule {
+public class OtpServerModule {
 
   @Provides
   OtpServerRequestContext providesServerContext(

--- a/src/main/java/org/opentripplanner/standalone/configure/OtpServerModule.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OtpServerModule.java
@@ -8,10 +8,12 @@ import javax.annotation.Nullable;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.ext.emissions.EmissionsService;
 import org.opentripplanner.ext.interactivelauncher.api.LauncherRequestDecorator;
+import org.opentripplanner.ext.reportapi.configure.ReportFactory;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -22,7 +24,7 @@ import org.opentripplanner.standalone.server.DefaultServerRequestContext;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.visualizer.GraphVisualizer;
 
-@Module
+@Module(subcomponents = ReportFactory.class)
 public class OtpServerModule {
 
   @Provides
@@ -59,6 +61,11 @@ public class OtpServerModule {
       stopConsolidationService,
       traverseVisitor
     );
+  }
+
+  @Provides
+  RouteRequest defaultRequest(OtpServerRequestContext ctx) {
+    return ctx.defaultRouteRequest();
   }
 
   @Provides

--- a/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -161,7 +161,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
 
   @Override
   public RoutingService routingService() {
-    return new DefaultRoutingService(this);
+    return new DefaultRoutingService(this, transitService);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -21,13 +21,13 @@ import org.opentripplanner.routing.service.DefaultRoutingService;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
 import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
-import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.standalone.api.OtpServerRequestScope;
 import org.opentripplanner.standalone.config.routerconfig.TransitRoutingConfig;
 import org.opentripplanner.standalone.config.sandbox.FlexConfig;
 import org.opentripplanner.transit.service.TransitService;
 
-@HttpRequestScoped
+@OtpServerRequestScope
 public class DefaultServerRequestContext implements OtpServerRequestContext {
 
   private final List<RideHailingService> rideHailingServices;

--- a/src/main/java/org/opentripplanner/standalone/server/JerseyToDaggerBridge.java
+++ b/src/main/java/org/opentripplanner/standalone/server/JerseyToDaggerBridge.java
@@ -2,14 +2,14 @@ package org.opentripplanner.standalone.server;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.standalone.configure.ConstructApplicationFactory;
+import org.opentripplanner.standalone.configure.OtpServerFactory;
 import org.opentripplanner.transit.service.TransitService;
 
 public class JerseyToDaggerBridge extends AbstractBinder {
 
-  private final ConstructApplicationFactory factory;
+  private final OtpServerFactory factory;
 
-  public JerseyToDaggerBridge(ConstructApplicationFactory factory) {
+  public JerseyToDaggerBridge(OtpServerFactory factory) {
     this.factory = factory;
   }
 

--- a/src/main/java/org/opentripplanner/standalone/server/JerseyToDaggerBridge.java
+++ b/src/main/java/org/opentripplanner/standalone/server/JerseyToDaggerBridge.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.standalone.server;
+
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.standalone.configure.ConstructApplicationFactory;
+import org.opentripplanner.transit.service.TransitService;
+
+public class JerseyToDaggerBridge extends AbstractBinder {
+
+  private final ConstructApplicationFactory factory;
+
+  public JerseyToDaggerBridge(ConstructApplicationFactory factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  protected void configure() {
+    bindFactory(factory::transitService).to(TransitService.class);
+    bindFactory(factory::graph).to(Graph.class);
+  }
+}

--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -17,6 +17,7 @@ import org.glassfish.jersey.internal.inject.Binder;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
 import org.opentripplanner.api.common.OTPExceptionMapper;
 import org.opentripplanner.apis.APIEndpoints;
+import org.opentripplanner.ext.reportapi.configure.ReportFactory;
 import org.opentripplanner.ext.restapi.serialization.JSONObjectMapperProvider;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
@@ -138,6 +139,7 @@ public class OTPWebApplication extends Application {
       protected void configure() {
         bindFactory(factory::createServerContext).to(OtpServerRequestContext.class);
         bindFactory(factory::transitService).to(TransitService.class);
+        bindFactory(() -> factory.reportFactoryBuilder().build()).to(ReportFactory.class);
       }
     };
   }

--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -21,7 +21,7 @@ import org.opentripplanner.apis.APIEndpoints;
 import org.opentripplanner.ext.restapi.serialization.JSONObjectMapperProvider;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
-import org.opentripplanner.standalone.configure.ConstructApplicationFactory;
+import org.opentripplanner.standalone.configure.OtpServerFactory;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
@@ -38,7 +38,7 @@ public class OTPWebApplication extends Application {
   /* This object groups together all the modules for a single running OTP server. */
   private final Supplier<OtpServerRequestContext> contextProvider;
 
-  private final ConstructApplicationFactory factory;
+  private final OtpServerFactory factory;
 
   private final List<Class<? extends ContainerResponseFilter>> customFilters;
 
@@ -53,7 +53,7 @@ public class OTPWebApplication extends Application {
   public OTPWebApplication(
     OTPWebApplicationParameters parameters,
     Supplier<OtpServerRequestContext> contextProvider,
-    ConstructApplicationFactory factory
+    OtpServerFactory factory
   ) {
     this.contextProvider = contextProvider;
     this.factory = factory;

--- a/src/main/java/org/opentripplanner/transit/configure/TransitModule.java
+++ b/src/main/java/org/opentripplanner/transit/configure/TransitModule.java
@@ -2,7 +2,7 @@ package org.opentripplanner.transit.configure;
 
 import dagger.Binds;
 import dagger.Module;
-import org.opentripplanner.standalone.api.HttpRequestScoped;
+import org.opentripplanner.standalone.api.OtpServerRequestScope;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -10,6 +10,6 @@ import org.opentripplanner.transit.service.TransitService;
 public abstract class TransitModule {
 
   @Binds
-  @HttpRequestScoped
+  @OtpServerRequestScope
   abstract TransitService bind(DefaultTransitService service);
 }

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -204,7 +204,8 @@ public abstract class GtfsTest {
     gtfsGraphBuilderImpl.buildGraph();
     transitModel.index();
     graph.index(transitModel.getStopModel());
-    serverContext = TestServerContext.createServerContext(graph, transitModel);
+    serverContext =
+      TestServerContextBuilder.of().withGraph(graph).withTransitModel(transitModel).serverContext();
     timetableSnapshotSource =
       new TimetableSnapshotSource(
         TimetableSnapshotSourceParameters.DEFAULT.withPurgeExpiredData(false),

--- a/src/test/java/org/opentripplanner/TestServerContextBuilder.java
+++ b/src/test/java/org/opentripplanner/TestServerContextBuilder.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.opentripplanner.ext.emissions.DefaultEmissionsService;
 import org.opentripplanner.ext.emissions.EmissionsDataModel;
 import org.opentripplanner.ext.emissions.EmissionsService;
+import org.opentripplanner.framework.lang.ObjectUtils;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
@@ -23,28 +24,64 @@ import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 
-public class TestServerContext {
+public class TestServerContextBuilder {
 
-  private TestServerContext() {}
+  private Graph graph;
+  private TransitModel transitModel;
+  private TransitService transitService;
+
+  private TestServerContextBuilder() {}
+
+  public static TestServerContextBuilder of() {
+    return new TestServerContextBuilder();
+  }
+
+  public TestServerContextBuilder withGraph(Graph graph) {
+    this.graph = ObjectUtils.requireNotInitialized(this.graph, graph);
+    return this;
+  }
+
+  public Graph graph() {
+    if (graph == null) {
+      this.graph = new Graph();
+    }
+    return graph;
+  }
+
+  public TestServerContextBuilder withTransitModel(TransitModel transitModel) {
+    this.transitModel = ObjectUtils.requireNotInitialized(this.transitModel, transitModel);
+    return this;
+  }
+
+  private TransitModel transitModel() {
+    if (transitModel == null) {
+      this.transitModel = new TransitModel();
+    }
+
+    return transitModel;
+  }
+
+  public TransitService transitService() {
+    if (transitService == null) {
+      this.transitService = new DefaultTransitService(transitModel());
+    }
+    return transitService;
+  }
 
   /** Create a context for unit testing, using the default RouteRequest. */
-  public static OtpServerRequestContext createServerContext(
-    Graph graph,
-    TransitModel transitModel
-  ) {
-    transitModel.index();
+  public OtpServerRequestContext serverContext() {
+    transitModel().index();
     final RouterConfig routerConfig = RouterConfig.DEFAULT;
-    var transitService = new DefaultTransitService(transitModel);
     DefaultServerRequestContext context = DefaultServerRequestContext.create(
       routerConfig.transitTuningConfig(),
       routerConfig.routingRequestDefaults(),
       new RaptorConfig<>(routerConfig.transitTuningConfig()),
-      graph,
-      new DefaultTransitService(transitModel),
+      graph(),
+      new DefaultTransitService(transitModel()),
       Metrics.globalRegistry,
       routerConfig.vectorTileLayers(),
       createWorldEnvelopeService(),
-      createRealtimeVehicleService(transitService),
+      createRealtimeVehicleService(),
       createVehicleRentalService(),
       createEmissionsService(),
       routerConfig.flexConfig(),
@@ -52,20 +89,20 @@ public class TestServerContext {
       null,
       null
     );
-    creatTransitLayerForRaptor(transitModel, routerConfig.transitTuningConfig());
+    creatTransitLayerForRaptor(transitModel(), routerConfig.transitTuningConfig());
     return context;
   }
 
   /** Static factory method to create a service for test purposes. */
-  public static WorldEnvelopeService createWorldEnvelopeService() {
+  public WorldEnvelopeService createWorldEnvelopeService() {
     return new DefaultWorldEnvelopeService(new DefaultWorldEnvelopeRepository());
   }
 
-  public static RealtimeVehicleService createRealtimeVehicleService(TransitService transitService) {
-    return new DefaultRealtimeVehicleService(transitService);
+  public RealtimeVehicleService createRealtimeVehicleService() {
+    return new DefaultRealtimeVehicleService(transitService());
   }
 
-  public static VehicleRentalService createVehicleRentalService() {
+  public VehicleRentalService createVehicleRentalService() {
     return new DefaultVehicleRentalService();
   }
 

--- a/src/test/java/org/opentripplanner/ext/restapi/resources/PlannerResourceTest.java
+++ b/src/test/java/org/opentripplanner/ext/restapi/resources/PlannerResourceTest.java
@@ -9,26 +9,24 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.TestServerContext;
+import org.opentripplanner.TestServerContextBuilder;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.api.parameter.QualifiedModeSet;
 import org.opentripplanner.routing.api.request.RequestModes;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.service.TransitModel;
 
 class PlannerResourceTest {
 
-  static OtpServerRequestContext context() {
+  static TestServerContextBuilder context() {
     var transitModel = new TransitModel();
     transitModel.initTimeZone(ZoneIds.BERLIN);
-    return TestServerContext.createServerContext(new Graph(), transitModel);
+    return TestServerContextBuilder.of().withTransitModel(transitModel);
   }
 
   @Test
   void defaultValues() {
-    var resource = new PlannerResource();
-    resource.serverContext = context();
+    var context = context();
+    var resource = new PlannerResource(context.serverContext(), context.transitService());
 
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(new HashMap<>());
     var req = resource.buildRequest(queryParams);
@@ -38,10 +36,10 @@ class PlannerResourceTest {
 
   @Test
   void bicycleRent() {
-    var resource = new PlannerResource();
+    var context = context();
+    var resource = new PlannerResource(context.serverContext(), context.transitService());
 
     resource.modes = new QualifiedModeSet("BICYCLE_RENT");
-    resource.serverContext = context();
 
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(new HashMap<>());
     var req = resource.buildRequest(queryParams);

--- a/src/test/java/org/opentripplanner/inspector/vector/VectorTileResponseFactoryTest.java
+++ b/src/test/java/org/opentripplanner/inspector/vector/VectorTileResponseFactoryTest.java
@@ -7,18 +7,21 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.TestServerContext;
+import org.opentripplanner.TestServerContextBuilder;
 import org.opentripplanner.inspector.vector.geofencing.GeofencingZonesLayerBuilder;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 
 class VectorTileResponseFactoryTest {
 
-  public static final OtpServerRequestContext SERVER_CONTEXT = TestServerContext.createServerContext(
-    new Graph(),
-    new TransitModel()
-  );
+  public static final OtpServerRequestContext SERVER_CONTEXT;
+  private static final TransitService TRANSIT_SERVICE;
+
+  static {
+    var ctxBuilder = TestServerContextBuilder.of();
+    SERVER_CONTEXT = ctxBuilder.serverContext();
+    TRANSIT_SERVICE = ctxBuilder.transitService();
+  }
 
   enum LayerType {
     RED,
@@ -40,7 +43,8 @@ class VectorTileResponseFactoryTest {
   private static LayerBuilder<?> createLayerBuilder(
     LayerParameters<LayerType> layerParameters,
     Locale locale,
-    OtpServerRequestContext context
+    OtpServerRequestContext context,
+    TransitService transitService
   ) {
     return new GeofencingZonesLayerBuilder(context.graph(), layerParameters);
   }
@@ -54,7 +58,8 @@ class VectorTileResponseFactoryTest {
       layers,
       LAYERS,
       VectorTileResponseFactoryTest::createLayerBuilder,
-      SERVER_CONTEXT
+      SERVER_CONTEXT,
+      TRANSIT_SERVICE
     );
   }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
@@ -46,10 +46,13 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
     -122.67525
   );
 
+  public BikeRentalSnapshotTest() {
+    super(false);
+  }
+
   @BeforeAll
   public static void beforeClass() {
     Locale.setDefault(Locale.US);
-    loadGraphBeforeClass(false);
   }
 
   @AfterAll

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/CarSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/CarSnapshotTest.java
@@ -49,10 +49,13 @@ public class CarSnapshotTest extends SnapshotTestBase {
     -122.69771
   );
 
+  public CarSnapshotTest() {
+    super(false);
+  }
+
   @BeforeAll
   public static void beforeClass() {
     Locale.setDefault(Locale.US);
-    loadGraphBeforeClass(false);
   }
 
   @AfterAll

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
-import org.opentripplanner.ConstantsForTests;
-import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.modes.ExcludeAllTransitFilter;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -51,10 +49,13 @@ public class ElevationSnapshotTest extends SnapshotTestBase {
 
   static GenericLocation p4 = new GenericLocation("Sulzer Pump (P4)", null, 45.54549, -122.69659);
 
+  public ElevationSnapshotTest() {
+    super(true);
+  }
+
   @BeforeAll
   public static void beforeClass() {
     Locale.setDefault(Locale.US);
-    loadGraphBeforeClass(true);
   }
 
   @AfterAll
@@ -152,10 +153,5 @@ public class ElevationSnapshotTest extends SnapshotTestBase {
     request.setTo(p1);
 
     expectArriveByToMatchDepartAtAndSnapshot(request);
-  }
-
-  @Override
-  protected TestOtpModel getGraph() {
-    return ConstantsForTests.getInstance().getCachedPortlandGraphWithElevation();
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.algorithm.mapping;
 
 import au.com.origin.snapshots.junit5.SnapshotExtension;
 import java.util.List;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,9 +57,8 @@ public class TransitSnapshotTest extends SnapshotTestBase {
     -122.64699
   );
 
-  @BeforeAll
-  public static void beforeClass() {
-    loadGraphBeforeClass(false);
+  public TransitSnapshotTest() {
+    super(false);
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import org.opentripplanner.TestServerContext;
+import org.opentripplanner.TestServerContextBuilder;
 import org.opentripplanner.datastore.OtpDataStore;
 import org.opentripplanner.framework.application.OtpAppException;
 import org.opentripplanner.model.plan.Itinerary;
@@ -30,8 +30,8 @@ import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.ConfigModel;
 import org.opentripplanner.standalone.config.OtpConfigLoader;
 import org.opentripplanner.standalone.server.DefaultServerRequestContext;
-import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.speed_test.model.SpeedTestProfile;
 import org.opentripplanner.transit.speed_test.model.testcase.CsvFileSupport;
 import org.opentripplanner.transit.speed_test.model.testcase.ExpectedResults;
@@ -62,6 +62,7 @@ public class SpeedTest {
   private final Map<String, ExpectedResults> expectedResultsByTcId;
   private final Map<SpeedTestProfile, TestCases> lastSampleResult = new HashMap<>();
   private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
   private final Map<SpeedTestProfile, List<Integer>> workerResults = new HashMap<>();
   private final Map<SpeedTestProfile, List<Integer>> totalResults = new HashMap<>();
   private final CsvFileSupport tcIO;
@@ -76,6 +77,7 @@ public class SpeedTest {
   ) {
     this.opts = opts;
     this.config = config;
+    var ctxBuilder = TestServerContextBuilder.of().withGraph(graph).withTransitModel(transitModel);
     this.transitModel = transitModel;
 
     this.tcIO =
@@ -90,7 +92,7 @@ public class SpeedTest {
     this.testCaseDefinitions = tcIO.readTestCaseDefinitions();
     this.expectedResultsByTcId = tcIO.readExpectedResults();
 
-    var transitService = new DefaultTransitService(transitModel);
+    this.transitService = ctxBuilder.transitService();
 
     UpdaterConfigurator.configure(
       graph,
@@ -109,13 +111,13 @@ public class SpeedTest {
         config.request,
         new RaptorConfig<>(config.transitRoutingParams),
         graph,
-        new DefaultTransitService(transitModel),
+        transitService,
         timer.getRegistry(),
         List::of,
-        TestServerContext.createWorldEnvelopeService(),
-        TestServerContext.createRealtimeVehicleService(transitService),
-        TestServerContext.createVehicleRentalService(),
-        TestServerContext.createEmissionsService(),
+        ctxBuilder.createWorldEnvelopeService(),
+        ctxBuilder.createRealtimeVehicleService(),
+        ctxBuilder.createVehicleRentalService(),
+        ctxBuilder.createEmissionsService(),
         config.flexConfig,
         List.of(),
         null,


### PR DESCRIPTION
### Summary

This PR is a POK on how to BRIDGE Dagger and Jersey. The ideal would be to replace Jersey DI with Dagger, but bridging is much simpler. The only code needed to do this is in the `JerseyToDaggerBridge`, the rest of the changes is to proof that it works by injecting the TransitService.

In the current design the `OtpServerRequestContext` is responsible for providing a consistent set of Services for a Request coped Resource. I think we can merge this PR, but before we continue injecting other services directly into Resources we need to make sure we can provide a consistent set of RequestScopedServices. 

Also, I do NOT want to inject anything else then Services into the Resources, so if resource `AbcResource` is using the e.g. RouterConfig then a `AbcResourceService` class should be created. Dagger should then wire the `AbcResourceService` and Jersey should inject `AbcResourceService` into `AbcResource`. 



### Unit tests

Fixed.

### Documentation

TODO: I would like to document the layers and injection strategy:


### Changelog
Not relevant

### Bumping the serialization version id
No.
