### PR TITLE
Fix issue with cancellations on trip patterns that run after midnight

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
@@ -119,9 +119,11 @@ public class TransitLayer {
 
   public List<TripPatternForDate> getTripPatternsStartingOnDateCopy(LocalDate date) {
     List<TripPatternForDate> tripPatternsRunningOnDate = getTripPatternsRunningOnDateCopy(date);
+    tripPatternsRunningOnDate.addAll(getTripPatternsRunningOnDateCopy(date.plusDays(1)));
     return tripPatternsRunningOnDate
       .stream()
       .filter(t -> t.getLocalDate().equals(date))
+      .distinct()
       .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### Summary

This fixes an issue that trips that belong to a trip pattern that has only trips which run after midnight on a specific date are used in routing despite being cancelled.

### Issue

Closes #5718

### Unit tests

TODO

### Documentation

I will add javadoc and maybe rename some methods to be more clear if they refer to service dates or actual dates.

### Changelog

From title

