### PR TITLE
Fix flex egress stop index

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
@@ -633,8 +633,8 @@ public class UnscheduledTripTest {
 
       assertEquals(4, templates.size());
       var template = templates.get(0);
-      assertEquals(template.fromStopIndex, 3);
-      assertEquals(template.toStopIndex, 0);
+      assertEquals(template.fromStopIndex, 0);
+      assertEquals(template.toStopIndex, 3);
     }
 
     @Nonnull

--- a/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
@@ -37,7 +37,7 @@ import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 
-public class UnscheduledTripTest {
+class UnscheduledTripTest {
 
   private static final int STOP_A = 0;
   private static final int STOP_B = 1;
@@ -620,8 +620,8 @@ public class UnscheduledTripTest {
         .of(0, 1)
         .forEach(index -> {
           var template = templates.get(index);
-          assertEquals(template.fromStopIndex, 0);
-          assertEquals(template.toStopIndex, index + 2);
+          assertEquals(0, template.fromStopIndex);
+          assertEquals(index + 2, template.toStopIndex);
         });
     }
 
@@ -633,8 +633,8 @@ public class UnscheduledTripTest {
 
       assertEquals(4, templates.size());
       var template = templates.get(0);
-      assertEquals(template.fromStopIndex, 0);
-      assertEquals(template.toStopIndex, 3);
+      assertEquals(0, template.fromStopIndex);
+      assertEquals(3, template.toStopIndex);
     }
 
     @Nonnull

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
@@ -23,14 +23,14 @@ public class FlexEgressTemplate extends FlexAccessEgressTemplate {
   public FlexEgressTemplate(
     NearbyStop accessEgress,
     FlexTrip trip,
-    int fromStopTime,
-    int toStopTime,
+    int fromStopIndex,
+    int toStopIndex,
     StopLocation transferStop,
     FlexServiceDate date,
     FlexPathCalculator calculator,
     FlexConfig config
   ) {
-    super(accessEgress, trip, fromStopTime, toStopTime, transferStop, date, calculator, config);
+    super(accessEgress, trip, fromStopIndex, toStopIndex, transferStop, date, calculator, config);
   }
 
   protected List<Edge> getTransferEdges(PathTransfer transfer) {
@@ -38,7 +38,7 @@ public class FlexEgressTemplate extends FlexAccessEgressTemplate {
   }
 
   protected RegularStop getFinalStop(PathTransfer transfer) {
-    return transfer.from instanceof RegularStop ? (RegularStop) transfer.from : null;
+    return transfer.from instanceof RegularStop regularStop ? regularStop : null;
   }
 
   protected Collection<PathTransfer> getTransfersFromTransferStop(TransitService transitService) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -180,8 +180,8 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
         new FlexEgressTemplate(
           egress,
           this,
-          toIndex,
           boardStop.index,
+          toIndex,
           boardStop.stop,
           date,
           calculator,


### PR DESCRIPTION
### Summary

#5376 introduced a bug in the way Flex egresses are created: the from and to stops were inverted.
This PR fixes it.


### Issue

No issue

### Unit tests

Fixed unit test

### Documentation

No
