### PR TITLE
Token serializer for paging and Leg.ID

### DIFF
--- a/src/main/java/org/opentripplanner/framework/lang/ObjectUtils.java
+++ b/src/main/java/org/opentripplanner/framework/lang/ObjectUtils.java
@@ -34,9 +34,17 @@ public class ObjectUtils {
   }
 
   public static <T> T requireNotInitialized(T oldValue, T newValue) {
+    return requireNotInitialized(null, oldValue, newValue);
+  }
+
+  public static <T> T requireNotInitialized(@Nullable String name, T oldValue, T newValue) {
     if (oldValue != null) {
       throw new IllegalStateException(
-        "Field is already set! Old value: " + oldValue + ", new value: " + newValue
+        "Field%s is already set! Old value: %s, new value: %s.".formatted(
+            (name == null ? "" : " " + name),
+            oldValue,
+            newValue
+          )
       );
     }
     return newValue;

--- a/src/main/java/org/opentripplanner/framework/token/Deserializer.java
+++ b/src/main/java/org/opentripplanner/framework/token/Deserializer.java
@@ -8,7 +8,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.opentripplanner.framework.time.DurationUtils;
 
 class Deserializer {
@@ -92,7 +91,6 @@ class Deserializer {
     return DurationUtils.duration(in.readUTF());
   }
 
-  @Nullable
   private static Instant readTimeInstant(ObjectInputStream in) throws IOException {
     return Instant.parse(in.readUTF());
   }

--- a/src/main/java/org/opentripplanner/framework/token/Deserializer.java
+++ b/src/main/java/org/opentripplanner/framework/token/Deserializer.java
@@ -1,0 +1,99 @@
+package org.opentripplanner.framework.token;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.opentripplanner.framework.time.DurationUtils;
+
+class Deserializer {
+
+  private final ByteArrayInputStream input;
+
+  Deserializer(String token) {
+    this.input = new ByteArrayInputStream(Base64.getUrlDecoder().decode(token));
+  }
+
+  List<Object> deserialize(TokenDefinition definition) throws IOException {
+    try {
+      // Assume deprecated fields are included in the token
+      return readFields(definition, false);
+    } catch (IOException ignore) {
+      // If the token is the next version, then deprecated field are removed. Try
+      // skipping the deprecated tokens
+      return readFields(definition, true);
+    }
+  }
+
+  private List<Object> readFields(TokenDefinition definition, boolean matchNewVersionPlusOne)
+    throws IOException {
+    input.reset();
+    List<Object> result = new ArrayList<>();
+
+    var in = new ObjectInputStream(input);
+
+    readAndMatchVersion(in, definition, matchNewVersionPlusOne);
+
+    for (FieldDefinition field : definition.listFields()) {
+      if (matchNewVersionPlusOne && field.deprecated()) {
+        continue;
+      }
+      var v = read(in, field);
+      if (!field.deprecated()) {
+        result.add(v);
+      }
+    }
+    return result;
+  }
+
+  private void readAndMatchVersion(
+    ObjectInputStream in,
+    TokenDefinition definition,
+    boolean matchVersionPlusOne
+  ) throws IOException {
+    int matchVersion = (matchVersionPlusOne ? 1 : 0) + definition.version();
+
+    int v = readInt(in);
+    if (v != matchVersion) {
+      throw new IOException(
+        "Version does not match. Token version: " + v + ", schema version: " + definition.version()
+      );
+    }
+  }
+
+  private Object read(ObjectInputStream in, FieldDefinition field) throws IOException {
+    return switch (field.type()) {
+      case BYTE -> readByte(in);
+      case DURATION -> readDuration(in);
+      case INT -> readInt(in);
+      case STRING -> readString(in);
+      case TIME_INSTANT -> readTimeInstant(in);
+    };
+  }
+
+  private static byte readByte(ObjectInputStream in) throws IOException {
+    return in.readByte();
+  }
+
+  private static int readInt(ObjectInputStream in) throws IOException {
+    return Integer.parseInt(in.readUTF());
+  }
+
+  private static String readString(ObjectInputStream in) throws IOException {
+    return in.readUTF();
+  }
+
+  private static Duration readDuration(ObjectInputStream in) throws IOException {
+    return DurationUtils.duration(in.readUTF());
+  }
+
+  @Nullable
+  private static Instant readTimeInstant(ObjectInputStream in) throws IOException {
+    return Instant.parse(in.readUTF());
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/FieldDefinition.java
+++ b/src/main/java/org/opentripplanner/framework/token/FieldDefinition.java
@@ -1,0 +1,54 @@
+package org.opentripplanner.framework.token;
+
+import java.util.Objects;
+
+class FieldDefinition {
+
+  private final String name;
+  private final TokenType type;
+  private final boolean deprecated;
+
+  private FieldDefinition(String name, TokenType type, boolean deprecated) {
+    this.name = Objects.requireNonNull(name);
+    this.type = Objects.requireNonNull(type);
+    this.deprecated = deprecated;
+  }
+
+  public FieldDefinition(String name, TokenType type) {
+    this(name, type, false);
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public TokenType type() {
+    return type;
+  }
+
+  public boolean deprecated() {
+    return deprecated;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FieldDefinition that = (FieldDefinition) o;
+    return deprecated == that.deprecated && Objects.equals(name, that.name) && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, deprecated);
+  }
+
+  @Override
+  public String toString() {
+    return (deprecated ? "@deprecated " : "") + name + ":" + type;
+  }
+
+  public FieldDefinition deprecate() {
+    return new FieldDefinition(name, type, true);
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/Serializer.java
+++ b/src/main/java/org/opentripplanner/framework/token/Serializer.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.framework.token;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import org.opentripplanner.framework.time.DurationUtils;
+
+class Serializer {
+
+  private final TokenDefinition definition;
+  private final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+  Serializer(TokenDefinition definition) {
+    this.definition = definition;
+  }
+
+  String serialize(Object[] values) throws IOException {
+    try (var out = new ObjectOutputStream(buf)) {
+      writeInt(out, definition.version());
+
+      for (var fieldName : definition.fieldNames()) {
+        var value = values[definition.index(fieldName)];
+        write(out, fieldName, value);
+      }
+      out.flush();
+    }
+    return Base64.getUrlEncoder().encodeToString(buf.toByteArray());
+  }
+
+  private void write(ObjectOutputStream out, String fieldName, Object value) throws IOException {
+    var type = definition.type(fieldName);
+    switch (type) {
+      case BYTE -> writeByte(out, (byte) value);
+      case DURATION -> writeDuration(out, (Duration) value);
+      case INT -> writeInt(out, (int) value);
+      case STRING -> writeString(out, (String) value);
+      case TIME_INSTANT -> writeTimeInstant(out, (Instant) value);
+      default -> throw new IllegalArgumentException("Unknown type: " + type);
+    }
+  }
+
+  private static void writeByte(ObjectOutputStream out, byte value) throws IOException {
+    out.writeByte(value);
+  }
+
+  private static void writeInt(ObjectOutputStream out, int value) throws IOException {
+    out.writeUTF(Integer.toString(value));
+  }
+
+  private static void writeString(ObjectOutputStream out, String value) throws IOException {
+    out.writeUTF(value);
+  }
+
+  private static void writeDuration(ObjectOutputStream out, Duration duration) throws IOException {
+    out.writeUTF(DurationUtils.durationToStr(duration));
+  }
+
+  private static void writeTimeInstant(ObjectOutputStream out, Instant time) throws IOException {
+    out.writeUTF(time.toString());
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/Token.java
+++ b/src/main/java/org/opentripplanner/framework/token/Token.java
@@ -1,0 +1,61 @@
+package org.opentripplanner.framework.token;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Given a schema definition and a token version this class holds the values for
+ * all fields in a token.
+ */
+public class Token {
+
+  private final TokenDefinition definition;
+  private final List<Object> fieldValues;
+
+  Token(TokenDefinition definition, List<Object> fieldValues) {
+    this.definition = Objects.requireNonNull(definition);
+    this.fieldValues = Objects.requireNonNull(fieldValues);
+  }
+
+  public int version() {
+    return definition.version();
+  }
+
+  public byte getByte(String fieldName) {
+    return (byte) get(fieldName, TokenType.BYTE);
+  }
+
+  public Duration getDuration(String fieldName) {
+    return (Duration) get(fieldName, TokenType.DURATION);
+  }
+
+  public int getInt(String fieldName) {
+    return (int) get(fieldName, TokenType.INT);
+  }
+
+  public String getString(String fieldName) {
+    return (String) get(fieldName, TokenType.STRING);
+  }
+
+  public Instant getTimeInstant(String fieldName) {
+    return (Instant) get(fieldName, TokenType.TIME_INSTANT);
+  }
+
+  private Object get(String fieldName, TokenType type) {
+    return fieldValues.get(definition.getIndex(fieldName, type));
+  }
+
+  @Override
+  public String toString() {
+    return (
+      "(v" +
+      version() +
+      ", " +
+      fieldValues.stream().map(Objects::toString).collect(Collectors.joining(", ")) +
+      ')'
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/TokenBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenBuilder.java
@@ -40,7 +40,7 @@ public class TokenBuilder {
 
   public String build() {
     try {
-      return new Serializer(definition).serialize(values);
+      return Serializer.serialize(definition, values);
     } catch (IOException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/src/main/java/org/opentripplanner/framework/token/TokenBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenBuilder.java
@@ -1,0 +1,55 @@
+package org.opentripplanner.framework.token;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import org.opentripplanner.framework.lang.ObjectUtils;
+
+/**
+ * This class is used to create a {@link Token} before encoding it.
+ */
+public class TokenBuilder {
+
+  private final TokenDefinition definition;
+  private final Object[] values;
+
+  public TokenBuilder(TokenDefinition definition) {
+    this.definition = definition;
+    this.values = new Object[definition.size()];
+  }
+
+  public TokenBuilder withByte(String fieldName, byte v) {
+    return with(fieldName, TokenType.BYTE, v);
+  }
+
+  public TokenBuilder withDuration(String fieldName, Duration v) {
+    return with(fieldName, TokenType.DURATION, v);
+  }
+
+  public TokenBuilder withInt(String fieldName, int v) {
+    return with(fieldName, TokenType.INT, v);
+  }
+
+  public TokenBuilder withString(String fieldName, String v) {
+    return with(fieldName, TokenType.STRING, v);
+  }
+
+  public TokenBuilder withTimeInstant(String fieldName, Instant v) {
+    return with(fieldName, TokenType.TIME_INSTANT, v);
+  }
+
+  public String build() {
+    try {
+      return new Serializer(definition).serialize(values);
+    } catch (IOException e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
+  }
+
+  private TokenBuilder with(String fieldName, TokenType type, Object value) {
+    int index = definition.getIndex(fieldName, type);
+    ObjectUtils.requireNotInitialized(fieldName, values[index], value);
+    values[index] = value;
+    return this;
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/TokenDefinition.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenDefinition.java
@@ -1,0 +1,107 @@
+package org.opentripplanner.framework.token;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
+
+/**
+ * A token definition is an ordered list of files. A field has a name and a type. The
+ * definition is used to encode/decode a token.
+ */
+public class TokenDefinition {
+
+  private final int version;
+  private final List<String> fieldNames;
+  private final Map<String, FieldDefinition> fields;
+
+  TokenDefinition(int version, List<FieldDefinition> fields) {
+    this.version = version;
+    this.fieldNames = fields.stream().map(FieldDefinition::name).toList();
+    this.fields = immutableMapOf(fields);
+  }
+
+  public int version() {
+    return version;
+  }
+
+  public List<String> fieldNames() {
+    return fieldNames;
+  }
+
+  public TokenType type(String fieldName) {
+    return fields.get(fieldName).type();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TokenDefinition that = (TokenDefinition) o;
+    return version == that.version && listFields().equals(that.listFields());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, listFields());
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(TokenDefinition.class)
+      .addNum("version", version, 0)
+      .addCol("fields", listFields())
+      .toString();
+  }
+
+  int size() {
+    return fieldNames.size();
+  }
+
+  int getIndex(String name, TokenType assertType) {
+    assertType(name, assertType);
+    return index(name);
+  }
+
+  int index(String name) {
+    for (int i = 0; i < fieldNames.size(); ++i) {
+      if (fieldNames.get(i).equals(name)) {
+        return i;
+      }
+    }
+    throw unknownFieldNameException(name);
+  }
+
+  List<FieldDefinition> listNoneDeprecatedFields() {
+    return listFields().stream().filter(it -> !it.deprecated()).toList();
+  }
+
+  List<FieldDefinition> listFields() {
+    return fieldNames.stream().map(fields::get).toList();
+  }
+
+  private void assertType(String name, TokenType assertType) {
+    Objects.requireNonNull(name);
+    var field = fields.get(name);
+
+    if (field == null) {
+      throw unknownFieldNameException(name);
+    }
+
+    if (field.type().isNot(assertType)) {
+      throw new IllegalArgumentException(
+        "The defined type for '" + name + "' is " + field.type() + " not " + assertType + "."
+      );
+    }
+  }
+
+  private IllegalArgumentException unknownFieldNameException(String name) {
+    return new IllegalArgumentException("Unknown field: '" + name + "'");
+  }
+
+  private static Map<String, FieldDefinition> immutableMapOf(List<FieldDefinition> fields) {
+    return Map.copyOf(fields.stream().collect(Collectors.toMap(FieldDefinition::name, it -> it)));
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/TokenDefinition.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenDefinition.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 
 /**
- * A token definition is an ordered list of files. A field has a name and a type. The
+ * A token definition is an ordered list of fields. A field has a name and a type. The
  * definition is used to encode/decode a token.
  */
 public class TokenDefinition {

--- a/src/main/java/org/opentripplanner/framework/token/TokenDefinition.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenDefinition.java
@@ -74,7 +74,7 @@ public class TokenDefinition {
     throw unknownFieldNameException(name);
   }
 
-  List<FieldDefinition> listNoneDeprecatedFields() {
+  List<FieldDefinition> listNonDeprecatedFields() {
     return listFields().stream().filter(it -> !it.deprecated()).toList();
   }
 

--- a/src/main/java/org/opentripplanner/framework/token/TokenDefinitionBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenDefinitionBuilder.java
@@ -17,7 +17,7 @@ public class TokenDefinitionBuilder {
 
   TokenDefinitionBuilder(List<TokenDefinition> head, TokenDefinition last) {
     this(last.version() + 1);
-    this.fields.addAll(last.listNoneDeprecatedFields());
+    this.fields.addAll(last.listNonDeprecatedFields());
     this.tokensHead.addAll(head);
     this.tokensHead.add(last);
   }

--- a/src/main/java/org/opentripplanner/framework/token/TokenDefinitionBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenDefinitionBuilder.java
@@ -1,0 +1,88 @@
+package org.opentripplanner.framework.token;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.opentripplanner.framework.lang.IntUtils;
+
+public class TokenDefinitionBuilder {
+
+  private final int version;
+  private final List<TokenDefinition> tokensHead = new ArrayList<>();
+  private final List<FieldDefinition> fields = new ArrayList<>();
+
+  TokenDefinitionBuilder(int version) {
+    this.version = IntUtils.requireInRange(version, 1, 1_000_000);
+  }
+
+  TokenDefinitionBuilder(List<TokenDefinition> head, TokenDefinition last) {
+    this(last.version() + 1);
+    this.fields.addAll(last.listNoneDeprecatedFields());
+    this.tokensHead.addAll(head);
+    this.tokensHead.add(last);
+  }
+
+  public TokenDefinitionBuilder addByte(String fieldName) {
+    return add(fieldName, TokenType.BYTE);
+  }
+
+  public TokenDefinitionBuilder addDuration(String fieldName) {
+    return add(fieldName, TokenType.DURATION);
+  }
+
+  public TokenDefinitionBuilder addInt(String fieldName) {
+    return add(fieldName, TokenType.INT);
+  }
+
+  public TokenDefinitionBuilder addString(String fieldName) {
+    return add(fieldName, TokenType.STRING);
+  }
+
+  public TokenDefinitionBuilder addTimeInstant(String fieldName) {
+    return add(fieldName, TokenType.TIME_INSTANT);
+  }
+
+  /**
+   * A deprecated field will be removed from the *next* token. A value must be provided for the
+   * deprecated field when encoding the current version. But, you can not read it! This make sure
+   * that the previous version sees the deprecated value, while this version will still work with
+   * a token provided with the next version. The deprecated field is automatically removed from
+   * the next version.
+   */
+  public TokenDefinitionBuilder deprecate(String fieldName) {
+    int index = indexOfField(fieldName);
+    if (index < 0) {
+      throw new IllegalArgumentException(
+        "The field '" + fieldName + "' does not exist! Deprecation failed."
+      );
+    }
+    fields.set(index, fields.get(index).deprecate());
+    return this;
+  }
+
+  private int indexOfField(String fieldName) {
+    for (int i = 0; i < fields.size(); i++) {
+      if (fields.get(i).name().equals(fieldName)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  public TokenDefinitionBuilder newVersion() {
+    return new TokenDefinitionBuilder(tokensHead, buildIt());
+  }
+
+  public TokenSchema build() {
+    return new TokenSchema(Stream.concat(tokensHead.stream(), Stream.of(buildIt())).toList());
+  }
+
+  private TokenDefinition buildIt() {
+    return new TokenDefinition(version, fields);
+  }
+
+  private TokenDefinitionBuilder add(String fieldName, TokenType type) {
+    fields.add(new FieldDefinition(fieldName, type));
+    return this;
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/TokenDefinitionBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenDefinitionBuilder.java
@@ -2,7 +2,7 @@ package org.opentripplanner.framework.token;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.framework.lang.IntUtils;
 
 public class TokenDefinitionBuilder {
@@ -74,7 +74,7 @@ public class TokenDefinitionBuilder {
   }
 
   public TokenSchema build() {
-    return new TokenSchema(Stream.concat(tokensHead.stream(), Stream.of(buildIt())).toList());
+    return new TokenSchema(ListUtils.combine(tokensHead, List.of(buildIt())));
   }
 
   private TokenDefinition buildIt() {

--- a/src/main/java/org/opentripplanner/framework/token/TokenSchema.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenSchema.java
@@ -8,7 +8,7 @@ import org.opentripplanner.framework.tostring.ToStringBuilder;
 /**
  * A token schema contains a set of token definitions, one for each version. This is
  * used to decode a token - the same version used to encode a token is used to
- * decode it. When encodeing a token the latest version is always used.
+ * decode it. When encoding a token the latest version is always used.
  * <p>
  * OTP only need to be backward compatible with the last version of otp. So, for each release of
  * OTP the schema that is older than the previous version can be merged. By doing so, you do not

--- a/src/main/java/org/opentripplanner/framework/token/TokenSchema.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenSchema.java
@@ -1,0 +1,81 @@
+package org.opentripplanner.framework.token;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
+
+/**
+ * A token schema contains a set of token definitions, one for each version. This is
+ * used to decode a token - the same version used to encode a token is used to
+ * decode it. When encodeing a token the latest version is always used.
+ * <p>
+ * OTP only need to be backward compatible with the last version of otp. So, for each release of
+ * OTP the schema that is older than the previous version can be merged. By doing so, you do not
+ * need to keep code around to support very old versions.
+ */
+public class TokenSchema {
+
+  private final List<TokenDefinition> definitions;
+
+  TokenSchema(List<TokenDefinition> definitions) {
+    // Reverse the list so the newest version is first and the oldest version is last
+    var list = new ArrayList<>(definitions);
+    Collections.reverse(list);
+    this.definitions = List.copyOf(list);
+  }
+
+  /**
+   * Define a set of versioned tokens. The version number for each will be auto-incremented.
+   * The provided {@code baseVersion} specify the version for the first token defined.
+   * <p>
+   * Old unused tokens definitions can merged into the first used definition. When this is done
+   * the "new" base should be given the exact same version number as it had before. The best way to
+   * ensure this is to add unit tests for all active version. If done right, the tests should not
+   * change when merging the versions.
+   * <p>
+   * Take a look at the unit tests to see an example on merging a schema.
+   * <p>
+   * @param baseVersion The initial version for the first definition. The version number is
+   *                    automatically incremented when new definitions are added. If there is many
+   *                    definitions, the oldest definitions can be merged into one. The new
+   *                    definition base version should match the highest version number of the
+   *                    definitions merged into one. For example, if version 3, 4 and 5 is merged,
+   *                    the new merged base version is 5. Legal range is [1, 1_000_000]
+   */
+  public static TokenDefinitionBuilder ofVersion(int baseVersion) {
+    return new TokenDefinitionBuilder(baseVersion);
+  }
+
+  public Token decode(String token) {
+    var deserializer = new Deserializer(token);
+    for (TokenDefinition definition : definitions) {
+      try {
+        return new Token(definition, deserializer.deserialize(definition));
+      } catch (Exception ignore) {}
+    }
+    throw new IllegalArgumentException(
+      "Token is not valid. Unable to parse token: '" + token + "'."
+    );
+  }
+
+  public TokenBuilder encode() {
+    return new TokenBuilder(currentDefinition());
+  }
+
+  /**
+   * We iterate over definitions in REVERSE order, because we want to use the
+   * latest version.
+   */
+  public TokenDefinition currentDefinition() {
+    return definitions.get(0);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(TokenSchema.class)
+      .addObj("definition", currentDefinition())
+      .toString();
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/TokenType.java
+++ b/src/main/java/org/opentripplanner/framework/token/TokenType.java
@@ -1,0 +1,20 @@
+package org.opentripplanner.framework.token;
+
+/**
+ * List of types we can store in a token.
+ * <p>
+ * Enums are not safe, so do not add support for them. The reason is that new values can be added
+ * to the enum and the previous version will fail to read the new version - it is no longer forward
+ * compatible with the new value of the enum.
+ */
+public enum TokenType {
+  BYTE,
+  DURATION,
+  INT,
+  STRING,
+  TIME_INSTANT;
+
+  boolean isNot(TokenType other) {
+    return this != other;
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/token/package.md
+++ b/src/main/java/org/opentripplanner/framework/token/package.md
@@ -1,0 +1,71 @@
+# Summary
+
+This adds a component to specify a very simple schema for a token. The schema is a list of 
+versioned token definitions and the encode/decode methods enforce versioning, and forward and 
+backward compatibility. It also allows definitions to be merged. We only need to support one OTP
+version. So after every release of OTP we can merge the definitions older than the last release.
+
+# Issue
+[Issue Create a reusable token generator #5451](https://github.com/opentripplanner/OpenTripPlanner/issues/5451)
+
+# Example
+
+## Define Schema
+```Java
+// v1:  (mode: byte)
+var builder = TokenSchema.ofVersion(1).addByte("mode");
+    
+// v2:  (mode: byte, searchWindow : Duration, numOfItineraries : int)
+builder.newVersion().addDuration("searchWindow").addInt("numOfItineraries");
+    
+// v3:  (mode: byte, @deprecated searchWindow : Duration, numOfItineraries : int, name : String)
+builder = builder.newVersion().deprecate("searchWindow").addString("name");
+    
+// v4:  (@deprecated mode: byte, numOfItineraries : int, name : String, dateTime : Instant)
+builder = builder.newVersion().deprecate("mode").addTimeInstant("dateTime");
+
+var schema = builder.build();
+```
+
+## Merge Schema
+
+The merging is provided to simplify the code when old versions of the schema is no longer needed.
+For example after releasing OTP `v2.5`, everything older than `v2.4` can be merged - we only 
+support backwards compatibility with the previous version. 
+
+```Java
+// v3  - v1, v2 and v3 merged
+var builder = TokenSchema
+    .ofVersion(3)
+    .addByte("mode")
+    .addInt("numOfItineraries")
+    .addString("name");
+```
+
+## Encode token
+
+Create a new token with latest version/definition(v4). Deprecated fields need to be inserted to 
+be forward compatible.
+
+```Java
+var token = schema.encode()
+    .withInt("numOfItineraries", 4)
+    .withByte("mode", BUS_CODE)
+    .withTimeInstant("dateTime", Instant.now())
+    .withString("name", "Oslo - Bergen")
+    .build();
+```
+
+## Decode token
+
+The token returned is parsed using the schema version that was used to generate the token. When
+acting on this, a mapping into the existing code must be provided for each supported version. If an
+old version can not be supported anymore, then merging the Schema is an option. 
+
+```Java
+var token = schema.decode("rO0ABXcaAAIxMwAUMjAyMy0xMC0yM1QxMDowMDo1OVo=");
+
+if(token.version() == 1) { token.getByte("mode") ... }
+if(token.version() == 2) { ... }
+if(token.version() == 3) { ... }
+```

--- a/src/test/java/org/opentripplanner/framework/lang/ObjectUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/lang/ObjectUtilsTest.java
@@ -34,10 +34,18 @@ class ObjectUtilsTest {
   @Test
   void requireNotInitialized() {
     assertEquals("new", ObjectUtils.requireNotInitialized(null, "new"));
-    assertThrows(
+    var ex = assertThrows(
       IllegalStateException.class,
-      () -> ObjectUtils.requireNotInitialized("old", "new")
+      () -> ObjectUtils.requireNotInitialized("foo", "old", "new")
     );
+    assertEquals("Field foo is already set! Old value: old, new value: new.", ex.getMessage());
+
+    ex =
+      assertThrows(
+        IllegalStateException.class,
+        () -> ObjectUtils.requireNotInitialized("old", "new")
+      );
+    assertEquals("Field is already set! Old value: old, new value: new.", ex.getMessage());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/framework/token/AdvancedTokenSchemaTest.java
+++ b/src/test/java/org/opentripplanner/framework/token/AdvancedTokenSchemaTest.java
@@ -1,0 +1,182 @@
+package org.opentripplanner.framework.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.framework.token.AdvancedTokenSchemaTest.TestCase.testCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AdvancedTokenSchemaTest implements TokenSchemaConstants {
+
+  private static final List<TestCase> TEST_CASES = new ArrayList<>();
+
+  static {
+    // Version 1: [BYTE]
+    var builder = TokenSchema.ofVersion(1).addByte(BYTE_FIELD);
+    TEST_CASES.add(
+      TestCase.testCase(builder, "(v1, 17)", it -> it.encode().withByte(BYTE_FIELD, BYTE_VALUE))
+    );
+
+    // Version 2: [BYTE, DURATION, INT]
+    builder = builder.newVersion().addDuration(DURATION_FIELD).addInt(INT_FIELD);
+    TEST_CASES.add(
+      testCase(
+        builder,
+        "(v2, 17, PT2M13S, 31)",
+        // We can add named fields in any order(token order: byte,Duration,Int)
+        it ->
+          it
+            .encode()
+            .withInt(INT_FIELD, INT_VALUE)
+            .withByte(BYTE_FIELD, BYTE_VALUE)
+            .withDuration(DURATION_FIELD, DURATION_VALUE)
+      )
+    );
+
+    // Version 3 - BYTE, @deprecated DURATION, INT
+    builder = builder.newVersion().deprecate(DURATION_FIELD);
+    TEST_CASES.add(
+      testCase(
+        builder,
+        "(v3, 17, 31)",
+        it ->
+          it
+            .encode()
+            .withInt(INT_FIELD, INT_VALUE)
+            .withByte(BYTE_FIELD, BYTE_VALUE)
+            .withDuration(DURATION_FIELD, DURATION_VALUE)
+      )
+    );
+
+    // Version 4 - BYTE, INT, STRING
+    builder = builder.newVersion().addString(STRING_FIELD);
+    TEST_CASES.add(
+      testCase(
+        builder,
+        "(v4, 17, 31, text)",
+        it ->
+          it
+            .encode()
+            .withInt(INT_FIELD, INT_VALUE)
+            .withByte(BYTE_FIELD, BYTE_VALUE)
+            .withString(STRING_FIELD, STRING_VALUE)
+      )
+    );
+
+    // Version 5 - @deprecated BYTE, INT, STRING, TIME_INSTANT
+    builder = builder.newVersion().deprecate(BYTE_FIELD).addTimeInstant(TIME_INSTANT_FIELD);
+    TEST_CASES.add(
+      testCase(
+        builder,
+        "(v5, 31, text, 2023-10-23T10:00:59Z)",
+        it ->
+          it
+            .encode()
+            .withInt(INT_FIELD, INT_VALUE)
+            .withByte(BYTE_FIELD, BYTE_VALUE)
+            .withTimeInstant(TIME_INSTANT_FIELD, TIME_INSTANT_VALUE)
+            .withString(STRING_FIELD, STRING_VALUE)
+      )
+    );
+    // Version 6 - INT, STRING, TIME_INSTANT
+    builder = builder.newVersion();
+    TEST_CASES.add(
+      testCase(
+        builder,
+        "(v6, 31, text, 2023-10-23T10:00:59Z)",
+        it ->
+          it
+            .encode()
+            .withInt(INT_FIELD, INT_VALUE)
+            .withTimeInstant(TIME_INSTANT_FIELD, TIME_INSTANT_VALUE)
+            .withString(STRING_FIELD, STRING_VALUE)
+      )
+    );
+  }
+
+  private static List<TestCase> testCases() {
+    return TEST_CASES;
+  }
+
+  @ParameterizedTest
+  @MethodSource(value = "testCases")
+  void testDecodeBackwardsCompatibility(TestCase testCase) {
+    allTestCasesFrom(testCase)
+      .forEach(s -> assertEquals(testCase.expected(), s.decode(testCase.token()).toString()));
+  }
+
+  @ParameterizedTest
+  @MethodSource(value = "testCases")
+  void testDecodeForwardCompatibility(TestCase testCase) {
+    nextTestCase(testCase)
+      .map(TestCase::token)
+      .ifPresent(nextVersionToken ->
+        assertEquals(testCase.expected(), testCase.subject().decode(nextVersionToken).toString())
+      );
+  }
+
+  @Test
+  void testMerge() {
+    var merged = TokenSchema
+      .ofVersion(6)
+      .addInt(INT_FIELD)
+      .addString(STRING_FIELD)
+      .addTimeInstant(TIME_INSTANT_FIELD)
+      .build();
+
+    var subjectV6 = TEST_CASES.get(5).subject();
+    assertEquals(merged.currentDefinition(), subjectV6.currentDefinition());
+  }
+
+  @Test
+  void testDefinitionToString() {
+    var expected = List.of(
+      "TokenDefinition{version: 1, fields: [AByte:BYTE]}",
+      "TokenDefinition{version: 2, fields: [AByte:BYTE, ADur:DURATION, ANum:INT]}",
+      "TokenDefinition{version: 3, fields: [AByte:BYTE, @deprecated ADur:DURATION, ANum:INT]}",
+      "TokenDefinition{version: 4, fields: [AByte:BYTE, ANum:INT, AStr:STRING]}",
+      "TokenDefinition{version: 5, fields: [@deprecated AByte:BYTE, ANum:INT, AStr:STRING, ATime:TIME_INSTANT]}",
+      "TokenDefinition{version: 6, fields: [ANum:INT, AStr:STRING, ATime:TIME_INSTANT]}"
+    );
+    for (int i = 0; i < TEST_CASES.size(); i++) {
+      assertEquals(expected.get(i), TEST_CASES.get(i).subject().currentDefinition().toString());
+    }
+  }
+
+  /**
+   * List of all test-cases including the given test-case until the end of all test-cases
+   */
+  private static Stream<TokenSchema> allTestCasesFrom(TestCase testCase) {
+    return TEST_CASES
+      .subList(TEST_CASES.indexOf(testCase), TEST_CASES.size() - 1)
+      .stream()
+      .map(TestCase::subject);
+  }
+
+  private static Optional<TestCase> nextTestCase(TestCase testCase) {
+    int index = TEST_CASES.indexOf(testCase) + 1;
+    return index < TEST_CASES.size() ? Optional.of(TEST_CASES.get(index)) : Optional.empty();
+  }
+
+  record TestCase(TokenSchema subject, String expected, String token) {
+    static TestCase testCase(
+      TokenDefinitionBuilder definitionBuilder,
+      String expected,
+      Function<TokenSchema, TokenBuilder> builder
+    ) {
+      var schema = definitionBuilder.build();
+      return new TestCase(schema, expected, builder.apply(schema).build());
+    }
+
+    @Override
+    public String toString() {
+      return subject.currentDefinition().toString();
+    }
+  }
+}

--- a/src/test/java/org/opentripplanner/framework/token/TokenSchemaConstants.java
+++ b/src/test/java/org/opentripplanner/framework/token/TokenSchemaConstants.java
@@ -1,0 +1,27 @@
+package org.opentripplanner.framework.token;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.opentripplanner.framework.time.DurationUtils;
+
+public interface TokenSchemaConstants {
+  // Token field names. These are used to reference a specific field value in theString BYTE_FIELD = "AByte";
+  // token to avoid index errors. They are not part of the serialized token.String DURATION_FIELD = "ADur";
+  String BYTE_FIELD = "AByte";
+  String DURATION_FIELD = "ADur";
+  String INT_FIELD = "ANum";
+  String STRING_FIELD = "AStr";
+  String TIME_INSTANT_FIELD = "ATime";
+
+  byte BYTE_VALUE = 17;
+  Duration DURATION_VALUE = DurationUtils.duration("2m13s");
+  int INT_VALUE = 31;
+  String STRING_VALUE = "text";
+  Instant TIME_INSTANT_VALUE = Instant.parse("2023-10-23T10:00:59Z");
+
+  String BYTE_ENCODED = "rO0ABXcEAAExEQ==";
+  String DURATION_ENCODED = "rO0ABXcKAAEyAAUybTEzcw==";
+  String INT_ENCODED = "rO0ABXcHAAEzAAIzMQ==";
+  String STRING_ENCODED = "rO0ABXcJAAE3AAR0ZXh0";
+  String TIME_INSTANT_ENCODED = "rO0ABXcaAAIxMwAUMjAyMy0xMC0yM1QxMDowMDo1OVo=";
+}

--- a/src/test/java/org/opentripplanner/framework/token/TokenSchemaTest.java
+++ b/src/test/java/org/opentripplanner/framework/token/TokenSchemaTest.java
@@ -1,0 +1,140 @@
+package org.opentripplanner.framework.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TokenSchemaTest implements TokenSchemaConstants {
+
+  // Token field names. These are used to reference a specific field value in the
+  // token to avoid index errors. They are not part of the serialized token.
+
+  private static final TokenSchema BYTE_SCHEMA = TokenSchema
+    .ofVersion(1)
+    .addByte(BYTE_FIELD)
+    .build();
+  private static final TokenSchema DURATION_SCHEMA = TokenSchema
+    .ofVersion(2)
+    .addDuration(DURATION_FIELD)
+    .build();
+  private static final TokenSchema INT_SCHEMA = TokenSchema.ofVersion(3).addInt(INT_FIELD).build();
+  private static final TokenSchema STRING_SCHEMA = TokenSchema
+    .ofVersion(7)
+    .addString(STRING_FIELD)
+    .build();
+  private static final TokenSchema TIME_INSTANT_SCHEMA = TokenSchema
+    .ofVersion(13)
+    .addTimeInstant(TIME_INSTANT_FIELD)
+    .build();
+
+  @Test
+  public void encodeByte() {
+    var token = BYTE_SCHEMA.encode().withByte(BYTE_FIELD, (byte) 17).build();
+    assertEquals(BYTE_ENCODED, token);
+    assertEquals(BYTE_VALUE, BYTE_SCHEMA.decode(token).getByte(BYTE_FIELD));
+  }
+
+  @Test
+  public void testDuration() {
+    var token = DURATION_SCHEMA.encode().withDuration(DURATION_FIELD, DURATION_VALUE).build();
+    assertEquals(DURATION_ENCODED, token);
+    assertEquals(DURATION_VALUE, DURATION_SCHEMA.decode(token).getDuration(DURATION_FIELD));
+  }
+
+  @Test
+  public void testInt() {
+    var token = INT_SCHEMA.encode().withInt(INT_FIELD, INT_VALUE).build();
+    assertEquals(INT_ENCODED, token);
+    assertEquals(INT_VALUE, INT_SCHEMA.decode(token).getInt(INT_FIELD));
+  }
+
+  @Test
+  public void testString() {
+    var token = STRING_SCHEMA.encode().withString(STRING_FIELD, STRING_VALUE).build();
+    assertEquals(STRING_ENCODED, token);
+    assertEquals(STRING_VALUE, STRING_SCHEMA.decode(token).getString(STRING_FIELD));
+  }
+
+  @Test
+  public void encodeTimeInstant() {
+    var token = TIME_INSTANT_SCHEMA
+      .encode()
+      .withTimeInstant(TIME_INSTANT_FIELD, TIME_INSTANT_VALUE)
+      .build();
+    assertEquals(TIME_INSTANT_ENCODED, token);
+    assertEquals(
+      TIME_INSTANT_VALUE,
+      TIME_INSTANT_SCHEMA.decode(token).getTimeInstant(TIME_INSTANT_FIELD)
+    );
+  }
+
+  @Test
+  public void encodeUndefinedFields() {
+    var ex = Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> INT_SCHEMA.encode().withString("foo", "A")
+    );
+    assertEquals("Unknown field: 'foo'", ex.getMessage());
+
+    Assertions.assertThrows(
+      NullPointerException.class,
+      () -> BYTE_SCHEMA.encode().withString(null, "A")
+    );
+  }
+
+  @Test
+  public void encodeFieldValueWithTypeMismatch() {
+    var ex = Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> STRING_SCHEMA.encode().withByte(STRING_FIELD, (byte) 12)
+    );
+    assertEquals("The defined type for 'AStr' is STRING not BYTE.", ex.getMessage());
+  }
+
+  @Test
+  public void decodeUndefinedToken() {
+    var ex = Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> INT_SCHEMA.decode("foo")
+    );
+    assertEquals("Token is not valid. Unable to parse token: 'foo'.", ex.getMessage());
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals(
+      "TokenSchema{definition: TokenDefinition{version: 1, fields: [AByte:BYTE]}}",
+      BYTE_SCHEMA.toString()
+    );
+    assertEquals(
+      "TokenSchema{definition: TokenDefinition{version: 3, fields: [ANum:INT]}}",
+      INT_SCHEMA.toString()
+    );
+    assertEquals(
+      "TokenSchema{definition: TokenDefinition{version: 7, fields: [AStr:STRING]}}",
+      STRING_SCHEMA.toString()
+    );
+    assertEquals(
+      "TokenSchema{definition: TokenDefinition{version: 2, fields: [ADur:DURATION]}}",
+      DURATION_SCHEMA.toString()
+    );
+    assertEquals(
+      "TokenSchema{definition: TokenDefinition{version: 13, fields: [ATime:TIME_INSTANT]}}",
+      TIME_INSTANT_SCHEMA.toString()
+    );
+  }
+
+  @Test
+  void testDefinitionEqualsAndHashCode() {
+    var subject = BYTE_SCHEMA.currentDefinition();
+    var same = TokenSchema.ofVersion(1).addByte(BYTE_FIELD).build().currentDefinition();
+
+    assertEquals(subject, same);
+    assertEquals(subject.hashCode(), same.hashCode());
+
+    assertNotEquals(subject, INT_SCHEMA.currentDefinition());
+    assertNotEquals(subject.hashCode(), INT_SCHEMA.currentDefinition().hashCode());
+  }
+}


### PR DESCRIPTION
### Summary

This adds a component to specify a very simple schema for a token. The schema is a list of versioned token definitions and the encode/decode methods enforce versioning, and forward and backward compatibillity. It also allow definitions to be merged. We only need to support one OTP version. So after every release of OTP we can merge the definitions older then the last release.

This module is not integrated into OTP code, but should be used in:
- [ ] Leg.ID 
- [ ] Paging 

### Issue
Closes #5451

### Example

#### Define Schema
```Java
// v1:  (mode: byte)
var builder = TokenSchema.ofVersion(1).addByte("mode");
    
// v2:  (mode: byte, searchWindow : Duration, numOfItineraries : int)
builder.newVersion().addDuration("searchWindow").addInt("numOfItineraries");
    
// v3:  (mode: byte, @deprecated searchWindow : Duration, numOfItineraries : int, name : String)
builder = builder.newVersion().deprecate("searchWindow").addString("name");
    
// v4:  (@deprecated mode: byte, numOfItineraries : int, name : String, dateTime : Instant)
builder = builder.newVersion().deprecate("mode").addTimeInstant("dateTime");

var schema = builder.build();
```

#### Merge Schema
```Java
// v3  - v1, v2 and v3 merged
var builder = TokenSchema
        .ofVersion(3)
        .addByte("mode")
        .addInt("numOfItineraries")
        .addString("name");
```

#### Encode token

Create a new token with latest version/definition(v4) including deprecated fields:

```Java
var token = schema.encode()
        .withInt("numOfItineraries", 4)
        .withByte("mode", BUS_CODE)
        .withTimeInstant("dateTime", Instant.now())
        .withString("name", "Oslo - Bergen")
        .build();
```

#### Decode token


```Java
var token = schema.decode("rO0ABXcaAAIxMwAUMjAyMy0xMC0yM1QxMDowMDo1OVo=");

if(token.version() == 1) { token.getByte("mode") ... }
if(token.version() == 2) { ... }
if(token.version() == 3) { ... }
...
```



### Unit tests

This module have almost >95% unit test *branch coverage*.

### Documentation

JavaDoc added.

### Changelog

No - this is a utility lib for tokens. 

### Bumping the serialization version id

No - tokens are not serialized.
