### PR TITLE
Netex: check and use gml:pos tag if Latitude and Longitude doesn't exists

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.rutebanken.netex.model.LocationStructure;
@@ -21,10 +22,19 @@ class WgsCoordinateMapper {
     }
     LocationStructure loc = point.getLocation();
 
-    // This should not happen
     if (loc.getLongitude() == null || loc.getLatitude() == null) {
-      throw new IllegalArgumentException("Coordinate is not valid: " + loc);
+      if (loc.getPos() == null) {
+        throw new IllegalArgumentException("Coordinate is not valid: " + loc);
+      }
+
+      List<Double> coordinates = loc.getPos().getValue();
+      if (coordinates.size() != 2) {
+        throw new IllegalArgumentException("Coordinate is not valid: " + loc);
+      }
+
+      return new WgsCoordinate(coordinates.get(1), coordinates.get(0));
     }
+
     // Location is safe to process
     return new WgsCoordinate(loc.getLatitude().doubleValue(), loc.getLongitude().doubleValue());
   }

--- a/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
@@ -80,4 +80,15 @@ public class WgsCoordinateMapperTest {
     assertEquals(LONGITUDE_VALUE, c.longitude(), DELTA);
     assertEquals(LATITUDE_VALUE, c.latitude(), DELTA);
   }
+
+  @Test
+  public void handleCoordinateWithIncompleteGmlPosition() {
+    LocationStructure locationStructure = new LocationStructure()
+      .withPos(new DirectPositionType().withValue(LONGITUDE_VALUE));
+
+    SimplePoint_VersionStructure point = new SimplePoint_VersionStructure()
+      .withLocation(locationStructure);
+
+    assertThrows(IllegalArgumentException.class, () -> WgsCoordinateMapper.mapToDomain(point));
+  }
 }

--- a/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import net.opengis.gml._3.DirectPositionType;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.rutebanken.netex.model.LocationStructure;
@@ -62,5 +63,21 @@ public class WgsCoordinateMapperTest {
       new SimplePoint_VersionStructure()
         .withLocation(new LocationStructure().withLatitude(LATITUDE));
     assertThrows(IllegalArgumentException.class, () -> WgsCoordinateMapper.mapToDomain(p));
+  }
+
+  @Test
+  public void handleCoordinateWithGmlPosition() {
+    LocationStructure locationStructure = new LocationStructure()
+      .withPos(new DirectPositionType().withValue(LONGITUDE_VALUE, LATITUDE_VALUE));
+
+    SimplePoint_VersionStructure point = new SimplePoint_VersionStructure()
+      .withLocation(locationStructure);
+
+    // When map coordinates
+    WgsCoordinate c = WgsCoordinateMapper.mapToDomain(point);
+
+    // Then verify coordinate
+    assertEquals(LONGITUDE_VALUE, c.longitude(), DELTA);
+    assertEquals(LATITUDE_VALUE, c.latitude(), DELTA);
   }
 }


### PR DESCRIPTION
### Summary

The coordinate mapper assume that is used Latitude and Longitude tag, but these tags can use replaced by gml:pos tag (used in some Netex italian files).

### Unit tests

Created a unit test **handleCoordinateWithGmlPosition** in **WgsCoordinateMapperTest**.
Tested with italian Netex files.
