### PR TITLE
Make logging of MQTT realtime updater more uniform

### DIFF
--- a/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -51,11 +51,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
     this.updateHandler.setTransitAlertService(transitAlertService);
     this.updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
     this.otpHttpClient = new OtpHttpClient();
-    LOG.info(
-      "Creating real-time alert updater running every {}: {}",
-      pollingPeriod(),
-      url
-    );
+    LOG.info("Creating real-time alert updater running every {}: {}", pollingPeriod(), url);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -52,7 +52,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
     this.updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
     this.otpHttpClient = new OtpHttpClient();
     LOG.info(
-      "Creating real-time alert updater running every {} seconds : {}",
+      "Creating real-time alert updater running every {}: {}",
       pollingPeriod(),
       url
     );

--- a/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
@@ -78,6 +78,9 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
         new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
     }
     this.recordMetrics = TripUpdateMetrics.streaming(parameters);
+    LOG.info(
+      "Creating streaming GTFS-RT TripUpdate updater subscribing to MQTT broker at {}", url
+    );
   }
 
   @Override
@@ -187,4 +190,15 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
     @Override
     public void deliveryComplete(IMqttDeliveryToken token) {}
   }
+
+  @Override
+  public String toString() {
+    return "MqttGtfsRealtimeUpdater{" +
+      "url='" + url + '\'' +
+      ", topic='" + topic + '\'' +
+      ", feedId='" + feedId + '\'' +
+      '}';
+  }
+
 }
+

--- a/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
@@ -78,9 +78,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
         new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
     }
     this.recordMetrics = TripUpdateMetrics.streaming(parameters);
-    LOG.info(
-      "Creating streaming GTFS-RT TripUpdate updater subscribing to MQTT broker at {}", url
-    );
+    LOG.info("Creating streaming GTFS-RT TripUpdate updater subscribing to MQTT broker at {}", url);
   }
 
   @Override
@@ -193,12 +191,18 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
 
   @Override
   public String toString() {
-    return "MqttGtfsRealtimeUpdater{" +
-      "url='" + url + '\'' +
-      ", topic='" + topic + '\'' +
-      ", feedId='" + feedId + '\'' +
-      '}';
+    return (
+      "MqttGtfsRealtimeUpdater{" +
+      "url='" +
+      url +
+      '\'' +
+      ", topic='" +
+      topic +
+      '\'' +
+      ", feedId='" +
+      feedId +
+      '\'' +
+      '}'
+    );
   }
-
 }
-

--- a/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
@@ -13,6 +13,7 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
@@ -191,18 +192,11 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
 
   @Override
   public String toString() {
-    return (
-      "MqttGtfsRealtimeUpdater{" +
-      "url='" +
-      url +
-      '\'' +
-      ", topic='" +
-      topic +
-      '\'' +
-      ", feedId='" +
-      feedId +
-      '\'' +
-      '}'
-    );
+    return ToStringBuilder
+      .of(MqttGtfsRealtimeUpdater.class)
+      .addStr("url", url)
+      .addStr("topic", topic)
+      .addStr("feedId", feedId)
+      .toString();
   }
 }


### PR DESCRIPTION
### Summary

This makes the messages output by the MQTT GTFS Realtime updater more similar to those produced by other updaters. It just makes the logs more uniform and slightly more informative.

It has been tested in local usage with a connection to the Digitransit MQTT RT feeds.

The code formatting rules make the toString method harder to read, so maybe this should be converted to a StringBuilder or equivalent.