### PR TITLE
Switchable debug tiles for new UI

### DIFF
--- a/client-next/package-lock.json
+++ b/client-next/package-lock.json
@@ -12,7 +12,7 @@
         "bootstrap": "5.3.1",
         "graphql": "16.8.0",
         "graphql-request": "6.1.0",
-        "maplibre-gl": "3.3.0",
+        "maplibre-gl": "3.6.2",
         "react": "18.2.0",
         "react-bootstrap": "2.8.0",
         "react-dom": "18.2.0",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.0.tgz",
-      "integrity": "sha512-ZbhX9CTV+Z7vHwkRIasDOwTSzr76e8Q6a55RMsAibjyX6+P0ZNL1qAKNzOjjBDP3+aEfNMl7hHo5knuY6pTAUQ==",
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
@@ -3306,9 +3306,9 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+      "version": "7946.0.13",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
+      "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
@@ -3335,14 +3335,14 @@
       "dev": true
     },
     "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA=="
     },
     "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-      "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
@@ -3364,9 +3364,9 @@
       "dev": true
     },
     "node_modules/@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -3412,9 +3412,9 @@
       "dev": true
     },
     "node_modules/@types/supercluster": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.0.tgz",
-      "integrity": "sha512-6JapQ2GmEkH66r23BK49I+u6zczVDGTtiJEVvKDYZVSm/vepWaJuTq6BXzJ6I4agG5s8vA1KM7m/gXWDg03O4Q==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -7379,9 +7379,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.3.0.tgz",
-      "integrity": "sha512-LDia3b8u2S8qtl50n8TYJM0IPLzfc01KDc71LNuydvDiEXAGBI5togty+juVtUipRZZjs4dAW6xhgrabc6lIgw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.6.2.tgz",
+      "integrity": "sha512-krg2KFIdOpLPngONDhP6ixCoWl5kbdMINP0moMSJFVX7wX1Clm2M9hlNKXS8vBGlVWwR5R3ZfI6IPrYz7c+aCQ==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -7390,12 +7390,12 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.0",
-        "@types/geojson": "^7946.0.10",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.0",
-        "@types/pbf": "^3.0.2",
-        "@types/supercluster": "^7.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^19.3.3",
+        "@types/geojson": "^7946.0.13",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
         "earcut": "^2.2.4",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",

--- a/client-next/package.json
+++ b/client-next/package.json
@@ -19,7 +19,7 @@
     "bootstrap": "5.3.1",
     "graphql": "16.8.0",
     "graphql-request": "6.1.0",
-    "maplibre-gl": "3.3.0",
+    "maplibre-gl": "3.6.2",
     "react": "18.2.0",
     "react-bootstrap": "2.8.0",
     "react-dom": "18.2.0",

--- a/client-next/src/components/MapView/ContextMenuPopup.tsx
+++ b/client-next/src/components/MapView/ContextMenuPopup.tsx
@@ -1,5 +1,5 @@
 import { TripQueryVariables } from '../../gql/graphql.ts';
-import { LngLat, Popup } from 'react-map-gl';
+import { LngLat, Popup } from 'react-map-gl/maplibre';
 import { Button, ButtonGroup } from 'react-bootstrap';
 
 export function ContextMenuPopup({

--- a/client-next/src/components/MapView/GeometryPropertyPopup.tsx
+++ b/client-next/src/components/MapView/GeometryPropertyPopup.tsx
@@ -11,7 +11,13 @@ export function GeometryPropertyPopup({
   onClose: () => void;
 }) {
   return (
-    <Popup latitude={coordinates.lat} longitude={coordinates.lng} closeButton={true} onClose={() => onClose()}>
+    <Popup
+      latitude={coordinates.lat}
+      longitude={coordinates.lng}
+      closeButton={true}
+      onClose={() => onClose()}
+      maxWidth="350px"
+    >
       <Table bordered>
         <tbody>
           {Object.entries(properties).map(([key, value]) => (

--- a/client-next/src/components/MapView/GeometryPropertyPopup.tsx
+++ b/client-next/src/components/MapView/GeometryPropertyPopup.tsx
@@ -1,4 +1,4 @@
-import { LngLat, Popup } from 'react-map-gl';
+import { LngLat, Popup } from 'react-map-gl/maplibre';
 import { Table } from 'react-bootstrap';
 
 export function GeometryPropertyPopup({

--- a/client-next/src/components/MapView/LayerControl.tsx
+++ b/client-next/src/components/MapView/LayerControl.tsx
@@ -1,12 +1,18 @@
 import type { ControlPosition } from 'react-map-gl';
 import { useControl } from 'react-map-gl';
-import { IControl, Map} from 'maplibre-gl';
+import { IControl, Map } from 'maplibre-gl';
 
 type LayerControlProps = {
   position: ControlPosition;
 };
 
-class LayerList implements IControl {
+/**
+ * A maplibre control that allows you to switch vector tile layers on and off.
+ *
+ * It appears that you cannot use React elements but have to drop down to raw DOM. Please correct
+ * me if I'm wrong.
+ */
+class LayerControl implements IControl {
   private readonly container: HTMLDivElement = document.createElement('div');
 
   onAdd(map: Map) {
@@ -67,8 +73,8 @@ class LayerList implements IControl {
   }
 }
 
-export default function LayerListControl(props: LayerControlProps) {
-  useControl(() => new LayerList(), {
+export default function DebugLayerControl(props: LayerControlProps) {
+  useControl(() => new LayerControl(), {
     position: props.position,
   });
 

--- a/client-next/src/components/MapView/LayerControl.tsx
+++ b/client-next/src/components/MapView/LayerControl.tsx
@@ -1,17 +1,15 @@
 import type { ControlPosition } from 'react-map-gl';
 import { useControl } from 'react-map-gl';
-import { Map } from 'maplibre-gl';
+import { IControl, Map} from 'maplibre-gl';
 
 type LayerControlProps = {
   position: ControlPosition;
 };
 
-class LayerList {
-  private map: Map | null = null;
+class LayerList implements IControl {
   private readonly container: HTMLDivElement = document.createElement('div');
 
   onAdd(map: Map) {
-    this.map = map;
     this.container.className = 'maplibregl-ctrl maplibregl-ctrl-group layer-select';
 
     map.on('load', () => {
@@ -34,20 +32,22 @@ class LayerList {
             const div = document.createElement('div');
             const input = document.createElement('input');
             input.type = 'checkbox';
-            input.value = layer?.id;
+            input.value = layer.id;
+            input.id = layer.id;
             input.onchange = (e) => {
               e.preventDefault();
               e.stopPropagation();
 
-              if (this.layerVisible(layer)) {
+              if (this.layerVisible(map, layer)) {
                 map.setLayoutProperty(layer.id, 'visibility', 'none');
               } else {
                 map.setLayoutProperty(layer.id, 'visibility', 'visible');
               }
             };
-            input.checked = this.layerVisible(layer);
+            input.checked = this.layerVisible(map, layer);
             const label = document.createElement('label');
             label.textContent = layer.id;
+            label.htmlFor = layer.id;
             div.appendChild(input);
             div.appendChild(label);
             this.container.appendChild(div);
@@ -58,15 +58,12 @@ class LayerList {
     return this.container;
   }
 
-  private layerVisible(layer: { id: string }) {
-    return this.map?.getLayoutProperty(layer.id, 'visibility') !== 'none';
+  private layerVisible(map: Map, layer: { id: string }) {
+    return map.getLayoutProperty(layer.id, 'visibility') !== 'none';
   }
-
-  onCreate() {}
 
   onRemove() {
     this.container.parentNode?.removeChild(this.container);
-    this.map = null;
   }
 }
 

--- a/client-next/src/components/MapView/LayerControl.tsx
+++ b/client-next/src/components/MapView/LayerControl.tsx
@@ -1,0 +1,78 @@
+import type { ControlPosition } from 'react-map-gl';
+import { useControl } from 'react-map-gl';
+import { Map } from 'maplibre-gl';
+
+type LayerControlProps = {
+  position?: ControlPosition;
+};
+
+class LayerList {
+  private map: Map | null = null;
+  private _container: HTMLDivElement;
+
+  onAdd(map: Map) {
+    this.map = map;
+    this._container = document.createElement('div');
+    this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group layer-select';
+
+    map?.on('load', () => {
+      while (this._container.firstChild) {
+        this._container.removeChild(this._container.firstChild);
+      }
+
+      const h3 = document.createElement('h6');
+      h3.textContent = 'Debug layers';
+      this._container.appendChild(h3);
+
+      map
+        ?.getLayersOrder()
+        .map((l) => map.getLayer(l))
+        .filter((s) => s?.type !== 'raster')
+        .reverse()
+        .forEach((layer) => {
+          const div = document.createElement('div');
+          const input = document.createElement('input');
+          input.type = 'checkbox';
+          input.value = layer?.id;
+          input.onchange = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            if (this.layerVisible(layer)) {
+              map.setLayoutProperty(layer.id, 'visibility', 'none');
+            } else {
+              map.setLayoutProperty(layer.id, 'visibility', 'visible');
+            }
+          };
+          const visible = map.getLayoutProperty(layer.id, 'visibility') !== 'none';
+          input.checked = visible;
+          const label = document.createElement('label');
+          label.textContent = layer.id;
+          div.appendChild(input);
+          div.appendChild(label);
+          this._container.appendChild(div);
+        });
+    });
+
+    return this._container;
+  }
+
+  private layerVisible(layer: { id: string }) {
+    return this.map?.getLayoutProperty(layer.id, 'visibility') !== 'none';
+  }
+
+  onCreate() {}
+
+  onRemove() {
+    this._container.parentNode.removeChild(this._container);
+    this.map = undefined;
+  }
+}
+
+export default function LayerListControl(props: LayerControlProps) {
+  useControl(() => new LayerList(), {
+    position: props.position,
+  });
+
+  return null;
+}

--- a/client-next/src/components/MapView/LayerControl.tsx
+++ b/client-next/src/components/MapView/LayerControl.tsx
@@ -3,58 +3,59 @@ import { useControl } from 'react-map-gl';
 import { Map } from 'maplibre-gl';
 
 type LayerControlProps = {
-  position?: ControlPosition;
+  position: ControlPosition;
 };
 
 class LayerList {
   private map: Map | null = null;
-  private _container: HTMLDivElement;
+  private readonly container: HTMLDivElement = document.createElement('div');
 
   onAdd(map: Map) {
     this.map = map;
-    this._container = document.createElement('div');
-    this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group layer-select';
+    this.container.className = 'maplibregl-ctrl maplibregl-ctrl-group layer-select';
 
-    map?.on('load', () => {
-      while (this._container.firstChild) {
-        this._container.removeChild(this._container.firstChild);
+    map.on('load', () => {
+      // clean on
+      while (this.container.firstChild) {
+        this.container.removeChild(this.container.firstChild);
       }
 
-      const h3 = document.createElement('h6');
-      h3.textContent = 'Debug layers';
-      this._container.appendChild(h3);
+      const title = document.createElement('h6');
+      title.textContent = 'Debug layers';
+      this.container.appendChild(title);
 
       map
-        ?.getLayersOrder()
+        .getLayersOrder()
         .map((l) => map.getLayer(l))
         .filter((s) => s?.type !== 'raster')
         .reverse()
         .forEach((layer) => {
-          const div = document.createElement('div');
-          const input = document.createElement('input');
-          input.type = 'checkbox';
-          input.value = layer?.id;
-          input.onchange = (e) => {
-            e.preventDefault();
-            e.stopPropagation();
+          if (layer) {
+            const div = document.createElement('div');
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.value = layer?.id;
+            input.onchange = (e) => {
+              e.preventDefault();
+              e.stopPropagation();
 
-            if (this.layerVisible(layer)) {
-              map.setLayoutProperty(layer.id, 'visibility', 'none');
-            } else {
-              map.setLayoutProperty(layer.id, 'visibility', 'visible');
-            }
-          };
-          const visible = map.getLayoutProperty(layer.id, 'visibility') !== 'none';
-          input.checked = visible;
-          const label = document.createElement('label');
-          label.textContent = layer.id;
-          div.appendChild(input);
-          div.appendChild(label);
-          this._container.appendChild(div);
+              if (this.layerVisible(layer)) {
+                map.setLayoutProperty(layer.id, 'visibility', 'none');
+              } else {
+                map.setLayoutProperty(layer.id, 'visibility', 'visible');
+              }
+            };
+            input.checked = this.layerVisible(layer);
+            const label = document.createElement('label');
+            label.textContent = layer.id;
+            div.appendChild(input);
+            div.appendChild(label);
+            this.container.appendChild(div);
+          }
         });
     });
 
-    return this._container;
+    return this.container;
   }
 
   private layerVisible(layer: { id: string }) {
@@ -64,8 +65,8 @@ class LayerList {
   onCreate() {}
 
   onRemove() {
-    this._container.parentNode.removeChild(this._container);
-    this.map = undefined;
+    this.container.parentNode?.removeChild(this.container);
+    this.map = null;
   }
 }
 

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -58,7 +58,7 @@ export function MapView({
     // provided by the WorldEnvelopeService
     if (map.getZoom() < 2) {
       const source = map.getSource('stops') as VectorTileSource;
-      map.fitBounds(source.bounds, { maxDuration: 50, linear: true });
+      map.fitBounds(source.bounds, { maxDuration: 50, linear: true});
     }
   };
 
@@ -75,7 +75,7 @@ export function MapView({
         }}
         // it's unfortunate that you have to list these layers here.
         // maybe there is a way around it: https://github.com/visgl/react-map-gl/discussions/2343
-        interactiveLayerIds={['regular-stop', 'edge-fallback', 'edge', 'link']}
+        interactiveLayerIds={['regular-stop', 'vertex', 'edge', 'link']}
         onClick={showFeaturePropPopup}
         // put lat/long in URL and pan to it on page reload
         hash={true}

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -1,4 +1,4 @@
-import { LngLat, Map, MapboxGeoJSONFeature, NavigationControl } from 'react-map-gl';
+import { LngLat, Map, MapGeoJSONFeature, MapMouseEvent, NavigationControl } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { TripPattern, TripQuery, TripQueryVariables } from '../../gql/graphql.ts';
 import { NavigationMarkers } from './NavigationMarkers.tsx';
@@ -7,6 +7,7 @@ import { useMapDoubleClick } from './useMapDoubleClick.ts';
 import { useState } from 'react';
 import { ContextMenuPopup } from './ContextMenuPopup.tsx';
 import { GeometryPropertyPopup } from './GeometryPropertyPopup.tsx';
+import LayerListControl from './LayerControl.tsx';
 
 // TODO: this should be configurable
 const initialViewState = {
@@ -17,7 +18,7 @@ const initialViewState = {
 
 const styleUrl = import.meta.env.VITE_DEBUG_STYLE_URL;
 
-type PopupData = { coordinates: LngLat; feature: MapboxGeoJSONFeature };
+type PopupData = { coordinates: LngLat; feature: MapGeoJSONFeature };
 
 export function MapView({
   tripQueryVariables,
@@ -36,8 +37,8 @@ export function MapView({
   const [showContextPopup, setShowContextPopup] = useState<LngLat | null>(null);
   const [showPropsPopup, setShowPropsPopup] = useState<PopupData | null>(null);
   const showFeaturePropPopup = (
-    e: mapboxgl.MapMouseEvent & {
-      features?: mapboxgl.MapboxGeoJSONFeature[] | undefined;
+    e: MapMouseEvent & {
+      features?: MapGeoJSONFeature[] | undefined;
     },
   ) => {
     if (e.features) {
@@ -75,6 +76,7 @@ export function MapView({
           setTripQueryVariables={setTripQueryVariables}
           loading={loading}
         />
+        <LayerListControl />
         {tripQueryResult?.trip.tripPatterns.length && (
           <LegLines tripPattern={tripQueryResult.trip.tripPatterns[selectedTripPatternIndex] as TripPattern} />
         )}

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -1,12 +1,12 @@
-import { LngLat, Map, MapboxGeoJSONFeature, NavigationControl } from 'react-map-gl';
+import {LngLat, Map, MapboxGeoJSONFeature, NavigationControl} from 'react-map-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { TripPattern, TripQuery, TripQueryVariables } from '../../gql/graphql.ts';
-import { NavigationMarkers } from './NavigationMarkers.tsx';
-import { LegLines } from './LegLines.tsx';
-import { useMapDoubleClick } from './useMapDoubleClick.ts';
-import { useState } from 'react';
-import { ContextMenuPopup } from './ContextMenuPopup.tsx';
-import { GeometryPropertyPopup } from './GeometryPropertyPopup.tsx';
+import {TripPattern, TripQuery, TripQueryVariables} from '../../gql/graphql.ts';
+import {NavigationMarkers} from './NavigationMarkers.tsx';
+import {LegLines} from './LegLines.tsx';
+import {useMapDoubleClick} from './useMapDoubleClick.ts';
+import {useState} from 'react';
+import {ContextMenuPopup} from './ContextMenuPopup.tsx';
+import {GeometryPropertyPopup} from './GeometryPropertyPopup.tsx';
 
 // TODO: this should be configurable
 const initialViewState = {
@@ -61,7 +61,7 @@ export function MapView({
         onContextMenu={(e) => {
           setShowContextPopup(e.lngLat);
         }}
-        interactiveLayerIds={['regular-stop']}
+        interactiveLayerIds={['regular-stop', 'edge-fallback', 'edge', 'link']}
         onClick={showFeaturePropPopup}
         // put lat/long in URL and pan to it on page reload
         hash={true}

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -1,12 +1,12 @@
-import {LngLat, Map, MapboxGeoJSONFeature, NavigationControl} from 'react-map-gl';
+import { LngLat, Map, MapboxGeoJSONFeature, NavigationControl } from 'react-map-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import {TripPattern, TripQuery, TripQueryVariables} from '../../gql/graphql.ts';
-import {NavigationMarkers} from './NavigationMarkers.tsx';
-import {LegLines} from './LegLines.tsx';
-import {useMapDoubleClick} from './useMapDoubleClick.ts';
-import {useState} from 'react';
-import {ContextMenuPopup} from './ContextMenuPopup.tsx';
-import {GeometryPropertyPopup} from './GeometryPropertyPopup.tsx';
+import { TripPattern, TripQuery, TripQueryVariables } from '../../gql/graphql.ts';
+import { NavigationMarkers } from './NavigationMarkers.tsx';
+import { LegLines } from './LegLines.tsx';
+import { useMapDoubleClick } from './useMapDoubleClick.ts';
+import { useState } from 'react';
+import { ContextMenuPopup } from './ContextMenuPopup.tsx';
+import { GeometryPropertyPopup } from './GeometryPropertyPopup.tsx';
 
 // TODO: this should be configurable
 const initialViewState = {

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -7,7 +7,7 @@ import { useMapDoubleClick } from './useMapDoubleClick.ts';
 import { useState } from 'react';
 import { ContextMenuPopup } from './ContextMenuPopup.tsx';
 import { GeometryPropertyPopup } from './GeometryPropertyPopup.tsx';
-import LayerListControl from './LayerControl.tsx';
+import DebugLayerControl from './LayerControl.tsx';
 
 // TODO: this should be configurable
 const initialViewState = {
@@ -76,7 +76,7 @@ export function MapView({
           setTripQueryVariables={setTripQueryVariables}
           loading={loading}
         />
-        <LayerListControl position="top-right" />
+        <DebugLayerControl position="top-right" />
         {tripQueryResult?.trip.tripPatterns.length && (
           <LegLines tripPattern={tripQueryResult.trip.tripPatterns[selectedTripPatternIndex] as TripPattern} />
         )}

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -76,7 +76,7 @@ export function MapView({
           setTripQueryVariables={setTripQueryVariables}
           loading={loading}
         />
-        <LayerListControl />
+        <LayerListControl position="top-right" />
         {tripQueryResult?.trip.tripPatterns.length && (
           <LegLines tripPattern={tripQueryResult.trip.tripPatterns[selectedTripPatternIndex] as TripPattern} />
         )}

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -54,7 +54,7 @@ export function MapView({
     const map = e.target;
     // if we are really far zoomed out and show the entire world it means that we are not starting
     // in a location selected from the URL hash.
-    // in such a case we pan to the area that is specified in the stop's tile bounds, which is
+    // in such a case we pan to the area that is specified in the tile bounds, which is
     // provided by the WorldEnvelopeService
     if (map.getZoom() < 2) {
       const source = map.getSource('stops') as VectorTileSource;
@@ -73,6 +73,8 @@ export function MapView({
         onContextMenu={(e) => {
           setShowContextPopup(e.lngLat);
         }}
+        // it's unfortunate that you have to list these layers here.
+        // maybe there is a way around it: https://github.com/visgl/react-map-gl/discussions/2343
         interactiveLayerIds={['regular-stop', 'edge-fallback', 'edge', 'link']}
         onClick={showFeaturePropPopup}
         // put lat/long in URL and pan to it on page reload

--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -58,7 +58,7 @@ export function MapView({
     // provided by the WorldEnvelopeService
     if (map.getZoom() < 2) {
       const source = map.getSource('stops') as VectorTileSource;
-      map.fitBounds(source.bounds, { maxDuration: 50, linear: true});
+      map.fitBounds(source.bounds, { maxDuration: 50, linear: true });
     }
   };
 

--- a/client-next/src/components/MapView/useMapDoubleClick.ts
+++ b/client-next/src/components/MapView/useMapDoubleClick.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { TripQueryVariables } from '../../gql/graphql.ts';
-import { LngLat, MapLayerMouseEvent } from 'react-map-gl';
+import { LngLat, MapLayerMouseEvent } from 'react-map-gl/maplibre';
 
 const setCoordinates = (tripQueryVariables: TripQueryVariables, lngLat: LngLat, key: 'from' | 'to') => ({
   ...tripQueryVariables,

--- a/client-next/src/style.css
+++ b/client-next/src/style.css
@@ -119,3 +119,12 @@
   font-size: 14px;
   padding-left: 2px;
 }
+
+/* debug layer selector */
+
+.maplibregl-ctrl-group.layer-select {
+  padding: 10px;
+}
+.maplibregl-ctrl-group.layer-select label {
+  margin-left: 6px;
+}

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -56,15 +56,6 @@ public class DebugStyleSpec {
       List.of(
         LayerStyleBuilder.ofId("background").typeRaster().source(BACKGROUND_SOURCE).minZoom(0),
         LayerStyleBuilder
-          .ofId("edge-fallback")
-          .typeLine()
-          .vectorSourceLayer(edges)
-          .lineColor(GREY)
-          .lineWidth(LINE_WIDTH)
-          .minZoom(15)
-          .maxZoom(MAX_ZOOM)
-          .intiallyHidden(),
-        LayerStyleBuilder
           .ofId("edge")
           .typeLine()
           .vectorSourceLayer(edges)
@@ -107,7 +98,7 @@ public class DebugStyleSpec {
             new ZoomDependentNumber(1, List.of(new ZoomStop(11, 1), new ZoomStop(MAX_ZOOM, 10)))
           )
           .circleColor("#fcf9fa")
-          .minZoom(11)
+          .minZoom(10)
           .maxZoom(MAX_ZOOM)
       )
     );

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -11,7 +11,9 @@ import org.opentripplanner.apis.vectortiles.model.TileSource.VectorSource;
 import org.opentripplanner.service.vehiclerental.street.StreetVehicleRentalLink;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.edge.BoardingLocationToStopLink;
+import org.opentripplanner.street.model.edge.ElevatorHopEdge;
 import org.opentripplanner.street.model.edge.EscalatorEdge;
+import org.opentripplanner.street.model.edge.PathwayEdge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetTransitEntranceLink;
 import org.opentripplanner.street.model.edge.StreetTransitStopLink;
@@ -60,7 +62,8 @@ public class DebugStyleSpec {
           .lineColor(GREY)
           .lineWidth(LINE_WIDTH)
           .minZoom(15)
-          .maxZoom(MAX_ZOOM),
+          .maxZoom(MAX_ZOOM)
+          .intiallyHidden(),
         LayerStyleBuilder
           .ofId("edge")
           .typeLine()
@@ -70,12 +73,14 @@ public class DebugStyleSpec {
             StreetEdge.class,
             AreaEdge.class,
             EscalatorEdge.class,
+            PathwayEdge.class,
+            ElevatorHopEdge.class,
             TemporaryPartialStreetEdge.class,
             TemporaryFreeEdge.class
           )
           .lineWidth(LINE_WIDTH)
           .minZoom(13)
-          .maxZoom(MAX_ZOOM),
+          .maxZoom(MAX_ZOOM).intiallyHidden(),
         LayerStyleBuilder
           .ofId("link")
           .typeLine()
@@ -90,7 +95,7 @@ public class DebugStyleSpec {
           )
           .lineWidth(LINE_WIDTH)
           .minZoom(13)
-          .maxZoom(MAX_ZOOM),
+          .maxZoom(MAX_ZOOM).intiallyHidden(),
         LayerStyleBuilder
           .ofId("regular-stop")
           .typeCircle()

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -39,12 +39,16 @@ public class DebugStyleSpec {
   private static final String MAGENTA = "#f21d52";
   private static final String GREEN = "#22DD9E";
   private static final String PURPLE = "#BC55F2";
+  private static final String BLACK = "#140d0e";
   private static final int MAX_ZOOM = 23;
   private static final ZoomDependentNumber LINE_WIDTH = new ZoomDependentNumber(
     1.3f,
     List.of(new ZoomStop(13, 0.5f), new ZoomStop(MAX_ZOOM, 10))
   );
-  private static final String BLACK = "#140d0e";
+  private static final ZoomDependentNumber CIRCLE_STROKE = new ZoomDependentNumber(
+    1,
+    List.of(new ZoomStop(15, 0.2f), new ZoomStop(MAX_ZOOM, 3))
+  );
 
   static StyleSpec build(
     VectorSourceLayer regularStops,
@@ -100,13 +104,14 @@ public class DebugStyleSpec {
           .ofId("vertex")
           .typeCircle()
           .vectorSourceLayer(vertices)
-          .circleStroke(BLACK, 2)
+          .circleStroke(BLACK, CIRCLE_STROKE)
           .circleRadius(
-            new ZoomDependentNumber(1, List.of(new ZoomStop(15, 1), new ZoomStop(MAX_ZOOM, 5)))
+            new ZoomDependentNumber(1, List.of(new ZoomStop(15, 1), new ZoomStop(MAX_ZOOM, 7)))
           )
           .circleColor(PURPLE)
           .minZoom(15)
-          .maxZoom(MAX_ZOOM),
+          .maxZoom(MAX_ZOOM)
+          .intiallyHidden(),
         StyleBuilder
           .ofId("regular-stop")
           .typeCircle()

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -80,7 +80,8 @@ public class DebugStyleSpec {
           )
           .lineWidth(LINE_WIDTH)
           .minZoom(13)
-          .maxZoom(MAX_ZOOM).intiallyHidden(),
+          .maxZoom(MAX_ZOOM)
+          .intiallyHidden(),
         LayerStyleBuilder
           .ofId("link")
           .typeLine()
@@ -95,13 +96,16 @@ public class DebugStyleSpec {
           )
           .lineWidth(LINE_WIDTH)
           .minZoom(13)
-          .maxZoom(MAX_ZOOM).intiallyHidden(),
+          .maxZoom(MAX_ZOOM)
+          .intiallyHidden(),
         LayerStyleBuilder
           .ofId("regular-stop")
           .typeCircle()
           .vectorSourceLayer(regularStops)
           .circleStroke("#140d0e", 2)
-          .circleRadius(new ZoomDependentNumber(1, List.of(new ZoomStop(11,1), new ZoomStop(MAX_ZOOM, 10))))
+          .circleRadius(
+            new ZoomDependentNumber(1, List.of(new ZoomStop(11, 1), new ZoomStop(MAX_ZOOM, 10)))
+          )
           .circleColor("#fcf9fa")
           .minZoom(11)
           .maxZoom(MAX_ZOOM)

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -37,7 +37,7 @@ public class DebugStyleSpec {
   private static final int MAX_ZOOM = 23;
   private static final ZoomDependentNumber LINE_WIDTH = new ZoomDependentNumber(
     1.3f,
-    List.of(new ZoomStop(13, 1), new ZoomStop(MAX_ZOOM, 10))
+    List.of(new ZoomStop(13, 0.5f), new ZoomStop(MAX_ZOOM, 10))
   );
 
   public record VectorSourceLayer(VectorSource vectorSource, String vectorLayer) {}
@@ -96,6 +96,7 @@ public class DebugStyleSpec {
           .typeCircle()
           .vectorSourceLayer(regularStops)
           .circleStroke("#140d0e", 2)
+          .circleRadius(new ZoomDependentNumber(1, List.of(new ZoomStop(11,1), new ZoomStop(MAX_ZOOM, 10))))
           .circleColor("#fcf9fa")
           .minZoom(11)
           .maxZoom(MAX_ZOOM)

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -6,6 +6,14 @@ import org.opentripplanner.apis.vectortiles.model.StyleSpec;
 import org.opentripplanner.apis.vectortiles.model.TileSource;
 import org.opentripplanner.apis.vectortiles.model.TileSource.RasterSource;
 import org.opentripplanner.apis.vectortiles.model.TileSource.VectorSource;
+import org.opentripplanner.street.model.edge.AreaEdge;
+import org.opentripplanner.street.model.edge.BoardingLocationToStopLink;
+import org.opentripplanner.street.model.edge.EscalatorEdge;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetTransitEntranceLink;
+import org.opentripplanner.street.model.edge.StreetTransitStopLink;
+import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
+import org.opentripplanner.street.model.edge.TemporaryPartialStreetEdge;
 
 /**
  *  A Mapbox/Mapblibre style specification for rendering debug information about transit and
@@ -19,21 +27,60 @@ public class DebugStyleSpec {
     256,
     "© OpenStreetMap Contributors"
   );
+  private static final String MAGENTA = "#f21d52";
+  private static final String YELLOW = "#e2d40d";
+  private static final String GREY = "#8e8e89";
+  private static final int MAX_ZOOM = 23;
 
   public record VectorSourceLayer(VectorSource vectorSource, String vectorLayer) {}
 
-  static StyleSpec build(VectorSource debugSource, VectorSourceLayer regularStops) {
+  static StyleSpec build(
+    VectorSource debugSource,
+    VectorSourceLayer regularStops,
+    VectorSourceLayer edges
+  ) {
     List<TileSource> sources = List.of(BACKGROUND_SOURCE, debugSource);
     return new StyleSpec(
       "OTP Debug Tiles",
       sources,
       List.of(
+        LayerStyleBuilder.ofId("background").typeRaster().source(BACKGROUND_SOURCE).minZoom(0),
         LayerStyleBuilder
-          .ofId("background")
-          .typeRaster()
-          .source(BACKGROUND_SOURCE)
-          .minZoom(0)
-          .maxZoom(22),
+          .ofId("edge-fallback")
+          .typeLine()
+          .vectorSourceLayer(edges)
+          .lineColor(GREY)
+          .lineWidth(3)
+          .minZoom(15)
+          .maxZoom(MAX_ZOOM),
+        LayerStyleBuilder
+          .ofId("edge")
+          .typeLine()
+          .vectorSourceLayer(edges)
+          .lineColor(MAGENTA)
+          .edgeFilter(
+            StreetEdge.class,
+            AreaEdge.class,
+            EscalatorEdge.class,
+            TemporaryPartialStreetEdge.class,
+            TemporaryFreeEdge.class
+          )
+          .lineWidth(3)
+          .minZoom(13)
+          .maxZoom(MAX_ZOOM),
+        LayerStyleBuilder
+          .ofId("link")
+          .typeLine()
+          .vectorSourceLayer(edges)
+          .lineColor(YELLOW)
+          .edgeFilter(
+            StreetTransitStopLink.class,
+            StreetTransitEntranceLink.class,
+            BoardingLocationToStopLink.class
+          )
+          .lineWidth(3)
+          .minZoom(13)
+          .maxZoom(MAX_ZOOM),
         LayerStyleBuilder
           .ofId("regular-stop")
           .typeCircle()
@@ -41,7 +88,7 @@ public class DebugStyleSpec {
           .circleStroke("#140d0e", 2)
           .circleColor("#fcf9fa")
           .minZoom(13)
-          .maxZoom(22)
+          .maxZoom(MAX_ZOOM)
       )
     );
   }

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -2,16 +2,20 @@ package org.opentripplanner.apis.vectortiles;
 
 import java.util.List;
 import org.opentripplanner.apis.vectortiles.model.LayerStyleBuilder;
+import org.opentripplanner.apis.vectortiles.model.LayerStyleBuilder.ZoomDependentNumber;
+import org.opentripplanner.apis.vectortiles.model.LayerStyleBuilder.ZoomStop;
 import org.opentripplanner.apis.vectortiles.model.StyleSpec;
 import org.opentripplanner.apis.vectortiles.model.TileSource;
 import org.opentripplanner.apis.vectortiles.model.TileSource.RasterSource;
 import org.opentripplanner.apis.vectortiles.model.TileSource.VectorSource;
+import org.opentripplanner.service.vehiclerental.street.StreetVehicleRentalLink;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.edge.BoardingLocationToStopLink;
 import org.opentripplanner.street.model.edge.EscalatorEdge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetTransitEntranceLink;
 import org.opentripplanner.street.model.edge.StreetTransitStopLink;
+import org.opentripplanner.street.model.edge.StreetVehicleParkingLink;
 import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
 import org.opentripplanner.street.model.edge.TemporaryPartialStreetEdge;
 
@@ -31,6 +35,10 @@ public class DebugStyleSpec {
   private static final String YELLOW = "#e2d40d";
   private static final String GREY = "#8e8e89";
   private static final int MAX_ZOOM = 23;
+  private static final ZoomDependentNumber LINE_WIDTH = new ZoomDependentNumber(
+    1.3f,
+    List.of(new ZoomStop(13, 1), new ZoomStop(MAX_ZOOM, 10))
+  );
 
   public record VectorSourceLayer(VectorSource vectorSource, String vectorLayer) {}
 
@@ -50,7 +58,7 @@ public class DebugStyleSpec {
           .typeLine()
           .vectorSourceLayer(edges)
           .lineColor(GREY)
-          .lineWidth(3)
+          .lineWidth(LINE_WIDTH)
           .minZoom(15)
           .maxZoom(MAX_ZOOM),
         LayerStyleBuilder
@@ -65,7 +73,7 @@ public class DebugStyleSpec {
             TemporaryPartialStreetEdge.class,
             TemporaryFreeEdge.class
           )
-          .lineWidth(3)
+          .lineWidth(LINE_WIDTH)
           .minZoom(13)
           .maxZoom(MAX_ZOOM),
         LayerStyleBuilder
@@ -76,9 +84,11 @@ public class DebugStyleSpec {
           .edgeFilter(
             StreetTransitStopLink.class,
             StreetTransitEntranceLink.class,
-            BoardingLocationToStopLink.class
+            BoardingLocationToStopLink.class,
+            StreetVehicleRentalLink.class,
+            StreetVehicleParkingLink.class
           )
-          .lineWidth(3)
+          .lineWidth(LINE_WIDTH)
           .minZoom(13)
           .maxZoom(MAX_ZOOM),
         LayerStyleBuilder
@@ -87,7 +97,7 @@ public class DebugStyleSpec {
           .vectorSourceLayer(regularStops)
           .circleStroke("#140d0e", 2)
           .circleColor("#fcf9fa")
-          .minZoom(13)
+          .minZoom(11)
           .maxZoom(MAX_ZOOM)
       )
     );

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -38,14 +38,22 @@ public class DebugStyleSpec {
   );
   private static final String MAGENTA = "#f21d52";
   private static final String GREEN = "#22DD9E";
+  private static final String PURPLE = "#BC55F2";
   private static final int MAX_ZOOM = 23;
   private static final ZoomDependentNumber LINE_WIDTH = new ZoomDependentNumber(
     1.3f,
     List.of(new ZoomStop(13, 0.5f), new ZoomStop(MAX_ZOOM, 10))
   );
+  private static final String BLACK = "#140d0e";
 
-  static StyleSpec build(VectorSourceLayer regularStops, VectorSourceLayer edges) {
-    var vectorSources = Stream.of(regularStops, edges).map(VectorSourceLayer::vectorSource);
+  static StyleSpec build(
+    VectorSourceLayer regularStops,
+    VectorSourceLayer edges,
+    VectorSourceLayer vertices
+  ) {
+    var vectorSources = Stream
+      .of(regularStops, edges, vertices)
+      .map(VectorSourceLayer::vectorSource);
     var allSources = Stream
       .concat(Stream.of(BACKGROUND_SOURCE), vectorSources)
       .collect(Collectors.toSet());
@@ -89,10 +97,21 @@ public class DebugStyleSpec {
           .maxZoom(MAX_ZOOM)
           .intiallyHidden(),
         StyleBuilder
+          .ofId("vertex")
+          .typeCircle()
+          .vectorSourceLayer(vertices)
+          .circleStroke(BLACK, 2)
+          .circleRadius(
+            new ZoomDependentNumber(1, List.of(new ZoomStop(15, 1), new ZoomStop(MAX_ZOOM, 5)))
+          )
+          .circleColor(PURPLE)
+          .minZoom(15)
+          .maxZoom(MAX_ZOOM),
+        StyleBuilder
           .ofId("regular-stop")
           .typeCircle()
           .vectorSourceLayer(regularStops)
-          .circleStroke("#140d0e", 2)
+          .circleStroke(BLACK, 2)
           .circleRadius(
             new ZoomDependentNumber(1, List.of(new ZoomStop(11, 1), new ZoomStop(MAX_ZOOM, 10)))
           )

--- a/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
@@ -31,7 +31,7 @@ import org.opentripplanner.framework.io.HttpUtils;
 import org.opentripplanner.inspector.vector.LayerBuilder;
 import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.inspector.vector.VectorTileResponseFactory;
-import org.opentripplanner.inspector.vector.edges.EdgeLayerBuilder;
+import org.opentripplanner.inspector.vector.edge.EdgeLayerBuilder;
 import org.opentripplanner.inspector.vector.geofencing.GeofencingZonesLayerBuilder;
 import org.opentripplanner.inspector.vector.stop.StopLayerBuilder;
 import org.opentripplanner.model.FeedInfo;

--- a/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
@@ -34,6 +34,7 @@ import org.opentripplanner.inspector.vector.VectorTileResponseFactory;
 import org.opentripplanner.inspector.vector.edge.EdgeLayerBuilder;
 import org.opentripplanner.inspector.vector.geofencing.GeofencingZonesLayerBuilder;
 import org.opentripplanner.inspector.vector.stop.StopLayerBuilder;
+import org.opentripplanner.inspector.vector.vertex.VertexLayerBuilder;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 
@@ -51,6 +52,7 @@ public class GraphInspectorVectorTileResource {
     GeofencingZones
   );
   private static final LayerParams EDGES = new LayerParams("edges", Edges);
+  private static final LayerParams VERTICES = new LayerParams("vertices", Edges);
   private static final List<LayerParameters<LayerType>> DEBUG_LAYERS = List.of(
     REGULAR_STOPS,
     AREA_STOPS,
@@ -181,6 +183,7 @@ public class GraphInspectorVectorTileResource {
       );
       case GeofencingZones -> new GeofencingZonesLayerBuilder(context.graph(), layerParameters);
       case Edges -> new EdgeLayerBuilder(context.graph(), layerParameters);
+      case Vertices -> new VertexLayerBuilder(context.graph(), layerParameters);
     };
   }
 }

--- a/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
@@ -1,8 +1,9 @@
 package org.opentripplanner.apis.vectortiles;
 
-import static org.opentripplanner.apis.vectortiles.model.LayerType.Edges;
+import static org.opentripplanner.apis.vectortiles.model.LayerType.Edge;
 import static org.opentripplanner.apis.vectortiles.model.LayerType.GeofencingZones;
 import static org.opentripplanner.apis.vectortiles.model.LayerType.RegularStop;
+import static org.opentripplanner.apis.vectortiles.model.LayerType.Vertex;
 import static org.opentripplanner.framework.io.HttpUtils.APPLICATION_X_PROTOBUF;
 
 import jakarta.ws.rs.GET;
@@ -51,13 +52,14 @@ public class GraphInspectorVectorTileResource {
     "geofencingZones",
     GeofencingZones
   );
-  private static final LayerParams EDGES = new LayerParams("edges", Edges);
-  private static final LayerParams VERTICES = new LayerParams("vertices", Edges);
+  private static final LayerParams EDGES = new LayerParams("edges", Edge);
+  private static final LayerParams VERTICES = new LayerParams("vertices", Vertex);
   private static final List<LayerParameters<LayerType>> DEBUG_LAYERS = List.of(
     REGULAR_STOPS,
     AREA_STOPS,
     GEOFENCING_ZONES,
-    EDGES
+    EDGES,
+    VERTICES
   );
 
   private final OtpServerRequestContext serverContext;
@@ -133,12 +135,13 @@ public class GraphInspectorVectorTileResource {
     );
     var streetSource = new VectorSource(
       "street",
-      tileJsonUrl(base, List.of(EDGES, GEOFENCING_ZONES))
+      tileJsonUrl(base, List.of(EDGES, GEOFENCING_ZONES, VERTICES))
     );
 
     return DebugStyleSpec.build(
       REGULAR_STOPS.toVectorSourceLayer(stopsSource),
-      EDGES.toVectorSourceLayer(streetSource)
+      EDGES.toVectorSourceLayer(streetSource),
+      VERTICES.toVectorSourceLayer(streetSource)
     );
   }
 
@@ -182,8 +185,8 @@ public class GraphInspectorVectorTileResource {
         e -> context.transitService().findAreaStops(e)
       );
       case GeofencingZones -> new GeofencingZonesLayerBuilder(context.graph(), layerParameters);
-      case Edges -> new EdgeLayerBuilder(context.graph(), layerParameters);
-      case Vertices -> new VertexLayerBuilder(context.graph(), layerParameters);
+      case Edge -> new EdgeLayerBuilder(context.graph(), layerParameters);
+      case Vertex -> new VertexLayerBuilder(context.graph(), layerParameters);
     };
   }
 }

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerParams.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerParams.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.apis.vectortiles.model;
 
-import org.opentripplanner.apis.vectortiles.DebugStyleSpec.VectorSourceLayer;
 import org.opentripplanner.apis.vectortiles.model.TileSource.VectorSource;
 import org.opentripplanner.inspector.vector.LayerParameters;
 

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerStyleBuilder.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerStyleBuilder.java
@@ -24,6 +24,8 @@ public class LayerStyleBuilder {
   private static final String SOURCE_LAYER = "source-layer";
   private final Map<String, Object> props = new LinkedHashMap<>();
   private final Map<String, Object> paint = new LinkedHashMap<>();
+  private final Map<String, Object> layout = new LinkedHashMap<>();
+  private final Map<String, Object> line = new LinkedHashMap<>();
   private List<String> filter = List.of();
 
   public static LayerStyleBuilder ofId(String id) {
@@ -34,6 +36,8 @@ public class LayerStyleBuilder {
     source(source.vectorSource());
     return sourceLayer(source.vectorLayer());
   }
+
+
 
   public enum LayerType {
     Circle,
@@ -82,7 +86,9 @@ public class LayerStyleBuilder {
   }
 
   public LayerStyleBuilder typeLine() {
-    return type(LayerType.Line);
+    type(LayerType.Line);
+    line.put("line-cap", "round");
+    return this;
   }
 
   private LayerStyleBuilder type(LayerType type) {
@@ -98,6 +104,11 @@ public class LayerStyleBuilder {
   public LayerStyleBuilder circleStroke(String color, int width) {
     paint.put("circle-stroke-color", validateColor(color));
     paint.put("circle-stroke-width", width);
+    return this;
+  }
+
+  public LayerStyleBuilder circleRadius(ZoomDependentNumber radius) {
+    paint.put("circle-radius", radius.toJson());
     return this;
   }
 
@@ -118,6 +129,11 @@ public class LayerStyleBuilder {
     return this;
   }
 
+  public LayerStyleBuilder intiallyHidden() {
+    layout.put("visibility", "none");
+    return this;
+  }
+
   // filtering edge
   @SafeVarargs
   public final LayerStyleBuilder edgeFilter(Class<? extends Edge>... classToFilter) {
@@ -135,6 +151,12 @@ public class LayerStyleBuilder {
     }
     if (!filter.isEmpty()) {
       copy.put("filter", filter);
+    }
+    if (!layout.isEmpty()) {
+      copy.put("layout", layout);
+    }
+    if (!line.isEmpty()) {
+      copy.put("line", line);
     }
     return OBJECT_MAPPER.valueToTree(copy);
   }

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerStyleBuilder.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerStyleBuilder.java
@@ -37,8 +37,6 @@ public class LayerStyleBuilder {
     return sourceLayer(source.vectorLayer());
   }
 
-
-
   public enum LayerType {
     Circle,
     Line,

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerType.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerType.java
@@ -4,6 +4,6 @@ public enum LayerType {
   RegularStop,
   AreaStop,
   GeofencingZones,
-  Edges,
-  Vertices
+  Edge,
+  Vertex,
 }

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerType.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerType.java
@@ -5,4 +5,5 @@ public enum LayerType {
   AreaStop,
   GeofencingZones,
   Edges,
+  Vertices
 }

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerType.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/LayerType.java
@@ -4,4 +4,5 @@ public enum LayerType {
   RegularStop,
   AreaStop,
   GeofencingZones,
+  Edges,
 }

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
@@ -104,6 +104,12 @@ public class StyleBuilder {
     return this;
   }
 
+  public StyleBuilder circleStroke(String color, ZoomDependentNumber width) {
+    paint.put("circle-stroke-color", validateColor(color));
+    paint.put("circle-stroke-width", width.toJson());
+    return this;
+  }
+
   public StyleBuilder circleRadius(ZoomDependentNumber radius) {
     paint.put("circle-radius", radius.toJson());
     return this;

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleSpec.java
@@ -2,6 +2,7 @@ package org.opentripplanner.apis.vectortiles.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,13 +16,13 @@ import java.util.Map;
 public final class StyleSpec {
 
   private final String name;
-  private final List<TileSource> sources;
+  private final Collection<TileSource> sources;
   private final List<JsonNode> layers;
 
-  public StyleSpec(String name, List<TileSource> sources, List<LayerStyleBuilder> layers) {
+  public StyleSpec(String name, Collection<TileSource> sources, List<StyleBuilder> layers) {
     this.name = name;
     this.sources = sources;
-    this.layers = layers.stream().map(LayerStyleBuilder::toJson).toList();
+    this.layers = layers.stream().map(StyleBuilder::toJson).toList();
   }
 
   @JsonSerialize

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/TileSource.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/TileSource.java
@@ -26,7 +26,7 @@ public sealed interface TileSource {
    * Represents a raster-based source for map tiles. These are used mainly for background
    * map layers with vector data being rendered on top of it.
    */
-  record RasterSource(String id, List<String> tiles, int tileSize, String attribution)
+  record RasterSource(String id, List<String> tiles, int maxzoom, int tileSize, String attribution)
     implements TileSource {
     @Override
     public String type() {

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/VectorSourceLayer.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/VectorSourceLayer.java
@@ -1,0 +1,8 @@
+package org.opentripplanner.apis.vectortiles.model;
+
+/**
+ * A vector source layer for use in a Maplibre style spec. It contains both the name of the layer
+ * inside the tile and a reference to the source (which in turn has the URL where to fetch the
+ * data).
+ */
+public record VectorSourceLayer(TileSource.VectorSource vectorSource, String vectorLayer) {}

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/ZoomDependentNumber.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/ZoomDependentNumber.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.apis.vectortiles.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.opentripplanner.framework.json.ObjectMappers;
+
+/**
+ * A style parameter that allows you to specify a number that changes dependent on the zoom level.
+ */
+public record ZoomDependentNumber(float base, List<ZoomStop> stops) {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.ignoringExtraFields();
+  public JsonNode toJson() {
+    var props = new LinkedHashMap<>();
+    props.put("base", base);
+    var vals = stops.stream().map(ZoomStop::toList).toList();
+    props.put("stops", vals);
+    return OBJECT_MAPPER.valueToTree(props);
+  }
+
+  /**
+   * @param zoom The zoom level.
+   * @param value What the value should be at the specified zoom.
+   */
+  public record ZoomStop(int zoom, float value) {
+    public List<Number> toList() {
+      return List.of(zoom, value);
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/inspector/vector/edge/EdgeLayerBuilder.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/edge/EdgeLayerBuilder.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.inspector.vector.edges;
+package org.opentripplanner.inspector.vector.edge;
 
 import java.util.List;
 import org.locationtech.jts.geom.Envelope;
@@ -9,6 +9,9 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.index.StreetIndex;
 import org.opentripplanner.street.model.edge.Edge;
 
+/**
+ * Selects all edges to be displayed for debugging.
+ */
 public class EdgeLayerBuilder extends LayerBuilder<Edge> {
 
   private final StreetIndex streetIndex;

--- a/src/main/java/org/opentripplanner/inspector/vector/edge/EdgePropertyMapper.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/edge/EdgePropertyMapper.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.inspector.vector.edges;
+package org.opentripplanner.inspector.vector.edge;
 
 import static org.opentripplanner.framework.lang.DoubleUtils.roundTo2Decimals;
 import static org.opentripplanner.inspector.vector.KeyValue.kv;

--- a/src/main/java/org/opentripplanner/inspector/vector/edges/EdgeLayerBuilder.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/edges/EdgeLayerBuilder.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.inspector.vector.edges;
+
+import java.util.List;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.inspector.vector.LayerBuilder;
+import org.opentripplanner.inspector.vector.LayerParameters;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.index.StreetIndex;
+import org.opentripplanner.street.model.edge.Edge;
+
+public class EdgeLayerBuilder extends LayerBuilder<Edge> {
+
+  private final StreetIndex streetIndex;
+
+  public EdgeLayerBuilder(Graph graph, LayerParameters layerParameters) {
+    super(new EdgePropertyMapper(), layerParameters.name(), layerParameters.expansionFactor());
+    this.streetIndex = graph.getStreetIndex();
+  }
+
+  @Override
+  protected List<Geometry> getGeometries(Envelope query) {
+    return streetIndex
+      .getEdgesForEnvelope(query)
+      .stream()
+      .filter(e -> e.getGeometry() != null)
+      .map(edge -> {
+        Geometry geometry = edge.getGeometry();
+        geometry.setUserData(edge);
+        return geometry;
+      })
+      .toList();
+  }
+}

--- a/src/main/java/org/opentripplanner/inspector/vector/edges/EdgePropertyMapper.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/edges/EdgePropertyMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.inspector.vector.edges;
 
+import static org.opentripplanner.framework.lang.DoubleUtils.roundTo2Decimals;
 import static org.opentripplanner.inspector.vector.KeyValue.kv;
 
 import java.util.Collection;
@@ -20,7 +21,7 @@ public class EdgePropertyMapper extends PropertyMapper<Edge> {
       switch (input) {
         case StreetEdge e -> List.of(
           kv("permission", e.getPermission().toString()),
-          kv("bicycleSafetyFactor", e.getBicycleSafetyFactor())
+          kv("bicycleSafetyFactor", roundTo2Decimals(e.getBicycleSafetyFactor()))
         );
         case EscalatorEdge e -> List.of(kv("distance", e.getDistanceMeters()));
         default -> List.of();

--- a/src/main/java/org/opentripplanner/inspector/vector/edges/EdgePropertyMapper.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/edges/EdgePropertyMapper.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.inspector.vector.edges;
+
+import static org.opentripplanner.inspector.vector.KeyValue.kv;
+
+import java.util.Collection;
+import java.util.List;
+import org.opentripplanner.apis.support.mapping.PropertyMapper;
+import org.opentripplanner.framework.collection.ListUtils;
+import org.opentripplanner.inspector.vector.KeyValue;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.EscalatorEdge;
+import org.opentripplanner.street.model.edge.StreetEdge;
+
+public class EdgePropertyMapper extends PropertyMapper<Edge> {
+
+  @Override
+  protected Collection<KeyValue> map(Edge input) {
+    List<KeyValue> baseProps = List.of(kv("class", input.getClass().getSimpleName()));
+    List<KeyValue> properties =
+      switch (input) {
+        case StreetEdge e -> List.of(
+          kv("permission", e.getPermission().toString()),
+          kv("bicycleSafetyFactor", e.getBicycleSafetyFactor())
+        );
+        case EscalatorEdge e -> List.of(kv("distance", e.getDistanceMeters()));
+        default -> List.of();
+      };
+    return ListUtils.combine(baseProps, properties);
+  }
+}

--- a/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexLayerBuilder.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexLayerBuilder.java
@@ -3,6 +3,7 @@ package org.opentripplanner.inspector.vector.vertex;
 import java.util.List;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.inspector.vector.LayerBuilder;
 import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.routing.graph.Graph;
@@ -24,12 +25,11 @@ public class VertexLayerBuilder extends LayerBuilder<Vertex> {
   @Override
   protected List<Geometry> getGeometries(Envelope query) {
     return streetIndex
-      .getEdgesForEnvelope(query)
+      .getVerticesForEnvelope(query)
       .stream()
-      .filter(e -> e.getGeometry() != null)
-      .map(edge -> {
-        Geometry geometry = edge.getGeometry();
-        geometry.setUserData(edge);
+      .map(vertex -> {
+        Geometry geometry = GeometryUtils.getGeometryFactory().createPoint(vertex.getCoordinate());
+        geometry.setUserData(vertex);
         return geometry;
       })
       .toList();

--- a/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexLayerBuilder.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexLayerBuilder.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.inspector.vector.vertex;
+
+import java.util.List;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.inspector.vector.LayerBuilder;
+import org.opentripplanner.inspector.vector.LayerParameters;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.index.StreetIndex;
+import org.opentripplanner.street.model.vertex.Vertex;
+
+/**
+ * Selects all vertices to be displayed for debugging.
+ */
+public class VertexLayerBuilder extends LayerBuilder<Vertex> {
+
+  private final StreetIndex streetIndex;
+
+  public VertexLayerBuilder(Graph graph, LayerParameters layerParameters) {
+    super(new VertexPropertyMapper(), layerParameters.name(), layerParameters.expansionFactor());
+    this.streetIndex = graph.getStreetIndex();
+  }
+
+  @Override
+  protected List<Geometry> getGeometries(Envelope query) {
+    return streetIndex
+      .getEdgesForEnvelope(query)
+      .stream()
+      .filter(e -> e.getGeometry() != null)
+      .map(edge -> {
+        Geometry geometry = edge.getGeometry();
+        geometry.setUserData(edge);
+        return geometry;
+      })
+      .toList();
+  }
+}

--- a/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
@@ -15,12 +15,13 @@ public class VertexPropertyMapper extends PropertyMapper<Vertex> {
 
   @Override
   protected Collection<KeyValue> map(Vertex input) {
-    List<KeyValue> baseProps = List.of(kv("class", input.getClass().getSimpleName()));
+    List<KeyValue> baseProps = List.of(
+      kv("class", input.getClass().getSimpleName()),
+      kv("label", input.getLabel().toString())
+    );
     List<KeyValue> properties =
       switch (input) {
-        case BarrierVertex v -> List.of(
-          kv("permission", v.getBarrierPermissions().toString())
-        );
+        case BarrierVertex v -> List.of(kv("permission", v.getBarrierPermissions().toString()));
         case VehicleRentalPlaceVertex v -> List.of(kv("rentalId", v.getStation().getId()));
         default -> List.of();
       };

--- a/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
+++ b/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.inspector.vector.vertex;
+
+import static org.opentripplanner.inspector.vector.KeyValue.kv;
+
+import java.util.Collection;
+import java.util.List;
+import org.opentripplanner.apis.support.mapping.PropertyMapper;
+import org.opentripplanner.framework.collection.ListUtils;
+import org.opentripplanner.inspector.vector.KeyValue;
+import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;
+import org.opentripplanner.street.model.vertex.BarrierVertex;
+import org.opentripplanner.street.model.vertex.Vertex;
+
+public class VertexPropertyMapper extends PropertyMapper<Vertex> {
+
+  @Override
+  protected Collection<KeyValue> map(Vertex input) {
+    List<KeyValue> baseProps = List.of(kv("class", input.getClass().getSimpleName()));
+    List<KeyValue> properties =
+      switch (input) {
+        case BarrierVertex v -> List.of(
+          kv("permission", v.getBarrierPermissions().toString())
+        );
+        case VehicleRentalPlaceVertex v -> List.of(kv("rentalId", v.getStation().getId()));
+        default -> List.of();
+      };
+    return ListUtils.combine(baseProps, properties);
+  }
+}

--- a/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -10,7 +10,7 @@ import org.opentripplanner.test.support.ResourceLoader;
 
 class DebugStyleSpecTest {
 
-  private final ResourceLoader RES = ResourceLoader.of(this);
+  private final ResourceLoader RESOURCES = ResourceLoader.of(this);
 
   @Test
   void spec() {
@@ -20,7 +20,7 @@ class DebugStyleSpecTest {
     var spec = DebugStyleSpec.build(vectorSource, regularStops, edges);
 
     var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);
-    var expectation = RES.fileToString("style.json");
+    var expectation = RESOURCES.fileToString("style.json");
     assertEqualJson(expectation, json);
   }
 }

--- a/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -3,8 +3,8 @@ package org.opentripplanner.apis.vectortiles;
 import static org.opentripplanner.test.support.JsonAssertions.assertEqualJson;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.apis.vectortiles.DebugStyleSpec.VectorSourceLayer;
 import org.opentripplanner.apis.vectortiles.model.TileSource.VectorSource;
+import org.opentripplanner.apis.vectortiles.model.VectorSourceLayer;
 import org.opentripplanner.framework.json.ObjectMappers;
 import org.opentripplanner.test.support.ResourceLoader;
 
@@ -15,9 +15,9 @@ class DebugStyleSpecTest {
   @Test
   void spec() {
     var vectorSource = new VectorSource("vectorSource", "https://example.com");
-    var regularStops = new VectorSourceLayer(vectorSource, "regularStops");
+    var stops = new VectorSourceLayer(vectorSource, "stops");
     var edges = new VectorSourceLayer(vectorSource, "edges");
-    var spec = DebugStyleSpec.build(vectorSource, regularStops, edges);
+    var spec = DebugStyleSpec.build(stops, edges);
 
     var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);
     var expectation = RESOURCES.fileToString("style.json");

--- a/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -16,7 +16,8 @@ class DebugStyleSpecTest {
   void spec() {
     var vectorSource = new VectorSource("vectorSource", "https://example.com");
     var regularStops = new VectorSourceLayer(vectorSource, "regularStops");
-    var spec = DebugStyleSpec.build(vectorSource, regularStops);
+    var edges = new VectorSourceLayer(vectorSource, "edges");
+    var spec = DebugStyleSpec.build(vectorSource, regularStops, edges);
 
     var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);
     var expectation = RES.fileToString("style.json");

--- a/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -17,7 +17,8 @@ class DebugStyleSpecTest {
     var vectorSource = new VectorSource("vectorSource", "https://example.com");
     var stops = new VectorSourceLayer(vectorSource, "stops");
     var edges = new VectorSourceLayer(vectorSource, "edges");
-    var spec = DebugStyleSpec.build(stops, edges, VERTICES.toVectorSourceLayer(streetSource));
+    var vertices = new VectorSourceLayer(vectorSource, "vertices");
+    var spec = DebugStyleSpec.build(stops, edges, vertices);
 
     var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);
     var expectation = RESOURCES.fileToString("style.json");

--- a/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -17,7 +17,7 @@ class DebugStyleSpecTest {
     var vectorSource = new VectorSource("vectorSource", "https://example.com");
     var stops = new VectorSourceLayer(vectorSource, "stops");
     var edges = new VectorSourceLayer(vectorSource, "edges");
-    var spec = DebugStyleSpec.build(stops, edges);
+    var spec = DebugStyleSpec.build(stops, edges, VERTICES.toVectorSourceLayer(streetSource));
 
     var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);
     var expectation = RESOURCES.fileToString("style.json");

--- a/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -1,4 +1,5 @@
 {
+
   "name" : "OTP Debug Tiles",
   "sources" : {
     "background" : {
@@ -6,6 +7,7 @@
       "tiles" : [
         "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
       ],
+      "maxzoom" : 19,
       "tileSize" : 256,
       "attribution" : "© OpenStreetMap Contributors",
       "type" : "raster"
@@ -24,30 +26,6 @@
       "minzoom" : 0
     },
     {
-      "id" : "edge-fallback",
-      "type" : "line",
-      "source" : "vectorSource",
-      "source-layer" : "edges",
-      "minzoom" : 15,
-      "maxzoom" : 23,
-      "paint" : {
-        "line-color" : "#8e8e89",
-        "line-width" : {
-          "base" : 1.3,
-          "stops" : [
-            [
-              13,
-              2.0
-            ],
-            [
-              23,
-              10.0
-            ]
-          ]
-        }
-      }
-    },
-    {
       "id" : "edge",
       "type" : "line",
       "source" : "vectorSource",
@@ -61,7 +39,7 @@
           "stops" : [
             [
               13,
-              2.0
+              0.5
             ],
             [
               23,
@@ -76,9 +54,15 @@
         "StreetEdge",
         "AreaEdge",
         "EscalatorEdge",
+        "PathwayEdge",
+        "ElevatorHopEdge",
         "TemporaryPartialStreetEdge",
         "TemporaryFreeEdge"
-      ]
+      ],
+      "layout" : {
+        "line-cap" : "round",
+        "visibility" : "none"
+      }
     },
     {
       "id" : "link",
@@ -88,13 +72,13 @@
       "minzoom" : 13,
       "maxzoom" : 23,
       "paint" : {
-        "line-color" : "#e2d40d",
+        "line-color" : "#22DD9E",
         "line-width" : {
           "base" : 1.3,
           "stops" : [
             [
               13,
-              2.0
+              0.5
             ],
             [
               23,
@@ -111,18 +95,35 @@
         "BoardingLocationToStopLink",
         "StreetVehicleRentalLink",
         "StreetVehicleParkingLink"
-      ]
+      ],
+      "layout" : {
+        "line-cap" : "round",
+        "visibility" : "none"
+      }
     },
     {
       "id" : "regular-stop",
       "type" : "circle",
       "source" : "vectorSource",
-      "source-layer" : "regularStops",
-      "minzoom" : 11,
+      "source-layer" : "stops",
+      "minzoom" : 10,
       "maxzoom" : 23,
       "paint" : {
         "circle-stroke-color" : "#140d0e",
         "circle-stroke-width" : 2,
+        "circle-radius" : {
+          "base" : 1.0,
+          "stops" : [
+            [
+              11,
+              1.0
+            ],
+            [
+              23,
+              10.0
+            ]
+          ]
+        },
         "circle-color" : "#fcf9fa"
       }
     }

--- a/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -1,5 +1,4 @@
 {
-
   "name" : "OTP Debug Tiles",
   "sources" : {
     "background" : {
@@ -98,6 +97,47 @@
       ],
       "layout" : {
         "line-cap" : "round",
+        "visibility" : "none"
+      }
+    },
+    {
+      "id" : "vertex",
+      "type" : "circle",
+      "source" : "vectorSource",
+      "source-layer" : "vertices",
+      "minzoom" : 15,
+      "maxzoom" : 23,
+      "paint" : {
+        "circle-stroke-color" : "#140d0e",
+        "circle-stroke-width" : {
+          "base" : 1.0,
+          "stops" : [
+            [
+              15,
+              0.2
+            ],
+            [
+              23,
+              3.0
+            ]
+          ]
+        },
+        "circle-radius" : {
+          "base" : 1.0,
+          "stops" : [
+            [
+              15,
+              1.0
+            ],
+            [
+              23,
+              7.0
+            ]
+          ]
+        },
+        "circle-color" : "#BC55F2"
+      },
+      "layout" : {
         "visibility" : "none"
       }
     },

--- a/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -1,42 +1,131 @@
 {
-  "name": "OTP Debug Tiles",
-  "sources": {
-    "background": {
-      "id": "background",
-      "tiles": [
+  "name" : "OTP Debug Tiles",
+  "sources" : {
+    "background" : {
+      "id" : "background",
+      "tiles" : [
         "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
       ],
-      "tileSize": 256,
+      "tileSize" : 256,
       "attribution" : "© OpenStreetMap Contributors",
-      "type": "raster"
+      "type" : "raster"
     },
-    "vectorSource": {
-      "id": "vectorSource",
-      "url": "https://example.com",
-      "type": "vector"
+    "vectorSource" : {
+      "id" : "vectorSource",
+      "url" : "https://example.com",
+      "type" : "vector"
     }
   },
-  "layers": [
+  "layers" : [
     {
-      "id": "background",
-      "source": "background",
-      "type": "raster",
-      "maxzoom": 22,
-      "minzoom": 0
+      "id" : "background",
+      "type" : "raster",
+      "source" : "background",
+      "minzoom" : 0
     },
     {
-      "maxzoom": 22,
-      "paint": {
-        "circle-stroke-width": 2,
-        "circle-color": "#fcf9fa",
-        "circle-stroke-color": "#140d0e"
+      "id" : "edge-fallback",
+      "type" : "line",
+      "source" : "vectorSource",
+      "source-layer" : "edges",
+      "minzoom" : 15,
+      "maxzoom" : 23,
+      "paint" : {
+        "line-color" : "#8e8e89",
+        "line-width" : {
+          "base" : 1.3,
+          "stops" : [
+            [
+              13,
+              2.0
+            ],
+            [
+              23,
+              10.0
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id" : "edge",
+      "type" : "line",
+      "source" : "vectorSource",
+      "source-layer" : "edges",
+      "minzoom" : 13,
+      "maxzoom" : 23,
+      "paint" : {
+        "line-color" : "#f21d52",
+        "line-width" : {
+          "base" : 1.3,
+          "stops" : [
+            [
+              13,
+              2.0
+            ],
+            [
+              23,
+              10.0
+            ]
+          ]
+        }
       },
-      "id": "regular-stop",
-      "source": "vectorSource",
-      "source-layer": "regularStops",
-      "type": "circle",
-      "minzoom": 13
+      "filter" : [
+        "in",
+        "class",
+        "StreetEdge",
+        "AreaEdge",
+        "EscalatorEdge",
+        "TemporaryPartialStreetEdge",
+        "TemporaryFreeEdge"
+      ]
+    },
+    {
+      "id" : "link",
+      "type" : "line",
+      "source" : "vectorSource",
+      "source-layer" : "edges",
+      "minzoom" : 13,
+      "maxzoom" : 23,
+      "paint" : {
+        "line-color" : "#e2d40d",
+        "line-width" : {
+          "base" : 1.3,
+          "stops" : [
+            [
+              13,
+              2.0
+            ],
+            [
+              23,
+              10.0
+            ]
+          ]
+        }
+      },
+      "filter" : [
+        "in",
+        "class",
+        "StreetTransitStopLink",
+        "StreetTransitEntranceLink",
+        "BoardingLocationToStopLink",
+        "StreetVehicleRentalLink",
+        "StreetVehicleParkingLink"
+      ]
+    },
+    {
+      "id" : "regular-stop",
+      "type" : "circle",
+      "source" : "vectorSource",
+      "source-layer" : "regularStops",
+      "minzoom" : 11,
+      "maxzoom" : 23,
+      "paint" : {
+        "circle-stroke-color" : "#140d0e",
+        "circle-stroke-width" : 2,
+        "circle-color" : "#fcf9fa"
+      }
     }
   ],
-  "version": 8
+  "version" : 8
 }


### PR DESCRIPTION
### Summary

This iteration adds switchable debug layers for edges to the Debug UI.

![image](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/007a7b9f-fcb0-4fcb-afc3-79e0261663f2)

I expect there to be many more iterations where we add more layers, styles and information to help debugging.

I also implemented an automatic pan to the area defined by the world envelope service.

### Issue

#5330 

### Unit tests

Updated.