### PR TITLE
 Report and throw away trip-times which fail sanity check

### DIFF
--- a/src/main/java/org/opentripplanner/framework/error/DefaultOtpError.java
+++ b/src/main/java/org/opentripplanner/framework/error/DefaultOtpError.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.framework.error;
+
+class DefaultOtpError implements OtpError {
+
+  private final String errorCode;
+  private final String messageTemplate;
+  private final Object[] messageArguments;
+
+  public DefaultOtpError(String errorCode, String messageTemplate, Object... messageArguments) {
+    this.errorCode = errorCode;
+    this.messageTemplate = messageTemplate;
+    this.messageArguments = messageArguments;
+  }
+
+  @Override
+  public String errorCode() {
+    return errorCode;
+  }
+
+  @Override
+  public String messageTemplate() {
+    return messageTemplate;
+  }
+
+  @Override
+  public Object[] messageArguments() {
+    return messageArguments;
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/error/OtpError.java
+++ b/src/main/java/org/opentripplanner/framework/error/OtpError.java
@@ -34,4 +34,11 @@ public interface OtpError {
   default String message() {
     return String.format(Locale.ROOT, messageTemplate(), messageArguments());
   }
+
+  /**
+   * Factory method to create an OTPError.
+   */
+  static OtpError of(String errorCode, String messageTemplate, Object... messageArguments) {
+    return new DefaultOtpError(errorCode, messageTemplate, messageArguments);
+  }
 }

--- a/src/test/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.time.TimeUtils;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.Accessibility;
+import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 class ScheduledTripTimesTest {
@@ -102,7 +103,7 @@ class ScheduledTripTimesTest {
   @Test
   void validateLastArrivalTimeIsNotMoreThan20DaysAfterFirstDepartureTime() {
     var ex = assertThrows(
-      IllegalArgumentException.class,
+      DataValidationException.class,
       () ->
         ScheduledTripTimes
           .of()
@@ -111,7 +112,10 @@ class ScheduledTripTimesTest {
           .withTrip(TRIP)
           .build()
     );
-    assertEquals("The value is not in range[-43200, 1728000]: 1728001", ex.getMessage());
+    assertEquals(
+      "The arrivalTime is not in range[-12h, 20d]. Time: 10:00:01+20d, stop-pos: 2, trip: F:Trip-1.",
+      ex.getMessage()
+    );
   }
 
   @Test


### PR DESCRIPTION
### Summary

This causes problems in the current Entur import with FLEX routes. Flex should not be imported as regular Scheduled trips, but until this is fixed we need to add this workaround. When encountering invalid trip-times, this PR will report it in the data issue report and continue the graph-build. It will not crash as it did before. 


### Issue
🟥  No issue for this.

### Unit tests
✅ Unit tests are updated.

### Documentation
🟥 Not relevant.

### Changelog

🟥 This is a problem isolated to the current 2.5-SNAPSHOT.

### Bumping the serialization version id
🟥 No state change.