### PR TITLE
Log trip and pattern id when negative trip-times occurs in routing.

### DIFF
--- a/src/main/java/org/opentripplanner/framework/lang/ObjectUtils.java
+++ b/src/main/java/org/opentripplanner/framework/lang/ObjectUtils.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.framework.lang;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -31,6 +32,18 @@ public class ObjectUtils {
       return defaultValue;
     }
     return ifNotNull(getter.apply(entity), defaultValue);
+  }
+
+  /**
+   * Get the value or {@code null}, ignore any exceptions. This is useful if you must traverse
+   * a long call-chain like {@code a.b().c().d()...} when e.g. logging.
+   */
+  public static <T> T safeGetOrNull(Supplier<T> body) {
+    try {
+      return body.get();
+    } catch (Exception ignore) {
+      return null;
+    }
   }
 
   public static <T> T requireNotInitialized(T oldValue, T newValue) {

--- a/src/main/java/org/opentripplanner/framework/tostring/ToStringBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/tostring/ToStringBuilder.java
@@ -13,9 +13,11 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.opentripplanner.framework.lang.ObjectUtils;
 import org.opentripplanner.framework.lang.OtpNumberFormat;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.framework.time.TimeUtils;
@@ -135,11 +137,19 @@ public class ToStringBuilder {
   }
 
   /**
+   * Add the result of the given supplier. If the supplier return {@code  null} or an exceptions
+   * is thrown, then nothing is added - the result is ignored.
+   */
+  public ToStringBuilder addObjOpSafe(String name, Supplier<?> body) {
+    return addObj(name, ObjectUtils.safeGetOrNull(body));
+  }
+
+  /**
    * Use this if you would like a custom toString function to convert the value. If the given value
    * is null, then the value is not printed.
    * <p>
    * Implementation note! The "Op" (Operation) suffix is necessary to separate this from
-   * {@link #addObj(String, Object, Object)},  when the last argument is null.
+   * {@link #addObj(String, Object, Object)}, when the last argument is null.
    */
   public <T> ToStringBuilder addObjOp(
     String name,
@@ -176,7 +186,7 @@ public class ToStringBuilder {
     return addIt(name, Arrays.toString(value));
   }
 
-  /** Add collection if not null or not empty, all elements are added */
+  /** Add the collection if not null or not empty, all elements are added */
   public ToStringBuilder addCol(String name, Collection<?> c) {
     return addIfNotNull(name, c == null || c.isEmpty() ? null : c);
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
@@ -107,7 +107,9 @@ public final class TripScheduleWithOffset implements TripSchedule {
   public String toString() {
     return ToStringBuilder
       .of(TripScheduleWithOffset.class)
-      .addObj("trip", pattern.debugInfo())
+      .addObj("info", pattern.debugInfo())
+      .addObjOpSafe("id", () -> tripTimes.getTrip().getId())
+      .addObjOpSafe("pattern.id", () -> pattern.getTripPattern().getPattern().getId())
       .addServiceTime("depart", secondsOffset + getOriginalTripTimes().getDepartureTime(0))
       .toString();
   }

--- a/src/main/java/org/opentripplanner/transit/model/network/RoutingTripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/RoutingTripPattern.java
@@ -117,7 +117,7 @@ public class RoutingTripPattern implements DefaultTripPattern, Serializable {
 
   @Override
   public String debugInfo() {
-    return pattern.logName() + " @" + index;
+    return pattern.logName() + " #" + index;
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/framework/lang/ObjectUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/lang/ObjectUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +47,18 @@ class ObjectUtilsTest {
         () -> ObjectUtils.requireNotInitialized("old", "new")
       );
     assertEquals("Field is already set! Old value: old, new value: new.", ex.getMessage());
+  }
+
+  @Test
+  void safeGetOrNull() {
+    assertEquals("test", ObjectUtils.safeGetOrNull(() -> "test"));
+    assertEquals(3000, ObjectUtils.safeGetOrNull(() -> Duration.ofSeconds(3).toMillis()));
+    assertNull(ObjectUtils.safeGetOrNull(() -> null));
+    assertNull(
+      ObjectUtils.safeGetOrNull(() -> {
+        throw new NullPointerException("Something went wrong - ignore");
+      })
+    );
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/framework/tostring/ToStringBuilderTest.java
+++ b/src/test/java/org/opentripplanner/framework/tostring/ToStringBuilderTest.java
@@ -112,6 +112,26 @@ public class ToStringBuilderTest {
   }
 
   @Test
+  public void addObjOpSafe() {
+    assertEquals(
+      "ToStringBuilderTest{obj: Foo{a: 5, b: 'X'}}",
+      subject().addObjOpSafe("obj", () -> new Foo(5, "X")).toString()
+    );
+    assertEquals("ToStringBuilderTest{}", subject().addObjOpSafe("obj", () -> null).toString());
+    assertEquals(
+      "ToStringBuilderTest{}",
+      subject()
+        .addObjOpSafe(
+          "obj",
+          () -> {
+            throw new IllegalStateException("Ignore");
+          }
+        )
+        .toString()
+    );
+  }
+
+  @Test
   public void addObjOp() {
     var duration = Duration.ofMinutes(1);
     assertEquals(


### PR DESCRIPTION
### Summary

This is a small improvement in the logging when negative trip-times occurs in Raptor due to inconsistent trip-times. The source of the problem is probably the updaters, but to find it we need the Trip/SJ id and TripPattern id.

At Entur we see the following error in the logs:

```
ERROR 2024-01-23T11:59:59.189249241Z [resource.labels.containerName: otp2] Traveling back in time is not allowed. Board time: 23:38:34+2d, alight stop pos: 0, stop arrival time: 00:23:34+3d, trip: TripScheduleWithOffset{trip: BUS RE10B @27235, depart: 11:47:27}.
```


### Issue

🟥  No issue for this exist.


### Unit tests

✅   Relevant Unit tests added.


### Documentation

✅ JavaDoc updated


### Changelog

🟥  This is too minor to be in the changelog.


### Bumping the serialization version id

🟥  Not needed.