### PR TITLE
Reduce flex default access/egress penalty

### DIFF
--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -411,7 +411,7 @@ The default values are
 - `car-to-park` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)
 - `car-rental` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)
 - `car-hailing` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)
-- `flexible` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)
+- `flexible` = (timePenalty: 10m + 1.30 t, costFactor: 1.30)
 
 Example: `"car-to-park" : { "timePenalty": "10m + 1.5t", "costFactor": 2.5 }`
 

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
@@ -25,12 +25,16 @@ public final class AccessEgressPreferences implements Serializable {
     TimePenalty.of(ofMinutes(20), 2f),
     1.5
   );
+  private static final TimeAndCostPenalty FLEX_DEFAULT_PENALTY = TimeAndCostPenalty.of(
+    TimePenalty.of(ofMinutes(10), 1.3f),
+    1.3
+  );
   private static final TimeAndCostPenaltyForEnum<StreetMode> DEFAULT_TIME_AND_COST = TimeAndCostPenaltyForEnum
     .of(StreetMode.class)
     .with(StreetMode.CAR_TO_PARK, DEFAULT_PENALTY)
     .with(StreetMode.CAR_HAILING, DEFAULT_PENALTY)
     .with(StreetMode.CAR_RENTAL, DEFAULT_PENALTY)
-    .with(StreetMode.FLEXIBLE, DEFAULT_PENALTY)
+    .with(StreetMode.FLEXIBLE, FLEX_DEFAULT_PENALTY)
     .build();
 
   public static final AccessEgressPreferences DEFAULT = new AccessEgressPreferences();

--- a/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -774,7 +774,7 @@ type QueryType {
   "Input type for executing a travel search for a trip between two locations. Returns trip patterns describing suggested alternatives for the trip."
   trip(
     "Time and cost penalty on access/egress modes."
-    accessEgressPenalty: [PenaltyForStreetMode!] = [{streetMode : car_park, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : flexible, timePenalty : "20m + 2.0 t", costFactor : 1.5}],
+    accessEgressPenalty: [PenaltyForStreetMode!] = [{streetMode : car_park, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : flexible, timePenalty : "10m + 1.30 t", costFactor : 1.3}],
     "The alightSlack is the minimum extra time after exiting a public transport vehicle. This is the default value used, if not overridden by the 'alightSlackList'."
     alightSlackDefault: Int = 0,
     "List of alightSlack for a given set of modes. Defaults: []"

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
@@ -112,7 +112,7 @@ class StreetPreferencesTest {
       "accessEgress: AccessEgressPreferences{penalty: TimeAndCostPenaltyForEnum{CAR_TO_PARK: " +
       CAR_PENALTY +
       ", CAR_RENTAL: (timePenalty: 20m + 2.0 t, costFactor: 1.50), CAR_HAILING: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
-      "FLEXIBLE: (timePenalty: 20m + 2.0 t, costFactor: 1.50)}, " +
+      "FLEXIBLE: (timePenalty: 10m + 1.30 t, costFactor: 1.30)}, " +
       "maxDuration: DurationForStreetMode{default:5m}" +
       "}, " +
       "maxDirectDuration: DurationForStreetMode{default:10m}" +


### PR DESCRIPTION
### Summary

In a previous PR #5381 I set the flex accessEgress penalty to the same value as Park&Ride. It turns out that this is too aggressive and I lowered the value accordingly.

### Documentation

Autogenerated.