### PR TITLE
Make product fare id optional for transfer rules inline with spec

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -351,7 +351,9 @@ public class GtfsModule implements GraphBuilderModule {
       fareProduct.getId().setAgencyId(reader.getDefaultAgencyId());
     }
     for (var transferRule : store.getAllEntitiesForType(FareTransferRule.class)) {
-      transferRule.getFareProductId().setAgencyId(reader.getDefaultAgencyId());
+      if (transferRule.getFareProductId() != null) {
+        transferRule.getFareProductId().setAgencyId(reader.getDefaultAgencyId());
+      }
       transferRule.getFromLegGroupId().setAgencyId(reader.getDefaultAgencyId());
       transferRule.getToLegGroupId().setAgencyId(reader.getDefaultAgencyId());
     }


### PR DESCRIPTION
### Summary

When using `FaresV2` check if `fareProductId` exists on a `transferRule` before trying to set agency Id.
This is because `fareProductId` is optional for `transferRule` in the spec

Spec: https://gtfs.org/schedule/reference/#fare_transfer_rulestxt

### Issue

[Issue](https://github.com/opentripplanner/OpenTripPlanner/issues/5691)
When compiling OTP with out GTFS data using FaresV2 it failed to compile with a null pointer exception.
This is because the transferRule expects a product Id to exist even though the field is optional in the GTFS spec.

Closes #5691

### Unit tests

No new tests were added.  This pull request passes all the existing tests.
