### PR TITLE
Add link to osm.org from new debug client

### DIFF
--- a/client-next/src/components/MapView/GeometryPropertyPopup.tsx
+++ b/client-next/src/components/MapView/GeometryPropertyPopup.tsx
@@ -28,6 +28,15 @@ export function GeometryPropertyPopup({
           ))}
         </tbody>
       </Table>
+      <div className="geometry-popup-osm-link">
+        <a
+          href={`https://www.openstreetmap.org/?mlat=${coordinates.lat}&mlon=${coordinates.lng}#map=18/${coordinates.lat}/${coordinates.lng}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          ↗️ osm.org
+        </a>
+      </div>
     </Popup>
   );
 }

--- a/client-next/src/style.css
+++ b/client-next/src/style.css
@@ -120,6 +120,13 @@
   padding-left: 2px;
 }
 
+/* geometry popup */
+
+.geometry-popup-osm-link {
+  text-align: right;
+  padding: 0 5px;
+}
+
 /* debug layer selector */
 
 .maplibregl-ctrl-group.layer-select {


### PR DESCRIPTION
### Summary

This is a small improvement to the new debug client: add the ability to link from the geometry popup to osm.org so you can quickly cross-reference the data.

![image](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/2653a895-4146-4834-a474-0788f5e40317)

