### PR TITLE
Fix preference cost comparisons

### DIFF
--- a/src/main/java/org/opentripplanner/routing/api/request/preference/BikePreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/BikePreferences.java
@@ -192,6 +192,7 @@ public final class BikePreferences implements Serializable {
       .addObj("parking", parking, DEFAULT.parking)
       .addEnum("optimizeType", optimizeType, DEFAULT.optimizeType)
       .addObj("optimizeTriangle", optimizeTriangle, DEFAULT.optimizeTriangle)
+      .addNum("stairsReluctance", stairsReluctance, DEFAULT.stairsReluctance)
       .toString();
   }
 

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/TransitPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/TransitPreferences.java
@@ -174,7 +174,7 @@ public final class TransitPreferences implements Serializable {
       boardSlack.equals(that.boardSlack) &&
       alightSlack.equals(that.alightSlack) &&
       reluctanceForMode.equals(that.reluctanceForMode) &&
-      otherThanPreferredRoutesPenalty == that.otherThanPreferredRoutesPenalty &&
+      Objects.equals(otherThanPreferredRoutesPenalty, that.otherThanPreferredRoutesPenalty) &&
       unpreferredCost.equals(that.unpreferredCost) &&
       Objects.equals(relaxTransitPriorityGroup, that.relaxTransitPriorityGroup) &&
       ignoreRealtimeUpdates == that.ignoreRealtimeUpdates &&

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/VehicleRentalPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/VehicleRentalPreferences.java
@@ -101,9 +101,9 @@ public final class VehicleRentalPreferences implements Serializable {
     VehicleRentalPreferences that = (VehicleRentalPreferences) o;
     return (
       pickupTime == that.pickupTime &&
-      pickupCost == that.pickupCost &&
+      Objects.equals(pickupCost, that.pickupCost) &&
       dropoffTime == that.dropoffTime &&
-      dropoffCost == that.dropoffCost &&
+      Objects.equals(dropoffCost, that.dropoffCost) &&
       useAvailabilityInformation == that.useAvailabilityInformation &&
       Double.compare(
         that.arrivingInRentalVehicleAtDestinationCost,


### PR DESCRIPTION
### Summary

While working on some related things, I noticed some wrong equal checks on Costs. This fixes those and adds one missing field from a toString.

### Issue

No issue as these are minor fixes but this can solve issues with transfer cache but most of these fixed fields are not exposed through any API.

### Unit tests

Not updated, we might want to refactor tests related to these comparisons more in the future.

### Documentation

Not updated

### Changelog

From title
