### PR TITLE
Orca Fares: No senior discount for cash payments

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -145,11 +145,7 @@ public class OrcaFareServiceTest {
       getLeg(COMM_TRANS_AGENCY_ID, 2)
     );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(3));
-    calculateFare(
-      rides,
-      FareType.senior,
-      DEFAULT_TEST_RIDE_PRICE.times(3)
-    );
+    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(3));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(
       rides,

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -125,7 +125,7 @@ public class OrcaFareServiceTest {
   void calculateFareForSingleAgency() {
     List<Leg> rides = List.of(getLeg(COMM_TRANS_AGENCY_ID, "400", 0));
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE);
-    calculateFare(rides, FareType.senior, TWO_DOLLARS);
+    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE);
     calculateFare(rides, FareType.youth, ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, TWO_DOLLARS);
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE);
@@ -148,7 +148,7 @@ public class OrcaFareServiceTest {
     calculateFare(
       rides,
       FareType.senior,
-      DEFAULT_TEST_RIDE_PRICE.plus(DEFAULT_TEST_RIDE_PRICE).plus(usDollars(1.25f))
+      DEFAULT_TEST_RIDE_PRICE.times(3)
     );
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(
@@ -429,7 +429,7 @@ public class OrcaFareServiceTest {
       getLeg(KC_METRO_AGENCY_ID, 130)
     );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(3));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(2).plus(usDollars(1.25f)));
+    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(3));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(1.25f));
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE.times(2));

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -304,7 +304,8 @@ public class OrcaFareService extends DefaultFareService {
     return switch (rideType) {
       case COMM_TRANS_LOCAL_SWIFT -> usesOrca(fareType) ? optionalUSD(1.25f) : regularFare;
       case COMM_TRANS_COMMUTER_EXPRESS -> usesOrca(fareType) ? optionalUSD(2f) : regularFare;
-      case EVERETT_TRANSIT, SKAGIT_TRANSIT, WHATCOM_LOCAL, SKAGIT_LOCAL -> optionalUSD(0.5f);
+      case SKAGIT_TRANSIT, WHATCOM_LOCAL, SKAGIT_LOCAL -> optionalUSD(0.5f);
+      case EVERETT_TRANSIT -> usesOrca(fareType) ? optionalUSD(0.5f) : regularFare;
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND,
         SOUND_TRANSIT,
         SOUND_TRANSIT_BUS,

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -300,8 +300,12 @@ public class OrcaFareService extends DefaultFareService {
   ) {
     var route = leg.getRoute();
     return switch (rideType) {
-      case COMM_TRANS_LOCAL_SWIFT -> optionalUSD(1.25f);
-      case COMM_TRANS_COMMUTER_EXPRESS -> optionalUSD(2f);
+      case COMM_TRANS_LOCAL_SWIFT -> usesOrca(fareType)
+        ? optionalUSD(1.25f)
+        : getRegularFare(fareType, rideType, defaultFare, leg);
+      case COMM_TRANS_COMMUTER_EXPRESS -> usesOrca(fareType)
+        ? optionalUSD(2f)
+        : getRegularFare(fareType, rideType, defaultFare, leg);
       case EVERETT_TRANSIT, SKAGIT_TRANSIT, WHATCOM_LOCAL, SKAGIT_LOCAL -> optionalUSD(0.5f);
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND -> fareType.equals(FareType.electronicSenior) // Kitsap only provide discounted senior fare for orca.
         ? optionalUSD(1f)

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -299,22 +299,14 @@ public class OrcaFareService extends DefaultFareService {
     Leg leg
   ) {
     var route = leg.getRoute();
+    var regularFare = getRegularFare(fareType, rideType, defaultFare, leg);
+    // Many agencies only provide senior discount if using ORCA
     return switch (rideType) {
-      case COMM_TRANS_LOCAL_SWIFT -> usesOrca(fareType)
-        ? optionalUSD(1.25f)
-        : getRegularFare(fareType, rideType, defaultFare, leg);
-      case COMM_TRANS_COMMUTER_EXPRESS -> usesOrca(fareType)
-        ? optionalUSD(2f)
-        : getRegularFare(fareType, rideType, defaultFare, leg);
+      case COMM_TRANS_LOCAL_SWIFT -> usesOrca(fareType) ? optionalUSD(1.25f) : regularFare;
+      case COMM_TRANS_COMMUTER_EXPRESS -> usesOrca(fareType) ? optionalUSD(2f) : regularFare;
       case EVERETT_TRANSIT, SKAGIT_TRANSIT, WHATCOM_LOCAL, SKAGIT_LOCAL -> optionalUSD(0.5f);
-      case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND -> fareType.equals(FareType.electronicSenior) // Kitsap only provide discounted senior fare for orca.
-        ? optionalUSD(1f)
-        : optionalUSD(2f);
-      case KC_WATER_TAXI_VASHON_ISLAND -> usesOrca(fareType) ? optionalUSD(3f) : optionalUSD(6.75f);
-      case KC_WATER_TAXI_WEST_SEATTLE -> usesOrca(fareType)
-        ? optionalUSD(2.5f)
-        : optionalUSD(5.75f);
-      case SOUND_TRANSIT,
+      case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND,
+        SOUND_TRANSIT,
         SOUND_TRANSIT_BUS,
         SOUND_TRANSIT_LINK,
         SOUND_TRANSIT_SOUNDER,
@@ -324,10 +316,12 @@ public class OrcaFareService extends DefaultFareService {
         SEATTLE_STREET_CAR,
         KITSAP_TRANSIT -> fareType.equals(FareType.electronicSenior)
         ? optionalUSD(1f)
-        : getRegularFare(fareType, rideType, defaultFare, leg);
+        : regularFare;
+      case KC_WATER_TAXI_VASHON_ISLAND -> usesOrca(fareType) ? optionalUSD(3f) : regularFare;
+      case KC_WATER_TAXI_WEST_SEATTLE -> usesOrca(fareType) ? optionalUSD(2.5f) : regularFare;
       case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> fareType.equals(FareType.electronicSenior)
         ? optionalUSD(5f)
-        : optionalUSD(10f);
+        : regularFare;
       // Discount specific to Skagit transit and not Orca.
       case WASHINGTON_STATE_FERRIES -> Optional.of(
         getWashingtonStateFerriesFare(route.getLongName(), fareType, defaultFare)


### PR DESCRIPTION
### Summary

Community Transit and Everett Transit do not allow cash to be used for senior fares, so this change makes the calculator use the regular fare for senior non-electronic.

The tests are also updated to match.