### PR TITLE
Add option to configure linear cost function for transit vs walk filter

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveTransitIfWalkingIsBetterFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveTransitIfWalkingIsBetterFilter.java
@@ -15,6 +15,12 @@ import org.opentripplanner.routing.api.request.framework.CostLinearFunction;
  */
 public class RemoveTransitIfWalkingIsBetterFilter implements ItineraryDeletionFlagger {
 
+  private final CostLinearFunction costLimitFunction;
+
+  public RemoveTransitIfWalkingIsBetterFilter(CostLinearFunction costLimitFunction) {
+    this.costLimitFunction = costLimitFunction;
+  }
+
   /**
    * Required for {@link org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChain},
    * to know which filters removed
@@ -38,7 +44,7 @@ public class RemoveTransitIfWalkingIsBetterFilter implements ItineraryDeletionFl
       return List.of();
     }
 
-    var limit = minWalkCost.getAsInt();
+    var limit = costLimitFunction.calculate(Cost.costOfSeconds(minWalkCost.getAsInt())).toSeconds();
 
     return itineraries
       .stream()

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -70,6 +70,9 @@ public class RouteRequestToFilterChainMapper {
       .withRemoveTransitWithHigherCostThanBestOnStreetOnly(
         params.removeTransitWithHigherCostThanBestOnStreetOnly()
       )
+      .withRemoveTransitWithHigherCostThanBestOnWalkOnly(
+        params.removeTransitWithHigherCostThanBestOnWalkOnly()
+      )
       .withSameFirstOrLastTripFilter(params.filterItinerariesWithSameFirstOrLastTrip())
       .withAccessibilityScore(
         params.useAccessibilityScore() && request.wheelchair(),

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/ItineraryFilterPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/ItineraryFilterPreferences.java
@@ -31,6 +31,7 @@ public final class ItineraryFilterPreferences {
   private final boolean removeItinerariesWithSameRoutesAndStops;
   private final TransitGeneralizedCostFilterParams transitGeneralizedCostLimit;
   private final CostLinearFunction removeTransitWithHigherCostThanBestOnStreetOnly;
+  private final CostLinearFunction removeTransitWithHigherCostThanBestOnWalkOnly;
   private final boolean removeTransitIfWalkingIsBetter;
 
   private ItineraryFilterPreferences() {
@@ -52,6 +53,8 @@ public final class ItineraryFilterPreferences {
       );
     this.removeTransitWithHigherCostThanBestOnStreetOnly =
       CostLinearFunction.of(Duration.ofMinutes(1), 1.3);
+    this.removeTransitWithHigherCostThanBestOnWalkOnly =
+      CostLinearFunction.of(Duration.ofMinutes(0), 1.0);
     this.removeTransitIfWalkingIsBetter = false;
   }
 
@@ -73,6 +76,8 @@ public final class ItineraryFilterPreferences {
     this.transitGeneralizedCostLimit = Objects.requireNonNull(builder.transitGeneralizedCostLimit);
     this.removeTransitWithHigherCostThanBestOnStreetOnly =
       Objects.requireNonNull(builder.removeTransitWithHigherCostThanBestOnStreetOnly);
+    this.removeTransitWithHigherCostThanBestOnWalkOnly =
+      Objects.requireNonNull(builder.removeTransitWithHigherCostThanBestOnWalkOnly);
     this.removeTransitIfWalkingIsBetter = builder.removeTransitIfWalkingIsBetter;
   }
 
@@ -136,6 +141,10 @@ public final class ItineraryFilterPreferences {
     return removeTransitWithHigherCostThanBestOnStreetOnly;
   }
 
+  public CostLinearFunction removeTransitWithHigherCostThanBestOnWalkOnly() {
+    return removeTransitWithHigherCostThanBestOnWalkOnly;
+  }
+
   public boolean removeTransitIfWalkingIsBetter() {
     return removeTransitIfWalkingIsBetter;
   }
@@ -183,6 +192,11 @@ public final class ItineraryFilterPreferences {
         removeTransitWithHigherCostThanBestOnStreetOnly,
         DEFAULT.removeTransitWithHigherCostThanBestOnStreetOnly
       )
+      .addObj(
+        "removeTransitWithHigherCostThanBestOnWalkOnly",
+        removeTransitWithHigherCostThanBestOnWalkOnly,
+        DEFAULT.removeTransitWithHigherCostThanBestOnWalkOnly
+      )
       .addBoolIfTrue(
         "removeItinerariesWithSameRoutesAndStops",
         removeItinerariesWithSameRoutesAndStops
@@ -217,6 +231,10 @@ public final class ItineraryFilterPreferences {
         removeTransitWithHigherCostThanBestOnStreetOnly,
         that.removeTransitWithHigherCostThanBestOnStreetOnly
       ) &&
+      Objects.equals(
+        removeTransitWithHigherCostThanBestOnWalkOnly,
+        that.removeTransitWithHigherCostThanBestOnWalkOnly
+      ) &&
       Objects.equals(transitGeneralizedCostLimit, that.transitGeneralizedCostLimit)
     );
   }
@@ -237,6 +255,7 @@ public final class ItineraryFilterPreferences {
       removeItinerariesWithSameRoutesAndStops,
       transitGeneralizedCostLimit,
       removeTransitWithHigherCostThanBestOnStreetOnly,
+      removeTransitWithHigherCostThanBestOnWalkOnly,
       removeTransitIfWalkingIsBetter
     );
   }
@@ -257,6 +276,7 @@ public final class ItineraryFilterPreferences {
     private boolean removeItinerariesWithSameRoutesAndStops;
     private TransitGeneralizedCostFilterParams transitGeneralizedCostLimit;
     private CostLinearFunction removeTransitWithHigherCostThanBestOnStreetOnly;
+    private CostLinearFunction removeTransitWithHigherCostThanBestOnWalkOnly;
     private boolean removeTransitIfWalkingIsBetter;
 
     public ItineraryFilterPreferences original() {
@@ -338,6 +358,14 @@ public final class ItineraryFilterPreferences {
     ) {
       this.removeTransitWithHigherCostThanBestOnStreetOnly =
         removeTransitWithHigherCostThanBestOnStreetOnly;
+      return this;
+    }
+
+    public Builder withRemoveTransitWithHigherCostThanBestOnWalkOnly(
+      CostLinearFunction removeTransitWithHigherCostThanBestOnWalkOnly
+    ) {
+      this.removeTransitWithHigherCostThanBestOnWalkOnly =
+        removeTransitWithHigherCostThanBestOnWalkOnly;
       return this;
     }
 

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/ItineraryFiltersConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/ItineraryFiltersConfig.java
@@ -174,6 +174,28 @@ a plain walk itinerary, it will be removed even if the cost limit function would
           )
           .asCostLinearFunction(dft.removeTransitWithHigherCostThanBestOnStreetOnly())
       )
+      .withRemoveTransitWithHigherCostThanBestOnStreetOnly(
+        c
+          .of("removeTransitWithHigherCostThanBestOnWalkOnly")
+          .since(V2_4)
+          .summary(
+            "Limit function for generalized-cost computed from street-only itineraries applied to transit itineraries."
+          )
+          .description(
+            """
+The max-limit is applied to itineraries with transit *legs*, and only itineraries
+without transit legs are considered when calculating the minimum cost. The smallest
+generalized-cost value is used as input to the function. The function is used to calculate a
+*max-limit*. The max-limit is then used to filter *transit* itineraries by
+*generalized-cost*. Itineraries with a cost higher than the max-limit are dropped from the result
+set. Walking is handled with a different logic: if a transit itinerary has higher cost than
+a plain walk itinerary, it will be removed even if the cost limit function would keep it.
+This function works in the same way as removeTransitWithHigherCostThanBestOnStreetOnly but only for WALK legs.
+Default value is 0 + 1.0x.
+"""
+          )
+          .asCostLinearFunction(dft.removeTransitWithHigherCostThanBestOnWalkOnly())
+      )
       .withBikeRentalDistanceRatio(
         c
           .of("bikeRentalDistanceRatio")

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveTransitIfWalkingIsBetterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveTransitIfWalkingIsBetterTest.java
@@ -7,8 +7,10 @@ import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.model.Cost;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.routing.api.request.framework.CostLinearFunction;
 
 public class RemoveTransitIfWalkingIsBetterTest implements PlanTestConstants {
 
@@ -21,7 +23,7 @@ public class RemoveTransitIfWalkingIsBetterTest implements PlanTestConstants {
     // When:
     List<Itinerary> result = DeletionFlaggerTestHelper.process(
       List.of(i1, i2),
-      new RemoveTransitIfWalkingIsBetterFilter()
+      new RemoveTransitIfWalkingIsBetterFilter(CostLinearFunction.of(Cost.ZERO, 1.0))
     );
 
     // Then:
@@ -44,9 +46,10 @@ public class RemoveTransitIfWalkingIsBetterTest implements PlanTestConstants {
 
     List<Itinerary> result = DeletionFlaggerTestHelper.process(
       List.of(i1, i2, bicycle, walk),
-      new RemoveTransitIfWalkingIsBetterFilter()
+      new RemoveTransitIfWalkingIsBetterFilter(CostLinearFunction.of(Cost.ZERO, 1.0))
     );
 
     assertEquals(toStr(List.of(i2, bicycle, walk)), toStr(result));
   }
+  // TODO: 2023-11-09 Write tests for cases other than 0 + 1.0x
 }


### PR DESCRIPTION
### Summary

This adds possibility to configure linear cost function for transit vs walk filter. The cost function works in the same way as transit vs street filter.
