### PR TITLE
Update Link in README.md [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ found in the main documentation.
 
 ## OTP Ecosystem
 
-- [awesome-transit](https://github.com/CUTR-at-USF/awesome-transit) Community list of transit APIs,
+- [awesome-transit](https://github.com/MobilityData/awesome-transit) Community list of transit APIs,
   apps, datasets, research, and software.


### PR DESCRIPTION
### Summary
The link referred to the older URL of the awesome-transit list, which is redirected to the new repository

