### PR TITLE
Transfer cost limit

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -15,6 +16,19 @@ import org.opentripplanner.street.search.state.EdgeTraverser;
 import org.opentripplanner.street.search.state.StateEditor;
 
 public class Transfer {
+
+  /**
+   * Since transfers costs are not computed through a full A* they can incur an absurdly high
+   * cost that overflows the integer cost inside raptor.
+   * <p>
+   * An example would be a transfer using lots of stairs being used on a wheelchair when no
+   * wheelchair-specific one has been generated.
+   * (see https://docs.opentripplanner.org/en/dev-2.x/Accessibility/).
+   * <p>
+   * For this reason there is this sanit limit that make sure that the transfer cost stays inside a
+   * bound that is still very high but far away from the integer overflow.
+   */
+  private final double MAX_TRANSFER_COST = Duration.ofDays(3).toSeconds();
 
   private final int toStop;
 
@@ -63,14 +77,19 @@ public class Transfer {
     WalkPreferences walkPreferences = request.preferences().walk();
     if (edges == null || edges.isEmpty()) {
       double durationSeconds = distanceMeters / walkPreferences.speed();
-      return Optional.of(
-        new DefaultRaptorTransfer(
-          this.toStop,
-          (int) Math.ceil(durationSeconds),
-          RaptorCostConverter.toRaptorCost(durationSeconds * walkPreferences.reluctance()),
-          this
-        )
-      );
+      final double domainCost = durationSeconds * walkPreferences.reluctance();
+      if (domainCost > MAX_TRANSFER_COST) {
+        return Optional.empty();
+      } else {
+        return Optional.of(
+          new DefaultRaptorTransfer(
+            this.toStop,
+            (int) Math.ceil(durationSeconds),
+            RaptorCostConverter.toRaptorCost(domainCost),
+            this
+          )
+        );
+      }
     }
 
     StateEditor se = new StateEditor(edges.get(0).getFromVertex(), request);
@@ -78,14 +97,17 @@ public class Transfer {
 
     var state = EdgeTraverser.traverseEdges(se.makeState(), edges);
 
-    return state.map(s ->
-      new DefaultRaptorTransfer(
-        this.toStop,
-        (int) s.getElapsedTimeSeconds(),
-        RaptorCostConverter.toRaptorCost(s.getWeight()),
-        this
-      )
-    );
+    return state
+      .filter(s -> s.weight < MAX_TRANSFER_COST)
+      .map(s -> {
+        final int raptorCost = RaptorCostConverter.toRaptorCost(s.getWeight());
+        return new DefaultRaptorTransfer(
+          this.toStop,
+          (int) s.getElapsedTimeSeconds(),
+          raptorCost,
+          this
+        );
+      });
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
@@ -17,7 +17,7 @@ import org.opentripplanner.street.search.state.StateEditor;
 public class Transfer {
 
   /**
-   * Since transfers costs are not computed through a full A* with pruning they can incur an
+   * Since transfer costs are not computed through a full A* with pruning they can incur an
    * absurdly high cost that overflows the integer cost inside RAPTOR
    * (https://github.com/opentripplanner/OpenTripPlanner/issues/5509).
    * <p>
@@ -31,8 +31,8 @@ public class Transfer {
    * <p>
    * The unit is in RAPTOR cost, so it's centiseconds.
    *
-   * @see RaptorCostConverter
    * @see EdgeTraverser
+   * @see RaptorCostConverter
    */
   private static final int MAX_TRANSFER_RAPTOR_COST = Integer.MAX_VALUE / 30;
 
@@ -80,7 +80,8 @@ public class Transfer {
   }
 
   public Optional<RaptorTransfer> asRaptorTransfer(StreetSearchRequest request) {
-    return toRaptor(request).filter(s -> s.generalizedCost() < MAX_TRANSFER_RAPTOR_COST);
+    return toRaptor(request)
+      .filter(s -> s.generalizedCost() < MAX_TRANSFER_RAPTOR_COST && s.generalizedCost() >= 0);
   }
 
   private Optional<RaptorTransfer> toRaptor(StreetSearchRequest request) {

--- a/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.framework.lang.ObjectUtils.requireNotInitializ
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -479,6 +480,21 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
       )
       .addBoolIfTrue("VEHICLE_PARKED", isVehicleParked())
       .toString();
+  }
+
+  /**
+   * Iterates over all back states of this instance and returns them as a list.
+   * <p>
+   * Note: Use this only for debugging not for performance-critical paths!
+   */
+  public List<State> chain() {
+    List<State> states = new ArrayList<>();
+    State current = this;
+    while (current != null) {
+      states.add(current);
+      current = current.backState;
+    }
+    return states;
   }
 
   void checkNegativeWeight() {

--- a/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.framework.lang.ObjectUtils.requireNotInitializ
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -480,21 +479,6 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
       )
       .addBoolIfTrue("VEHICLE_PARKED", isVehicleParked())
       .toString();
-  }
-
-  /**
-   * Iterates over all back states of this instance and returns them as a list.
-   * <p>
-   * Note: Use this only for debugging not for performance-critical paths!
-   */
-  public List<State> chain() {
-    List<State> states = new ArrayList<>();
-    State current = this;
-    while (current != null) {
-      states.add(current);
-      current = current.backState;
-    }
-    return states;
   }
 
   void checkNegativeWeight() {

--- a/src/test/java/org/opentripplanner/_support/geometry/Coordinates.java
+++ b/src/test/java/org/opentripplanner/_support/geometry/Coordinates.java
@@ -5,6 +5,7 @@ import org.locationtech.jts.geom.Coordinate;
 public class Coordinates {
 
   public static final Coordinate BERLIN = new Coordinate(52.5212, 13.4105);
+  public static final Coordinate BERLIN_BRANDENBURG_GATE = new Coordinate(52.51627, 13.37770);
   public static final Coordinate HAMBURG = new Coordinate(53.5566, 10.0003);
   public static final Coordinate KONGSBERG_PLATFORM_1 = new Coordinate(59.67216, 9.65107);
 }

--- a/src/test/java/org/opentripplanner/_support/geometry/Coordinates.java
+++ b/src/test/java/org/opentripplanner/_support/geometry/Coordinates.java
@@ -8,4 +8,5 @@ public class Coordinates {
   public static final Coordinate BERLIN_BRANDENBURG_GATE = new Coordinate(52.51627, 13.37770);
   public static final Coordinate HAMBURG = new Coordinate(53.5566, 10.0003);
   public static final Coordinate KONGSBERG_PLATFORM_1 = new Coordinate(59.67216, 9.65107);
+  public static final Coordinate BOSTON = new Coordinate(42.36541, -71.06129);
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
@@ -21,9 +21,7 @@ class TransferTest {
   private static final IntersectionVertex BRANDENBURG_GATE_V = intersectionVertex(
     Coordinates.BERLIN_BRANDENBURG_GATE
   );
-  private static final IntersectionVertex BOSTON_V = intersectionVertex(
-    Coordinates.BOSTON
-  );
+  private static final IntersectionVertex BOSTON_V = intersectionVertex(Coordinates.BOSTON);
 
   @Nested
   class WithEdges {
@@ -48,10 +46,9 @@ class TransferTest {
         StreetSearchRequest.of().build()
       );
       // cost is below max limit and should be included in RAPTOR
-      assertTrue(raptorTransfer.isPresent());
+      assertBelowMaxCost(raptorTransfer.get());
     }
   }
-
 
   @Nested
   class WithoutEdges {
@@ -82,12 +79,20 @@ class TransferTest {
         StreetSearchRequest.of().build()
       );
       // cost is below max limit and should be included in RAPTOR
-      assertTrue(raptorTransfer.isPresent());
+      assertBelowMaxCost(raptorTransfer.get());
     }
   }
 
   private static void assertMaxCost(RaptorTransfer transfer) {
-    assertEquals(RaptorCostConverter.toRaptorCost(Transfer.MAX_TRANSFER_COST), transfer.generalizedCost());
+    assertEquals(
+      RaptorCostConverter.toRaptorCost(Transfer.MAX_TRANSFER_COST),
+      transfer.generalizedCost()
+    );
   }
 
+  private static void assertBelowMaxCost(RaptorTransfer transfer) {
+    assertTrue(
+      RaptorCostConverter.toRaptorCost(Transfer.MAX_TRANSFER_COST) > transfer.generalizedCost()
+    );
+  }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
@@ -45,7 +45,7 @@ class TransferTest {
       final Optional<RaptorTransfer> raptorTransfer = transfer.asRaptorTransfer(
         StreetSearchRequest.of().build()
       );
-      // cost is below max limit and should be included in RAPTOR
+      // cost is below max limit and included in RAPTOR unchanged
       assertBelowMaxCost(raptorTransfer.get());
     }
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
@@ -54,6 +54,18 @@ class TransferTest {
   class WithoutEdges {
 
     @Test
+    void overflow() {
+      var veryLongTransfer = new Transfer(0, Integer.MAX_VALUE);
+      assertTrue(veryLongTransfer.asRaptorTransfer(StreetSearchRequest.of().build()).isEmpty());
+    }
+
+    @Test
+    void negativeCost() {
+      var veryLongTransfer = new Transfer(0, -5);
+      assertTrue(veryLongTransfer.asRaptorTransfer(StreetSearchRequest.of().build()).isEmpty());
+    }
+
+    @Test
     void limitMaxCost() {
       var veryLongTransfer = new Transfer(0, 800_000);
       // cost would be too high, so it should not be included in RAPTOR search

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransferTest.java
@@ -1,0 +1,73 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner._support.geometry.Coordinates;
+import org.opentripplanner.raptor.api.model.RaptorTransfer;
+import org.opentripplanner.street.model._data.StreetModelForTest;
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+
+class TransferTest {
+
+  private static final IntersectionVertex BERLIN_V = intersectionVertex(Coordinates.BERLIN);
+  private static final IntersectionVertex BRANDENBURG_GATE_V = intersectionVertex(
+    Coordinates.BERLIN_BRANDENBURG_GATE
+  );
+  private static final IntersectionVertex KONGSBERG_V = intersectionVertex(
+    Coordinates.KONGSBERG_PLATFORM_1
+  );
+
+  @Nested
+  class WithEdges {
+
+    @Test
+    void limitMaxCost() {
+      // very long edge from Berlin to Kongsberg, Norway that has of course a huge cost to traverse
+      var edge = StreetModelForTest.streetEdge(BERLIN_V, KONGSBERG_V);
+
+      var veryLongTransfer = new Transfer(0, List.of(edge));
+      assertTrue(veryLongTransfer.getDistanceMeters() > 800_000);
+      // cost would be too high, so it should not be included in RAPTOR search
+      assertTrue(veryLongTransfer.asRaptorTransfer(StreetSearchRequest.of().build()).isEmpty());
+    }
+
+    @Test
+    void allowLowCost() {
+      var edge = StreetModelForTest.streetEdge(BERLIN_V, BRANDENBURG_GATE_V);
+      var transfer = new Transfer(0, List.of(edge));
+      assertTrue(transfer.getDistanceMeters() < 4000);
+      final Optional<RaptorTransfer> raptorTransfer = transfer.asRaptorTransfer(
+        StreetSearchRequest.of().build()
+      );
+      // cost is below max limit and should be included in RAPTOR
+      assertTrue(raptorTransfer.isPresent());
+    }
+  }
+
+  @Nested
+  class WithoutEdges {
+
+    @Test
+    void limitMaxCost() {
+      var veryLongTransfer = new Transfer(0, 800_000);
+      // cost would be too high, so it should not be included in RAPTOR search
+      assertTrue(veryLongTransfer.asRaptorTransfer(StreetSearchRequest.of().build()).isEmpty());
+    }
+
+    @Test
+    void allowLowCost() {
+      var transfer = new Transfer(0, 200);
+      final Optional<RaptorTransfer> raptorTransfer = transfer.asRaptorTransfer(
+        StreetSearchRequest.of().build()
+      );
+      // cost is below max limit and should be included in RAPTOR
+      assertTrue(raptorTransfer.isPresent());
+    }
+  }
+}


### PR DESCRIPTION
### Summary

As discussed in today's dev meeting and described in #5509 absurdly high transfer costs can lead to an integer overflow in RAPTOR.

This PR adds a safety limit when transfer costs are being calculated. This limit is still pretty high (several days of transit-equiavalence) but well below `Integer.MAX_VALUE`.

### Issue

Closes #5509

### Unit tests

:heavy_check_mark: 

### Documentation

Javadoc.

cc @miles-grant-ibigroup @binh-dam-ibigroup 