### PR TITLE
Create edge namer that sets names to OSM way IDs

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/services/osm/EdgeNamer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/osm/EdgeNamer.java
@@ -65,6 +65,7 @@ public interface EdgeNamer {
 
       return switch (type) {
         case "portland" -> new PortlandCustomNamer();
+        case "osmid" -> new OsmIdNamer();
         default -> throw new IllegalArgumentException(
           String.format("Unknown osmNaming type: '%s'", type)
         );

--- a/src/main/java/org/opentripplanner/graph_builder/services/osm/OsmIdNamer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/osm/OsmIdNamer.java
@@ -6,10 +6,19 @@ import org.opentripplanner.openstreetmap.model.OSMWithTags;
 import org.opentripplanner.street.model.edge.StreetEdge;
 
 public class OsmIdNamer implements EdgeNamer {
+
   @Override
-  public I18NString name(OSMWithTags way) { return new NonLocalizedString(Long.toString(way.getId())); }
+  public I18NString name(OSMWithTags way) {
+    return new NonLocalizedString(Long.toString(way.getId()));
+  }
+
   @Override
-  public void recordEdge(OSMWithTags way, StreetEdge edge) { return;}
+  public void recordEdge(OSMWithTags way, StreetEdge edge) {
+    return;
+  }
+
   @Override
-  public void postprocess() { return; }
+  public void postprocess() {
+    return;
+  }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/services/osm/OsmIdNamer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/osm/OsmIdNamer.java
@@ -1,0 +1,15 @@
+package org.opentripplanner.graph_builder.services.osm;
+
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.framework.i18n.NonLocalizedString;
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.opentripplanner.street.model.edge.StreetEdge;
+
+public class OsmIdNamer implements EdgeNamer {
+  @Override
+  public I18NString name(OSMWithTags way) { return new NonLocalizedString(Long.toString(way.getId())); }
+  @Override
+  public void recordEdge(OSMWithTags way, StreetEdge edge) { return;}
+  @Override
+  public void postprocess() { return; }
+}


### PR DESCRIPTION
### Summary

The end goal here is to allow a user of the trip planning API to see street portions of the itinerary in terms of OSM way IDs instead of human readable street names. Users commented on the mailing list and Gitter chat that they were performing geographic matching of OTP output against OSM data to guess which ways were being traveled over. This is a roundabout and error-prone way to get information that is already unambiguously available within OTP. Any small change to expose this data could greatly improve some users' experience of working with OTP.

This is a DRAFT PR demonstrating a very basic idea, which may be sufficient for the few people who have asked about it, but may also require some more work to be suitable for inclusion in OTP.

The namer can be enabled by adding ` "osmNaming": "osmid"` to build-config.json.

### Explanation

Paraphrasing from the Gitter chat:
@t2gran suggested adding numeric IDs as a new field within OTP's data model. Something like this is probably the cleanest long-term solution (see below). However, the text name of streets in OSM sometimes already includes the OSM ID so this is a promising route. In OsmModule.java line 522 we've got:

```
String label = "way " + way.getId() + " from " + index;
label = label.intern();
I18NString name = params.edgeNamer().getNameForWay(way, label);
```

The name of each edge is created by the EdgeNamer, and if it can't figure out the real name, it falls back on a string containing the OSM ID and the index of the node within that way. The EdgeNamer is pluggable (we have a DefaultNamer and a PortlandCustomNamer). It is then possible to make an OsmIdNamer that just names every edge after its OSM ID.
The specific edgeNamer can be set in the build-config with the parameter osmNaming, which selects specific kinds of namers in EdgeNamer.EdgeNamerFactory#fromConfig().

Alternatively, instead of the new namer module generating way ID strings it could just return null, in which case OsmModule will just fall back on the default `way 1234 from 0` style labels.

### Testing

This has been tested locally and appears to work as intended. Returned itineraries now contain OSM way IDs instead of street names. See screen capture below:
<img width="665" alt="image" src="https://github.com/opentripplanner/OpenTripPlanner/assets/112871/fa0ef0a5-bb68-4a72-8e09-a3f6ed0c006f">

No unit tests or other tests were added.

### Commentary and Future Work

Space efficiency: the suggested patch stores the way IDs as Strings, which is non-ideal. OSM IDs these are often 10-digit numbers, so Strings will take something like 28 bytes as opposed to their 8 byte int64 representation. On the other hand, these are taking the place of existing name strings so the resulting in-memory / on-disk transit data size may not increase much if at all. Note that these strings are not deduplicated so multiple copies will be created even if they're identical. A look at Deduplicator.java seems to indicate that Strings are not being widely deduplicated elsewhere either, which may be considered a different issue. The reason these numeric IDs might be duplicates is that every street segment on the same OSM way will have the same ID. Which brings us to the next point.

Information completeness: there is still a loss of information here. The way ID is still not sufficiently detailed to really understand the path. A street edge in OTP is a section of an OSM way between two OSM nodes, which are not necessarily adjacent nodes, and each way can produce multiple edges. This could be resolved by expanding the names to `way 1234 from node 4633 to node 5435` or a compact parseable equivalent like `w1234 n4633 n5435` or even `1234, 4633, 5435`. However, this is packing even more numeric information into text fields, so while it would get the job done for some use cases it's not really a good long-term course of action (it may be preferable to invest in creating real numeric fields). Expanding the text names to include node IDs is not straightforward using the existing namer interface. That interface provides only the OSM way as a parameter, not the specific nodes at the beginning and end of the edge. So either a) the interface would need to be changed to pass in node information (not too bad since there are very few implementations); b) the default `label` string that is passed into `params.edgeNamer().getNameForWay(way, label)` could be changed to include the node IDs (or the vertices, of which one particular type have OSM node IDs present).

Numeric fields: It should be possible to read these off the vertices and edges and include them in the routing result in the StatesToWalkStepsMapper. In fact, importantly *we already have `long nodeId` on OsmVertex*. This kind of softens the point about space consumption since we're already storing the node IDs on vertices but just not the way IDs on edges. This way ID would probably be stored on StreetEdge if following the same approach as OsmVertex. Alternatively, all these OSM IDs could be stored in a map if they're only looked up at the end of the search to decorate itineraries; this would make them optional so not everyone has to store millions of 64 bit integers unless they need them for debugging or interfacing with another system. Note that vertexGenerator.getVertexForOsmNode returns an OsmVertex but this is immediately stored as a reference to its superclass IntersectionVertex so we lose sight of its nodeId field.

### Further notes

On org/opentripplanner/graph_builder/module/osm/OsmModule.java:521 we're calling string.intern() when a) this String probably won't appear more than once, as it contains a unique index number; b) we have our own string deduplicator that is not being used much; c) String.intern() is "broken" as mentioned on the Javadoc of that deduplicator class.

The EdgeNamer interface Javadoc could stand to be updated/expanded. The explanations "so more complicated names can be built in the post-processing step" and "Called after each edge has been named to build a more complex name" are not very clear, it's not obvious how they should be implemented, and it's not obvious that they can just return without doing anything (that only name() is actually necessary).