### PR TITLE
Set defaults of the modes WALK, even if one and not the others are set

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
@@ -7,6 +7,10 @@ import org.opentripplanner.routing.api.request.StreetMode;
 
 class RequestModesMapper {
 
+  private static final String accessModeKey = "accessMode";
+  private static final String egressModeKey = "egressMode";
+  private static final String directModeKey = "directMode";
+
   /**
    * Maps GraphQL Modes input type to RequestModes.
    * <p>
@@ -16,16 +20,16 @@ class RequestModesMapper {
   static RequestModes mapRequestModes(Map<String, ?> modesInput) {
     RequestModesBuilder mBuilder = RequestModes.of();
 
-    if (modesInput.containsKey("accessMode")) {
-      StreetMode accessMode = (StreetMode) modesInput.get("accessMode");
+    if (modesInput.containsKey(accessModeKey)) {
+      StreetMode accessMode = (StreetMode) modesInput.get(accessModeKey);
       mBuilder.withAccessMode(accessMode);
       mBuilder.withTransferMode(accessMode == StreetMode.BIKE ? StreetMode.BIKE : StreetMode.WALK);
     }
-    if (modesInput.containsKey("egressMode")) {
-      mBuilder.withEgressMode((StreetMode) modesInput.get("egressMode"));
+    if (modesInput.containsKey(egressModeKey)) {
+      mBuilder.withEgressMode((StreetMode) modesInput.get(egressModeKey));
     }
-    if (modesInput.containsKey("directMode")) {
-      mBuilder.withDirectMode((StreetMode) modesInput.get("directMode"));
+    if (modesInput.containsKey(directModeKey)) {
+      mBuilder.withDirectMode((StreetMode) modesInput.get(directModeKey));
     }
 
     return mBuilder.build();

--- a/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
@@ -8,11 +8,10 @@ import org.opentripplanner.routing.api.request.StreetMode;
 class RequestModesMapper {
 
   /**
-   * Maps a GraphQL Modes input type to a RequestModes.
-   *
-   * This only maps access, egress, direct & transfer.
-   * Transport modes are now part of filters.
-   * Only in case filters are not present we will use this mapping
+   * Maps GraphQL Modes input type to RequestModes.
+   * <p>
+   * This only maps access, egress, direct & transfer modes. Transport modes are set using filters.
+   * Default modes are WALK for access, egress, direct & transfer.
    */
   @SuppressWarnings("unchecked")
   static RequestModes mapRequestModes(Map<String, ?> modesInput) {

--- a/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
@@ -16,14 +16,19 @@ class RequestModesMapper {
    */
   @SuppressWarnings("unchecked")
   static RequestModes mapRequestModes(Map<String, ?> modesInput) {
-    StreetMode accessMode = (StreetMode) modesInput.get("accessMode");
-    RequestModesBuilder mBuilder = RequestModes
-      .of()
-      .withAccessMode(accessMode)
-      .withEgressMode((StreetMode) modesInput.get("egressMode"))
-      .withDirectMode((StreetMode) modesInput.get("directMode"));
+    RequestModesBuilder mBuilder = RequestModes.of();
 
-    mBuilder.withTransferMode(accessMode == StreetMode.BIKE ? StreetMode.BIKE : StreetMode.WALK);
+    if (modesInput.containsKey("accessMode")) {
+      StreetMode accessMode = (StreetMode) modesInput.get("accessMode");
+      mBuilder.withAccessMode(accessMode);
+      mBuilder.withTransferMode(accessMode == StreetMode.BIKE ? StreetMode.BIKE : StreetMode.WALK);
+    }
+    if (modesInput.containsKey("egressMode")) {
+      mBuilder.withEgressMode((StreetMode) modesInput.get("egressMode"));
+    }
+    if (modesInput.containsKey("directMode")) {
+      mBuilder.withDirectMode((StreetMode) modesInput.get("directMode"));
+    }
 
     return mBuilder.build();
   }

--- a/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
@@ -13,7 +13,6 @@ class RequestModesMapper {
    * This only maps access, egress, direct & transfer modes. Transport modes are set using filters.
    * Default modes are WALK for access, egress, direct & transfer.
    */
-  @SuppressWarnings("unchecked")
   static RequestModes mapRequestModes(Map<String, ?> modesInput) {
     RequestModesBuilder mBuilder = RequestModes.of();
 

--- a/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.apis.transmodel.mapping;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.api.request.RequestModes;
@@ -12,7 +11,7 @@ class RequestModesMapperTest {
 
   @Test
   void testMapRequestModesEmptyMapReturnsDefaults() {
-    Map<String, StreetMode> inputModes = new HashMap<>();
+    Map<String, StreetMode> inputModes = Map.of();
 
     RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
 
@@ -36,9 +35,7 @@ class RequestModesMapperTest {
 
   @Test
   void testMapRequestModesEgressSetReturnsDefaultsForOthers() {
-    Map<String, StreetMode> inputModes = new HashMap<>();
-
-    inputModes.put("egressMode", StreetMode.CAR);
+    Map<String, StreetMode> inputModes = Map.of("egressMode", StreetMode.CAR);
 
     RequestModes wantModes = RequestModes.of().withEgressMode(StreetMode.CAR).build();
 
@@ -49,9 +46,7 @@ class RequestModesMapperTest {
 
   @Test
   void testMapRequestModesDirectSetReturnsDefaultsForOthers() {
-    Map<String, StreetMode> inputModes = new HashMap<>();
-
-    inputModes.put("directMode", StreetMode.CAR);
+    Map<String, StreetMode> inputModes = Map.of("directMode", StreetMode.CAR);
 
     RequestModes wantModes = RequestModes.of().withDirectMode(StreetMode.CAR).build();
 

--- a/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.api.request.RequestModes;
+import org.opentripplanner.routing.api.request.StreetMode;
+
+class RequestModesMapperTest {
+
+  @Test
+  void testMapRequestModesEmptyMapReturnsDefaults() {
+    Map<String, StreetMode> inputModes = new HashMap<>();
+
+    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+
+    assertEquals(RequestModes.of().build(), mappedModes);
+  }
+
+  @Test
+  void testMapRequestModesAccessSetReturnsDefaultsForOthers() {
+    Map<String, StreetMode> inputModes = new HashMap<>();
+
+    inputModes.put("accessMode", StreetMode.BIKE);
+
+    RequestModes wantModes = RequestModes
+      .of()
+      .withAccessMode(StreetMode.BIKE)
+      .withTransferMode(StreetMode.BIKE)
+      .build();
+
+    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+
+    assertEquals(wantModes, mappedModes);
+  }
+
+  @Test
+  void testMapRequestModesEgressSetReturnsDefaultsForOthers() {
+    Map<String, StreetMode> inputModes = new HashMap<>();
+
+    inputModes.put("egressMode", StreetMode.CAR);
+
+    RequestModes wantModes = RequestModes.of().withEgressMode(StreetMode.CAR).build();
+
+    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+
+    assertEquals(wantModes, mappedModes);
+  }
+
+  @Test
+  void testMapRequestModesDirectSetReturnsDefaultsForOthers() {
+    Map<String, StreetMode> inputModes = new HashMap<>();
+
+    inputModes.put("directMode", StreetMode.CAR);
+
+    RequestModes wantModes = RequestModes.of().withDirectMode(StreetMode.CAR).build();
+
+    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+
+    assertEquals(wantModes, mappedModes);
+  }
+}

--- a/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
@@ -21,9 +21,7 @@ class RequestModesMapperTest {
 
   @Test
   void testMapRequestModesAccessSetReturnsDefaultsForOthers() {
-    Map<String, StreetMode> inputModes = new HashMap<>();
-
-    inputModes.put("accessMode", StreetMode.BIKE);
+    Map<String, StreetMode> inputModes = Map.of("accessMode", StreetMode.BIKE);
 
     RequestModes wantModes = RequestModes
       .of()


### PR DESCRIPTION
### Summary

This PR changes the behavior of the modes field so that the "WALK" defaults are applied also when some of the access, egress, and direct modes are set. Previously the default would only be applied if none of the three are set.

### Unit tests

Added new unittest for the mapping of GraphQL modes to OTP internal modes.

### Documentation

Updated javadoc.
