### PR TITLE
Add documentation about MQTT updater [ci skip]

### DIFF
--- a/doc-templates/UpdaterConfig.md
+++ b/doc-templates/UpdaterConfig.md
@@ -8,8 +8,8 @@
 
 # Updater configuration
 
-This section covers all options that can be set in the *router-config.json* in the 
-[updaters](RouterConfiguration.md) section.
+This section covers options that can be set in the updaters section of `router-config.json`. 
+See the parameter summary and examples in the router configuration documentation
 
 Real-time data are those that are not added to OTP during the graph build phase but during runtime.
 
@@ -44,6 +44,15 @@ The information is downloaded in a single HTTP request and polled regularly.
 
 <!-- INSERT: stop-time-updater -->
 
+### Streaming TripUpdates via MQTT
+
+This updater connects to an MQTT broker and processes TripUpdates in a streaming fashion. This means
+that they will be applied individually in near-realtime rather than in batches at a certain interval.
+
+This system powers the realtime updates in Helsinki and more information can be found 
+[on Github](https://github.com/HSLdevcom/transitdata).
+
+<!-- INSERT: mqtt-gtfs-rt-updater -->
 
 ### Vehicle Positions
 

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -728,6 +728,13 @@ Used to group requests when monitoring OTP.
       }
     },
     {
+      "type" : "mqtt-gtfs-rt-updater",
+      "url" : "tcp://pred.rt.hsl.fi",
+      "topic" : "gtfsrt/v2/fi/hsl/tu",
+      "feedId" : "HSL",
+      "fuzzyTripMatching" : true
+    },
+    {
       "type" : "vehicle-positions",
       "url" : "https://s3.amazonaws.com/kcm-alerts-realtime-prod/vehiclepositions.pb",
       "feedId" : "1",

--- a/docs/UpdaterConfig.md
+++ b/docs/UpdaterConfig.md
@@ -8,8 +8,8 @@
 
 # Updater configuration
 
-This section covers all options that can be set in the *router-config.json* in the 
-[updaters](RouterConfiguration.md) section.
+This section covers options that can be set in the updaters section of `router-config.json`. 
+See the parameter summary and examples in the router configuration documentation
 
 Real-time data are those that are not added to OTP during the graph build phase but during runtime.
 
@@ -164,6 +164,72 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 <!-- stop-time-updater END -->
 
+### Streaming TripUpdates via MQTT
+
+This updater connects to an MQTT broker and processes TripUpdates in a streaming fashion. This means
+that they will be applied individually in near-realtime rather than in batches at a certain interval.
+
+This system powers the realtime updates in Helsinki and more information can be found 
+[on Github](https://github.com/HSLdevcom/transitdata).
+
+<!-- mqtt-gtfs-rt-updater BEGIN -->
+<!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
+
+| Config Parameter                                                      |    Type   | Summary                                      |  Req./Opt. | Default Value        | Since |
+|-----------------------------------------------------------------------|:---------:|----------------------------------------------|:----------:|----------------------|:-----:|
+| type = "mqtt-gtfs-rt-updater"                                         |   `enum`  | The type of the updater.                     | *Required* |                      |  1.5  |
+| [backwardsDelayPropagationType](#u__6__backwardsDelayPropagationType) |   `enum`  | How backwards propagation should be handled. | *Optional* | `"required-no-data"` |  2.2  |
+| feedId                                                                |  `string` | The feed id to apply the updates to.         | *Required* |                      |   na  |
+| fuzzyTripMatching                                                     | `boolean` | Whether to match trips fuzzily.              | *Optional* | `false`              |   na  |
+| qos                                                                   | `integer` | QOS level.                                   | *Optional* | `0`                  |   na  |
+| topic                                                                 |  `string` | The topic to subscribe to.                   | *Required* |                      |   na  |
+| url                                                                   |  `string` | URL of the MQTT broker.                      | *Required* |                      |   na  |
+
+
+##### Parameter details
+
+<h4 id="u__6__backwardsDelayPropagationType">backwardsDelayPropagationType</h4>
+
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"required-no-data"`   
+**Path:** /updaters/[6]   
+**Enum values:** `required-no-data` | `required` | `always`
+
+How backwards propagation should be handled.
+
+  REQUIRED_NO_DATA:
+  Default value. Only propagates delays backwards when it is required to ensure that the times
+  are increasing, and it sets the NO_DATA flag on the stops so these automatically updated times
+  are not exposed through APIs.
+
+  REQUIRED:
+  Only propagates delays backwards when it is required to ensure that the times are increasing.
+  The updated times are exposed through APIs.
+
+  ALWAYS:
+  Propagates delays backwards on stops with no estimates regardless if it's required or not.
+  The updated times are exposed through APIs.
+
+
+
+
+##### Example configuration
+
+```JSON
+// router-config.json
+{
+  "updaters" : [
+    {
+      "type" : "mqtt-gtfs-rt-updater",
+      "url" : "tcp://pred.rt.hsl.fi",
+      "topic" : "gtfsrt/v2/fi/hsl/tu",
+      "feedId" : "HSL",
+      "fuzzyTripMatching" : true
+    }
+  ]
+}
+```
+
+<!-- mqtt-gtfs-rt-updater END -->
 
 ### Vehicle Positions
 
@@ -181,24 +247,24 @@ The information is downloaded in a single HTTP request and polled regularly.
 | frequency                   |    `duration`   | How often the positions should be updated.                                 | *Optional* | `"PT1M"`      |  2.2  |
 | fuzzyTripMatching           |    `boolean`    | Whether to match trips fuzzily.                                            | *Optional* | `false`       |  2.5  |
 | url                         |      `uri`      | The URL of GTFS-RT protobuf HTTP resource to download the positions from.  | *Required* |               |  2.2  |
-| [features](#u__6__features) |    `enum set`   | Which features of GTFS RT vehicle positions should be loaded into OTP.     | *Optional* |               |  2.5  |
-| [headers](#u__6__headers)   | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted. | *Optional* |               |  2.3  |
+| [features](#u__7__features) |    `enum set`   | Which features of GTFS RT vehicle positions should be loaded into OTP.     | *Optional* |               |  2.5  |
+| [headers](#u__7__headers)   | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted. | *Optional* |               |  2.3  |
 
 
 ##### Parameter details
 
-<h4 id="u__6__features">features</h4>
+<h4 id="u__7__features">features</h4>
 
 **Since version:** `2.5` ∙ **Type:** `enum set` ∙ **Cardinality:** `Optional`   
-**Path:** /updaters/[6]   
+**Path:** /updaters/[7]   
 **Enum values:** `position` | `stop-position` | `occupancy`
 
 Which features of GTFS RT vehicle positions should be loaded into OTP.
 
-<h4 id="u__6__headers">headers</h4>
+<h4 id="u__7__headers">headers</h4>
 
 **Since version:** `2.3` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
-**Path:** /updaters/[6] 
+**Path:** /updaters/[7] 
 
 HTTP headers to add to the request. Any header key, value can be inserted.
 

--- a/docs/UpdaterConfig.md
+++ b/docs/UpdaterConfig.md
@@ -179,11 +179,11 @@ This system powers the realtime updates in Helsinki and more information can be 
 |-----------------------------------------------------------------------|:---------:|----------------------------------------------|:----------:|----------------------|:-----:|
 | type = "mqtt-gtfs-rt-updater"                                         |   `enum`  | The type of the updater.                     | *Required* |                      |  1.5  |
 | [backwardsDelayPropagationType](#u__6__backwardsDelayPropagationType) |   `enum`  | How backwards propagation should be handled. | *Optional* | `"required-no-data"` |  2.2  |
-| feedId                                                                |  `string` | The feed id to apply the updates to.         | *Required* |                      |   na  |
-| fuzzyTripMatching                                                     | `boolean` | Whether to match trips fuzzily.              | *Optional* | `false`              |   na  |
-| qos                                                                   | `integer` | QOS level.                                   | *Optional* | `0`                  |   na  |
-| topic                                                                 |  `string` | The topic to subscribe to.                   | *Required* |                      |   na  |
-| url                                                                   |  `string` | URL of the MQTT broker.                      | *Required* |                      |   na  |
+| feedId                                                                |  `string` | The feed id to apply the updates to.         | *Required* |                      |  2.0  |
+| fuzzyTripMatching                                                     | `boolean` | Whether to match trips fuzzily.              | *Optional* | `false`              |  2.0  |
+| qos                                                                   | `integer` | QOS level.                                   | *Optional* | `0`                  |  2.0  |
+| topic                                                                 |  `string` | The topic to subscribe to.                   | *Required* |                      |  2.0  |
+| url                                                                   |  `string` | URL of the MQTT broker.                      | *Required* |                      |  2.0  |
 
 
 ##### Parameter details

--- a/docs/sandbox/SiriUpdater.md
+++ b/docs/sandbox/SiriUpdater.md
@@ -37,16 +37,16 @@ To enable the SIRI updater you need to add it to the updaters section of the `ro
 | previewInterval                |    `duration`   | TODO                                                                                                   | *Optional* |               |  2.0  |
 | requestorRef                   |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
 | timeout                        |    `duration`   | The HTTP timeout to download the updates.                                                              | *Optional* | `"PT15S"`     |  2.0  |
-| [url](#u__7__url)              |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
-| [headers](#u__7__headers)      | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
+| [url](#u__8__url)              |     `string`    | The URL to send the HTTP requests to.                                                                  | *Required* |               |  2.0  |
+| [headers](#u__8__headers)      | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
 
 
 ##### Parameter details
 
-<h4 id="u__7__url">url</h4>
+<h4 id="u__8__url">url</h4>
 
 **Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
-**Path:** /updaters/[7] 
+**Path:** /updaters/[8] 
 
 The URL to send the HTTP requests to.
 
@@ -58,10 +58,10 @@ renamed by the loader when processed:
 
 
 
-<h4 id="u__7__headers">headers</h4>
+<h4 id="u__8__headers">headers</h4>
 
 **Since version:** `2.3` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
-**Path:** /updaters/[7] 
+**Path:** /updaters/[8] 
 
 HTTP headers to add to the request. Any header key, value can be inserted.
 
@@ -97,21 +97,21 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 |---------------------------------|:---------------:|--------------------------------------------------------------------------------------------------------|:----------:|---------------|:-----:|
 | type = "siri-sx-updater"        |      `enum`     | The type of the updater.                                                                               | *Required* |               |  1.5  |
 | blockReadinessUntilInitialized  |    `boolean`    | Whether catching up with the updates should block the readiness check from returning a 'ready' result. | *Optional* | `false`       |  2.0  |
-| [earlyStart](#u__8__earlyStart) |    `duration`   | This value is subtracted from the actual validity defined in the message.                              | *Optional* | `"PT0S"`      |  2.0  |
+| [earlyStart](#u__9__earlyStart) |    `duration`   | This value is subtracted from the actual validity defined in the message.                              | *Optional* | `"PT0S"`      |  2.0  |
 | feedId                          |     `string`    | The ID of the feed to apply the updates to.                                                            | *Required* |               |  2.0  |
 | frequency                       |    `duration`   | How often the updates should be retrieved.                                                             | *Optional* | `"PT1M"`      |  2.0  |
 | requestorRef                    |     `string`    | The requester reference.                                                                               | *Optional* |               |  2.0  |
 | timeout                         |    `duration`   | The HTTP timeout to download the updates.                                                              | *Optional* | `"PT15S"`     |  2.0  |
-| [url](#u__8__url)               |     `string`    | The URL to send the HTTP requests to. Supports http/https and file protocol.                           | *Required* |               |  2.0  |
-| [headers](#u__8__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
+| [url](#u__9__url)               |     `string`    | The URL to send the HTTP requests to. Supports http/https and file protocol.                           | *Required* |               |  2.0  |
+| [headers](#u__9__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                             | *Optional* |               |  2.3  |
 
 
 ##### Parameter details
 
-<h4 id="u__8__earlyStart">earlyStart</h4>
+<h4 id="u__9__earlyStart">earlyStart</h4>
 
 **Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`   
-**Path:** /updaters/[8] 
+**Path:** /updaters/[9] 
 
 This value is subtracted from the actual validity defined in the message.
 
@@ -119,10 +119,10 @@ Normally the planned departure time is used, so setting this to 10s will cause t
 SX-message to be included in trip-results 10 seconds before the the planned departure
 time.
 
-<h4 id="u__8__url">url</h4>
+<h4 id="u__9__url">url</h4>
 
 **Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
-**Path:** /updaters/[8] 
+**Path:** /updaters/[9] 
 
 The URL to send the HTTP requests to. Supports http/https and file protocol.
 
@@ -135,10 +135,10 @@ renamed by the loader when processed:
 
 
 
-<h4 id="u__8__headers">headers</h4>
+<h4 id="u__9__headers">headers</h4>
 
 **Since version:** `2.3` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
-**Path:** /updaters/[8] 
+**Path:** /updaters/[9] 
 
 HTTP headers to add to the request. Any header key, value can be inserted.
 

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/MqttGtfsRealtimeUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/MqttGtfsRealtimeUpdaterConfig.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.standalone.config.routerconfig.updaters;
 
-import static org.opentripplanner.standalone.config.framework.json.OtpVersion.NA;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
 
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
@@ -12,13 +12,13 @@ public class MqttGtfsRealtimeUpdaterConfig {
   public static MqttGtfsRealtimeUpdaterParameters create(String configRef, NodeAdapter c) {
     return new MqttGtfsRealtimeUpdaterParameters(
       configRef,
-      c.of("feedId").since(NA).summary("The feed id to apply the updates to.").asString(),
-      c.of("url").since(NA).summary("URL of the MQTT broker.").asString(),
-      c.of("topic").since(NA).summary("The topic to subscribe to.").asString(),
-      c.of("qos").since(NA).summary("QOS level.").asInt(0),
+      c.of("feedId").since(V2_0).summary("The feed id to apply the updates to.").asString(),
+      c.of("url").since(V2_0).summary("URL of the MQTT broker.").asString(),
+      c.of("topic").since(V2_0).summary("The topic to subscribe to.").asString(),
+      c.of("qos").since(V2_0).summary("QOS level.").asInt(0),
       c
         .of("fuzzyTripMatching")
-        .since(NA)
+        .since(V2_0)
         .summary("Whether to match trips fuzzily.")
         .asBoolean(false),
       c

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -283,6 +283,14 @@
         "Authorization": "A-Token"
       }
     },
+    // Streaming GTFS-RT TripUpdates through an MQTT broker
+    {
+      "type": "mqtt-gtfs-rt-updater",
+      "url": "tcp://pred.rt.hsl.fi",
+      "topic": "gtfsrt/v2/fi/hsl/tu",
+      "feedId": "HSL",
+      "fuzzyTripMatching": true
+    },
     // Polling for GTFS-RT Vehicle Positions - output can be fetched via trip pattern GraphQL API
     {
       "type": "vehicle-positions",


### PR DESCRIPTION
@abyrd has correctly pointed out that we don't have any docs about the streaming MQTT updater, which is definitely an innovative feature that we should advertise more. Threfore I added some documentation about it.