### PR TITLE
Rename hopCost/Time -> mountDismountCost/Time  in router-config.json

### DIFF
--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -78,8 +78,8 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 |       [safety](#rd_bicycle_triangle_safety)                                                                  |        `double`        | Relative importance of safety (range 0-1).                                                                                                     | *Optional* | `0.0`            |  2.0  |
 |       time                                                                                                   |        `double`        | Relative importance of duration of travel (range 0-1).                                                                                         | *Optional* | `0.0`            |  2.0  |
 |    walk                                                                                                      |        `object`        | Preferences for walking a vehicle.                                                                                                             | *Optional* |                  |  2.5  |
-|       [hopCost](#rd_bicycle_walk_hopCost)                                                                    |        `integer`       | The cost of hopping on or off a vehicle.                                                                                                       | *Optional* | `0`              |  2.0  |
-|       [hopTime](#rd_bicycle_walk_hopTime)                                                                    |       `duration`       | The time it takes the user to hop on or off a vehicle.                                                                                         | *Optional* | `"PT0S"`         |  2.0  |
+|       [mountDismountCost](#rd_bicycle_walk_mountDismountCost)                                                |        `integer`       | The cost of hopping on or off a vehicle.                                                                                                       | *Optional* | `0`              |  2.0  |
+|       [mountDismountTime](#rd_bicycle_walk_mountDismountTime)                                                |       `duration`       | The time it takes the user to hop on or off a vehicle.                                                                                         | *Optional* | `"PT0S"`         |  2.0  |
 |       reluctance                                                                                             |        `double`        | A multiplier for how bad walking with a vehicle is, compared to being in transit for equal lengths of time.                                    | *Optional* | `5.0`            |  2.1  |
 |       speed                                                                                                  |        `double`        | The user's vehicle walking speed in meters/second. Defaults to approximately 3 MPH.                                                            | *Optional* | `1.33`           |  2.1  |
 |       stairsReluctance                                                                                       |        `double`        | How bad is it to walk the vehicle up/down a flight of stairs compared to taking a detour.                                                      | *Optional* | `10.0`           |  2.3  |
@@ -525,7 +525,7 @@ This factor can also include other concerns such as convenience and general cycl
 preferences by taking into account road surface etc.
 
 
-<h3 id="rd_bicycle_walk_hopCost">hopCost</h3>
+<h3 id="rd_bicycle_walk_mountDismountCost">mountDismountCost</h3>
 
 **Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0`   
 **Path:** /routingDefaults/bicycle/walk 
@@ -536,7 +536,7 @@ There are different parameters for the cost of renting or parking a vehicle and 
 not meant for controlling the cost of those events.
 
 
-<h3 id="rd_bicycle_walk_hopTime">hopTime</h3>
+<h3 id="rd_bicycle_walk_mountDismountTime">mountDismountTime</h3>
 
 **Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`   
 **Path:** /routingDefaults/bicycle/walk 

--- a/src/ext/java/org/opentripplanner/ext/restapi/resources/RequestToPreferencesMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/resources/RequestToPreferencesMapper.java
@@ -89,8 +89,8 @@ class RequestToPreferencesMapper {
       bike.withWalking(walk -> {
         setIfNotNull(req.bikeWalkingSpeed, walk::withSpeed);
         setIfNotNull(req.bikeWalkingReluctance, walk::withReluctance);
-        setIfNotNull(req.bikeSwitchTime, walk::withHopTime);
-        setIfNotNull(req.bikeSwitchCost, walk::withHopCost);
+        setIfNotNull(req.bikeSwitchTime, walk::withMountDismountTime);
+        setIfNotNull(req.bikeSwitchCost, walk::withMountDismountCost);
       });
     });
   }

--- a/src/main/java/org/opentripplanner/apis/gtfs/mapping/RouteRequestMapper.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/mapping/RouteRequestMapper.java
@@ -340,8 +340,8 @@ public class RouteRequestMapper {
   ) {
     callWith.argument("bikeWalkingReluctance", walking::withReluctance);
     callWith.argument("bikeWalkingSpeed", walking::withSpeed);
-    callWith.argument("bikeSwitchTime", time -> walking.withHopTime((int) time));
-    callWith.argument("bikeSwitchCost", cost -> walking.withHopCost((int) cost));
+    callWith.argument("bikeSwitchTime", time -> walking.withMountDismountTime((int) time));
+    callWith.argument("bikeSwitchCost", cost -> walking.withMountDismountCost((int) cost));
   }
 
   private static class CallerWithEnvironment {

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/VehicleWalkingPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/VehicleWalkingPreferences.java
@@ -19,15 +19,15 @@ public class VehicleWalkingPreferences implements Serializable {
 
   private final double speed;
   private final double reluctance;
-  private final Duration hopTime;
-  private final Cost hopCost;
+  private final Duration mountDismountTime;
+  private final Cost mountDismountCost;
   private final double stairsReluctance;
 
   private VehicleWalkingPreferences() {
     this.speed = 1.33;
     this.reluctance = 5.0;
-    this.hopTime = Duration.ZERO;
-    this.hopCost = Cost.ZERO;
+    this.mountDismountTime = Duration.ZERO;
+    this.mountDismountCost = Cost.ZERO;
     // very high reluctance to carry the bike up/down a flight of stairs
     this.stairsReluctance = 10;
   }
@@ -39,8 +39,8 @@ public class VehicleWalkingPreferences implements Serializable {
   private VehicleWalkingPreferences(Builder builder) {
     this.speed = Units.speed(builder.speed);
     this.reluctance = Units.reluctance(builder.reluctance);
-    this.hopTime = Duration.ofSeconds(Units.duration(builder.hopTime));
-    this.hopCost = Cost.costOfSeconds(builder.hopCost);
+    this.mountDismountTime = Duration.ofSeconds(Units.duration(builder.mountDismountTime));
+    this.mountDismountCost = Cost.costOfSeconds(builder.mountDismountCost);
     this.stairsReluctance = Units.reluctance(builder.stairsReluctance);
   }
 
@@ -73,13 +73,13 @@ public class VehicleWalkingPreferences implements Serializable {
   }
 
   /** Time to get on and off your own vehicle. */
-  public Duration hopTime() {
-    return hopTime;
+  public Duration mountDismountTime() {
+    return mountDismountTime;
   }
 
   /** Cost of getting on and off your own vehicle. */
-  public Cost hopCost() {
-    return hopCost;
+  public Cost mountDismountCost() {
+    return mountDismountCost;
   }
 
   /** Reluctance of walking carrying a vehicle up a flight of stairs. */
@@ -95,15 +95,15 @@ public class VehicleWalkingPreferences implements Serializable {
     return (
       speed == that.speed &&
       reluctance == that.reluctance &&
-      Objects.equals(hopTime, that.hopTime) &&
-      Objects.equals(hopCost, that.hopCost) &&
+      Objects.equals(mountDismountTime, that.mountDismountTime) &&
+      Objects.equals(mountDismountCost, that.mountDismountCost) &&
       stairsReluctance == that.stairsReluctance
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(speed, reluctance, hopTime, hopCost, stairsReluctance);
+    return Objects.hash(speed, reluctance, mountDismountTime, mountDismountCost, stairsReluctance);
   }
 
   @Override
@@ -112,8 +112,8 @@ public class VehicleWalkingPreferences implements Serializable {
       .of(VehicleWalkingPreferences.class)
       .addNum("speed", speed, DEFAULT.speed)
       .addNum("reluctance", reluctance, DEFAULT.reluctance)
-      .addObj("hopTime", hopTime, DEFAULT.hopTime)
-      .addObj("hopCost", hopCost, DEFAULT.hopCost)
+      .addObj("mountDismountTime", mountDismountTime, DEFAULT.mountDismountTime)
+      .addObj("mountDismountCost", mountDismountCost, DEFAULT.mountDismountCost)
       .addNum("stairsReluctance", stairsReluctance, DEFAULT.stairsReluctance)
       .toString();
   }
@@ -123,16 +123,16 @@ public class VehicleWalkingPreferences implements Serializable {
     private final VehicleWalkingPreferences original;
     private double speed;
     private double reluctance;
-    private int hopTime;
-    private int hopCost;
+    private int mountDismountTime;
+    private int mountDismountCost;
     private double stairsReluctance;
 
     private Builder(VehicleWalkingPreferences original) {
       this.original = original;
       this.speed = original.speed;
       this.reluctance = original.reluctance;
-      this.hopTime = (int) original.hopTime.toSeconds();
-      this.hopCost = original.hopCost.toSeconds();
+      this.mountDismountTime = (int) original.mountDismountTime.toSeconds();
+      this.mountDismountCost = original.mountDismountCost.toSeconds();
       this.stairsReluctance = original.stairsReluctance;
     }
 
@@ -146,18 +146,18 @@ public class VehicleWalkingPreferences implements Serializable {
       return this;
     }
 
-    public VehicleWalkingPreferences.Builder withHopTime(Duration hopTime) {
-      this.hopTime = (int) hopTime.toSeconds();
+    public VehicleWalkingPreferences.Builder withMountDismountTime(Duration mountDismountTime) {
+      this.mountDismountTime = (int) mountDismountTime.toSeconds();
       return this;
     }
 
-    public VehicleWalkingPreferences.Builder withHopTime(int hopTime) {
-      this.hopTime = hopTime;
+    public VehicleWalkingPreferences.Builder withMountDismountTime(int mountDismountTime) {
+      this.mountDismountTime = mountDismountTime;
       return this;
     }
 
-    public VehicleWalkingPreferences.Builder withHopCost(int hopCost) {
-      this.hopCost = hopCost;
+    public VehicleWalkingPreferences.Builder withMountDismountCost(int mountDismountCost) {
+      this.mountDismountCost = mountDismountCost;
       return this;
     }
 

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/VehicleWalkingConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/VehicleWalkingConfig.java
@@ -43,9 +43,9 @@ public class VehicleWalkingConfig {
           )
           .asDouble(dft.reluctance())
       )
-      .withHopTime(
+      .withMountDismountTime(
         c
-          .of("hopTime")
+          .of("mountDismountTime")
           .since(V2_0)
           .summary("The time it takes the user to hop on or off a vehicle.")
           .description(
@@ -54,11 +54,11 @@ public class VehicleWalkingConfig {
             for controlling the duration of those events.
             """
           )
-          .asDuration(dft.hopTime())
+          .asDuration(dft.mountDismountTime())
       )
-      .withHopCost(
+      .withMountDismountCost(
         c
-          .of("hopCost")
+          .of("mountDismountCost")
           .since(V2_0)
           .summary("The cost of hopping on or off a vehicle.")
           .description(
@@ -67,7 +67,7 @@ public class VehicleWalkingConfig {
             not meant for controlling the cost of those events.
             """
           )
-          .asInt(dft.hopCost().toSeconds())
+          .asInt(dft.mountDismountCost().toSeconds())
       )
       .withStairsReluctance(
         c

--- a/src/main/java/org/opentripplanner/street/model/edge/BikeWalkableEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/BikeWalkableEdge.java
@@ -17,8 +17,10 @@ public interface BikeWalkableEdge {
 
     editor.setBackWalkingBike(true);
     if (shouldIncludeCost) {
-      editor.incrementWeight(preferences.bike().walking().hopCost().toSeconds());
-      editor.incrementTimeInSeconds((int) preferences.bike().walking().hopTime().toSeconds());
+      editor.incrementWeight(preferences.bike().walking().mountDismountCost().toSeconds());
+      editor.incrementTimeInSeconds(
+        (int) preferences.bike().walking().mountDismountTime().toSeconds()
+      );
     }
   }
 
@@ -28,8 +30,10 @@ public interface BikeWalkableEdge {
 
     editor.setBackWalkingBike(false);
     if (shouldIncludeCost) {
-      editor.incrementWeight(preferences.bike().walking().hopCost().toSeconds());
-      editor.incrementTimeInSeconds((int) preferences.bike().walking().hopTime().toSeconds());
+      editor.incrementWeight(preferences.bike().walking().mountDismountCost().toSeconds());
+      editor.incrementTimeInSeconds(
+        (int) preferences.bike().walking().mountDismountTime().toSeconds()
+      );
     }
   }
 

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/VehicleWalkingPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/VehicleWalkingPreferencesTest.java
@@ -11,8 +11,8 @@ class VehicleWalkingPreferencesTest {
 
   private static final double SPEED = 1.45;
   private static final double RELUCTANCE = 5.5;
-  private static final Duration HOP_TIME = Duration.ofSeconds(15);
-  private static final Cost HOP_COST = Cost.costOfSeconds(20);
+  private static final Duration MOUNT_DISMOUNT_TIME = Duration.ofSeconds(15);
+  private static final Cost MOUNT_DISMOUNT_COST = Cost.costOfSeconds(20);
   private static final double STAIRS_RELUCTANCE = 11;
 
   private final VehicleWalkingPreferences subject = createPreferences();
@@ -28,13 +28,13 @@ class VehicleWalkingPreferencesTest {
   }
 
   @Test
-  void hopTime() {
-    assertEquals(HOP_TIME, subject.hopTime());
+  void mountDismountTime() {
+    assertEquals(MOUNT_DISMOUNT_TIME, subject.mountDismountTime());
   }
 
   @Test
-  void hopCost() {
-    assertEquals(HOP_COST, subject.hopCost());
+  void mountDismountCost() {
+    assertEquals(MOUNT_DISMOUNT_COST, subject.mountDismountCost());
   }
 
   @Test
@@ -57,8 +57,8 @@ class VehicleWalkingPreferencesTest {
       "VehicleWalkingPreferences{" +
       "speed: 1.45, " +
       "reluctance: 5.5, " +
-      "hopTime: PT15S, " +
-      "hopCost: $20, " +
+      "mountDismountTime: PT15S, " +
+      "mountDismountCost: $20, " +
       "stairsReluctance: 11.0}",
       subject.toString()
     );
@@ -69,8 +69,8 @@ class VehicleWalkingPreferencesTest {
       .of()
       .withSpeed(SPEED)
       .withReluctance(RELUCTANCE)
-      .withHopTime(HOP_TIME)
-      .withHopCost(HOP_COST.toSeconds())
+      .withMountDismountTime(MOUNT_DISMOUNT_TIME)
+      .withMountDismountCost(MOUNT_DISMOUNT_COST.toSeconds())
       .withStairsReluctance(STAIRS_RELUCTANCE)
       .build();
   }

--- a/src/test/java/org/opentripplanner/street/integration/BikeWalkingTest.java
+++ b/src/test/java/org/opentripplanner/street/integration/BikeWalkingTest.java
@@ -375,7 +375,10 @@ public class BikeWalkingTest extends GraphRoutingTest {
       preferences
         .withWalk(w -> w.withSpeed(10))
         .withBike(it ->
-          it.withSpeed(20d).withWalking(w -> w.withSpeed(5d).withHopTime(100).withHopCost(1000))
+          it
+            .withSpeed(20d)
+            .withWalking(w -> w.withSpeed(5d).withMountDismountTime(100).withMountDismountCost(1000)
+            )
         )
     );
     request.setArriveBy(arriveBy);

--- a/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -221,7 +221,7 @@ public class StreetEdgeTest {
 
     StreetSearchRequestBuilder noPenalty = StreetSearchRequest.copyOf(proto);
     noPenalty.withPreferences(p ->
-      p.withBike(it -> it.withWalking(w -> w.withHopTime(0).withHopCost(0)))
+      p.withBike(it -> it.withWalking(w -> w.withMountDismountTime(0).withMountDismountCost(0)))
     );
 
     State s0 = new State(v0, noPenalty.withMode(StreetMode.BIKE).build());
@@ -231,7 +231,7 @@ public class StreetEdgeTest {
 
     StreetSearchRequestBuilder withPenalty = StreetSearchRequest.copyOf(proto);
     withPenalty.withPreferences(p ->
-      p.withBike(it -> it.withWalking(w -> w.withHopTime(42).withHopCost(23)))
+      p.withBike(it -> it.withWalking(w -> w.withMountDismountTime(42).withMountDismountCost(23)))
     );
 
     State s4 = new State(v0, withPenalty.withMode(StreetMode.BIKE).build());


### PR DESCRIPTION
### Summary

This renames hopCost and hopTime to mountDismountCost and mountDismountTime in the internal model and in router-config.json as the old naming was confusing.

### Issue

This is related to https://github.com/opentripplanner/OpenTripPlanner/issues/4803

### Unit tests

Updated tests

### Documentation

Updated docs

### Changelog

From title
