### PR TITLE
Avoid cumulative real-time updates

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/mapper/PickDropMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/mapper/PickDropMapper.java
@@ -18,12 +18,12 @@ public class PickDropMapper {
    * The Siri ArrivalBoardingActivity includes less information than the pick drop type, therefore is it only
    * changed if routability has changed.
    *
-   * @param currentValue The current pick drop value on a stopTime
+   * @param plannedValue The current pick drop value on a stopTime
    * @param call The incoming call to be mapped
    * @return Mapped PickDrop type, empty if routability is not changed.
    */
-  public static Optional<PickDrop> mapDropOffType(CallWrapper call, PickDrop currentValue) {
-    if (shouldBeCancelled(currentValue, call.isCancellation(), call.getArrivalStatus())) {
+  public static Optional<PickDrop> mapDropOffType(CallWrapper call, PickDrop plannedValue) {
+    if (shouldBeCancelled(plannedValue, call.isCancellation(), call.getArrivalStatus())) {
       return Optional.of(CANCELLED);
     }
 
@@ -33,7 +33,7 @@ public class PickDropMapper {
     }
 
     return switch (arrivalBoardingActivityEnumeration) {
-      case ALIGHTING -> currentValue.isNotRoutable() ? Optional.of(SCHEDULED) : Optional.empty();
+      case ALIGHTING -> plannedValue.isNotRoutable() ? Optional.of(SCHEDULED) : Optional.empty();
       case NO_ALIGHTING -> Optional.of(NONE);
       case PASS_THRU -> Optional.of(CANCELLED);
     };
@@ -45,12 +45,12 @@ public class PickDropMapper {
    * The Siri DepartureBoardingActivity includes less information than the planned data, therefore is it only
    * changed if routability has changed.
    *
-   * @param currentValue The current pick drop value on a stopTime
+   * @param plannedValue The current pick drop value on a stopTime
    * @param call The incoming call to be mapped
    * @return Mapped PickDrop type, empty if routability is not changed.
    */
-  public static Optional<PickDrop> mapPickUpType(CallWrapper call, PickDrop currentValue) {
-    if (shouldBeCancelled(currentValue, call.isCancellation(), call.getDepartureStatus())) {
+  public static Optional<PickDrop> mapPickUpType(CallWrapper call, PickDrop plannedValue) {
+    if (shouldBeCancelled(plannedValue, call.isCancellation(), call.getDepartureStatus())) {
       return Optional.of(CANCELLED);
     }
 
@@ -60,7 +60,7 @@ public class PickDropMapper {
     }
 
     return switch (departureBoardingActivityEnumeration) {
-      case BOARDING -> currentValue.isNotRoutable() ? Optional.of(SCHEDULED) : Optional.empty();
+      case BOARDING -> plannedValue.isNotRoutable() ? Optional.of(SCHEDULED) : Optional.empty();
       case NO_BOARDING -> Optional.of(NONE);
       case PASS_THRU -> Optional.of(CANCELLED);
     };
@@ -71,17 +71,16 @@ public class PickDropMapper {
    *
    * If the existing PickDrop is non-routable, the value is not changed.
    *
-   * @param currentValue The current pick drop value on a stopTime
+   * @param plannedValue The planned pick drop value on a stopTime
    * @param isCallCancellation The incoming call cancellation-flag
    * @param callStatus The incoming call arrival/departure status
-   * @return
    */
   private static boolean shouldBeCancelled(
-    PickDrop currentValue,
+    PickDrop plannedValue,
     Boolean isCallCancellation,
     CallStatusEnumeration callStatus
   ) {
-    if (currentValue.isNotRoutable()) {
+    if (plannedValue.isNotRoutable()) {
       return false;
     }
     return TRUE.equals(isCallCancellation) || callStatus == CallStatusEnumeration.CANCELLED;

--- a/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModule.java
+++ b/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModule.java
@@ -67,7 +67,7 @@ public class StopConsolidationModule implements GraphBuilderModule {
     TripPattern pattern,
     List<StopReplacement> replacements
   ) {
-    var updatedStopPattern = pattern.getStopPattern().mutate();
+    var updatedStopPattern = pattern.copyPlannedStopPattern();
     replacements.forEach(r -> updatedStopPattern.replaceStop(r.secondary(), r.primary()));
     return pattern.copy().withStopPattern(updatedStopPattern.build()).build();
   }

--- a/src/main/java/org/opentripplanner/framework/lang/MemEfficientArrayBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/lang/MemEfficientArrayBuilder.java
@@ -5,13 +5,13 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /**
- * This array builder is used to minimize creating new objects(arrays). It takes an array as base,
+ * This array builder is used to minimize the creation of new objects (arrays). It takes an array as base,
  * the original array. A new array is created only if there are differences.
  * <p>
  * A common case is that one original is updated several times. In this case, you can use the
- * {@link #build(Object[])}, too also make sure the existing update is reused (deduplicated).
+ * {@link #build(Object[])} method to also make sure that the existing update is reused (deduplicated).
  * <p>
- * Arrays are mutable, so be careful this class helps you reuse the original if it has the same
+ * Arrays are mutable, so be careful as this class helps you reuse the original if it has the same
  * values. It protects the original while in scope, but you should only use it if you do not
  * modify the original or the result on the outside. This builder does not help protect the arrays.
  */

--- a/src/main/java/org/opentripplanner/framework/lang/MemEfficientArrayBuilder.java
+++ b/src/main/java/org/opentripplanner/framework/lang/MemEfficientArrayBuilder.java
@@ -1,0 +1,99 @@
+package org.opentripplanner.framework.lang;
+
+import java.util.Arrays;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+/**
+ * This array builder is used to minimize creating new objects(arrays). It takes an array as base,
+ * the original array. A new array is created only if there are differences.
+ * <p>
+ * A common case is that one original is updated several times. In this case, you can use the
+ * {@link #build(Object[])}, too also make sure the existing update is reused (deduplicated).
+ * <p>
+ * Arrays are mutable, so be careful this class helps you reuse the original if it has the same
+ * values. It protects the original while in scope, but you should only use it if you do not
+ * modify the original or the result on the outside. This builder does not help protect the arrays.
+ */
+public final class MemEfficientArrayBuilder<T> {
+
+  private final T[] original;
+  private T[] array = null;
+
+  private MemEfficientArrayBuilder(@Nonnull T[] original) {
+    this.original = Objects.requireNonNull(original);
+  }
+
+  /**
+   * Create a new array with the same size and values as the original.
+   */
+  public static <T> MemEfficientArrayBuilder<T> of(T[] original) {
+    return new MemEfficientArrayBuilder<>(original);
+  }
+
+  /**
+   * The size of the original and new array under construction.
+   */
+  public int size() {
+    return original.length;
+  }
+
+  /**
+   * Set the value at the given index.
+   */
+  public MemEfficientArrayBuilder<T> with(int index, T value) {
+    if (isNotModified()) {
+      if (value == original[index]) {
+        return this;
+      }
+      array = Arrays.copyOf(original, original.length);
+    } else if (value == array[index]) {
+      return this;
+    }
+    array[index] = value;
+    return this;
+  }
+
+  /**
+   * Return the value at the given index from the original array.
+   */
+  public T original(int index) {
+    return original[index];
+  }
+
+  /**
+   * Return the new value or fallback to the original value at the given index.
+   */
+  public T getOrOriginal(int index) {
+    return isNotModified() ? original[index] : array[index];
+  }
+
+  /**
+   * There are no changes compared to the original array so far.
+   */
+  public boolean isNotModified() {
+    return array == null;
+  }
+
+  /**
+   * Build a new array.
+   * <ol>
+   *   <li>If no modifications exist the original array is returned</li>
+   *   <li>If the new array equals the candidate the candidate is returned</li>
+   *   <li>If not, a new array is returned</li>
+   * </ol>
+   */
+  public T[] build(T[] candidate) {
+    if (isNotModified()) {
+      return original;
+    }
+    return Arrays.equals(candidate, array) ? candidate : array;
+  }
+
+  /**
+   * Create a new array or return the original [if not modified]
+   */
+  public T[] build() {
+    return isNotModified() ? original : array;
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -159,6 +159,20 @@ public final class TripPattern
     return stopPattern;
   }
 
+  /**
+   * Return the "original"/planned stop pattern as a builder. This is used when a realtime-update
+   * contains a full set of stops/pickup/droppoff for a pattern. This will wipe out any changes
+   * to the stop-pattern from previous updates.
+   * <p>
+   * Be aware, if the same update is applied twice, then the first instance will be reused to avoid
+   * unnecessary objects creation and gc.
+   */
+  public StopPattern.StopPatternBuilder copyPlannedStopPattern() {
+    return isModified()
+      ? originalTripPattern.stopPattern.mutate(stopPattern)
+      : stopPattern.mutate();
+  }
+
   public LineString getGeometry() {
     if (hopGeometries == null || hopGeometries.length == 0) {
       return null;
@@ -346,7 +360,7 @@ public final class TripPattern
    */
   public boolean isModifiedFromTripPatternWithEqualStops(TripPattern other) {
     return (
-      originalTripPattern != null &&
+      isModified() &&
       originalTripPattern.equals(other) &&
       getStopPattern().stopsEqual(other.getStopPattern())
     );
@@ -392,6 +406,10 @@ public final class TripPattern
 
   public TripPattern getOriginalTripPattern() {
     return originalTripPattern;
+  }
+
+  public boolean isModified() {
+    return originalTripPattern != null;
   }
 
   /**
@@ -481,7 +499,7 @@ public final class TripPattern
    * is added through a realtime update. The pickup and dropoff values don't have to be the same.
    */
   private boolean containsSameStopsAsOriginalPattern() {
-    return originalTripPattern != null && getStops().equals(originalTripPattern.getStops());
+    return isModified() && getStops().equals(originalTripPattern.getStops());
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -161,7 +161,7 @@ public final class TripPattern
 
   /**
    * Return the "original"/planned stop pattern as a builder. This is used when a realtime-update
-   * contains a full set of stops/pickup/droppoff for a pattern. This will wipe out any changes
+   * contains a full set of stops/pickup/dropoff for a pattern. This will wipe out any changes
    * to the stop-pattern from previous updates.
    * <p>
    * Be aware, if the same update is applied twice, then the first instance will be reused to avoid

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -467,8 +467,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     // If there are skipped stops, we need to change the pattern from the scheduled one
     if (skippedStopIndices.size() > 0) {
       StopPattern newStopPattern = pattern
-        .getStopPattern()
-        .mutate()
+        .copyPlannedStopPattern()
         .cancelStops(skippedStopIndices)
         .build();
 

--- a/src/test/java/org/opentripplanner/framework/lang/MemEfficientArrayBuilderTest.java
+++ b/src/test/java/org/opentripplanner/framework/lang/MemEfficientArrayBuilderTest.java
@@ -1,0 +1,91 @@
+package org.opentripplanner.framework.lang;
+
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.DayOfWeek;
+import org.junit.jupiter.api.Test;
+
+class MemEfficientArrayBuilderTest {
+
+  private final DayOfWeek[] WEEKEND = { SATURDAY, SUNDAY };
+
+  @Test
+  void size() {
+    assertEquals(WEEKEND.length, MemEfficientArrayBuilder.of(WEEKEND).size());
+  }
+
+  @Test
+  void with() {
+    var smallWeekend = MemEfficientArrayBuilder
+      .of(WEEKEND)
+      .with(0, DayOfWeek.THURSDAY)
+      .with(1, DayOfWeek.FRIDAY)
+      .build();
+    assertArrayEquals(new DayOfWeek[] { DayOfWeek.THURSDAY, DayOfWeek.FRIDAY }, smallWeekend);
+  }
+
+  @Test
+  void withOutChange() {
+    var array = MemEfficientArrayBuilder.of(WEEKEND).build();
+    assertSame(WEEKEND, array);
+
+    array = MemEfficientArrayBuilder.of(WEEKEND).with(0, SATURDAY).build();
+    assertSame(WEEKEND, array);
+
+    array = MemEfficientArrayBuilder.of(WEEKEND).with(1, SUNDAY).with(0, SATURDAY).build();
+    assertSame(WEEKEND, array);
+  }
+
+  @Test
+  void getOrOriginal() {
+    var array = MemEfficientArrayBuilder.of(WEEKEND).with(1, MONDAY);
+    assertEquals(SATURDAY, array.getOrOriginal(0));
+    assertEquals(MONDAY, array.getOrOriginal(1));
+  }
+
+  @Test
+  void original() {
+    // Verify that modifications do not change original
+    var array = MemEfficientArrayBuilder.of(WEEKEND).with(1, MONDAY);
+    assertEquals(SATURDAY, array.original(0));
+    assertEquals(SUNDAY, array.original(1));
+  }
+
+  @Test
+  void isNotModified() {
+    var array = MemEfficientArrayBuilder.of(WEEKEND);
+    assertTrue(array.isNotModified());
+
+    array.with(0, SATURDAY).with(1, SUNDAY);
+    assertTrue(array.isNotModified());
+
+    array.with(0, MONDAY);
+    assertFalse(array.isNotModified());
+  }
+
+  @Test
+  void testBuildWithCandidate() {
+    DayOfWeek[] candidate = { TUESDAY, WEDNESDAY };
+    var array = MemEfficientArrayBuilder.of(WEEKEND);
+
+    // Without changes, we expect the original to be retuned
+    assertSame(WEEKEND, array.build(candidate));
+
+    // Second value set, but not first
+    array = MemEfficientArrayBuilder.of(WEEKEND).with(1, WEDNESDAY);
+    assertArrayEquals(new DayOfWeek[] { SATURDAY, WEDNESDAY }, array.build(candidate));
+
+    // Same as candidate build
+    array = MemEfficientArrayBuilder.of(WEEKEND).with(1, WEDNESDAY).with(0, TUESDAY);
+    assertArrayEquals(candidate, array.build(candidate));
+  }
+}

--- a/src/test/java/org/opentripplanner/model/TripPatternTest.java
+++ b/src/test/java/org/opentripplanner/model/TripPatternTest.java
@@ -95,11 +95,11 @@ public class TripPatternTest {
     List<LineString> geometry
   ) {
     var builder = StopPattern.create(2);
-    builder.stops[0] = origin;
-    builder.stops[1] = destination;
+    builder.stops.with(0, origin);
+    builder.stops.with(1, destination);
     for (int i = 0; i < 2; i++) {
-      builder.pickups[i] = PickDrop.SCHEDULED;
-      builder.dropoffs[i] = PickDrop.SCHEDULED;
+      builder.pickups.with(i, PickDrop.SCHEDULED);
+      builder.dropoffs.with(i, PickDrop.SCHEDULED);
     }
 
     var stopPattern = builder.build();

--- a/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
@@ -124,7 +124,7 @@ class ServiceLinkMapperTest {
         new NetexMainAndSubMode(TransitMode.BUS, "UNKNOWN"),
         Accessibility.NO_INFORMATION
       );
-      stopPatternBuilder.stops[i] = stop;
+      stopPatternBuilder.stops.with(i, stop);
       stopsById.add(stop);
     }
 

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -221,9 +221,9 @@ public class TransitModelForTest {
   public StopPattern stopPattern(int numberOfStops) {
     var builder = StopPattern.create(numberOfStops);
     for (int i = 0; i < numberOfStops; i++) {
-      builder.stops[i] = stop("Stop_" + i).build();
-      builder.pickups[i] = PickDrop.SCHEDULED;
-      builder.dropoffs[i] = PickDrop.SCHEDULED;
+      builder.stops.with(i, stop("Stop_" + i).build());
+      builder.pickups.with(i, PickDrop.SCHEDULED);
+      builder.dropoffs.with(i, PickDrop.SCHEDULED);
     }
     return builder.build();
   }
@@ -231,9 +231,9 @@ public class TransitModelForTest {
   public static StopPattern stopPattern(RegularStop... stops) {
     var builder = StopPattern.create(stops.length);
     for (int i = 0; i < stops.length; i++) {
-      builder.stops[i] = stops[i];
-      builder.pickups[i] = PickDrop.SCHEDULED;
-      builder.dropoffs[i] = PickDrop.SCHEDULED;
+      builder.stops.with(i, stops[i]);
+      builder.pickups.with(i, PickDrop.SCHEDULED);
+      builder.dropoffs.with(i, PickDrop.SCHEDULED);
     }
     return builder.build();
   }


### PR DESCRIPTION
### Summary

Realtime updates (at least Siri ET) should in general not be treated as cumulative updates. This make the logic complicated, you need to account for all kind of updates when applying a new on top of others. In the case of a malicious update, resending a ok one will not fix the problem as well. 

This PR changes the stop-pattern logic so that a update is applied on top of the planned stop-pattern and not the last version from the previous update. ~~There are a few places where this happens, so I included a few commits witch revert the changes if needed. The plan is either to drop those commits or to squash them.~~ (I have removed these commits now, since no one requested them).

I would like to see som tests of this with various updators:

- [x] Siri (Entur)
- [x] Siri (Skaanetrafiken)
- [ ] GTFS (HSL)
- [x] StopConsolidation - IBI (Sandbox)


### Issue

At Entur we applied the following update several time and OTP toggled between the expected state (Stop 1,,2,3 CANCELED) and not (Stop 1,2,3 SCHEDULED). 

[Netex data set - One line](https://github.com/opentripplanner/OpenTripPlanner/files/14407200/rb_flt-aggregated-netex.zip)
[Siri update](https://github.com/opentripplanner/OpenTripPlanner/files/14407202/siri-update.xml.zip)

To reproduce the problem, you can start OTP with the given data set and use the following _build-config.json_
```json
"updaters": [
 {
      "type": "siri-et-updater",
      "url": "file://[PATH-TO-LOCAL-FOLDER-WITH-SIRI-XML-FILE]",
      "frequency": "3s",
      "previewInterval": "3h",
      "feedId": "RB",
      "blockReadinessUntilInitialized": true,
      "fuzzyTripMatching": true
     }
  ]
```

### Possible challanges

Existing systems may relay on cumulative updates.


### Unit tests
✅  One unit tests is added, and a few updated.

### Documentation
Only JavaDoc

### Changelog

✅  


### Bumping the serialization version id

🟥  Not needed
