### PR TITLE
Change the GroupStop's getEncompassingAreaGeometry method to return an empty optional if the group stop is not defined as an area

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
@@ -94,13 +94,12 @@ public class GroupStop
 
   /**
    * Returns the geometry of the area that encompasses the bounds of this StopLocation group. If the
-   * group is defined only as a list of stops, this will return the same as getGeometry. If on the
-   * other hand the group is defined as an area and the stops are inferred from that area, then this
-   * will return the geometry of the area.
+   * group is defined as all the stops within an area, then this will return the geometry of the
+   * area. If the group is defined simply as a list of stops, this will return an empty optional.
    */
   @Override
   public Optional<? extends Geometry> getEncompassingAreaGeometry() {
-    return Optional.ofNullable(encompassingAreaGeometry).or(() -> Optional.of(geometry));
+    return Optional.ofNullable(encompassingAreaGeometry);
   }
 
   @Override


### PR DESCRIPTION
### Summary

This was an oversight earlier. Returning the list of coordinates of the memberstops of a GroupStop is confusing when an area is expected.