### PR TITLE
Remove container images that have not been pulled for over a year

### DIFF
--- a/.github/workflows/prune-container-images.yml
+++ b/.github/workflows/prune-container-images.yml
@@ -2,7 +2,7 @@ name: 'Delete unused snapshot container images'
 
 on:
   schedule:
-    - cron: '0 12 1 * *'
+    - cron: '0 12 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/prune-container-images.yml
+++ b/.github/workflows/prune-container-images.yml
@@ -1,0 +1,22 @@
+name: 'Delete unused snapshot container images'
+
+on:
+  schedule:
+    - cron: '0 12 1 * *'
+  workflow_dispatch:
+
+jobs:
+  container-image:
+    if: github.repository_owner == 'opentripplanner'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete unused container images
+        env:
+          CONTAINER_REPO: opentripplanner/opentripplanner
+          CONTAINER_REGISTRY_USER: otpbot
+          CONTAINER_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          # remove all snapshot container images that have not been pulled for over a year
+          # --keep-semver makes sure that any image with a x.y.z version scheme is unaffected by this
+          pip install prune-container-repo==0.0.3
+          prune-container-repo -u ${CONTAINER_REGISTRY_USER} -r ${CONTAINER_REPO} --days=365 --keep-semver --activate


### PR DESCRIPTION
### Summary

We push a lot of container images (50-100 per month) to the Dockerhub repository but we never clean them up making navigating the tags page quite hard.

This PR introduces a tool that deletes all container images that have not been pulled in over a year.