### PR TITLE
Fix transfer of zoneId in `ScheduledTransitLegBuilder`

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -75,7 +76,7 @@ public class ScheduledTransitLeg implements TransitLeg {
     this.endTime = builder.endTime();
 
     this.serviceDate = builder.serviceDate();
-    this.zoneId = builder.zoneId();
+    this.zoneId = Objects.requireNonNull(builder.zoneId());
 
     this.tripOnServiceDate = builder.tripOnServiceDate();
 

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
-import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -40,6 +39,7 @@ public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>>
     transferToNextLeg = original.getTransferToNextLeg();
     generalizedCost = original.getGeneralizedCost();
     accessibilityScore = original.accessibilityScore();
+    zoneId = original.getZoneId();
   }
 
   public B withTripTimes(TripTimes tripTimes) {

--- a/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilderTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilderTest.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.model.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner._support.time.ZoneIds;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.basic.TransitMode;
+
+class ScheduledTransitLegBuilderTest {
+
+  @Test
+  void transferZoneId() {
+    var pattern = TransitModelForTest.of().pattern(TransitMode.BUS).build();
+    var leg = new ScheduledTransitLegBuilder<>()
+      .withZoneId(ZoneIds.BERLIN)
+      .withServiceDate(LocalDate.of(2023, 11, 15))
+      .withTripPattern(pattern)
+      .withBoardStopIndexInPattern(0)
+      .withAlightStopIndexInPattern(1)
+      .build();
+
+    var newLeg = new ScheduledTransitLegBuilder<>(leg);
+    assertEquals(ZoneIds.BERLIN, newLeg.zoneId());
+
+    var withScore = newLeg.withAccessibilityScore(4f).build();
+
+    assertEquals(ZoneIds.BERLIN, withScore.getZoneId());
+  }
+}


### PR DESCRIPTION
### Summary

When converting a `ScheduledTransitLeg` to a builder the field `zoneId` was not transferred correctly, which this PR fixes.

### Unit tests

:heavy_check_mark: 