### PR TITLE
Warn if routing is empty and there are no errors in the result

### DIFF
--- a/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
@@ -58,6 +58,12 @@ public class DefaultRoutingService implements RoutingService {
   }
 
   private void logResponse(RoutingResponse response) {
+    if (response.getTripPlan().itineraries.isEmpty() && response.getRoutingErrors().isEmpty()) {
+      // We should provide an error if there is no results, this is important for the client so
+      // it knows if it can page or abort.
+      LOG.warn("The routing result is empty, but there is no errors...");
+    }
+
     if (LOG.isDebugEnabled()) {
       var m = response.getMetadata();
       var text = MultiLineToStringBuilder


### PR DESCRIPTION
### Summary
We should include at least one error (code) when the router fails to find any results (zero itineraries). This is important so the client knows what to do. The client may retry the same query, abort, goto next/prev page or change the input - depending on the error code. If we do not provide an error code it become hard to know what to do.

### Issue
🟥  This is a minor problem which came up in a developer meeting.

### Unit tests
🟥 We do not unit-test logging.

### Documentation
✅ No doc added, but proper logging is also doc.

### Changelog
🟥 Too minor

### Bumping the serialization version id
🟥 No state cahnged.
