### PR TITLE
Add a matcher API for filters in the transit service used for datedServiceJourneyQuery

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyQuery.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyQuery.java
@@ -10,13 +10,13 @@ import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLOutputType;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Stream;
 import org.opentripplanner.apis.transmodel.mapping.TransitIdMapper;
 import org.opentripplanner.apis.transmodel.model.EnumTypes;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
+import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
+import org.opentripplanner.transit.api.request.TripOnServiceDateRequestBuilder;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
-import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 
 /**
  * A GraphQL query for retrieving data on DatedServiceJourneys
@@ -93,72 +93,38 @@ public class DatedServiceJourneyQuery {
           .type(new GraphQLList(new GraphQLNonNull(Scalars.GraphQLString)))
       )
       .dataFetcher(environment -> {
-        Stream<TripOnServiceDate> stream = GqlUtil
-          .getTransitService(environment)
-          .getAllTripOnServiceDates()
-          .stream();
-
+        var authorities = mapIDsToDomainNullSafe(environment.getArgument("authorities"));
         var lines = mapIDsToDomainNullSafe(environment.getArgument("lines"));
         var serviceJourneys = mapIDsToDomainNullSafe(environment.getArgument("serviceJourneys"));
+        var replacementFor = mapIDsToDomainNullSafe(environment.getArgument("replacementFor"));
         var privateCodes = environment.<List<String>>getArgument("privateCodes");
         var operatingDays = environment.<List<LocalDate>>getArgument("operatingDays");
         var alterations = environment.<List<TripAlteration>>getArgument("alterations");
-        var authorities = mapIDsToDomainNullSafe(environment.getArgument("authorities"));
-        var replacementFor = mapIDsToDomainNullSafe(environment.getArgument("replacementFor"));
 
-        if (!lines.isEmpty()) {
-          stream =
-            stream.filter(tripOnServiceDate ->
-              lines.contains(tripOnServiceDate.getTrip().getRoute().getId())
-            );
+        if (operatingDays == null || operatingDays.isEmpty()) {
+          throw new IllegalArgumentException("At least one operatingDay must be provided.");
         }
 
-        if (!serviceJourneys.isEmpty()) {
-          stream =
-            stream.filter(tripOnServiceDate ->
-              serviceJourneys.contains(tripOnServiceDate.getTrip().getId())
-            );
-        }
+        TripOnServiceDateRequestBuilder tripOnServiceDateRequestBuilder = TripOnServiceDateRequest
+          .of(operatingDays)
+          .withAuthorities(authorities)
+          .withLines(lines)
+          .withServiceJourneys(serviceJourneys)
+          .withReplacementFor(replacementFor);
 
         if (privateCodes != null && !privateCodes.isEmpty()) {
-          stream =
-            stream.filter(tripOnServiceDate ->
-              privateCodes.contains(tripOnServiceDate.getTrip().getNetexInternalPlanningCode())
-            );
+          tripOnServiceDateRequestBuilder =
+            tripOnServiceDateRequestBuilder.withPrivateCodes(privateCodes);
         }
-
-        // At least one operationg day is required
-        var days = operatingDays.stream().toList();
-
-        stream =
-          stream.filter(tripOnServiceDate -> days.contains(tripOnServiceDate.getServiceDate()));
 
         if (alterations != null && !alterations.isEmpty()) {
-          stream =
-            stream.filter(tripOnServiceDate ->
-              alterations.contains(tripOnServiceDate.getTripAlteration())
-            );
+          tripOnServiceDateRequestBuilder =
+            tripOnServiceDateRequestBuilder.withAlterations(alterations);
         }
 
-        if (!authorities.isEmpty()) {
-          stream =
-            stream.filter(tripOnServiceDate ->
-              authorities.contains(tripOnServiceDate.getTrip().getRoute().getAgency().getId())
-            );
-        }
-
-        if (!replacementFor.isEmpty()) {
-          stream =
-            stream.filter(tripOnServiceDate ->
-              !tripOnServiceDate.getReplacementFor().isEmpty() &&
-              tripOnServiceDate
-                .getReplacementFor()
-                .stream()
-                .anyMatch(replacement -> replacementFor.contains(replacement.getId()))
-            );
-        }
-
-        return stream.toList();
+        return GqlUtil
+          .getTransitService(environment)
+          .getTripOnServiceDates(tripOnServiceDateRequestBuilder.build());
       })
       .build();
   }

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyQuery.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyQuery.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.opentripplanner.apis.transmodel.mapping.TransitIdMapper;
 import org.opentripplanner.apis.transmodel.model.EnumTypes;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
+import org.opentripplanner.framework.collection.CollectionUtils;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequestBuilder;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -101,7 +102,7 @@ public class DatedServiceJourneyQuery {
         var operatingDays = environment.<List<LocalDate>>getArgument("operatingDays");
         var alterations = environment.<List<TripAlteration>>getArgument("alterations");
 
-        if (operatingDays == null || operatingDays.isEmpty()) {
+        if (CollectionUtils.isEmpty(operatingDays)) {
           throw new IllegalArgumentException("At least one operatingDay must be provided.");
         }
 
@@ -112,12 +113,12 @@ public class DatedServiceJourneyQuery {
           .withServiceJourneys(serviceJourneys)
           .withReplacementFor(replacementFor);
 
-        if (privateCodes != null && !privateCodes.isEmpty()) {
+        if (!CollectionUtils.isEmpty(privateCodes)) {
           tripOnServiceDateRequestBuilder =
             tripOnServiceDateRequestBuilder.withPrivateCodes(privateCodes);
         }
 
-        if (alterations != null && !alterations.isEmpty()) {
+        if (!CollectionUtils.isEmpty(alterations)) {
           tripOnServiceDateRequestBuilder =
             tripOnServiceDateRequestBuilder.withAlterations(alterations);
         }

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyQuery.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyQuery.java
@@ -107,7 +107,8 @@ public class DatedServiceJourneyQuery {
         }
 
         TripOnServiceDateRequestBuilder tripOnServiceDateRequestBuilder = TripOnServiceDateRequest
-          .of(operatingDays)
+          .of()
+          .withOperatingDays(operatingDays)
           .withAuthorities(authorities)
           .withLines(lines)
           .withServiceJourneys(serviceJourneys)

--- a/src/main/java/org/opentripplanner/framework/collection/CollectionUtils.java
+++ b/src/main/java/org/opentripplanner/framework/collection/CollectionUtils.java
@@ -36,6 +36,9 @@ public class CollectionUtils {
   /**
    * A null-safe version of isEmpty() for a collection.
    * <p>
+   * The main strategy handling collections in OTP is to avoid nullable collection fields and use empty
+   * collections instead. So, before using this method check if the variable/field is indeed `@Nullable`.
+   * <p>
    * If the collection is {@code null} then {@code true} is returned.
    * <p>
    * If the collection is empty then {@code true} is returned.

--- a/src/main/java/org/opentripplanner/framework/collection/ListUtils.java
+++ b/src/main/java/org/opentripplanner/framework/collection/ListUtils.java
@@ -69,4 +69,13 @@ public class ListUtils {
       return List.of(input);
     }
   }
+
+  /**
+   * This method converts the given collection to an instance of a List. If the input is
+   * {@code null} an empty collection is returned. If not the {@link List#copyOf(Collection)} is
+   * called.
+   */
+  public static <T> List<T> nullSafeImmutableList(Collection<T> c) {
+    return (c == null) ? List.of() : List.copyOf(c);
+  }
 }

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -1,0 +1,73 @@
+package org.opentripplanner.transit.api.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.TripAlteration;
+
+/*
+ * A request for trips on a specific service date.
+ *
+ * This request is used to retrieve TripsOnServiceDates that match the provided criteria.
+ * At least one operatingDay must be provided.
+ */
+public class TripOnServiceDateRequest {
+
+  private final List<FeedScopedId> authorities;
+  private final List<FeedScopedId> lines;
+  private final List<FeedScopedId> serviceJourneys;
+  private final List<FeedScopedId> replacementFor;
+  private final List<String> privateCodes;
+  private final List<TripAlteration> alterations;
+  private final List<LocalDate> operatingDays;
+
+  protected TripOnServiceDateRequest(
+    List<FeedScopedId> authorities,
+    List<FeedScopedId> lines,
+    List<FeedScopedId> serviceJourneys,
+    List<FeedScopedId> replacementFor,
+    List<String> privateCodes,
+    List<LocalDate> operatingDays,
+    List<TripAlteration> alterations
+  ) {
+    this.authorities = authorities;
+    this.lines = lines;
+    this.serviceJourneys = serviceJourneys;
+    this.replacementFor = replacementFor;
+    this.privateCodes = privateCodes;
+    this.alterations = alterations;
+    this.operatingDays = operatingDays;
+  }
+
+  public static TripOnServiceDateRequestBuilder of(List<LocalDate> operatingDays) {
+    return new TripOnServiceDateRequestBuilder(operatingDays);
+  }
+
+  public List<FeedScopedId> getAuthorities() {
+    return authorities;
+  }
+
+  public List<FeedScopedId> getLines() {
+    return lines;
+  }
+
+  public List<FeedScopedId> getServiceJourneys() {
+    return serviceJourneys;
+  }
+
+  public List<FeedScopedId> getReplacementFor() {
+    return replacementFor;
+  }
+
+  public List<String> getPrivateCodes() {
+    return privateCodes;
+  }
+
+  public List<TripAlteration> getAlterations() {
+    return alterations;
+  }
+
+  public List<LocalDate> getOperatingDays() {
+    return operatingDays;
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -43,31 +43,31 @@ public class TripOnServiceDateRequest {
     return new TripOnServiceDateRequestBuilder(operatingDays);
   }
 
-  public List<FeedScopedId> getAuthorities() {
+  public List<FeedScopedId> authorities() {
     return authorities;
   }
 
-  public List<FeedScopedId> getLines() {
+  public List<FeedScopedId> lines() {
     return lines;
   }
 
-  public List<FeedScopedId> getServiceJourneys() {
+  public List<FeedScopedId> serviceJourneys() {
     return serviceJourneys;
   }
 
-  public List<FeedScopedId> getReplacementFor() {
+  public List<FeedScopedId> replacementFor() {
     return replacementFor;
   }
 
-  public List<String> getPrivateCodes() {
+  public List<String> privateCodes() {
     return privateCodes;
   }
 
-  public List<TripAlteration> getAlterations() {
+  public List<TripAlteration> alterations() {
     return alterations;
   }
 
-  public List<LocalDate> getOperatingDays() {
+  public List<LocalDate> operatingDays() {
     return operatingDays;
   }
 }

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -13,34 +13,37 @@ import org.opentripplanner.transit.model.timetable.TripAlteration;
  */
 public class TripOnServiceDateRequest {
 
+  private final List<LocalDate> operatingDays;
   private final List<FeedScopedId> authorities;
   private final List<FeedScopedId> lines;
   private final List<FeedScopedId> serviceJourneys;
   private final List<FeedScopedId> replacementFor;
   private final List<String> privateCodes;
   private final List<TripAlteration> alterations;
-  private final List<LocalDate> operatingDays;
 
   protected TripOnServiceDateRequest(
+    List<LocalDate> operatingDays,
     List<FeedScopedId> authorities,
     List<FeedScopedId> lines,
     List<FeedScopedId> serviceJourneys,
     List<FeedScopedId> replacementFor,
     List<String> privateCodes,
-    List<LocalDate> operatingDays,
     List<TripAlteration> alterations
   ) {
+    if (operatingDays == null || operatingDays.isEmpty()) {
+      throw new IllegalArgumentException("operatingDays must have at least one date");
+    }
+    this.operatingDays = List.copyOf(operatingDays);
     this.authorities = List.copyOf(authorities);
     this.lines = List.copyOf(lines);
     this.serviceJourneys = List.copyOf(serviceJourneys);
     this.replacementFor = List.copyOf(replacementFor);
     this.privateCodes = List.copyOf(privateCodes);
     this.alterations = List.copyOf(alterations);
-    this.operatingDays = List.copyOf(operatingDays);
   }
 
-  public static TripOnServiceDateRequestBuilder of(List<LocalDate> operatingDays) {
-    return new TripOnServiceDateRequestBuilder(operatingDays);
+  public static TripOnServiceDateRequestBuilder of() {
+    return new TripOnServiceDateRequestBuilder();
   }
 
   public List<FeedScopedId> authorities() {

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -30,13 +30,13 @@ public class TripOnServiceDateRequest {
     List<LocalDate> operatingDays,
     List<TripAlteration> alterations
   ) {
-    this.authorities = authorities;
-    this.lines = lines;
-    this.serviceJourneys = serviceJourneys;
-    this.replacementFor = replacementFor;
-    this.privateCodes = privateCodes;
-    this.alterations = alterations;
-    this.operatingDays = operatingDays;
+    this.authorities = List.copyOf(authorities);
+    this.lines = List.copyOf(lines);
+    this.serviceJourneys = List.copyOf(serviceJourneys);
+    this.replacementFor = List.copyOf(replacementFor);
+    this.privateCodes = List.copyOf(privateCodes);
+    this.alterations = List.copyOf(alterations);
+    this.operatingDays = List.copyOf(operatingDays);
   }
 
   public static TripOnServiceDateRequestBuilder of(List<LocalDate> operatingDays) {

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.transit.api.request;
 
 import java.time.LocalDate;
 import java.util.List;
+import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
 
@@ -33,13 +34,13 @@ public class TripOnServiceDateRequest {
     if (operatingDays == null || operatingDays.isEmpty()) {
       throw new IllegalArgumentException("operatingDays must have at least one date");
     }
-    this.operatingDays = List.copyOf(operatingDays);
-    this.authorities = List.copyOf(authorities);
-    this.lines = List.copyOf(lines);
-    this.serviceJourneys = List.copyOf(serviceJourneys);
-    this.replacementFor = List.copyOf(replacementFor);
-    this.privateCodes = List.copyOf(privateCodes);
-    this.alterations = List.copyOf(alterations);
+    this.operatingDays = ListUtils.nullSafeImmutableList(operatingDays);
+    this.authorities = ListUtils.nullSafeImmutableList(authorities);
+    this.lines = ListUtils.nullSafeImmutableList(lines);
+    this.serviceJourneys = ListUtils.nullSafeImmutableList(serviceJourneys);
+    this.replacementFor = ListUtils.nullSafeImmutableList(replacementFor);
+    this.privateCodes = ListUtils.nullSafeImmutableList(privateCodes);
+    this.alterations = ListUtils.nullSafeImmutableList(alterations);
   }
 
   public static TripOnServiceDateRequestBuilder of() {

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
@@ -1,0 +1,66 @@
+package org.opentripplanner.transit.api.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.TripAlteration;
+
+public class TripOnServiceDateRequestBuilder {
+
+  private List<FeedScopedId> authorities = List.of();
+  private List<FeedScopedId> lines = List.of();
+  private List<FeedScopedId> serviceJourneys = List.of();
+  private List<FeedScopedId> replacementFor = List.of();
+  private List<String> privateCodes = List.of();
+  private List<TripAlteration> alterations = List.of();
+  private final List<LocalDate> operatingDays;
+
+  protected TripOnServiceDateRequestBuilder(List<LocalDate> operatingDays) {
+    if (operatingDays == null || operatingDays.isEmpty()) {
+      throw new IllegalArgumentException("operatingDays must have at least one date");
+    }
+    this.operatingDays = operatingDays;
+  }
+
+  public TripOnServiceDateRequestBuilder withAuthorities(List<FeedScopedId> authorities) {
+    this.authorities = authorities;
+    return this;
+  }
+
+  public TripOnServiceDateRequestBuilder withLines(List<FeedScopedId> lines) {
+    this.lines = lines;
+    return this;
+  }
+
+  public TripOnServiceDateRequestBuilder withServiceJourneys(List<FeedScopedId> serviceJourneys) {
+    this.serviceJourneys = serviceJourneys;
+    return this;
+  }
+
+  public TripOnServiceDateRequestBuilder withReplacementFor(List<FeedScopedId> replacementFor) {
+    this.replacementFor = replacementFor;
+    return this;
+  }
+
+  public TripOnServiceDateRequestBuilder withPrivateCodes(List<String> privateCodes) {
+    this.privateCodes = privateCodes;
+    return this;
+  }
+
+  public TripOnServiceDateRequestBuilder withAlterations(List<TripAlteration> alterations) {
+    this.alterations = alterations;
+    return this;
+  }
+
+  public TripOnServiceDateRequest build() {
+    return new TripOnServiceDateRequest(
+      authorities,
+      lines,
+      serviceJourneys,
+      replacementFor,
+      privateCodes,
+      operatingDays,
+      alterations
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
@@ -13,13 +13,13 @@ public class TripOnServiceDateRequestBuilder {
   private List<FeedScopedId> replacementFor = List.of();
   private List<String> privateCodes = List.of();
   private List<TripAlteration> alterations = List.of();
-  private final List<LocalDate> operatingDays;
+  private List<LocalDate> operatingDays;
 
-  protected TripOnServiceDateRequestBuilder(List<LocalDate> operatingDays) {
-    if (operatingDays == null || operatingDays.isEmpty()) {
-      throw new IllegalArgumentException("operatingDays must have at least one date");
-    }
+  protected TripOnServiceDateRequestBuilder() {}
+
+  public TripOnServiceDateRequestBuilder withOperatingDays(List<LocalDate> operatingDays) {
     this.operatingDays = operatingDays;
+    return this;
   }
 
   public TripOnServiceDateRequestBuilder withAuthorities(List<FeedScopedId> authorities) {
@@ -54,12 +54,12 @@ public class TripOnServiceDateRequestBuilder {
 
   public TripOnServiceDateRequest build() {
     return new TripOnServiceDateRequest(
+      operatingDays,
       authorities,
       lines,
       serviceJourneys,
       replacementFor,
       privateCodes,
-      operatingDays,
       alterations
     );
   }

--- a/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
@@ -7,12 +7,12 @@ import org.opentripplanner.transit.model.timetable.TripAlteration;
 
 public class TripOnServiceDateRequestBuilder {
 
-  private List<FeedScopedId> authorities = List.of();
-  private List<FeedScopedId> lines = List.of();
-  private List<FeedScopedId> serviceJourneys = List.of();
-  private List<FeedScopedId> replacementFor = List.of();
-  private List<String> privateCodes = List.of();
-  private List<TripAlteration> alterations = List.of();
+  private List<FeedScopedId> authorities;
+  private List<FeedScopedId> lines;
+  private List<FeedScopedId> serviceJourneys;
+  private List<FeedScopedId> replacementFor;
+  private List<String> privateCodes;
+  private List<TripAlteration> alterations;
   private List<LocalDate> operatingDays;
 
   protected TripOnServiceDateRequestBuilder() {}

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/AndMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/AndMatcher.java
@@ -1,0 +1,41 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import static org.opentripplanner.transit.model.filter.expr.BinaryOperator.AND;
+
+import java.util.List;
+
+/**
+ * Takes a list of matchers and provides a single interface. All matchers in the list must match for
+ * the composite matcher to return a match.
+ */
+public final class AndMatcher<T> implements Matcher<T> {
+
+  private final Matcher<T>[] matchers;
+
+  private AndMatcher(List<Matcher<T>> matchers) {
+    this.matchers = matchers.toArray(Matcher[]::new);
+  }
+
+  public static <T> Matcher<T> of(List<Matcher<T>> matchers) {
+    // simplify a list of one element
+    if (matchers.size() == 1) {
+      return matchers.get(0);
+    }
+    return new AndMatcher<>(matchers);
+  }
+
+  @Override
+  public boolean match(T entity) {
+    for (var m : matchers) {
+      if (!m.match(entity)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + AND.arrayToString(matchers) + ')';
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/AndMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/AndMatcher.java
@@ -7,6 +7,8 @@ import java.util.List;
 /**
  * Takes a list of matchers and provides a single interface. All matchers in the list must match for
  * the composite matcher to return a match.
+ *
+ * @param <T> The entity type the AndMatcher matches.
  */
 public final class AndMatcher<T> implements Matcher<T> {
 

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/BinaryOperator.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/BinaryOperator.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Used to concatenate matches with either the logical "AND" or "OR" operator.
+ */
+enum BinaryOperator {
+  AND("&"),
+  OR("|");
+
+  private final String token;
+
+  BinaryOperator(String token) {
+    this.token = token;
+  }
+
+  @Override
+  public String toString() {
+    return token;
+  }
+
+  <T> String arrayToString(T[] values) {
+    return colToString(Arrays.asList(values));
+  }
+
+  <T> String colToString(Collection<T> values) {
+    return values.stream().map(Objects::toString).collect(Collectors.joining(" " + token + " "));
+  }
+
+  <T> String toString(T a, T b) {
+    return a.toString() + " " + token + " " + b.toString();
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcher.java
@@ -8,13 +8,13 @@ import java.util.function.Function;
  * <p>
  * The collection is provided by a function that takes the entity being matched as an argument.
  */
-public class ContainsMatcher<T, V> implements Matcher<T> {
+public class ContainsMatcher<T, S> implements Matcher<T> {
 
   private final String typeName;
-  private final V value;
-  private final Function<T, Collection<V>> valueProvider;
+  private final S value;
+  private final Function<T, Collection<S>> valueProvider;
 
-  public ContainsMatcher(String typeName, V value, Function<T, Collection<V>> valueProvider) {
+  public ContainsMatcher(String typeName, S value, Function<T, Collection<S>> valueProvider) {
     this.typeName = typeName;
     this.value = value;
     this.valueProvider = valueProvider;
@@ -22,7 +22,7 @@ public class ContainsMatcher<T, V> implements Matcher<T> {
 
   @Override
   public boolean match(T entity) {
-    Collection<V> values = valueProvider.apply(entity);
+    Collection<S> values = valueProvider.apply(entity);
     if (values == null) {
       return false;
     }

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcher.java
@@ -1,36 +1,55 @@
 package org.opentripplanner.transit.model.filter.expr;
 
-import java.util.Collection;
 import java.util.function.Function;
 
 /**
- * A matcher that checks if a collection contains a value.
- * <p>
- * The collection is provided by a function that takes the entity being matched as an argument.
+ * A matcher that applies a provided matcher to an iterable of child entities returned from the main
+ * entity that this matcher is for.
+ * <p/>
+ * If any of the iterable entities match the valueMatcher, then the match method returns true. In
+ * this way it is similar to an OR.
+ * <p/>
+ * @param <S> The main entity type this matcher is applied to.
+ * @param <T> The type of the child entities, for which there is a mapping from S to T.
  */
-public class ContainsMatcher<T, S> implements Matcher<T> {
+public class ContainsMatcher<S, T> implements Matcher<S> {
 
-  private final String typeName;
-  private final S value;
-  private final Function<T, Collection<S>> valueProvider;
+  private final String relationshipName;
+  private final Function<S, Iterable<T>> valuesProvider;
+  private final Matcher<T> valueMatcher;
 
-  public ContainsMatcher(String typeName, S value, Function<T, Collection<S>> valueProvider) {
-    this.typeName = typeName;
-    this.value = value;
-    this.valueProvider = valueProvider;
+  /**
+   * @param relationshipName The name of the type of relationship between the main entity and the
+   *                         entity matched by the valueMatcher.
+   * @param valuesProvider The function that maps the entity being matched by this matcher (S) to
+   *                       the iterable of items being matched by valueMatcher.
+   * @param valueMatcher The matcher that is applied each of the iterable entities returned from the
+   *                     valuesProvider function.
+   */
+  public ContainsMatcher(
+    String relationshipName,
+    Function<S, Iterable<T>> valuesProvider,
+    Matcher<T> valueMatcher
+  ) {
+    this.relationshipName = relationshipName;
+    this.valuesProvider = valuesProvider;
+    this.valueMatcher = valueMatcher;
   }
 
-  @Override
-  public boolean match(T entity) {
-    Collection<S> values = valueProvider.apply(entity);
-    if (values == null) {
+  public boolean match(S entity) {
+    if (valuesProvider.apply(entity) == null) {
       return false;
     }
-    return values.contains(value);
+    for (T it : valuesProvider.apply(entity)) {
+      if (valueMatcher.match(it)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
   public String toString() {
-    return typeName + " contains " + value;
+    return "ContainsMatcher: " + relationshipName + ": " + valueMatcher.toString();
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcher.java
@@ -1,0 +1,36 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * A matcher that checks if a collection contains a value.
+ * <p>
+ * The collection is provided by a function that takes the entity being matched as an argument.
+ */
+public class ContainsMatcher<T, V> implements Matcher<T> {
+
+  private final String typeName;
+  private final V value;
+  private final Function<T, Collection<V>> valueProvider;
+
+  public ContainsMatcher(String typeName, V value, Function<T, Collection<V>> valueProvider) {
+    this.typeName = typeName;
+    this.value = value;
+    this.valueProvider = valueProvider;
+  }
+
+  @Override
+  public boolean match(T entity) {
+    Collection<V> values = valueProvider.apply(entity);
+    if (values == null) {
+      return false;
+    }
+    return values.contains(value);
+  }
+
+  @Override
+  public String toString() {
+    return typeName + " contains " + value;
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcher.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import java.util.function.Function;
+
+/**
+ * A matcher that checks if a value is equal to another value.
+ * <p>
+ * The value is provided by a function that takes the entity being matched as an argument.
+ */
+public class EqualityMatcher<T, V> implements Matcher<T> {
+
+  private final String typeName;
+  private final V value;
+  private final Function<T, V> valueProvider;
+
+  public EqualityMatcher(String typeName, V value, Function<T, V> valueProvider) {
+    this.typeName = typeName;
+    this.value = value;
+    this.valueProvider = valueProvider;
+  }
+
+  @Override
+  public boolean match(T entity) {
+    return value.equals(valueProvider.apply(entity));
+  }
+
+  @Override
+  public String toString() {
+    return typeName + "==" + value;
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcher.java
@@ -3,9 +3,9 @@ package org.opentripplanner.transit.model.filter.expr;
 import java.util.function.Function;
 
 /**
- * A matcher that checks if a value is equal to another value.
+ * A matcher that checks if a value is equal to another value derived from the matched entities.
  * <p>
- * The value is provided by a function that takes the entity being matched as an argument.
+ * The derived entity value is provided by a function that takes the entity being matched as an argument.
  */
 public class EqualityMatcher<T, V> implements Matcher<T> {
 

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcher.java
@@ -4,8 +4,11 @@ import java.util.function.Function;
 
 /**
  * A matcher that checks if a value is equal to another value derived from the matched entities.
- * <p>
+ * <p/>
  * The derived entity value is provided by a function that takes the entity being matched as an argument.
+ * <p/>
+ * @param <T> The type of the entity being matched.
+ * @param <V> The type of the value that the matcher will test equality for.
  */
 public class EqualityMatcher<T, V> implements Matcher<T> {
 
@@ -13,6 +16,12 @@ public class EqualityMatcher<T, V> implements Matcher<T> {
   private final V value;
   private final Function<T, V> valueProvider;
 
+  /**
+   * @param typeName The typeName appears in the toString for easier debugging.
+   * @param value The value that this matcher will check equality for.
+   * @param valueProvider The function that maps the entity being matched by this matcher (T) to
+   *                      the value being matched by this matcher.
+   */
   public EqualityMatcher(String typeName, V value, Function<T, V> valueProvider) {
     this.typeName = typeName;
     this.value = value;

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/ExpressionBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/ExpressionBuilder.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A builder for creating complex matchers composed of other matchers.
+ * <p/>
+ * This builder contains convenience methods for creating complex matchers from simpler ones. The
+ * resulting matcher "ands" together all the matchers it has built up. This supports the common
+ * pattern of narrowing results with multiple filters.
+ *
+ * @param <T> The type of entity to match in the expression.
+ */
+public class ExpressionBuilder<T> {
+
+  private final List<Matcher<T>> matchers = new ArrayList<>();
+
+  public static <T> ExpressionBuilder<T> of() {
+    return new ExpressionBuilder<>();
+  }
+
+  public <V> ExpressionBuilder<T> or(Collection<V> values, Function<V, Matcher<T>> valueProvider) {
+    if (values.isEmpty()) {
+      return this;
+    }
+
+    matchers.add(OrMatcher.of(values.stream().map(valueProvider).toList()));
+    return this;
+  }
+
+  public Matcher<T> build() {
+    return AndMatcher.of(matchers);
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/Matcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/Matcher.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+/**
+ * Generic matcher interface - this is the root of the matcher type hierarchy.
+ * <p/>
+ * @param <T> Domain type to match.
+ */
+@FunctionalInterface
+public interface Matcher<T> {
+  boolean match(T entity);
+
+  static <T> Matcher<T> everything() {
+    return e -> true;
+  }
+
+  static <T> Matcher<T> nothing() {
+    return e -> false;
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/OrMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/OrMatcher.java
@@ -9,6 +9,8 @@ import java.util.List;
 /**
  * Takes a list of matchers and provides a single interface. At least one of the matchers in the
  * list must match for the composite matcher to return a match.
+ * <p/>
+ * @param <T> The entity type the OrMatcher matches.
  */
 public final class OrMatcher<T> implements Matcher<T> {
 

--- a/src/main/java/org/opentripplanner/transit/model/filter/expr/OrMatcher.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/expr/OrMatcher.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import static org.opentripplanner.transit.model.filter.expr.BinaryOperator.OR;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Takes a list of matchers and provides a single interface. At least one of the matchers in the
+ * list must match for the composite matcher to return a match.
+ */
+public final class OrMatcher<T> implements Matcher<T> {
+
+  private final Matcher<T>[] matchers;
+
+  private OrMatcher(List<Matcher<T>> matchers) {
+    this.matchers = matchers.toArray(Matcher[]::new);
+  }
+
+  public static <T> Matcher<T> of(Matcher<T> a, Matcher<T> b) {
+    return of(List.of(a, b));
+  }
+
+  public static <T> Matcher<T> of(List<Matcher<T>> matchers) {
+    // Simplify if there is just one matcher in the list
+    if (matchers.size() == 1) {
+      return matchers.get(0);
+    }
+    // Collapse nested or matchers
+    var expr = new ArrayList<Matcher<T>>();
+    for (Matcher<T> it : matchers) {
+      if (it instanceof OrMatcher<T> orMatcher) {
+        expr.addAll(Arrays.asList(orMatcher.matchers));
+      } else {
+        expr.add(it);
+      }
+    }
+    return new OrMatcher<>(expr);
+  }
+
+  @Override
+  public boolean match(T entity) {
+    for (var m : matchers) {
+      if (m.match(entity)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + OR.arrayToString(matchers) + ')';
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -1,0 +1,150 @@
+package org.opentripplanner.transit.model.filter.transit;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
+import org.opentripplanner.transit.model.filter.expr.AndMatcher;
+import org.opentripplanner.transit.model.filter.expr.ContainsMatcher;
+import org.opentripplanner.transit.model.filter.expr.EqualityMatcher;
+import org.opentripplanner.transit.model.filter.expr.Matcher;
+import org.opentripplanner.transit.model.filter.expr.OrMatcher;
+import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.TripAlteration;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+
+/**
+ * A factory for creating matchers for TripOnServiceDate objects.
+ * <p/>
+ * This factory is used to create matchers for TripOnServiceDate objects based on a request. The
+ * resulting matcher can be used to filter a list of TripOnServiceDate objects.
+ */
+public class TripOnServiceDateMatcherFactory {
+
+  public static Matcher<TripOnServiceDate> of(TripOnServiceDateRequest request) {
+    List<Matcher<TripOnServiceDate>> matchers = new ArrayList<>();
+
+    matchers.add(
+      or(
+        request
+          .getOperatingDays()
+          .stream()
+          .map(TripOnServiceDateMatcherFactory::operatingDay)
+          .toList()
+      )
+    );
+
+    if (!request.getAuthorities().isEmpty()) {
+      matchers.add(
+        or(
+          request
+            .getAuthorities()
+            .stream()
+            .map(TripOnServiceDateMatcherFactory::authorityId)
+            .toList()
+        )
+      );
+    }
+
+    if (!request.getLines().isEmpty()) {
+      matchers.add(
+        or(request.getLines().stream().map(TripOnServiceDateMatcherFactory::routeId).toList())
+      );
+    }
+
+    if (!request.getServiceJourneys().isEmpty()) {
+      matchers.add(
+        or(
+          request
+            .getServiceJourneys()
+            .stream()
+            .map(TripOnServiceDateMatcherFactory::serviceJourneyId)
+            .toList()
+        )
+      );
+    }
+
+    if (!request.getReplacementFor().isEmpty()) {
+      matchers.add(
+        or(
+          request
+            .getReplacementFor()
+            .stream()
+            .map(TripOnServiceDateMatcherFactory::replacementFor)
+            .toList()
+        )
+      );
+    }
+
+    if (!request.getPrivateCodes().isEmpty()) {
+      matchers.add(
+        or(
+          request
+            .getPrivateCodes()
+            .stream()
+            .map(TripOnServiceDateMatcherFactory::privateCode)
+            .toList()
+        )
+      );
+    }
+
+    if (!request.getAlterations().isEmpty()) {
+      matchers.add(
+        or(
+          request
+            .getAlterations()
+            .stream()
+            .map(TripOnServiceDateMatcherFactory::alteration)
+            .toList()
+        )
+      );
+    }
+
+    return and(matchers);
+  }
+
+  static Matcher<TripOnServiceDate> authorityId(FeedScopedId id) {
+    return new EqualityMatcher<>("agency", id, t -> t.getTrip().getRoute().getAgency().getId());
+  }
+
+  static Matcher<TripOnServiceDate> routeId(FeedScopedId id) {
+    return new EqualityMatcher<>("route", id, t -> t.getTrip().getRoute().getId());
+  }
+
+  static Matcher<TripOnServiceDate> serviceJourneyId(FeedScopedId id) {
+    return new EqualityMatcher<>("serviceJourney", id, t -> t.getTrip().getId());
+  }
+
+  static Matcher<TripOnServiceDate> replacementFor(FeedScopedId id) {
+    return new ContainsMatcher<>(
+      "replacementFor",
+      id,
+      t -> t.getReplacementFor().stream().map(AbstractTransitEntity::getId).toList()
+    );
+  }
+
+  static Matcher<TripOnServiceDate> privateCode(String code) {
+    return new EqualityMatcher<>(
+      "privateCode",
+      code,
+      t -> t.getTrip().getNetexInternalPlanningCode()
+    );
+  }
+
+  static Matcher<TripOnServiceDate> operatingDay(LocalDate date) {
+    return new EqualityMatcher<>("operatingDay", date, TripOnServiceDate::getServiceDate);
+  }
+
+  static Matcher<TripOnServiceDate> alteration(TripAlteration alteration) {
+    return new EqualityMatcher<>("alteration", alteration, TripOnServiceDate::getTripAlteration);
+  }
+
+  static Matcher<TripOnServiceDate> and(List<Matcher<TripOnServiceDate>> matchers) {
+    return AndMatcher.of(matchers);
+  }
+
+  static Matcher<TripOnServiceDate> or(List<Matcher<TripOnServiceDate>> matchers) {
+    return OrMatcher.of(matchers);
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -1,14 +1,11 @@
 package org.opentripplanner.transit.model.filter.transit;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
-import org.opentripplanner.transit.model.filter.expr.AndMatcher;
 import org.opentripplanner.transit.model.filter.expr.ContainsMatcher;
 import org.opentripplanner.transit.model.filter.expr.EqualityMatcher;
+import org.opentripplanner.transit.model.filter.expr.ExpressionBuilder;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
-import org.opentripplanner.transit.model.filter.expr.OrMatcher;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
@@ -23,85 +20,16 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 public class TripOnServiceDateMatcherFactory {
 
   public static Matcher<TripOnServiceDate> of(TripOnServiceDateRequest request) {
-    List<Matcher<TripOnServiceDate>> matchers = new ArrayList<>();
+    ExpressionBuilder<TripOnServiceDate> expr = ExpressionBuilder.of();
 
-    matchers.add(
-      or(
-        request
-          .getOperatingDays()
-          .stream()
-          .map(TripOnServiceDateMatcherFactory::operatingDay)
-          .toList()
-      )
-    );
-
-    if (!request.getAuthorities().isEmpty()) {
-      matchers.add(
-        or(
-          request
-            .getAuthorities()
-            .stream()
-            .map(TripOnServiceDateMatcherFactory::authorityId)
-            .toList()
-        )
-      );
-    }
-
-    if (!request.getLines().isEmpty()) {
-      matchers.add(
-        or(request.getLines().stream().map(TripOnServiceDateMatcherFactory::routeId).toList())
-      );
-    }
-
-    if (!request.getServiceJourneys().isEmpty()) {
-      matchers.add(
-        or(
-          request
-            .getServiceJourneys()
-            .stream()
-            .map(TripOnServiceDateMatcherFactory::serviceJourneyId)
-            .toList()
-        )
-      );
-    }
-
-    if (!request.getReplacementFor().isEmpty()) {
-      matchers.add(
-        or(
-          request
-            .getReplacementFor()
-            .stream()
-            .map(TripOnServiceDateMatcherFactory::replacementFor)
-            .toList()
-        )
-      );
-    }
-
-    if (!request.getPrivateCodes().isEmpty()) {
-      matchers.add(
-        or(
-          request
-            .getPrivateCodes()
-            .stream()
-            .map(TripOnServiceDateMatcherFactory::privateCode)
-            .toList()
-        )
-      );
-    }
-
-    if (!request.getAlterations().isEmpty()) {
-      matchers.add(
-        or(
-          request
-            .getAlterations()
-            .stream()
-            .map(TripOnServiceDateMatcherFactory::alteration)
-            .toList()
-        )
-      );
-    }
-
-    return and(matchers);
+    expr.or(request.getOperatingDays(), TripOnServiceDateMatcherFactory::operatingDay);
+    expr.or(request.getAuthorities(), TripOnServiceDateMatcherFactory::authorityId);
+    expr.or(request.getLines(), TripOnServiceDateMatcherFactory::routeId);
+    expr.or(request.getServiceJourneys(), TripOnServiceDateMatcherFactory::serviceJourneyId);
+    expr.or(request.getReplacementFor(), TripOnServiceDateMatcherFactory::replacementFor);
+    expr.or(request.getPrivateCodes(), TripOnServiceDateMatcherFactory::privateCode);
+    expr.or(request.getAlterations(), TripOnServiceDateMatcherFactory::alteration);
+    return expr.build();
   }
 
   static Matcher<TripOnServiceDate> authorityId(FeedScopedId id) {
@@ -138,13 +66,5 @@ public class TripOnServiceDateMatcherFactory {
 
   static Matcher<TripOnServiceDate> alteration(TripAlteration alteration) {
     return new EqualityMatcher<>("alteration", alteration, TripOnServiceDate::getTripAlteration);
-  }
-
-  static Matcher<TripOnServiceDate> and(List<Matcher<TripOnServiceDate>> matchers) {
-    return AndMatcher.of(matchers);
-  }
-
-  static Matcher<TripOnServiceDate> or(List<Matcher<TripOnServiceDate>> matchers) {
-    return OrMatcher.of(matchers);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -46,9 +46,9 @@ public class TripOnServiceDateMatcherFactory {
 
   static Matcher<TripOnServiceDate> replacementFor(FeedScopedId id) {
     return new ContainsMatcher<>(
-      "replacementFor",
-      id,
-      t -> t.getReplacementFor().stream().map(AbstractTransitEntity::getId).toList()
+      "replacementForContains",
+      t -> t.getReplacementFor().stream().map(AbstractTransitEntity::getId).toList(),
+      new EqualityMatcher<>("replacementForIdEquals", id, (idToMatch -> idToMatch))
     );
   }
 

--- a/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -22,13 +22,13 @@ public class TripOnServiceDateMatcherFactory {
   public static Matcher<TripOnServiceDate> of(TripOnServiceDateRequest request) {
     ExpressionBuilder<TripOnServiceDate> expr = ExpressionBuilder.of();
 
-    expr.or(request.getOperatingDays(), TripOnServiceDateMatcherFactory::operatingDay);
-    expr.or(request.getAuthorities(), TripOnServiceDateMatcherFactory::authorityId);
-    expr.or(request.getLines(), TripOnServiceDateMatcherFactory::routeId);
-    expr.or(request.getServiceJourneys(), TripOnServiceDateMatcherFactory::serviceJourneyId);
-    expr.or(request.getReplacementFor(), TripOnServiceDateMatcherFactory::replacementFor);
-    expr.or(request.getPrivateCodes(), TripOnServiceDateMatcherFactory::privateCode);
-    expr.or(request.getAlterations(), TripOnServiceDateMatcherFactory::alteration);
+    expr.or(request.operatingDays(), TripOnServiceDateMatcherFactory::operatingDay);
+    expr.or(request.authorities(), TripOnServiceDateMatcherFactory::authorityId);
+    expr.or(request.lines(), TripOnServiceDateMatcherFactory::routeId);
+    expr.or(request.serviceJourneys(), TripOnServiceDateMatcherFactory::serviceJourneyId);
+    expr.or(request.replacementFor(), TripOnServiceDateMatcherFactory::replacementFor);
+    expr.or(request.privateCodes(), TripOnServiceDateMatcherFactory::privateCode);
+    expr.or(request.alterations(), TripOnServiceDateMatcherFactory::alteration);
     return expr.build();
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -34,8 +34,11 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.routing.stoptimes.StopTimesHelper;
+import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.filter.expr.Matcher;
+import org.opentripplanner.transit.model.filter.transit.TripOnServiceDateMatcherFactory;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -546,6 +549,23 @@ public class DefaultTransitService implements TransitEditorService {
     TripIdAndServiceDate tripIdAndServiceDate
   ) {
     return transitModelIndex.getTripOnServiceDateForTripAndDay().get(tripIdAndServiceDate);
+  }
+
+  /**
+   * Returns a list of TripOnServiceDates that match the filtering defined in the request.
+   *
+   * @param request - A TripOnServiceDateRequest object with filtering defined.
+   * @return - A list of TripOnServiceDates
+   */
+  @Override
+  public List<TripOnServiceDate> getTripOnServiceDates(TripOnServiceDateRequest request) {
+    Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
+    return transitModelIndex
+      .getTripOnServiceDateForTripAndDay()
+      .values()
+      .stream()
+      .filter(matcher::match)
+      .collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -24,6 +24,7 @@ import org.opentripplanner.model.transfer.TransferService;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
+import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
@@ -261,4 +262,12 @@ public interface TransitService {
   Set<LocalDate> getAllServiceCodes();
 
   Map<LocalDate, TIntSet> getServiceCodesRunningForDate();
+
+  /**
+   * Returns a list of TripOnServiceDates that match the filtering defined in the request.
+   *
+   * @param request - A TripOnServiceDateRequest object with filtering defined.
+   * @return - A list of TripOnServiceDates
+   */
+  List<TripOnServiceDate> getTripOnServiceDates(TripOnServiceDateRequest request);
 }

--- a/src/test/java/org/opentripplanner/framework/collection/CollectionUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/collection/CollectionUtilsTest.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.framework.collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.type.Month;
 import java.time.Duration;
@@ -14,6 +16,13 @@ import org.junit.jupiter.api.Test;
 class CollectionUtilsTest {
 
   public static final String NULL_STRING = "<null>";
+
+  @Test
+  void testIsEmpty() {
+    assertTrue(CollectionUtils.isEmpty(null));
+    assertTrue(CollectionUtils.isEmpty(List.of()));
+    assertFalse(CollectionUtils.isEmpty(List.of(1)));
+  }
 
   @Test
   void testToString() {

--- a/src/test/java/org/opentripplanner/transit/model/filter/expr/AndMatcherTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/filter/expr/AndMatcherTest.java
@@ -1,0 +1,39 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AndMatcherTest {
+
+  @Test
+  void testMatchSingleMatcher() {
+    var matcher = AndMatcher.of(List.of(new EqualityMatcher<>("int", 42, i -> i)));
+    assertTrue(matcher.match(42));
+    assertFalse(matcher.match(43));
+  }
+
+  @Test
+  void testMatchMultiple() {
+    var matcher = AndMatcher.of(
+      List.of(new EqualityMatcher<>("int", 42, i -> i), new EqualityMatcher<>("int", 43, i -> i))
+    );
+    assertFalse(matcher.match(42));
+    assertFalse(matcher.match(43));
+    assertFalse(matcher.match(44));
+  }
+
+  @Test
+  void testMatchComposites() {
+    var matcher = AndMatcher.of(
+      List.of(
+        OrMatcher.of(List.of(new EqualityMatcher<>("int", 42, i -> i))),
+        OrMatcher.of(List.of(new EqualityMatcher<>("int", 43, i -> i)))
+      )
+    );
+    assertFalse(matcher.match(42));
+    assertFalse(matcher.match(43));
+    assertFalse(matcher.match(44));
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcherTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcherTest.java
@@ -19,7 +19,11 @@ class ContainsMatcherTest {
 
   @Test
   void testMatch() {
-    var matcher = new ContainsMatcher<>("integer:string", "foo", i -> integerListMap.get(i));
+    var matcher = new ContainsMatcher<>(
+      "contains",
+      integerListMap::get,
+      new EqualityMatcher<>("string", "foo", s -> s)
+    );
 
     assertTrue(matcher.match(1));
     assertFalse(matcher.match(2));

--- a/src/test/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcherTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/filter/expr/ContainsMatcherTest.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ContainsMatcherTest {
+
+  private static final Map<Integer, List<String>> integerListMap = Map.of(
+    1,
+    List.of("foo"),
+    2,
+    List.of("bar"),
+    3,
+    List.of("foo", "bar")
+  );
+
+  @Test
+  void testMatch() {
+    var matcher = new ContainsMatcher<>("integer:string", "foo", i -> integerListMap.get(i));
+
+    assertTrue(matcher.match(1));
+    assertFalse(matcher.match(2));
+    assertTrue(matcher.match(3));
+    assertFalse(matcher.match(4));
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcherTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/filter/expr/EqualityMatcherTest.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class EqualityMatcherTest {
+
+  @Test
+  void testMatchesPrimitive() {
+    var matcher = new EqualityMatcher<>("int", 42, i -> i);
+    assertTrue(matcher.match(42));
+    assertFalse(matcher.match(43));
+  }
+
+  @Test
+  void testMatchesObject() {
+    var matcher = new EqualityMatcher<>("string", "foo", s -> s);
+    assertTrue(matcher.match("foo"));
+    assertFalse(matcher.match("bar"));
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/model/filter/expr/OrMatcherTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/filter/expr/OrMatcherTest.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.transit.model.filter.expr;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OrMatcherTest {
+
+  @Test
+  void testMatch() {
+    var matcher = OrMatcher.of(
+      new EqualityMatcher<>("int", 42, i -> i),
+      new EqualityMatcher<>("int", 43, i -> i)
+    );
+    assertTrue(matcher.match(42));
+    assertTrue(matcher.match(43));
+    assertFalse(matcher.match(44));
+  }
+
+  @Test
+  void testMatchComposites() {
+    var matcher = OrMatcher.of(
+      AndMatcher.of(List.of(new EqualityMatcher<>("int", 42, i -> i))),
+      AndMatcher.of(List.of(new EqualityMatcher<>("int", 43, i -> i)))
+    );
+    assertTrue(matcher.match(42));
+    assertTrue(matcher.match(43));
+    assertFalse(matcher.match(44));
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
@@ -102,7 +102,8 @@ class TripOnServiceDateMatcherFactoryTest {
   @Test
   void testMatchOperatingDays() {
     TripOnServiceDateRequest request = TripOnServiceDateRequest
-      .of(List.of(LocalDate.of(2024, 2, 22)))
+      .of()
+      .withOperatingDays(List.of(LocalDate.of(2024, 2, 22)))
       .build();
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
@@ -115,7 +116,8 @@ class TripOnServiceDateMatcherFactoryTest {
   @Test
   void testMatchMultiple() {
     TripOnServiceDateRequest request = TripOnServiceDateRequest
-      .of(List.of(LocalDate.of(2024, 2, 22)))
+      .of()
+      .withOperatingDays(List.of(LocalDate.of(2024, 2, 22)))
       .withAuthorities(List.of(new FeedScopedId("RUT", "3")))
       .withLines(List.of(new FeedScopedId("RUT:route", "2")))
       .withServiceJourneys(List.of(new FeedScopedId("RUT:route:trip", "1")))
@@ -131,7 +133,8 @@ class TripOnServiceDateMatcherFactoryTest {
   @Test
   void testMatchMultipleServiceJourneyMatchers() {
     TripOnServiceDateRequest request = TripOnServiceDateRequest
-      .of(List.of(LocalDate.of(2024, 2, 22)))
+      .of()
+      .withOperatingDays(List.of(LocalDate.of(2024, 2, 22)))
       .withAuthorities(List.of(new FeedScopedId("RUT", "3")))
       .withLines(List.of(new FeedScopedId("RUT:route", "2")))
       .withServiceJourneys(

--- a/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
@@ -1,0 +1,148 @@
+package org.opentripplanner.transit.model.filter.transit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.filter.expr.Matcher;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+
+class TripOnServiceDateMatcherFactoryTest {
+
+  private TripOnServiceDate tripOnServiceDateRut;
+  private TripOnServiceDate tripOnServiceDateRut2;
+  private TripOnServiceDate tripOnServiceDateAkt;
+
+  @BeforeEach
+  void setup() {
+    tripOnServiceDateRut =
+      TripOnServiceDate
+        .of(new FeedScopedId("RUT:route:trip:date", "123"))
+        .withTrip(
+          Trip
+            .of(new FeedScopedId("RUT:route:trip", "1"))
+            .withRoute(
+              Route
+                .of(new FeedScopedId("RUT:route", "2"))
+                .withAgency(
+                  Agency
+                    .of(new FeedScopedId("RUT", "3"))
+                    .withName("RUT")
+                    .withTimezone("Europe/Oslo")
+                    .build()
+                )
+                .withMode(TransitMode.BUS)
+                .withShortName("BUS")
+                .build()
+            )
+            .build()
+        )
+        .withServiceDate(LocalDate.of(2024, 2, 22))
+        .build();
+
+    tripOnServiceDateRut2 =
+      TripOnServiceDate
+        .of(new FeedScopedId("RUT:route:trip:date", "123"))
+        .withTrip(
+          Trip
+            .of(new FeedScopedId("RUT:route:trip2", "1"))
+            .withRoute(
+              Route
+                .of(new FeedScopedId("RUT:route", "2"))
+                .withAgency(
+                  Agency
+                    .of(new FeedScopedId("RUT", "3"))
+                    .withName("RUT")
+                    .withTimezone("Europe/Oslo")
+                    .build()
+                )
+                .withMode(TransitMode.BUS)
+                .withShortName("BUS")
+                .build()
+            )
+            .build()
+        )
+        .withServiceDate(LocalDate.of(2024, 2, 22))
+        .build();
+
+    tripOnServiceDateAkt =
+      TripOnServiceDate
+        .of(new FeedScopedId("AKT:route:trip:date", "123"))
+        .withTrip(
+          Trip
+            .of(new FeedScopedId("AKT:route:trip", "1"))
+            .withRoute(
+              Route
+                .of(new FeedScopedId("AKT:route", "2"))
+                .withAgency(
+                  Agency
+                    .of(new FeedScopedId("AKT", "3"))
+                    .withName("AKT")
+                    .withTimezone("Europe/Oslo")
+                    .build()
+                )
+                .withMode(TransitMode.BUS)
+                .withShortName("BUS")
+                .build()
+            )
+            .build()
+        )
+        .withServiceDate(LocalDate.of(2024, 2, 22))
+        .build();
+  }
+
+  @Test
+  void testMatchOperatingDays() {
+    TripOnServiceDateRequest request = TripOnServiceDateRequest
+      .of(List.of(LocalDate.of(2024, 2, 22)))
+      .build();
+
+    Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
+
+    assertTrue(matcher.match(tripOnServiceDateRut));
+    assertTrue(matcher.match(tripOnServiceDateRut2));
+    assertTrue(matcher.match(tripOnServiceDateAkt));
+  }
+
+  @Test
+  void testMatchMultiple() {
+    TripOnServiceDateRequest request = TripOnServiceDateRequest
+      .of(List.of(LocalDate.of(2024, 2, 22)))
+      .withAuthorities(List.of(new FeedScopedId("RUT", "3")))
+      .withLines(List.of(new FeedScopedId("RUT:route", "2")))
+      .withServiceJourneys(List.of(new FeedScopedId("RUT:route:trip", "1")))
+      .build();
+
+    Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
+
+    assertTrue(matcher.match(tripOnServiceDateRut));
+    assertFalse(matcher.match(tripOnServiceDateRut2));
+    assertFalse(matcher.match(tripOnServiceDateAkt));
+  }
+
+  @Test
+  void testMatchMultipleServiceJourneyMatchers() {
+    TripOnServiceDateRequest request = TripOnServiceDateRequest
+      .of(List.of(LocalDate.of(2024, 2, 22)))
+      .withAuthorities(List.of(new FeedScopedId("RUT", "3")))
+      .withLines(List.of(new FeedScopedId("RUT:route", "2")))
+      .withServiceJourneys(
+        List.of(new FeedScopedId("RUT:route:trip", "1"), new FeedScopedId("RUT:route:trip2", "1"))
+      )
+      .build();
+
+    Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
+
+    assertTrue(matcher.match(tripOnServiceDateRut));
+    assertTrue(matcher.match(tripOnServiceDateRut2));
+    assertFalse(matcher.match(tripOnServiceDateAkt));
+  }
+}


### PR DESCRIPTION
Also make use of it in the DatedServiceJourneyQuery

This is the first simple implementation of a filter using the unified matcher API.

### Issue

#5630

### Unit tests

Added unit tests for each matcher and the new TripOnServiceDateMatcherFactory. Also ensured that the API in local runs behaves as expected.

### Documentation

Added JavaDoc.
