### PR TITLE
Add new path for GTFS GraphQL API, remove batch feature

### DIFF
--- a/docs/apis/GTFS-GraphQL-API.md
+++ b/docs/apis/GTFS-GraphQL-API.md
@@ -6,7 +6,7 @@ used heavily by [digitransit-ui](https://github.com/HSLdevcom/digitransit-ui).
 [otp-react-redux](https://github.com/opentripplanner/otp-react-redux) has also migrated to this API in 2023.
 
 ## URLs 
- - GraphQL endpoint: [`http://localhost:8080/otp/routers/default/index/graphql`](http://localhost:8080/otp/routers/default/index/graphql)
+ - GraphQL endpoint: [`http://localhost:8080/otp/gtfs/v1`](http://localhost:8080/otp/gtfs/v1)
  - HTML schema documentation: [https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/)
  - Built-in visual GraphQL client: [http://localhost:8080/graphiql](http://localhost:8080/graphiql)
 
@@ -22,7 +22,7 @@ A complete example that fetches the list of all stops from OTP is:
 
 ```
 curl --request POST \
-  --url http://localhost:8080/otp/routers/default/index/graphql \
+  --url http://localhost:8080/otp/gtfs/v1 \
   --header 'Content-Type: application/json' \
   --header 'OTPTimeout: 180000' \
   --data '{"query":"query stops {\n  stops {\n    gtfsId\n    name\n  }\n}\n","operationName":"stops"}'

--- a/magidoc.mjs
+++ b/magidoc.mjs
@@ -17,7 +17,7 @@ export default {
 This is the static documentation of the OTP GraphQL GTFS API.
 
 The GraphQL endpoint of your instance, which you should point your tooling to, is 
-\`http://localhost:8080/otp/routers/default/index/graphql\`
+\`http://localhost:8080/otp/gtfs/v1\`
 
 Please also check out the interactive API explorer built into every instance and available
 at http://localhost:8080/graphiql 

--- a/src/client/graphiql/index.html
+++ b/src/client/graphiql/index.html
@@ -152,7 +152,7 @@ query TransmodelExampleQuery {
 
   let apiFlavor = parameters.flavor || "gtfs";
   let urls = {
-    gtfs: '/otp/routers/default/index/graphql',
+    gtfs: '/otp/gtfs/v1',
     transmodel: '/otp/routers/default/transmodel/index/graphql'
   }
 

--- a/src/main/java/org/opentripplanner/apis/APIEndpoints.java
+++ b/src/main/java/org/opentripplanner/apis/APIEndpoints.java
@@ -51,6 +51,8 @@ public class APIEndpoints {
     addIfEnabled(APIServerInfo, ServerInfo.class);
     addIfEnabled(APIUpdaterStatus, UpdaterStatusResource.class);
     addIfEnabled(GtfsGraphQlApi, GtfsGraphQLAPI.class);
+    // scheduled to be removed and only here for backwards compatibility
+    addIfEnabled(GtfsGraphQlApi, GtfsGraphQLAPI.GtfsGraphQLAPIOldPath.class);
     addIfEnabled(TransmodelGraphQlApi, TransmodelAPI.class);
 
     // Sandbox extension APIs

--- a/src/main/java/org/opentripplanner/framework/graphql/GraphQLResponseSerializer.java
+++ b/src/main/java/org/opentripplanner/framework/graphql/GraphQLResponseSerializer.java
@@ -33,30 +33,4 @@ public class GraphQLResponseSerializer {
       throw new RuntimeException(e);
     }
   }
-
-  public static String serializeBatch(
-    List<HashMap<String, Object>> queries,
-    List<Future<ExecutionResult>> futures
-  ) {
-    List<Map<String, Object>> responses = new LinkedList<>();
-    for (int i = 0; i < queries.size(); i++) {
-      ExecutionResult executionResult;
-      // Try each request separately, returning both completed and failed responses is ok
-      try {
-        executionResult = futures.get(i).get();
-      } catch (InterruptedException | ExecutionException e) {
-        executionResult = new AbortExecutionException(e).toExecutionResult();
-      }
-      responses.add(
-        Map.of("id", queries.get(i).get("id"), "payload", executionResult.toSpecification())
-      );
-    }
-
-    try {
-      return objectMapper.writeValueAsString(responses);
-    } catch (JsonProcessingException e) {
-      LOG.error("Unable to serialize response", e);
-      throw new RuntimeException(e);
-    }
-  }
 }


### PR DESCRIPTION
### Summary

Changes the official path of the GTFS GraphQL API to `otp/graphql/gtfs/v1` and keeps the old one around for backwards-compatibility. We can remove the backwards-compat when all known users have migrated their systems off it, which I expect to take quite a long time.

It also removes the batch functionality which is confusing, unintuitive and in the age of HTTP2 doesn't have performance benefits.

### Issue

#4052

### Documentation

Updated.

cc @hbruch @vesameskanen @binh-dam-ibigroup @miles-grant-ibigroup 