### PR TITLE
Fix sort order bug in optimized transfers

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.raptor.api.model.RaptorTransfer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.RaptorCostConverter;
 import org.opentripplanner.routing.api.request.preference.WalkPreferences;
@@ -85,5 +86,14 @@ public class Transfer {
         this
       )
     );
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(Transfer.class)
+      .addNum("toStop", toStop)
+      .addNum("distance", distanceMeters, "m")
+      .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/costfilter/MinCostPathTailFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/costfilter/MinCostPathTailFilter.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.ToIntFunction;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.routing.algorithm.transferoptimization.model.OptimizedPathTail;
 import org.opentripplanner.routing.algorithm.transferoptimization.model.PathTailFilter;
@@ -63,5 +64,13 @@ class MinCostPathTailFilter<T extends RaptorTripSchedule> implements PathTailFil
       }
     }
     return result;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(MinCostPathTailFilter.class)
+      .addCol("costFunctions", costFunctions)
+      .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/passthrough/PassThroughPathTailFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/passthrough/PassThroughPathTailFilter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.raptor.api.request.PassThroughPoint;
 import org.opentripplanner.routing.algorithm.transferoptimization.model.OptimizedPathTail;
@@ -89,5 +90,14 @@ public class PassThroughPathTailFilter<T extends RaptorTripSchedule> implements 
       .collect(toSet());
 
     return filterChain.filterFinalResult(result);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(PassThroughPathTailFilter.class)
+      .addObj("c2Calculator", c2Calculator)
+      .addObj("filterChain", filterChain)
+      .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
@@ -106,7 +106,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
     List<TransitPathLeg<T>> transitLegs = originalPath.transitLegs().collect(Collectors.toList());
 
     // Find all possible transfers between each pair of transit legs, and sort on arrival time
-    var possibleTransfers = sortTransfersOnArrivalTimeInDecOrder(
+    var possibleTransfers = sortTransfersOnArrivalStopPosInDecOrder(
       transferGenerator.findAllPossibleTransfers(transitLegs)
     );
 
@@ -242,7 +242,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
     return tail.mutate().addTransitAndTransferLeg(originalLeg, tx);
   }
 
-  private List<List<TripToTripTransfer<T>>> sortTransfersOnArrivalTimeInDecOrder(
+  private List<List<TripToTripTransfer<T>>> sortTransfersOnArrivalStopPosInDecOrder(
     List<List<TripToTripTransfer<T>>> transfers
   ) {
     return transfers
@@ -250,7 +250,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
       .map(it ->
         it
           .stream()
-          .sorted(Comparator.comparingInt(l -> -l.to().time()))
+          .sorted(Comparator.comparingInt(l -> -l.to().stopPosition()))
           .collect(Collectors.toList())
       )
       .collect(Collectors.toList());

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
@@ -105,7 +105,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
   public Set<OptimizedPath<T>> findBestTransitPath(RaptorPath<T> originalPath) {
     List<TransitPathLeg<T>> transitLegs = originalPath.transitLegs().collect(Collectors.toList());
 
-    // Find all possible transfers between each pair of transit legs, and sort on arrival time
+    // Find all possible transfers between each pair of transit legs, and sort on stop position
     var possibleTransfers = sortTransfersOnArrivalStopPosInDecOrder(
       transferGenerator.findAllPossibleTransfers(transitLegs)
     );

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelector.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelector.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.transferoptimization.services;
 
 import java.util.HashSet;
 import java.util.Set;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.routing.algorithm.transferoptimization.model.OptimizedPathTail;
 import org.opentripplanner.routing.algorithm.transferoptimization.model.PathTailFilter;
@@ -74,5 +75,16 @@ class TransitPathLegSelector<T extends RaptorTripSchedule> {
     selectedLegs = filter.filterIntermediateResult(candidates, fromStopPosition);
 
     return selectedLegs;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(TransitPathLegSelector.class)
+      .addObj("filter", filter)
+      .addCol("remindingLegs", remindingLegs)
+      .addCol("selectedLegs", selectedLegs)
+      .addNum("prevStopPosition", prevStopPosition)
+      .toString();
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
@@ -286,7 +286,7 @@ public class OptimizePathDomainServiceTest implements RaptorTestConstants {
    * </pre>
    * Case: A trip may have the exact same times for more than one stop. This is a regression test
    *       see https://github.com/opentripplanner/OpenTripPlanner/issues/5444.
-   *       The following transfers are exist: A-B, A-C, B-B, B-C, C-B and C-C.
+   *       The following transfers exist: A-B, A-C, B-B, B-C, C-B and C-C.
    * Expect: Transfer B-B, the earliest transfer with the lowest transfer time and cost.
    */
   @Test


### PR DESCRIPTION
### Summary

The optimized path service relay on sorting transfer between two trips on the toTrip boardStopPosition. The sort function used board time, witch in most cases works. But, it is allowed to use the same time for two stops next to each other. Many trip schedules only uses minutes precision, so two stops close to each other can be visited within the same minute.

### Issue

Closes #5444

### Unit tests

A regression unit-test is added.

### Documentation

Not applicable.


### Changelog
✅ This is a minor bugfix.

### Bumping the serialization version id
No