### PR TITLE
Add AreaStop layer to new debug frontend

### DIFF
--- a/client-next/src/components/MapView/MapView.tsx
+++ b/client-next/src/components/MapView/MapView.tsx
@@ -75,7 +75,7 @@ export function MapView({
         }}
         // it's unfortunate that you have to list these layers here.
         // maybe there is a way around it: https://github.com/visgl/react-map-gl/discussions/2343
-        interactiveLayerIds={['regular-stop', 'vertex', 'edge', 'link']}
+        interactiveLayerIds={['regular-stop', 'area-stop', 'vertex', 'edge', 'link']}
         onClick={showFeaturePropPopup}
         // put lat/long in URL and pan to it on page reload
         hash={true}

--- a/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -52,6 +52,7 @@ public class DebugStyleSpec {
 
   static StyleSpec build(
     VectorSourceLayer regularStops,
+    VectorSourceLayer areaStops,
     VectorSourceLayer edges,
     VectorSourceLayer vertices
   ) {
@@ -112,6 +113,15 @@ public class DebugStyleSpec {
           .minZoom(15)
           .maxZoom(MAX_ZOOM)
           .intiallyHidden(),
+        StyleBuilder
+          .ofId("area-stop")
+          .typeFill()
+          .vectorSourceLayer(areaStops)
+          .fillColor(GREEN)
+          .fillOpacity(0.5f)
+          .fillOutlineColor(BLACK)
+          .minZoom(6)
+          .maxZoom(MAX_ZOOM),
         StyleBuilder
           .ofId("regular-stop")
           .typeCircle()

--- a/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/GraphInspectorVectorTileResource.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.apis.vectortiles;
 
+import static org.opentripplanner.apis.vectortiles.model.LayerType.AreaStop;
 import static org.opentripplanner.apis.vectortiles.model.LayerType.Edge;
 import static org.opentripplanner.apis.vectortiles.model.LayerType.GeofencingZones;
 import static org.opentripplanner.apis.vectortiles.model.LayerType.RegularStop;
@@ -47,7 +48,7 @@ import org.opentripplanner.standalone.api.OtpServerRequestContext;
 public class GraphInspectorVectorTileResource {
 
   private static final LayerParams REGULAR_STOPS = new LayerParams("regularStops", RegularStop);
-  private static final LayerParams AREA_STOPS = new LayerParams("areaStops", LayerType.AreaStop);
+  private static final LayerParams AREA_STOPS = new LayerParams("areaStops", AreaStop);
   private static final LayerParams GEOFENCING_ZONES = new LayerParams(
     "geofencingZones",
     GeofencingZones
@@ -140,6 +141,7 @@ public class GraphInspectorVectorTileResource {
 
     return DebugStyleSpec.build(
       REGULAR_STOPS.toVectorSourceLayer(stopsSource),
+      AREA_STOPS.toVectorSourceLayer(stopsSource),
       EDGES.toVectorSourceLayer(streetSource),
       VERTICES.toVectorSourceLayer(streetSource)
     );

--- a/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
+++ b/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
@@ -40,6 +40,7 @@ public class StyleBuilder {
     Circle,
     Line,
     Raster,
+    Fill,
   }
 
   private StyleBuilder(String id) {
@@ -88,6 +89,11 @@ public class StyleBuilder {
     return this;
   }
 
+  public StyleBuilder typeFill() {
+    type(LayerType.Fill);
+    return this;
+  }
+
   private StyleBuilder type(LayerType type) {
     props.put(TYPE, type.name().toLowerCase());
     return this;
@@ -129,6 +135,21 @@ public class StyleBuilder {
 
   public StyleBuilder lineWidth(ZoomDependentNumber zoomStops) {
     paint.put("line-width", zoomStops.toJson());
+    return this;
+  }
+
+  public StyleBuilder fillColor(String color) {
+    paint.put("fill-color", validateColor(color));
+    return this;
+  }
+
+  public StyleBuilder fillOpacity(float opacity) {
+    paint.put("fill-opacity", opacity);
+    return this;
+  }
+
+  public StyleBuilder fillOutlineColor(String color) {
+    paint.put("fill-outline-color", validateColor(color));
     return this;
   }
 

--- a/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -15,10 +15,11 @@ class DebugStyleSpecTest {
   @Test
   void spec() {
     var vectorSource = new VectorSource("vectorSource", "https://example.com");
-    var stops = new VectorSourceLayer(vectorSource, "stops");
+    var regularStops = new VectorSourceLayer(vectorSource, "stops");
+    var areaStops = new VectorSourceLayer(vectorSource, "stops");
     var edges = new VectorSourceLayer(vectorSource, "edges");
     var vertices = new VectorSourceLayer(vectorSource, "vertices");
-    var spec = DebugStyleSpec.build(stops, edges, vertices);
+    var spec = DebugStyleSpec.build(regularStops, areaStops, edges, vertices);
 
     var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);
     var expectation = RESOURCES.fileToString("style.json");

--- a/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -142,6 +142,19 @@
       }
     },
     {
+      "id" : "area-stop",
+      "type" : "fill",
+      "source" : "vectorSource",
+      "source-layer" : "stops",
+      "minzoom" : 6,
+      "maxzoom" : 23,
+      "paint" : {
+        "fill-color" : "#22DD9E",
+        "fill-opacity" : 0.5,
+        "fill-outline-color" : "#140d0e"
+      }
+    },
+    {
       "id" : "regular-stop",
       "type" : "circle",
       "source" : "vectorSource",


### PR DESCRIPTION
### Summary

This PR adds the ability to draw the area of AreaStops onto the map in the new debug UI.

### Unit tests

Updated relevant tests and ran locally.

### Documentation

The same level of documentation as used elsewhere in the affected files.