### PR TITLE
Allow early creation of StopModelBuilder

### DIFF
--- a/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
@@ -19,8 +19,7 @@ import org.opentripplanner.transit.model.site.Station;
 
 public class StopModelBuilder {
 
-  private final StopModel original;
-  private final AtomicInteger indexCounter;
+  private final AtomicInteger stopIndexCounter;
 
   private final EntityById<RegularStop> regularStopById = new DefaultEntityById<>();
   private final EntityById<AreaStop> areaStopById = new DefaultEntityById<>();
@@ -29,17 +28,8 @@ public class StopModelBuilder {
   private final EntityById<MultiModalStation> multiModalStationById = new DefaultEntityById<>();
   private final EntityById<GroupOfStations> groupOfStationById = new DefaultEntityById<>();
 
-  StopModelBuilder(StopModel original) {
-    this.original = original;
-    this.indexCounter = new AtomicInteger(original.stopIndexSize());
-  }
-
-  public StopModel original() {
-    return original;
-  }
-
-  int stopIndexSize() {
-    return indexCounter.get();
+  StopModelBuilder(AtomicInteger stopIndexCounter) {
+    this.stopIndexCounter = stopIndexCounter;
   }
 
   public ImmutableEntityById<RegularStop> regularStopsById() {
@@ -47,7 +37,7 @@ public class StopModelBuilder {
   }
 
   public RegularStopBuilder regularStop(FeedScopedId id) {
-    return RegularStop.of(id, indexCounter::getAndIncrement);
+    return RegularStop.of(id, stopIndexCounter::getAndIncrement);
   }
 
   public RegularStop computeRegularStopIfAbsent(
@@ -104,7 +94,7 @@ public class StopModelBuilder {
   }
 
   public AreaStopBuilder areaStop(FeedScopedId id) {
-    return AreaStop.of(id, indexCounter::getAndIncrement);
+    return AreaStop.of(id, stopIndexCounter::getAndIncrement);
   }
 
   public ImmutableEntityById<AreaStop> areaStopById() {
@@ -122,7 +112,7 @@ public class StopModelBuilder {
   }
 
   public GroupStopBuilder groupStop(FeedScopedId id) {
-    return GroupStop.of(id, indexCounter::getAndIncrement);
+    return GroupStop.of(id, stopIndexCounter::getAndIncrement);
   }
 
   public ImmutableEntityById<GroupStop> groupStopById() {
@@ -155,5 +145,9 @@ public class StopModelBuilder {
 
   public StopModel build() {
     return new StopModel(this);
+  }
+
+  AtomicInteger stopIndexCounter() {
+    return stopIndexCounter;
   }
 }

--- a/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 import java.util.BitSet;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.JarFile;
 import org.geotools.util.WeakValueHashMap;
 import org.jets3t.service.io.TempFile;
@@ -42,6 +43,8 @@ public class GraphSerializationTest {
 
   static Class<?>[] IGNORED_CLASSES = Set
     .of(
+      // Skip AtomicInteger, it does not implement equals/hashCode
+      AtomicInteger.class,
       ThreadPoolExecutor.class,
       WeakValueHashMap.class,
       Method.class,


### PR DESCRIPTION
### Summary

The problem with the current code is that the stop model builders are created at the same time as the GraphBuilderModules. When the models are merged back the StopModel change, and only the first GraphBuilderModule is allowed to merge its result - this happens, because a stop model is only allowed to be merged with the model it originated from.


#### Solution

 - To solve this, we can create a stop model builder late to allow other graph builder models to complete their work before we continue. 
 - Or, we can change the stop model builder and stop model merge so more than one builder can exist at once. 

This PR take the second approach. It is easier, because we do not have to change the dependency injection. We kan inject the stop model builder at graph builder modules construction time. And we allow for parallell processing of the stops in the future. The model is more flexible.


### Issue

Closes #5497

### Unit tests

I have tested this with the data from Skaanetrafiken, which failed. It does work now.

I have not added any test on this - we have however a speed-test integration test witch fails due to this error.

The serializations tests had to be updated because the AtomicInteger (witch is now serialized) needs special handling.

### Documentation

JavaDoc is updated

### Changelog
No - this fixes a bug introduced in #5488 - same version as this fix

### Bumping the serialization version id
✅ The StopModel is changed
