### PR TITLE
New vectortile layer for Digitransit realtime stops

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
@@ -1,15 +1,28 @@
 package org.opentripplanner.ext.vectortiles.layers.stops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.framework.time.TimeUtils.time;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.realtimeresolver.RealtimeResolver;
 import org.opentripplanner.framework.i18n.TranslatedString;
+import org.opentripplanner.model.plan.Place;
+import org.opentripplanner.routing.alertpatch.AlertEffect;
+import org.opentripplanner.routing.alertpatch.EntitySelector;
+import org.opentripplanner.routing.alertpatch.TimePeriod;
+import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
+import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.StopModel;
@@ -18,9 +31,10 @@ import org.opentripplanner.transit.service.TransitModel;
 public class StopsLayerTest {
 
   private RegularStop stop;
+  private RegularStop stop2;
 
   @BeforeEach
-  public void setUp() {
+  public final void setUp() {
     var nameTranslations = TranslatedString.getI18NString(
       new HashMap<>() {
         {
@@ -48,6 +62,14 @@ public class StopsLayerTest {
         .withName(nameTranslations)
         .withDescription(descTranslations)
         .withCoordinate(50, 10)
+        .build();
+    stop2 =
+      StopModel
+        .of()
+        .regularStop(new FeedScopedId("F", "name"))
+        .withName(nameTranslations)
+        .withDescription(descTranslations)
+        .withCoordinate(51, 10)
         .build();
   }
 
@@ -88,5 +110,48 @@ public class StopsLayerTest {
 
     assertEquals("nameDE", map.get("name"));
     assertEquals("descDE", map.get("desc"));
+  }
+
+  @Test
+  public void digitransitRealtimeStopPropertyMapperTest() {
+    var deduplicator = new Deduplicator();
+    var transitModel = new TransitModel(new StopModel(), deduplicator);
+    transitModel.index();
+    var alertService = new TransitAlertServiceImpl(transitModel);
+    var transitService = new DefaultTransitService(transitModel) {
+      @Override
+      public TransitAlertService getTransitAlertService() {
+        return alertService;
+      }
+    };
+
+    Route route = TransitModelForTest.route("route").build();
+    var itinerary = newItinerary(Place.forStop(stop), time("11:00"))
+      .bus(route, 1, time("11:05"), time("11:20"), Place.forStop(stop2))
+      .build();
+
+    var alert = TransitAlert
+      .of(stop.getId())
+      .addEntity(new EntitySelector.Stop(stop.getId()))
+      .addTimePeriod(new TimePeriod(0, 0))
+      .withEffect(AlertEffect.NO_SERVICE)
+      .build();
+    transitService.getTransitAlertService().setAlerts(List.of(alert));
+
+    var itineraries = List.of(itinerary);
+    RealtimeResolver.populateLegsWithRealtime(itineraries, transitService);
+
+    DigitransitRealtimeStopPropertyMapper mapper = DigitransitRealtimeStopPropertyMapper.create(
+      transitService,
+      new Locale("en-US")
+    );
+
+    Map<String, Object> map = new HashMap<>();
+    mapper.map(stop).forEach(o -> map.put(o.key(), o.value()));
+
+    assertEquals("F:name", map.get("gtfsId"));
+    assertEquals("name", map.get("name"));
+    assertEquals("desc", map.get("desc"));
+    assertEquals("[{\"alertEffect\":\"NO_SERVICE\"}]", map.get("alerts"));
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -20,7 +20,7 @@ import org.glassfish.grizzly.http.server.Request;
 import org.opentripplanner.apis.support.TileJson;
 import org.opentripplanner.ext.vectortiles.layers.areastops.AreaStopsLayerBuilder;
 import org.opentripplanner.ext.vectortiles.layers.stations.StationsLayerBuilder;
-import org.opentripplanner.ext.vectortiles.layers.stops.StopsLayerBuilder;
+import org.opentripplanner.ext.vectortiles.layers.stops.StopsBaseLayerBuilder;
 import org.opentripplanner.ext.vectortiles.layers.vehicleparkings.VehicleParkingGroupsLayerBuilder;
 import org.opentripplanner.ext.vectortiles.layers.vehicleparkings.VehicleParkingsLayerBuilder;
 import org.opentripplanner.ext.vectortiles.layers.vehiclerental.VehicleRentalPlacesLayerBuilder;
@@ -122,7 +122,7 @@ public class VectorTilesResource {
     OtpServerRequestContext context
   ) {
     return switch (layerParameters.type()) {
-      case Stop -> new StopsLayerBuilder(context.transitService(), layerParameters, locale);
+      case Stop -> new StopsBaseLayerBuilder(context.transitService(), layerParameters, locale);
       case Station -> new StationsLayerBuilder(context.transitService(), layerParameters, locale);
       case AreaStop -> new AreaStopsLayerBuilder(context.transitService(), layerParameters, locale);
       case VehicleRental -> new VehicleRentalPlacesLayerBuilder(

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -15,21 +15,21 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
-public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
+public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<RegularStop> {
 
   private final TransitService transitService;
   private final I18NStringMapper i18NStringMapper;
 
-  DigitransitStopPropertyMapper(TransitService transitService, Locale locale) {
+  public DigitransitRealtimeStopPropertyMapper(TransitService transitService, Locale locale) {
     this.transitService = transitService;
     this.i18NStringMapper = new I18NStringMapper(locale);
   }
 
-  protected static DigitransitStopPropertyMapper create(
+  protected static DigitransitRealtimeStopPropertyMapper create(
     TransitService transitService,
     Locale locale
   ) {
-    return new DigitransitStopPropertyMapper(transitService, locale);
+    return new DigitransitRealtimeStopPropertyMapper(transitService, locale);
   }
 
   @Override
@@ -58,6 +58,20 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
         })
         .toList()
     );
+
+    String alerts = JSONArray.toJSONString(
+      transitService
+        .getTransitAlertService()
+        .getStopAlerts(stop.getId())
+        .stream()
+        .map(alert -> {
+          JSONObject alertObject = new JSONObject();
+          alertObject.put("alertEffect", alert.effect().toString());
+          return alertObject;
+        })
+        .toList()
+    );
+
     return List.of(
       new KeyValue("gtfsId", stop.getId().toString()),
       new KeyValue("name", i18NStringMapper.mapNonnullToApi(stop.getName())),
@@ -69,7 +83,8 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
         stop.getParentStation() != null ? stop.getParentStation().getId() : "null"
       ),
       new KeyValue("type", type),
-      new KeyValue("routes", routes)
+      new KeyValue("routes", routes),
+      new KeyValue("alerts", alerts)
     );
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsBaseLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsBaseLayerBuilder.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.ext.vectortiles.layers.stops;
+
+import static java.util.Map.entry;
+
+import java.util.Locale;
+import java.util.Map;
+import org.opentripplanner.ext.vectortiles.VectorTilesResource;
+import org.opentripplanner.inspector.vector.LayerParameters;
+import org.opentripplanner.transit.service.TransitService;
+
+public class StopsBaseLayerBuilder extends StopsLayerBuilder {
+
+  public StopsBaseLayerBuilder(
+    TransitService service,
+    LayerParameters<VectorTilesResource.LayerType> layerParameters,
+    Locale locale
+  ) {
+    super(
+      service,
+      Map.ofEntries(
+        entry(MapperType.Digitransit, new DigitransitStopPropertyMapper(service, locale)),
+        entry(
+          MapperType.DigitransitRealtime,
+          new DigitransitRealtimeStopPropertyMapper(service, locale)
+        )
+      ),
+      layerParameters
+    );
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
@@ -14,7 +14,7 @@ import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
-public class StopsLayerBuilder extends LayerBuilder<RegularStop> {
+public class StopsLayerBuilder<T> extends LayerBuilder<T> {
 
   static Map<MapperType, BiFunction<TransitService, Locale, PropertyMapper<RegularStop>>> mappers = Map.of(
     MapperType.Digitransit,
@@ -24,11 +24,11 @@ public class StopsLayerBuilder extends LayerBuilder<RegularStop> {
 
   public StopsLayerBuilder(
     TransitService transitService,
-    LayerParameters<VectorTilesResource.LayerType> layerParameters,
-    Locale locale
+    Map<MapperType, PropertyMapper<T>> mappers,
+    LayerParameters<VectorTilesResource.LayerType> layerParameters
   ) {
     super(
-      mappers.get(MapperType.valueOf(layerParameters.mapper())).apply(transitService, locale),
+      mappers.get(MapperType.valueOf(layerParameters.mapper())),
       layerParameters.name(),
       layerParameters.expansionFactor()
     );
@@ -51,5 +51,6 @@ public class StopsLayerBuilder extends LayerBuilder<RegularStop> {
 
   enum MapperType {
     Digitransit,
+    DigitransitRealtime,
   }
 }


### PR DESCRIPTION
### Summary

A new Digitransit vectortile layer for stops which also includes realtime alert information. 

### Issue

The new layer allows showing information related to alerts affecting stops on the map. Alert information is only fetched when the map is zoomed in, hence the requirement for a new layer. The implementation follows the same structure as VehicleRental layers. The realtime stop mapper uses the code from the previously existing stop layer for the parts that are identical between the two layers. 

### Unit tests

Unit test for alerts added to StopsLayerTest.
Manual testing was also performed.
