### PR TITLE
Improve handling of invalid leg reference

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -66,7 +66,7 @@ public class LegReferenceSerializer {
       var type = readEnum(in, LegReferenceType.class);
       return type.getDeserializer().read(in);
     } catch (IOException e) {
-      LOG.info(
+      LOG.warn(
         "Unable to decode leg reference (incompatible serialization format): '{}'",
         legReference,
         e

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -51,8 +51,14 @@ public class LegReferenceSerializer {
       return null;
     }
 
-    var buf = Base64.getUrlDecoder().decode(legReference);
-    var input = new ByteArrayInputStream(buf);
+    byte[] serializedLegReference;
+    try {
+      serializedLegReference = Base64.getUrlDecoder().decode(legReference);
+    } catch (IllegalArgumentException e) {
+      LOG.info("Unable to decode leg reference (invalid base64 encoding): '{}'", legReference, e);
+      return null;
+    }
+    var input = new ByteArrayInputStream(serializedLegReference);
 
     try (var in = new ObjectInputStream(input)) {
       // The order must be the same in the encode and decode function
@@ -60,7 +66,11 @@ public class LegReferenceSerializer {
       var type = readEnum(in, LegReferenceType.class);
       return type.getDeserializer().read(in);
     } catch (IOException e) {
-      LOG.error("Unable to decode leg reference: '" + legReference + "'", e);
+      LOG.info(
+        "Unable to decode leg reference (incompatible serialization format): '{}'",
+        legReference,
+        e
+      );
       return null;
     }
   }

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model.plan.legreference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
@@ -85,5 +86,20 @@ class LegReferenceSerializerTest {
     assertEquals(SERVICE_DATE, ref.serviceDate());
     assertEquals(FROM_STOP_POS, ref.fromStopPositionInPattern());
     assertEquals(TO_STOP_POS, ref.toStopPositionInPattern());
+  }
+
+  @Test
+  void testNullSerializedLegReference() {
+    assertNull(LegReferenceSerializer.decode(null));
+  }
+
+  @Test
+  void testEmptySerializedLegReference() {
+    assertNull(LegReferenceSerializer.decode(""));
+  }
+
+  @Test
+  void testIllegalBase64CharacterInSerializedLegReference() {
+    assertNull(LegReferenceSerializer.decode("RUT:Line:5"));
   }
 }


### PR DESCRIPTION
### Summary

When OTP fails to base64-decode an invalid serialized leg reference, this is currently reported as a server error with the following error message :
```
Exception while fetching data (/leg) : Last unit does not have enough valid bits
java.lang.IllegalArgumentException: Last unit does not have enough valid bits
	at java.base/java.util.Base64$Decoder.decode0(Base64.java:872)
	at java.base/java.util.Base64$Decoder.decode(Base64.java:570)
	at java.base/java.util.Base64$Decoder.decode(Base64.java:593)
	at org.opentripplanner.model.plan.legreference.LegReferenceSerializer.decode(LegReferenceSerializer.java:54)
	at org.opentripplanner.apis.transmodel.TransmodelGraphQLSchema.lambda$create$56(TransmodelGraphQLSchema.java:1605)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:311)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:287)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:213)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:55)
	at graphql.execution.Execution.executeOperation(Execution.java:161)
	at graphql.execution.Execution.execute(Execution.java:103)
	at graphql.GraphQL.execute(GraphQL.java:568)
	at graphql.GraphQL.lambda$parseValidateAndExecute$13(GraphQL.java:487)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2341)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:482)
	at graphql.GraphQL.lambda$executeAsync$9(GraphQL.java:440)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2341)
	at graphql.GraphQL.executeAsync(GraphQL.java:428)
	at graphql.GraphQL.execute(GraphQL.java:366)
	at org.opentripplanner.apis.transmodel.TransmodelGraph.executeGraphQL(TransmodelGraph.java:67)
	at org.opentripplanner.apis.transmodel.TransmodelAPI.getGraphQL(TransmodelAPI.java:114)
```
This PR ensures that the response returns an empty result and the decoding error is reported at INFO level in the logs. 

### Issue
No

### Unit tests

Added unit tests.

### Documentation

No
