### PR TITLE
Relax TripTimes validation to [-12h, 20d] to allow support for "Hurtigruten"

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
@@ -35,7 +35,7 @@ public final class ScheduledTripTimes implements TripTimes {
   /**
    * We allow a trip to last for maximum 10 days. In Norway the longest trip is 6 days.
    */
-  private static final int MAX_TIME = DurationUtils.durationInSeconds("10d");
+  private static final int MAX_TIME = DurationUtils.durationInSeconds("20d");
 
   /**
    * Implementation notes: This allows re-using the same scheduled arrival and departure time

--- a/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
@@ -33,7 +33,7 @@ public final class ScheduledTripTimes implements TripTimes {
    */
   private static final int MIN_TIME = DurationUtils.durationInSeconds("-12h");
   /**
-   * We allow a trip to last for maximum 10 days. In Norway the longest trip is 6 days.
+   * We allow a trip to last for maximum 20 days. In Norway the longest trip is 6 days.
    */
   private static final int MAX_TIME = DurationUtils.durationInSeconds("20d");
 

--- a/src/test/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.model.timetable;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 
@@ -36,7 +37,7 @@ class ScheduledTripTimesTest {
   }
 
   private final ScheduledTripTimes subject = ScheduledTripTimes
-    .of(null)
+    .of()
     .withArrivalTimes("10:00 11:00 12:00")
     .withDepartureTimes("10:01 11:02 12:03")
     .withServiceCode(SERVICE_CODE)
@@ -96,6 +97,21 @@ class ScheduledTripTimesTest {
     assertFalse(subject.isTimepoint(STOP_POS_0));
     assertTrue(subject.isTimepoint(STOP_POS_1));
     assertFalse(subject.isTimepoint(STOP_POS_2));
+  }
+
+  @Test
+  void validateLastArrivalTimeIsNotMoreThan20DaysAfterFirstDepartureTime() {
+    var ex = assertThrows(
+      IllegalArgumentException.class,
+      () ->
+        ScheduledTripTimes
+          .of()
+          .withDepartureTimes("10:00 12:00 10:00:01+20d")
+          .withServiceCode(SERVICE_CODE)
+          .withTrip(TRIP)
+          .build()
+    );
+    assertEquals("The value is not in range[-43200, 1728000]: 1728001", ex.getMessage());
   }
 
   @Test


### PR DESCRIPTION
### Summary

Some trips last for more than 10 days, so we relax this sanity check to 20 days.


### Issue
Closes #5560

### Unit tests
✅  Unit test added.

### Documentation
🟥 

### Changelog
🟥  - The bug was introduced after the last release.

### Bumping the serialization version id
🟥 
