### PR TITLE
Disallow defining the same stop id twice

### DIFF
--- a/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
@@ -48,12 +48,17 @@ public class StopModelBuilder {
   }
 
   public StopModelBuilder withRegularStop(RegularStop stop) {
+    if (regularStopById.containsKey(stop.getId())) {
+      throw new IllegalArgumentException(
+        "StopModelBuilder %s already contains a stop with the id %s".formatted(this, stop.getId())
+      );
+    }
     regularStopById.add(stop);
     return this;
   }
 
   public StopModelBuilder withRegularStops(Collection<RegularStop> stops) {
-    regularStopById.addAll(stops);
+    stops.forEach(this::withRegularStop);
     return this;
   }
 


### PR DESCRIPTION
### Summary

Together with @daniel-heppner-ibigroup we debugged a very confusing IBI deployment: graph build was successful but OTP would crash at runtime because transfers referred to non-existing entities.

It turned out that a GTFS feed had feed_info.feed_id set to `3` which collided with the auto-generated id for another feed.

I would like to disallow using the same `FeedScopedId` several times and this PR enforces it during construction and merging of `StopModel`s.

It's not as polished as it could be because I want to discuss this

### Unit tests

Before I write tests, I would like to discuss the approach.