### PR TITLE
Update NeTEx Java Model 2.0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <slf4j.version>2.0.9</slf4j.version>
         <netex-java-model.version>2.0.15</netex-java-model.version>
         <siri-java-model.version>1.25</siri-java-model.version>
-        <jakarta.xml.bind-api.version>4.0.1</jakarta.xml.bind-api.version>
         <jaxb-runtime.version>4.0.4</jaxb-runtime.version>
         <!-- Other properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -542,33 +541,6 @@
 
     <dependencyManagement>
         <dependencies>
-
-
-            <!-- Jakarta EE-->
-            <dependency>
-                <groupId>jakarta.annotation</groupId>
-                <artifactId>jakarta.annotation-api</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.validation</groupId>
-                <artifactId>jakarta.validation-api</artifactId>
-            </dependency>
-            <!--
-                The jaxb-api provides annotations like XmlElement indicating how classes should be (de)serialized.
-                The jaxb-runtime pulls in the jaxb-api of the same version transitively. But we specify both api and
-                runtime dependencies anyway here at the top level to prevent transitive dependencies from pulling in
-                mismatched versions.
-            -->
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${jakarta.xml.bind-api.version}</version>
-            </dependency>
-
             <dependency>
                 <!-- This make sure all google libraries are using compatible versions. -->
                 <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
         <slf4j.version>2.0.9</slf4j.version>
         <netex-java-model.version>2.0.15</netex-java-model.version>
         <siri-java-model.version>1.25</siri-java-model.version>
-        <jaxb-runtime.version>3.0.2</jaxb-runtime.version>
+        <jakarta.xml.bind-api.version>4.0.1</jakarta.xml.bind-api.version>
+        <jaxb-runtime.version>4.0.4</jaxb-runtime.version>
         <!-- Other properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <GITHUB_REPOSITORY>opentripplanner/OpenTripPlanner</GITHUB_REPOSITORY>
@@ -560,12 +561,12 @@
                 The jaxb-api provides annotations like XmlElement indicating how classes should be (de)serialized.
                 The jaxb-runtime pulls in the jaxb-api of the same version transitively. But we specify both api and
                 runtime dependencies anyway here at the top level to prevent transitive dependencies from pulling in
-                mismatched versions. This is overriding an older version of jaxb-api pulled in by the netex-java-model.
+                mismatched versions.
             -->
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>3.0.1</version>
+                <version>${jakarta.xml.bind-api.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <logback.version>1.4.11</logback.version>
         <lucene.version>9.8.0</lucene.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <netex-java-model.version>2.0.14</netex-java-model.version>
+        <netex-java-model.version>2.0.15</netex-java-model.version>
         <siri-java-model.version>1.25</siri-java-model.version>
         <jaxb-runtime.version>3.0.2</jaxb-runtime.version>
         <!-- Other properties -->

--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
@@ -6,8 +6,8 @@ import jakarta.xml.bind.JAXBElement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import org.opentripplanner.netex.index.NetexEntityIndex;
+import org.opentripplanner.netex.support.JAXBUtils;
 import org.rutebanken.netex.model.DayType;
 import org.rutebanken.netex.model.DayTypeAssignment;
 import org.rutebanken.netex.model.DayTypeAssignmentsInFrame_RelStructure;
@@ -100,13 +100,11 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
     if (operatingPeriods == null) {
       return;
     }
-
-    operatingPeriods
-      .getOperatingPeriodRefOrOperatingPeriodOrUicOperatingPeriod()
-      .stream()
-      .filter(Objects::nonNull)
-      .map(JAXBElement::getValue)
-      .forEach(this::parseOperatingPeriod);
+    JAXBUtils.forEachJAXBElementValue(
+      Object.class,
+      operatingPeriods.getOperatingPeriodRefOrOperatingPeriodOrUicOperatingPeriod(),
+      this::parseOperatingPeriod
+    );
   }
 
   private void parseOperatingPeriod(Object operatingPeriod) {

--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
@@ -6,6 +6,7 @@ import jakarta.xml.bind.JAXBElement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import org.opentripplanner.netex.index.NetexEntityIndex;
 import org.rutebanken.netex.model.DayType;
 import org.rutebanken.netex.model.DayTypeAssignment;
@@ -100,9 +101,12 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
       return;
     }
 
-    for (Object p : operatingPeriods.getOperatingPeriodRefOrOperatingPeriodOrUicOperatingPeriod()) {
-      parseOperatingPeriod(p);
-    }
+    operatingPeriods
+      .getOperatingPeriodRefOrOperatingPeriodOrUicOperatingPeriod()
+      .stream()
+      .filter(Objects::nonNull)
+      .map(JAXBElement::getValue)
+      .forEach(this::parseOperatingPeriod);
   }
 
   private void parseOperatingPeriod(Object operatingPeriod) {

--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -180,8 +180,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
     if (routes == null) return;
 
     for (JAXBElement<?> element : routes.getRoute_()) {
-      if (element.getValue() instanceof Route) {
-        Route route = (Route) element.getValue();
+      if (element.getValue() instanceof Route route) {
         this.routes.add(route);
       }
     }

--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -149,7 +149,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
             assignment.getId()
           );
         } else {
-          String quayRef = assignment.getQuayRef().getRef();
+          String quayRef = assignment.getQuayRef().getValue().getRef();
           String stopPointRef = assignment.getScheduledStopPointRef().getValue().getRef();
           quayIdByStopPointRef.put(stopPointRef, quayRef);
         }

--- a/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.netex.index.NetexEntityIndex;
+import org.opentripplanner.netex.support.JAXBUtils;
 import org.rutebanken.netex.model.FlexibleStopPlace;
 import org.rutebanken.netex.model.GroupOfStopPlaces;
 import org.rutebanken.netex.model.Quay;
@@ -109,15 +110,10 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
   }
 
   private void parseQuays(Quays_RelStructure quayRefOrQuay) {
-    if (quayRefOrQuay == null) return;
-
-    quayRefOrQuay
-      .getQuayRefOrQuay()
-      .stream()
-      .map(JAXBElement::getValue)
-      .filter(Quay.class::isInstance)
-      .map(Quay.class::cast)
-      .forEach(quays::add);
+    if (quayRefOrQuay == null) {
+      return;
+    }
+    JAXBUtils.forEachJAXBElementValue(Quay.class, quayRefOrQuay.getQuayRefOrQuay(), quays::add);
   }
 
   private boolean isMultiModalStopPlace(StopPlace stopPlace) {

--- a/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
@@ -11,6 +11,7 @@ import org.rutebanken.netex.model.GroupOfStopPlaces;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.Quays_RelStructure;
 import org.rutebanken.netex.model.Site_VersionFrameStructure;
+import org.rutebanken.netex.model.Site_VersionStructure;
 import org.rutebanken.netex.model.StopPlace;
 import org.rutebanken.netex.model.TariffZone;
 import org.rutebanken.netex.model.TariffZone_VersionStructure;
@@ -37,7 +38,7 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
   @Override
   public void parse(Site_VersionFrameStructure frame) {
     if (frame.getStopPlaces() != null) {
-      parseStopPlaces(frame.getStopPlaces().getStopPlace());
+      parseStopPlaces(frame.getStopPlaces().getStopPlace_());
     }
     if (frame.getGroupsOfStopPlaces() != null) {
       parseGroupsOfStopPlaces(frame.getGroupsOfStopPlaces().getGroupOfStopPlaces());
@@ -87,8 +88,9 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
     groupsOfStopPlaces.addAll(groupsOfStopPlacesList);
   }
 
-  private void parseStopPlaces(Collection<StopPlace> stopPlaceList) {
-    for (StopPlace stopPlace : stopPlaceList) {
+  private void parseStopPlaces(List<JAXBElement<? extends Site_VersionStructure>> stopPlaceList) {
+    for (JAXBElement<? extends Site_VersionStructure> jaxBStopPlace : stopPlaceList) {
+      StopPlace stopPlace = (StopPlace) jaxBStopPlace.getValue();
       if (isMultiModalStopPlace(stopPlace)) {
         multiModalStopPlaces.add(stopPlace);
       } else {
@@ -109,9 +111,9 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
   private void parseQuays(Quays_RelStructure quayRefOrQuay) {
     if (quayRefOrQuay == null) return;
 
-    for (Object quayObject : quayRefOrQuay.getQuayRefOrQuay()) {
-      if (quayObject instanceof Quay) {
-        quays.add((Quay) quayObject);
+    for (JAXBElement<?> quayObject : quayRefOrQuay.getQuayRefOrQuay()) {
+      if (quayObject.getValue() instanceof Quay quay) {
+        quays.add(quay);
       }
     }
   }

--- a/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
@@ -111,11 +111,13 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
   private void parseQuays(Quays_RelStructure quayRefOrQuay) {
     if (quayRefOrQuay == null) return;
 
-    for (JAXBElement<?> quayObject : quayRefOrQuay.getQuayRefOrQuay()) {
-      if (quayObject.getValue() instanceof Quay quay) {
-        quays.add(quay);
-      }
-    }
+    quayRefOrQuay
+      .getQuayRefOrQuay()
+      .stream()
+      .map(JAXBElement::getValue)
+      .filter(Quay.class::isInstance)
+      .map(Quay.class::cast)
+      .forEach(quays::add);
   }
 
   private boolean isMultiModalStopPlace(StopPlace stopPlace) {

--- a/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(NetexParser.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SiteFrameParser.class);
 
   private final Collection<FlexibleStopPlace> flexibleStopPlaces = new ArrayList<>();
 

--- a/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
@@ -39,7 +39,7 @@ class TimeTableFrameParser extends NetexParser<Timetable_VersionFrameStructure> 
 
     // Keep list sorted alphabetically
     warnOnMissingMapping(LOG, frame.getBookingTimes());
-    warnOnMissingMapping(LOG, frame.getVehicleTypeRef());
+    warnOnMissingMapping(LOG, frame.getVehicleTypes());
     warnOnMissingMapping(LOG, frame.getCoupledJourneys());
     warnOnMissingMapping(LOG, frame.getDefaultInterchanges());
     warnOnMissingMapping(LOG, frame.getFlexibleServiceProperties());
@@ -58,7 +58,7 @@ class TimeTableFrameParser extends NetexParser<Timetable_VersionFrameStructure> 
     warnOnMissingMapping(LOG, frame.getTrainNumbers());
     warnOnMissingMapping(LOG, frame.getTypesOfService());
     warnOnMissingMapping(LOG, frame.getVehicleTypes());
-    warnOnMissingMapping(LOG, frame.getVehicleTypeRef());
+    warnOnMissingMapping(LOG, frame.getVehicleTypes());
 
     verifyCommonUnusedPropertiesIsNotSet(LOG, frame);
   }

--- a/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
@@ -76,10 +76,10 @@ class TimeTableFrameParser extends NetexParser<Timetable_VersionFrameStructure> 
       return;
     }
     for (Journey_VersionStructure it : element.getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney()) {
-      if (it instanceof ServiceJourney) {
-        serviceJourneys.add((ServiceJourney) it);
-      } else if (it instanceof DatedServiceJourney) {
-        datedServiceJourneys.add((DatedServiceJourney) it);
+      if (it instanceof ServiceJourney serviceJourney) {
+        serviceJourneys.add(serviceJourney);
+      } else if (it instanceof DatedServiceJourney datedServiceJourney) {
+        datedServiceJourneys.add(datedServiceJourney);
       } else {
         warnOnMissingMapping(LOG, it);
       }
@@ -92,8 +92,8 @@ class TimeTableFrameParser extends NetexParser<Timetable_VersionFrameStructure> 
     }
     var list = element.getServiceJourneyPatternInterchangeOrServiceJourneyInterchange();
     for (Interchange_VersionStructure it : list) {
-      if (it instanceof ServiceJourneyInterchange) {
-        serviceJourneyInterchanges.add((ServiceJourneyInterchange) it);
+      if (it instanceof ServiceJourneyInterchange serviceJourneyInterchange) {
+        serviceJourneyInterchanges.add(serviceJourneyInterchange);
       } else {
         warnOnMissingMapping(LOG, it);
       }

--- a/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
@@ -39,7 +39,6 @@ class TimeTableFrameParser extends NetexParser<Timetable_VersionFrameStructure> 
 
     // Keep list sorted alphabetically
     warnOnMissingMapping(LOG, frame.getBookingTimes());
-    warnOnMissingMapping(LOG, frame.getVehicleTypes());
     warnOnMissingMapping(LOG, frame.getCoupledJourneys());
     warnOnMissingMapping(LOG, frame.getDefaultInterchanges());
     warnOnMissingMapping(LOG, frame.getFlexibleServiceProperties());
@@ -57,7 +56,6 @@ class TimeTableFrameParser extends NetexParser<Timetable_VersionFrameStructure> 
     warnOnMissingMapping(LOG, frame.getTimingLinkGroups());
     warnOnMissingMapping(LOG, frame.getTrainNumbers());
     warnOnMissingMapping(LOG, frame.getTypesOfService());
-    warnOnMissingMapping(LOG, frame.getVehicleTypes());
     warnOnMissingMapping(LOG, frame.getVehicleTypes());
 
     verifyCommonUnusedPropertiesIsNotSet(LOG, frame);

--- a/src/main/java/org/opentripplanner/netex/mapping/GroupOfStationsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/GroupOfStationsMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
+import jakarta.xml.bind.JAXBElement;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
@@ -51,7 +52,11 @@ class GroupOfStationsMapper {
         "GroupOfStopPlaces {} does not contain a name.",
         groupOfStopPlaces.getId()
       );
-      StopPlaceRefStructure ref = groupOfStopPlaces.getMembers().getStopPlaceRef().get(0);
+      StopPlaceRefStructure ref = groupOfStopPlaces
+        .getMembers()
+        .getStopPlaceRef()
+        .get(0)
+        .getValue();
       name = stations.get(idFactory.createId(ref.getRef())).getName();
     }
     GroupOfStationsBuilder groupOfStations = GroupOfStations
@@ -83,9 +88,9 @@ class GroupOfStationsMapper {
   ) {
     StopPlaceRefs_RelStructure members = groupOfStopPlaces.getMembers();
     if (members != null) {
-      List<StopPlaceRefStructure> memberList = members.getStopPlaceRef();
-      for (StopPlaceRefStructure stopPlaceRefStructure : memberList) {
-        FeedScopedId stationId = idFactory.createId(stopPlaceRefStructure.getRef());
+      List<JAXBElement<? extends StopPlaceRefStructure>> memberList = members.getStopPlaceRef();
+      for (JAXBElement<? extends StopPlaceRefStructure> stopPlaceRefStructure : memberList) {
+        FeedScopedId stationId = idFactory.createId(stopPlaceRefStructure.getValue().getRef());
         StopLocationsGroup station = lookupStation(stationId);
         if (station != null) {
           groupOfStations.addChildStation(station);

--- a/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
+import jakarta.xml.bind.JAXBElement;
 import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -131,8 +132,8 @@ class StationMapper {
         stopPlace.getId() + " " + stopPlace.getName()
       );
       List<WgsCoordinate> coordinates = new ArrayList<>();
-      for (Object it : stopPlace.getQuays().getQuayRefOrQuay()) {
-        if (it instanceof Quay quay && quay.getCentroid() != null) {
+      for (JAXBElement<?> it : stopPlace.getQuays().getQuayRefOrQuay()) {
+        if (it.getValue() instanceof Quay quay && quay.getCentroid() != null) {
           coordinates.add(WgsCoordinateMapper.mapToDomain(quay.getCentroid()));
         }
       }

--- a/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.netex.mapping;
 
-import jakarta.xml.bind.JAXBElement;
 import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.HashMap;
@@ -14,6 +13,7 @@ import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.i18n.TranslatedString;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.opentripplanner.netex.support.JAXBUtils;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.site.Station;
 import org.rutebanken.netex.model.LimitedUseTypeEnumeration;
@@ -132,14 +132,8 @@ class StationMapper {
         "Station %s does not contain any coordinates.",
         stopPlace.getId() + " " + stopPlace.getName()
       );
-      List<WgsCoordinate> coordinates = stopPlace
-        .getQuays()
-        .getQuayRefOrQuay()
-        .stream()
-        .map(JAXBElement::getValue)
-        .filter(Objects::nonNull)
-        .filter(Quay.class::isInstance)
-        .map(Quay.class::cast)
+      List<WgsCoordinate> coordinates = JAXBUtils
+        .streamJAXBElementValue(Quay.class, stopPlace.getQuays().getQuayRefOrQuay())
         .map(Zone_VersionStructure::getCentroid)
         .filter(Objects::nonNull)
         .map(WgsCoordinateMapper::mapToDomain)

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import jakarta.xml.bind.JAXBElement;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -129,9 +130,9 @@ class StopAndStationMapper {
 
     return stopPlace
       .getTariffZones()
-      .getTariffZoneRef()
+      .getTariffZoneRef_()
       .stream()
-      .map(ref -> findTariffZone(stopPlace, ref))
+      .map(ref -> findTariffZone(stopPlace, (TariffZoneRef) ref.getValue()))
       .filter(Objects::nonNull)
       .collect(Collectors.toList());
   }
@@ -209,9 +210,9 @@ class StopAndStationMapper {
 
     List<Quay> result = new ArrayList<>();
 
-    for (Object it : quays.getQuayRefOrQuay()) {
-      if (it instanceof Quay) {
-        result.add((Quay) it);
+    for (JAXBElement<?> it : quays.getQuayRefOrQuay()) {
+      if (it.getValue() instanceof Quay quay) {
+        result.add(quay);
       } else {
         issueStore.add(
           Issue.issue(

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -230,7 +230,7 @@ class StopAndStationMapper {
   /**
    * Get WheelChairBoarding from Quay and parent Station.
    *
-   * @param quay      NeTEx quay could contain information about accessability
+   * @param quay      NeTEx quay could contain information about accessibility
    * @param stopPlace Parent StopPlace for given Quay
    * @return not null value with default NO_INFORMATION if nothing defined in quay or parentStation.
    */

--- a/src/main/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapper.java
@@ -36,7 +36,16 @@ class StopPlaceTypeMapper {
       case RAIL -> TransitMode.RAIL;
       case TRAM -> TransitMode.TRAM;
       case WATER, FERRY -> TransitMode.FERRY;
-      case LIFT, OTHER, SNOW_AND_ICE -> null;
+      case LIFT,
+        OTHER,
+        SNOW_AND_ICE,
+        TAXI,
+        ALL,
+        ANY_MODE,
+        INTERCITY_RAIL,
+        URBAN_RAIL,
+        SELF_DRIVE,
+        UNKNOWN -> null;
     };
   }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
@@ -63,6 +63,8 @@ class TransportModeMapper {
       return new NetexMainAndSubMode(TransitMode.TRAM, submode.getTramSubmode().value());
     } else if (submode.getWaterSubmode() != null) {
       return new NetexMainAndSubMode(TransitMode.FERRY, submode.getWaterSubmode().value());
+    } else if (submode.getTaxiSubmode() != null) {
+      return new NetexMainAndSubMode(TransitMode.TAXI, submode.getTaxiSubmode().value());
     }
     throw new IllegalArgumentException();
   }

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
@@ -153,7 +153,7 @@ public class DayTypeAssignmentMapper {
   private void addOperatingPeriod(DayTypeAssignment dayTypeAssignment) {
     boolean isAvailable = isDayTypeAvailableForAssigment(dayTypeAssignment);
 
-    String ref = dayTypeAssignment.getOperatingPeriodRef().getRef();
+    String ref = dayTypeAssignment.getOperatingPeriodRef().getValue().getRef();
     OperatingPeriod_VersionStructure period = operatingPeriods.lookup(ref);
 
     if (period instanceof OperatingPeriod operatingPeriod) {

--- a/src/main/java/org/opentripplanner/netex/support/JAXBUtils.java
+++ b/src/main/java/org/opentripplanner/netex/support/JAXBUtils.java
@@ -1,0 +1,54 @@
+package org.opentripplanner.netex.support;
+
+import jakarta.xml.bind.JAXBElement;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * Utility class for processing JAXB objects.
+ */
+public final class JAXBUtils {
+
+  private JAXBUtils() {}
+
+  /**
+   * Transform a collection of JAXBElement wrappers into a stream containing the unwrapped values.
+   * Null values are filtered out. Note:
+   * <ul>A null JAXBElement represents an element not present in the document.</ul>
+   * <ul>A non-null JAXBElement wrapping a null value represents an xsi:nil element.</ul>
+   * There is currently no nillable elements in NeTEx.
+   *
+   * @param type the Java type of the wrapped element.
+   * @param c    the collection of JAXBElement wrappers.
+   */
+  public static <S extends JAXBElement<?>, T> Stream<T> streamJAXBElementValue(
+    Class<T> type,
+    Collection<S> c
+  ) {
+    return c
+      .stream()
+      .filter(Objects::nonNull)
+      .map(JAXBElement::getValue)
+      .filter(Objects::nonNull)
+      .filter(type::isInstance)
+      .map(type::cast);
+  }
+
+  /**
+   * Transform a collection of JAXBElement wrappers into a stream containing the unwrapped values
+   * and apply a consumer on each value. Null values are filtered out.
+   *
+   * @param type the Java type of the wrapped element.
+   * @param c    the collection of JAXBElement wrappers.
+   * @param body a consumer to apply on each unwrapped value.
+   */
+  public static <S extends JAXBElement<?>, T> void forEachJAXBElementValue(
+    Class<T> type,
+    Collection<S> c,
+    Consumer<T> body
+  ) {
+    streamJAXBElementValue(type, c).forEach(body);
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
+++ b/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
@@ -1,11 +1,15 @@
 package org.opentripplanner.netex;
 
 import jakarta.xml.bind.JAXBElement;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collection;
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.xml.namespace.QName;
+import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.DayOfWeekEnumeration;
 import org.rutebanken.netex.model.DayType;
@@ -13,6 +17,8 @@ import org.rutebanken.netex.model.DayTypeAssignment;
 import org.rutebanken.netex.model.DayTypeRefStructure;
 import org.rutebanken.netex.model.DayTypeRefs_RelStructure;
 import org.rutebanken.netex.model.JourneyRefStructure;
+import org.rutebanken.netex.model.LocationStructure;
+import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.OperatingDay;
 import org.rutebanken.netex.model.OperatingDayRefStructure;
@@ -20,10 +26,31 @@ import org.rutebanken.netex.model.OperatingPeriod;
 import org.rutebanken.netex.model.OperatingPeriodRefStructure;
 import org.rutebanken.netex.model.PropertiesOfDay_RelStructure;
 import org.rutebanken.netex.model.PropertyOfDay;
+import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.Quays_RelStructure;
 import org.rutebanken.netex.model.ServiceAlterationEnumeration;
+import org.rutebanken.netex.model.SimplePoint_VersionStructure;
+import org.rutebanken.netex.model.StopPlace;
 import org.rutebanken.netex.model.UicOperatingPeriod;
 
 public final class NetexTestDataSupport {
+
+  public static final String QUAY_ID = "TEST_QUAY_ID";
+  public static final String QUAY_NAME = "TEST_QUAY_NAME";
+  public static final String QUAY_VERSION = "TEST_QUAY_VERSION";
+  public static final double QUAY_LAT = 0.1;
+  public static final double QUAY_LON = 0.2;
+  public static final String QUAY_PLATFORM_CODE = "TEST_QUAY_PLATFORM_CODE";
+
+  public static final String STOP_PLACE_ID = "TEST_STOP_PLACE_ID";
+  public static final String STOP_PLACE_NAME = "TEST_STOP_PLACE_NAME";
+  public static final String STOP_PLACE_VERSION = "TEST_STOP_PLACE_VERSION";
+  public static final double STOP_PLACE_LAT = 0.11;
+  public static final double STOP_PLACE_LON = 0.22;
+  public static final AllVehicleModesOfTransportEnumeration STOP_PLACE_TRANSPORT_MODE =
+    AllVehicleModesOfTransportEnumeration.BUS;
+
+  private static final ObjectFactory OBJECT_FACTORY = new ObjectFactory();
 
   /** Utility class, prevent instantiation. */
   private NetexTestDataSupport() {}
@@ -170,5 +197,90 @@ public final class NetexTestDataSupport {
 
   public static OperatingDayRefStructure operatingDayRef(String id) {
     return new OperatingDayRefStructure().withRef(id);
+  }
+
+  public static StopPlace createStopPlace(
+    String id,
+    String name,
+    String version,
+    Double lat,
+    Double lon,
+    AllVehicleModesOfTransportEnumeration transportMode,
+    Quay quay
+  ) {
+    StopPlace stopPlace = new StopPlace()
+      .withName(createMLString(name))
+      .withVersion(version)
+      .withId(id)
+      .withCentroid(createSimplePoint(lat, lon))
+      .withTransportMode(transportMode);
+
+    if (quay != null) {
+      Collection<JAXBElement<?>> jaxbQuays = List.of(OBJECT_FACTORY.createQuay(quay));
+      Quays_RelStructure quays = OBJECT_FACTORY
+        .createQuays_RelStructure()
+        .withQuayRefOrQuay(jaxbQuays);
+      stopPlace.withQuays(quays);
+    }
+
+    return stopPlace;
+  }
+
+  public static StopPlace createStopPlace(
+    String id,
+    String name,
+    String version,
+    Double lat,
+    Double lon,
+    AllVehicleModesOfTransportEnumeration transportMode
+  ) {
+    return createStopPlace(id, name, version, lat, lon, transportMode, null);
+  }
+
+  public static StopPlace createStopPlace(Quay quay) {
+    return createStopPlace(
+      STOP_PLACE_ID,
+      STOP_PLACE_NAME,
+      STOP_PLACE_VERSION,
+      STOP_PLACE_LAT,
+      STOP_PLACE_LON,
+      STOP_PLACE_TRANSPORT_MODE,
+      quay
+    );
+  }
+
+  public static StopPlace createStopPlace() {
+    return createStopPlace(null);
+  }
+
+  public static Quay createQuay(
+    String id,
+    String name,
+    String version,
+    Double lat,
+    Double lon,
+    String platformCode
+  ) {
+    return new Quay()
+      .withName(createMLString(name))
+      .withId(id)
+      .withVersion(version)
+      .withPublicCode(platformCode)
+      .withCentroid(createSimplePoint(lat, lon));
+  }
+
+  public static Quay createQuay() {
+    return createQuay(QUAY_ID, QUAY_NAME, QUAY_VERSION, QUAY_LAT, QUAY_LON, QUAY_PLATFORM_CODE);
+  }
+
+  private static MultilingualString createMLString(String name) {
+    return new MultilingualString().withValue(name);
+  }
+
+  private static SimplePoint_VersionStructure createSimplePoint(Double lat, Double lon) {
+    return new SimplePoint_VersionStructure()
+      .withLocation(
+        new LocationStructure().withLatitude(new BigDecimal(lat)).withLongitude(new BigDecimal(lon))
+      );
   }
 }

--- a/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
+++ b/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
@@ -13,6 +13,7 @@ import org.rutebanken.netex.model.DayTypeAssignment;
 import org.rutebanken.netex.model.DayTypeRefStructure;
 import org.rutebanken.netex.model.DayTypeRefs_RelStructure;
 import org.rutebanken.netex.model.JourneyRefStructure;
+import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.OperatingDay;
 import org.rutebanken.netex.model.OperatingDayRefStructure;
 import org.rutebanken.netex.model.OperatingPeriod;
@@ -89,7 +90,10 @@ public final class NetexTestDataSupport {
     Boolean isAvailable
   ) {
     return createDayTypeAssignment(dayTypeId, isAvailable)
-      .withOperatingPeriodRef(new OperatingPeriodRefStructure().withRef(opPeriodId));
+      .withOperatingPeriodRef(
+        new ObjectFactory()
+          .createOperatingPeriodRef(new OperatingPeriodRefStructure().withRef(opPeriodId))
+      );
   }
 
   public static DayTypeAssignment createDayTypeAssignmentWithOpDay(

--- a/src/test/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParserTest.java
+++ b/src/test/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParserTest.java
@@ -1,0 +1,73 @@
+package org.opentripplanner.netex.loader.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.xml.bind.JAXBElement;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.netex.index.NetexEntityIndex;
+import org.rutebanken.netex.model.ObjectFactory;
+import org.rutebanken.netex.model.OperatingPeriod;
+import org.rutebanken.netex.model.OperatingPeriod_VersionStructure;
+import org.rutebanken.netex.model.ServiceCalendarFrame_VersionFrameStructure;
+
+class ServiceCalendarFrameParserTest {
+
+  private static final LocalDateTime FROM_DATE = LocalDateTime.of(2023, 1, 1, 0, 0);
+  private static final LocalDateTime TO_DATE = LocalDateTime.of(2023, 2, 1, 0, 0);
+  private static final ObjectFactory OBJECT_FACTORY = new ObjectFactory();
+  private ServiceCalendarFrameParser serviceCalendarFrameParser;
+  private ServiceCalendarFrame_VersionFrameStructure serviceCalendarFrame;
+  private NetexEntityIndex netexEntityIndex;
+
+  @BeforeEach
+  void setUp() {
+    serviceCalendarFrameParser = new ServiceCalendarFrameParser();
+    serviceCalendarFrame = OBJECT_FACTORY.createServiceCalendarFrame_VersionFrameStructure();
+    netexEntityIndex = new NetexEntityIndex();
+  }
+
+  @Test
+  void testParseOperatingPeriodInServiceFrame() {
+    serviceCalendarFrame.setOperatingPeriods(
+      OBJECT_FACTORY.createOperatingPeriodsInFrame_RelStructure()
+    );
+
+    OperatingPeriod_VersionStructure operatingPeriod = OBJECT_FACTORY
+      .createOperatingPeriod_VersionStructure()
+      .withFromDate(FROM_DATE)
+      .withToDate(TO_DATE);
+    serviceCalendarFrame
+      .getOperatingPeriods()
+      .getOperatingPeriodOrUicOperatingPeriod()
+      .add(operatingPeriod);
+
+    serviceCalendarFrameParser.parse(serviceCalendarFrame);
+    serviceCalendarFrameParser.setResultOnIndex(netexEntityIndex);
+    assertEquals(1, netexEntityIndex.operatingPeriodById.size());
+  }
+
+  @Test
+  void testParseOperatingPeriodInServiceCalendar() {
+    serviceCalendarFrame.setServiceCalendar(OBJECT_FACTORY.createServiceCalendar());
+    serviceCalendarFrame
+      .getServiceCalendar()
+      .setOperatingPeriods(OBJECT_FACTORY.createOperatingPeriods_RelStructure());
+
+    OperatingPeriod operatingPeriod = OBJECT_FACTORY
+      .createOperatingPeriod()
+      .withFromDate(FROM_DATE)
+      .withToDate(TO_DATE);
+    JAXBElement<?> jaxbOperatingPeriod = OBJECT_FACTORY.createOperatingPeriod(operatingPeriod);
+    serviceCalendarFrame
+      .getServiceCalendar()
+      .getOperatingPeriods()
+      .getOperatingPeriodRefOrOperatingPeriodOrUicOperatingPeriod()
+      .add(jaxbOperatingPeriod);
+
+    serviceCalendarFrameParser.parse(serviceCalendarFrame);
+    serviceCalendarFrameParser.setResultOnIndex(netexEntityIndex);
+    assertEquals(1, netexEntityIndex.operatingPeriodById.size());
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/loader/parser/SiteFrameParserTest.java
+++ b/src/test/java/org/opentripplanner/netex/loader/parser/SiteFrameParserTest.java
@@ -1,0 +1,42 @@
+package org.opentripplanner.netex.loader.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.netex.NetexTestDataSupport.createQuay;
+import static org.opentripplanner.netex.NetexTestDataSupport.createStopPlace;
+
+import jakarta.xml.bind.JAXBElement;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.netex.NetexTestDataSupport;
+import org.opentripplanner.netex.index.NetexEntityIndex;
+import org.rutebanken.netex.model.ObjectFactory;
+import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.SiteFrame;
+import org.rutebanken.netex.model.Site_VersionStructure;
+import org.rutebanken.netex.model.StopPlace;
+
+class SiteFrameParserTest {
+
+  private static final ObjectFactory OBJECT_FACTORY = new ObjectFactory();
+
+  @Test
+  void testParseQuays() {
+    SiteFrameParser siteFrameParser = new SiteFrameParser();
+    SiteFrame siteFrame = OBJECT_FACTORY.createSiteFrame();
+    NetexEntityIndex netexEntityIndex = new NetexEntityIndex();
+
+    Quay quay = createQuay();
+    StopPlace stopPlace = createStopPlace(quay);
+    JAXBElement<? extends Site_VersionStructure> jaxbStopPlace = OBJECT_FACTORY.createStopPlace(
+      stopPlace
+    );
+
+    siteFrame.setStopPlaces(OBJECT_FACTORY.createStopPlacesInFrame_RelStructure());
+    siteFrame.getStopPlaces().getStopPlace_().add(jaxbStopPlace);
+
+    siteFrameParser.parse(siteFrame);
+    siteFrameParser.setResultOnIndex(netexEntityIndex);
+    Collection<Quay> mappedQuays = netexEntityIndex.quayById.lookup(NetexTestDataSupport.QUAY_ID);
+    assertEquals(1, mappedQuays.size());
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
@@ -31,6 +31,7 @@ import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Network;
 import org.rutebanken.netex.model.OrganisationRefStructure;
 import org.rutebanken.netex.model.PresentationStructure;
+import org.rutebanken.netex.model.TransportOrganisationRefStructure;
 
 public class RouteMapperTest {
 
@@ -81,7 +82,7 @@ public class RouteMapperTest {
     Network network = new Network()
       .withId(NETWORK_ID)
       .withTransportOrganisationRef(
-        createJaxbElement(new OrganisationRefStructure().withRef(AUTHORITY_ID))
+        createJaxbElement(new TransportOrganisationRefStructure().withRef(AUTHORITY_ID))
       );
 
     netexIndex.networkById.add(network);

--- a/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
@@ -29,11 +29,10 @@ import org.rutebanken.netex.model.GroupOfLinesRefStructure;
 import org.rutebanken.netex.model.Line;
 import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Network;
-import org.rutebanken.netex.model.OrganisationRefStructure;
 import org.rutebanken.netex.model.PresentationStructure;
 import org.rutebanken.netex.model.TransportOrganisationRefStructure;
 
-public class RouteMapperTest {
+class RouteMapperTest {
 
   private static final String NETWORK_ID = "RUT:Network:1";
   private static final String GOL_ID_1 = "RUT:GroupOfLines:1";
@@ -48,7 +47,7 @@ public class RouteMapperTest {
   private static final Set<String> EMPTY_FERRY_WITHOUT_BICYCLE_IDS = Collections.emptySet();
 
   @Test
-  public void mapRouteWithDefaultAgency() {
+  void mapRouteWithDefaultAgency() {
     NetexEntityIndex netexEntityIndex = new NetexEntityIndex();
     Line line = createExampleLine();
 
@@ -73,7 +72,7 @@ public class RouteMapperTest {
   }
 
   @Test
-  public void mapRouteWithAgencySpecified() {
+  void mapRouteWithAgencySpecified() {
     NetexEntityIndex netexIndex = new NetexEntityIndex();
     OtpTransitServiceBuilder transitBuilder = new OtpTransitServiceBuilder(
       DataImportIssueStore.NOOP
@@ -111,7 +110,7 @@ public class RouteMapperTest {
   }
 
   @Test
-  public void mapRouteWithColor() {
+  void mapRouteWithColor() {
     NetexEntityIndex netexEntityIndex = new NetexEntityIndex();
     Line line = createExampleLine();
     byte[] color = new byte[] { 127, 0, 0 };
@@ -133,12 +132,12 @@ public class RouteMapperTest {
 
     Route route = routeMapper.mapRoute(line);
 
-    assertEquals(route.getColor(), "7F0000");
-    assertEquals(route.getTextColor(), "007F00");
+    assertEquals("7F0000", route.getColor());
+    assertEquals("007F00", route.getTextColor());
   }
 
   @Test
-  public void allowBicyclesOnFerries() {
+  void allowBicyclesOnFerries() {
     NetexEntityIndex netexEntityIndex = new NetexEntityIndex();
     Line lineWithBicycles = createExampleFerry(LINE_ID);
     Line lineWithOutBicycles = createExampleFerry(FERRY_WITHOUT_BICYCLES_ID);
@@ -164,7 +163,7 @@ public class RouteMapperTest {
   }
 
   @Test
-  public void mapRouteWithoutBranding() {
+  void mapRouteWithoutBranding() {
     NetexEntityIndex netexEntityIndex = new NetexEntityIndex();
     Line line = createExampleLine();
 
@@ -187,7 +186,7 @@ public class RouteMapperTest {
   }
 
   @Test
-  public void mapRouteWithBranding() {
+  void mapRouteWithBranding() {
     NetexEntityIndex netexIndex = new NetexEntityIndex();
     OtpTransitServiceBuilder transitBuilder = new OtpTransitServiceBuilder(
       DataImportIssueStore.NOOP
@@ -220,7 +219,7 @@ public class RouteMapperTest {
   }
 
   @Test
-  public void mapRouteWithGroupOfRoutes() {
+  void mapRouteWithGroupOfRoutes() {
     NetexEntityIndex netexIndex = new NetexEntityIndex();
     OtpTransitServiceBuilder transitBuilder = new OtpTransitServiceBuilder(
       DataImportIssueStore.NOOP

--- a/src/test/java/org/opentripplanner/netex/mapping/StationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StationMapperTest.java
@@ -1,0 +1,52 @@
+package org.opentripplanner.netex.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.netex.NetexTestDataSupport.createQuay;
+import static org.opentripplanner.netex.NetexTestDataSupport.createStopPlace;
+
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.netex.NetexTestDataSupport;
+import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.opentripplanner.transit.model.framework.EntityById;
+import org.opentripplanner.transit.model.site.Station;
+import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.StopPlace;
+
+class StationMapperTest {
+
+  private StationMapper stationMapper;
+
+  @BeforeEach
+  void setUp() {
+    EntityById<Station> stationsById = new EntityById<>();
+    stationMapper =
+      new StationMapper(
+        DataImportIssueStore.NOOP,
+        new FeedScopedIdFactory("FEED_ID"),
+        ZoneId.of("UTC"),
+        false,
+        stationsById
+      );
+  }
+
+  @Test
+  void testMappingWithStopPlaceCentroid() {
+    StopPlace stopPlace = createStopPlace();
+    Station station = stationMapper.map(stopPlace);
+    assertEquals(NetexTestDataSupport.STOP_PLACE_LAT, station.getLat());
+    assertEquals(NetexTestDataSupport.STOP_PLACE_LON, station.getLon());
+  }
+
+  @Test
+  void testMappingWithQuayCentroid() {
+    Quay quay = createQuay();
+    StopPlace stopPlace = createStopPlace(quay);
+    stopPlace.withCentroid(null);
+    Station station = stationMapper.map(stopPlace);
+    assertEquals(NetexTestDataSupport.QUAY_LAT, station.getLat());
+    assertEquals(NetexTestDataSupport.QUAY_LON, station.getLon());
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -36,13 +36,13 @@ import org.rutebanken.netex.model.Quays_RelStructure;
 import org.rutebanken.netex.model.SimplePoint_VersionStructure;
 import org.rutebanken.netex.model.StopPlace;
 
-public class StopAndStationMapperTest {
+class StopAndStationMapperTest {
 
   public static final ZoneId DEFAULT_TIME_ZONE = ZoneIds.OSLO;
   private final ObjectFactory objectFactory = new ObjectFactory();
 
   @Test
-  public void testWheelChairBoarding() {
+  void testWheelChairBoarding() {
     var stopPlace = createStopPlace(
       "ST:StopPlace:1",
       "Lunce C",
@@ -105,7 +105,7 @@ public class StopAndStationMapperTest {
   }
 
   @Test
-  public void mapStopPlaceAndQuays() {
+  void mapStopPlaceAndQuays() {
     Collection<StopPlace> stopPlaces = new ArrayList<>();
 
     StopPlace stopPlaceNew = createStopPlace(
@@ -209,7 +209,7 @@ public class StopAndStationMapperTest {
 
   @ParameterizedTest
   @CsvSource(value = { "true", "false" })
-  public void testMapIsolatedStopPlace(boolean isolated) {
+  void testMapIsolatedStopPlace(boolean isolated) {
     Collection<StopPlace> stopPlaces = new ArrayList<>();
     StopPlace stopPlace;
     stopPlace =
@@ -247,7 +247,7 @@ public class StopAndStationMapperTest {
   }
 
   @Test
-  public void testDuplicateStopIndices() {
+  void testDuplicateStopIndices() {
     StopLocation.initIndexCounter(0);
     var stopPlace = createStopPlace(
       "ST:StopPlace:1",

--- a/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -4,8 +4,9 @@ import static graphql.Assert.assertFalse;
 import static graphql.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.opentripplanner.netex.NetexTestDataSupport.createQuay;
+import static org.opentripplanner.netex.NetexTestDataSupport.createStopPlace;
 
-import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,12 +29,9 @@ import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.LimitationStatusEnumeration;
 import org.rutebanken.netex.model.LimitedUseTypeEnumeration;
-import org.rutebanken.netex.model.LocationStructure;
-import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.Quays_RelStructure;
-import org.rutebanken.netex.model.SimplePoint_VersionStructure;
 import org.rutebanken.netex.model.StopPlace;
 
 class StopAndStationMapperTest {
@@ -295,49 +293,6 @@ class StopAndStationMapperTest {
       DataImportIssueStore.NOOP,
       false
     );
-  }
-
-  private static StopPlace createStopPlace(
-    String id,
-    String name,
-    String version,
-    Double lat,
-    Double lon,
-    AllVehicleModesOfTransportEnumeration transportMode
-  ) {
-    return new StopPlace()
-      .withName(createMLString(name))
-      .withVersion(version)
-      .withId(id)
-      .withCentroid(createSimplePoint(lat, lon))
-      .withTransportMode(transportMode);
-  }
-
-  private static Quay createQuay(
-    String id,
-    String name,
-    String version,
-    Double lat,
-    Double lon,
-    String platformCode
-  ) {
-    return new Quay()
-      .withName(createMLString(name))
-      .withId(id)
-      .withVersion(version)
-      .withPublicCode(platformCode)
-      .withCentroid(createSimplePoint(lat, lon));
-  }
-
-  private static MultilingualString createMLString(String name) {
-    return new MultilingualString().withValue(name);
-  }
-
-  private static SimplePoint_VersionStructure createSimplePoint(Double lat, Double lon) {
-    return new SimplePoint_VersionStructure()
-      .withLocation(
-        new LocationStructure().withLatitude(new BigDecimal(lat)).withLongitude(new BigDecimal(lon))
-      );
   }
 
   /**

--- a/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -25,19 +25,21 @@ import org.opentripplanner.transit.service.StopModelBuilder;
 import org.rutebanken.netex.model.AccessibilityAssessment;
 import org.rutebanken.netex.model.AccessibilityLimitation;
 import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
+import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.LimitationStatusEnumeration;
 import org.rutebanken.netex.model.LimitedUseTypeEnumeration;
 import org.rutebanken.netex.model.LocationStructure;
 import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.Quays_RelStructure;
 import org.rutebanken.netex.model.SimplePoint_VersionStructure;
 import org.rutebanken.netex.model.StopPlace;
-import org.rutebanken.netex.model.VehicleModeEnumeration;
 
 public class StopAndStationMapperTest {
 
   public static final ZoneId DEFAULT_TIME_ZONE = ZoneIds.OSLO;
+  private final ObjectFactory objectFactory = new ObjectFactory();
 
   @Test
   public void testWheelChairBoarding() {
@@ -47,7 +49,7 @@ public class StopAndStationMapperTest {
       "1",
       55.707005,
       13.186816,
-      VehicleModeEnumeration.BUS
+      AllVehicleModesOfTransportEnumeration.BUS
     );
 
     // Create on quay with access, one without, and one with NULL
@@ -68,9 +70,9 @@ public class StopAndStationMapperTest {
 
     stopPlace.setQuays(
       new Quays_RelStructure()
-        .withQuayRefOrQuay(quay1)
-        .withQuayRefOrQuay(quay2)
-        .withQuayRefOrQuay(quay3)
+        .withQuayRefOrQuay(objectFactory.createQuay(quay1))
+        .withQuayRefOrQuay(objectFactory.createQuay(quay2))
+        .withQuayRefOrQuay(objectFactory.createQuay(quay3))
     );
 
     var stopPlaceById = new HierarchicalVersionMapById<StopPlace>();
@@ -94,7 +96,7 @@ public class StopAndStationMapperTest {
     );
 
     // Add quay with no AccessibilityAssessment, then it should take default from stopPlace
-    stopPlace.getQuays().withQuayRefOrQuay(quay4);
+    stopPlace.getQuays().withQuayRefOrQuay(objectFactory.createQuay(quay4));
 
     stopAndStationMapper.mapParentAndChildStops(List.of(stopPlace));
 
@@ -112,7 +114,7 @@ public class StopAndStationMapperTest {
       "2",
       59.909584,
       10.755165,
-      VehicleModeEnumeration.TRAM
+      AllVehicleModesOfTransportEnumeration.TRAM
     );
 
     StopPlace stopPlaceOld = createStopPlace(
@@ -121,7 +123,7 @@ public class StopAndStationMapperTest {
       "1",
       59.909584,
       10.755165,
-      VehicleModeEnumeration.TRAM
+      AllVehicleModesOfTransportEnumeration.TRAM
     );
 
     stopPlaces.add(stopPlaceNew);
@@ -136,11 +138,15 @@ public class StopAndStationMapperTest {
     Quay quay3 = createQuay("NSR:Quay:3", "", "1", 59.909911, 10.753008, "C");
 
     stopPlaceNew.setQuays(
-      new Quays_RelStructure().withQuayRefOrQuay(quay1b).withQuayRefOrQuay(quay2)
+      new Quays_RelStructure()
+        .withQuayRefOrQuay(objectFactory.createQuay(quay1b))
+        .withQuayRefOrQuay(objectFactory.createQuay(quay2))
     );
 
     stopPlaceOld.setQuays(
-      new Quays_RelStructure().withQuayRefOrQuay(quay1a).withQuayRefOrQuay(quay3)
+      new Quays_RelStructure()
+        .withQuayRefOrQuay(objectFactory.createQuay(quay1a))
+        .withQuayRefOrQuay(objectFactory.createQuay(quay3))
     );
 
     HierarchicalVersionMapById<Quay> quaysById = new HierarchicalVersionMapById<>();
@@ -213,7 +219,7 @@ public class StopAndStationMapperTest {
         "1",
         59.909584,
         10.755165,
-        VehicleModeEnumeration.TRAM
+        AllVehicleModesOfTransportEnumeration.TRAM
       );
 
     stopPlace.withLimitedUse(LimitedUseTypeEnumeration.ISOLATED);
@@ -249,13 +255,13 @@ public class StopAndStationMapperTest {
       "1",
       55.707005,
       13.186816,
-      VehicleModeEnumeration.BUS
+      AllVehicleModesOfTransportEnumeration.BUS
     );
 
     // Create on quay with access, one without, and one with NULL
     var quay1 = createQuay("ST:Quay:1", "Quay1", "1", 55.706063, 13.186708, "a");
 
-    stopPlace.setQuays(new Quays_RelStructure().withQuayRefOrQuay(quay1));
+    stopPlace.setQuays(new Quays_RelStructure().withQuayRefOrQuay(objectFactory.createQuay(quay1)));
 
     StopModelBuilder stopModelBuilder = StopModel.of();
 
@@ -297,7 +303,7 @@ public class StopAndStationMapperTest {
     String version,
     Double lat,
     Double lon,
-    VehicleModeEnumeration transportMode
+    AllVehicleModesOfTransportEnumeration transportMode
   ) {
     return new StopPlace()
       .withName(createMLString(name))

--- a/src/test/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapperTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.basic.TransitMode;
+import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.BusSubmodeEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
 import org.rutebanken.netex.model.StopPlace;
-import org.rutebanken.netex.model.VehicleModeEnumeration;
 
 public class StopPlaceTypeMapperTest {
 
@@ -24,7 +24,7 @@ public class StopPlaceTypeMapperTest {
   @Test
   public void mapWithTransportModeOnly() {
     var transitMode = stopPlaceTypeMapper.map(
-      new StopPlace().withTransportMode(VehicleModeEnumeration.RAIL)
+      new StopPlace().withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
     );
     assertEquals(TransitMode.RAIL, transitMode.mainMode());
     assertNull(transitMode.subMode());
@@ -34,7 +34,7 @@ public class StopPlaceTypeMapperTest {
   public void mapWithSubMode() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace()
-        .withTransportMode(VehicleModeEnumeration.RAIL)
+        .withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
         .withRailSubmode(RailSubmodeEnumeration.REGIONAL_RAIL)
     );
     assertEquals(TransitMode.RAIL, transitMode.mainMode());
@@ -54,7 +54,7 @@ public class StopPlaceTypeMapperTest {
   public void checkSubModePrecedensOverMainMode() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace()
-        .withTransportMode(VehicleModeEnumeration.RAIL)
+        .withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
         .withBusSubmode(BusSubmodeEnumeration.SIGHTSEEING_BUS)
     );
     assertEquals(TransitMode.BUS, transitMode.mainMode());

--- a/src/test/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapperTest.java
@@ -10,19 +10,19 @@ import org.rutebanken.netex.model.BusSubmodeEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
 import org.rutebanken.netex.model.StopPlace;
 
-public class StopPlaceTypeMapperTest {
+class StopPlaceTypeMapperTest {
 
   private final StopPlaceTypeMapper stopPlaceTypeMapper = new StopPlaceTypeMapper();
 
   @Test
-  public void mapWithoutTransportMode() {
+  void mapWithoutTransportMode() {
     var transitMode = stopPlaceTypeMapper.map(new StopPlace());
     assertNull(transitMode.mainMode());
     assertNull(transitMode.subMode());
   }
 
   @Test
-  public void mapWithTransportModeOnly() {
+  void mapWithTransportModeOnly() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace().withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
     );
@@ -31,7 +31,7 @@ public class StopPlaceTypeMapperTest {
   }
 
   @Test
-  public void mapWithSubMode() {
+  void mapWithSubMode() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace()
         .withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
@@ -42,7 +42,7 @@ public class StopPlaceTypeMapperTest {
   }
 
   @Test
-  public void mapWithSubModeOnly() {
+  void mapWithSubModeOnly() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace().withRailSubmode(RailSubmodeEnumeration.REGIONAL_RAIL)
     );
@@ -51,7 +51,7 @@ public class StopPlaceTypeMapperTest {
   }
 
   @Test
-  public void checkSubModePrecedensOverMainMode() {
+  void checkSubModePrecedenceOverMainMode() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace()
         .withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)

--- a/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
@@ -1,35 +1,63 @@
 package org.opentripplanner.netex.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.netex.mapping.TransportModeMapper.UnsupportedModeException;
 import org.opentripplanner.transit.model.basic.TransitMode;
+import org.rutebanken.netex.model.AirSubmodeEnumeration;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.BusSubmodeEnumeration;
+import org.rutebanken.netex.model.CoachSubmodeEnumeration;
+import org.rutebanken.netex.model.FunicularSubmodeEnumeration;
+import org.rutebanken.netex.model.MetroSubmodeEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
+import org.rutebanken.netex.model.TaxiSubmodeEnumeration;
+import org.rutebanken.netex.model.TelecabinSubmodeEnumeration;
+import org.rutebanken.netex.model.TramSubmodeEnumeration;
 import org.rutebanken.netex.model.TransportSubmodeStructure;
 import org.rutebanken.netex.model.WaterSubmodeEnumeration;
 
 class TransportModeMapperTest {
 
-  private static final TransportSubmodeStructure VALID_SUBMODE_STRUCTURE = new TransportSubmodeStructure()
-    .withRailSubmode(RailSubmodeEnumeration.LONG_DISTANCE);
-  private static final EnumSet<AllVehicleModesOfTransportEnumeration> SUPPORTED_MODES = EnumSet.of(
+  private static final Map<AllVehicleModesOfTransportEnumeration, TransportSubmodeStructure> VALID_SUBMODE_STRUCTURES = Map.of(
     AllVehicleModesOfTransportEnumeration.AIR,
+    new TransportSubmodeStructure().withAirSubmode(AirSubmodeEnumeration.DOMESTIC_FLIGHT),
     AllVehicleModesOfTransportEnumeration.BUS,
+    new TransportSubmodeStructure().withBusSubmode(BusSubmodeEnumeration.LOCAL_BUS),
     AllVehicleModesOfTransportEnumeration.CABLEWAY,
+    new TransportSubmodeStructure().withTelecabinSubmode(TelecabinSubmodeEnumeration.TELECABIN),
     AllVehicleModesOfTransportEnumeration.COACH,
+    new TransportSubmodeStructure().withCoachSubmode(CoachSubmodeEnumeration.NATIONAL_COACH),
     AllVehicleModesOfTransportEnumeration.FUNICULAR,
+    new TransportSubmodeStructure().withFunicularSubmode(FunicularSubmodeEnumeration.FUNICULAR),
     AllVehicleModesOfTransportEnumeration.METRO,
+    new TransportSubmodeStructure().withMetroSubmode(MetroSubmodeEnumeration.METRO),
     AllVehicleModesOfTransportEnumeration.RAIL,
+    new TransportSubmodeStructure().withRailSubmode(RailSubmodeEnumeration.LONG_DISTANCE),
     AllVehicleModesOfTransportEnumeration.TAXI,
+    new TransportSubmodeStructure().withTaxiSubmode(TaxiSubmodeEnumeration.COMMUNAL_TAXI),
     AllVehicleModesOfTransportEnumeration.TRAM,
-    AllVehicleModesOfTransportEnumeration.WATER
+    new TransportSubmodeStructure().withTramSubmode(TramSubmodeEnumeration.CITY_TRAM),
+    AllVehicleModesOfTransportEnumeration.WATER,
+    new TransportSubmodeStructure()
+      .withWaterSubmode(WaterSubmodeEnumeration.INTERNATIONAL_PASSENGER_FERRY)
   );
+
+  private static final EnumSet<AllVehicleModesOfTransportEnumeration> SUPPORTED_MODES = EnumSet.copyOf(
+    VALID_SUBMODE_STRUCTURES.keySet()
+  );
+
   private final TransportModeMapper transportModeMapper = new TransportModeMapper();
 
   @Test
@@ -43,10 +71,19 @@ class TransportModeMapperTest {
   void mapWithSubMode() throws UnsupportedModeException {
     var transitMode = transportModeMapper.map(
       AllVehicleModesOfTransportEnumeration.RAIL,
-      VALID_SUBMODE_STRUCTURE
+      VALID_SUBMODE_STRUCTURES.get(AllVehicleModesOfTransportEnumeration.RAIL)
     );
     assertEquals(TransitMode.RAIL, transitMode.mainMode());
     assertEquals("longDistance", transitMode.subMode());
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("createSubModeTestCases")
+  void acceptAllValidSubModes(
+    AllVehicleModesOfTransportEnumeration mode,
+    TransportSubmodeStructure submodeStructure
+  ) throws UnsupportedModeException {
+    assertNotNull(transportModeMapper.map(mode, submodeStructure));
   }
 
   @Test
@@ -80,5 +117,13 @@ class TransportModeMapperTest {
       });
 
     assertThrows(UnsupportedModeException.class, () -> transportModeMapper.map(null, null));
+  }
+
+  private static List<Arguments> createSubModeTestCases() {
+    return VALID_SUBMODE_STRUCTURES
+      .entrySet()
+      .stream()
+      .map(entry -> Arguments.of(entry.getKey(), entry.getValue()))
+      .toList();
   }
 }


### PR DESCRIPTION
### Summary

The release 2.0.15 aims primarily at synchronizing the Entur fork of the NeTEx XML schema with the upstream version hosted by CEN at https://github.com/NeTEx-CEN/NeTEx
This introduces breaking changes at the Java object model level.

See https://github.com/entur/netex-java-model/releases/tag/netex-java-model-2.0.15 for details

**Note:** v2.0.15 supports JakartaEE 10, dependencies in OTP are upgraded accordingly.
JakartaEE 10 deprecates obsolete JAXB features and is otherwise backward compatible with Jakarta EE 9.

### Issue

No

### Unit tests

Added missing unit test coverage for NeTEx parsing.

### Documentation

No

