### PR TITLE
Clean up fare attribute, remove non-standard senior and youth prices

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/FareModelForTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/FareModelForTest.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.ext.fares.impl;
 
-import static org.opentripplanner.transit.model._data.TransitModelForTest.FEED_ID;
-import static org.opentripplanner.transit.model._data.TransitModelForTest.OTHER_AGENCY;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.OTHER_FEED_AGENCY;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 
@@ -9,6 +7,7 @@ import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
+import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -57,15 +56,13 @@ public class FareModelForTest {
     .build();
   static FareAttribute TEN_DOLLARS = FareAttribute
     .of(id("airport-to-city-center"))
-    .setCurrencyType("USD")
-    .setPrice(10)
+    .setPrice(Money.usDollars(10))
     .setTransfers(0)
     .build();
 
   static FareAttribute OTHER_FEED_ATTRIBUTE = FareAttribute
     .of(FeedScopedId.ofNullable("F2", "other-feed-attribute"))
-    .setCurrencyType("USD")
-    .setPrice(10)
+    .setPrice(Money.usDollars(10))
     .setTransfers(1)
     .setAgency(OTHER_FEED_AGENCY.getId())
     .build();

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.fares.impl;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.FEED_ID;
+import static org.opentripplanner.transit.model.basic.Money.euros;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -20,6 +21,7 @@ import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.core.FareComponent;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -84,13 +86,13 @@ public class HSLFareServiceTest implements PlanTestConstants {
     Place D1 = PlanTestConstants.place("D1", 10.0, 12.0, D);
     Place D2 = PlanTestConstants.place("D2", 10.0, 12.0, D);
 
-    float AB_PRICE = 2.80f;
-    float BC_PRICE = 2.80f;
-    float CD_PRICE = 3.20f;
-    float ABC_PRICE = 4.10f;
-    float BCD_PRICE = 4.10f;
-    float ABCD_PRICE = 5.70f;
-    float D_PRICE = 2.80f;
+    var AB_PRICE = euros(2.80f);
+    var BC_PRICE = euros(2.80f);
+    var CD_PRICE = euros(3.20f);
+    var ABC_PRICE = euros(4.10f);
+    var BCD_PRICE = euros(4.10f);
+    var ABCD_PRICE = euros(5.70f);
+    var D_PRICE = euros(2.80f);
 
     HSLFareService hslFareService = new HSLFareService();
     int fiveMinutes = 60 * 5;
@@ -99,28 +101,24 @@ public class HSLFareServiceTest implements PlanTestConstants {
 
     FareAttribute fareAttributeAB = FareAttribute
       .of(new FeedScopedId(FEED_ID, "AB"))
-      .setCurrencyType("EUR")
       .setPrice(AB_PRICE)
       .setTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeBC = FareAttribute
       .of(new FeedScopedId(FEED_ID, "BC"))
-      .setCurrencyType("EUR")
       .setPrice(BC_PRICE)
       .setTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeCD = FareAttribute
       .of(new FeedScopedId(FEED_ID, "CD"))
-      .setCurrencyType("EUR")
       .setPrice(CD_PRICE)
       .setTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeD = FareAttribute
       .of(new FeedScopedId(FEED_ID, "D"))
-      .setCurrencyType("EUR")
       .setPrice(D_PRICE)
       .setTransferDuration(fiveMinutes)
       //.setAgency(agency1.getId().getId())
@@ -128,34 +126,31 @@ public class HSLFareServiceTest implements PlanTestConstants {
 
     FareAttribute fareAttributeABC = FareAttribute
       .of(new FeedScopedId(FEED_ID, "ABC"))
-      .setCurrencyType("EUR")
       .setPrice(ABC_PRICE)
       .setTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeBCD = FareAttribute
       .of(new FeedScopedId(FEED_ID, "BCD"))
-      .setCurrencyType("EUR")
       .setPrice(BCD_PRICE)
       .setTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeABCD = FareAttribute
       .of(new FeedScopedId(FEED_ID, "ABCD"))
-      .setCurrencyType("EUR")
       .setPrice(ABCD_PRICE)
       .setTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeD2 = FareAttribute
       .of(new FeedScopedId(FEED_ID, "D2"))
-      .setCurrencyType("EUR")
+      .setPrice(Money.euros(0))
       .setAgency(agency2.getId())
       .build();
 
     FareAttribute fareAttributeAgency3 = FareAttribute
       .of(new FeedScopedId("FEED2", "attribute"))
-      .setCurrencyType("EUR")
+      .setPrice(Money.euros(0))
       .setAgency(agency3.getId())
       .build();
 
@@ -439,8 +434,7 @@ public class HSLFareServiceTest implements PlanTestConstants {
   void unknownFare() {
     FareAttribute fareAttributeAB = FareAttribute
       .of(new FeedScopedId(FEED_ID, "AB"))
-      .setCurrencyType("EUR")
-      .setPrice(2.80f)
+      .setPrice(euros(2.80f))
       .setTransferDuration(60 * 5)
       .build();
 

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -40,11 +40,10 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     String testCaseName, // used to create parameterized test name
     FareService fareService,
     Itinerary i,
-    float expectedFare
+    Money expectedFare
   ) {
     var fares = fareService.calculateFares(i);
-    final Money expected = Money.usDollars(expectedFare);
-    assertEquals(expected, fares.getFare(FareType.regular));
+    assertEquals(expectedFare, fares.getFare(FareType.regular));
 
     for (var type : fares.getFareTypes()) {
       assertTrue(fares.getComponents(type).isEmpty());
@@ -55,7 +54,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
         .filter(fp -> fp.name().equals(type.name()))
         .map(FareProduct::price)
         .toList();
-      assertEquals(List.of(expected), prices);
+      assertEquals(List.of(expectedFare), prices);
     }
   }
 
@@ -71,10 +70,9 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     List<FareRuleSet> defaultFareRules = new LinkedList<>();
 
     // $1 fares
-    float oneDollar = 1.0f;
+    var oneDollar = Money.usDollars(1.0f);
     FareAttribute oneDollarFareAttribute = FareAttribute
       .of(new FeedScopedId(FEED_ID, "oneDollarAttribute"))
-      .setCurrencyType("USD")
       .setPrice(oneDollar)
       .build();
     FareRuleSet oneDollarRouteBasedFares = new FareRuleSet(oneDollarFareAttribute);
@@ -83,10 +81,9 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     defaultFareRules.add(oneDollarRouteBasedFares);
 
     // $2 fares
-    float twoDollars = 2.0f;
+    var twoDollars = Money.usDollars(2.0f);
     FareAttribute twoDollarFareAttribute = FareAttribute
       .of(new FeedScopedId(FEED_ID, "twoDollarAttribute"))
-      .setCurrencyType("USD")
       .setPrice(twoDollars)
       .build();
 
@@ -166,7 +163,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
         "Two transit legs, second leg starts outside free transfer window",
         defaultFareService,
         twoTransitLegSecondRouteHappensAfterFreeTransferWindowPath,
-        oneDollar + oneDollar
+        oneDollar.plus(oneDollar)
       )
     );
 
@@ -182,7 +179,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
         "Three transit legs, second leg starts outside free transfer window, third leg within second free transfer window",
         defaultFareService,
         threeTransitLegSecondRouteHappensAfterFreeTransferWindowPath,
-        oneDollar + oneDollar
+        oneDollar.plus(oneDollar)
       )
     );
 
@@ -198,7 +195,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
         "Three transit legs, all starting outside free transfer window",
         defaultFareService,
         threeTransitLegAllOutsideFreeTransferWindowPath,
-        oneDollar + oneDollar + oneDollar
+        oneDollar.plus(oneDollar).plus(oneDollar)
       )
     );
 

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -129,9 +129,7 @@ public class DefaultFareService implements FareService {
 
         // Get the currency from the first fareAttribute, assuming that all tickets use the same currency.
         if (fareRules != null && !fareRules.isEmpty()) {
-          Currency currency = Currency.getInstance(
-            fareRules.iterator().next().getFareAttribute().getCurrencyType()
-          );
+          Currency currency = fareRules.iterator().next().getFareAttribute().getPrice().currency();
           boolean feedHasFare = populateFare(
             currentFare,
             currency,
@@ -359,7 +357,7 @@ public class DefaultFareService implements FareService {
           journeyTime
         )
       ) {
-        Money newFare = getFarePrice(attribute, fareType);
+        Money newFare = attribute.getPrice();
         if (bestFare == null || newFare.lessThan(bestFare)) {
           bestAttribute = attribute;
           bestFare = newFare;
@@ -371,22 +369,6 @@ public class DefaultFareService implements FareService {
     return Optional
       .ofNullable(bestAttribute)
       .map(attribute -> new FareAndId(finalBestFare, attribute.getId()));
-  }
-
-  protected Money getFarePrice(FareAttribute fare, FareType type) {
-    var currency = Currency.getInstance(fare.getCurrencyType());
-    return switch (type) {
-      case senior:
-        if (fare.getSeniorPrice() >= 0) {
-          yield Money.ofFractionalAmount(currency, fare.getSeniorPrice());
-        }
-      case youth:
-        if (fare.getYouthPrice() >= 0) {
-          yield Money.ofFractionalAmount(currency, fare.getYouthPrice());
-        }
-      default:
-        yield Money.ofFractionalAmount(currency, fare.getPrice());
-    };
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
@@ -118,7 +118,7 @@ public class HSLFareService extends DefaultFareService {
             Duration.between(lastRideStartTime, startTime).getSeconds() <
             attribute.getTransferDuration()
           ) {
-            Money newFare = getFarePrice(attribute, fareType);
+            Money newFare = attribute.getPrice();
             if (newFare.lessThan(bestSpecialFare)) {
               bestSpecialFare = newFare;
               ruleZones = ruleSet.getContains();
@@ -181,7 +181,7 @@ public class HSLFareService extends DefaultFareService {
               );
             }
           }
-          Money newFare = getFarePrice(attribute, fareType);
+          Money newFare = attribute.getPrice();
           if (newFare.lessThan(bestFare)) {
             bestAttribute = attribute;
             bestFare = newFare;

--- a/src/ext/java/org/opentripplanner/ext/fares/model/FareAttribute.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/model/FareAttribute.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.fares.model;
 
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
@@ -10,9 +11,7 @@ public final class FareAttribute
   extends AbstractTransitEntity<FareAttribute, FareAttributeBuilder> {
 
   private FeedScopedId agency;
-  private final float price;
-
-  private final String currencyType;
+  private final Money price;
 
   private final int paymentMethod;
 
@@ -20,34 +19,21 @@ public final class FareAttribute
 
   private final Integer transferDuration;
 
-  /** youthPrice is an extension to the GTFS spec to support Seattle fare types. */
-  private final float youthPrice;
-
-  /** seniorPrice is an extension to the GTFS spec to support Seattle fare types. */
-  private final float seniorPrice;
-
   /** This is a proposed extension to the GTFS spec */
   private final Integer journeyDuration;
 
   FareAttribute(FareAttributeBuilder builder) {
     super(builder.getId());
-    this.price = builder.price();
-    this.currencyType = builder.currencyType();
+    this.price = Objects.requireNonNull(builder.price());
     this.paymentMethod = builder.paymentMethod();
     this.transfers = builder.transfers();
     this.transferDuration = builder.transferDuration();
-    this.youthPrice = builder.youthPrice();
-    this.seniorPrice = builder.seniorPrice();
     this.journeyDuration = builder.journeyDuration();
     this.agency = builder.agency();
   }
 
   public static FareAttributeBuilder of(FeedScopedId id) {
     return new FareAttributeBuilder(id);
-  }
-
-  public boolean isAgencySet() {
-    return agency != null;
   }
 
   public FeedScopedId getAgency() {
@@ -58,12 +44,8 @@ public final class FareAttribute
     this.agency = agency;
   }
 
-  public float getPrice() {
+  public Money getPrice() {
     return price;
-  }
-
-  public String getCurrencyType() {
-    return currencyType;
   }
 
   public int getPaymentMethod() {
@@ -94,25 +76,14 @@ public final class FareAttribute
     return journeyDuration;
   }
 
-  public float getYouthPrice() {
-    return youthPrice;
-  }
-
-  public float getSeniorPrice() {
-    return seniorPrice;
-  }
-
   @Override
   public boolean sameAs(@Nonnull FareAttribute other) {
     return (
       getId().equals(other.getId()) &&
-      price == other.getPrice() &&
-      Objects.equals(currencyType, other.getCurrencyType()) &&
+      getPrice().equals(other.getPrice()) &&
       paymentMethod == other.getPaymentMethod() &&
       Objects.equals(transfers, other.getTransfers()) &&
       Objects.equals(transferDuration, other.getTransferDuration()) &&
-      youthPrice == other.getYouthPrice() &&
-      seniorPrice == other.getSeniorPrice() &&
       Objects.equals(journeyDuration, other.getJourneyDuration())
     );
   }

--- a/src/ext/java/org/opentripplanner/ext/fares/model/FareAttributeBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/model/FareAttributeBuilder.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.fares.model;
 
+import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.framework.AbstractEntityBuilder;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
@@ -7,19 +8,13 @@ public class FareAttributeBuilder
   extends AbstractEntityBuilder<FareAttribute, FareAttributeBuilder> {
 
   private FeedScopedId agency;
-  private float price;
-
-  private String currencyType;
+  private Money price;
 
   private int paymentMethod;
 
   private Integer transfers;
 
   private Integer transferDuration;
-
-  private float youthPrice;
-
-  private float seniorPrice;
 
   private Integer journeyDuration;
 
@@ -31,12 +26,9 @@ public class FareAttributeBuilder
     super(original.getId());
     this.agency = original.getAgency();
     this.price = original.getPrice();
-    this.currencyType = original.getCurrencyType();
     this.paymentMethod = original.getPaymentMethod();
     this.transfers = original.getTransfers();
     this.transferDuration = original.getTransferDuration();
-    this.youthPrice = original.getYouthPrice();
-    this.seniorPrice = original.getSeniorPrice();
     this.journeyDuration = original.getJourneyDuration();
   }
 
@@ -49,21 +41,12 @@ public class FareAttributeBuilder
     return this;
   }
 
-  public float price() {
+  public Money price() {
     return price;
   }
 
-  public FareAttributeBuilder setPrice(float price) {
+  public FareAttributeBuilder setPrice(Money price) {
     this.price = price;
-    return this;
-  }
-
-  public String currencyType() {
-    return currencyType;
-  }
-
-  public FareAttributeBuilder setCurrencyType(String currencyType) {
-    this.currencyType = currencyType;
     return this;
   }
 
@@ -100,24 +83,6 @@ public class FareAttributeBuilder
 
   public FareAttributeBuilder setJourneyDuration(int journeyDuration) {
     this.journeyDuration = journeyDuration;
-    return this;
-  }
-
-  public float youthPrice() {
-    return youthPrice;
-  }
-
-  public FareAttributeBuilder setYouthPrice(float youthPrice) {
-    this.youthPrice = youthPrice;
-    return this;
-  }
-
-  public float seniorPrice() {
-    return seniorPrice;
-  }
-
-  public FareAttributeBuilder setSeniorPrice(float seniorPrice) {
-    this.seniorPrice = seniorPrice;
     return this;
   }
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TicketTypeImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TicketTypeImpl.java
@@ -12,7 +12,10 @@ public class TicketTypeImpl implements GraphQLDataFetchers.GraphQLTicketType {
   @Override
   public DataFetcher<String> currency() {
     return environment ->
-      ((FareRuleSet) environment.getSource()).getFareAttribute().getCurrencyType();
+      ((FareRuleSet) environment.getSource()).getFareAttribute()
+        .getPrice()
+        .currency()
+        .getCurrencyCode();
   }
 
   @Override
@@ -39,7 +42,10 @@ public class TicketTypeImpl implements GraphQLDataFetchers.GraphQLTicketType {
       symbols.setDecimalSeparator('.');
       format.setDecimalFormatSymbols(symbols);
       String price = format.format(
-        ((FareRuleSet) environment.getSource()).getFareAttribute().getPrice()
+        ((FareRuleSet) environment.getSource()).getFareAttribute()
+          .getPrice()
+          .fractionalAmount()
+          .floatValue()
       );
       return Double.valueOf(price);
     };

--- a/src/main/java/org/opentripplanner/gtfs/mapping/FareAttributeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/FareAttributeMapper.java
@@ -3,11 +3,13 @@ package org.opentripplanner.gtfs.mapping;
 import static org.opentripplanner.gtfs.mapping.AgencyAndIdMapper.mapAgencyAndId;
 
 import java.util.Collection;
+import java.util.Currency;
 import java.util.HashMap;
 import java.util.Map;
 import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.ext.fares.model.FareAttributeBuilder;
 import org.opentripplanner.framework.collection.MapUtils;
+import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /** Responsible for mapping GTFS FareAttribute into the OTP model. */
@@ -25,13 +27,14 @@ class FareAttributeMapper {
   }
 
   private FareAttribute doMap(org.onebusaway.gtfs.model.FareAttribute rhs) {
+    var price = Money.ofFractionalAmount(
+      Currency.getInstance(rhs.getCurrencyType()),
+      rhs.getPrice()
+    );
     FareAttributeBuilder builder = FareAttribute
       .of(mapAgencyAndId(rhs.getId()))
-      .setPrice(rhs.getPrice())
-      .setCurrencyType(rhs.getCurrencyType())
-      .setPaymentMethod(rhs.getPaymentMethod())
-      .setYouthPrice(rhs.getYouthPrice())
-      .setSeniorPrice(rhs.getSeniorPrice());
+      .setPrice(price)
+      .setPaymentMethod(rhs.getPaymentMethod());
 
     if (rhs.getId().getAgencyId() != null && rhs.getAgencyId() != null) {
       builder.setAgency(new FeedScopedId(rhs.getId().getAgencyId(), rhs.getAgencyId()));

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FareAttributeMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FareAttributeMapperTest.java
@@ -10,9 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Currency;
 import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.FareAttribute;
+import org.opentripplanner.transit.model.basic.Money;
 
 public class FareAttributeMapperTest {
 
@@ -35,6 +37,7 @@ public class FareAttributeMapperTest {
   private static final int TRANSFER_DURATION = 3;
 
   private static final int TRANSFERS = 2;
+  private static final Currency NOK = Currency.getInstance("NOK");
   private final FareAttributeMapper subject = new FareAttributeMapper();
 
   static {
@@ -61,12 +64,9 @@ public class FareAttributeMapperTest {
     org.opentripplanner.ext.fares.model.FareAttribute result = subject.map(FARE_ATTRIBUTE);
 
     assertEquals("A:1", result.getId().toString());
-    assertEquals(CURRENCY_TYPE, result.getCurrencyType());
     assertEquals(JOURNEY_DURATION, result.getJourneyDuration());
     assertEquals(PAY_MENTMETHOD, result.getPaymentMethod());
-    assertEquals(PRICE, result.getPrice(), 0.00001f);
-    assertEquals(SENIOR_PRICE, result.getSeniorPrice(), 0.00001f);
-    assertEquals(YOUTH_PRICE, result.getYouthPrice(), 0.00001f);
+    assertEquals(Money.ofFractionalAmount(NOK, PRICE), result.getPrice());
     assertEquals(TRANSFER_DURATION, result.getTransferDuration());
     assertEquals(TRANSFERS, result.getTransfers());
   }
@@ -75,15 +75,13 @@ public class FareAttributeMapperTest {
   public void testMapWithNulls() throws Exception {
     FareAttribute orginal = new FareAttribute();
     orginal.setId(ID);
+    orginal.setCurrencyType("EUR");
     org.opentripplanner.ext.fares.model.FareAttribute result = subject.map(orginal);
 
     assertNotNull(result.getId());
-    assertNull(result.getCurrencyType());
     assertFalse(result.isJourneyDurationSet());
     assertEquals(0, result.getPaymentMethod());
-    assertEquals(0, result.getPrice(), 0.001d);
-    assertEquals(0, result.getSeniorPrice(), 0.001d);
-    assertEquals(0, result.getYouthPrice(), 0.001d);
+    assertEquals(Money.euros(0), result.getPrice());
     assertFalse(result.isTransferDurationSet());
     assertFalse(result.isTransfersSet());
   }

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FareRuleMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FareRuleMapperTest.java
@@ -41,6 +41,7 @@ public class FareRuleMapperTest {
     var data = new GtfsTestData();
 
     FARE_ATTRIBUTE.setId(AGENCY_AND_ID);
+    FARE_ATTRIBUTE.setCurrencyType("USD");
 
     FARE_RULE.setId(ID);
     FARE_RULE.setContainsId(CONTAINS_ID);
@@ -79,7 +80,7 @@ public class FareRuleMapperTest {
     assertNull(result.getRoute());
   }
 
-  /** Mapping the same object twice, should return the the same instance. */
+  /** Mapping the same object twice, should return the same instance. */
   @Test
   public void testMapCache() throws Exception {
     org.opentripplanner.ext.fares.model.FareRule result1 = subject.map(FARE_RULE);


### PR DESCRIPTION
### Summary

Removes the fields "youth price" and "senior price" from the mapping of the GTFS fare_attribute. These fields were non-standard when they were added in 2016 and are still nowhere in the spec.

They references deployments in Seattle. Since IBI has taken over these deployments in the last couple of years, we can be sure that these fields are no longer used.

Another clean up of the code is the conversion of a float/currency field combination for the price into a `Money` instance which makes integration with the rest of the fares code a little easier.

### Unit tests

Existing unit tests were updated.

### Bumping the serialization version id

:heavy_check_mark: 