### PR TITLE
Siri file loader

### DIFF
--- a/docs/sandbox/SiriUpdater.md
+++ b/docs/sandbox/SiriUpdater.md
@@ -37,11 +37,26 @@ To enable the SIRI updater you need to add it to the updaters section of the `ro
 | previewInterval                |    `duration`   | TODO                                                                                                   | *Optional* |               |  2.0  |
 | requestorRef                   |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
 | timeout                        |    `duration`   | The HTTP timeout to download the updates.                                                              | *Optional* | `"PT15S"`     |  2.0  |
-| url                            |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
+| [url](#u__8__url)              |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
 | [headers](#u__8__headers)      | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
 
 
 ##### Parameter details
+
+<h4 id="u__8__url">url</h4>
+
+**Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[8] 
+
+The URL to send the HTTP requests to.
+
+Use the file protocol to set a directory for reading updates from a directory. The file
+loader will look for xml files: '*.xml' in the configured directory. The files are
+renamed by the loader when possessed:
+
+&nbsp;&nbsp;&nbsp; _a.xml_ &nbsp; ➞ &nbsp; _a.xml.inProgress_ &nbsp; ➞ &nbsp; _a.xml.ok_ &nbsp; or &nbsp; _a.xml.failed_
+
+
 
 <h4 id="u__8__headers">headers</h4>
 
@@ -87,7 +102,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 | frequency                       |    `duration`   | How often the updates should be retrieved.                                                             | *Optional* | `"PT1M"`      |  2.0  |
 | requestorRef                    |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
 | timeout                         |    `duration`   | The HTTP timeout to download the updates.                                                              | *Optional* | `"PT15S"`     |  2.0  |
-| url                             |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
+| [url](#u__9__url)               |     `string`    | The URL to send the HTTP requests to. Support http/https and file protocol.                            | *Required* |               |  2.0  |
 | [headers](#u__9__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
 
 
@@ -103,6 +118,22 @@ This value is subtracted from the actual validity defined in the message.
 Normally the planned departure time is used, so setting this to 10s will cause the
 SX-message to be included in trip-results 10 seconds before the the planned departure
 time.
+
+<h4 id="u__9__url">url</h4>
+
+**Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[9] 
+
+The URL to send the HTTP requests to. Support http/https and file protocol.
+
+
+Use the file protocol to set a directory for reading updates from a directory. The file
+loader will look for xml files: '*.xml' in the configured directory. The files are
+renamed by the loader when possessed:
+
+&nbsp;&nbsp;&nbsp; _a.xml_ &nbsp; ➞ &nbsp; _a.xml.inProgress_ &nbsp; ➞ &nbsp; _a.xml.ok_ &nbsp; or &nbsp; _a.xml.failed_
+
+
 
 <h4 id="u__9__headers">headers</h4>
 

--- a/docs/sandbox/SiriUpdater.md
+++ b/docs/sandbox/SiriUpdater.md
@@ -52,7 +52,7 @@ The URL to send the HTTP requests to.
 
 Use the file protocol to set a directory for reading updates from a directory. The file
 loader will look for xml files: '*.xml' in the configured directory. The files are
-renamed by the loader when possessed:
+renamed by the loader when processed:
 
 &nbsp;&nbsp;&nbsp; _a.xml_ &nbsp; ➞ &nbsp; _a.xml.inProgress_ &nbsp; ➞ &nbsp; _a.xml.ok_ &nbsp; or &nbsp; _a.xml.failed_
 
@@ -102,7 +102,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 | frequency                       |    `duration`   | How often the updates should be retrieved.                                                             | *Optional* | `"PT1M"`      |  2.0  |
 | requestorRef                    |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
 | timeout                         |    `duration`   | The HTTP timeout to download the updates.                                                              | *Optional* | `"PT15S"`     |  2.0  |
-| [url](#u__9__url)               |     `string`    | The URL to send the HTTP requests to. Support http/https and file protocol.                            | *Required* |               |  2.0  |
+| [url](#u__9__url)               |     `string`    | The URL to send the HTTP requests to. Supports http/https and file protocol.                           | *Required* |               |  2.0  |
 | [headers](#u__9__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
 
 
@@ -124,12 +124,12 @@ time.
 **Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[9] 
 
-The URL to send the HTTP requests to. Support http/https and file protocol.
+The URL to send the HTTP requests to. Supports http/https and file protocol.
 
 
 Use the file protocol to set a directory for reading updates from a directory. The file
 loader will look for xml files: '*.xml' in the configured directory. The files are
-renamed by the loader when possessed:
+renamed by the loader when processed:
 
 &nbsp;&nbsp;&nbsp; _a.xml_ &nbsp; ➞ &nbsp; _a.xml.inProgress_ &nbsp; ➞ &nbsp; _a.xml.ok_ &nbsp; or &nbsp; _a.xml.failed_
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/EstimatedTimetableSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/EstimatedTimetableSource.java
@@ -1,15 +1,16 @@
 package org.opentripplanner.ext.siri.updater;
 
+import java.util.Optional;
 import uk.org.siri.siri20.Siri;
 
 public interface EstimatedTimetableSource {
   /**
    * Wait for one message to arrive, and decode it into a List of TripUpdates. Blocking call.
    *
-   * @return a Siri-object potentially containing updates for several different trips, or null if an
-   * exception occurred while processing the message
+   * @return a Siri-object potentially containing updates for several trips, or empty if an
+   * exception occurred while processing the message.
    */
-  Siri getUpdates();
+  Optional<Siri> getUpdates();
 
   /**
    * @return true iff the last list with updates represent all updates that are active right now,

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -110,7 +110,9 @@ public class SiriETUpdater extends PollingGraphUpdater {
             );
             ResultLogger.logUpdateResult(feedId, "siri-et", result);
             recordMetrics.accept(result);
-            if (markPrimed) primed = true;
+            if (markPrimed) {
+              primed = true;
+            }
           });
         }
       }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
 import uk.org.siri.siri20.ServiceDelivery;
-import uk.org.siri.siri20.Siri;
 
 /**
  * Update OTP stop timetables from some a Siri-ET HTTP sources.
@@ -90,10 +89,10 @@ public class SiriETUpdater extends PollingGraphUpdater {
   public void runPolling() {
     boolean moreData = false;
     do {
-      Siri updates = updateSource.getUpdates();
-      if (updates != null) {
+      var updates = updateSource.getUpdates();
+      if (updates.isPresent()) {
         boolean fullDataset = updateSource.getFullDatasetValueOfLastUpdates();
-        ServiceDelivery serviceDelivery = updates.getServiceDelivery();
+        ServiceDelivery serviceDelivery = updates.get().getServiceDelivery();
         moreData = Boolean.TRUE.equals(serviceDelivery.isMoreData());
         // Mark this updater as primed after last page of updates. Copy moreData into a final
         // primitive, because the object moreData persists across iterations.

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriFileLoader.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriFileLoader.java
@@ -1,0 +1,101 @@
+package org.opentripplanner.ext.siri.updater;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.org.siri.siri20.Siri;
+
+/**
+ * Load real-time updates from SIRI-SX and SIRI-ET feeds from a local directory. The
+ * files are renamed during the processing like this:
+ * <pre>
+ * update.xml  ➞  update.xml.inProgress  ➞  ( update.xml.ok | update.xml.failed )
+ * </pre>
+ * The renaming of the file guarantee that the file is not processed twice. A {@code .ok} file
+ * indicate that the file is processed and the content parsed ok. The status of the update
+ * might be different - se logs for update errors.
+ * <p>
+ * The file updater will pick up any file matching {@code *.xml} in the configured directory.
+ */
+public class SiriFileLoader implements SiriLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SiriFileLoader.class);
+  public static final String SUFFIX_IN_PROGRESS = ".inProgress";
+  public static final String SUFFIX_OK = ".ok";
+  public static final String SUFFIX_FAILED = ".failed";
+  private final File directory;
+
+  public SiriFileLoader(String url) {
+    try {
+      this.directory = new File(new URL(url).toURI());
+
+      if (!directory.exists() || !directory.isDirectory()) {
+        throw new IllegalArgumentException("Could not find directory: " + url);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
+  }
+
+  public static boolean matchesUrl(String url) {
+    return url.startsWith("file:");
+  }
+
+  /**
+   * Send a SIRI-SX service request and unmarshal the response as JAXB.
+   */
+  @Override
+  public Optional<Siri> fetchSXFeed(String requestorRef) {
+    return fetchFeed();
+  }
+
+  /**
+   * Send a SIRI-ET service request and unmarshal the response as JAXB.
+   */
+  @Override
+  public Optional<Siri> fetchETFeed(String requestorRef) {
+    return fetchFeed();
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  private Optional<Siri> fetchFeed() {
+    File[] files = directory.listFiles();
+    if (files == null) {
+      return Optional.empty();
+    }
+
+    for (File file : files) {
+      if (!matchFilename(file)) {
+        continue;
+      }
+      LOG.info("Process realtime input file: " + file.getAbsolutePath());
+      var inProgressFile = newFile(file, SUFFIX_IN_PROGRESS);
+      try {
+        file.renameTo(inProgressFile);
+        Siri siri = null;
+
+        try (InputStream is = new FileInputStream(inProgressFile)) {
+          siri = SiriHelper.unmarshal(is);
+          inProgressFile.renameTo(newFile(file, SUFFIX_OK));
+          return Optional.of(siri);
+        }
+      } catch (Exception ex) {
+        inProgressFile.renameTo(newFile(file, SUFFIX_FAILED));
+        throw new RuntimeException(ex.getMessage(), ex);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean matchFilename(File file) {
+    return file.getName().endsWith(".xml");
+  }
+
+  private static File newFile(File originalFile, String suffix) {
+    return new File(originalFile.getParentFile(), originalFile.getName() + suffix);
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriFileLoader.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriFileLoader.java
@@ -15,9 +15,9 @@ import uk.org.siri.siri20.Siri;
  * <pre>
  * update.xml  ➞  update.xml.inProgress  ➞  ( update.xml.ok | update.xml.failed )
  * </pre>
- * The renaming of the file guarantee that the file is not processed twice. A {@code .ok} file
+ * The renaming of the file guarantees that the file is not processed twice. A {@code .ok} file
  * indicate that the file is processed and the content parsed ok. The status of the update
- * might be different - se logs for update errors.
+ * might be different - see logs for update errors.
  * <p>
  * The file updater will pick up any file matching {@code *.xml} in the configured directory.
  */

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriLoader.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriLoader.java
@@ -1,0 +1,20 @@
+package org.opentripplanner.ext.siri.updater;
+
+import jakarta.xml.bind.JAXBException;
+import java.util.Optional;
+import uk.org.siri.siri20.Siri;
+
+/**
+ * The Siri loader is used to fetch updates from a source like http(s) or directory.
+ */
+public interface SiriLoader {
+  /**
+   * Request a new Siri SX update.
+   */
+  Optional<Siri> fetchSXFeed(String requestorRef) throws JAXBException;
+
+  /**
+   * Request a new Siri ET update.
+   */
+  Optional<Siri> fetchETFeed(String requestorRef) throws JAXBException;
+}

--- a/src/main/java/org/opentripplanner/framework/time/CountdownTimer.java
+++ b/src/main/java/org/opentripplanner/framework/time/CountdownTimer.java
@@ -1,0 +1,73 @@
+package org.opentripplanner.framework.time;
+
+import java.time.Duration;
+import java.util.function.LongSupplier;
+
+/**
+ * This class will track time and is useful when for example throttling something. It does NOT
+ * notify anyone, but the caller must regularly check if the timer is finished.
+ */
+public class CountdownTimer {
+
+  private final LongSupplier clock;
+  private final long countDownDuration;
+  private long timeLimit;
+
+  /**
+   * Create new timer with the given count-down-duration time.
+   */
+  public CountdownTimer(Duration countDownDuration) {
+    this(countDownDuration, System::currentTimeMillis);
+  }
+
+  /**
+   * This constructor allows us to unit test the timer without using
+   * {@code System::currentTimeMillis}.
+   * <p>
+   * The timer is started, no need to explicit call {@link #restart()} right
+   * after the construction.
+   */
+  CountdownTimer(Duration countDownDuration, LongSupplier clock) {
+    this.clock = clock;
+    this.countDownDuration = countDownDuration.toMillis();
+    restart();
+  }
+
+  /**
+   * Start/restart the counting down the time.
+   */
+  public void restart() {
+    restart(now());
+  }
+
+  /**
+   * The timer has past the count-down-limit (startTime + countDownDuration)
+   */
+  public boolean timeIsUp() {
+    return timeIsUp(now());
+  }
+
+  /**
+   * Return {@code true} if time is up, and then imitatively start the timer again.
+   */
+  public boolean nextLap() {
+    long time = now();
+    if (timeIsUp(time)) {
+      restart(time);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean timeIsUp(long time) {
+    return time >= timeLimit;
+  }
+
+  private void restart(long time) {
+    this.timeLimit = time + countDownDuration;
+  }
+
+  private long now() {
+    return clock.getAsLong();
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/time/CountdownTimer.java
+++ b/src/main/java/org/opentripplanner/framework/time/CountdownTimer.java
@@ -48,7 +48,7 @@ public class CountdownTimer {
   }
 
   /**
-   * Return {@code true} if time is up, and then imitatively start the timer again.
+   * Return {@code true} if time is up, and then immediately start the timer again.
    */
   public boolean nextLap() {
     long time = now();

--- a/src/main/java/org/opentripplanner/framework/tostring/ToStringBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/tostring/ToStringBuilder.java
@@ -237,7 +237,7 @@ public class ToStringBuilder {
    * DATE is not printed. {@code null} value is ignored.
    */
   public ToStringBuilder addTime(String name, ZonedDateTime time) {
-    return addIfNotNull(name, time, DateTimeFormatter.ISO_LOCAL_TIME::format);
+    return addIfNotNull(name, time, DateTimeFormatter.ISO_LOCAL_DATE_TIME::format);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -202,7 +202,9 @@ public class TimetableSnapshot {
         temp.addAll(sortedTimetables);
         sortedTimetables = temp;
       }
-      if (old.getServiceDate() != null) sortedTimetables.remove(old);
+      if (old.getServiceDate() != null) {
+        sortedTimetables.remove(old);
+      }
       sortedTimetables.add(tt);
       timetables.put(pattern, sortedTimetables);
       dirtyTimetables.add(tt);

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETUpdaterConfig.java
@@ -20,7 +20,12 @@ public class SiriETUpdaterConfig {
           "Whether catching up with the updates should block the readiness check from returning a 'ready' result."
         )
         .asBoolean(false),
-      c.of("url").since(V2_0).summary("The URL to send the HTTP requests to.").asString(),
+      c
+        .of("url")
+        .since(V2_0)
+        .summary("The URL to send the HTTP requests to.")
+        .description(SiriSXUpdaterConfig.URL_DESCRIPTION)
+        .asString(),
       c
         .of("frequency")
         .since(V2_0)

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
@@ -9,11 +9,30 @@ import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 public class SiriSXUpdaterConfig {
 
+  static final String URL_DESCRIPTION =
+    """
+    Use the file protocol to set a directory for reading updates from a directory. The file
+    loader will look for xml files: '*.xml' in the configured directory. The files are
+    renamed by the loader when possessed:
+    
+    &nbsp;&nbsp;&nbsp; _a.xml_ &nbsp; ➞ &nbsp; _a.xml.inProgress_ &nbsp; ➞ &nbsp; _a.xml.ok_ &nbsp; or &nbsp; _a.xml.failed_
+    
+    """;
+
   public static SiriSXUpdaterParameters create(String configRef, NodeAdapter c) {
     return new SiriSXUpdaterParameters(
       configRef,
       c.of("feedId").since(V2_0).summary("The ID of the feed to apply the updates to.").asString(),
-      c.of("url").since(V2_0).summary("The URL to send the HTTP requests to.").asString(),
+      c
+        .of("url")
+        .since(V2_0)
+        .summary(
+          """
+          The URL to send the HTTP requests to. Support http/https and file protocol.
+          """
+        )
+        .description(URL_DESCRIPTION)
+        .asString(),
       c.of("requestorRef").since(V2_0).summary("The requester reference.").asString(null),
       c
         .of("frequency")

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriSXUpdaterConfig.java
@@ -13,7 +13,7 @@ public class SiriSXUpdaterConfig {
     """
     Use the file protocol to set a directory for reading updates from a directory. The file
     loader will look for xml files: '*.xml' in the configured directory. The files are
-    renamed by the loader when possessed:
+    renamed by the loader when processed:
     
     &nbsp;&nbsp;&nbsp; _a.xml_ &nbsp; ➞ &nbsp; _a.xml.inProgress_ &nbsp; ➞ &nbsp; _a.xml.ok_ &nbsp; or &nbsp; _a.xml.failed_
     
@@ -28,7 +28,7 @@ public class SiriSXUpdaterConfig {
         .since(V2_0)
         .summary(
           """
-          The URL to send the HTTP requests to. Support http/https and file protocol.
+          The URL to send the HTTP requests to. Supports http/https and file protocol.
           """
         )
         .description(URL_DESCRIPTION)

--- a/src/test/java/org/opentripplanner/framework/time/CountdownTimerTest.java
+++ b/src/test/java/org/opentripplanner/framework/time/CountdownTimerTest.java
@@ -1,0 +1,72 @@
+package org.opentripplanner.framework.time;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class CountdownTimerTest {
+
+  private long time = 9_999;
+
+  @Test
+  void finished() {
+    time = 500;
+    var subject = new CountdownTimer(Duration.ofMillis(100), this::time);
+    assertFalse(subject.timeIsUp());
+
+    time = 599;
+    assertFalse(subject.timeIsUp());
+
+    time = 600;
+    assertTrue(subject.timeIsUp());
+
+    time = 600;
+    assertTrue(subject.timeIsUp());
+  }
+
+  @Test
+  void restart() {
+    time = 500;
+    var subject = new CountdownTimer(Duration.ofMillis(100), this::time);
+
+    time = 620;
+    subject.restart();
+
+    time = 719;
+    assertFalse(subject.timeIsUp());
+
+    time = 720;
+    assertTrue(subject.timeIsUp());
+  }
+
+  @Test
+  void nextLap() {
+    time = 0;
+    var subject = new CountdownTimer(Duration.ofMillis(100), this::time);
+    assertFalse(subject.nextLap());
+
+    time = 99;
+    assertFalse(subject.nextLap());
+
+    time = 100;
+    assertTrue(subject.nextLap());
+
+    time = 99;
+    assertFalse(subject.nextLap());
+
+    time = 220;
+    assertTrue(subject.nextLap());
+
+    time = 319;
+    assertFalse(subject.nextLap());
+
+    time = 320;
+    assertTrue(subject.nextLap());
+  }
+
+  long time() {
+    return time;
+  }
+}

--- a/src/test/java/org/opentripplanner/framework/tostring/ToStringBuilderTest.java
+++ b/src/test/java/org/opentripplanner/framework/tostring/ToStringBuilderTest.java
@@ -251,7 +251,10 @@ public class ToStringBuilderTest {
       LocalDateTime.of(2012, 1, 28, 23, 45, 12),
       TIME_ZONE_ID_PARIS
     );
-    assertEquals("ToStringBuilderTest{t: 23:45:12}", subject().addTime("t", c).toString());
+    assertEquals(
+      "ToStringBuilderTest{t: 2012-01-28T23:45:12}",
+      subject().addTime("t", c).toString()
+    );
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByDistanceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByDistanceTest.java
@@ -224,7 +224,7 @@ public class GroupByDistanceTest implements PlanTestConstants {
     var subject = new GroupByDistance(itinerary, 0.5);
 
     assertEquals(
-      "GroupByDistance{streetOnly, keySet: [StreetLeg{start: 11:00:00, end: 11:00:00, mode: BICYCLE}]}",
+      "GroupByDistance{streetOnly, keySet: [StreetLeg{start: 2020-02-02T11:00:00, end: 2020-02-02T11:00:00, mode: BICYCLE}]}",
       subject.toString()
     );
 
@@ -232,7 +232,7 @@ public class GroupByDistanceTest implements PlanTestConstants {
     subject = new GroupByDistance(itinerary, 0.5);
 
     assertEquals(
-      "GroupByDistance{keySet: [ScheduledTransitLeg{start: 11:10:00, end: 11:10:00, mode: BUS, tripId: F:11}]}",
+      "GroupByDistance{keySet: [ScheduledTransitLeg{start: 2020-02-02T11:10:00, end: 2020-02-02T11:10:00, mode: BUS, tripId: F:11}]}",
       subject.toString()
     );
   }


### PR DESCRIPTION
### Summary

Add support for loading xml files for Siri SX and EX updates. This feature make it much simpler to test realtime updates. This PR also has a few minor improvements and code cleanup.

#### Always commit the first update after a long break

In a busy updater it does not matter if we commit early or late, as long as we throttle the update commits to happen with a given frequency. But, when testing OTP manually, it is easy to do mistakes and assume that an update is applied when you
see (log):

> INFO 1 of 1 update messages were applied successfully (success rate: 100.0%)

In OTP before this commit, the update was not committed, waiting to fill up the "buffer", and if not other update was applied - nothing happened. 

#### File loader

Use the `url` to set a directory. The updater will use the directory instead of connecting to a http resource. The file loader will look for xml files: `*.xml` in the configured directory. The files are renamed by the loader when possessed:
```    
    update.xml  ➞  update.xml.inProgress  ➞  update.xml.ok  or  update.xml.failed
```    

### Issue
No.

### Unit tests
No.

### Documentation
✅ 

### Changelog
No

### Bumping the serialization version id
No
