### PR TITLE
Report issue for duplicate journey patterns in NeTEx

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -5,10 +5,12 @@ import com.google.common.collect.Multimap;
 import jakarta.xml.bind.JAXBElement;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.StopTime;
@@ -84,8 +86,6 @@ class TripPatternMapper {
 
   private final Deduplicator deduplicator;
 
-  private TripPatternMapperResult result;
-
   TripPatternMapper(
     DataImportIssueStore issueStore,
     FeedScopedIdFactory idFactory,
@@ -157,9 +157,7 @@ class TripPatternMapper {
     }
   }
 
-  TripPatternMapperResult mapTripPattern(JourneyPattern_VersionStructure journeyPattern) {
-    // Make sure the result is clean, by creating a new object.
-    result = new TripPatternMapperResult();
+  Optional<TripPatternMapperResult> mapTripPattern(JourneyPattern_VersionStructure journeyPattern) {
     Collection<ServiceJourney> serviceJourneys = serviceJourniesByPatternId.get(
       journeyPattern.getId()
     );
@@ -170,10 +168,14 @@ class TripPatternMapper {
         "ServiceJourneyPattern %s does not contain any serviceJourneys.",
         journeyPattern.getId()
       );
-      return result;
+      return Optional.empty();
     }
 
     List<Trip> trips = new ArrayList<>();
+    ArrayListMultimap<String, String> scheduledStopPointsIndex = ArrayListMultimap.create();
+    HashMap<Trip, List<StopTime>> tripStopTimes = new HashMap<>();
+    Map<String, StopTime> stopTimeByNetexId = new HashMap<>();
+    ArrayList<TripOnServiceDate> tripOnServiceDates = new ArrayList<>();
 
     for (ServiceJourney serviceJourney : serviceJourneys) {
       Trip trip = mapTrip(journeyPattern, serviceJourney);
@@ -184,7 +186,7 @@ class TripPatternMapper {
       }
 
       // Add the dated service journey to the model for this trip [if it exists]
-      mapDatedServiceJourney(journeyPattern, serviceJourney, trip);
+      tripOnServiceDates.addAll(mapDatedServiceJourney(journeyPattern, serviceJourney, trip));
 
       StopTimesMapperResult stopTimes = stopTimesMapper.mapToStopTimes(
         journeyPattern,
@@ -198,25 +200,22 @@ class TripPatternMapper {
         continue;
       }
 
-      result.scheduledStopPointsIndex.putAll(
-        serviceJourney.getId(),
-        stopTimes.scheduledStopPointIds
-      );
-      result.tripStopTimes.put(trip, stopTimes.stopTimes);
-      result.stopTimeByNetexId.putAll(stopTimes.stopTimeByNetexId);
+      scheduledStopPointsIndex.putAll(serviceJourney.getId(), stopTimes.scheduledStopPointIds);
+      tripStopTimes.put(trip, stopTimes.stopTimes);
+      stopTimeByNetexId.putAll(stopTimes.stopTimeByNetexId);
 
       trips.add(trip);
     }
 
     // No trips successfully mapped
     if (trips.isEmpty()) {
-      return result;
+      return Optional.empty();
     }
 
     // Create StopPattern from any trip (since they are part of the same JourneyPattern)
     StopPattern stopPattern = deduplicator.deduplicateObject(
       StopPattern.class,
-      new StopPattern(result.tripStopTimes.get(trips.get(0)))
+      new StopPattern(tripStopTimes.get(trips.get(0)))
     );
 
     var tripPatternModes = new HashSet<TransitMode>();
@@ -246,7 +245,7 @@ class TripPatternMapper {
       );
     }
 
-    TripPatternBuilder tripPatternBuilder = TripPattern
+    var tripPattern = TripPattern
       .of(idFactory.createId(journeyPattern.getId()))
       .withRoute(lookupRoute(journeyPattern))
       .withStopPattern(stopPattern)
@@ -256,30 +255,35 @@ class TripPatternMapper {
       .withName(journeyPattern.getName() == null ? "" : journeyPattern.getName().getValue())
       .withHopGeometries(
         serviceLinkMapper.getGeometriesByJourneyPattern(journeyPattern, stopPattern)
-      );
+      )
+      .build();
+    createTripTimes(trips, tripStopTimes).forEach(tripPattern::add);
 
-    TripPattern tripPattern = tripPatternBuilder.build();
-    createTripTimes(trips, tripPattern);
-
-    result.tripPatterns.put(stopPattern, tripPattern);
-
-    return result;
+    return Optional.of(
+      new TripPatternMapperResult(
+        tripPattern,
+        scheduledStopPointsIndex,
+        tripStopTimes,
+        stopTimeByNetexId,
+        tripOnServiceDates
+      )
+    );
   }
 
-  private void mapDatedServiceJourney(
+  private ArrayList<TripOnServiceDate> mapDatedServiceJourney(
     JourneyPattern_VersionStructure journeyPattern,
     ServiceJourney serviceJourney,
     Trip trip
   ) {
+    var tripsOnServiceDates = new ArrayList<TripOnServiceDate>();
     if (datedServiceJourneysBySJId.containsKey(serviceJourney.getId())) {
       for (DatedServiceJourney datedServiceJourney : datedServiceJourneysBySJId.get(
         serviceJourney.getId()
       )) {
-        result.tripOnServiceDates.add(
-          mapDatedServiceJourney(journeyPattern, trip, datedServiceJourney)
-        );
+        tripsOnServiceDates.add(mapDatedServiceJourney(journeyPattern, trip, datedServiceJourney));
       }
     }
+    return tripsOnServiceDates;
   }
 
   private TripOnServiceDate mapDatedServiceJourney(
@@ -360,9 +364,13 @@ class TripPatternMapper {
     return otpRouteById.get(idFactory.createId(lineId));
   }
 
-  private void createTripTimes(List<Trip> trips, TripPattern tripPattern) {
+  private List<TripTimes> createTripTimes(
+    List<Trip> trips,
+    Map<Trip, List<StopTime>> tripStopTimes
+  ) {
+    var tripTimesResult = new ArrayList<TripTimes>();
     for (Trip trip : trips) {
-      List<StopTime> stopTimes = result.tripStopTimes.get(trip);
+      List<StopTime> stopTimes = tripStopTimes.get(trip);
       if (stopTimes.isEmpty()) {
         issueStore.add(
           "TripWithoutTripTimes",
@@ -372,12 +380,13 @@ class TripPatternMapper {
       } else {
         try {
           TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, deduplicator);
-          tripPattern.add(tripTimes);
+          tripTimesResult.add(tripTimes);
         } catch (DataValidationException e) {
           issueStore.add(e.error());
         }
       }
     }
+    return tripTimesResult;
   }
 
   private Trip mapTrip(

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapperResult.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapperResult.java
@@ -13,24 +13,15 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 
 /**
- * This mapper returnes two collections, so we need to use a simple wraper to be able to return the
- * result from the mapping method.
+ * Wrapper class for the result of TripPatternMapper
+ *
+ * @param scheduledStopPointsIndex A map from trip/serviceJourney id to an ordered list of scheduled stop point ids.
+ * @param stopTimeByNetexId stopTimes by the timetabled-passing-time id
  */
-class TripPatternMapperResult {
-
-  /**
-   * A map from trip/serviceJourney id to an ordered list of scheduled stop point ids.
-   */
-  final ArrayListMultimap<String, String> scheduledStopPointsIndex = ArrayListMultimap.create();
-
-  final Map<Trip, List<StopTime>> tripStopTimes = new HashMap<>();
-
-  final Multimap<StopPattern, TripPattern> tripPatterns = ArrayListMultimap.create();
-
-  /**
-   * stopTimes by the timetabled-passing-time id
-   */
-  final Map<String, StopTime> stopTimeByNetexId = new HashMap<>();
-
-  final ArrayList<TripOnServiceDate> tripOnServiceDates = new ArrayList<>();
-}
+record TripPatternMapperResult(
+  TripPattern tripPattern,
+  ArrayListMultimap<String, String> scheduledStopPointsIndex,
+  Map<Trip, List<StopTime>> tripStopTimes,
+  Map<String, StopTime> stopTimeByNetexId,
+  ArrayList<TripOnServiceDate> tripOnServiceDates
+) {}

--- a/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.netex.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ArrayListMultimap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
@@ -12,7 +14,6 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
@@ -55,26 +56,28 @@ public class TripPatternMapperTest {
       150
     );
 
-    TripPatternMapperResult r = tripPatternMapper.mapTripPattern(sample.getJourneyPattern());
+    Optional<TripPatternMapperResult> res = tripPatternMapper.mapTripPattern(
+      sample.getJourneyPattern()
+    );
 
-    assertEquals(1, r.tripPatterns.size());
+    assertTrue(res.isPresent());
 
-    TripPattern tripPattern = r.tripPatterns.values().stream().findFirst().orElseThrow();
+    TripPatternMapperResult r = res.get();
 
-    assertEquals(4, tripPattern.numberOfStops());
-    assertEquals(1, tripPattern.scheduledTripsAsStream().count());
+    assertEquals(4, r.tripPattern().numberOfStops());
+    assertEquals(1, r.tripPattern().scheduledTripsAsStream().count());
 
-    Trip trip = tripPattern.scheduledTripsAsStream().findFirst().get();
+    Trip trip = r.tripPattern().scheduledTripsAsStream().findFirst().get();
 
     assertEquals("RUT:ServiceJourney:1", trip.getId().getId());
-    assertEquals("NSR:Quay:1", tripPattern.getStop(0).getId().getId());
-    assertEquals("NSR:Quay:2", tripPattern.getStop(1).getId().getId());
-    assertEquals("NSR:Quay:3", tripPattern.getStop(2).getId().getId());
-    assertEquals("NSR:Quay:4", tripPattern.getStop(3).getId().getId());
+    assertEquals("NSR:Quay:1", r.tripPattern().getStop(0).getId().getId());
+    assertEquals("NSR:Quay:2", r.tripPattern().getStop(1).getId().getId());
+    assertEquals("NSR:Quay:3", r.tripPattern().getStop(2).getId().getId());
+    assertEquals("NSR:Quay:4", r.tripPattern().getStop(3).getId().getId());
 
-    assertEquals(1, tripPattern.getScheduledTimetable().getTripTimes().size());
+    assertEquals(1, r.tripPattern().getScheduledTimetable().getTripTimes().size());
 
-    TripTimes tripTimes = tripPattern.getScheduledTimetable().getTripTimes().get(0);
+    TripTimes tripTimes = r.tripPattern().getScheduledTimetable().getTripTimes().get(0);
 
     assertEquals(4, tripTimes.getNumStops());
 
@@ -115,15 +118,19 @@ public class TripPatternMapperTest {
       150
     );
 
-    TripPatternMapperResult r = tripPatternMapper.mapTripPattern(sample.getJourneyPattern());
+    Optional<TripPatternMapperResult> res = tripPatternMapper.mapTripPattern(
+      sample.getJourneyPattern()
+    );
 
-    assertEquals(1, r.tripPatterns.size());
-    assertEquals(2, r.tripOnServiceDates.size());
+    assertTrue(res.isPresent());
 
-    TripPattern tripPattern = r.tripPatterns.values().stream().findFirst().orElseThrow();
-    Trip trip = tripPattern.scheduledTripsAsStream().findFirst().get();
+    var r = res.get();
 
-    for (TripOnServiceDate tripOnServiceDate : r.tripOnServiceDates) {
+    assertEquals(2, r.tripOnServiceDates().size());
+
+    Trip trip = r.tripPattern().scheduledTripsAsStream().findFirst().get();
+
+    for (TripOnServiceDate tripOnServiceDate : r.tripOnServiceDates()) {
       assertEquals(trip, tripOnServiceDate.getTrip());
       assertEquals(TripAlteration.PLANNED, tripOnServiceDate.getTripAlteration());
       assertEquals(


### PR DESCRIPTION
### Summary

As a follow-up to #5552, this PR reports an issue to the issueStore if there are duplicate journeypatterns in the Netex data.

- A small refactor to make TripPatternMapper less stateful and also make it easier to get the tripPatternId.
- Report DuplicateJourneyPattern issue for duplicate journey patterns.

### Unit tests

Had to do some minor touches to the TripPatternMapperTest.

### Bumping the serialization version id

No
