### PR TITLE
Add headway to GraphQL API

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -254,6 +254,11 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
     return environment -> getSource(environment).getWalkingBike();
   }
 
+  @Override
+  public DataFetcher<Integer> headway() {
+    return environment -> getSource(environment).getHeadway();
+  }
+
   private Leg getSource(DataFetchingEnvironment environment) {
     return environment.getSource();
   }

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -491,6 +491,8 @@ public class GraphQLDataFetchers {
     public DataFetcher<Trip> trip();
 
     public DataFetcher<Boolean> walkingBike();
+
+    public DataFetcher<Integer> headway();
   }
 
   /** A span of time. */

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/plan/LegType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/plan/LegType.java
@@ -157,6 +157,15 @@ public class LegType {
       .field(
         GraphQLFieldDefinition
           .newFieldDefinition()
+          .name("headway")
+          .description("The leg's headway in seconds")
+          .type(Scalars.GraphQLInt)
+          .dataFetcher(env -> leg(env).getHeadway())
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
           .name("directDuration")
           .type(new GraphQLNonNull(ExtendedScalars.GraphQLLong))
           .description("NOT IMPLEMENTED")

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -64,6 +64,7 @@ public class ScheduledTransitLeg implements TransitLeg {
   private final double directDistanceMeters;
   private final Float accessibilityScore;
   private List<FareProductUse> fareProducts = List.of();
+  private final Integer headway;
 
   protected ScheduledTransitLeg(ScheduledTransitLegBuilder<?> builder) {
     this.tripTimes = builder.tripTimes();
@@ -101,6 +102,7 @@ public class ScheduledTransitLeg implements TransitLeg {
           transitLegCoordinates.get(transitLegCoordinates.size() - 1)
         )
       );
+    this.headway = builder.headway();
   }
 
   public ZoneId getZoneId() {
@@ -415,6 +417,7 @@ public class ScheduledTransitLeg implements TransitLeg {
       .addEnum("alightRule", getAlightRule())
       .addObj("transferFromPrevLeg", transferFromPrevLeg)
       .addObj("transferToNextLeg", transferToNextLeg)
+      .addNum("headway", headway)
       .toString();
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
@@ -23,6 +23,7 @@ public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>>
   private ConstrainedTransfer transferToNextLeg;
   private int generalizedCost;
   private Float accessibilityScore;
+  private Integer headway;
 
   public ScheduledTransitLegBuilder() {}
 
@@ -40,6 +41,7 @@ public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>>
     generalizedCost = original.getGeneralizedCost();
     accessibilityScore = original.accessibilityScore();
     zoneId = original.getZoneId();
+    headway = original.getHeadway();
   }
 
   public B withTripTimes(TripTimes tripTimes) {
@@ -165,5 +167,9 @@ public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>>
 
   final B instance() {
     return (B) this;
+  }
+
+  public Integer headway() {
+    return headway;
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
@@ -35,6 +35,7 @@ public class StreetLeg implements Leg {
   private final Boolean rentedVehicle;
   private final String vehicleRentalNetwork;
   private final Float accessibilityScore;
+  private final Integer headway;
 
   public StreetLeg(StreetLegBuilder builder) {
     this.mode = Objects.requireNonNull(builder.getMode());
@@ -52,6 +53,7 @@ public class StreetLeg implements Leg {
     this.rentedVehicle = builder.getRentedVehicle();
     this.vehicleRentalNetwork = builder.getVehicleRentalNetwork();
     this.accessibilityScore = builder.getAccessibilityScore();
+    this.headway = builder.getHeadway();
   }
 
   public static StreetLegBuilder create() {
@@ -137,6 +139,12 @@ public class StreetLeg implements Leg {
   }
 
   @Override
+  @Nullable
+  public Integer getHeadway() {
+    return headway;
+  }
+
+  @Override
   public Boolean getRentedVehicle() {
     return rentedVehicle;
   }
@@ -200,6 +208,7 @@ public class StreetLeg implements Leg {
       .addBool("walkingBike", walkingBike)
       .addBool("rentedVehicle", rentedVehicle)
       .addStr("bikeRentalNetwork", vehicleRentalNetwork)
+      .addNum("headway", headway)
       .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/StreetLegBuilder.java
+++ b/src/main/java/org/opentripplanner/model/plan/StreetLegBuilder.java
@@ -26,6 +26,8 @@ public class StreetLegBuilder {
   private Float accessibilityScore;
   private Set<StreetNote> streetNotes = new HashSet<>();
 
+  private Integer headway;
+
   protected StreetLegBuilder() {}
 
   public static StreetLegBuilder of(StreetLeg leg) {
@@ -44,7 +46,8 @@ public class StreetLegBuilder {
       .withRentedVehicle(leg.getRentedVehicle())
       .withVehicleRentalNetwork(leg.getVehicleRentalNetwork())
       .withAccessibilityScore(leg.accessibilityScore())
-      .withStreetNotes(leg.getStreetNotes());
+      .withStreetNotes(leg.getStreetNotes())
+      .withHeadway(leg.getHeadway());
   }
 
   public StreetLeg build() {
@@ -105,6 +108,10 @@ public class StreetLegBuilder {
 
   public Float getAccessibilityScore() {
     return accessibilityScore;
+  }
+
+  public Integer getHeadway() {
+    return headway;
   }
 
   public Set<StreetNote> getStreetNotes() {
@@ -183,6 +190,11 @@ public class StreetLegBuilder {
 
   public StreetLegBuilder withStreetNotes(Set<StreetNote> notes) {
     streetNotes = Set.copyOf(notes);
+    return this;
+  }
+
+  public StreetLegBuilder withHeadway(Integer headway) {
+    this.headway = headway;
     return this;
   }
 }

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1766,6 +1766,13 @@ type Leg {
     interlineWithPreviousLeg: Boolean
 
     """
+    The best estimate of the time between two arriving vehicles. This is particularly important for
+    non-strict frequency trips, but could become important for real-time trips, strict frequency
+    trips, and scheduled trips with empirical headways.
+    """
+    headway: Int
+
+    """
     Special booking information for the drop off stop of this leg if, for example, it needs
     to be booked in advance. This could be due to a flexible or on-demand service.
     """

--- a/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -325,6 +325,8 @@ type Leg {
   fromPlace: Place!
   "Generalized cost or weight of the leg. Used for debugging."
   generalizedCost: Int
+  "The leg's headway in seconds"
+  headway: Int
   "An identifier for the leg, which can be used to re-fetch the information."
   id: ID
   interchangeFrom: Interchange


### PR DESCRIPTION
### Summary

Added headway to the GraphQLLeg, allow access of this field(Itinerary-[Leg]-headway) when plan trip.

### Unit tests

Manual tests were done will success. The headway value is already there in ApiLeg, this is just to add it to GraphQLLeg.

### Documentation

Documentation is added to the schema's headway
