### PR TITLE
Overwrite default WALK directMode when it is not set in the request, but modes is set

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
@@ -15,7 +15,7 @@ class RequestModesMapper {
    * Maps GraphQL Modes input type to RequestModes.
    * <p>
    * This only maps access, egress, direct & transfer modes. Transport modes are set using filters.
-   * Default modes are WALK for access, egress, direct & transfer.
+   * Default modes are WALK for access, egress & transfer.
    */
   static RequestModes mapRequestModes(Map<String, ?> modesInput) {
     RequestModesBuilder mBuilder = RequestModes.of();
@@ -28,9 +28,8 @@ class RequestModesMapper {
     if (modesInput.containsKey(egressModeKey)) {
       mBuilder.withEgressMode((StreetMode) modesInput.get(egressModeKey));
     }
-    if (modesInput.containsKey(directModeKey)) {
-      mBuilder.withDirectMode((StreetMode) modesInput.get(directModeKey));
-    }
+    // An unset directMode should overwrite the walk default, so we don't check for existence first.
+    mBuilder.withDirectMode((StreetMode) modesInput.get(directModeKey));
 
     return mBuilder.build();
   }

--- a/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
@@ -13,9 +13,11 @@ class RequestModesMapperTest {
   void testMapRequestModesEmptyMapReturnsDefaults() {
     Map<String, StreetMode> inputModes = Map.of();
 
+    RequestModes wantModes = RequestModes.of().withDirectMode(null).build();
+
     RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
 
-    assertEquals(RequestModes.of().build(), mappedModes);
+    assertEquals(wantModes, mappedModes);
   }
 
   @Test
@@ -26,6 +28,7 @@ class RequestModesMapperTest {
       .of()
       .withAccessMode(StreetMode.BIKE)
       .withTransferMode(StreetMode.BIKE)
+      .withDirectMode(null)
       .build();
 
     RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
@@ -37,7 +40,11 @@ class RequestModesMapperTest {
   void testMapRequestModesEgressSetReturnsDefaultsForOthers() {
     Map<String, StreetMode> inputModes = Map.of("egressMode", StreetMode.CAR);
 
-    RequestModes wantModes = RequestModes.of().withEgressMode(StreetMode.CAR).build();
+    RequestModes wantModes = RequestModes
+      .of()
+      .withEgressMode(StreetMode.CAR)
+      .withDirectMode(null)
+      .build();
 
     RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
 


### PR DESCRIPTION
Overwrite default WALK directMode when it is not set in the request, but modes is set. Defaulting it to walk when it was not set caused issues when the user expected no results because transportModes are defined.

### Unit tests

Updated existing unit test to pass. Also verified that the results are as expected with the related [Entur Shamash Query](https://api.staging.entur.io/graphql-explorer/journey-planner-v3?query=query%28%24from%3ALocation%21%24to%3ALocation%21%24dateTime%3ADateTime%21%24arriveBy%3ABoolean%21%24whitelistedAuthorities%3A%5BID%5D%21%24blacklistedAuthorities%3A%5BID%5D%21%24blacklistedLines%3A%5BID%5D%21%24whitelistedLines%3A%5BID%5D%21%24modes%3AModes%24searchWindow%3AInt%24numTripPatterns%3AInt%21%24includeRealtimeCancellations%3ABoolean%24includePlannedCancellations%3ABoolean%24transferSlack%3AInt%24blacklistedServiceJourneyIDs%3A%5BID%5D%21%24costLimitFunction%3ADoubleFunction%21%24intervalRelaxFactor%3AFloat%21%29%7Btrip%28from%3A%24from%20to%3A%24to%20numTripPatterns%3A%24numTripPatterns%20dateTime%3A%24dateTime%20arriveBy%3A%24arriveBy%20whiteListed%3A%7Bauthorities%3A%24whitelistedAuthorities%20lines%3A%24whitelistedLines%7Dbanned%3A%7Bauthorities%3A%24blacklistedAuthorities%20lines%3A%24blacklistedLines%20serviceJourneys%3A%24blacklistedServiceJourneyIDs%7Dmodes%3A%24modes%20searchWindow%3A%24searchWindow%20includeRealtimeCancellations%3A%24includeRealtimeCancellations%20includePlannedCancellations%3A%24includePlannedCancellations%20transferSlack%3A%24transferSlack%20itineraryFilters%3A%7BtransitGeneralizedCostLimit%3A%7BcostLimitFunction%3A%24costLimitFunction%20intervalRelaxFactor%3A%24intervalRelaxFactor%7D%7D%29%7BtripPatterns%7BgeneralizedCost%20startTime%20endTime%20legs%7Bid%20datedServiceJourney%7Bid%20operatingDay%20serviceJourney%7Bid%7DtripAlteration%20replacementFor%7Bid%20serviceJourney%7Bid%7D%7D%7DgeneralizedCost%20aimedStartTime%20aimedEndTime%20realtime%20expectedStartTime%20expectedEndTime%20mode%20transportSubmode%20distance%20authority%7Bid%20name%7Doperator%7Bid%20name%7Dline%7Bid%20publicCode%20presentation%7Bcolour%20textColour%7D%7DfromPlace%7Bname%20latitude%20longitude%7DfromEstimatedCall%7B...estimatedCallFields%7DtoPlace%7Bname%20latitude%20longitude%7DtoEstimatedCall%7B...estimatedCallFields%7DintermediateEstimatedCalls%7Bquay%7BstopPlace%7Bname%20id%7D%7DaimedDepartureTime%20forBoarding%20forAlighting%20requestStop%20expectedDepartureTime%20realtime%20cancellation%7DpointsOnLink%7Bpoints%7DserviceJourney%7Bid%20privateCode%20pointsOnLink%7Bpoints%7Dnotices%7Btext%7D%7DserviceJourneyEstimatedCalls%7Bquay%7BstopPlace%7Bname%20id%7D%7DactualDepartureTime%20aimedDepartureTime%20aimedArrivalTime%20cancellation%7Dsituations%7BreportType%20situationNumber%20description%7Bvalue%20language%7Dsummary%7Bvalue%20language%7Dadvice%7Bvalue%20language%7DvalidityPeriod%7BstartTime%20endTime%7DinfoLinks%7Buri%20label%7D%7DinterchangeFrom%7BstaySeated%20guaranteed%7DinterchangeTo%7BstaySeated%20guaranteed%7D%7D%7D%7D%7Dfragment%20estimatedCallFields%20on%20EstimatedCall%7Bquay%7Blatitude%20longitude%20stopPlace%7Bid%20description%7Ddescription%20publicCode%20name%7DdestinationDisplay%7BfrontText%7DforBoarding%20cancellation%20forAlighting%20requestStop%20date%20notices%7Btext%7DpredictionInaccurate%7D&variables=%7B%22intervalRelaxFactor%22%3A0.5%2C%22costLimitFunction%22%3A%228000.0%20%2B2.0x%22%2C%22blacklistedServiceJourneyIDs%22%3A%5B%5D%2C%22transferSlack%22%3A120%2C%22includeRealtimeCancellations%22%3Afalse%2C%22includePlannedCancellations%22%3Afalse%2C%22numTripPatterns%22%3A15%2C%22searchWindow%22%3A360%2C%22modes%22%3A%7B%22accessMode%22%3A%22foot%22%2C%22egressMode%22%3A%22foot%22%2C%22transportModes%22%3A%5B%7B%22transportMode%22%3A%22rail%22%7D%2C%7B%22transportMode%22%3A%22bus%22%2C%22transportSubModes%22%3A%5B%22railReplacementBus%22%5D%7D%5D%7D%2C%22arriveBy%22%3Afalse%2C%22blacklistedLines%22%3A%5B%22VYG%3ALine%3AF8%22%5D%2C%22whitelistedLines%22%3A%5B%5D%2C%22blacklistedAuthorities%22%3A%5B%22NWY%3AAuthority%3ANWY%22%2C%22NWY%3AAuthority%3Ad1ea7af1-3c2a-4825-893f-21408ef08480%22%2C%22UNI%3AAuthority%3AUNI%22%2C%22UNI%3AOperator%3ALavExp%22%2C%22ATU%3AAuthority%3A1%22%2C%22FLI%3AAuthority%3AFlixMobility%22%2C%22NBU%3AAuthority%3A000444%22%2C%22NBU%3AAuthority%3A002%22%5D%2C%22whitelistedAuthorities%22%3A%5B%22VYG%3AAuthority%3AVYT%22%2C%22VYG%3AAuthority%3ATAG%22%2C%22VYX%3AAuthority%3A1%22%2C%22NSB%3AAuthority%3ANSB%22%2C%22VYB%3AAuthority%3A1%22%2C%22GJB%3AAuthority%3AGJB%22%2C%22TAG%3AAuthority%3ATAG%22%2C%22FLB%3AAuthority%3AFLB%22%2C%22SJV%3AAuthority%3ASJV%22%2C%22SJN%3AAuthority%3ASJN%22%2C%22GOA%3AAuthority%3AGOA%22%2C%22RUT%3AAuthority%3ARUT%22%2C%22ATB%3AAuthority%3A1%22%2C%22ATB%3AAuthority%3A2%22%2C%22NOR%3AAuthority%3A12%22%2C%22NOR%3AAuthority%3ANOR%22%2C%22TRO%3AAuthority%3A1%22%2C%22OST%3AAuthority%3A1%22%2C%22BRA%3AAuthority%3A1%22%2C%22BRA%3AAuthority%3A4%22%2C%22KOL%3AAuthority%3AKOL%22%2C%22KOL%3AAuthority%3A8%22%2C%22VKT%3AAuthority%3AVKT_ID%22%2C%22AKT%3AAuthority%3AAKT_ID%22%2C%22SOF%3AAuthority%3A17%22%2C%22TEL%3AAuthority%3ATFK_ID%22%2C%22MOR%3AAuthority%3AMOR%22%2C%22SKY%3AAuthority%3ASKY%22%2C%22INN%3AAuthority%3AINN_ID%22%2C%22FIN%3AAuthority%3AFIN_ID%22%5D%2C%22dateTime%22%3A%222024-03-29T00%3A00%3A00Z%22%2C%22to%22%3A%7B%22coordinates%22%3A%7B%22latitude%22%3A59.90990447998047%2C%22longitude%22%3A10.763497352600098%7D%7D%2C%22from%22%3A%7B%22place%22%3A%22NSR%3AStopPlace%3A59872%22%2C%22coordinates%22%3A%7B%22latitude%22%3A59.91035842895508%2C%22longitude%22%3A10.753050804138184%7D%7D%7D)

### Documentation

Updated JavaDoc.
