### PR TITLE
Fix issue where stop points are sometimes added twice to index

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/GroupNetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/GroupNetexMapper.java
@@ -3,7 +3,9 @@ package org.opentripplanner.netex.mapping;
 import com.google.common.collect.ArrayListMultimap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
@@ -25,7 +27,7 @@ class GroupNetexMapper {
   /**
    * A map from trip/serviceJourney id to an ordered list of scheduled stop point ids.
    */
-  final ArrayListMultimap<String, String> scheduledStopPointsIndex = ArrayListMultimap.create();
+  final Map<String, List<String>> scheduledStopPointsIndex = new HashMap<>();
 
   GroupNetexMapper(
     FeedScopedIdFactory idFactory,

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import jakarta.xml.bind.JAXBElement;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -469,7 +470,7 @@ public class NetexMapper {
         transitBuilder.getTripPatterns().put(it.getKey(), it.getValue());
       }
       currentMapperIndexes.addStopTimesByNetexId(result.stopTimeByNetexId);
-      groupMapper.scheduledStopPointsIndex.putAll(result.scheduledStopPointsIndex);
+      groupMapper.scheduledStopPointsIndex.putAll(Multimaps.asMap(result.scheduledStopPointsIndex));
       transitBuilder.getTripOnServiceDates().addAll(result.tripOnServiceDates);
     }
   }


### PR DESCRIPTION
### Summary

When netex data contains duplicate JourneyPatterns the scheduledStopPointsIndex will get duplicates of all the stop points for those JourneyPatterns during graph build. When the graph is loaded this will result in strange IndexOutOfBoundsExceptions in the TransferMapper.

### Issue

NetexMapper uses a `Multimap` for the scheduledStopPointsIndex. But the semantics of a multimap is that putting to a key that already exists will extend any existing data that has already been added. This is not really the behaviour we want in this case.

This PR fixes this issue by replacing the `Multimap` with a `Map<List>`. This way we will replace the current values when calling putAll().

I suppose that duplicate JourneyPatterns could cause all kinds of other problems, so to solve the underlying issue we should really add some validation of the netex data for this. But I think these changes are worthwhile anyway, since it makes the code less brittle.

### Unit tests

There aren't any tests for this code that I could find, and writing them feels a bit out of scope for this PR.

### Documentation

Nothing needed.

### Bumping the serialization version id

Nope
