### PR TITLE
Save startup model when InteractiveOtpMain starts

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/InteractiveOtpMain.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/InteractiveOtpMain.java
@@ -31,6 +31,7 @@ public class InteractiveOtpMain {
   }
 
   private void startOtp() {
+    model.save();
     startDebugControllerAndSetupRequestInterceptor();
 
     System.out.println("Start OTP: " + model + "\n");

--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/Model.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/Model.java
@@ -55,7 +55,7 @@ public class Model implements Serializable {
     }
   }
 
-  private void save() {
+  void save() {
     try {
       var mapper = new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, true);
       mapper.writeValue(MODEL_FILE, this);


### PR DESCRIPTION
### Summary

This is a regression. The bug was introduced when the controller was added. The startUpView is saved if the user start OTP, while the controller models are saved if changed.

### Issue
🟥  No issue for this

### Unit tests
🟥  No tests

### Documentation
🟥  No doc - this is a bug fix.

### Changelog
🟥  Not relevant - Sandbox

### Bumping the serialization version id
🟥  No changes to OTP ser. graph
