### PR TITLE
Revert REST API spelling change of real-time

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/restapi/mapping/TripTimeMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/mapping/TripTimeMapper.java
@@ -29,13 +29,13 @@ public class TripTimeMapper {
     api.stopCount = domain.getStopCount();
     api.scheduledArrival = domain.getScheduledArrival();
     api.scheduledDeparture = domain.getScheduledDeparture();
-    api.realTimeArrival = domain.getRealtimeArrival();
-    api.realTimeDeparture = domain.getRealtimeDeparture();
+    api.realimeArrival = domain.getRealtimeArrival();
+    api.realtimeDeparture = domain.getRealtimeDeparture();
     api.arrivalDelay = domain.getArrivalDelay();
     api.departureDelay = domain.getDepartureDelay();
     api.timepoint = domain.isTimepoint();
-    api.realTime = domain.isRealtime();
-    api.realTimeState = ApiRealTimeState.RealTimeState(domain.getRealTimeState());
+    api.realtime = domain.isRealtime();
+    api.realtimeState = ApiRealTimeState.RealTimeState(domain.getRealTimeState());
     api.blockId = domain.getBlockId();
     api.headsign = I18NStringMapper.mapToApi(domain.getHeadsign(), null);
     api.tripId = FeedScopedIdMapper.mapToApi(domain.getTrip().getId());

--- a/src/ext/java/org/opentripplanner/ext/restapi/model/ApiTripTimeShort.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/model/ApiTripTimeShort.java
@@ -11,13 +11,13 @@ public class ApiTripTimeShort implements Serializable {
   public int stopCount;
   public int scheduledArrival = UNDEFINED;
   public int scheduledDeparture = UNDEFINED;
-  public int realTimeArrival = UNDEFINED;
-  public int realTimeDeparture = UNDEFINED;
+  public int realimeArrival = UNDEFINED;
+  public int realtimeDeparture = UNDEFINED;
   public int arrivalDelay = UNDEFINED;
   public int departureDelay = UNDEFINED;
   public boolean timepoint = false;
-  public boolean realTime = false;
-  public ApiRealTimeState realTimeState = ApiRealTimeState.SCHEDULED;
+  public boolean realtime = false;
+  public ApiRealTimeState realtimeState = ApiRealTimeState.SCHEDULED;
   public long serviceDay;
   public String tripId;
   public String blockId;

--- a/src/ext/java/org/opentripplanner/ext/restapi/model/ApiVehicleParkingWithEntrance.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/model/ApiVehicleParkingWithEntrance.java
@@ -81,7 +81,7 @@ public class ApiVehicleParkingWithEntrance {
   /**
    * True if real-time information is used for checking availability.
    */
-  public final boolean realTime;
+  public final boolean realtime;
 
   ApiVehicleParkingWithEntrance(
     String id,
@@ -114,7 +114,7 @@ public class ApiVehicleParkingWithEntrance {
     this.hasWheelchairAccessibleCarPlaces = hasWheelchairAccessibleCarPlaces;
     this.capacity = capacity;
     this.availability = availability;
-    this.realTime = realTime;
+    this.realtime = realTime;
   }
 
   public static ApiVehicleParkingWithEntranceBuilder builder() {

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/CarSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/CarSnapshotTest.snap
@@ -106,7 +106,7 @@ org.opentripplanner.routing.algorithm.mapping.CarSnapshotTest.directCarPark=[
               "hasWheelchairAccessibleCarPlaces" : false,
               "id" : "OSM:OSMWay/-102488",
               "name" : "P+R",
-              "realTime" : false,
+              "realtime" : false,
               "tags" : [
                 "osm:amenity=parking"
               ]
@@ -137,7 +137,7 @@ org.opentripplanner.routing.algorithm.mapping.CarSnapshotTest.directCarPark=[
               "hasWheelchairAccessibleCarPlaces" : false,
               "id" : "OSM:OSMWay/-102488",
               "name" : "P+R",
-              "realTime" : false,
+              "realtime" : false,
               "tags" : [
                 "osm:amenity=parking"
               ]


### PR DESCRIPTION
### Summary

#5535 has inadvertently introduced a breaking change to the REST API by changing the spelling of `realtime` to `realTime` in the API model classes.

This has caused some IBI frontend code to break, therefore I'm reverting this change.  


@amy-corson-ibigroup Can you confirm that it's correct now?

cc @miles-grant-ibigroup @daniel-heppner-ibigroup 