### PR TITLE
Add user agent to HTTP client

### DIFF
--- a/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
+++ b/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
@@ -36,7 +36,6 @@ import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.pool.PoolReusePolicy;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
-import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,7 +138,7 @@ public class OtpHttpClient implements AutoCloseable {
 
     HttpClientBuilder httpClientBuilder = HttpClients
       .custom()
-      .setUserAgent("OpenTripPlanner %s".formatted(OtpProjectInfo.projectInfo().version.toString()))
+      .setUserAgent("OpenTripPlanner")
       .setConnectionManager(connectionManager)
       .setDefaultRequestConfig(requestConfig(timeout));
 

--- a/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
+++ b/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.pool.PoolReusePolicy;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
+import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,6 +139,7 @@ public class OtpHttpClient implements AutoCloseable {
 
     HttpClientBuilder httpClientBuilder = HttpClients
       .custom()
+      .setUserAgent("OpenTripPlanner %s".formatted(OtpProjectInfo.projectInfo().version.toString()))
       .setConnectionManager(connectionManager)
       .setDefaultRequestConfig(requestConfig(timeout));
 


### PR DESCRIPTION
### Summary

On one of my deployments we also use Entur's Lamassu with ~70 GBFS feeds. OTP's regular GBFS downloading was 
leading another developer looking after Lamassu to think that a load test was underway. :flushed: 

For this reason I'm setting a user agent identifying HTTP calls that originate from OTP.

cc @derhuerst @hbruch 