### PR TITLE
Refactor GroupStopBuilder addLocation method

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
@@ -75,7 +75,12 @@ public class GroupStopBuilder extends AbstractEntityBuilder<GroupStop, GroupStop
       )
     ) {
       throw new RuntimeException(
-        "Unsupported location for GroupStop. Must be Regular or FlexibleArea."
+        String.format(
+          "Unsupported location for %s. Must be %s or %s.",
+          GroupStop.class.getSimpleName(),
+          StopType.REGULAR,
+          StopType.FLEXIBLE_AREA
+        )
       );
     }
 

--- a/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntSupplier;
 import javax.annotation.Nonnull;
-import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.opentripplanner.framework.geometry.GeometryUtils;
@@ -69,6 +68,17 @@ public class GroupStopBuilder extends AbstractEntityBuilder<GroupStop, GroupStop
   }
 
   public GroupStopBuilder addLocation(StopLocation location) {
+    if (
+      !(
+        location.getStopType() == StopType.REGULAR ||
+        location.getStopType() == StopType.FLEXIBLE_AREA
+      )
+    ) {
+      throw new RuntimeException(
+        "Unsupported location for GroupStop. Must be Regular or FlexibleArea."
+      );
+    }
+
     stopLocations.add(location);
 
     int numGeometries = geometry.getNumGeometries();
@@ -76,17 +86,8 @@ public class GroupStopBuilder extends AbstractEntityBuilder<GroupStop, GroupStop
     for (int i = 0; i < numGeometries; i++) {
       newGeometries[i] = geometry.getGeometryN(i);
     }
-    if (location instanceof RegularStop) {
-      WgsCoordinate coordinate = location.getCoordinate();
-      Envelope envelope = new Envelope(coordinate.asJtsCoordinate());
-      double xscale = Math.cos(coordinate.latitude() * Math.PI / 180);
-      envelope.expandBy(100 / xscale, 100);
-      newGeometries[numGeometries] = GeometryUtils.getGeometryFactory().toGeometry(envelope);
-    } else if (location instanceof AreaStop) {
-      newGeometries[numGeometries] = location.getGeometry();
-    } else {
-      throw new RuntimeException("Unknown location type");
-    }
+    newGeometries[numGeometries] = location.getGeometry();
+
     geometry = new GeometryCollection(newGeometries, GeometryUtils.getGeometryFactory());
     centroid = new WgsCoordinate(geometry.getCentroid());
 

--- a/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.opentripplanner.framework.geometry.GeometryUtils;
+import org.opentripplanner._support.geometry.Coordinates;
+import org.opentripplanner._support.geometry.Polygons;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -24,7 +24,9 @@ class GroupStopTest {
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
 
-  private static final StopLocation STOP_LOCATION = TEST_MODEL.stop("1:stop", 1d, 1d).build();
+  private static final StopLocation STOP_LOCATION = TEST_MODEL
+    .stop("1:stop", Coordinates.BERLIN.getX(), Coordinates.BERLIN.getY())
+    .build();
   private static final GroupStop subject = StopModel
     .of()
     .groupStop(TransitModelForTest.id(ID))
@@ -34,8 +36,12 @@ class GroupStopTest {
 
   @Test
   void testGroupStopGeometry() {
-    StopLocation stopLocation1 = TEST_MODEL.stop("1:stop", 1d, 1d).build();
-    StopLocation stopLocation2 = TEST_MODEL.stop("2:stop", 2d, 2d).build();
+    StopLocation stopLocation1 = TEST_MODEL
+      .stop("1:stop", Coordinates.BERLIN.getX(), Coordinates.BERLIN.getY())
+      .build();
+    StopLocation stopLocation2 = TEST_MODEL
+      .stop("2:stop", Coordinates.HAMBURG.getX(), Coordinates.HAMBURG.getY())
+      .build();
 
     GroupStop groupStop = StopModel
       .of()
@@ -54,16 +60,8 @@ class GroupStopTest {
 
   @Test
   void testGroupStopEncompassingAreaGeometry() {
-    Geometry encompassingAreaGeometry = GeometryUtils
-      .getGeometryFactory()
-      .toGeometry(new Envelope(1d, 2d, 1d, 2d));
-
     StopLocation stopLocation = TEST_MODEL
-      .stop(
-        "1:stop",
-        encompassingAreaGeometry.getCentroid().getX(),
-        encompassingAreaGeometry.getCentroid().getY()
-      )
+      .stop("1:stop", Coordinates.BERLIN.getX(), Coordinates.BERLIN.getY())
       .build();
 
     GroupStop groupStop = StopModel
@@ -71,14 +69,14 @@ class GroupStopTest {
       .groupStop(TransitModelForTest.id(ID))
       .withName(NAME)
       .addLocation(stopLocation)
-      .withEncompassingAreaGeometries(List.of(encompassingAreaGeometry))
+      .withEncompassingAreaGeometries(List.of(Polygons.BERLIN))
       .build();
 
     Geometry groupStopGeometry = Objects.requireNonNull(groupStop.getGeometry()).getGeometryN(0);
     assertEquals(stopLocation.getGeometry(), groupStopGeometry);
 
     assertEquals(
-      encompassingAreaGeometry,
+      Polygons.BERLIN,
       groupStop.getEncompassingAreaGeometry().orElseThrow().getGeometryN(0)
     );
   }

--- a/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
@@ -6,7 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -14,7 +19,7 @@ import org.opentripplanner.transit.service.StopModel;
 
 class GroupStopTest {
 
-  private static TransitModelForTest TEST_MODEL = TransitModelForTest.of();
+  private static final TransitModelForTest TEST_MODEL = TransitModelForTest.of();
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
@@ -26,6 +31,57 @@ class GroupStopTest {
     .withName(NAME)
     .addLocation(STOP_LOCATION)
     .build();
+
+  @Test
+  void testGroupStopGeometry() {
+    StopLocation stopLocation1 = TEST_MODEL.stop("1:stop", 1d, 1d).build();
+    StopLocation stopLocation2 = TEST_MODEL.stop("2:stop", 2d, 2d).build();
+
+    GroupStop groupStop = StopModel
+      .of()
+      .groupStop(TransitModelForTest.id(ID))
+      .withName(NAME)
+      .addLocation(stopLocation1)
+      .addLocation(stopLocation2)
+      .build();
+
+    Geometry groupStopGeometry1 = Objects.requireNonNull(groupStop.getGeometry()).getGeometryN(0);
+    assertEquals(stopLocation1.getGeometry(), groupStopGeometry1);
+
+    Geometry groupStopGeometry2 = Objects.requireNonNull(groupStop.getGeometry()).getGeometryN(1);
+    assertEquals(stopLocation2.getGeometry(), groupStopGeometry2);
+  }
+
+  @Test
+  void testGroupStopEncompassingAreaGeometry() {
+    Geometry encompassingAreaGeometry = GeometryUtils
+      .getGeometryFactory()
+      .toGeometry(new Envelope(1d, 2d, 1d, 2d));
+
+    StopLocation stopLocation = TEST_MODEL
+      .stop(
+        "1:stop",
+        encompassingAreaGeometry.getCentroid().getX(),
+        encompassingAreaGeometry.getCentroid().getY()
+      )
+      .build();
+
+    GroupStop groupStop = StopModel
+      .of()
+      .groupStop(TransitModelForTest.id(ID))
+      .withName(NAME)
+      .addLocation(stopLocation)
+      .withEncompassingAreaGeometries(List.of(encompassingAreaGeometry))
+      .build();
+
+    Geometry groupStopGeometry = Objects.requireNonNull(groupStop.getGeometry()).getGeometryN(0);
+    assertEquals(stopLocation.getGeometry(), groupStopGeometry);
+
+    assertEquals(
+      encompassingAreaGeometry,
+      groupStop.getEncompassingAreaGeometry().orElseThrow().getGeometryN(0)
+    );
+  }
 
   @Test
   void copy() {


### PR DESCRIPTION
### Summary

It now simply adds the geometry of the location to the geometry collection of the GroupStop. It was unclear what the large (100x100 degree) envelopes around regular stops were doing. It  looked like a bug, and the geometry of GroupStops appears unused so it should be safe to change.

### Unit tests

Added unittests for geometry and encompassingAreaGeometry in GroupStop. Existing unittests pass and local runs look good.