### PR TITLE
Create the NumItinerariesFilter and the associated NumItinerariesFilterResults to limit itineraries based on the numItineraries parameter.

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/SortOrder.java
+++ b/src/main/java/org/opentripplanner/model/plan/SortOrder.java
@@ -36,10 +36,10 @@ public enum SortOrder {
    * paging we need to know which end of the list of itineraries we should crop. This method is used
    * to decide that together with the current page type (next/previous).
    * <p>
-   * This return {@code true} for the default depart-after search, and {@code false} for an
+   * This returns {@code true} for the default depart-after search, and {@code false} for an
    * arrive-by search.
    */
-  public boolean isSortedByArrivalTimeAcceding() {
+  public boolean isSortedByArrivalTimeAscending() {
     return this == STREET_AND_ARRIVAL_TIME;
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactory.java
+++ b/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactory.java
@@ -9,6 +9,7 @@ import java.time.temporal.ChronoUnit;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.model.plan.SortOrder;
+import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NumItinerariesFilterResults;
 
 public class PageCursorFactory {
 
@@ -18,8 +19,7 @@ public class PageCursorFactory {
   private SearchTime current = null;
   private Duration currentSearchWindow = null;
   private boolean wholeSwUsed = true;
-  private Instant removedItineraryStartTime = null;
-  private Instant removedItineraryEndTime = null;
+  private NumItinerariesFilterResults numItinerariesFilterResults = null;
 
   private PageCursor nextCursor = null;
   private PageCursor prevCursor = null;
@@ -48,27 +48,18 @@ public class PageCursorFactory {
   }
 
   /**
-   * Set the start and end time for removed itineraries. The current implementation uses the FIRST
-   * removed itinerary, but this can in some cases lead to missed itineraries in the next search.
-   * So, we will document here what should be done.
-   * <p>
-   * For case {@code depart-after-crop-sw} and {@code arrive-by-crop-sw-reversed-filter} the {@code
-   * startTime} should be the EARLIEST departure time for all removed itineraries.
-   * <p>
-   * For case {@code depart-after-crop-sw-reversed-filter} and {@code arrive-by-crop-sw} the {@code
-   * startTime} should be the LATEST departure time for all removed itineraries.
-   * <p>
-   * The {@code endTime} should be replaced by removing duplicates between the to pages. This can
-   * for example be done by including a hash for each potential itinerary in the token, and make a
-   * filter to remove those in the following page response.
+   * If there were itineraries removed in the current search because the numItineraries parameter
+   * was used, then we want to allow the caller to move within some of the itineraries that were
+   * removed in the next and previous pages. This means we will use information from when we cropped
+   * the list of itineraries to create the new search encoded in the page cursors.
    *
-   * @param startTime is rounded down to the closest minute.
-   * @param endTime   is round up to the closest minute.
+   * @param numItinerariesFilterResults the result from the {@code NumItinerariesFilter}
    */
-  public PageCursorFactory withRemovedItineraries(Instant startTime, Instant endTime) {
+  public PageCursorFactory withRemovedItineraries(
+    NumItinerariesFilterResults numItinerariesFilterResults
+  ) {
     this.wholeSwUsed = false;
-    this.removedItineraryStartTime = startTime.truncatedTo(ChronoUnit.MINUTES);
-    this.removedItineraryEndTime = endTime.plusSeconds(59).truncatedTo(ChronoUnit.MINUTES);
+    this.numItinerariesFilterResults = numItinerariesFilterResults;
     return this;
   }
 
@@ -94,8 +85,7 @@ public class PageCursorFactory {
       .addDuration("currentSearchWindow", currentSearchWindow)
       .addDuration("newSearchWindow", newSearchWindow)
       .addBoolIfTrue("searchWindowCropped", !wholeSwUsed)
-      .addDateTime("removedItineraryStartTime", removedItineraryStartTime)
-      .addDateTime("removedItineraryEndTime", removedItineraryEndTime)
+      .addObj("numItinerariesFilterResults", numItinerariesFilterResults)
       .addObj("nextCursor", nextCursor)
       .addObj("prevCursor", prevCursor)
       .toString();
@@ -107,7 +97,7 @@ public class PageCursorFactory {
    * equivalent when creating new cursors.
    */
   private static PageType resolvePageTypeForTheFirstSearch(SortOrder sortOrder) {
-    return sortOrder.isSortedByArrivalTimeAcceding() ? NEXT_PAGE : PREVIOUS_PAGE;
+    return sortOrder.isSortedByArrivalTimeAscending() ? NEXT_PAGE : PREVIOUS_PAGE;
   }
 
   /** Create page cursor pair (next and previous) */
@@ -119,64 +109,41 @@ public class PageCursorFactory {
     SearchTime prev = new SearchTime(null, null);
     SearchTime next = new SearchTime(null, null);
 
-    // Depart after, sort on arrival time with the earliest first
-    if (sortOrder.isSortedByArrivalTimeAcceding()) {
-      if (currentPageType == NEXT_PAGE) {
-        prev.edt = calcPrevSwStartRelativeToUsedSw();
-        next.edt = wholeSwUsed ? calcNextSwStartRelativeToUsedSw() : removedItineraryStartTime;
-      }
-      // current page type == PREV_PAGE
-      else {
-        if (wholeSwUsed) {
-          prev.edt = calcPrevSwStartRelativeToUsedSw();
-        } else {
-          //TODO: The start time for the removed itinerary is not the best thing to use
-          //      here. We should take the LATEST start time of all removed itineraries
-          //      instead.
-          prev.edt = calcPrevSwStartRelativeToRmItinerary();
-          prev.lat = removedItineraryEndTime;
-        }
-        next.edt = calcNextSwStartRelativeToUsedSw();
-      }
-    }
-    // Arrive-by, sort on departure time with the latest first
-    else {
-      if (currentPageType == PREVIOUS_PAGE) {
-        if (wholeSwUsed) {
-          prev.edt = calcPrevSwStartRelativeToUsedSw();
-          prev.lat = current.lat;
-        } else {
-          prev.edt = calcPrevSwStartRelativeToRmItinerary();
-          // TODO: Replace this by hashing removed itineraries
-          prev.lat = removedItineraryEndTime;
-        }
-        next.edt = calcNextSwStartRelativeToUsedSw();
-      }
-      // Use normal sort and removal in ItineraryFilterChain
-      else {
-        prev.edt = calcPrevSwStartRelativeToUsedSw();
+    if (wholeSwUsed) {
+      prev.edt = edtBeforeNewSw();
+      next.edt = edtAfterUsedSw();
+      if (!sortOrder.isSortedByArrivalTimeAscending()) {
         prev.lat = current.lat;
-        next.edt = wholeSwUsed ? calcNextSwStartRelativeToUsedSw() : removedItineraryStartTime;
+      }
+    } else { // If the whole search window was not used (i.e. if there were removed itineraries)
+      if (currentPageType == NEXT_PAGE) {
+        prev.edt = edtBeforeNewSw();
+        next.edt = numItinerariesFilterResults.earliestRemovedDeparture;
+        if (sortOrder.isSortedByArrivalTimeAscending()) {
+          prev.lat =
+            numItinerariesFilterResults.earliestKeptArrival.truncatedTo(ChronoUnit.MINUTES);
+        } else {
+          prev.lat = current.lat;
+        }
+      } else {
+        // The search-window start and end is [inclusive, exclusive], so to calculate the start of the
+        // search-window from the last time included in the search window we need to include one extra
+        // minute at the end.
+        prev.edt =
+          numItinerariesFilterResults.latestRemovedDeparture.minus(newSearchWindow).plusSeconds(60);
+        next.edt = edtAfterUsedSw();
+        prev.lat = numItinerariesFilterResults.latestRemovedArrival;
       }
     }
     prevCursor = new PageCursor(PREVIOUS_PAGE, sortOrder, prev.edt, prev.lat, newSearchWindow);
     nextCursor = new PageCursor(NEXT_PAGE, sortOrder, next.edt, next.lat, newSearchWindow);
   }
 
-  /**
-   * The search-window start and end is [inclusive, exclusive], so to calculate the start of the
-   * search-window from the last time included in the search window we need to include one extra
-   * minute at the end.
-   */
-  private Instant calcPrevSwStartRelativeToRmItinerary() {
-    return removedItineraryStartTime.minus(newSearchWindow).plusSeconds(60);
-  }
-
-  private Instant calcPrevSwStartRelativeToUsedSw() {
+  private Instant edtBeforeNewSw() {
     return current.edt.minus(newSearchWindow);
   }
 
-  private Instant calcNextSwStartRelativeToUsedSw() {
+  private Instant edtAfterUsedSw() {
     return current.edt.plus(currentSearchWindow);
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryParameters.java
+++ b/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryParameters.java
@@ -2,6 +2,13 @@ package org.opentripplanner.model.plan.pagecursor;
 
 import java.time.Instant;
 
+/**
+ * This class holds information needed to create the next/previous page cursors when there were
+ * itineraries removed due to cropping the list of itineraries using the numItineraries parameter.
+ * <p>
+ * The Instant fields come from the sets of itineraries that were removed and the ones that were
+ * kept as a result of using the numItineraries parameter.
+ */
 public interface PageCursorFactoryParameters {
   Instant earliestRemovedDeparture();
 

--- a/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryParameters.java
+++ b/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryParameters.java
@@ -1,0 +1,13 @@
+package org.opentripplanner.model.plan.pagecursor;
+
+import java.time.Instant;
+
+public interface PageCursorFactoryParameters {
+  Instant earliestRemovedDeparture();
+
+  Instant earliestKeptArrival();
+
+  Instant latestRemovedDeparture();
+
+  Instant latestRemovedArrival();
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
@@ -17,6 +17,8 @@ import org.opentripplanner.routing.algorithm.filterchain.api.TransitGeneralizedC
 import org.opentripplanner.routing.algorithm.filterchain.comparator.SortOrderComparator;
 import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.MaxLimitFilter;
 import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NonTransitGeneralizedCostFilter;
+import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NumItinerariesFilter;
+import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NumItinerariesFilterResults;
 import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.OtherThanSameLegsMaxGeneralizedCostFilter;
 import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.OutsideSearchWindowFilter;
 import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.RemoveBikerentalWithMostlyWalkingFilter;
@@ -65,7 +67,7 @@ public class ItineraryListFilterChainBuilder {
   private double parkAndRideDurationRatio;
   private CostLinearFunction nonTransitGeneralizedCostLimit;
   private Instant latestDepartureTimeLimit = null;
-  private Consumer<Itinerary> maxLimitReachedSubscriber;
+  private Consumer<NumItinerariesFilterResults> numItinerariesFilterResultsConsumer;
   private boolean accessibilityScore;
   private double wheelchairMaxSlope;
   private FareService faresService;
@@ -111,7 +113,7 @@ public class ItineraryListFilterChainBuilder {
 
   /**
    * Group itineraries by the main legs and keeping approximately the given total number of
-   * itineraries. The itineraries are grouped by the legs that account for more then 'p' % for the
+   * itineraries. The itineraries are grouped by the legs that account for more than 'p' % for the
    * total distance.
    *
    * @see GroupBySimilarity for more details.
@@ -186,7 +188,7 @@ public class ItineraryListFilterChainBuilder {
   /**
    * The direct street search(walk, bicycle, car) is not pruning the transit search, so in some
    * cases we get "silly" transit itineraries that is marginally better on travel-duration compared
-   * with a on-street-all-the-way itinerary. Use this method to filter worse enough itineraries.
+   * with an on-street-all-the-way itinerary. Use this method to filter worse enough itineraries.
    * <p>
    * The filter removes all itineraries with a generalized-cost that is higher than the best
    * on-street-all-the-way itinerary.
@@ -205,7 +207,7 @@ public class ItineraryListFilterChainBuilder {
    * A transit itinerary with higher generalized-cost than a walk-only itinerary is silly. This filter removes such
    * itineraries.
    * <p>
-   * This filter only have an effect, if an walk-all-the-way itinerary exist.
+   * This filter only have an effect, if a walk-all-the-way itinerary exist.
    */
   public ItineraryListFilterChainBuilder withRemoveTransitIfWalkingIsBetter(boolean value) {
     this.removeTransitIfWalkingIsBetter = value;
@@ -234,18 +236,17 @@ public class ItineraryListFilterChainBuilder {
 
   /**
    * If the maximum number of itineraries is exceeded, then the excess itineraries are removed. To
-   * get notified about this a subscriber can be added. The first itinerary removed by the {@code
-   * maxLimit} is returned. The 'maxLimit' check is the last thing happening in the filter-chain
-   * after the final sort. So, if another filter remove an itinerary, the itinerary is not
-   * considered with the respect to this the {@link #withMaxNumberOfItineraries(int)} limit.
+   * get notified about this a consumer can be added. The 'maxLimit' check is the last thing
+   * happening in the filter-chain after the final sort. So, if another filter removes an itinerary,
+   * the itinerary is not considered with respect to the {@link #withMaxNumberOfItineraries(int)}
+   * limit.
    *
-   * @param maxLimitReachedSubscriber the subscriber to notify in case any elements are removed.
-   *                                  Only the first element removed is passed to the subscriber.
+   * @param numItinerariesFilterResultsConsumer the consumer to notify when elements are removed.
    */
-  public ItineraryListFilterChainBuilder withMaxLimitReachedSubscriber(
-    Consumer<Itinerary> maxLimitReachedSubscriber
+  public ItineraryListFilterChainBuilder withNumItinerariesFilterResultsConsumer(
+    Consumer<NumItinerariesFilterResults> numItinerariesFilterResultsConsumer
   ) {
-    this.maxLimitReachedSubscriber = maxLimitReachedSubscriber;
+    this.numItinerariesFilterResultsConsumer = numItinerariesFilterResultsConsumer;
     return this;
   }
 
@@ -410,11 +411,10 @@ public class ItineraryListFilterChainBuilder {
       filters.add(new SortingFilter(SortOrderComparator.comparator(sortOrder)));
       filters.add(
         new DeletionFlaggingFilter(
-          new MaxLimitFilter(
-            MAX_NUMBER_OF_ITINERARIES_TAG,
+          new NumItinerariesFilter(
             maxNumberOfItineraries,
             maxNumberOfItinerariesCrop,
-            maxLimitReachedSubscriber
+            numItinerariesFilterResultsConsumer
           )
         )
       );
@@ -465,7 +465,7 @@ public class ItineraryListFilterChainBuilder {
    * of the total travel distance.
    * <p>
    * Each group is filtered using generalized-cost, keeping only the itineraries with the lowest
-   * cost. If there is a tie, the filter look at the number-of-transfers as a tie breaker.
+   * cost. If there is a tie, the filter look at the number-of-transfers as a tiebreaker.
    * <p>
    * The filter name is dynamically created: similar-legs-filter-68p-1
    */

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ListSection.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ListSection.java
@@ -2,7 +2,7 @@ package org.opentripplanner.routing.algorithm.filterchain;
 
 /**
  * This enum is used to signal which part of a list an operation apply to. You may remove elements
- * from the HEAD or TAIL of the list. It may refere to on or more elements.
+ * from the HEAD or TAIL of the list. It may refer to one or more elements.
  */
 public enum ListSection {
   /** The beginning of the list. */

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/MaxLimitFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/MaxLimitFilter.java
@@ -1,41 +1,20 @@
 package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 
 import java.util.List;
-import java.util.function.Consumer;
 import org.opentripplanner.model.plan.Itinerary;
-import org.opentripplanner.routing.algorithm.filterchain.ListSection;
 
 /**
- * Flag all itineraries after the provided limit. This flags the itineraries at the end of the list
- * for removal, so the list should be sorted on the desired key before this filter is applied.
- * <p>
- * The filter can also report the first itinerary in the list it will flag. The subscriber is
- * optional.
+ * Flags the itineraries at the end of the list for removal. The list should be sorted on the
+ * desired key before this filter is applied.
  */
 public class MaxLimitFilter implements ItineraryDeletionFlagger {
 
-  private static final Consumer<Itinerary> IGNORE_SUBSCRIBER = i -> {};
-
   private final String name;
   private final int maxLimit;
-  private final ListSection cropSection;
-  private final Consumer<Itinerary> changedSubscriber;
 
-  /** Create filter with default crop(TAIL) and without any callback. */
   public MaxLimitFilter(String name, int maxLimit) {
-    this(name, maxLimit, ListSection.TAIL, IGNORE_SUBSCRIBER);
-  }
-
-  public MaxLimitFilter(
-    String name,
-    int maxLimit,
-    ListSection cropSection,
-    Consumer<Itinerary> changedSubscriber
-  ) {
     this.name = name;
     this.maxLimit = maxLimit;
-    this.cropSection = cropSection;
-    this.changedSubscriber = changedSubscriber == null ? IGNORE_SUBSCRIBER : changedSubscriber;
   }
 
   @Override
@@ -49,13 +28,6 @@ public class MaxLimitFilter implements ItineraryDeletionFlagger {
       return List.of();
     }
 
-    if (cropSection == ListSection.HEAD) {
-      int limit = itineraries.size() - maxLimit;
-      changedSubscriber.accept(itineraries.get(limit - 1));
-      return itineraries.subList(0, limit);
-    }
-
-    changedSubscriber.accept(itineraries.get(maxLimit));
     return itineraries.subList(maxLimit, itineraries.size());
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilter.java
@@ -1,0 +1,65 @@
+package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.filterchain.ListSection;
+
+/**
+ * Flag all itineraries after the provided limit. This flags the itineraries at the end of the list
+ * for removal, so the list should be sorted on the desired key before this filter is applied.
+ * <p>
+ * This filter reports information about the removed itineraries in the results consumer.
+ */
+public class NumItinerariesFilter implements ItineraryDeletionFlagger {
+
+  private static final Consumer<NumItinerariesFilterResults> IGNORE_SUBSCRIBER = i -> {};
+
+  private final int maxLimit;
+  private final ListSection cropSection;
+  private final Consumer<NumItinerariesFilterResults> numItinerariesFilterResultsConsumer;
+
+  public NumItinerariesFilter(
+    int maxLimit,
+    ListSection cropSection,
+    Consumer<NumItinerariesFilterResults> numItinerariesFilterResultsConsumer
+  ) {
+    this.maxLimit = maxLimit;
+    this.cropSection = cropSection;
+    this.numItinerariesFilterResultsConsumer =
+      numItinerariesFilterResultsConsumer == null
+        ? IGNORE_SUBSCRIBER
+        : numItinerariesFilterResultsConsumer;
+  }
+
+  @Override
+  public String name() {
+    return "number-of-itineraries-filter";
+  }
+
+  @Override
+  public List<Itinerary> flagForRemoval(List<Itinerary> itineraries) {
+    if (itineraries.size() <= maxLimit) {
+      return List.of();
+    }
+
+    List<Itinerary> itinerariesToKeep;
+    List<Itinerary> itinerariesToRemove;
+
+    if (cropSection == ListSection.HEAD) {
+      int limit = itineraries.size() - maxLimit;
+
+      itinerariesToRemove = itineraries.subList(0, limit);
+      itinerariesToKeep = itineraries.subList(limit, itineraries.size());
+    } else {
+      itinerariesToRemove = itineraries.subList(maxLimit, itineraries.size());
+      itinerariesToKeep = itineraries.subList(0, maxLimit);
+    }
+
+    numItinerariesFilterResultsConsumer.accept(
+      new NumItinerariesFilterResults(itinerariesToKeep, itinerariesToRemove, cropSection)
+    );
+
+    return itinerariesToRemove;
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterResults.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterResults.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 
 import java.time.Instant;
 import java.util.List;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.pagecursor.PageCursorFactoryParameters;
 import org.opentripplanner.routing.algorithm.filterchain.ListSection;
@@ -49,7 +50,7 @@ public class NumItinerariesFilterResults implements PageCursorFactoryParameters 
         .stream()
         .map(it -> it.endTime().toInstant())
         .min(Instant::compareTo)
-        .orElse(null);
+        .orElseThrow();
 
     Itinerary firstRemovedItinerary;
     if (cropSection == ListSection.HEAD) {
@@ -68,30 +69,19 @@ public class NumItinerariesFilterResults implements PageCursorFactoryParameters 
 
   @Override
   public String toString() {
-    return (
-      "NumItinerariesFilterResults{" +
-      "earliestRemovedDeparture=" +
-      earliestRemovedDeparture +
-      ", latestRemovedDeparture=" +
-      latestRemovedDeparture +
-      ", earliestRemovedArrival=" +
-      earliestRemovedArrival +
-      ", latestRemovedArrival=" +
-      latestRemovedArrival +
-      ", earliestKeptArrival=" +
-      earliestKeptArrival +
-      ", firstRemovedArrivalTime=" +
-      firstRemovedArrivalTime +
-      ", firstRemovedGeneralizedCost=" +
-      firstRemovedGeneralizedCost +
-      ", firstRemovedNumOfTransfers=" +
-      firstRemovedNumOfTransfers +
-      ", firstRemovedDepartureTime=" +
-      firstRemovedDepartureTime +
-      ", cropSection=" +
-      cropSection +
-      '}'
-    );
+    return ToStringBuilder
+      .of(NumItinerariesFilterResults.class)
+      .addDateTime("earliestRemovedDeparture", earliestRemovedDeparture)
+      .addDateTime("latestRemovedDeparture", latestRemovedDeparture)
+      .addDateTime("earliestRemovedArrival", earliestRemovedArrival)
+      .addDateTime("latestRemovedArrival", latestRemovedArrival)
+      .addDateTime("earliestKeptArrival", earliestKeptArrival)
+      .addDateTime("firstRemovedArrivalTime", firstRemovedArrivalTime)
+      .addNum("firstRemovedGeneralizedCost", firstRemovedGeneralizedCost)
+      .addNum("firstRemovedNumOfTransfers", firstRemovedNumOfTransfers)
+      .addDateTime("firstRemovedDepartureTime", firstRemovedDepartureTime)
+      .addEnum("cropSection", cropSection)
+      .toString();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterResults.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterResults.java
@@ -3,9 +3,10 @@ package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 import java.time.Instant;
 import java.util.List;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.pagecursor.PageCursorFactoryParameters;
 import org.opentripplanner.routing.algorithm.filterchain.ListSection;
 
-public class NumItinerariesFilterResults {
+public class NumItinerariesFilterResults implements PageCursorFactoryParameters {
 
   public final Instant earliestRemovedDeparture;
   public final Instant latestRemovedDeparture;
@@ -91,5 +92,25 @@ public class NumItinerariesFilterResults {
       cropSection +
       '}'
     );
+  }
+
+  @Override
+  public Instant earliestRemovedDeparture() {
+    return earliestRemovedDeparture;
+  }
+
+  @Override
+  public Instant earliestKeptArrival() {
+    return earliestKeptArrival;
+  }
+
+  @Override
+  public Instant latestRemovedDeparture() {
+    return latestRemovedDeparture;
+  }
+
+  @Override
+  public Instant latestRemovedArrival() {
+    return latestRemovedArrival;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterResults.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterResults.java
@@ -1,0 +1,95 @@
+package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
+
+import java.time.Instant;
+import java.util.List;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.filterchain.ListSection;
+
+public class NumItinerariesFilterResults {
+
+  public final Instant earliestRemovedDeparture;
+  public final Instant latestRemovedDeparture;
+  public final Instant earliestRemovedArrival;
+  public final Instant latestRemovedArrival;
+  public final Instant earliestKeptArrival;
+  public final Instant firstRemovedArrivalTime;
+  public final int firstRemovedGeneralizedCost;
+  public final int firstRemovedNumOfTransfers;
+  public final Instant firstRemovedDepartureTime;
+  public final ListSection cropSection;
+
+  /**
+   * The NumItinerariesFilter removes itineraries from a list of itineraries based on the number to
+   * keep and whether it should crop at the head or the tail of the list. The results class keeps
+   * the extreme endpoints of the sets of itineraries that were kept and removed, as well as more
+   * details about the first itinerary removed (bottom of the head, or top of the tail) and whether
+   * itineraries were cropped at the head or the tail.
+   */
+  public NumItinerariesFilterResults(
+    List<Itinerary> keptItineraries,
+    List<Itinerary> removedItineraries,
+    ListSection cropSection
+  ) {
+    List<Instant> removedDepartures = removedItineraries
+      .stream()
+      .map(it -> it.startTime().toInstant())
+      .toList();
+    List<Instant> removedArrivals = removedItineraries
+      .stream()
+      .map(it -> it.endTime().toInstant())
+      .toList();
+    this.earliestRemovedDeparture = removedDepartures.stream().min(Instant::compareTo).orElse(null);
+    this.latestRemovedDeparture = removedDepartures.stream().max(Instant::compareTo).orElse(null);
+    this.earliestRemovedArrival = removedArrivals.stream().min(Instant::compareTo).orElse(null);
+    this.latestRemovedArrival = removedArrivals.stream().max(Instant::compareTo).orElse(null);
+
+    this.earliestKeptArrival =
+      keptItineraries
+        .stream()
+        .map(it -> it.endTime().toInstant())
+        .min(Instant::compareTo)
+        .orElse(null);
+
+    Itinerary firstRemovedItinerary;
+    if (cropSection == ListSection.HEAD) {
+      firstRemovedItinerary = removedItineraries.get(removedItineraries.size() - 1);
+    } else {
+      firstRemovedItinerary = removedItineraries.get(0);
+    }
+
+    this.firstRemovedArrivalTime = firstRemovedItinerary.endTime().toInstant();
+    this.firstRemovedGeneralizedCost = firstRemovedItinerary.getGeneralizedCost();
+    this.firstRemovedNumOfTransfers = firstRemovedItinerary.getNumberOfTransfers();
+    this.firstRemovedDepartureTime = firstRemovedItinerary.startTime().toInstant();
+
+    this.cropSection = cropSection;
+  }
+
+  @Override
+  public String toString() {
+    return (
+      "NumItinerariesFilterResults{" +
+      "earliestRemovedDeparture=" +
+      earliestRemovedDeparture +
+      ", latestRemovedDeparture=" +
+      latestRemovedDeparture +
+      ", earliestRemovedArrival=" +
+      earliestRemovedArrival +
+      ", latestRemovedArrival=" +
+      latestRemovedArrival +
+      ", earliestKeptArrival=" +
+      earliestKeptArrival +
+      ", firstRemovedArrivalTime=" +
+      firstRemovedArrivalTime +
+      ", firstRemovedGeneralizedCost=" +
+      firstRemovedGeneralizedCost +
+      ", firstRemovedNumOfTransfers=" +
+      firstRemovedNumOfTransfers +
+      ", firstRemovedDepartureTime=" +
+      firstRemovedDepartureTime +
+      ", cropSection=" +
+      cropSection +
+      '}'
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -4,11 +4,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.function.Consumer;
 import org.opentripplanner.ext.ridehailing.RideHailingFilter;
-import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.filterchain.GroupBySimilarity;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChain;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChainBuilder;
 import org.opentripplanner.routing.algorithm.filterchain.ListSection;
+import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NumItinerariesFilterResults;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.ItineraryFilterPreferences;
@@ -27,7 +27,7 @@ public class RouteRequestToFilterChainMapper {
     OtpServerRequestContext context,
     Instant filterOnLatestDepartureTime,
     boolean removeWalkAllTheWayResults,
-    Consumer<Itinerary> maxLimitReachedSubscriber
+    Consumer<NumItinerariesFilterResults> maxLimitFilterResultsSubscriber
   ) {
     var builder = new ItineraryListFilterChainBuilder(request.itinerariesSortOrder());
 
@@ -83,7 +83,7 @@ public class RouteRequestToFilterChainMapper {
         context.transitService()::getMultiModalStationForStation
       )
       .withLatestDepartureTimeLimit(filterOnLatestDepartureTime)
-      .withMaxLimitReachedSubscriber(maxLimitReachedSubscriber)
+      .withNumItinerariesFilterResultsConsumer(maxLimitFilterResultsSubscriber)
       .withRemoveWalkAllTheWayResults(removeWalkAllTheWayResults)
       .withRemoveTransitIfWalkingIsBetter(true)
       .withDebugEnabled(params.debug());

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
@@ -111,7 +111,9 @@ public class RoutingResponseMapper {
       return factory;
     }
 
-    Instant edt = transitSearchTimeZero.plusSeconds(searchParams.earliestDepartureTime()).toInstant();
+    Instant edt = transitSearchTimeZero
+      .plusSeconds(searchParams.earliestDepartureTime())
+      .toInstant();
     Instant lat = searchParams.isLatestArrivalTimeSet()
       ? transitSearchTimeZero.plusSeconds(searchParams.latestArrivalTime()).toInstant()
       : null;

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
@@ -111,12 +111,11 @@ public class RoutingResponseMapper {
       return factory;
     }
 
-    long t0 = transitSearchTimeZero.toEpochSecond();
-    var edt = Instant.ofEpochSecond(t0 + searchParams.earliestDepartureTime());
-    var lat = searchParams.isLatestArrivalTimeSet()
-      ? Instant.ofEpochSecond(t0 + searchParams.latestArrivalTime())
+    Instant edt = transitSearchTimeZero.plusSeconds(searchParams.earliestDepartureTime()).toInstant();
+    Instant lat = searchParams.isLatestArrivalTimeSet()
+      ? transitSearchTimeZero.plusSeconds(searchParams.latestArrivalTime()).toInstant()
       : null;
-    var searchWindow = Duration.ofSeconds(searchParams.searchWindowInSeconds());
+    Duration searchWindow = Duration.ofSeconds(searchParams.searchWindowInSeconds());
     factory = factory.withOriginalSearch(currentPageType, edt, lat, searchWindow);
 
     if (numItinerariesFilterResults != null) {

--- a/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -195,7 +195,7 @@ public class RouteRequest implements Cloneable, Serializable {
     }
 
     var previousPage = pageCursor.type == PageType.PREVIOUS_PAGE;
-    return pageCursor.originalSortOrder.isSortedByArrivalTimeAcceding() == previousPage;
+    return pageCursor.originalSortOrder.isSortedByArrivalTimeAscending() == previousPage;
   }
 
   /**
@@ -207,7 +207,7 @@ public class RouteRequest implements Cloneable, Serializable {
    */
   public boolean doCropSearchWindowAtTail() {
     if (pageCursor == null) {
-      return itinerariesSortOrder().isSortedByArrivalTimeAcceding();
+      return itinerariesSortOrder().isSortedByArrivalTimeAscending();
     }
     return pageCursor.type == PageType.NEXT_PAGE;
   }

--- a/src/test/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryTest.java
@@ -3,18 +3,14 @@ package org.opentripplanner.model.plan.pagecursor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_ARRIVAL_TIME;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_DEPARTURE_TIME;
-import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.model.plan.pagecursor.PageType.NEXT_PAGE;
 import static org.opentripplanner.model.plan.pagecursor.PageType.PREVIOUS_PAGE;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.time.TimeUtils;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.routing.algorithm.filterchain.ListSection;
-import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NumItinerariesFilterResults;
 
 @SuppressWarnings("ConstantConditions")
 class PageCursorFactoryTest implements PlanTestConstants {
@@ -37,33 +33,23 @@ class PageCursorFactoryTest implements PlanTestConstants {
       .withOriginalSearch(null, T12_00, null, D1H);
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T10_30, null, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T10_30, null, D90M, PREVIOUS_PAGE);
   }
 
   @Test
   public void sortArrivalAscendingCropSearchWindow() {
     var factory = new PageCursorFactory(STREET_AND_ARRIVAL_TIME, D90M)
       .withOriginalSearch(NEXT_PAGE, T12_00, null, D1H)
-      .withRemovedItineraries(
-        new NumItinerariesFilterResults(
-          List.of(
-            newItinerary(A).bus(22, TimeUtils.time("12:00"), TimeUtils.time("13:00"), B).build()
-          ),
-          List.of(
-            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
-          ),
-          ListSection.TAIL
-        )
-      );
+      .withRemovedItineraries(new PageCursorFactoryParametersImpl(T12_00, T12_30, T12_30, T13_30));
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T12_30, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T12_30, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T10_30, T13_00, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T10_30, T12_00, D90M, PREVIOUS_PAGE);
   }
 
   @Test
@@ -72,33 +58,23 @@ class PageCursorFactoryTest implements PlanTestConstants {
       .withOriginalSearch(PREVIOUS_PAGE, T12_00, null, D1H);
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T10_30, null, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T10_30, null, D90M, PREVIOUS_PAGE);
   }
 
   @Test
   public void sortArrivalAscendingCropSearchWindowPreviousPage() {
     var factory = new PageCursorFactory(STREET_AND_ARRIVAL_TIME, D90M)
       .withOriginalSearch(PREVIOUS_PAGE, T12_00, null, D1H)
-      .withRemovedItineraries(
-        new NumItinerariesFilterResults(
-          List.of(
-            newItinerary(A).bus(22, TimeUtils.time("12:00"), TimeUtils.time("13:00"), B).build()
-          ),
-          List.of(
-            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
-          ),
-          ListSection.HEAD
-        )
-      );
+      .withRemovedItineraries(new PageCursorFactoryParametersImpl(T12_00, T12_30, T12_30, T13_30));
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T11_01, T13_30, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T11_01, T13_30, D90M, PREVIOUS_PAGE);
   }
 
   @Test
@@ -107,33 +83,23 @@ class PageCursorFactoryTest implements PlanTestConstants {
       .withOriginalSearch(null, T12_00, T13_30, D1H);
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T10_30, T13_30, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T10_30, T13_30, D90M, PREVIOUS_PAGE);
   }
 
   @Test
   public void sortDepartureDescendingCropSearchWindow() {
     var factory = new PageCursorFactory(STREET_AND_DEPARTURE_TIME, D90M)
       .withOriginalSearch(PREVIOUS_PAGE, T12_00, T13_30, D1H)
-      .withRemovedItineraries(
-        new NumItinerariesFilterResults(
-          List.of(
-            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
-          ),
-          List.of(
-            newItinerary(A).bus(22, TimeUtils.time("12:30"), TimeUtils.time("13:00"), B).build()
-          ),
-          ListSection.TAIL
-        )
-      );
+      .withRemovedItineraries(new PageCursorFactoryParametersImpl(T12_30, T12_30, T12_30, T13_00));
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T11_01, T13_00, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T11_01, T13_00, D90M, PREVIOUS_PAGE);
   }
 
   @Test
@@ -142,40 +108,30 @@ class PageCursorFactoryTest implements PlanTestConstants {
       .withOriginalSearch(NEXT_PAGE, T12_00, T13_30, D1H);
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T10_30, T13_30, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T10_30, T13_30, D90M, PREVIOUS_PAGE);
   }
 
   @Test
   public void sortDepartureDescendingCropSearchWindowNextPage() {
     var factory = new PageCursorFactory(STREET_AND_DEPARTURE_TIME, D90M)
       .withOriginalSearch(NEXT_PAGE, T12_00, T13_30, D1H)
-      .withRemovedItineraries(
-        new NumItinerariesFilterResults(
-          List.of(
-            newItinerary(A).bus(22, TimeUtils.time("12:00"), TimeUtils.time("13:00"), B).build()
-          ),
-          List.of(
-            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
-          ),
-          ListSection.HEAD
-        )
-      );
+      .withRemovedItineraries(new PageCursorFactoryParametersImpl(T12_00, T12_30, T12_30, T13_30));
 
     var nextPage = factory.nextPageCursor();
-    assetPageCursor(nextPage, T12_30, null, D90M, NEXT_PAGE);
+    assertPageCursor(nextPage, T12_30, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T10_30, T13_30, D90M, PREVIOUS_PAGE);
+    assertPageCursor(prevPage, T10_30, T13_30, D90M, PREVIOUS_PAGE);
   }
 
   private static Instant time(String input) {
     return TIME_ZERO.plusSeconds(TimeUtils.time(input));
   }
 
-  private void assetPageCursor(
+  private void assertPageCursor(
     PageCursor pageCursor,
     Instant expEdt,
     Instant expLat,
@@ -187,4 +143,12 @@ class PageCursorFactoryTest implements PlanTestConstants {
     assertEquals(expSearchWindow, pageCursor.searchWindow);
     assertEquals(expPageType, pageCursor.type);
   }
+
+  private record PageCursorFactoryParametersImpl(
+    Instant earliestKeptArrival,
+    Instant earliestRemovedDeparture,
+    Instant latestRemovedDeparture,
+    Instant latestRemovedArrival
+  )
+    implements PageCursorFactoryParameters {}
 }

--- a/src/test/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/pagecursor/PageCursorFactoryTest.java
@@ -3,14 +3,18 @@ package org.opentripplanner.model.plan.pagecursor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_ARRIVAL_TIME;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_DEPARTURE_TIME;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.model.plan.pagecursor.PageType.NEXT_PAGE;
 import static org.opentripplanner.model.plan.pagecursor.PageType.PREVIOUS_PAGE;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.time.TimeUtils;
 import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.routing.algorithm.filterchain.ListSection;
+import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NumItinerariesFilterResults;
 
 @SuppressWarnings("ConstantConditions")
 class PageCursorFactoryTest implements PlanTestConstants {
@@ -43,13 +47,23 @@ class PageCursorFactoryTest implements PlanTestConstants {
   public void sortArrivalAscendingCropSearchWindow() {
     var factory = new PageCursorFactory(STREET_AND_ARRIVAL_TIME, D90M)
       .withOriginalSearch(NEXT_PAGE, T12_00, null, D1H)
-      .withRemovedItineraries(T12_30, T13_30);
+      .withRemovedItineraries(
+        new NumItinerariesFilterResults(
+          List.of(
+            newItinerary(A).bus(22, TimeUtils.time("12:00"), TimeUtils.time("13:00"), B).build()
+          ),
+          List.of(
+            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
+          ),
+          ListSection.TAIL
+        )
+      );
 
     var nextPage = factory.nextPageCursor();
     assetPageCursor(nextPage, T12_30, null, D90M, NEXT_PAGE);
 
     var prevPage = factory.previousPageCursor();
-    assetPageCursor(prevPage, T10_30, null, D90M, PREVIOUS_PAGE);
+    assetPageCursor(prevPage, T10_30, T13_00, D90M, PREVIOUS_PAGE);
   }
 
   @Test
@@ -68,7 +82,17 @@ class PageCursorFactoryTest implements PlanTestConstants {
   public void sortArrivalAscendingCropSearchWindowPreviousPage() {
     var factory = new PageCursorFactory(STREET_AND_ARRIVAL_TIME, D90M)
       .withOriginalSearch(PREVIOUS_PAGE, T12_00, null, D1H)
-      .withRemovedItineraries(T12_30, T13_30);
+      .withRemovedItineraries(
+        new NumItinerariesFilterResults(
+          List.of(
+            newItinerary(A).bus(22, TimeUtils.time("12:00"), TimeUtils.time("13:00"), B).build()
+          ),
+          List.of(
+            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
+          ),
+          ListSection.HEAD
+        )
+      );
 
     var nextPage = factory.nextPageCursor();
     assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
@@ -93,7 +117,17 @@ class PageCursorFactoryTest implements PlanTestConstants {
   public void sortDepartureDescendingCropSearchWindow() {
     var factory = new PageCursorFactory(STREET_AND_DEPARTURE_TIME, D90M)
       .withOriginalSearch(PREVIOUS_PAGE, T12_00, T13_30, D1H)
-      .withRemovedItineraries(T12_30, T13_00);
+      .withRemovedItineraries(
+        new NumItinerariesFilterResults(
+          List.of(
+            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
+          ),
+          List.of(
+            newItinerary(A).bus(22, TimeUtils.time("12:30"), TimeUtils.time("13:00"), B).build()
+          ),
+          ListSection.TAIL
+        )
+      );
 
     var nextPage = factory.nextPageCursor();
     assetPageCursor(nextPage, T13_00, null, D90M, NEXT_PAGE);
@@ -118,7 +152,17 @@ class PageCursorFactoryTest implements PlanTestConstants {
   public void sortDepartureDescendingCropSearchWindowNextPage() {
     var factory = new PageCursorFactory(STREET_AND_DEPARTURE_TIME, D90M)
       .withOriginalSearch(NEXT_PAGE, T12_00, T13_30, D1H)
-      .withRemovedItineraries(T12_30, T13_00);
+      .withRemovedItineraries(
+        new NumItinerariesFilterResults(
+          List.of(
+            newItinerary(A).bus(22, TimeUtils.time("12:00"), TimeUtils.time("13:00"), B).build()
+          ),
+          List.of(
+            newItinerary(A).bus(21, TimeUtils.time("12:30"), TimeUtils.time("13:30"), B).build()
+          ),
+          ListSection.HEAD
+        )
+      );
 
     var nextPage = factory.nextPageCursor();
     assetPageCursor(nextPage, T12_30, null, D90M, NEXT_PAGE);

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/MaxLimitFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/MaxLimitFilterTest.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.Itinerary.toStr;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.routing.algorithm.filterchain.ListSection;
 
 public class MaxLimitFilterTest implements PlanTestConstants {
 
@@ -49,37 +47,5 @@ public class MaxLimitFilterTest implements PlanTestConstants {
     List<Itinerary> itineraries = List.of(i1, i2, i3);
     var result = DeletionFlaggerTestHelper.process(itineraries, subject);
     assertEquals(toStr(List.of()), toStr(result));
-  }
-
-  @Test
-  public void testCropHead() {
-    MaxLimitFilter subject = new MaxLimitFilter("Test", 1, ListSection.HEAD, null);
-    List<Itinerary> itineraries = List.of(i1, i2, i3);
-    var result = DeletionFlaggerTestHelper.process(itineraries, subject);
-    assertEquals(toStr(List.of(i3)), toStr(result));
-  }
-
-  @Test
-  public void testCropTailAndSubscribe() {
-    var subscribeResult = new ArrayList<Itinerary>();
-    var subject = new MaxLimitFilter("Test", 2, ListSection.TAIL, subscribeResult::add);
-    var itineraries = List.of(i1, i2, i3);
-
-    var processedList = DeletionFlaggerTestHelper.process(itineraries, subject);
-
-    assertEquals(toStr(List.of(i3)), toStr(subscribeResult));
-    assertEquals(toStr(List.of(i1, i2)), toStr(processedList));
-  }
-
-  @Test
-  public void testCropHeadAndSubscribe() {
-    var subscribeResult = new ArrayList<Itinerary>();
-    var subject = new MaxLimitFilter("Test", 1, ListSection.HEAD, subscribeResult::add);
-    var itineraries = List.of(i1, i2, i3);
-
-    var processedList = DeletionFlaggerTestHelper.process(itineraries, subject);
-
-    assertEquals(toStr(List.of(i2)), toStr(subscribeResult));
-    assertEquals(toStr(List.of(i3)), toStr(processedList));
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/NumItinerariesFilterTest.java
@@ -1,0 +1,111 @@
+package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.model.plan.Itinerary.toStr;
+import static org.opentripplanner.model.plan.PlanTestConstants.A;
+import static org.opentripplanner.model.plan.PlanTestConstants.B;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.filterchain.ListSection;
+
+public class NumItinerariesFilterTest {
+
+  private static final Itinerary i1 = newItinerary(A, 6).walk(1, B).build();
+  private static final Itinerary i2 = newItinerary(A).bicycle(6, 8, B).build();
+  private static final Itinerary i3 = newItinerary(A).bus(21, 7, 9, B).build();
+
+  private NumItinerariesFilterResults subscribeResult = null;
+
+  @Test
+  public void name() {
+    NumItinerariesFilter subject = new NumItinerariesFilter(3, ListSection.TAIL, null);
+    assertEquals("number-of-itineraries-filter", subject.name());
+  }
+
+  @Test
+  public void testCropHead() {
+    NumItinerariesFilter subject = new NumItinerariesFilter(1, ListSection.HEAD, null);
+    List<Itinerary> itineraries = List.of(i1, i2, i3);
+    var result = DeletionFlaggerTestHelper.process(itineraries, subject);
+    assertEquals(toStr(List.of(i3)), toStr(result));
+  }
+
+  @Test
+  public void testCropTailAndSubscribe() {
+    var subject = new NumItinerariesFilter(2, ListSection.TAIL, it -> subscribeResult = it);
+    var itineraries = List.of(i1, i2, i3);
+
+    var processedList = DeletionFlaggerTestHelper.process(itineraries, subject);
+
+    assertEquals(
+      i3.startTime().toInstant().toString(),
+      subscribeResult.earliestRemovedDeparture.toString()
+    );
+    assertEquals(
+      i3.endTime().toInstant().toString(),
+      subscribeResult.earliestRemovedArrival.toString()
+    );
+
+    assertEquals(
+      i3.startTime().toInstant().toString(),
+      subscribeResult.latestRemovedDeparture.toString()
+    );
+    assertEquals(
+      i3.endTime().toInstant().toString(),
+      subscribeResult.latestRemovedArrival.toString()
+    );
+
+    assertEquals(
+      i3.startTime().toInstant().toString(),
+      subscribeResult.firstRemovedDepartureTime.toString()
+    );
+
+    assertEquals(
+      i1.endTime().toInstant().toString(),
+      subscribeResult.earliestKeptArrival.toString()
+    );
+
+    assertEquals(toStr(List.of(i1, i2)), toStr(processedList));
+  }
+
+  @Test
+  public void testCropHeadAndSubscribe() {
+    var subject = new NumItinerariesFilter(1, ListSection.HEAD, it -> subscribeResult = it);
+    var itineraries = List.of(i1, i2, i3);
+
+    var processedList = DeletionFlaggerTestHelper.process(itineraries, subject);
+
+    assertEquals(
+      i2.startTime().toInstant().toString(),
+      subscribeResult.earliestRemovedDeparture.toString()
+    );
+    assertEquals(
+      i1.endTime().toInstant().toString(),
+      subscribeResult.earliestRemovedArrival.toString()
+    );
+
+    assertEquals(
+      i2.startTime().toInstant().toString(),
+      subscribeResult.latestRemovedDeparture.toString()
+    );
+    assertEquals(
+      i2.endTime().toInstant().toString(),
+      subscribeResult.latestRemovedArrival.toString()
+    );
+
+    assertEquals(
+      i2.startTime().toInstant().toString(),
+      subscribeResult.firstRemovedDepartureTime.toString()
+    );
+
+    assertEquals(
+      i3.endTime().toInstant().toString(),
+      subscribeResult.earliestKeptArrival.toString()
+    );
+
+    assertEquals(toStr(List.of(i3)), toStr(processedList));
+  }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapperTest.java
@@ -8,6 +8,7 @@ import static org.opentripplanner.model.plan.PlanTestConstants.B;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.time.TimeUtils;
 import org.opentripplanner.model.plan.Itinerary;
@@ -17,6 +18,8 @@ import org.opentripplanner.model.plan.pagecursor.PageType;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.api.request.SearchParams;
+import org.opentripplanner.routing.algorithm.filterchain.ListSection;
+import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.NumItinerariesFilterResults;
 
 public class RoutingResponseMapperTest {
 
@@ -40,6 +43,11 @@ public class RoutingResponseMapperTest {
   private static final Itinerary REMOVED_ITINERARY = TestItineraryBuilder
     .newItinerary(A, T12_30)
     .bus(1, T12_30, T13_00, B)
+    .build();
+
+  private static final Itinerary KEPT_ITINERARY = TestItineraryBuilder
+    .newItinerary(A, T12_00)
+    .bus(1, T12_00, T12_30, B)
     .build();
 
   @Test
@@ -88,7 +96,11 @@ public class RoutingResponseMapperTest {
       TRANSIT_TIME_ZERO,
       SEARCH_PARAMS,
       D90M,
-      REMOVED_ITINERARY,
+      new NumItinerariesFilterResults(
+        List.of(KEPT_ITINERARY),
+        List.of(REMOVED_ITINERARY),
+        ListSection.TAIL
+      ),
       PageType.NEXT_PAGE
     );
 
@@ -101,8 +113,12 @@ public class RoutingResponseMapperTest {
       "currentSearchWindow: 1h, " +
       "newSearchWindow: 1h30m, " +
       "searchWindowCropped, " +
-      "removedItineraryStartTime: 2020-02-02T12:30:00Z, " +
-      "removedItineraryEndTime: 2020-02-02T13:00:00Z" +
+      "numItinerariesFilterResults: " +
+      new NumItinerariesFilterResults(
+        List.of(KEPT_ITINERARY),
+        List.of(REMOVED_ITINERARY),
+        ListSection.TAIL
+      ) +
       "}",
       factory.toString()
     );

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapperTest.java
@@ -113,7 +113,7 @@ public class RoutingResponseMapperTest {
       "currentSearchWindow: 1h, " +
       "newSearchWindow: 1h30m, " +
       "searchWindowCropped, " +
-      "numItinerariesFilterResults: " +
+      "pageCursorFactoryParams: " +
       new NumItinerariesFilterResults(
         List.of(KEPT_ITINERARY),
         List.of(REMOVED_ITINERARY),


### PR DESCRIPTION
### Summary

This PR pulls functionality to limit the number of itineraries to the numItineraries parameter into a separate filter from the MaxLimitFilter because of the need to keep more information about the filtered itineraries than just the first one that is removed. The NumItinerariesFilterResults contains information used in the creation of page cursors currently, as well as information that will be used in the future deduplication feature.

### Issue

N/A

### Unit tests

Updated relevant unit tests and added a unittest for the new filter.

### Documentation

Added JavaDoc.

### Changelog

N/A

### Bumping the serialization version id

N/A
