### PR TITLE
Improve shutdown logic

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -196,15 +196,6 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   }
 
   @Override
-  public void teardown() {
-    if (subscriber != null) {
-      LOG.info("Stopping SIRI-ET PubSub subscriber  {}", subscriptionName);
-      subscriber.stopAsync();
-    }
-    deleteSubscription();
-  }
-
-  @Override
   public boolean isPrimed() {
     return this.primed;
   }
@@ -215,17 +206,16 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   }
 
   private void addShutdownHook() {
-    // TODO: This should probably be on a higher level?
-    Thread shutdownHook = new Thread(this::teardown, "siri-et-google-pubsub-shutdown");
-    boolean added = ApplicationShutdownSupport.addShutdownHook(
-      shutdownHook,
-      shutdownHook.getName()
+    ApplicationShutdownSupport.addShutdownHook(
+      "siri-et-google-pubsub-shutdown",
+      () -> {
+        if (subscriber != null) {
+          LOG.info("Stopping SIRI-ET PubSub subscriber '{}'.", subscriptionName);
+          subscriber.stopAsync();
+        }
+        deleteSubscription();
+      }
     );
-    if (!added) {
-      // Handling corner case when instance is being shut down before it has been initialized
-      LOG.info("Instance is already shutting down - cleaning up immediately.");
-      teardown();
-    }
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -149,23 +149,15 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
       subscriptionName
     );
 
-    Thread shutdownHook = new Thread(this::teardown, "azur-siri-updater-shutdown");
-    boolean added = ApplicationShutdownSupport.addShutdownHook(
-      shutdownHook,
-      shutdownHook.getName()
+    ApplicationShutdownSupport.addShutdownHook(
+      "azure-siri-updater-shutdown",
+      () -> {
+        LOG.info("Calling shutdownHook on AbstractAzureSiriUpdater");
+        eventProcessor.close();
+        serviceBusAdmin.deleteSubscription(topicName, subscriptionName).block();
+        LOG.info("Subscription '{}' deleted on topic '{}'.", subscriptionName, topicName);
+      }
     );
-    if (!added) {
-      // Handling corner case when instance is being shut down before it has been initialized
-      LOG.info("Instance is already shutting down - cleaning up immediately.");
-      teardown();
-    }
-  }
-
-  @Override
-  public void teardown() {
-    eventProcessor.close();
-    serviceBusAdmin.deleteSubscription(topicName, subscriptionName).block();
-    LOG.info("Subscription {} deleted on topic {}", subscriptionName, topicName);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -163,7 +163,7 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
 
   @Override
   public void teardown() {
-    eventProcessor.stop();
+    eventProcessor.close();
     serviceBusAdmin.deleteSubscription(topicName, subscriptionName).block();
     LOG.info("Subscription {} deleted on topic {}", subscriptionName, topicName);
   }

--- a/src/main/java/org/opentripplanner/framework/application/ApplicationShutdownSupport.java
+++ b/src/main/java/org/opentripplanner/framework/application/ApplicationShutdownSupport.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.framework.application;
 
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,5 +31,36 @@ public final class ApplicationShutdownSupport {
       );
       return false;
     }
+  }
+
+  /**
+   * Attempt to add a shutdown hook. If the application is already shutting down, the shutdown hook
+   * will be executed immediately.
+   *
+   * @param hookName the name of the thread
+   * @param shutdownHook the payload to be executed in the thread
+   * @return an Optional possibly containing the created thread, needed to un-schedule the shutdown hook
+   */
+  public static Optional<Thread> addShutdownHook(String hookName, Runnable shutdownHook) {
+    final Thread shutdownThread = new Thread(shutdownHook, hookName);
+    try {
+      LOG.info("Adding shutdown hook '{}'.", hookName);
+      Runtime.getRuntime().addShutdownHook(shutdownThread);
+      return Optional.of(shutdownThread);
+    } catch (IllegalStateException ignore) {
+      LOG.info("OTP is already shutting down, running shutdown hook '{}' immediately.", hookName);
+      shutdownThread.start();
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Remove a previously scheduled shutdown hook.
+   *
+   * @param shutdownThread an Optional possibly containing a thread
+   */
+  public static void removeShutdownHook(Thread shutdownThread) {
+    LOG.info("Removing shutdown hook '{}'.", shutdownThread.getName());
+    Runtime.getRuntime().removeShutdownHook(shutdownThread);
   }
 }

--- a/src/main/java/org/opentripplanner/framework/application/ApplicationShutdownSupport.java
+++ b/src/main/java/org/opentripplanner/framework/application/ApplicationShutdownSupport.java
@@ -15,26 +15,6 @@ public final class ApplicationShutdownSupport {
 
   /**
    * Attempt to add a shutdown hook. If the application is already shutting down, the shutdown hook
-   * will not be added.
-   *
-   * @return true if the shutdown hook is successfully added, false otherwise.
-   */
-  public static boolean addShutdownHook(Thread shutdownHook, String shutdownHookName) {
-    try {
-      LOG.info("Adding shutdown hook {}", shutdownHookName);
-      Runtime.getRuntime().addShutdownHook(shutdownHook);
-      return true;
-    } catch (IllegalStateException ignore) {
-      LOG.info(
-        "OTP is already shutting down, the shutdown hook {} will not be added",
-        shutdownHookName
-      );
-      return false;
-    }
-  }
-
-  /**
-   * Attempt to add a shutdown hook. If the application is already shutting down, the shutdown hook
    * will be executed immediately.
    *
    * @param hookName the name of the thread

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -221,7 +221,8 @@ public class OTPMain {
     TransitModel transitModel,
     RaptorConfig<?> raptorConfig
   ) {
-    var hook = new Thread(
+    ApplicationShutdownSupport.addShutdownHook(
+      "server-shutdown",
       () -> {
         LOG.info("OTP shutdown started...");
         UpdaterConfigurator.shutdownGraph(transitModel);
@@ -229,10 +230,8 @@ public class OTPMain {
         WeakCollectionCleaner.DEFAULT.exit();
         DeferredAuthorityFactory.exit();
         LOG.info("OTP shutdown: resources released...");
-      },
-      "server-shutdown"
+      }
     );
-    ApplicationShutdownSupport.addShutdownHook(hook, hook.getName());
   }
 
   private static void setOtpConfigVersionsOnServerInfo(ConstructApplication app) {

--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.model.projectinfo.OtpProjectInfo.projectInfo;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.opentripplanner.framework.application.ApplicationShutdownSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,14 +38,10 @@ public class OtpStartupInfo {
     // This is good when aggregating logs across multiple load balanced instances of OTP
     // Hint: a regexp filter like "^OTP (START|SHUTTING)" will list nodes going up/down
     LOG.info("OTP STARTING UP ({}) using Java {}", projectInfo().getVersionString(), javaVersion());
-    Runtime
-      .getRuntime()
-      .addShutdownHook(
-        new Thread(
-          () -> LOG.info("OTP SHUTTING DOWN ({})", projectInfo().getVersionString()),
-          "server-shutdown-info"
-        )
-      );
+    ApplicationShutdownSupport.addShutdownHook(
+      "server-shutdown-info",
+      () -> LOG.info("OTP SHUTTING DOWN ({})", projectInfo().getVersionString())
+    );
     LOG.info(NEW_LINE + "{}", info());
   }
 

--- a/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
@@ -1,10 +1,14 @@
 package org.opentripplanner.standalone.server;
 
+import static org.opentripplanner.framework.application.ApplicationShutdownSupport.addShutdownHook;
+import static org.opentripplanner.framework.application.ApplicationShutdownSupport.removeShutdownHook;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import jakarta.ws.rs.core.Application;
 import java.io.IOException;
 import java.net.BindException;
 import java.time.Duration;
+import java.util.Optional;
 import org.glassfish.grizzly.http.CompressionConfig;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpHandler;
@@ -13,7 +17,6 @@ import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.http.server.StaticHttpHandler;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
 import org.glassfish.jersey.server.ContainerFactory;
-import org.opentripplanner.framework.application.ApplicationShutdownSupport;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.slf4j.Logger;
@@ -126,10 +129,11 @@ public class GrizzlyServer {
     // Graph graph = gs.getGraph();
     // httpServer.getServerConfiguration().addHttpHandler(new OTPHttpHandler(graph), "/test/*");
 
-    // Add shutdown hook to gracefully shut down Grizzly.
-    // Signal handling (sun.misc.Signal) is potentially not available on all JVMs.
-    Thread shutdownThread = new Thread(httpServer::shutdown, "grizzly-shutdown");
-    ApplicationShutdownSupport.addShutdownHook(shutdownThread, shutdownThread.getName());
+    // Add shutdown hook to gracefully shut down Grizzly. If no thread is returned then shutdown is already in progress.
+    Optional<Thread> shutdownThread = addShutdownHook("grizzly-shutdown", httpServer::shutdown);
+    if (!shutdownThread.isPresent()) {
+      return;
+    }
 
     /* RELINQUISH CONTROL TO THE SERVER THREAD */
     try {
@@ -144,8 +148,7 @@ public class GrizzlyServer {
       LOG.info("Interrupted, shutting down.");
     }
 
-    // Clean up graceful shutdown hook before shutting down Grizzly.
-    Runtime.getRuntime().removeShutdownHook(shutdownThread);
+    shutdownThread.ifPresent(thread -> removeShutdownHook(thread));
     httpServer.shutdown();
   }
 


### PR DESCRIPTION
### Summary

* Don't execute updater teardown logic twice on shutdown.
* Consistently handle the edge-case where the JVM is already on its way to terminate when the shutdown code is scheduled.
* Improve Azure ServiceBus subscriptions removal.

### Details on the implementation and answers to questions that may arise while reading it
* The code design would for sure look more satisfactory if just `teardown()` was called on each updater in a simple loop.
* However, some of the updaters performs external remote calls, which may run for a long time - potentially never succeeding.
* If executed synchronously in a serialized matter, this could mean that some updaters never get the chance to execute.
* Therefore, these updaters could/should execute their code in a thread. Currently this is done by scheduling their own JVM shutdown hook, which makes them asynchronous.
* The issue (that this PR solves) is that if the teardown() method is used as the payload in the shutdown hook it will be executed twice: once by the JVM shutdown hook and once by the `GraphUpdaterManager` calling teardown() as part of the normal shutdown process.
* In the case of at least the AzureSiriUpdater, this leads to error messages and dreary stacktraces.
* Since the `GraphUpdaterManager` loop is done synchronously, this may delay the shutdown.
* ApplicationShutdownSupport has been applied to a couple of other usages as well, closing the window when the JVM is already shutting down.
* Empty teardown() methods have been removed (there is an empty default implementation).
* The main OTP shutdown is now executed immediately if the JVM is currently shutting down. This could potentially be controversial.
* The event processor in AzureSiriUpdater is now closed instead of stopped, suppressing errors when removing subscriptions.

Bonus question:
* How is WebsocketGtfsRealtimeUpdater terminated? Seems like an endless while(true) loop.

### Unit tests

This is mostly untestable (for once).
