### PR TITLE
Add support for DSJ in transit leg reference

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolver.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
+import org.opentripplanner.model.plan.ScheduledTransitLegBuilder;
 import org.opentripplanner.transit.service.TransitService;
 
 public class RealtimeResolver {
@@ -53,20 +54,12 @@ public class RealtimeResolver {
     ScheduledTransitLeg reference,
     ScheduledTransitLeg original
   ) {
-    var leg = new ScheduledTransitLeg(
-      reference.getTripTimes(),
-      reference.getTripPattern(),
-      reference.getBoardStopPosInPattern(),
-      reference.getAlightStopPosInPattern(),
-      reference.getStartTime(),
-      reference.getEndTime(),
-      reference.getServiceDate(),
-      reference.getZoneId(),
-      original.getTransferFromPrevLeg(),
-      original.getTransferToNextLeg(),
-      original.getGeneralizedCost(),
-      original.accessibilityScore()
-    );
+    var leg = new ScheduledTransitLegBuilder<>(reference)
+      .withTransferFromPreviousLeg(original.getTransferFromPrevLeg())
+      .withTransferToNextLeg(original.getTransferToNextLeg())
+      .withGeneralizedCost(original.getGeneralizedCost())
+      .withAccessibilityScore(original.accessibilityScore())
+      .build();
     reference.getTransitAlerts().forEach(leg::addAlert);
     return leg;
   }

--- a/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLeg.java
@@ -21,36 +21,9 @@ public class FrequencyTransitLeg extends ScheduledTransitLeg {
 
   private final int frequencyHeadwayInSeconds;
 
-  public FrequencyTransitLeg(
-    TripTimes tripTimes,
-    TripPattern tripPattern,
-    int boardStopIndexInPattern,
-    int alightStopIndexInPattern,
-    ZonedDateTime startTime,
-    ZonedDateTime endTime,
-    LocalDate serviceDate,
-    ZoneId zoneId,
-    ConstrainedTransfer transferFromPreviousLeg,
-    ConstrainedTransfer transferToNextLeg,
-    int generalizedCost,
-    int frequencyHeadwayInSeconds,
-    @Nullable Float accessibilityScore
-  ) {
-    super(
-      tripTimes,
-      tripPattern,
-      boardStopIndexInPattern,
-      alightStopIndexInPattern,
-      startTime,
-      endTime,
-      serviceDate,
-      zoneId,
-      transferFromPreviousLeg,
-      transferToNextLeg,
-      generalizedCost,
-      accessibilityScore
-    );
-    this.frequencyHeadwayInSeconds = frequencyHeadwayInSeconds;
+  FrequencyTransitLeg(FrequencyTransitLegBuilder builder) {
+    super(builder);
+    this.frequencyHeadwayInSeconds = builder.frequencyHeadwayInSeconds();
   }
 
   @Override
@@ -101,20 +74,6 @@ public class FrequencyTransitLeg extends ScheduledTransitLeg {
 
   @Override
   public ScheduledTransitLeg withAccessibilityScore(Float score) {
-    return new FrequencyTransitLeg(
-      tripTimes,
-      tripPattern,
-      boardStopPosInPattern,
-      alightStopPosInPattern,
-      getStartTime(),
-      getEndTime(),
-      serviceDate,
-      zoneId,
-      getTransferFromPrevLeg(),
-      getTransferToNextLeg(),
-      getGeneralizedCost(),
-      frequencyHeadwayInSeconds,
-      score
-    );
+    return new FrequencyTransitLegBuilder(this).withAccessibilityScore(score).build();
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLegBuilder.java
+++ b/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLegBuilder.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.model.plan;
+
+public class FrequencyTransitLegBuilder
+  extends ScheduledTransitLegBuilder<FrequencyTransitLegBuilder> {
+
+  private int frequencyHeadwayInSeconds;
+
+  public FrequencyTransitLegBuilder() {}
+
+  public FrequencyTransitLegBuilder(FrequencyTransitLeg original) {
+    super(original);
+    frequencyHeadwayInSeconds = original.getHeadway();
+  }
+
+  public FrequencyTransitLegBuilder withFrequencyHeadwayInSeconds(int frequencyHeadwayInSeconds) {
+    this.frequencyHeadwayInSeconds = frequencyHeadwayInSeconds;
+    return instance();
+  }
+
+  public int frequencyHeadwayInSeconds() {
+    return frequencyHeadwayInSeconds;
+  }
+
+  @Override
+  public FrequencyTransitLeg build() {
+    return new FrequencyTransitLeg(this);
+  }
+}

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -24,6 +24,7 @@ import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.FareZone;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 
 /**
  * One leg of a trip -- that is, a temporally continuous piece of the journey that takes place on a
@@ -184,6 +185,14 @@ public interface Leg {
    * For transit legs, the trip. For non-transit legs, null.
    */
   default Trip getTrip() {
+    return null;
+  }
+
+  /**
+   * For transit legs, the trip on service date, if it exists. For non-transit legs, null.
+   */
+  @Nullable
+  default TripOnServiceDate getTripOnServiceDate() {
     return null;
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -35,6 +35,7 @@ import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 
 /**
@@ -57,47 +58,37 @@ public class ScheduledTransitLeg implements TransitLeg {
   private final int generalizedCost;
   protected final LocalDate serviceDate;
   protected final ZoneId zoneId;
+  private final TripOnServiceDate tripOnServiceDate;
   private double distanceMeters;
   private final double directDistanceMeters;
   private final Float accessibilityScore;
   private List<FareProductUse> fareProducts = List.of();
 
-  public ScheduledTransitLeg(
-    TripTimes tripTimes,
-    TripPattern tripPattern,
-    int boardStopIndexInPattern,
-    int alightStopIndexInPattern,
-    ZonedDateTime startTime,
-    ZonedDateTime endTime,
-    LocalDate serviceDate,
-    ZoneId zoneId,
-    ConstrainedTransfer transferFromPreviousLeg,
-    ConstrainedTransfer transferToNextLeg,
-    int generalizedCost,
-    @Nullable Float accessibilityScore
-  ) {
-    this.tripTimes = tripTimes;
-    this.tripPattern = tripPattern;
+  ScheduledTransitLeg(ScheduledTransitLegBuilder<?> builder) {
+    this.tripTimes = builder.tripTimes();
+    this.tripPattern = builder.tripPattern();
 
-    this.boardStopPosInPattern = boardStopIndexInPattern;
-    this.alightStopPosInPattern = alightStopIndexInPattern;
+    this.boardStopPosInPattern = builder.boardStopIndexInPattern();
+    this.alightStopPosInPattern = builder.alightStopIndexInPattern();
 
-    this.startTime = startTime;
-    this.endTime = endTime;
+    this.startTime = builder.startTime();
+    this.endTime = builder.endTime();
 
-    this.serviceDate = serviceDate;
-    this.zoneId = zoneId;
+    this.serviceDate = builder.serviceDate();
+    this.zoneId = builder.zoneId();
 
-    this.transferFromPrevLeg = transferFromPreviousLeg;
-    this.transferToNextLeg = transferToNextLeg;
+    this.tripOnServiceDate = builder.tripOnServiceDate();
 
-    this.generalizedCost = generalizedCost;
+    this.transferFromPrevLeg = builder.transferFromPreviousLeg();
+    this.transferToNextLeg = builder.transferToNextLeg();
 
-    this.accessibilityScore = accessibilityScore;
+    this.generalizedCost = builder.generalizedCost();
+
+    this.accessibilityScore = builder.accessibilityScore();
     List<Coordinate> transitLegCoordinates = extractTransitLegCoordinates(
       tripPattern,
-      boardStopIndexInPattern,
-      alightStopIndexInPattern
+      builder.boardStopIndexInPattern(),
+      builder.alightStopIndexInPattern()
     );
     this.legGeometry = GeometryUtils.makeLineString(transitLegCoordinates);
 
@@ -127,10 +118,12 @@ public class ScheduledTransitLeg implements TransitLeg {
     return ServiceDateUtils.asStartOfService(serviceDate, zoneId).toInstant();
   }
 
+  @Override
   public boolean isScheduledTransitLeg() {
     return true;
   }
 
+  @Override
   public ScheduledTransitLeg asScheduledTransitLeg() {
     return this;
   }
@@ -245,6 +238,12 @@ public class ScheduledTransitLeg implements TransitLeg {
   }
 
   @Override
+  @Nullable
+  public TripOnServiceDate getTripOnServiceDate() {
+    return tripOnServiceDate;
+  }
+
+  @Override
   public Place getFrom() {
     return Place.forStop(tripPattern.getStop(boardStopPosInPattern));
   }
@@ -344,18 +343,25 @@ public class ScheduledTransitLeg implements TransitLeg {
     return generalizedCost;
   }
 
+  /**
+   * Construct a leg reference from this leg.
+   * If the trip is based on a TripOnServiceDate, the leg reference will contain the
+   * TripOnServiceDate id instead of the Trip id.
+   */
   @Override
   public LegReference getLegReference() {
     return new ScheduledTransitLegReference(
-      tripTimes.getTrip().getId(),
+      tripOnServiceDate == null ? tripTimes.getTrip().getId() : null,
       serviceDate,
       boardStopPosInPattern,
       alightStopPosInPattern,
       tripPattern.getStops().get(boardStopPosInPattern).getId(),
-      tripPattern.getStops().get(alightStopPosInPattern).getId()
+      tripPattern.getStops().get(alightStopPosInPattern).getId(),
+      tripOnServiceDate == null ? null : tripOnServiceDate.getId()
     );
   }
 
+  @Override
   public void addAlert(TransitAlert alert) {
     transitAlerts.add(alert);
   }
@@ -377,20 +383,7 @@ public class ScheduledTransitLeg implements TransitLeg {
   }
 
   public ScheduledTransitLeg withAccessibilityScore(Float score) {
-    return new ScheduledTransitLeg(
-      tripTimes,
-      tripPattern,
-      boardStopPosInPattern,
-      alightStopPosInPattern,
-      startTime,
-      endTime,
-      serviceDate,
-      zoneId,
-      transferFromPrevLeg,
-      transferToNextLeg,
-      generalizedCost,
-      score
-    );
+    return new ScheduledTransitLegBuilder<>(this).withAccessibilityScore(score).build();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
@@ -1,0 +1,169 @@
+package org.opentripplanner.model.plan;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.opentripplanner.model.transfer.ConstrainedTransfer;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+import org.opentripplanner.transit.model.timetable.TripTimes;
+
+public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>> {
+
+  private TripTimes tripTimes;
+  private TripPattern tripPattern;
+  private int boardStopIndexInPattern;
+  private int alightStopIndexInPattern;
+  private ZonedDateTime startTime;
+  private ZonedDateTime endTime;
+  private LocalDate serviceDate;
+  private ZoneId zoneId;
+  private TripOnServiceDate tripOnServiceDate;
+  private ConstrainedTransfer transferFromPreviousLeg;
+  private ConstrainedTransfer transferToNextLeg;
+  private int generalizedCost;
+  private Float accessibilityScore;
+
+  public ScheduledTransitLegBuilder() {}
+
+  public ScheduledTransitLegBuilder(ScheduledTransitLeg original) {
+    tripTimes = original.getTripTimes();
+    tripPattern = original.getTripPattern();
+    boardStopIndexInPattern = original.getBoardStopPosInPattern();
+    alightStopIndexInPattern = original.getAlightStopPosInPattern();
+    startTime = original.getStartTime();
+    endTime = original.getEndTime();
+    serviceDate = original.getServiceDate();
+    tripOnServiceDate = original.getTripOnServiceDate();
+    transferFromPreviousLeg = original.getTransferFromPrevLeg();
+    transferToNextLeg = original.getTransferToNextLeg();
+    generalizedCost = original.getGeneralizedCost();
+    accessibilityScore = original.accessibilityScore();
+  }
+
+  public B withTripTimes(TripTimes tripTimes) {
+    this.tripTimes = tripTimes;
+    return instance();
+  }
+
+  public TripTimes tripTimes() {
+    return tripTimes;
+  }
+
+  public B withTripPattern(TripPattern tripPattern) {
+    this.tripPattern = tripPattern;
+    return instance();
+  }
+
+  public TripPattern tripPattern() {
+    return tripPattern;
+  }
+
+  public B withBoardStopIndexInPattern(int boardStopIndexInPattern) {
+    this.boardStopIndexInPattern = boardStopIndexInPattern;
+    return instance();
+  }
+
+  public int boardStopIndexInPattern() {
+    return boardStopIndexInPattern;
+  }
+
+  public B withAlightStopIndexInPattern(int alightStopIndexInPattern) {
+    this.alightStopIndexInPattern = alightStopIndexInPattern;
+    return instance();
+  }
+
+  public int alightStopIndexInPattern() {
+    return alightStopIndexInPattern;
+  }
+
+  public B withStartTime(ZonedDateTime startTime) {
+    this.startTime = startTime;
+    return instance();
+  }
+
+  public ZonedDateTime startTime() {
+    return startTime;
+  }
+
+  public B withEndTime(ZonedDateTime endTime) {
+    this.endTime = endTime;
+    return instance();
+  }
+
+  public ZonedDateTime endTime() {
+    return endTime;
+  }
+
+  public B withServiceDate(LocalDate serviceDate) {
+    this.serviceDate = serviceDate;
+    return instance();
+  }
+
+  public LocalDate serviceDate() {
+    return serviceDate;
+  }
+
+  public B withZoneId(ZoneId zoneId) {
+    this.zoneId = zoneId;
+    return instance();
+  }
+
+  public ZoneId zoneId() {
+    return zoneId;
+  }
+
+  public B withTripOnServiceDate(TripOnServiceDate tripOnServiceDate) {
+    this.tripOnServiceDate = tripOnServiceDate;
+    return instance();
+  }
+
+  public TripOnServiceDate tripOnServiceDate() {
+    return tripOnServiceDate;
+  }
+
+  public B withTransferFromPreviousLeg(ConstrainedTransfer transferFromPreviousLeg) {
+    this.transferFromPreviousLeg = transferFromPreviousLeg;
+    return instance();
+  }
+
+  public ConstrainedTransfer transferFromPreviousLeg() {
+    return transferFromPreviousLeg;
+  }
+
+  public B withTransferToNextLeg(ConstrainedTransfer transferToNextLeg) {
+    this.transferToNextLeg = transferToNextLeg;
+    return instance();
+  }
+
+  public ConstrainedTransfer transferToNextLeg() {
+    return transferToNextLeg;
+  }
+
+  public B withGeneralizedCost(int generalizedCost) {
+    this.generalizedCost = generalizedCost;
+    return instance();
+  }
+
+  public int generalizedCost() {
+    return generalizedCost;
+  }
+
+  public B withAccessibilityScore(Float accessibilityScore) {
+    this.accessibilityScore = accessibilityScore;
+    return instance();
+  }
+
+  public Float accessibilityScore() {
+    return accessibilityScore;
+  }
+
+  public ScheduledTransitLeg build() {
+    return new ScheduledTransitLeg(this);
+  }
+
+  final B instance() {
+    return (B) this;
+  }
+}

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
@@ -22,6 +22,13 @@ enum LegReferenceType {
     ScheduledTransitLegReference.class,
     LegReferenceSerializer::writeScheduledTransitLegV2,
     LegReferenceSerializer::readScheduledTransitLegV2
+  ),
+
+  SCHEDULED_TRANSIT_LEG_V3(
+    3,
+    ScheduledTransitLegReference.class,
+    LegReferenceSerializer::writeScheduledTransitLegV3,
+    LegReferenceSerializer::readScheduledTransitLegV3
   );
 
   private final int version;
@@ -45,8 +52,8 @@ enum LegReferenceType {
   /**
    * Return the latest LegReferenceType version for a given leg reference class.
    */
-  static LegReferenceType forClass(Class<? extends LegReference> legReferenceClass) {
-    Optional<LegReferenceType> latestVersion = Arrays
+  static Optional<LegReferenceType> forClass(Class<? extends LegReference> legReferenceClass) {
+    return Arrays
       .stream(LegReferenceType.values())
       .filter(legReferenceType -> legReferenceType.legReferenceClass.equals(legReferenceClass))
       .reduce((legReferenceType, other) -> {
@@ -55,8 +62,6 @@ enum LegReferenceType {
         }
         return other;
       });
-
-    return latestVersion.orElse(null);
   }
 
   Writer<LegReference> getSerializer() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -10,11 +10,11 @@ import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.model.plan.FrequencyTransitLeg;
+import org.opentripplanner.model.plan.FrequencyTransitLegBuilder;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
-import org.opentripplanner.model.plan.ScheduledTransitLeg;
+import org.opentripplanner.model.plan.ScheduledTransitLegBuilder;
 import org.opentripplanner.model.plan.StreetLeg;
 import org.opentripplanner.model.plan.UnknownTransitPathLeg;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
@@ -39,6 +39,8 @@ import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.request.StreetSearchRequestMapper;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.StateEditor;
+import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -57,6 +59,7 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
   private final ZonedDateTime transitSearchTimeZero;
 
   private final GraphPathToItineraryMapper graphPathToItineraryMapper;
+  private final TransitService transitService;
 
   /**
    * Constructs an itinerary mapper for a request and a set of results
@@ -84,6 +87,7 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
         graph.streetNotesService,
         graph.ellipsoidToGeoidDifference
       );
+    this.transitService = transitService;
   }
 
   public Itinerary createItinerary(RaptorPath<T> path) {
@@ -204,36 +208,53 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
 
     if (tripSchedule.isFrequencyBasedTrip()) {
       int frequencyHeadwayInSeconds = tripSchedule.frequencyHeadwayInSeconds();
-      return new FrequencyTransitLeg(
-        tripSchedule.getOriginalTripTimes(),
-        tripSchedule.getOriginalTripPattern(),
-        boardStopIndexInPattern,
-        alightStopIndexInPattern,
-        createZonedDateTime(pathLeg.fromTime() + frequencyHeadwayInSeconds),
-        createZonedDateTime(pathLeg.toTime()),
-        tripSchedule.getServiceDate(),
-        transitSearchTimeZero.getZone().normalized(),
-        (prevTransitLeg == null ? null : prevTransitLeg.getTransferToNextLeg()),
-        (ConstrainedTransfer) pathLeg.getConstrainedTransferAfterLeg(),
-        toOtpDomainCost(pathLeg.generalizedCost() + lastLegCost),
-        frequencyHeadwayInSeconds,
-        null
-      );
+      return new FrequencyTransitLegBuilder()
+        .withTripTimes(tripSchedule.getOriginalTripTimes())
+        .withTripPattern(tripSchedule.getOriginalTripPattern())
+        .withBoardStopIndexInPattern(boardStopIndexInPattern)
+        .withAlightStopIndexInPattern(alightStopIndexInPattern)
+        .withStartTime(createZonedDateTime(pathLeg.fromTime() + frequencyHeadwayInSeconds))
+        .withEndTime(createZonedDateTime(pathLeg.toTime()))
+        .withServiceDate(tripSchedule.getServiceDate())
+        .withZoneId(transitSearchTimeZero.getZone().normalized())
+        .withTransferFromPreviousLeg(
+          (prevTransitLeg == null ? null : prevTransitLeg.getTransferToNextLeg())
+        )
+        .withTransferToNextLeg((ConstrainedTransfer) pathLeg.getConstrainedTransferAfterLeg())
+        .withGeneralizedCost(toOtpDomainCost(pathLeg.generalizedCost() + lastLegCost))
+        .withFrequencyHeadwayInSeconds(frequencyHeadwayInSeconds)
+        .build();
     }
-    return new ScheduledTransitLeg(
-      tripSchedule.getOriginalTripTimes(),
-      tripSchedule.getOriginalTripPattern(),
-      boardStopIndexInPattern,
-      alightStopIndexInPattern,
-      createZonedDateTime(pathLeg.fromTime()),
-      createZonedDateTime(pathLeg.toTime()),
-      tripSchedule.getServiceDate(),
-      transitSearchTimeZero.getZone().normalized(),
-      (prevTransitLeg == null ? null : prevTransitLeg.getTransferToNextLeg()),
-      (ConstrainedTransfer) pathLeg.getConstrainedTransferAfterLeg(),
-      toOtpDomainCost(pathLeg.generalizedCost() + lastLegCost),
-      null
+
+    TripOnServiceDate tripOnServiceDate = getTripOnServiceDate(tripSchedule);
+
+    return new ScheduledTransitLegBuilder<>()
+      .withTripTimes(tripSchedule.getOriginalTripTimes())
+      .withTripPattern(tripSchedule.getOriginalTripPattern())
+      .withBoardStopIndexInPattern(boardStopIndexInPattern)
+      .withAlightStopIndexInPattern(alightStopIndexInPattern)
+      .withStartTime(createZonedDateTime(pathLeg.fromTime()))
+      .withEndTime(createZonedDateTime(pathLeg.toTime()))
+      .withServiceDate(tripSchedule.getServiceDate())
+      .withZoneId(transitSearchTimeZero.getZone().normalized())
+      .withTripOnServiceDate(tripOnServiceDate)
+      .withTransferFromPreviousLeg(
+        (prevTransitLeg == null ? null : prevTransitLeg.getTransferToNextLeg())
+      )
+      .withTransferToNextLeg((ConstrainedTransfer) pathLeg.getConstrainedTransferAfterLeg())
+      .withGeneralizedCost(toOtpDomainCost(pathLeg.generalizedCost() + lastLegCost))
+      .build();
+  }
+
+  private TripOnServiceDate getTripOnServiceDate(T tripSchedule) {
+    if (tripSchedule.getOriginalTripTimes() == null) {
+      return null;
+    }
+    TripIdAndServiceDate tripIdAndServiceDate = new TripIdAndServiceDate(
+      tripSchedule.getOriginalTripTimes().getTrip().getId(),
+      tripSchedule.getServiceDate()
     );
+    return transitService.getTripOnServiceDateForTripAndDay(tripIdAndServiceDate);
   }
 
   private boolean isFree(EgressPathLeg<T> egressPathLeg) {

--- a/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegTest.java
@@ -23,20 +23,17 @@ class ScheduledTransitLegTest {
       .tripPattern("1", route)
       .withStopPattern(TransitModelForTest.stopPattern(3))
       .build();
-    var leg = new ScheduledTransitLeg(
-      null,
-      pattern,
-      0,
-      2,
-      TIME,
-      TIME.plusMinutes(10),
-      TIME.toLocalDate(),
-      ZoneIds.BERLIN,
-      null,
-      null,
-      100,
-      null
-    );
+    var leg = new ScheduledTransitLegBuilder()
+      .withTripTimes(null)
+      .withTripPattern(pattern)
+      .withBoardStopIndexInPattern(0)
+      .withAlightStopIndexInPattern(2)
+      .withStartTime(TIME)
+      .withEndTime(TIME.plusMinutes(10))
+      .withServiceDate(TIME.toLocalDate())
+      .withZoneId(ZoneIds.BERLIN)
+      .withGeneralizedCost(100)
+      .build();
 
     assertEquals(List.of(), leg.fareProducts());
   }

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -482,37 +482,33 @@ public class TestItineraryBuilder implements PlanTestConstants {
 
     if (headwaySecs != null) {
       leg =
-        new FrequencyTransitLeg(
-          tripTimes,
-          tripPattern,
-          fromStopIndex,
-          toStopIndex,
-          newTime(start),
-          newTime(end),
-          serviceDate != null ? serviceDate : SERVICE_DAY,
-          UTC,
-          transferFromPreviousLeg,
-          null,
-          legCost,
-          headwaySecs,
-          null
-        );
+        new FrequencyTransitLegBuilder()
+          .withTripTimes(tripTimes)
+          .withTripPattern(tripPattern)
+          .withBoardStopIndexInPattern(fromStopIndex)
+          .withAlightStopIndexInPattern(toStopIndex)
+          .withStartTime(newTime(start))
+          .withEndTime(newTime(end))
+          .withServiceDate(serviceDate != null ? serviceDate : SERVICE_DAY)
+          .withZoneId(UTC)
+          .withTransferFromPreviousLeg(transferFromPreviousLeg)
+          .withGeneralizedCost(legCost)
+          .withFrequencyHeadwayInSeconds(headwaySecs)
+          .build();
     } else {
       leg =
-        new ScheduledTransitLeg(
-          tripTimes,
-          tripPattern,
-          fromStopIndex,
-          toStopIndex,
-          newTime(start),
-          newTime(end),
-          serviceDate != null ? serviceDate : SERVICE_DAY,
-          UTC,
-          transferFromPreviousLeg,
-          null,
-          legCost,
-          null
-        );
+        new ScheduledTransitLegBuilder()
+          .withTripTimes(tripTimes)
+          .withTripPattern(tripPattern)
+          .withBoardStopIndexInPattern(fromStopIndex)
+          .withAlightStopIndexInPattern(toStopIndex)
+          .withStartTime(newTime(start))
+          .withEndTime(newTime(end))
+          .withServiceDate(serviceDate != null ? serviceDate : SERVICE_DAY)
+          .withZoneId(UTC)
+          .withTransferFromPreviousLeg(transferFromPreviousLeg)
+          .withGeneralizedCost(legCost)
+          .build();
     }
 
     leg.setDistanceMeters(speed(leg.getMode()) * (end - start));

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -19,16 +19,22 @@ class LegReferenceSerializerTest {
   private static final FeedScopedId TO_STOP_ID = TransitModelForTest.id("Alighting Stop");
 
   /**
-   * Token based on the latest format, including stop ids.
+   * Token based on the initial format, without stop ids.
+   */
+  private static final String ENCODED_TOKEN_V1 =
+    "rO0ABXc2ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAAD";
+
+  /**
+   * Token based on the second version of the format, including stop ids.
    */
   private static final String ENCODED_TOKEN_V2 =
     "rO0ABXdZABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjIABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAADAA9GOkJvYXJkaW5nIFN0b3AAEEY6QWxpZ2h0aW5nIFN0b3A=";
 
   /**
-   * Token based on the previous format, without stop ids.
+   * Token based on the latest format, including stop ids and TripOnServiceDate id.
    */
-  private static final String ENCODED_TOKEN_V1 =
-    "rO0ABXc2ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAAD";
+  private static final String ENCODED_TOKEN_V3 =
+    "rO0ABXdbABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjMABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAADAA9GOkJvYXJkaW5nIFN0b3AAEEY6QWxpZ2h0aW5nIFN0b3AAAA==";
 
   @Test
   void testScheduledTransitLegReferenceRoundTrip() {
@@ -38,12 +44,13 @@ class LegReferenceSerializerTest {
       FROM_STOP_POS,
       TO_STOP_POS,
       FROM_STOP_ID,
-      TO_STOP_ID
+      TO_STOP_ID,
+      null
     );
 
     var out = LegReferenceSerializer.encode(ref);
 
-    assertEquals(ENCODED_TOKEN_V2, out);
+    assertEquals(ENCODED_TOKEN_V3, out);
 
     var ref2 = LegReferenceSerializer.decode(out);
 
@@ -52,7 +59,7 @@ class LegReferenceSerializerTest {
 
   @Test
   void testScheduledTransitLegReferenceDeserialize() {
-    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN_V2);
+    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN_V3);
     assertNotNull(ref);
     assertEquals(TRIP_ID, ref.tripId());
     assertEquals(SERVICE_DATE, ref.serviceDate());
@@ -61,8 +68,18 @@ class LegReferenceSerializerTest {
   }
 
   @Test
-  void testScheduledTransitLegReferenceLegacyDeserialize() {
+  void testScheduledTransitLegReferenceLegacyV1Deserialize() {
     var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN_V1);
+    assertNotNull(ref);
+    assertEquals(TRIP_ID, ref.tripId());
+    assertEquals(SERVICE_DATE, ref.serviceDate());
+    assertEquals(FROM_STOP_POS, ref.fromStopPositionInPattern());
+    assertEquals(TO_STOP_POS, ref.toStopPositionInPattern());
+  }
+
+  @Test
+  void testScheduledTransitLegReferenceLegacyV2Deserialize() {
+    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN_V2);
     assertNotNull(ref);
     assertEquals(TRIP_ID, ref.tripId());
     assertEquals(SERVICE_DATE, ref.serviceDate());

--- a/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
@@ -42,7 +42,8 @@ class AlternativeLegsTest extends GtfsTest {
       1,
       2,
       STOP_ID_B,
-      STOP_ID_C
+      STOP_ID_C,
+      null
     )
       .getLeg(transitService);
 
@@ -80,7 +81,8 @@ class AlternativeLegsTest extends GtfsTest {
       0,
       1,
       STOP_ID_B,
-      STOP_ID_C
+      STOP_ID_C,
+      null
     )
       .getLeg(transitService);
 
@@ -118,7 +120,8 @@ class AlternativeLegsTest extends GtfsTest {
       1,
       2,
       STOP_ID_X,
-      STOP_ID_Y
+      STOP_ID_Y,
+      null
     )
       .getLeg(transitService);
 
@@ -151,7 +154,8 @@ class AlternativeLegsTest extends GtfsTest {
       1,
       7,
       STOP_ID_X,
-      STOP_ID_B
+      STOP_ID_B,
+      null
     )
       .getLeg(transitService);
 


### PR DESCRIPTION
### Summary
As detailed in #5422, a transit leg reference should refer to a TripOnServiceDate id (i.e. dated service journey id) when one exists,
since a dated service journey provides a more stable id across deliveries of planned data.

The PR introduces also a builder for ScheduledTransitLeg and FrequencyTransitLeg.

### Issue


Closes #5422

### Unit tests

Added unit tests

### Documentation

No

