### PR TITLE
Fix small bug in time-travel logging

### DIFF
--- a/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/MinTravelDurationRoutingStrategy.java
+++ b/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/MinTravelDurationRoutingStrategy.java
@@ -2,6 +2,7 @@ package org.opentripplanner.raptor.rangeraptor.standard;
 
 import static org.opentripplanner.raptor.spi.RaptorTripScheduleSearch.UNBOUNDED_TRIP_INDEX;
 
+import org.opentripplanner.framework.time.TimeUtils;
 import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.raptor.rangeraptor.internalapi.RoutingStrategy;
@@ -182,10 +183,10 @@ public final class MinTravelDurationRoutingStrategy<T extends RaptorTripSchedule
     if (logCount < 3) {
       ++logCount;
       LOG.error(
-        "Traveling back in time is not allowed. Board stop pos: {}, alight stop pos: {}, stop arrival time: {}, trip: {}.",
-        onTrip.findDepartureStopPosition(onTripBoardTime, onTripBoardStop),
+        "Traveling back in time is not allowed. Board time: {}, alight stop pos: {}, stop arrival time: {}, trip: {}.",
+        TimeUtils.timeToStrLong(onTripBoardTime),
         stopPos,
-        stopArrivalTime,
+        TimeUtils.timeToStrLong(stopArrivalTime),
         onTrip
       );
     }


### PR DESCRIPTION
### Summary
This fixes and improve the logging af a critical error inside Raptor on negative-travel times.

### Issue
🟥  No issue for this, too small.

### Unit tests
🟥 No tests, only logging changed.

### Documentation
🟥 No doc

### Changelog
🟥 Too small.

### Bumping the serialization version id
🟥  Not relevant.
