### PR TITLE
Fix: Linestring will now only be uncompacted when the pattern matches hop geometry

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -140,6 +140,7 @@ public final class TripPattern
 
   public LineString getHopGeometry(int stopPosInPattern) {
     //Only uncompact the line string if the hop geometry and stop pattern have the same size.
+    //Trip patterns can have been extended by RT updates, while the geometry has not been updated.
     if (hopGeometries != null && hopGeometries.length == stopPattern.getSize() - 1) {
       return CompactLineStringUtils.uncompactLineString(hopGeometries[stopPosInPattern], false);
     } else {

--- a/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -139,7 +139,8 @@ public final class TripPattern
   }
 
   public LineString getHopGeometry(int stopPosInPattern) {
-    if (hopGeometries != null) {
+    //Only uncompact the line string if the hop geometry and stop pattern have the same size.
+    if (hopGeometries != null && hopGeometries.length == stopPattern.getSize() - 1) {
       return CompactLineStringUtils.uncompactLineString(hopGeometries[stopPosInPattern], false);
     } else {
       return GeometryUtils


### PR DESCRIPTION
### Summary

Previously, when the trip pattern of a trip during routing did not match the planned trip (added or removed stops), the hop geometry would throw an out-of-bounds exception. This PR fixes that by checking if both the trip geometry and hop geometry have the same length. If not, the fallback geometry generator using stop positions is used.

### Issue

No issue was created, as it's a simple fix.

### Unit tests

No tests were added or modified.

### Documentation

Added comment to explain why we check for equal lengths.