### PR TITLE
Allow configuring a custom attribution for vector tiles

### DIFF
--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -148,6 +148,7 @@ For each layer, the configuration includes:
 
 | Config Parameter                                               |    Type    | Summary                                                                                    |  Req./Opt. | Default Value | Since |
 |----------------------------------------------------------------|:----------:|--------------------------------------------------------------------------------------------|:----------:|---------------|:-----:|
+| attribution                                                    |  `string`  | Set a custom attribution to be returned in `tilejson.json`                                 | *Optional* |               |  2.5  |
 | [basePath](#vectorTiles_basePath)                              |  `string`  | The path of the vector tile source URLs in `tilejson.json`.                                | *Optional* |               |  2.5  |
 | [layers](#vectorTiles_layers)                                  | `object[]` | Configuration of the individual layers for the Mapbox vector tiles.                        | *Optional* |               |  2.0  |
 |       type = "stop"                                            |   `enum`   | Type of the layer.                                                                         | *Required* |               |  2.0  |

--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -169,12 +169,13 @@ For each layer, the configuration includes:
 
 Custom attribution to be returned in `tilejson.json`
 
-By default the `attribution` property in `tilejson.json` is computed from the names and
+By default the, `attribution` property in `tilejson.json` is computed from the names and
 URLs of the feed publishers.
 If the OTP deployment contains many fields, this can become very unwieldy.
 
-This configuration parameter allows you to set the `attribution` to any string you wish,
-for example `<a href='https://trimet.org/tools'>TriMet, C-Tran, SMART and Friends</a>`.
+This configuration parameter allows you to set the `attribution` to any string you wish
+including HTML tags,
+for example `<a href='https://trimet.org/mod'>Regional Partners</a>`.
 
 
 <h4 id="vectorTiles_basePath">basePath</h4>

--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -148,7 +148,7 @@ For each layer, the configuration includes:
 
 | Config Parameter                                               |    Type    | Summary                                                                                    |  Req./Opt. | Default Value | Since |
 |----------------------------------------------------------------|:----------:|--------------------------------------------------------------------------------------------|:----------:|---------------|:-----:|
-| attribution                                                    |  `string`  | Set a custom attribution to be returned in `tilejson.json`                                 | *Optional* |               |  2.5  |
+| [attribution](#vectorTiles_attribution)                        |  `string`  | Custom attribution to be returned in `tilejson.json`                                       | *Optional* |               |  2.5  |
 | [basePath](#vectorTiles_basePath)                              |  `string`  | The path of the vector tile source URLs in `tilejson.json`.                                | *Optional* |               |  2.5  |
 | [layers](#vectorTiles_layers)                                  | `object[]` | Configuration of the individual layers for the Mapbox vector tiles.                        | *Optional* |               |  2.0  |
 |       type = "stop"                                            |   `enum`   | Type of the layer.                                                                         | *Required* |               |  2.0  |
@@ -161,6 +161,21 @@ For each layer, the configuration includes:
 
 
 #### Details
+
+<h4 id="vectorTiles_attribution">attribution</h4>
+
+**Since version:** `2.5` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
+**Path:** /vectorTiles 
+
+Custom attribution to be returned in `tilejson.json`
+
+By default the `attribution` property in `tilejson.json` is computed from the names and
+URLs of the feed publishers.
+If the OTP deployment contains many fields, this can become very unwieldy.
+
+This configuration parameter allows you to set the `attribution` to any string you wish,
+for example `<a href='https://trimet.org/tools'>TriMet, C-Tran, SMART and Friends</a>`.
+
 
 <h4 id="vectorTiles_basePath">basePath</h4>
 

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -101,7 +101,11 @@ public class VectorTilesResource {
         TileJson.urlWithDefaultPath(uri, headers, rLayers, ignoreRouterId, "vectorTiles")
       );
 
-    return new TileJson(url, envelope, feedInfos);
+    return serverContext
+      .vectorTileConfig()
+      .attribution()
+      .map(attr -> new TileJson(url, envelope, attr))
+      .orElseGet(() -> new TileJson(url, envelope, feedInfos));
   }
 
   private static LayerBuilder<?> crateLayerBuilder(

--- a/src/main/java/org/opentripplanner/apis/support/TileJson.java
+++ b/src/main/java/org/opentripplanner/apis/support/TileJson.java
@@ -6,7 +6,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.opentripplanner.framework.io.HttpUtils;
 import org.opentripplanner.model.FeedInfo;
@@ -57,17 +56,6 @@ public class TileJson implements Serializable {
     this(tileUrl, envelope, attributionFromFeedInfo(feedInfos));
   }
 
-  @Nonnull
-  private static String attributionFromFeedInfo(Collection<FeedInfo> feedInfos) {
-    var attribution = feedInfos
-      .stream()
-      .map(feedInfo ->
-        "<a href='" + feedInfo.getPublisherUrl() + "'>" + feedInfo.getPublisherName() + "</a>"
-      )
-      .collect(Collectors.joining(", "));
-    return attribution;
-  }
-
   /**
    * Creates a vector source layer URL from a hard-coded path plus information from the incoming
    * HTTP request.
@@ -104,5 +92,15 @@ public class TileJson implements Serializable {
         strippedPath,
         String.join(",", layers)
       );
+  }
+
+  private static String attributionFromFeedInfo(Collection<FeedInfo> feedInfos) {
+    return feedInfos
+      .stream()
+      .map(feedInfo ->
+        "<a href='" + feedInfo.getPublisherUrl() + "'>" + feedInfo.getPublisherName() + "</a>"
+      )
+      .distinct()
+      .collect(Collectors.joining(", "));
   }
 }

--- a/src/main/java/org/opentripplanner/apis/support/TileJson.java
+++ b/src/main/java/org/opentripplanner/apis/support/TileJson.java
@@ -98,7 +98,7 @@ public class TileJson implements Serializable {
     return feedInfos
       .stream()
       .map(feedInfo ->
-        "<a href='" + feedInfo.getPublisherUrl() + "'>" + feedInfo.getPublisherName() + "</a>"
+        "<a href='%s'>%s</a>".formatted(feedInfo.getPublisherUrl(), feedInfo.getPublisherName())
       )
       .distinct()
       .collect(Collectors.joining(", "));

--- a/src/main/java/org/opentripplanner/apis/support/TileJson.java
+++ b/src/main/java/org/opentripplanner/apis/support/TileJson.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.opentripplanner.framework.io.HttpUtils;
 import org.opentripplanner.model.FeedInfo;
@@ -36,15 +37,8 @@ public class TileJson implements Serializable {
   public final double[] bounds;
   public final double[] center;
 
-  public TileJson(String tileUrl, WorldEnvelope envelope, Collection<FeedInfo> feedInfos) {
-    attribution =
-      feedInfos
-        .stream()
-        .map(feedInfo ->
-          "<a href='" + feedInfo.getPublisherUrl() + "'>" + feedInfo.getPublisherName() + "</a>"
-        )
-        .collect(Collectors.joining(", "));
-
+  public TileJson(String tileUrl, WorldEnvelope envelope, String attribution) {
+    this.attribution = attribution;
     tiles = new String[] { tileUrl };
 
     bounds =
@@ -57,6 +51,21 @@ public class TileJson implements Serializable {
 
     var c = envelope.center();
     center = new double[] { c.longitude(), c.latitude(), 9 };
+  }
+
+  public TileJson(String tileUrl, WorldEnvelope envelope, Collection<FeedInfo> feedInfos) {
+    this(tileUrl, envelope, attributionFromFeedInfo(feedInfos));
+  }
+
+  @Nonnull
+  private static String attributionFromFeedInfo(Collection<FeedInfo> feedInfos) {
+    var attribution = feedInfos
+      .stream()
+      .map(feedInfo ->
+        "<a href='" + feedInfo.getPublisherUrl() + "'>" + feedInfo.getPublisherName() + "</a>"
+      )
+      .collect(Collectors.joining(", "));
+    return attribution;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
@@ -47,6 +47,6 @@ public final class HttpUtils {
    * https://stackoverflow.com/questions/66042952/http-proxy-behavior-for-x-forwarded-host-header
    */
   private static String extractHost(String xForwardedFor) {
-    return Arrays.stream(xForwardedFor.split(",")).map(String::strip).toList().getFirst();
+    return Arrays.stream(xForwardedFor.split(",")).map(String::strip).findFirst().get();
   }
 }

--- a/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/framework/io/HttpUtils.java
@@ -3,6 +3,7 @@ package org.opentripplanner.framework.io;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.UriInfo;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import org.apache.hc.core5.http.ContentType;
 
 public final class HttpUtils {
@@ -31,7 +32,7 @@ public final class HttpUtils {
 
     String host;
     if (headers.getRequestHeader(HEADER_X_FORWARDED_HOST) != null) {
-      host = headers.getRequestHeader(HEADER_X_FORWARDED_HOST).getFirst();
+      host = extractHost(headers.getRequestHeader(HEADER_X_FORWARDED_HOST).getFirst());
     } else if (headers.getRequestHeader(HEADER_HOST) != null) {
       host = headers.getRequestHeader(HEADER_HOST).getFirst();
     } else {
@@ -39,5 +40,13 @@ public final class HttpUtils {
     }
 
     return protocol + "://" + host;
+  }
+
+  /**
+   * The X-Forwarded-Host header can contain a comma-separated list so we account for that.
+   * https://stackoverflow.com/questions/66042952/http-proxy-behavior-for-x-forwarded-host-header
+   */
+  private static String extractHost(String xForwardedFor) {
+    return Arrays.stream(xForwardedFor.split(",")).map(String::strip).toList().getFirst();
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
@@ -84,7 +84,17 @@ public class VectorTileConfig
       root
         .of("attribution")
         .since(V2_5)
-        .summary("Set a custom attribution to be returned in `tilejson.json`")
+        .summary("Custom attribution to be returned in `tilejson.json`")
+        .description(
+          """
+          By default the `attribution` property in `tilejson.json` is computed from the names and 
+          URLs of the feed publishers.
+          If the OTP deployment contains many fields, this can become very unwieldy. 
+          
+          This configuration parameter allows you to set the `attribution` to any string you wish,
+          for example `<a href='https://trimet.org/tools'>TriMet, C-Tran, SMART and Friends</a>`.
+          """
+        )
         .asString(DEFAULT.attribution)
     );
   }

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
@@ -18,18 +18,23 @@ import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 public class VectorTileConfig
   implements VectorTilesResource.LayersParameters<VectorTilesResource.LayerType> {
 
-  public static final VectorTileConfig DEFAULT = new VectorTileConfig(List.of(), null);
+  public static final VectorTileConfig DEFAULT = new VectorTileConfig(List.of(), null, null);
   private final List<LayerParameters<VectorTilesResource.LayerType>> layers;
 
   @Nullable
   private final String basePath;
 
+  @Nullable
+  private final String attribution;
+
   VectorTileConfig(
     Collection<? extends LayerParameters<VectorTilesResource.LayerType>> layers,
-    @Nullable String basePath
+    @Nullable String basePath,
+    @Nullable String attribution
   ) {
     this.layers = List.copyOf(layers);
     this.basePath = basePath;
+    this.attribution = attribution;
   }
 
   @Override
@@ -39,6 +44,10 @@ public class VectorTileConfig
 
   public Optional<String> basePath() {
     return Optional.ofNullable(basePath);
+  }
+
+  public Optional<String> attribution() {
+    return Optional.ofNullable(attribution);
   }
 
   public static VectorTileConfig mapVectorTilesParameters(NodeAdapter node, String paramName) {
@@ -71,7 +80,12 @@ public class VectorTileConfig
           is expected to be handled by a proxy.
           """
         )
-        .asString(DEFAULT.basePath)
+        .asString(DEFAULT.basePath),
+      root
+        .of("attribution")
+        .since(V2_5)
+        .summary("Set a custom attribution to be returned in `tilejson.json`")
+        .asString(DEFAULT.attribution)
     );
   }
 

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
@@ -87,12 +87,13 @@ public class VectorTileConfig
         .summary("Custom attribution to be returned in `tilejson.json`")
         .description(
           """
-          By default the `attribution` property in `tilejson.json` is computed from the names and 
+          By default the, `attribution` property in `tilejson.json` is computed from the names and 
           URLs of the feed publishers.
           If the OTP deployment contains many fields, this can become very unwieldy. 
           
-          This configuration parameter allows you to set the `attribution` to any string you wish,
-          for example `<a href='https://trimet.org/tools'>TriMet, C-Tran, SMART and Friends</a>`.
+          This configuration parameter allows you to set the `attribution` to any string you wish 
+          including HTML tags,
+          for example `<a href='https://trimet.org/mod'>Regional Partners</a>`.
           """
         )
         .asString(DEFAULT.attribution)

--- a/src/test/java/org/opentripplanner/apis/support/TileJsonTest.java
+++ b/src/test/java/org/opentripplanner/apis/support/TileJsonTest.java
@@ -20,6 +20,15 @@ class TileJsonTest {
     .expandToIncludeStreetEntities(1, 1)
     .expandToIncludeStreetEntities(2, 2)
     .build();
+  private static final FeedInfo FEED_INFO = new FeedInfo(
+    "1",
+    "Trimet",
+    "https://trimet.org",
+    "en",
+    LocalDate.MIN,
+    LocalDate.MIN,
+    "1"
+  );
 
   @ParameterizedTest
   @ValueSource(
@@ -51,22 +60,19 @@ class TileJsonTest {
 
   @Test
   void attributionFromFeedInfo() {
-    var feedInfo = new FeedInfo(
-      "1",
-      "Trimet",
-      "https://trimet.org",
-      "en",
-      LocalDate.MIN,
-      LocalDate.MIN,
-      "1"
-    );
-    var tileJson = new TileJson("http://example.com", ENVELOPE, List.of(feedInfo));
+    var tileJson = new TileJson("http://example.com", ENVELOPE, List.of(FEED_INFO));
+    assertEquals("<a href='https://trimet.org'>Trimet</a>", tileJson.attribution);
+  }
+
+  @Test
+  void duplicateAttribution() {
+    var tileJson = new TileJson("http://example.com", ENVELOPE, List.of(FEED_INFO, FEED_INFO));
     assertEquals("<a href='https://trimet.org'>Trimet</a>", tileJson.attribution);
   }
 
   @Test
   void attributionFromOverride() {
-    final String override = "OVERRIDE";
+    var override = "OVERRIDE";
     var tileJson = new TileJson("http://example.com", ENVELOPE, override);
     assertEquals(override, tileJson.attribution);
   }

--- a/src/test/java/org/opentripplanner/apis/support/TileJsonTest.java
+++ b/src/test/java/org/opentripplanner/apis/support/TileJsonTest.java
@@ -2,16 +2,24 @@ package org.opentripplanner.apis.support;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.glassfish.jersey.server.internal.routing.UriRoutingContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentripplanner.model.FeedInfo;
+import org.opentripplanner.service.worldenvelope.model.WorldEnvelope;
 import org.opentripplanner.test.support.HttpForTest;
 
 class TileJsonTest {
 
   private static final List<String> LAYERS = List.of("stops", "rentalVehicles");
+  private static final WorldEnvelope ENVELOPE = WorldEnvelope
+    .of()
+    .expandToIncludeStreetEntities(1, 1)
+    .expandToIncludeStreetEntities(2, 2)
+    .build();
 
   @ParameterizedTest
   @ValueSource(
@@ -39,5 +47,27 @@ class TileJsonTest {
       "https://localhost:8080/otp/routers/default/vectorTiles/stops,rentalVehicles/{z}/{x}/{y}.pbf",
       TileJson.urlWithDefaultPath(uriInfo, req, LAYERS, "default", "vectorTiles")
     );
+  }
+
+  @Test
+  void attributionFromFeedInfo() {
+    var feedInfo = new FeedInfo(
+      "1",
+      "Trimet",
+      "https://trimet.org",
+      "en",
+      LocalDate.MIN,
+      LocalDate.MIN,
+      "1"
+    );
+    var tileJson = new TileJson("http://example.com", ENVELOPE, List.of(feedInfo));
+    assertEquals("<a href='https://trimet.org'>Trimet</a>", tileJson.attribution);
+  }
+
+  @Test
+  void attributionFromOverride() {
+    final String override = "OVERRIDE";
+    var tileJson = new TileJson("http://example.com", ENVELOPE, override);
+    assertEquals(override, tileJson.attribution);
   }
 }

--- a/src/test/java/org/opentripplanner/framework/io/HttpUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/io/HttpUtilsTest.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.framework.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.glassfish.jersey.server.internal.routing.UriRoutingContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.test.support.HttpForTest;
+
+class HttpUtilsTest {
+
+  private static final String HOSTNAME = "example.com";
+
+  static List<String> testCases() {
+    return List.of(
+      HOSTNAME,
+      "example.com,",
+      " example.com ,",
+      "example.com,example.com",
+      "example.com, example.com",
+      "example.com, example.net",
+      "example.com, example.net, example.com",
+      " example.com,    example.net,   example.com"
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void extractHost(String headerValue) {
+    var req = HttpForTest.containerRequest();
+    req.headers(Map.of("X-Forwarded-Host", List.of(headerValue)));
+    var uriInfo = new UriRoutingContext(req);
+    var baseAddress = HttpUtils.getBaseAddress(uriInfo, req);
+    assertEquals("https://" + HOSTNAME, baseAddress);
+  }
+}


### PR DESCRIPTION
### Summary

@fpurcell has requested that the `attribution` in `tilejson.json` be made configurable as the automatically generated one can become very long when there are many feeds in the graph.

### Issue

Closes #5661

### Unit tests

:heavy_check_mark: 

### Documentation

:heavy_check_mark: 