### PR TITLE
Pass-through should override transit-group-priority

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -121,7 +121,7 @@ public class TransitRouter {
     );
 
     // Prepare transit search
-    var raptorRequest = RaptorRequestMapper.mapRequest(
+    var raptorRequest = RaptorRequestMapper.<TripSchedule>mapRequest(
       request,
       transitSearchTimeZero,
       serverContext.raptorConfig().isMultiThreaded(),

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
@@ -12,6 +12,7 @@ import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.raptor.api.model.GeneralizedCostRelaxFunction;
 import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.api.model.RaptorConstants;
+import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.raptor.api.model.RelaxFunction;
 import org.opentripplanner.raptor.api.request.DebugRequestBuilder;
 import org.opentripplanner.raptor.api.request.Optimization;
@@ -28,7 +29,7 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.framework.CostLinearFunction;
 import org.opentripplanner.transit.model.site.StopLocation;
 
-public class RaptorRequestMapper {
+public class RaptorRequestMapper<T extends RaptorTripSchedule> {
 
   private final RouteRequest request;
   private final Collection<? extends RaptorAccessEgress> accessPaths;
@@ -56,7 +57,7 @@ public class RaptorRequestMapper {
     this.meterRegistry = meterRegistry;
   }
 
-  public static RaptorRequest<TripSchedule> mapRequest(
+  public static <T extends RaptorTripSchedule> RaptorRequest<T> mapRequest(
     RouteRequest request,
     ZonedDateTime transitSearchTimeZero,
     boolean isMultiThreaded,
@@ -65,7 +66,7 @@ public class RaptorRequestMapper {
     Duration searchWindowAccessSlack,
     MeterRegistry meterRegistry
   ) {
-    return new RaptorRequestMapper(
+    return new RaptorRequestMapper<T>(
       request,
       isMultiThreaded,
       accessPaths,
@@ -77,8 +78,8 @@ public class RaptorRequestMapper {
       .doMap();
   }
 
-  private RaptorRequest<TripSchedule> doMap() {
-    var builder = new RaptorRequestBuilder<TripSchedule>();
+  private RaptorRequest<T> doMap() {
+    var builder = new RaptorRequestBuilder<T>();
     var searchParams = builder.searchParams();
 
     var preferences = request.preferences();
@@ -176,13 +177,15 @@ public class RaptorRequestMapper {
     }
 
     // Add this last, it depends on generating an alias from the set values
-    builder.performanceTimers(
-      new PerformanceTimersForRaptor(
-        builder.generateAlias(),
-        preferences.system().tags(),
-        meterRegistry
-      )
-    );
+    if (meterRegistry != null) {
+      builder.performanceTimers(
+        new PerformanceTimersForRaptor(
+          builder.generateAlias(),
+          preferences.system().tags(),
+          meterRegistry
+        )
+      );
+    }
 
     return builder.build();
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
@@ -119,12 +119,14 @@ public class RaptorRequestMapper {
     builder.withMultiCriteria(mcBuilder -> {
       var pt = preferences.transit();
       var r = pt.raptor();
-      if (!pt.relaxTransitGroupPriority().isNormal()) {
-        mcBuilder.withTransitPriorityCalculator(TransitGroupPriority32n.priorityCalculator());
-        mcBuilder.withRelaxC1(mapRelaxCost(pt.relaxTransitGroupPriority()));
-      } else {
+
+      // Note! If a pass-through-point exists, then the transit-group-priority feature is disabled
+      if (!request.getPassThroughPoints().isEmpty()) {
         mcBuilder.withPassThroughPoints(mapPassThroughPoints());
         r.relaxGeneralizedCostAtDestination().ifPresent(mcBuilder::withRelaxCostAtDestination);
+      } else if (!pt.relaxTransitGroupPriority().isNormal()) {
+        mcBuilder.withTransitPriorityCalculator(TransitGroupPriority32n.priorityCalculator());
+        mcBuilder.withRelaxC1(mapRelaxCost(pt.relaxTransitGroupPriority()));
       }
     });
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
@@ -1,14 +1,32 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.raptor._data.transit.TestAccessEgress;
+import org.opentripplanner.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
+import org.opentripplanner.raptor.api.request.RaptorRequest;
+import org.opentripplanner.routing.api.request.PassThroughPoint;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.framework.CostLinearFunction;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.site.StopLocation;
 
 class RaptorRequestMapperTest {
+
+  private static final TransitModelForTest TEST_MODEL = TransitModelForTest.of();
+  private static final StopLocation STOP_A = TEST_MODEL.stop("Stop:A").build();
+  private static final List<RaptorAccessEgress> ACCESS = List.of(TestAccessEgress.walk(12, 45));
+  private static final List<RaptorAccessEgress> EGRESS = List.of(TestAccessEgress.walk(144, 54));
+  private static final Duration D0s = Duration.ofSeconds(0);
 
   private static final CostLinearFunction R1 = CostLinearFunction.of("50 + 1.0x");
   private static final CostLinearFunction R2 = CostLinearFunction.of("0 + 1.5x");
@@ -32,5 +50,48 @@ class RaptorRequestMapperTest {
   void mapRelaxCost(CostLinearFunction input, int cost, int expected) {
     var calcCost = RaptorRequestMapper.mapRelaxCost(input);
     assertEquals(expected, calcCost.relax(cost));
+  }
+
+  @Test
+  void testPassThroughPoints() {
+    var req = new RouteRequest();
+
+    req.setPassThroughPoints(List.of(new PassThroughPoint(List.of(STOP_A), "Via A")));
+
+    var result = map(req);
+
+    assertTrue(result.multiCriteria().hasPassThroughPoints());
+    assertEquals(
+      "[(Via A, stops: " + STOP_A.getIndex() + ")]",
+      result.multiCriteria().passThroughPoints().toString()
+    );
+  }
+
+  @Test
+  void testPassThroughPointsTurnTransitGroupPriorityOff() {
+    var req = new RouteRequest();
+
+    // Set pass-through and relax transit-group-priority
+    req.setPassThroughPoints(List.of(new PassThroughPoint(List.of(STOP_A), "Via A")));
+    req.withPreferences(p ->
+      p.withTransit(t -> t.withRelaxTransitGroupPriority(CostLinearFunction.of("30m + 1.2t")))
+    );
+
+    var result = map(req);
+
+    //  transit-group-priority CANNOT be used with pass-through and is turned off...
+    assertTrue(result.multiCriteria().transitPriorityCalculator().isEmpty());
+  }
+
+  private static RaptorRequest<TestTripSchedule> map(RouteRequest request) {
+    return RaptorRequestMapper.mapRequest(
+      request,
+      ZonedDateTime.now(),
+      false,
+      ACCESS,
+      EGRESS,
+      D0s,
+      null
+    );
   }
 }


### PR DESCRIPTION
### Summary

Pass-through and transit-group-priority uses the same Raptor feature and can not be use at the same time (for now - if needed we can fix this). In OTP now pass-through is disabled if transit-priority is enabled. This is a bit unfortunate since transit-priority is a more general thing that might be set up as a default configured feature, while pass-through is always specific to a request. So, it make more sense to turn it around and only allow transit-group-priority if no pass-through-stops exist in the request. This PR does exactly this.

### Issue
🟥 This issue was reported internally at Entur, and no issue was created for it. The fix is very simple.


### Unit tests
✅ Added a regression test and a smoke test on the mapping of pass-through-points

### Documentation
🟥 No doc added

### Changelog
🟥  This bug did not exist tín the previous version of OTP; Hence, there is no change.

### Bumping the serialization version id
🟥 Not required
