### PR TITLE
Fix error in access filter when access with time-penalty exits

### DIFF
--- a/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPaths.java
+++ b/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPaths.java
@@ -194,7 +194,7 @@ public class AccessPaths {
     if (list == null) {
       return List.of();
     }
-    if (hasTimePenalty()) {
+    if (iterationTimePenaltyLimit != RaptorConstants.TIME_NOT_SET) {
       return list.stream().filter(e -> e.timePenalty() > iterationTimePenaltyLimit).toList();
     }
     return list;

--- a/src/test/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPathsTest.java
+++ b/src/test/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPathsTest.java
@@ -83,7 +83,7 @@ class AccessPathsTest implements RaptorTestConstants {
   }
 
   @Test
-  void iterateOverPathsWithPenalty() {
+  void iterateOverPathsWithTimePenalty() {
     // Expected at departure 540
     var flexFastWithPenalty = FLEX_FAST.withTimePenalty(60);
 
@@ -112,6 +112,25 @@ class AccessPathsTest implements RaptorTestConstants {
       MULTI_CRITERIA,
       FORWARD
     );
+
+    // Make sure standard iterator works
+    expect(
+      accessPaths.arrivedOnStreetByNumOfRides(0),
+      WALK_B,
+      walkFastWithPenalty,
+      walkCostWithPenalty
+    );
+    expect(accessPaths.arrivedOnBoardByNumOfRides(1));
+    expect(accessPaths.arrivedOnStreetByNumOfRides(1));
+    expect(accessPaths.arrivedOnBoardByNumOfRides(2), flexTxWithPenalty);
+    expect(accessPaths.arrivedOnStreetByNumOfRides(2), FLEX_WALK_B);
+    expect(
+      accessPaths.arrivedOnBoardByNumOfRides(3),
+      FLEX_B,
+      flexFastWithPenalty,
+      flexCostWithPenalty
+    );
+    expect(accessPaths.arrivedOnStreetByNumOfRides(3));
 
     var iterator = accessPaths.iterateOverPathsWithPenalty(600);
 
@@ -146,7 +165,7 @@ class AccessPathsTest implements RaptorTestConstants {
   }
 
   @Test
-  void iterateOverPathsWithPenaltyInReversDirection() {
+  void iterateOverPathsWithTimePenaltyInReversDirection() {
     // Expected at departure 540
     var flexFastWithPenalty = FLEX_FAST.withTimePenalty(60);
 
@@ -163,6 +182,10 @@ class AccessPathsTest implements RaptorTestConstants {
       STANDARD,
       REVERSE
     );
+
+    // Make sure standard iterator works
+    expect(accessPaths.arrivedOnStreetByNumOfRides(0), WALK_B, walkFastWithPenalty);
+    expect(accessPaths.arrivedOnBoardByNumOfRides(3), FLEX_B, flexFastWithPenalty);
 
     var iterator = accessPaths.iterateOverPathsWithPenalty(600);
 
@@ -193,6 +216,34 @@ class AccessPathsTest implements RaptorTestConstants {
     expect(accessPaths.arrivedOnBoardByNumOfRides(2));
     expect(accessPaths.arrivedOnBoardByNumOfRides(3));
 
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void testRegularIteratorsAndIteratorWithPenaltyWorksTogether() {
+    var walkFastWithPenalty = WALK_FAST.withTimePenalty(60);
+
+    // Without time-penalty, the iterator should be empty
+    var accessPaths = AccessPaths.create(
+      60,
+      List.of(walkFastWithPenalty, WALK_COST),
+      MULTI_CRITERIA,
+      FORWARD
+    );
+
+    // Both accesses are expected before with enter the "time-penalty" iteration
+    expect(accessPaths.arrivedOnStreetByNumOfRides(0), WALK_COST, walkFastWithPenalty);
+    expect(accessPaths.arrivedOnBoardByNumOfRides(0));
+
+    var iterator = accessPaths.iterateOverPathsWithPenalty(600);
+
+    // First iteration - only access with time-penalty is expected
+    assertTrue(iterator.hasNext());
+    assertEquals(540, iterator.next());
+    expect(accessPaths.arrivedOnStreetByNumOfRides(0), walkFastWithPenalty);
+    expect(accessPaths.arrivedOnBoardByNumOfRides(0));
+
+    // Second iteration - Done
     assertFalse(iterator.hasNext());
   }
 


### PR DESCRIPTION
### Summary

A critical bug was introduced with the #5715. The effect of the bug was that all normal access was filtered out when an access with time-penalty existed. So, normal transit with walk access would dissapaer from the result. When setting the access mode to WALK the system would work as normal, only if an access with opening-hours exist would the walk access be filtered away.

### Issue

This was discovered at Entur 2 days ago, and we have not created an issue for it.


### Unit tests

✅  The unit tests are updated to cover this case.


### Documentation

🟥  Not relevant


### Changelog

🟥  This bug was introduced in 2.5-SNAPSHOT, so it does not exist in the last release of OTP; Hence, do not belong in the change log.


### Bumping the serialization version id

🟥  The model is not changed.
