### PR TITLE
Check transport mode when mapping GroupStops

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -128,10 +128,10 @@ class FlexStopsMapper {
    */
   List<RegularStop> findStopsInFlexArea(
     FlexibleArea area,
-    Geometry geometry,
-    TransitMode flexibleStopTransitMode
+    @Nullable Geometry geometry,
+    @Nullable TransitMode flexibleStopTransitMode
   ) {
-    if (geometry == null) {
+    if (geometry == null || flexibleStopTransitMode == null) {
       return List.of();
     }
     List<RegularStop> stops = stopsSpatialIndex

--- a/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
@@ -24,7 +24,7 @@ class TransportModeMapper {
     }
   }
 
-  private TransitMode mapAllVehicleModesOfTransport(AllVehicleModesOfTransportEnumeration mode)
+  public TransitMode mapAllVehicleModesOfTransport(AllVehicleModesOfTransportEnumeration mode)
     throws UnsupportedModeException {
     if (mode == null) {
       throw new UnsupportedModeException(null);

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -9,6 +9,7 @@ import static org.opentripplanner.netex.mapping.MappingSupport.ID_FACTORY;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import net.opengis.gml._3.AbstractRingPropertyType;
 import net.opengis.gml._3.DirectPositionListType;
 import net.opengis.gml._3.LinearRingType;
@@ -18,11 +19,13 @@ import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.StopModelBuilder;
+import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.FlexibleArea;
 import org.rutebanken.netex.model.FlexibleStopPlace;
 import org.rutebanken.netex.model.FlexibleStopPlace_VersionStructure;
@@ -117,6 +120,12 @@ class FlexStopsMapperTest {
     63.596915083462335,
     10.878374152208456
   );
+  private static final KeyListStructure KEY_LIST_UNRESTRICTED_PUBLIC_TRANSPORT_AREAS = new KeyListStructure()
+    .withKeyValue(
+      new KeyValueStructure()
+        .withKey("FlexibleStopAreaType")
+        .withValue("UnrestrictedPublicTransportAreas")
+    );
 
   private final TransitModelForTest testModel = TransitModelForTest.of();
   private final StopModelBuilder stopModelBuilder = testModel.stopModelBuilder();
@@ -162,81 +171,27 @@ class FlexStopsMapperTest {
   }
 
   @Test
-  void testMapGroupStop() {
-    RegularStop stop1 = testModel.stop("A").withCoordinate(59.6505778, 6.3608759).build();
-    RegularStop stop2 = testModel.stop("B").withCoordinate(59.6630333, 6.3697245).build();
-
+  void testMapGroupStopWithKeyValueOnFlexibleStopPlace() {
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(AREA_POS_LIST);
-    flexibleStopPlace.setKeyList(
-      new KeyListStructure()
-        .withKeyValue(
-          new KeyValueStructure()
-            .withKey("FlexibleStopAreaType")
-            .withValue("UnrestrictedPublicTransportAreas")
-        )
-    );
-
-    FlexStopsMapper subject = new FlexStopsMapper(
-      ID_FACTORY,
-      List.of(stop1, stop2),
-      stopModelBuilder,
-      DataImportIssueStore.NOOP
-    );
-
-    GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
-
-    assertNotNull(groupStop);
-
-    // Only one of the stops should be inside the polygon
-    assertEquals(1, groupStop.getLocations().size());
+    flexibleStopPlace.setKeyList(KEY_LIST_UNRESTRICTED_PUBLIC_TRANSPORT_AREAS);
+    assertGroupStopMapping(flexibleStopPlace);
   }
 
   @Test
-  void testMapGroupStopVariantWithKeyValueOnArea() {
-    RegularStop stop1 = testModel.stop("A").withCoordinate(59.6505778, 6.3608759).build();
-    RegularStop stop2 = testModel.stop("B").withCoordinate(59.6630333, 6.3697245).build();
-
+  void testMapGroupStopWithKeyValueOnArea() {
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(AREA_POS_LIST);
-
     var area = (FlexibleArea) flexibleStopPlace
       .getAreas()
       .getFlexibleAreaOrFlexibleAreaRefOrHailAndRideArea()
       .get(0);
-    area.withKeyList(
-      new KeyListStructure()
-        .withKeyValue(
-          new KeyValueStructure()
-            .withKey("FlexibleStopAreaType")
-            .withValue("UnrestrictedPublicTransportAreas")
-        )
-    );
-
-    FlexStopsMapper subject = new FlexStopsMapper(
-      ID_FACTORY,
-      List.of(stop1, stop2),
-      stopModelBuilder,
-      DataImportIssueStore.NOOP
-    );
-
-    GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
-
-    assertNotNull(groupStop);
-
-    // Only one of the stops should be inside the polygon
-    assertEquals(1, groupStop.getLocations().size());
+    area.withKeyList(KEY_LIST_UNRESTRICTED_PUBLIC_TRANSPORT_AREAS);
+    assertGroupStopMapping(flexibleStopPlace);
   }
 
   @Test
   void testMapFlexibleStopPlaceMissingStops() {
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(AREA_POS_LIST);
-    flexibleStopPlace.setKeyList(
-      new KeyListStructure()
-        .withKeyValue(
-          new KeyValueStructure()
-            .withKey("FlexibleStopAreaType")
-            .withValue("UnrestrictedPublicTransportAreas")
-        )
-    );
+    flexibleStopPlace.setKeyList(KEY_LIST_UNRESTRICTED_PUBLIC_TRANSPORT_AREAS);
 
     FlexStopsMapper subject = new FlexStopsMapper(
       ID_FACTORY,
@@ -257,14 +212,7 @@ class FlexStopsMapperTest {
 
     var invalidPolygon = List.of(1.0);
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace(invalidPolygon);
-    flexibleStopPlace.setKeyList(
-      new KeyListStructure()
-        .withKeyValue(
-          new KeyValueStructure()
-            .withKey("FlexibleStopAreaType")
-            .withValue("UnrestrictedPublicTransportAreas")
-        )
-    );
+    flexibleStopPlace.setKeyList(KEY_LIST_UNRESTRICTED_PUBLIC_TRANSPORT_AREAS);
 
     FlexStopsMapper subject = new FlexStopsMapper(
       ID_FACTORY,
@@ -278,10 +226,48 @@ class FlexStopsMapperTest {
     assertNull(groupStop);
   }
 
+  private void assertGroupStopMapping(FlexibleStopPlace flexibleStopPlace) {
+    // Regular stop inside the polygon with same transport mode as the flexible stop
+    RegularStop stop1 = testModel
+      .stop("A")
+      .withCoordinate(59.6505778, 6.3608759)
+      .withVehicleType(TransitMode.BUS)
+      .build();
+    // Regular stop outside the polygon with same transport mode as the flexible stop
+    RegularStop stop2 = testModel
+      .stop("B")
+      .withCoordinate(59.6630333, 6.3697245)
+      .withVehicleType(TransitMode.BUS)
+      .build();
+    // Regular stop inside the polygon with another transport mode than the flexible stop
+    RegularStop stop3 = testModel
+      .stop("A")
+      .withCoordinate(59.6505778, 6.3608759)
+      .withVehicleType(TransitMode.RAIL)
+      .build();
+
+    FlexStopsMapper subject = new FlexStopsMapper(
+      ID_FACTORY,
+      List.of(stop1, stop2, stop3),
+      stopModelBuilder,
+      DataImportIssueStore.NOOP
+    );
+
+    GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
+
+    assertNotNull(groupStop);
+
+    // Only one of the stops should be inside the polygon
+    Set<StopLocation> locations = groupStop.getLocations();
+    assertEquals(1, locations.size());
+    assertEquals(stop1.getId(), locations.stream().findFirst().orElseThrow().getId());
+  }
+
   private FlexibleStopPlace getFlexibleStopPlace(Collection<Double> areaPosList) {
     return new FlexibleStopPlace()
       .withId(FLEXIBLE_STOP_PLACE_ID)
       .withName(new MultilingualString().withValue(FLEXIBLE_STOP_PLACE_NAME))
+      .withTransportMode(AllVehicleModesOfTransportEnumeration.BUS)
       .withAreas(
         new FlexibleStopPlace_VersionStructure.Areas()
           .withFlexibleAreaOrFlexibleAreaRefOrHailAndRideArea(


### PR DESCRIPTION
### Summary

As detailed in #5506, when mapping "fixedStopAreaWide" FlexibleStopPlaces  (i.e. "UnrestrictedPublicTransportAreas" stop areas), group stops should include only regular stops that match the transport mode of the FlexibleStopPlace.

Note: The Nordic NeTEx profile defines the transport mode as a mandatory field of a FlexibleStopPlace. If the transport mode is unset or unknown in the input dataset, no stop will be mapped.

### Issue
Closes #5506

### Unit tests


Updated unit tests.

### Documentation
No.