### PR TITLE
Add logging of siri errors to SiriAzureETUpdater

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -22,6 +22,7 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.spi.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.trip.metrics.TripUpdateMetrics;
@@ -117,7 +118,7 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
           false,
           updates
         );
-        logErrors(result);
+        ResultLogger.logUpdateResultErrors(feedId, "siri-et", result);
         recordMetrics.accept(result);
       });
     } catch (JAXBException | XMLStreamException e) {
@@ -144,7 +145,7 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
             false,
             updates
           );
-          logErrors(result);
+          ResultLogger.logUpdateResultErrors(feedId, "siri-et", result);
           recordMetrics.accept(result);
 
           setPrimed(true);
@@ -180,26 +181,5 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
     }
 
     return siri.getServiceDelivery().getEstimatedTimetableDeliveries();
-  }
-
-  private void logErrors(UpdateResult updateResult) {
-    if (updateResult.failed() == 0) {
-      return;
-    }
-    var errorIndex = updateResult.failures();
-    errorIndex
-      .keySet()
-      .forEach(key -> {
-        var value = errorIndex.get(key);
-        var tripIds = value.stream().map(UpdateError::debugId).collect(Collectors.toSet());
-        LOG.warn(
-          "[{} {}] {} failures of {}: {}",
-          keyValue("feedId", feedId),
-          keyValue("type", "siri-et"),
-          value.size(),
-          keyValue("errorType", key),
-          tripIds
-        );
-      });
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.siri.updater.azure;
 
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+
 import com.azure.messaging.servicebus.ServiceBusErrorContext;
 import com.azure.messaging.servicebus.ServiceBusReceivedMessageContext;
 import jakarta.xml.bind.JAXBException;
@@ -14,11 +16,13 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.xml.stream.XMLStreamException;
 import org.apache.hc.core5.net.URIBuilder;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.trip.metrics.TripUpdateMetrics;
 import org.rutebanken.siri20.util.SiriXml;
@@ -106,13 +110,15 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
       }
 
       super.saveResultOnGraph.execute((graph, transitModel) -> {
-        snapshotSource.applyEstimatedTimetable(
+        var result = snapshotSource.applyEstimatedTimetable(
           fuzzyTripMatcher(),
           entityResolver(),
           feedId,
           false,
           updates
         );
+        logErrors(result);
+        recordMetrics.accept(result);
       });
     } catch (JAXBException | XMLStreamException e) {
       LOG.error(e.getLocalizedMessage(), e);
@@ -138,6 +144,7 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
             false,
             updates
           );
+          logErrors(result);
           recordMetrics.accept(result);
 
           setPrimed(true);
@@ -173,5 +180,26 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
     }
 
     return siri.getServiceDelivery().getEstimatedTimetableDeliveries();
+  }
+
+  private void logErrors(UpdateResult updateResult) {
+    if (updateResult.failed() == 0) {
+      return;
+    }
+    var errorIndex = updateResult.failures();
+    errorIndex
+      .keySet()
+      .forEach(key -> {
+        var value = errorIndex.get(key);
+        var tripIds = value.stream().map(UpdateError::debugId).collect(Collectors.toSet());
+        LOG.warn(
+          "[{} {}] {} failures of {}: {}",
+          keyValue("feedId", feedId),
+          keyValue("type", "siri-et"),
+          value.size(),
+          keyValue("errorType", key),
+          tripIds
+        );
+      });
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdaterParameters.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.siri.updater.azure;
 
+import com.azure.core.amqp.implementation.ConnectionStringProperties;
 import java.time.LocalDate;
 import org.opentripplanner.updater.trip.UrlUpdaterParameters;
 
@@ -23,6 +24,11 @@ public class SiriAzureETUpdaterParameters
 
   @Override
   public String url() {
-    return getDataInitializationUrl();
+    var url = getServiceBusUrl();
+    try {
+      return new ConnectionStringProperties(url).getEndpoint().toString();
+    } catch (IllegalArgumentException e) {
+      return url;
+    }
   }
 }

--- a/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
+++ b/src/main/java/org/opentripplanner/updater/spi/ResultLogger.java
@@ -27,24 +27,30 @@ public class ResultLogger {
         DoubleUtils.roundTo2Decimals((double) updateResult.successful() / totalUpdates * 100)
       );
 
-      var errorIndex = updateResult.failures();
-
-      errorIndex
-        .keySet()
-        .forEach(key -> {
-          var value = errorIndex.get(key);
-          var tripIds = value.stream().map(UpdateError::debugId).collect(Collectors.toSet());
-          LOG.warn(
-            "[{} {}] {} failures of {}: {}",
-            keyValue("feedId", feedId),
-            keyValue("type", type),
-            value.size(),
-            keyValue("errorType", key),
-            tripIds
-          );
-        });
+      logUpdateResultErrors(feedId, type, updateResult);
     } else {
       LOG.info("[feedId={}, type={}] Feed did not contain any updates", feedId, type);
     }
+  }
+
+  public static void logUpdateResultErrors(String feedId, String type, UpdateResult updateResult) {
+    if (updateResult.failed() == 0) {
+      return;
+    }
+    var errorIndex = updateResult.failures();
+    errorIndex
+      .keySet()
+      .forEach(key -> {
+        var value = errorIndex.get(key);
+        var tripIds = value.stream().map(UpdateError::debugId).collect(Collectors.toSet());
+        LOG.warn(
+          "[{} {}] {} failures of {}: {}",
+          keyValue("feedId", feedId),
+          keyValue("type", type),
+          value.size(),
+          keyValue("errorType", key),
+          tripIds
+        );
+      });
   }
 }


### PR DESCRIPTION
### Summary

Add logging and metrics in SiriAzureETUpdater

Also use the service bus endpoint instead of the dataInitializationUrl as the url tag in metrics, since this is the more relevant url.