### PR TITLE
refactor: Add "-Dps" as alias for -P prettierSkip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -966,6 +966,17 @@
         </profile>
         <profile>
             <id>prettierSkip</id>
+            <activation>
+                <property>
+                    <!--
+                      This work as a short alias to enable this from the command line. To skip
+                      prettier, set the 'ps' system property with the '-D ps' parameter:
+                      # mvn test -D ps
+                    -->
+                    <name>ps</name>
+                    <value/>
+                </property>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -969,7 +969,7 @@
             <activation>
                 <property>
                     <!--
-                      This work as a short alias to enable this from the command line. To skip
+                      This works as a short alias to enable this from the command line. To skip
                       prettier, set the 'ps' system property with the '-D ps' parameter:
                       # mvn test -D ps
                     -->


### PR DESCRIPTION
### Summary

This work as a short alias to enable this from the command line. To skip
prettier, set the 'ps' system property with the '-D ps' parameter:

> \# mvn test -D ps


### Issue
🟥 

### Unit tests
🟥 

### Documentation
✅ Explained in pom file only

### Changelog
🟥 

### Bumping the serialization version id
🟥 
