### PR TITLE
Expose `numberOfTransfers` in GTFS GraphQL API

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/ItineraryImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/ItineraryImpl.java
@@ -72,6 +72,11 @@ public class ItineraryImpl implements GraphQLDataFetchers.GraphQLItinerary {
   }
 
   @Override
+  public DataFetcher<Integer> numberOfTransfers() {
+    return environment -> getSource(environment).getNumberOfTransfers();
+  }
+
+  @Override
   public DataFetcher<Long> startTime() {
     return environment -> getSource(environment).startTime().toInstant().toEpochMilli();
   }

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -409,6 +409,8 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<Iterable<Leg>> legs();
 
+    public DataFetcher<Integer> numberOfTransfers();
+
     public DataFetcher<Long> startTime();
 
     public DataFetcher<Iterable<SystemNotice>> systemNotices();

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1551,7 +1551,7 @@ type Itinerary {
 
     Note: Interlined/stay-seated transfers also increase the count.
     """
-    numberOfTransfers: Int
+    numberOfTransfers: Int!
 
     #
     # deprecated fields

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1547,9 +1547,11 @@ type Itinerary {
     accessibilityScore: Float
 
     """
-    How many transfers are contained in this itinerary.
+    How many transfers are part of this itinerary.
 
-    Note: Interlined/stay-seated transfers also increase the count.
+    Notes:
+     - Interlined/stay-seated transfers do not increase this count.
+     - Transferring from a flex to a fixed schedule trip and vice versa increases this count.
     """
     numberOfTransfers: Int!
 

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1546,6 +1546,13 @@ type Itinerary {
     """
     accessibilityScore: Float
 
+    """
+    How many transfers are contained in this itinerary.
+
+    Note: Interlined/stay-seated transfers also increase the count.
+    """
+    numberOfTransfers: Int
+
     #
     # deprecated fields
     #

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-extended.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-extended.json
@@ -10,6 +10,7 @@
           "emissionsPerPerson" : {
             "co2" : 123.0
           },
+          "numberOfTransfers" : 1,
           "legs" : [
             {
               "mode" : "WALK",

--- a/src/test/resources/org/opentripplanner/apis/gtfs/queries/plan-extended.graphql
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/queries/plan-extended.graphql
@@ -23,6 +23,7 @@
             emissionsPerPerson {
                 co2
             }
+            numberOfTransfers
             legs {
                 mode
                 from {


### PR DESCRIPTION
### Summary

@binh-dam-ibigroup has requested that the property `numberOfTransfers` which was part of the REST API be exposed in the GTFS GraphQL API.

### Unit tests

GraphQL tests added.

### Documentation

:heavy_check_mark: 