### PR TITLE
Use TRIP_NOT_FOUND when Siri journey cannot be resolved

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -4,7 +4,7 @@ import static java.lang.Boolean.TRUE;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NOT_MONITORED;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_FUZZY_TRIP_MATCH;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_START_DATE;
-import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_TRIP_ID;
+import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TRIP_NOT_FOUND;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TRIP_NOT_FOUND_IN_PATTERN;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.UNKNOWN;
 
@@ -325,7 +325,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       trip = tripAndPattern.trip();
       pattern = tripAndPattern.tripPattern();
     } else {
-      return UpdateError.result(null, NO_TRIP_ID);
+      return UpdateError.result(null, TRIP_NOT_FOUND);
     }
 
     Timetable currentTimetable = getCurrentTimetable(pattern, serviceDate);

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETHttpTripUpdateSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETHttpTripUpdateSource.java
@@ -49,7 +49,7 @@ public class SiriETHttpTripUpdateSource implements EstimatedTimetableSource {
     long t1 = System.currentTimeMillis();
     try {
       var siri = siriLoader.fetchETFeed(requestorRef);
-      if (siri.isEmpty()) {
+      if (siri.map(Siri::getServiceDelivery).isEmpty()) {
         return Optional.empty();
       }
 


### PR DESCRIPTION
### Summary

When working with a Siri feed in Germany, I noticed that OTP returns a confusing error code when the journey could not be resolved to a trip. This is fixed now.

It also fixes an exception when there is a Siri object that doesn't have a service delivery.