### PR TITLE
Make `feedId` required for realtime updaters

### DIFF
--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -111,6 +111,15 @@ Sections follow that describe particular settings in more depth.
 |       [sharedGroupFilePattern](#tf_1_sharedGroupFilePattern)             |   `regexp`  | Pattern for matching shared group NeTEx files in a NeTEx bundle.                                                                                               | *Optional* | `"(\w{3})-.*-shared\.xml"`        |  2.0  |
 |       source                                                             |    `uri`    | The unique URI pointing to the data file.                                                                                                                      | *Required* |                                   |  2.2  |
 |       [ferryIdsNotAllowedForBicycle](#tf_1_ferryIdsNotAllowedForBicycle) |  `string[]` | List ferries which do not allow bikes.                                                                                                                         | *Optional* |                                   |  2.0  |
+|    { object }                                                            |   `object`  | Nested object in array. The object type is determined by the parameters.                                                                                       | *Optional* |                                   |  2.2  |
+|       type = "gtfs"                                                      |    `enum`   | The feed input format.                                                                                                                                         | *Required* |                                   |  2.2  |
+|       blockBasedInterlining                                              |  `boolean`  | Whether to create stay-seated transfers in between two trips with the same block id. Overrides the value specified in `gtfsDefaults`.                          | *Optional* | `true`                            |  2.3  |
+|       [discardMinTransferTimes](#tf__2__discardMinTransferTimes)         |  `boolean`  | Should minimum transfer times in GTFS files be discarded. Overrides the value specified in `gtfsDefaults`.                                                     | *Optional* | `false`                           |  2.3  |
+|       feedId                                                             |   `string`  | The unique ID for this feed. This overrides any feed ID defined within the feed itself.                                                                        | *Optional* |                                   |  2.2  |
+|       maxInterlineDistance                                               |  `integer`  | Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle. Overrides the value specified in `gtfsDefaults`. | *Optional* | `200`                             |  2.3  |
+|       removeRepeatedStops                                                |  `boolean`  | Should consecutive identical stops be merged into one stop time entry. Overrides the value specified in `gtfsDefaults`.                                        | *Optional* | `true`                            |  2.3  |
+|       source                                                             |    `uri`    | The unique URI pointing to the data file.                                                                                                                      | *Required* |                                   |  2.2  |
+|       [stationTransferPreference](#tf__2__stationTransferPreference)     |    `enum`   | Should there be some preference or aversion for transfers at stops that are part of a station. Overrides the value specified in `gtfsDefaults`.                | *Optional* | `"allowed"`                       |  2.3  |
 
 <!-- PARAMETERS-TABLE END -->
 
@@ -1073,6 +1082,29 @@ For this reason we allow bicycles on ferries by default and allow to override th
 case where this is not the case.
 
 
+<h3 id="tf__2__discardMinTransferTimes">discardMinTransferTimes</h3>
+
+**Since version:** `2.3` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
+**Path:** /transitFeeds/[2] 
+
+Should minimum transfer times in GTFS files be discarded. Overrides the value specified in `gtfsDefaults`.
+
+This is useful eg. when the minimum transfer time is only set for ticketing purposes,
+but we want to calculate the transfers always from OSM data.
+
+
+<h3 id="tf__2__stationTransferPreference">stationTransferPreference</h3>
+
+**Since version:** `2.3` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"allowed"`   
+**Path:** /transitFeeds/[2]   
+**Enum values:** `discouraged` | `allowed` | `recommended` | `preferred`
+
+Should there be some preference or aversion for transfers at stops that are part of a station. Overrides the value specified in `gtfsDefaults`.
+
+This parameter sets the generic level of preference. What is the actual cost can be changed
+with the `stopTransferCost` parameter in the router configuration.
+
+
 
 <!-- PARAMETERS-DETAILS END -->
 
@@ -1152,6 +1184,11 @@ case where this is not the case.
       "sharedGroupFilePattern" : "_(\\w{3})_shared_data.xml",
       "groupFilePattern" : "(\\w{3})_.*\\.xml",
       "ignoreFilePattern" : "(temp|tmp)"
+    },
+    {
+      "source" : "https://data.itsfactory.fi/journeys/files/gtfs/latest/gtfs_tampere.zip",
+      "type" : "gtfs",
+      "feedId" : "tampere"
     }
   ],
   "transferRequests" : [

--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -111,15 +111,6 @@ Sections follow that describe particular settings in more depth.
 |       [sharedGroupFilePattern](#tf_1_sharedGroupFilePattern)             |   `regexp`  | Pattern for matching shared group NeTEx files in a NeTEx bundle.                                                                                               | *Optional* | `"(\w{3})-.*-shared\.xml"`        |  2.0  |
 |       source                                                             |    `uri`    | The unique URI pointing to the data file.                                                                                                                      | *Required* |                                   |  2.2  |
 |       [ferryIdsNotAllowedForBicycle](#tf_1_ferryIdsNotAllowedForBicycle) |  `string[]` | List ferries which do not allow bikes.                                                                                                                         | *Optional* |                                   |  2.0  |
-|    { object }                                                            |   `object`  | Nested object in array. The object type is determined by the parameters.                                                                                       | *Optional* |                                   |  2.2  |
-|       type = "gtfs"                                                      |    `enum`   | The feed input format.                                                                                                                                         | *Required* |                                   |  2.2  |
-|       blockBasedInterlining                                              |  `boolean`  | Whether to create stay-seated transfers in between two trips with the same block id. Overrides the value specified in `gtfsDefaults`.                          | *Optional* | `true`                            |  2.3  |
-|       [discardMinTransferTimes](#tf__2__discardMinTransferTimes)         |  `boolean`  | Should minimum transfer times in GTFS files be discarded. Overrides the value specified in `gtfsDefaults`.                                                     | *Optional* | `false`                           |  2.3  |
-|       feedId                                                             |   `string`  | The unique ID for this feed. This overrides any feed ID defined within the feed itself.                                                                        | *Optional* |                                   |  2.2  |
-|       maxInterlineDistance                                               |  `integer`  | Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle. Overrides the value specified in `gtfsDefaults`. | *Optional* | `200`                             |  2.3  |
-|       removeRepeatedStops                                                |  `boolean`  | Should consecutive identical stops be merged into one stop time entry. Overrides the value specified in `gtfsDefaults`.                                        | *Optional* | `true`                            |  2.3  |
-|       source                                                             |    `uri`    | The unique URI pointing to the data file.                                                                                                                      | *Required* |                                   |  2.2  |
-|       [stationTransferPreference](#tf__2__stationTransferPreference)     |    `enum`   | Should there be some preference or aversion for transfers at stops that are part of a station. Overrides the value specified in `gtfsDefaults`.                | *Optional* | `"allowed"`                       |  2.3  |
 
 <!-- PARAMETERS-TABLE END -->
 
@@ -1082,29 +1073,6 @@ For this reason we allow bicycles on ferries by default and allow to override th
 case where this is not the case.
 
 
-<h3 id="tf__2__discardMinTransferTimes">discardMinTransferTimes</h3>
-
-**Since version:** `2.3` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
-**Path:** /transitFeeds/[2] 
-
-Should minimum transfer times in GTFS files be discarded. Overrides the value specified in `gtfsDefaults`.
-
-This is useful eg. when the minimum transfer time is only set for ticketing purposes,
-but we want to calculate the transfers always from OSM data.
-
-
-<h3 id="tf__2__stationTransferPreference">stationTransferPreference</h3>
-
-**Since version:** `2.3` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"allowed"`   
-**Path:** /transitFeeds/[2]   
-**Enum values:** `discouraged` | `allowed` | `recommended` | `preferred`
-
-Should there be some preference or aversion for transfers at stops that are part of a station. Overrides the value specified in `gtfsDefaults`.
-
-This parameter sets the generic level of preference. What is the actual cost can be changed
-with the `stopTransferCost` parameter in the router configuration.
-
-
 
 <!-- PARAMETERS-DETAILS END -->
 
@@ -1174,7 +1142,7 @@ with the `stopTransferCost` parameter in the router configuration.
     {
       "type" : "gtfs",
       "feedId" : "SE",
-      "source" : "gs://BUCKET/OTP_GCS_WORK_DIR/sweeden-gtfs.obj"
+      "source" : "https://skanetrafiken.se/download/sweden.gtfs.zip"
     },
     {
       "type" : "netex",
@@ -1184,11 +1152,6 @@ with the `stopTransferCost` parameter in the router configuration.
       "sharedGroupFilePattern" : "_(\\w{3})_shared_data.xml",
       "groupFilePattern" : "(\\w{3})_.*\\.xml",
       "ignoreFilePattern" : "(temp|tmp)"
-    },
-    {
-      "source" : "https://data.itsfactory.fi/journeys/files/gtfs/latest/gtfs_tampere.zip",
-      "type" : "gtfs",
-      "feedId" : "tampere"
     }
   ],
   "transferRequests" : [

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -741,7 +741,8 @@ Used to group requests when monitoring OTP.
       ]
     },
     {
-      "type" : "websocket-gtfs-rt-updater"
+      "type" : "websocket-gtfs-rt-updater",
+      "feedId" : "ov"
     },
     {
       "type" : "siri-et-updater",

--- a/docs/UpdaterConfig.md
+++ b/docs/UpdaterConfig.md
@@ -40,7 +40,7 @@ The information is downloaded in a single HTTP request and polled regularly.
 |---------------------------|:---------------:|------------------------------------------------------------------------------|:----------:|---------------|:-----:|
 | type = "real-time-alerts" |      `enum`     | The type of the updater.                                                     | *Required* |               |  1.5  |
 | earlyStartSec             |    `integer`    | How long before the posted start of an event it should be displayed to users | *Optional* | `0`           |  1.5  |
-| feedId                    |     `string`    | The id of the feed to apply the alerts to.                                   | *Optional* |               |  1.5  |
+| feedId                    |     `string`    | The id of the feed to apply the alerts to.                                   | *Required* |               |  1.5  |
 | frequency                 |    `duration`   | How often the URL should be fetched.                                         | *Optional* | `"PT1M"`      |  1.5  |
 | fuzzyTripMatching         |    `boolean`    | Whether to match trips fuzzily.                                              | *Optional* | `false`       |  1.5  |
 | url                       |     `string`    | URL to fetch the GTFS-RT feed from.                                          | *Required* |               |  1.5  |
@@ -93,7 +93,7 @@ The information is downloaded in a single HTTP request and polled regularly.
 |-----------------------------------------------------------------------|:---------------:|----------------------------------------------------------------------------|:----------:|----------------------|:-----:|
 | type = "stop-time-updater"                                            |      `enum`     | The type of the updater.                                                   | *Required* |                      |  1.5  |
 | [backwardsDelayPropagationType](#u__5__backwardsDelayPropagationType) |      `enum`     | How backwards propagation should be handled.                               | *Optional* | `"required-no-data"` |  2.2  |
-| feedId                                                                |     `string`    | Which feed the updates apply to.                                           | *Optional* |                      |  1.5  |
+| feedId                                                                |     `string`    | Which feed the updates apply to.                                           | *Required* |                      |  1.5  |
 | frequency                                                             |    `duration`   | How often the data should be downloaded.                                   | *Optional* | `"PT1M"`             |  1.5  |
 | fuzzyTripMatching                                                     |    `boolean`    | If the trips should be matched fuzzily.                                    | *Optional* | `false`              |  1.5  |
 | [url](#u__5__url)                                                     |     `string`    | The URL of the GTFS-RT resource.                                           | *Required* |                      |  1.5  |
@@ -181,7 +181,7 @@ file.
 |-----------------------------------------------------------------------|:---------:|--------------------------|:----------:|----------------------|:-----:|
 | type = "websocket-gtfs-rt-updater"                                    |   `enum`  | The type of the updater. | *Required* |                      |  1.5  |
 | [backwardsDelayPropagationType](#u__7__backwardsDelayPropagationType) |   `enum`  | TODO                     | *Optional* | `"required-no-data"` |  1.5  |
-| feedId                                                                |  `string` | TODO                     | *Optional* |                      |  1.5  |
+| feedId                                                                |  `string` | TODO                     | *Required* |                      |  1.5  |
 | reconnectPeriodSec                                                    | `integer` | TODO                     | *Optional* | `60`                 |  1.5  |
 | url                                                                   |  `string` | TODO                     | *Optional* |                      |  1.5  |
 
@@ -205,7 +205,8 @@ TODO
 {
   "updaters" : [
     {
-      "type" : "websocket-gtfs-rt-updater"
+      "type" : "websocket-gtfs-rt-updater",
+      "feedId" : "ov"
     }
   ]
 }

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -37,7 +37,7 @@ All updaters have the following parameters in common:
 | type = "vehicle-parking"        |    `enum`   | The type of the updater.                     | *Required* |               |  1.5  |
 | facilitiesFrequencySec          |  `integer`  | How often the facilities should be updated.  | *Optional* | `3600`        |  2.2  |
 | facilitiesUrl                   |   `string`  | URL of the facilities.                       | *Optional* |               |  2.2  |
-| [feedId](#u__2__feedId)         |   `string`  | The name of the data source.                 | *Optional* |               |  2.2  |
+| [feedId](#u__2__feedId)         |   `string`  | The name of the data source.                 | *Required* |               |  2.2  |
 | hubsUrl                         |   `string`  | Hubs URL                                     | *Optional* |               |  2.2  |
 | [sourceType](#u__2__sourceType) |    `enum`   | The source of the vehicle updates.           | *Required* |               |  2.2  |
 | [timeZone](#u__2__timeZone)     | `time-zone` | The time zone of the feed.                   | *Optional* |               |  2.2  |
@@ -49,7 +49,7 @@ All updaters have the following parameters in common:
 
 <h4 id="u__2__feedId">feedId</h4>
 
-**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
+**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[2] 
 
 The name of the data source.
@@ -106,7 +106,7 @@ Used for converting abstract opening hours into concrete points in time.
 | Config Parameter                |       Type      | Summary                                                                    |  Req./Opt. | Default Value | Since |
 |---------------------------------|:---------------:|----------------------------------------------------------------------------|:----------:|---------------|:-----:|
 | type = "vehicle-parking"        |      `enum`     | The type of the updater.                                                   | *Required* |               |  1.5  |
-| [feedId](#u__3__feedId)         |     `string`    | The name of the data source.                                               | *Optional* |               |  2.2  |
+| [feedId](#u__3__feedId)         |     `string`    | The name of the data source.                                               | *Required* |               |  2.2  |
 | frequency                       |    `duration`   | How often to update the source.                                            | *Optional* | `"PT1M"`      |  2.2  |
 | [sourceType](#u__3__sourceType) |      `enum`     | The source of the vehicle updates.                                         | *Required* |               |  2.2  |
 | [timeZone](#u__3__timeZone)     |   `time-zone`   | The time zone of the feed.                                                 | *Optional* |               |  2.2  |
@@ -119,7 +119,7 @@ Used for converting abstract opening hours into concrete points in time.
 
 <h4 id="u__3__feedId">feedId</h4>
 
-**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
+**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[3] 
 
 The name of the data source.
@@ -193,7 +193,7 @@ Tags to add to the parking lots.
 | Config Parameter                |       Type      | Summary                                                                    |  Req./Opt. | Default Value | Since |
 |---------------------------------|:---------------:|----------------------------------------------------------------------------|:----------:|---------------|:-----:|
 | type = "vehicle-parking"        |      `enum`     | The type of the updater.                                                   | *Required* |               |  1.5  |
-| [feedId](#u__4__feedId)         |     `string`    | The name of the data source.                                               | *Optional* |               |  2.2  |
+| [feedId](#u__4__feedId)         |     `string`    | The name of the data source.                                               | *Required* |               |  2.2  |
 | frequency                       |    `duration`   | How often to update the source.                                            | *Optional* | `"PT1M"`      |  2.3  |
 | [sourceType](#u__4__sourceType) |      `enum`     | The source of the vehicle updates.                                         | *Required* |               |  2.2  |
 | url                             |     `string`    | URL of the locations endpoint.                                             | *Optional* |               |  2.3  |
@@ -204,7 +204,7 @@ Tags to add to the parking lots.
 
 <h4 id="u__4__feedId">feedId</h4>
 
-**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
+**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[4] 
 
 The name of the data source.

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/GtfsRealtimeAlertsUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/GtfsRealtimeAlertsUpdaterConfig.java
@@ -12,11 +12,7 @@ public class GtfsRealtimeAlertsUpdaterConfig {
   public static GtfsRealtimeAlertsUpdaterParameters create(String configRef, NodeAdapter c) {
     return new GtfsRealtimeAlertsUpdaterParameters(
       configRef,
-      c
-        .of("feedId")
-        .since(V1_5)
-        .summary("The id of the feed to apply the alerts to.")
-        .asString(null),
+      c.of("feedId").since(V1_5).summary("The id of the feed to apply the alerts to.").asString(),
       c.of("url").since(V1_5).summary("URL to fetch the GTFS-RT feed from.").asString(),
       c
         .of("earlyStartSec")

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/MqttGtfsRealtimeUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/MqttGtfsRealtimeUpdaterConfig.java
@@ -12,7 +12,7 @@ public class MqttGtfsRealtimeUpdaterConfig {
   public static MqttGtfsRealtimeUpdaterParameters create(String configRef, NodeAdapter c) {
     return new MqttGtfsRealtimeUpdaterParameters(
       configRef,
-      c.of("feedId").since(NA).summary("The feed id to apply the updates to.").asString(null),
+      c.of("feedId").since(NA).summary("The feed id to apply the updates to.").asString(),
       c.of("url").since(NA).summary("URL of the MQTT broker.").asString(),
       c.of("topic").since(NA).summary("The topic to subscribe to.").asString(),
       c.of("qos").since(NA).summary("QOS level.").asInt(0),

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/PollingTripUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/PollingTripUpdaterConfig.java
@@ -56,7 +56,7 @@ public class PollingTripUpdaterConfig {
 """
         )
         .asEnum(BackwardsDelayPropagationType.REQUIRED_NO_DATA),
-      c.of("feedId").since(V1_5).summary("Which feed the updates apply to.").asString(null),
+      c.of("feedId").since(V1_5).summary("Which feed the updates apply to.").asString(),
       url,
       headers
     );

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
@@ -27,7 +27,7 @@ public class VehicleParkingUpdaterConfig {
       .since(V2_2)
       .summary("The name of the data source.")
       .description("This will end up in the API responses as the feed id of of the parking lot.")
-      .asString(null);
+      .asString();
     return switch (sourceType) {
       case HSL_PARK -> new HslParkUpdaterParameters(
         updaterRef,

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/WebsocketGtfsRealtimeUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/WebsocketGtfsRealtimeUpdaterConfig.java
@@ -11,7 +11,7 @@ public class WebsocketGtfsRealtimeUpdaterConfig {
   public static WebsocketGtfsRealtimeUpdaterParameters create(String configRef, NodeAdapter c) {
     return new WebsocketGtfsRealtimeUpdaterParameters(
       configRef,
-      c.of("feedId").since(V1_5).summary("TODO").asString(null),
+      c.of("feedId").since(V1_5).summary("TODO").asString(),
       c.of("url").since(V1_5).summary("TODO").asString(null),
       c.of("reconnectPeriodSec").since(V1_5).summary("TODO").asInt(60),
       c

--- a/src/test/resources/standalone/config/build-config.json
+++ b/src/test/resources/standalone/config/build-config.json
@@ -61,6 +61,11 @@
       "groupFilePattern" : "(\\w{3})_.*\\.xml",
       "ignoreFilePattern" : "(temp|tmp)"
       //"ferryIdsNotAllowedForBicycle" : ["RUT:B107", "RUT:B209"]
+    },
+    {
+      "source": "https://data.itsfactory.fi/journeys/files/gtfs/latest/gtfs_tampere.zip",
+      "type": "gtfs",
+      "feedId": "tampere"
     }
   ],
   "transferRequests": [

--- a/src/test/resources/standalone/config/build-config.json
+++ b/src/test/resources/standalone/config/build-config.json
@@ -50,7 +50,7 @@
     {
       "type" : "gtfs",
       "feedId" : "SE",
-      "source" : "gs://BUCKET/OTP_GCS_WORK_DIR/sweeden-gtfs.obj"
+      "source" : "https://skanetrafiken.se/download/sweden.gtfs.zip"
     },
     {
       "type" : "netex",
@@ -61,11 +61,6 @@
       "groupFilePattern" : "(\\w{3})_.*\\.xml",
       "ignoreFilePattern" : "(temp|tmp)"
       //"ferryIdsNotAllowedForBicycle" : ["RUT:B107", "RUT:B209"]
-    },
-    {
-      "source": "https://data.itsfactory.fi/journeys/files/gtfs/latest/gtfs_tampere.zip",
-      "type": "gtfs",
-      "feedId": "tampere"
     }
   ],
   "transferRequests": [

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -297,7 +297,8 @@
     },
     // Streaming differential GTFS-RT TripUpdates over websockets
     {
-      "type": "websocket-gtfs-rt-updater"
+      "type": "websocket-gtfs-rt-updater",
+      "feedId": "ov"
     },
     // Siri-ET over HTTP
     {


### PR DESCRIPTION
### Summary

@markstos has correctly pointed out that the `feedId` is incorrectly documented as optional.

This fixes the config schema and docs.

### Issue

Closes #5499.