### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -20,20 +20,20 @@ jobs:
     timeout-minutes: 20
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       # nodejs is needed because the dynamic download of it via the prettier maven plugin often
       # times out
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
       # Java setup step completes very fast, no need to run in a preconfigured docker container
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
@@ -65,9 +65,9 @@ jobs:
     timeout-minutes: 20
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
@@ -91,7 +91,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4
         # this is necessary so that the correct credentials are put into the git configuration
         # when we push to dev-2.x and push the HTML to the git repo
         if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
@@ -101,7 +101,7 @@ jobs:
           # was modified last
           fetch-depth: 1000
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4
         # for a simple PR where we don't push, we don't need any credentials
         if: github.event_name == 'pull_request'
 
@@ -113,7 +113,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: mkdocs build
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -174,8 +174,8 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Run code generator
@@ -184,7 +184,7 @@ jobs:
           yarn install
           yarn generate
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
@@ -199,16 +199,16 @@ jobs:
       - build-windows
       - build-linux
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
           cache: maven
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Build container image with Jib, push to Dockerhub

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -60,14 +60,14 @@ jobs:
             profile: extended
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         with:
           fetch-depth: 0
 
       - name: Set up JDK
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
@@ -62,7 +62,7 @@ jobs:
           git config --global user.email 'serialization-version-bot@opentripplanner.org'
 
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 


### PR DESCRIPTION
### Summary

Github Actions is removing support for older node versions and this is producing warnings like these: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/7672427245

![image](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/ce1f5eec-3486-433a-b4ac-545593f90c72)

Fortunately, the solution is simple: update the actions versions.