### PR TITLE
use 0.179 as the threshold per W3C recommendation to generate routeTextColor

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -402,7 +402,8 @@ public class GtfsModule implements GraphBuilderModule {
     double luminance = Math.sqrt(newRed + newGreen + newBlue);
 
     //For brighter colors use black text color and reverse for darker
-    if (luminance > 0.5) {
+    //the threshold is based on W3C guideline, see https://stackoverflow.com/a/3943023/272733
+    if (luminance > 0.179) {
       textColor = "000000";
     } else {
       textColor = "FFFFFF";


### PR DESCRIPTION
### Summary

This changes the threshold of color to be 0.179, per W3C recommendation, to generate textColor if not specified in the GTFS but if the background color is specified.

### Issue

The original code uses 0.500 as the threshold to decide black / white text when it is not specified in the GTFS, which is not what I expect and runs foul of the W3C guideline.

### Unit tests

There is no new code, no test on the existing code and the change is trivial, so no new tests are needed.

### Documentation

The rationale of the change, and a link to the Stack Overflow answer, is added as a comment

