### PR TITLE
Deploy new debug client to a CDN

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -211,11 +211,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Build debug client
-        working-directory: ./client-next
-        run: |
-          npm install
-          npm run build
       - name: Build container image with Jib, push to Dockerhub
         env:
           CONTAINER_REPO: docker.io/opentripplanner/opentripplanner

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -39,12 +39,6 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Build debug client
-        working-directory: ./client-next
-        run: |
-          npm install
-          npm run build
-
       - name: Prepare coverage agent, build and test
         # these are split into two steps because otherwise maven keeps long-running HTTP connections
         # to Maven Central open which then hang during the package phase because the Azure (Github Actions)

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -8,8 +8,9 @@ on:
     paths:
       - 'client-next/**'
 
+# to avoid conflicts, make sure that only one workflow pushes to Github at the same time
 concurrency:
-  group: git-commit
+  group: github-push
 
 jobs:
   debug-client:
@@ -83,4 +84,4 @@ jobs:
           
           git add ${CLIENT_HTML_OUTPUT}
           git commit -m "Upgrade debug client to version ${VERSION}"
-          git push origin dev-2.x
+          git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -5,15 +5,19 @@ on:
     paths:
       - 'client-next/**'
 
+concurrency:
+  group: git-commit
+
 jobs:
   debug-client:
+    if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       # this is necessary so that the correct credentials are put into the git configuration
       # when we push to dev-2.x and push the HTML to the git repo
       - uses: actions/checkout@v4
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/debug-client-cdn' || github.ref == 'refs/heads/master')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x')
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
           fetch-depth: 0
@@ -33,35 +37,47 @@ jobs:
           npm run build
 
       - name: Deploy compiled assets to repo
-        if: github.event_name == 'push' && github.ref == 'refs/heads/debug-client-cdn'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev-2.x'
         env:
           REMOTE: debug-client
           LOCAL_BRANCH: local-assets
           REMOTE_BRANCH: main
+          TOKEN: ${{ secrets.CHANGELOG_TOKEN }}
         run: |
+          # Configure git user
           git config --global user.name 'OTP Bot'
           git config --global user.email 'bot@opentripplanner.org'
           
+          # Fetch the assets repo
           git remote add $REMOTE https://$TOKEN@github.com/opentripplanner/debug-client-assets.git 
           git fetch --depth=1 $REMOTE $REMOTE_BRANCH:$LOCAL_BRANCH
 
           git checkout $LOCAL_BRANCH
           
-          version=`date +%Y-%m-%dT%H-%M`
+          VERSION=`date +%Y-%m-%dT%H-%M`
           
-          mkdir -p $version
-          rsync -r client-next/output/* $version
-          git add $version
-          git commit -am "Add version ${version} of debug client"
+          # Copy the compiled output to a versioned folder
+          mkdir -p $VERSION
+          rsync -r client-next/output/* $VERSION
+          git add $VERSION
+          git commit -am "Add version ${VERSION} of debug client"
           
+          # Push to assets repo https://github.com/opentripplanner/debug-client-assets
           git push $REMOTE $LOCAL_BRANCH:$REMOTE_BRANCH
           
+          # Switch back to the OTP code
           git checkout dev-2.x
-          git pull
+          git pull --rebase
           
-          CLIENT_HTML=src/client/debug-client-preview/index.html
+          # Modify the compiled output of the index.html to the CDN version
+          CLIENT_HTML_OUTPUT=src/client/debug-client-preview/index.html
           mkdir -p src/client/debug-client-preview/
           # this line is admittedly pretty unreadable it replaces the string "/debug-client-preview/" with the JsDelivr CDN URL prefix
-          sed "s|\/debug-client-preview\/|https:\/\/cdn.jsdelivr.net\/gh\/opentripplanner\/debug-client-assets@main\/${version}\/|g" <client-next/output/index.html >${CLIENT_HTML}
+          sed "s|\/debug-client-preview\/|https:\/\/cdn.jsdelivr.net\/gh\/opentripplanner\/debug-client-assets@main\/${VERSION}\/|g" <client-next/output/index.html >${CLIENT_HTML_OUTPUT}
           
-          cat ${CLIENT_HTML}
+          # just to debug
+          cat ${CLIENT_HTML_OUTPUT}
+          
+          git add ${CLIENT_HTML_OUTPUT}
+          git commit -m "Upgrade debug client to version ${VERSION}"
+          git push origin dev-2.x

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: 18
 
       - name: Set version
-        run: echo "VERSION=`date +%Y-%m-%dT%H:%M`" >> $GITHUB_ENV
+        run: echo "VERSION=`date +%Y/%m/%Y-%m-%dT%H:%M`" >> $GITHUB_ENV
 
       - name: Build debug client
         working-directory: client-next

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - 'client-next/**'
+  pull_request:
+    paths:
+      - 'client-next/**'
 
 concurrency:
   group: git-commit

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -19,9 +19,9 @@ jobs:
     timeout-minutes: 20
     steps:
       # this is necessary so that the correct credentials are put into the git configuration
-      # when we push to dev-2.x and push the HTML to the git repo
+      # when we push to dev-2.x and push the compiled output to the git repo
       - uses: actions/checkout@v4
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x')
+        if: github.event_name == 'push'
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
           fetch-depth: 0
@@ -34,11 +34,14 @@ jobs:
         with:
           node-version: 18
 
+      - name: Set version
+        run: echo "VERSION=`date +%Y-%m-%dT%H:%M`" >> $GITHUB_ENV
+
       - name: Build debug client
         working-directory: client-next
         run: |
           npm install
-          npm run build
+          npm run build -- --base https://cdn.jsdelivr.net/gh/opentripplanner/debug-client-assets@main/${VERSION}/
 
       - name: Deploy compiled assets to repo
         if: github.event_name == 'push' && github.ref == 'refs/heads/dev-2.x'
@@ -58,11 +61,10 @@ jobs:
 
           git checkout $LOCAL_BRANCH
           
-          VERSION=`date +%Y-%m-%dT%H-%M`
           
           # Copy the compiled output to a versioned folder
           mkdir -p $VERSION
-          rsync -r client-next/output/* $VERSION
+          rsync -r client-next/output/* ./$VERSION/
           git add $VERSION
           git commit -am "Add version ${VERSION} of debug client"
           
@@ -73,15 +75,13 @@ jobs:
           git checkout dev-2.x
           git pull --rebase
           
-          # Modify the compiled output of the index.html to the CDN version
           CLIENT_HTML_OUTPUT=src/client/debug-client-preview/index.html
           mkdir -p src/client/debug-client-preview/
-          # this line is admittedly pretty unreadable it replaces the string "/debug-client-preview/" with the JsDelivr CDN URL prefix
-          sed "s|\/debug-client-preview\/|https:\/\/cdn.jsdelivr.net\/gh\/opentripplanner\/debug-client-assets@main\/${VERSION}\/|g" <client-next/output/index.html >${CLIENT_HTML_OUTPUT}
+          cp client-next/output/index.html ${CLIENT_HTML_OUTPUT}
           
           # just to debug
           cat ${CLIENT_HTML_OUTPUT}
           
-          git add ${CLIENT_HTML_OUTPUT}
+          git add -f ${CLIENT_HTML_OUTPUT}
           git commit -m "Upgrade debug client to version ${VERSION}"
           git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -1,0 +1,67 @@
+name: Debug client
+
+on:
+  push:
+    paths:
+      - 'client-next/**'
+
+jobs:
+  debug-client:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # this is necessary so that the correct credentials are put into the git configuration
+      # when we push to dev-2.x and push the HTML to the git repo
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/debug-client-cdn' || github.ref == 'refs/heads/master')
+        with:
+          token: ${{ secrets.CHANGELOG_TOKEN }}
+          fetch-depth: 0
+
+      # for a simple PR where we don't push, we don't need any credentials
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Build debug client
+        working-directory: client-next
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy compiled assets to repo
+        if: github.event_name == 'push' && github.ref == 'refs/heads/debug-client-cdn'
+        env:
+          REMOTE: debug-client
+          LOCAL_BRANCH: local-assets
+          REMOTE_BRANCH: main
+        run: |
+          git config --global user.name 'OTP Bot'
+          git config --global user.email 'bot@opentripplanner.org'
+          
+          git remote add $REMOTE https://$TOKEN@github.com/opentripplanner/debug-client-assets.git 
+          git fetch --depth=1 $REMOTE $REMOTE_BRANCH:$LOCAL_BRANCH
+
+          git checkout $LOCAL_BRANCH
+          
+          version=`date +%Y-%m-%dT%H-%M`
+          
+          mkdir -p $version
+          rsync -r client-next/output/* $version
+          git add $version
+          git commit -am "Add version ${version} of debug client"
+          
+          git push $REMOTE $LOCAL_BRANCH:$REMOTE_BRANCH
+          
+          git checkout dev-2.x
+          git pull
+          
+          CLIENT_HTML=src/client/debug-client-preview/index.html
+          mkdir -p src/client/debug-client-preview/
+          # this line is admittedly pretty unreadable it replaces the string "/debug-client-preview/" with the JsDelivr CDN URL prefix
+          sed "s|\/debug-client-preview\/|https:\/\/cdn.jsdelivr.net\/gh\/opentripplanner\/debug-client-assets@main\/${version}\/|g" <client-next/output/index.html >${CLIENT_HTML}
+          
+          cat ${CLIENT_HTML}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -5,9 +5,9 @@ on:
       - dev-2.x
     types: [closed]
 
-# make sure that only one workflow pushes to Github at the same time
+# to avoid conflicts, make sure that only one workflow pushes to Github at the same time
 concurrency:
-  group: git-commit
+  group: github-push
 
 jobs:
   changelog-entry:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -5,6 +5,10 @@ on:
       - dev-2.x
     types: [closed]
 
+# make sure that only one workflow pushes to Github at the same time
+concurrency:
+  group: git-commit
+
 jobs:
   changelog-entry:
     if: github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && !contains(github.event.pull_request.labels.*.name, 'skip changelog')

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ gen-py/
 node_modules/
 target/
 /graphs
-/src/client/debug-client-preview/
 
 # for local dev only
 /src/test/resources/speedtest/travelSearch-results-*.csv

--- a/client-next/README.md
+++ b/client-next/README.md
@@ -62,4 +62,4 @@ or add it to a new `.env.development.local` file (this file will be ignored by g
 
 In production mode, the default is to access OTP via the same origin as the client (see `.env`).
 This behavior can also be modified by changing the previously mentioned environment variable at
-build-time.
+build-time..

--- a/client-next/vite.config.ts
+++ b/client-next/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   base: '/debug-client-preview/',
   build: {
-    outDir: '../src/client/debug-client-preview',
+    outDir: 'output',
     emptyOutDir: true,
   },
 });


### PR DESCRIPTION
### Summary

This adds a new CI workflow that:

- builds the new debug client
- pushes the compiled output to a separate repo [like this](https://github.com/opentripplanner/debug-client-assets/commit/1e2f3502d3ba24a5ea3543182cb751fe4fa3fdc6)
- adjusts the index.html so that the assets are fetched from [CDN URLs](https://cdn.jsdelivr.net/gh/opentripplanner/debug-client-assets@main/2023-12-16T14-49/assets/index-caa4bace.js)
- commits the updated index.html to the main OTP repo

This has the advantage of not needing to faff with npm when you do local development of OTP.

### Issue

#5330 

### Documentation

Line comments.