### PR TITLE
Add implementation for Service Journey filter

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/mapping/SelectRequestMapper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/mapping/SelectRequestMapper.java
@@ -32,6 +32,11 @@ class SelectRequestMapper {
       selectRequestBuilder.withGroupOfRoutes(mapIDsToDomainNullSafe(groupOfLines));
     }
 
+    if (input.containsKey("serviceJourneys")) {
+      var serviceJourneys = (List<String>) input.get("serviceJourneys");
+      selectRequestBuilder.withTrips(mapIDsToDomainNullSafe(serviceJourneys));
+    }
+
     if (input.containsKey("transportModes")) {
       var tModes = new ArrayList<MainAndSubMode>();
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
@@ -38,6 +38,8 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
 
   private final boolean hasSubModeFilters;
 
+  private final boolean hasTripFilters;
+
   public RouteRequestTransitDataProviderFilter(RouteRequest request) {
     this(
       request.journey().transfer().mode() == StreetMode.BIKE,
@@ -68,11 +70,17 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
     this.bannedTrips = bannedTrips;
     this.filters = filters.toArray(TransitFilter[]::new);
     this.hasSubModeFilters = filters.stream().anyMatch(TransitFilter::isSubModePredicate);
+    this.hasTripFilters = filters.stream().anyMatch(TransitFilter::isTripPredicate);
   }
 
   @Override
   public boolean hasSubModeFilters() {
     return hasSubModeFilters;
+  }
+
+  @Override
+  public boolean hasTripFilters() {
+    return hasTripFilters;
   }
 
   public static BikeAccess bikeAccessForTrip(Trip trip) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TransitDataProviderFilter.java
@@ -20,6 +20,8 @@ public interface TransitDataProviderFilter {
 
   boolean hasSubModeFilters();
 
+  boolean hasTripFilters();
+
   boolean tripTimesPredicate(TripTimes tripTimes, boolean withFilters);
 
   /**

--- a/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilter.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilter.java
@@ -17,4 +17,8 @@ public interface TransitFilter {
   default boolean isSubModePredicate() {
     return false;
   }
+
+  default boolean isTripPredicate() {
+    return false;
+  }
 }

--- a/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequest.java
@@ -58,8 +58,26 @@ public class TransitFilterRequest implements Serializable, TransitFilter {
   }
 
   @Override
+  public boolean isTripPredicate() {
+    for (var selectRequest : select) {
+      if (selectRequest.getTrips() != null && !selectRequest.getTrips().isEmpty()) {
+        return true;
+      }
+    }
+
+    for (var selectRequest : not) {
+      if (selectRequest.getTrips() != null && !selectRequest.getTrips().isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
   public boolean matchTripPattern(TripPattern tripPattern) {
-    if (select.length != 0) {
+    var tripPatternSelect = Arrays.stream(select).filter(s -> !s.isTripsOnly()).toArray();
+
+    if (tripPatternSelect.length != 0) {
       var anyMatch = false;
       for (SelectRequest s : select) {
         if (s.matches(tripPattern)) {
@@ -73,7 +91,8 @@ public class TransitFilterRequest implements Serializable, TransitFilter {
     }
 
     for (SelectRequest s : not) {
-      if (s.matches(tripPattern)) {
+      // We'll filter trips in the next step
+      if (!s.isTripsOnly() && s.matches(tripPattern)) {
         return false;
       }
     }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
@@ -145,6 +145,11 @@ public class RaptorRoutingRequestTransitDataCreatorTest {
     }
 
     @Override
+    public boolean hasTripFilters() {
+      return false;
+    }
+
+    @Override
     public BitSet filterAvailableStops(
       RoutingTripPattern tripPattern,
       BitSet boardingPossible,

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
@@ -53,7 +53,9 @@ class RouteRequestTransitDataProviderFilterTest {
 
   private static final Route ROUTE = TransitModelForTest.route("1").build();
 
-  private static final FeedScopedId TRIP_ID = TransitModelForTest.id("T1");
+  private static final FeedScopedId TRIP_ID_1 = TransitModelForTest.id("T1");
+
+  private static final FeedScopedId TRIP_ID_2 = TransitModelForTest.id("T2");
 
   private static final RegularStop STOP_FOR_TEST = TEST_MODEL.stop("TEST:STOP", 0, 0).build();
 
@@ -241,7 +243,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void bannedTripFilteringTest() {
     TripTimes tripTimes = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -256,7 +258,7 @@ class RouteRequestTransitDataProviderFilterTest {
       DEFAULT_ACCESSIBILITY,
       false,
       false,
-      Set.of(TRIP_ID),
+      Set.of(TRIP_ID_1),
       filterForMode(TransitMode.BUS)
     );
 
@@ -381,7 +383,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void transitModeFilteringTest() {
     TripTimes tripTimes = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -407,7 +409,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void notFilteringExpectedTripTimesTest() {
     TripTimes tripTimes = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -434,7 +436,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void bikesAllowedFilteringTest() {
     TripTimes tripTimes = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -461,7 +463,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void removeInaccessibleTrip() {
     TripTimes tripTimes = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -488,7 +490,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void keepAccessibleTrip() {
     TripTimes wheelchairAccessibleTrip = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -515,7 +517,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void keepRealTimeAccessibleTrip() {
     RealTimeTripTimes realTimeWheelchairAccessibleTrip = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -544,7 +546,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void includePlannedCancellationsTest() {
     TripTimes tripTimesWithCancellation = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -553,7 +555,7 @@ class RouteRequestTransitDataProviderFilterTest {
       TripAlteration.CANCELLATION
     );
     TripTimes tripTimesWithReplaced = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -608,7 +610,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void includeRealtimeCancellationsTest() {
     TripTimes tripTimes = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -618,7 +620,7 @@ class RouteRequestTransitDataProviderFilterTest {
     );
 
     RealTimeTripTimes tripTimesWithCancellation = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,
@@ -710,7 +712,7 @@ class RouteRequestTransitDataProviderFilterTest {
   @Test
   void multipleFilteringTest() {
     TripTimes matchingTripTimes = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.ALLOWED,
       TransitMode.BUS,
@@ -719,7 +721,7 @@ class RouteRequestTransitDataProviderFilterTest {
       TripAlteration.PLANNED
     );
     TripTimes failingTripTimes1 = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.ALLOWED,
       TransitMode.RAIL,
@@ -728,7 +730,7 @@ class RouteRequestTransitDataProviderFilterTest {
       TripAlteration.PLANNED
     );
     TripTimes failingTripTimes2 = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.RAIL,
@@ -737,7 +739,7 @@ class RouteRequestTransitDataProviderFilterTest {
       TripAlteration.CANCELLATION
     );
     TripTimes failingTripTimes3 = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.RAIL,
@@ -746,7 +748,7 @@ class RouteRequestTransitDataProviderFilterTest {
       TripAlteration.CANCELLATION
     );
     TripTimes failingTripTimes4 = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.ALLOWED,
       TransitMode.BUS,
@@ -755,7 +757,7 @@ class RouteRequestTransitDataProviderFilterTest {
       TripAlteration.PLANNED
     );
     TripTimes failingTripTimes5 = createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.ALLOWED,
       TransitMode.BUS,
@@ -781,6 +783,88 @@ class RouteRequestTransitDataProviderFilterTest {
     assertFalse(filter.tripTimesPredicate(failingTripTimes3, true));
     assertFalse(filter.tripTimesPredicate(failingTripTimes4, true));
     assertFalse(filter.tripTimesPredicate(failingTripTimes5, true));
+  }
+
+  @Test
+  public void selectTripFilteringTest() {
+    TripTimes tripTimes1 = createTestTripTimes(
+      TRIP_ID_1,
+      ROUTE,
+      BikeAccess.NOT_ALLOWED,
+      TransitMode.BUS,
+      null,
+      Accessibility.NOT_POSSIBLE,
+      null
+    );
+
+    TripTimes tripTimes2 = createTestTripTimes(
+      TRIP_ID_2,
+      ROUTE,
+      BikeAccess.NOT_ALLOWED,
+      TransitMode.BUS,
+      null,
+      Accessibility.NOT_POSSIBLE,
+      null
+    );
+
+    var filter = new RouteRequestTransitDataProviderFilter(
+      false,
+      false,
+      DEFAULT_ACCESSIBILITY,
+      false,
+      false,
+      Set.of(),
+      List.of(
+        TransitFilterRequest
+          .of()
+          .addSelect(SelectRequest.of().withTrips(List.of(TRIP_ID_1)).build())
+          .build()
+      )
+    );
+
+    assertTrue(filter.tripTimesPredicate(tripTimes1, true));
+    assertFalse(filter.tripTimesPredicate(tripTimes2, true));
+  }
+
+  @Test
+  public void NotTripFilterTest() {
+    TripTimes tripTimes1 = createTestTripTimes(
+      TRIP_ID_1,
+      ROUTE,
+      BikeAccess.NOT_ALLOWED,
+      TransitMode.BUS,
+      null,
+      Accessibility.NOT_POSSIBLE,
+      null
+    );
+
+    TripTimes tripTimes2 = createTestTripTimes(
+      TRIP_ID_2,
+      ROUTE,
+      BikeAccess.NOT_ALLOWED,
+      TransitMode.BUS,
+      null,
+      Accessibility.NOT_POSSIBLE,
+      null
+    );
+
+    var filter = new RouteRequestTransitDataProviderFilter(
+      false,
+      false,
+      DEFAULT_ACCESSIBILITY,
+      false,
+      false,
+      Set.of(),
+      List.of(
+        TransitFilterRequest
+          .of()
+          .addNot(SelectRequest.of().withTrips(List.of(TRIP_ID_1)).build())
+          .build()
+      )
+    );
+
+    assertFalse(filter.tripTimesPredicate(tripTimes1, true));
+    assertTrue(filter.tripTimesPredicate(tripTimes2, true));
   }
 
   private boolean validateModesOnTripTimes(
@@ -891,7 +975,7 @@ class RouteRequestTransitDataProviderFilterTest {
 
   private TripTimes createTestTripTimesWithSubmode(String submode) {
     return createTestTripTimes(
-      TRIP_ID,
+      TRIP_ID_1,
       ROUTE,
       BikeAccess.NOT_ALLOWED,
       TransitMode.BUS,


### PR DESCRIPTION
### Summary
This PR adds implemnetation for the Service Journey input in the new filter API. Previously we did not had this functionality and the API was broken. No results were returned if user tried to perform a search with Service Journey as filter input. 

### Issue
N/A

### Unit tests

Included new unit tests for the functionality

### Documentation
N/A

