### PR TITLE
Add same submode in alternative legs filter

### DIFF
--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -1405,6 +1405,7 @@ enum AlternativeLegsFilter {
   sameAuthority
   sameLine
   sameMode
+  "Must match both subMode and mode"
   sameSubmode
 }
 

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -1405,6 +1405,7 @@ enum AlternativeLegsFilter {
   sameAuthority
   sameLine
   sameMode
+  sameSubmode
 }
 
 enum ArrivalDeparture {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -49,7 +49,7 @@ public class EnumTypes {
     .value("noFilter", AlternativeLegsFilter.NO_FILTER)
     .value("sameAuthority", AlternativeLegsFilter.SAME_AGENCY)
     .value("sameMode", AlternativeLegsFilter.SAME_MODE)
-    .value("sameSubmode", AlternativeLegsFilter.SAME_SUBMODE)
+    .value("sameSubmode", AlternativeLegsFilter.SAME_SUBMODE, "Must match both subMode and mode")
     .value("sameLine", AlternativeLegsFilter.SAME_ROUTE)
     .build();
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -49,6 +49,7 @@ public class EnumTypes {
     .value("noFilter", AlternativeLegsFilter.NO_FILTER)
     .value("sameAuthority", AlternativeLegsFilter.SAME_AGENCY)
     .value("sameMode", AlternativeLegsFilter.SAME_MODE)
+    .value("sameSubmode", AlternativeLegsFilter.SAME_SUBMODE)
     .value("sameLine", AlternativeLegsFilter.SAME_ROUTE)
     .build();
 

--- a/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegsFilter.java
+++ b/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegsFilter.java
@@ -14,6 +14,10 @@ public enum AlternativeLegsFilter {
   ),
   SAME_MODE((Leg leg) ->
     (TripPattern tripPattern) -> leg.getTrip().getMode().equals(tripPattern.getMode())
+  ),
+  SAME_SUBMODE((Leg leg) ->
+    (TripPattern tripPattern) ->
+      leg.getTrip().getNetexSubMode().equals(tripPattern.getNetexSubmode())
   );
 
   public final Function<Leg, Predicate<TripPattern>> predicateGenerator;


### PR DESCRIPTION
### Summary

This PR adds the ability to filter for same submode in the alternative legs filter.

### Issue

Closes #5300 

### Unit tests

All existing unit tests pass. Additionally tested manually by running locally.

### Documentation

This is a trivial addition to existing functionality.
