### PR TITLE
Change Transmodel API path to `/otp/transmodel/v3`

### DIFF
--- a/docs/apis/TransmodelApi.md
+++ b/docs/apis/TransmodelApi.md
@@ -15,6 +15,8 @@ queries.
 
 When running OTP locally the endpoint is available at: `http://localhost:8080/otp/transmodel/v3`
 
+Note! Version `v1` and `v2` does not exist in the main OTP git repository, but in the (Entur fork)[https://github.com/entur/OpenTripPlanner] from which this code originate from.
+
 ### Configuration
 
 To turn this API off, add the feature `TransmodelGraphQlApi : false` in `otp-config.json`.

--- a/docs/apis/TransmodelApi.md
+++ b/docs/apis/TransmodelApi.md
@@ -13,12 +13,11 @@ Transmodel (NeTEx) with some limitations/simplification. It provides both a rout
 Entur provides a [GraphQL explorer](https://api.entur.io/graphql-explorer) where you may browse the GraphQL schema and try your own
 queries.
 
-When running OTP locally the endpoint is available at: `http://localhost:8080/otp/routers/default/transmodel/index/graphql`
+When running OTP locally the endpoint is available at: `http://localhost:8080/otp/transmodel/v3`
 
 ### Configuration
 
-To turn this API off, add the feature `TransmodelGraphQlApi : false` in _otp-config.json_.
-
+To turn this API off, add the feature `TransmodelGraphQlApi : false` in `otp-config.json`.
 
 ## Changelog - old
 

--- a/docs/apis/TransmodelApi.md
+++ b/docs/apis/TransmodelApi.md
@@ -15,7 +15,8 @@ queries.
 
 When running OTP locally the endpoint is available at: `http://localhost:8080/otp/transmodel/v3`
 
-Note! Version `v1` and `v2` does not exist in the main OTP git repository, but in the (Entur fork)[https://github.com/entur/OpenTripPlanner] from which this code originate from.
+**Note!** Versions `v1` and `v2` do not exist in the main OTP git repository, but in 
+the [Entur fork](https://github.com/entur/OpenTripPlanner) from which this code originates from.
 
 ### Configuration
 

--- a/src/client/graphiql/index.html
+++ b/src/client/graphiql/index.html
@@ -153,7 +153,7 @@ query TransmodelExampleQuery {
   let apiFlavor = parameters.flavor || "gtfs";
   let urls = {
     gtfs: '/otp/gtfs/v1',
-    transmodel: '/otp/routers/default/transmodel/index/graphql'
+    transmodel: '/otp/transmodel/v3'
   }
 
   let defaultQueries = {

--- a/src/main/java/org/opentripplanner/apis/APIEndpoints.java
+++ b/src/main/java/org/opentripplanner/apis/APIEndpoints.java
@@ -54,6 +54,8 @@ public class APIEndpoints {
     // scheduled to be removed and only here for backwards compatibility
     addIfEnabled(GtfsGraphQlApi, GtfsGraphQLAPI.GtfsGraphQLAPIOldPath.class);
     addIfEnabled(TransmodelGraphQlApi, TransmodelAPI.class);
+    // scheduled to be removed and only here for backwards compatibility
+    addIfEnabled(TransmodelGraphQlApi, TransmodelAPI.TransmodelAPIOldPath.class);
 
     // Sandbox extension APIs
     addIfEnabled(ActuatorAPI, ActuatorAPI.class);

--- a/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.opentripplanner.apis.gtfs.GtfsGraphQLAPI;
 import org.opentripplanner.apis.transmodel.mapping.TransitIdMapper;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -34,7 +33,6 @@ import org.slf4j.LoggerFactory;
 @Produces(MediaType.APPLICATION_JSON)
 public class TransmodelAPI {
 
-  @SuppressWarnings("unused")
   private static final Logger LOG = LoggerFactory.getLogger(TransmodelAPI.class);
 
   private static GraphQLSchema schema;
@@ -44,9 +42,7 @@ public class TransmodelAPI {
   private final TransmodelGraph index;
   private final ObjectMapper deserializer = new ObjectMapper();
 
-  public TransmodelAPI(
-    @Context OtpServerRequestContext serverContext
-  ) {
+  public TransmodelAPI(@Context OtpServerRequestContext serverContext) {
     this.serverContext = serverContext;
     this.index = new TransmodelGraph(schema);
   }
@@ -55,7 +51,7 @@ public class TransmodelAPI {
    * This class is only here for backwards-compatibility. It will be removed in the future.
    */
   @Path("/routers/{ignoreRouterId}/transmodel/index/graphql")
-  public static class TransmodelAPIOldPath extends GtfsGraphQLAPI {
+  public static class TransmodelAPIOldPath extends TransmodelAPI {
 
     public TransmodelAPIOldPath(
       @Context OtpServerRequestContext serverContext,

--- a/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
@@ -6,7 +6,6 @@ import io.micrometer.core.instrument.Tag;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -22,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.opentripplanner.apis.gtfs.GtfsGraphQLAPI;
 import org.opentripplanner.apis.transmodel.mapping.TransitIdMapper;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -30,11 +30,8 @@ import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO move to org.opentripplanner.api.resource, this is a Jersey resource class
-
-@Path("/routers/{ignoreRouterId}/transmodel/index")
-// It would be nice to get rid of the final /index.
-@Produces(MediaType.APPLICATION_JSON) // One @Produces annotation for all endpoints.
+@Path("/transmodel/v3")
+@Produces(MediaType.APPLICATION_JSON)
 public class TransmodelAPI {
 
   @SuppressWarnings("unused")
@@ -48,15 +45,24 @@ public class TransmodelAPI {
   private final ObjectMapper deserializer = new ObjectMapper();
 
   public TransmodelAPI(
-    @Context OtpServerRequestContext serverContext,
-    /**
-     * @deprecated The support for multiple routers are removed from OTP2.
-     * See https://github.com/opentripplanner/OpenTripPlanner/issues/2760
-     */
-    @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
+    @Context OtpServerRequestContext serverContext
   ) {
     this.serverContext = serverContext;
     this.index = new TransmodelGraph(schema);
+  }
+
+  /**
+   * This class is only here for backwards-compatibility. It will be removed in the future.
+   */
+  @Path("/routers/{ignoreRouterId}/transmodel/index/graphql")
+  public static class TransmodelAPIOldPath extends GtfsGraphQLAPI {
+
+    public TransmodelAPIOldPath(
+      @Context OtpServerRequestContext serverContext,
+      @PathParam("ignoreRouterId") String ignore
+    ) {
+      super(serverContext);
+    }
   }
 
   /**
@@ -77,17 +83,7 @@ public class TransmodelAPI {
     schema = TransmodelGraphQLSchema.create(defaultRouteRequest, gqlUtil);
   }
 
-  /**
-   * Return 200 when service is loaded.
-   */
-  @GET
-  @Path("/live")
-  public Response isAlive() {
-    return Response.status(Response.Status.NO_CONTENT).build();
-  }
-
   @POST
-  @Path("/graphql")
   @Consumes(MediaType.APPLICATION_JSON)
   public Response getGraphQL(
     HashMap<String, Object> queryParameters,
@@ -130,7 +126,6 @@ public class TransmodelAPI {
   }
 
   @POST
-  @Path("/graphql")
   @Consumes("application/graphql")
   public Response getGraphQL(
     String query,


### PR DESCRIPTION
### Summary

This PR changes the path of the Transmodel API to `/otp/transmodel/v3`. In line with others it is totally backwards-compatible and you can keep using the old path for the time being.

In line with @t2gran's suggestion the endpoint at `/otp/routers/default/transmodel/live` has been removed as it simplified the migration of this path a lot.

### Issue

#4052

### Documentation

Updated.