### PR TITLE
Improve linking of fixed stops used by flex trips

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -23,7 +23,7 @@ import org.opentripplanner.TestServerContext;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.DirectTransferGenerator;
-import org.opentripplanner.graph_builder.module.StreetLinkerModule;
+import org.opentripplanner.graph_builder.module.TestStreetLinkerModule;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundle;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModule;
 import org.opentripplanner.model.GenericLocation;
@@ -34,7 +34,6 @@ import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.filter.AllowAllTransitFilter;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.test.support.ResourceLoader;
 import org.opentripplanner.transit.service.TransitModel;
 
 /**
@@ -186,7 +185,7 @@ public class FlexIntegrationTest {
     gtfsModule.buildGraph();
 
     // link stations to streets
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
 
     // link flex locations to streets
     new AreaStopsToVerticesMapper(graph, transitModel).buildGraph();

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -108,7 +108,7 @@ public class StreetLinkerModule implements GraphBuilderModule {
         continue;
       }
       // check if stop is already linked, to allow multiple idempotent linking cycles
-      if (tStop.getDegreeOut() + tStop.getDegreeIn() > 0) {
+      if (tStop.isConnectedToGraph()) {
         continue;
       }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -150,6 +150,7 @@ public class StreetLinkerModule implements GraphBuilderModule {
 
           // If regular stops or group stops are used for flex trips, they also need to be connected to car routable
           // street edges. This does not apply to zones as street vertices store which zones they are part of.
+          // see https://github.com/opentripplanner/OpenTripPlanner/issues/5498
           if (
             linkType == StopLinkType.WALK_AND_CAR && !walkStreetVertex.isConnectedToDriveableEdge()
           ) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -129,6 +129,13 @@ public class StreetLinkerModule implements GraphBuilderModule {
     LOG.info(progress.completeMessage());
   }
 
+  /**
+   * Link a stop to the nearest "relevant" edges.
+   * <p>
+   * These are mostly walk edges but if a stop is used by a flex pattern it also needs to be
+   * car-accessible. Therefore, flex stops are ensured to be connected to the car-accessible
+   * edge. This may lead to several links being created.
+   */
   private void linkStopToStreetNetwork(TransitStopVertex tStop, StopLinkType linkType) {
     graph
       .getLinker()

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -362,8 +362,7 @@ public class StreetLinkerModule implements GraphBuilderModule {
      */
     WALK_ONLY,
     /**
-     * Make sure that the stop is linked to an edge that is both walkable and drivable which is
-     * required if the stop used by a flex trip.
+     * Make sure that the stop is linked to an edge each that is walkable and drivable.
      * This may lead to several links being created.
      */
     WALK_AND_CAR,

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -61,11 +61,6 @@ public class StreetLinkerModule implements GraphBuilderModule {
     this.addExtraEdgesToAreas = addExtraEdgesToAreas;
   }
 
-  /** For test only */
-  public static void linkStreetsForTestOnly(Graph graph, TransitModel model) {
-    new StreetLinkerModule(graph, model, DataImportIssueStore.NOOP, false).buildGraph();
-  }
-
   @Override
   public void buildGraph() {
     transitModel.index();
@@ -148,7 +143,9 @@ public class StreetLinkerModule implements GraphBuilderModule {
 
           // If regular stops or group stops are used for flex trips, they also need to be connected to car routable
           // street edges. This does not apply to zones as street vertices store which zones they are part of.
-          if (linkType == StopLinkType.WALK_AND_CAR && !walkStreetVertex.isConnectedToDriveableEdge()) {
+          if (
+            linkType == StopLinkType.WALK_AND_CAR && !walkStreetVertex.isConnectedToDriveableEdge()
+          ) {
             graph
               .getLinker()
               .linkVertexPermanently(
@@ -358,9 +355,10 @@ public class StreetLinkerModule implements GraphBuilderModule {
      */
     WALK_ONLY,
     /**
-     * Make sure that the stop is linked to an edge that is both walkable and drivable.
-     * This may lead to several links created.
+     * Make sure that the stop is linked to an edge that is both walkable and drivable which is
+     * required if the stop used by a flex trip.
+     * This may lead to several links being created.
      */
-    WALK_AND_CAR
+    WALK_AND_CAR,
   }
 }

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -201,7 +201,7 @@ public class Graph implements Serializable {
 
   @Nullable
   public TransitStopVertex getStopVertexForStopId(FeedScopedId id) {
-    return streetIndex.getTransitStopVertex(id);
+    return streetIndex.findTransitStopVertices(id);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -199,8 +199,9 @@ public class Graph implements Serializable {
       .collect(Collectors.toList());
   }
 
+  @Nullable
   public TransitStopVertex getStopVertexForStopId(FeedScopedId id) {
-    return streetIndex.findTransitStopVertices(id);
+    return streetIndex.getTransitStopVertex(id);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.LineString;
@@ -138,7 +139,8 @@ public class StreetIndex {
     return vertexLinker;
   }
 
-  public TransitStopVertex findTransitStopVertices(FeedScopedId stopId) {
+  @Nullable
+  public TransitStopVertex getTransitStopVertex(FeedScopedId stopId) {
     return transitStopVertices.get(stopId);
   }
 

--- a/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
@@ -140,7 +140,7 @@ public class StreetIndex {
   }
 
   @Nullable
-  public TransitStopVertex getTransitStopVertex(FeedScopedId stopId) {
+  public TransitStopVertex findTransitStopVertices(FeedScopedId stopId) {
     return transitStopVertices.get(stopId);
   }
 

--- a/src/main/java/org/opentripplanner/street/model/vertex/StreetVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/StreetVertex.java
@@ -66,6 +66,9 @@ public abstract class StreetVertex extends Vertex {
       );
   }
 
+  /**
+   * Does the vertex have an outgoing edge that allows driving.
+   */
   public boolean isConnectedToDriveableEdge() {
     return this.getOutgoing()
       .stream()

--- a/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertex.java
@@ -86,6 +86,9 @@ public class TransitStopVertex extends StationElementVertex {
     return this.stop;
   }
 
+  /**
+   * Is this vertex already linked to the street network?
+   */
   public boolean isConnectedToGraph() {
     return getDegreeOut() + getDegreeIn() > 0;
   }

--- a/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertex.java
@@ -3,7 +3,6 @@ package org.opentripplanner.street.model.vertex;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
-import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.PathwayEdge;
 import org.opentripplanner.transit.model.basic.Accessibility;
@@ -85,5 +84,9 @@ public class TransitStopVertex extends StationElementVertex {
   @Override
   public StationElement getStationElement() {
     return this.stop;
+  }
+
+  public boolean isConnectedToGraph() {
+    return getDegreeOut() + getDegreeIn() > 0;
   }
 }

--- a/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -16,7 +16,7 @@ import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.graph_builder.ConfiguredDataSource;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.GtfsFeedId;
-import org.opentripplanner.graph_builder.module.StreetLinkerModule;
+import org.opentripplanner.graph_builder.module.TestStreetLinkerModule;
 import org.opentripplanner.graph_builder.module.ned.ElevationModule;
 import org.opentripplanner.graph_builder.module.ned.GeotiffGridCoverageFactoryImpl;
 import org.opentripplanner.graph_builder.module.osm.OsmModule;
@@ -140,7 +140,7 @@ public class ConstantsForTests {
         addGtfsToGraph(graph, transitModel, PORTLAND_GTFS, new DefaultFareServiceFactory(), "prt");
       }
       // Link transit stops to streets
-      StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+      TestStreetLinkerModule.link(graph, transitModel);
 
       // Add elevation data
       if (withElevation) {
@@ -192,7 +192,7 @@ public class ConstantsForTests {
     );
 
     // Link transit stops to streets
-    StreetLinkerModule.linkStreetsForTestOnly(otpModel.graph(), otpModel.transitModel());
+    TestStreetLinkerModule.link(otpModel.graph(), otpModel.transitModel());
 
     return otpModel;
   }
@@ -236,7 +236,7 @@ public class ConstantsForTests {
           .buildGraph();
       }
       // Link transit stops to streets
-      StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+      TestStreetLinkerModule.link(graph, transitModel);
 
       return new TestOtpModel(graph, transitModel);
     } catch (Exception e) {

--- a/src/test/java/org/opentripplanner/_support/geometry/Coordinates.java
+++ b/src/test/java/org/opentripplanner/_support/geometry/Coordinates.java
@@ -6,4 +6,5 @@ public class Coordinates {
 
   public static final Coordinate BERLIN = new Coordinate(52.5212, 13.4105);
   public static final Coordinate HAMBURG = new Coordinate(53.5566, 10.0003);
+  public static final Coordinate KONGSBERG_PLATFORM_1 = new Coordinate(59.67216, 9.65107);
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
@@ -33,6 +33,19 @@ class StreetLinkerModuleTest {
   private static final double DELTA = 0.0001;
 
   @Test
+  void linkingIsIdempotent() {
+    var model = new TestModel();
+    var module = model.streetLinkerModule();
+
+    module.buildGraph();
+    module.buildGraph();
+    module.buildGraph();
+
+    assertTrue(model.stopVertex().isConnectedToGraph());
+    assertEquals(1, model.stopVertex().getOutgoing().size());
+  }
+
+  @Test
   void linkRegularStop() {
     var model = new TestModel();
     var module = model.streetLinkerModule();
@@ -42,7 +55,7 @@ class StreetLinkerModuleTest {
     assertTrue(model.stopVertex().isConnectedToGraph());
 
     assertEquals(1, model.stopVertex().getOutgoing().size());
-    var outgoing = model.outgoingLinks().get(0);
+    var outgoing = model.outgoingLinks().getFirst();
     assertInstanceOf(StreetTransitStopLink.class, outgoing);
 
     SplitterVertex linkedTo = (SplitterVertex) outgoing.getToVertex();
@@ -66,13 +79,13 @@ class StreetLinkerModuleTest {
 
       // stop is used by a flex trip, needs to be linked to both the walk and car edge
       assertEquals(2, model.stopVertex().getOutgoing().size());
-      var linkToWalk = model.outgoingLinks().get(0);
+      var linkToWalk = model.outgoingLinks().getFirst();
       SplitterVertex walkSplit = (SplitterVertex) linkToWalk.getToVertex();
 
       assertTrue(walkSplit.isConnectedToWalkingEdge());
       assertFalse(walkSplit.isConnectedToDriveableEdge());
 
-      var linkToCar = model.outgoingLinks().get(1);
+      var linkToCar = model.outgoingLinks().getLast();
       SplitterVertex carSplit = (SplitterVertex) linkToCar.getToVertex();
 
       assertFalse(carSplit.isConnectedToWalkingEdge());

--- a/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
@@ -1,0 +1,147 @@
+package org.opentripplanner.graph_builder.module;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner._support.geometry.Coordinates.KONGSBERG_PLATFORM_1;
+import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
+import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.street.model._data.StreetModelForTest;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.StreetTransitStopLink;
+import org.opentripplanner.street.model.vertex.SplitterVertex;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.street.model.vertex.TransitStopVertexBuilder;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
+
+class StreetLinkerModuleTest {
+
+  private static final double DELTA = 0.0001;
+
+  @Test
+  void linkRegularStop() {
+    var model = new TestModel();
+    var module = model.streetLinkerModule();
+
+    module.buildGraph();
+
+    assertTrue(model.stopVertex().isConnectedToGraph());
+
+    assertEquals(1, model.stopVertex().getOutgoing().size());
+    var outgoing = model.outgoingLinks().get(0);
+    assertInstanceOf(StreetTransitStopLink.class, outgoing);
+
+    SplitterVertex linkedTo = (SplitterVertex) outgoing.getToVertex();
+
+    assertTrue(linkedTo.isConnectedToWalkingEdge());
+    assertFalse(linkedTo.isConnectedToDriveableEdge());
+  }
+
+  @Test
+  void linkFlexStop() {
+    OTPFeature.FlexRouting.testOn(() -> {
+      var model = new TestModel();
+      var flexTrip = TransitModelForTest.of().unscheduledTrip(id("flex"), model.stop());
+      model.withFlexTrip(flexTrip);
+
+      var module = model.streetLinkerModule();
+
+      module.buildGraph();
+
+      assertTrue(model.stopVertex().isConnectedToGraph());
+
+      // stop is used by a flex trip, needs to be linked to both the walk and car edge
+      assertEquals(2, model.stopVertex().getOutgoing().size());
+      var linkToWalk = model.outgoingLinks().get(0);
+      SplitterVertex walkSplit = (SplitterVertex) linkToWalk.getToVertex();
+
+      assertTrue(walkSplit.isConnectedToWalkingEdge());
+      assertFalse(walkSplit.isConnectedToDriveableEdge());
+
+      var linkToCar = model.outgoingLinks().get(1);
+      SplitterVertex carSplit = (SplitterVertex) linkToCar.getToVertex();
+
+      assertFalse(carSplit.isConnectedToWalkingEdge());
+      assertTrue(carSplit.isConnectedToDriveableEdge());
+    });
+  }
+
+  private static class TestModel {
+
+    private final TransitStopVertex stopVertex;
+    private final StreetLinkerModule module;
+    private final RegularStop stop;
+    private final TransitModel transitModel;
+
+    public TestModel() {
+      var from = StreetModelForTest.intersectionVertex(
+        KONGSBERG_PLATFORM_1.x - DELTA,
+        KONGSBERG_PLATFORM_1.y - DELTA
+      );
+      var to = StreetModelForTest.intersectionVertex(
+        KONGSBERG_PLATFORM_1.x + DELTA,
+        KONGSBERG_PLATFORM_1.y + DELTA
+      );
+
+      Graph graph = new Graph();
+      graph.addVertex(from);
+      graph.addVertex(to);
+
+      var walkableEdge = StreetModelForTest.streetEdge(from, to, PEDESTRIAN);
+      var drivableEdge = StreetModelForTest.streetEdge(from, to, CAR);
+      var builder = StopModel.of();
+      stop =
+        builder
+          .regularStop(id("platform-1"))
+          .withCoordinate(new WgsCoordinate(KONGSBERG_PLATFORM_1))
+          .build();
+      builder.withRegularStop(stop);
+
+      transitModel = new TransitModel(builder.build(), new Deduplicator());
+
+      stopVertex = new TransitStopVertexBuilder().withStop(stop).build();
+      graph.addVertex(stopVertex);
+      graph.hasStreets = true;
+
+      module = new StreetLinkerModule(graph, transitModel, DataImportIssueStore.NOOP, false);
+
+      assertFalse(stopVertex.isConnectedToGraph());
+      assertTrue(stopVertex.getIncoming().isEmpty());
+      assertTrue(stopVertex.getOutgoing().isEmpty());
+    }
+
+    public TransitStopVertex stopVertex() {
+      return stopVertex;
+    }
+
+    public StreetLinkerModule streetLinkerModule() {
+      return module;
+    }
+
+    public List<Edge> outgoingLinks() {
+      return List.copyOf(stopVertex.getOutgoing());
+    }
+
+    public RegularStop stop() {
+      return stop;
+    }
+
+    public void withFlexTrip(UnscheduledTrip flexTrip) {
+      transitModel.addFlexTrip(flexTrip.getId(), flexTrip);
+    }
+  }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/module/TestStreetLinkerModule.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/TestStreetLinkerModule.java
@@ -1,0 +1,13 @@
+package org.opentripplanner.graph_builder.module;
+
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
+
+public class TestStreetLinkerModule {
+
+  /** For test only */
+  public static void link(Graph graph, TransitModel model) {
+    new StreetLinkerModule(graph, model, DataImportIssueStore.NOOP, false).buildGraph();
+  }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
@@ -54,7 +54,7 @@ public class VehicleParkingLinkingTest {
       .build();
     var parkingVertex = vertexFactory.vehicleParkingEntrance(parking);
 
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
 
     assertEquals(1, parkingVertex.getOutgoing().size());
     parkingVertex.getOutgoing().forEach(e -> assertEquals(e.getToVertex(), A));
@@ -77,7 +77,7 @@ public class VehicleParkingLinkingTest {
       .build();
     var parkingVertex = vertexFactory.vehicleParkingEntrance(parking.getEntrances().get(0));
 
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
 
     var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
     assertEquals(2, streetLinks.size());
@@ -111,7 +111,7 @@ public class VehicleParkingLinkingTest {
       .build();
     var parkingVertex = vertexFactory.vehicleParkingEntrance(parking.getEntrances().get(0));
 
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
 
     var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
     assertEquals(4, streetLinks.size());
@@ -147,7 +147,7 @@ public class VehicleParkingLinkingTest {
 
     graph.remove(A);
 
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
 
     assertEquals(1, vehicleParking.getEntrances().size());
 
@@ -178,7 +178,7 @@ public class VehicleParkingLinkingTest {
 
     graph.remove(A);
 
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
 
     assertEquals(0, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
@@ -12,7 +12,6 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingHelper;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingTestGraphData;
-import org.opentripplanner.routing.vehicle_parking.VehicleParkingTestUtil;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetVehicleParkingLink;
@@ -96,9 +95,9 @@ public class VehicleParkingLinkingTest {
     graph.addVertex(C);
     graph.addVertex(D);
 
-    VehicleParkingTestUtil.createStreet(C, D, StreetTraversalPermission.CAR);
+    StreetModelForTest.streetEdge(C, D, StreetTraversalPermission.CAR);
 
-    VehicleParkingTestUtil.createStreet(A, C, StreetTraversalPermission.NONE);
+    StreetModelForTest.streetEdge(A, C, StreetTraversalPermission.NONE);
 
     var parking = VehicleParking
       .builder()

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/UnconnectedAreasTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/UnconnectedAreasTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.ParkAndRideUnlinked;
-import org.opentripplanner.graph_builder.module.StreetLinkerModule;
+import org.opentripplanner.graph_builder.module.TestStreetLinkerModule;
 import org.opentripplanner.openstreetmap.OsmProvider;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.edge.StreetVehicleParkingLink;
@@ -171,7 +171,7 @@ public class UnconnectedAreasTest {
 
     loader.buildGraph();
 
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
 
     return graph;
   }

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -21,7 +21,7 @@ import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
-import org.opentripplanner.graph_builder.module.StreetLinkerModule;
+import org.opentripplanner.graph_builder.module.TestStreetLinkerModule;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -674,7 +674,7 @@ public class TestHalfEdges {
   @Test
   public void testNetworkLinker() {
     int numVerticesBefore = graph.getVertices().size();
-    StreetLinkerModule.linkStreetsForTestOnly(graph, transitModel);
+    TestStreetLinkerModule.link(graph, transitModel);
     int numVerticesAfter = graph.getVertices().size();
     assertEquals(4, numVerticesAfter - numVerticesBefore);
     Collection<Edge> outgoing = station1.getOutgoing();

--- a/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -7,7 +7,7 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.graph_builder.module.StreetLinkerModule;
+import org.opentripplanner.graph_builder.module.TestStreetLinkerModule;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -77,7 +77,7 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
     graph = otpModel.graph();
 
     graph.hasStreets = true;
-    StreetLinkerModule.linkStreetsForTestOnly(graph, otpModel.transitModel());
+    TestStreetLinkerModule.link(graph, otpModel.transitModel());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.graph_builder.linking;
+package org.opentripplanner.routing.linking;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,8 +16,6 @@ import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedString;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.linking.LinkingDirection;
-import org.opentripplanner.routing.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.edge.AreaEdgeBuilder;

--- a/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestGraphData.java
+++ b/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestGraphData.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.vehicle_parking;
 
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.VertexFactory;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -23,12 +24,12 @@ public class VehicleParkingTestGraphData {
     transitModel = new TransitModel(stopModel, deduplicator);
     graph.hasStreets = true;
 
-    var intersection = new VertexFactory(graph);
+    var factory = new VertexFactory(graph);
 
-    A = intersection.intersection("A", 0, 0);
-    B = intersection.intersection("B", 0.01, 0);
+    A = factory.intersection("A", 0, 0);
+    B = factory.intersection("B", 0.01, 0);
 
-    VehicleParkingTestUtil.createStreet(A, B, StreetTraversalPermission.PEDESTRIAN);
+    StreetModelForTest.streetEdge(A, B, StreetTraversalPermission.PEDESTRIAN);
   }
 
   public Graph getGraph() {

--- a/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
+++ b/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
@@ -1,12 +1,7 @@
 package org.opentripplanner.routing.vehicle_parking;
 
-import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
-import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
-import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 public class VehicleParkingTestUtil {
@@ -38,23 +33,5 @@ public class VehicleParkingTestUtil {
       .availability(vehiclePlaces)
       .entrance(entrance)
       .build();
-  }
-
-  public static void createStreet(
-    StreetVertex from,
-    StreetVertex to,
-    StreetTraversalPermission permissions
-  ) {
-    new StreetEdgeBuilder<>()
-      .withFromVertex(from)
-      .withToVertex(to)
-      .withGeometry(
-        GeometryUtils.makeLineString(from.getLat(), from.getLon(), to.getLat(), to.getLon())
-      )
-      .withName(String.format("%s%s street", from.getDefaultName(), to.getDefaultName()))
-      .withMeterLength(1)
-      .withPermission(permissions)
-      .withBack(false)
-      .buildAndConnect();
   }
 }

--- a/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
+++ b/src/test/java/org/opentripplanner/street/model/_data/StreetModelForTest.java
@@ -85,4 +85,12 @@ public class StreetModelForTest {
   ) {
     return streetEdgeBuilder(vA, vB, length, perm).buildAndConnect();
   }
+
+  public static StreetEdge streetEdge(
+    StreetVertex from,
+    StreetVertex to,
+    StreetTraversalPermission permissions
+  ) {
+    return streetEdge(from, to, 1, permissions);
+  }
 }

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -1,9 +1,12 @@
 package org.opentripplanner.transit.model._data;
 
+import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
@@ -241,5 +244,24 @@ public class TransitModelForTest {
   public TripPatternBuilder pattern(TransitMode mode) {
     return tripPattern(mode.name(), route(mode.name()).withMode(mode).build())
       .withStopPattern(stopPattern(3));
+  }
+
+  public UnscheduledTrip unscheduledTrip(FeedScopedId id, StopLocation... stops) {
+    var stopTimes = Arrays
+      .stream(stops)
+      .map(s -> {
+        var st = new StopTime();
+        st.setStop(s);
+        st.setFlexWindowStart(LocalTime.of(10, 0).toSecondOfDay());
+        st.setFlexWindowEnd(LocalTime.of(18, 0).toSecondOfDay());
+
+        return st;
+      })
+      .toList();
+    return UnscheduledTrip
+      .of(id)
+      .withTrip(trip("flex-trip").build())
+      .withStopTimes(stopTimes)
+      .build();
   }
 }


### PR DESCRIPTION
### Summary

As shown in #5498 adding stops which are far away from walkable edges to flex trips can lead to catastrophic results.

This PR improves the situation as follows:

- flex stops are first linked to walkable edges
- if these edges are _not_ drivable then a second link to drivable edges is created

This leads to desirable results like these

![image](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/d4757369-48f9-4be9-bd23-9f899f8063ba)

### Further work

There is a slight problem though: the extra link for the flex trip is also accessible for pedestrians.

![image](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/1d273fba-bd20-47da-a1ee-eeb371287a30)

We can improve this by making the links mode specific. I suggest that we improve this problem in this PR and follow up later.

### Issue

Closes #5498

### Unit tests

Some added plus a bit of refactoring of the existing tests.

### Documentation

Javadoc.