### PR TITLE
Make `GraphQLIntegrationTest` less flaky

### DIFF
--- a/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -119,7 +119,15 @@ class GraphQLIntegrationTest {
       );
 
     var stopModel = StopModel.of();
-    PlanTestConstants.listStops().forEach(sl -> stopModel.withRegularStop((RegularStop) sl));
+    PlanTestConstants
+      .listStops()
+      .forEach(sl -> {
+        // because of https://github.com/opentripplanner/OpenTripPlanner/issues/5480
+        // we make copies of the stops so that they will have an index that is more likely to
+        // exist during indexing of the stop model
+        var stop = (RegularStop) sl;
+        stopModel.withRegularStop(stop.copy().build());
+      });
     var model = stopModel.build();
     var transitModel = new TransitModel(model, DEDUPLICATOR);
 


### PR DESCRIPTION
### Summary

Since last week we have seen some flaky tests which are due to #5480.

Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/6765951122/job/18386315013#step:5:5932

Often it is solved by re-running the tests, which is quite annoying.

This PR attempts to fix it by re-creating new stops which hopefully have an index that is in sync with the current state of `StopLocation.INDEX_COUNTER`. It's just papering over the problem so we need a proper fix for that.

### Issue

Relates to  #5480

