### PR TITLE
Remove dependency on org.json-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -586,20 +586,6 @@
             <version>${google.dagger.version}</version>
         </dependency>
 
-        <!-- JSON AST, not used much and is a good candidate for removal -->
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-            <exclusions>
-                <!-- This includes a dependency on an ancient version of Junit which we want to exclude -->
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- GEOTOOLS AND JTS TOPOLOGY: geometry, rasters and projections. -->
         <!-- GEOTOOLS includes JTS as a transitive dependency. -->
 

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/TestTransitService.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/TestTransitService.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.ext.vectortiles.layers;
+
+import java.util.Set;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
+
+public class TestTransitService extends DefaultTransitService {
+
+  public TestTransitService(TransitModel transitModel) {
+    super(transitModel);
+  }
+
+  @Override
+  public Set<Route> getRoutesForStop(StopLocation stop) {
+    return Set.of(
+      TransitModelForTest.route("1").withMode(TransitMode.RAIL).withGtfsType(100).build()
+    );
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
@@ -1,0 +1,46 @@
+package org.opentripplanner.ext.vectortiles.layers.stations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.vectortiles.layers.TestTransitService;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.site.Station;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
+
+public class DigitransitStationPropertyMapperTest {
+
+  @Test
+  void map() {
+    var deduplicator = new Deduplicator();
+    var transitModel = new TransitModel(new StopModel(), deduplicator);
+    transitModel.index();
+    var transitService = new TestTransitService(transitModel);
+
+    var mapper = DigitransitStationPropertyMapper.create(transitService, Locale.US);
+
+    var station = Station
+      .of(id("a-station"))
+      .withCoordinate(1, 1)
+      .withName(I18NString.of("A station"))
+      .build();
+
+    TransitModelForTest.of().stop("stop-1").withParentStation(station).build();
+
+    Map<String, Object> map = new HashMap<>();
+    mapper.map(station).forEach(o -> map.put(o.key(), o.value()));
+
+    assertEquals("F:a-station", map.get("gtfsId"));
+    assertEquals("A station", map.get("name"));
+    assertEquals("", map.get("type"));
+    assertEquals("[{\"mode\":\"RAIL\",\"shortName\":\"R1\"}]", map.get("routes"));
+    assertEquals("[\"F:stop-1\"]", map.get("stops"));
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -1,0 +1,104 @@
+package org.opentripplanner.ext.vectortiles.layers.stops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.framework.time.TimeUtils.time;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner._support.time.ZoneIds;
+import org.opentripplanner.ext.realtimeresolver.RealtimeResolver;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.model.plan.Place;
+import org.opentripplanner.routing.alertpatch.AlertEffect;
+import org.opentripplanner.routing.alertpatch.EntitySelector;
+import org.opentripplanner.routing.alertpatch.TimePeriod;
+import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
+import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
+
+public class RealtimeStopsLayerTest {
+
+  private RegularStop stop;
+  private RegularStop stop2;
+
+  @BeforeEach
+  public void setUp() {
+    var name = I18NString.of("name");
+    var desc = I18NString.of("desc");
+    stop =
+      StopModel
+        .of()
+        .regularStop(new FeedScopedId("F", "name"))
+        .withName(name)
+        .withDescription(desc)
+        .withCoordinate(50, 10)
+        .build();
+    stop2 =
+      StopModel
+        .of()
+        .regularStop(new FeedScopedId("F", "name"))
+        .withName(name)
+        .withDescription(desc)
+        .withCoordinate(51, 10)
+        .build();
+  }
+
+  @Test
+  void realtimeStopLayer() {
+    var deduplicator = new Deduplicator();
+    var transitModel = new TransitModel(new StopModel(), deduplicator);
+    transitModel.initTimeZone(ZoneIds.HELSINKI);
+    transitModel.index();
+    var alertService = new TransitAlertServiceImpl(transitModel);
+    var transitService = new DefaultTransitService(transitModel) {
+      @Override
+      public TransitAlertService getTransitAlertService() {
+        return alertService;
+      }
+    };
+
+    Route route = TransitModelForTest.route("route").build();
+    var itinerary = newItinerary(Place.forStop(stop), time("11:00"))
+      .bus(route, 1, time("11:05"), time("11:20"), Place.forStop(stop2))
+      .build();
+    var startDate = ZonedDateTime.now(ZoneIds.HELSINKI).minusDays(1).toEpochSecond();
+    var endDate = ZonedDateTime.now(ZoneIds.HELSINKI).plusDays(1).toEpochSecond();
+    var alert = TransitAlert
+      .of(stop.getId())
+      .addEntity(new EntitySelector.Stop(stop.getId()))
+      .addTimePeriod(new TimePeriod(startDate, endDate))
+      .withEffect(AlertEffect.NO_SERVICE)
+      .build();
+    transitService.getTransitAlertService().setAlerts(List.of(alert));
+
+    var itineraries = List.of(itinerary);
+    RealtimeResolver.populateLegsWithRealtime(itineraries, transitService);
+
+    DigitransitRealtimeStopPropertyMapper mapper = new DigitransitRealtimeStopPropertyMapper(
+      transitService,
+      new Locale("en-US")
+    );
+
+    Map<String, Object> map = new HashMap<>();
+    mapper.map(stop).forEach(o -> map.put(o.key(), o.value()));
+
+    assertEquals("F:name", map.get("gtfsId"));
+    assertEquals("name", map.get("name"));
+    assertEquals("desc", map.get("desc"));
+    assertEquals(true, map.get("closedByServiceAlert"));
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
@@ -1,32 +1,16 @@
 package org.opentripplanner.ext.vectortiles.layers.stops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.framework.time.TimeUtils.time;
-import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner._support.time.ZoneIds;
-import org.opentripplanner.ext.realtimeresolver.RealtimeResolver;
+import org.opentripplanner.ext.vectortiles.layers.TestTransitService;
 import org.opentripplanner.framework.i18n.TranslatedString;
-import org.opentripplanner.model.plan.Place;
-import org.opentripplanner.routing.alertpatch.AlertEffect;
-import org.opentripplanner.routing.alertpatch.EntitySelector;
-import org.opentripplanner.routing.alertpatch.TimePeriod;
-import org.opentripplanner.routing.alertpatch.TransitAlert;
-import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.StopModel;
@@ -35,7 +19,6 @@ import org.opentripplanner.transit.service.TransitModel;
 public class StopsLayerTest {
 
   private RegularStop stop;
-  private RegularStop stop2;
 
   @BeforeEach
   public void setUp() {
@@ -67,14 +50,6 @@ public class StopsLayerTest {
         .withDescription(descTranslations)
         .withCoordinate(50, 10)
         .build();
-    stop2 =
-      StopModel
-        .of()
-        .regularStop(new FeedScopedId("F", "name"))
-        .withName(nameTranslations)
-        .withDescription(descTranslations)
-        .withCoordinate(51, 10)
-        .build();
   }
 
   @Test
@@ -82,7 +57,7 @@ public class StopsLayerTest {
     var deduplicator = new Deduplicator();
     var transitModel = new TransitModel(new StopModel(), deduplicator);
     transitModel.index();
-    var transitService = new DefaultTransitService(transitModel);
+    var transitService = new TestTransitService(transitModel);
 
     DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(
       transitService,
@@ -95,6 +70,7 @@ public class StopsLayerTest {
     assertEquals("F:name", map.get("gtfsId"));
     assertEquals("name", map.get("name"));
     assertEquals("desc", map.get("desc"));
+    assertEquals("[{\"gtfsType\":100}]", map.get("routes"));
   }
 
   @Test
@@ -114,50 +90,5 @@ public class StopsLayerTest {
 
     assertEquals("nameDE", map.get("name"));
     assertEquals("descDE", map.get("desc"));
-  }
-
-  @Test
-  public void digitransitRealtimeStopPropertyMapperTest() {
-    var deduplicator = new Deduplicator();
-    var transitModel = new TransitModel(new StopModel(), deduplicator);
-    transitModel.initTimeZone(ZoneIds.HELSINKI);
-    transitModel.index();
-    var alertService = new TransitAlertServiceImpl(transitModel);
-    var transitService = new DefaultTransitService(transitModel) {
-      @Override
-      public TransitAlertService getTransitAlertService() {
-        return alertService;
-      }
-    };
-
-    Route route = TransitModelForTest.route("route").build();
-    var itinerary = newItinerary(Place.forStop(stop), time("11:00"))
-      .bus(route, 1, time("11:05"), time("11:20"), Place.forStop(stop2))
-      .build();
-    var startDate = ZonedDateTime.now(ZoneIds.HELSINKI).minusDays(1).toEpochSecond();
-    var endDate = ZonedDateTime.now(ZoneIds.HELSINKI).plusDays(1).toEpochSecond();
-    var alert = TransitAlert
-      .of(stop.getId())
-      .addEntity(new EntitySelector.Stop(stop.getId()))
-      .addTimePeriod(new TimePeriod(startDate, endDate))
-      .withEffect(AlertEffect.NO_SERVICE)
-      .build();
-    transitService.getTransitAlertService().setAlerts(List.of(alert));
-
-    var itineraries = List.of(itinerary);
-    RealtimeResolver.populateLegsWithRealtime(itineraries, transitService);
-
-    DigitransitRealtimeStopPropertyMapper mapper = new DigitransitRealtimeStopPropertyMapper(
-      transitService,
-      new Locale("en-US")
-    );
-
-    Map<String, Object> map = new HashMap<>();
-    mapper.map(stop).forEach(o -> map.put(o.key(), o.value()));
-
-    assertEquals("F:name", map.get("gtfsId"));
-    assertEquals("name", map.get("name"));
-    assertEquals("desc", map.get("desc"));
-    assertEquals(true, map.get("closedByServiceAlert"));
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingGroupsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingGroupsLayerTest.java
@@ -144,7 +144,7 @@ public class VehicleParkingGroupsLayerTest {
     assertEquals("groupName", map.get("name").toString());
 
     assertEquals(
-      "[{\"bicyclePlaces\":false,\"carPlaces\":true,\"name\":\"name\",\"id\":\"F:id\"}]",
+      "[{\"carPlaces\":true,\"bicyclePlaces\":false,\"id\":\"F:id\",\"name\":\"name\"}]",
       map.get("vehicleParking")
     );
   }
@@ -162,7 +162,7 @@ public class VehicleParkingGroupsLayerTest {
     assertEquals("groupDE", map.get("name").toString());
 
     assertEquals(
-      "[{\"bicyclePlaces\":false,\"carPlaces\":true,\"name\":\"DE\",\"id\":\"F:id\"}]",
+      "[{\"carPlaces\":true,\"bicyclePlaces\":false,\"id\":\"F:id\",\"name\":\"DE\"}]",
       map.get("vehicleParking")
     );
   }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/DigitransitVehicleParkingGroupPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/DigitransitVehicleParkingGroupPropertyMapper.java
@@ -1,17 +1,19 @@
 package org.opentripplanner.ext.vectortiles.layers.vehicleparkings;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
 import org.opentripplanner.framework.i18n.I18NStringMapper;
+import org.opentripplanner.framework.json.ObjectMappers;
 import org.opentripplanner.inspector.vector.KeyValue;
 
 public class DigitransitVehicleParkingGroupPropertyMapper
   extends PropertyMapper<VehicleParkingAndGroup> {
 
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.ignoringExtraFields();
   private final I18NStringMapper i18NStringMapper;
 
   public DigitransitVehicleParkingGroupPropertyMapper(Locale locale) {
@@ -24,25 +26,28 @@ public class DigitransitVehicleParkingGroupPropertyMapper
 
   @Override
   protected Collection<KeyValue> map(VehicleParkingAndGroup parkingAndGroup) {
-    var group = parkingAndGroup.vehicleParkingGroup();
-    String parking = JSONArray.toJSONString(
-      parkingAndGroup
+    try {
+      var group = parkingAndGroup.vehicleParkingGroup();
+      var lots = parkingAndGroup
         .vehicleParking()
         .stream()
         .map(vehicleParkingPlace -> {
-          JSONObject parkingObject = new JSONObject();
+          var parkingObject = OBJECT_MAPPER.createObjectNode();
           parkingObject.put("carPlaces", vehicleParkingPlace.hasCarPlaces());
           parkingObject.put("bicyclePlaces", vehicleParkingPlace.hasBicyclePlaces());
           parkingObject.put("id", vehicleParkingPlace.getId().toString());
           parkingObject.put("name", i18NStringMapper.mapToApi(vehicleParkingPlace.getName()));
           return parkingObject;
         })
-        .toList()
-    );
-    return List.of(
-      new KeyValue("id", group.id().toString()),
-      new KeyValue("name", i18NStringMapper.mapToApi(group.name())),
-      new KeyValue("vehicleParking", parking)
-    );
+        .toList();
+      var string = OBJECT_MAPPER.writeValueAsString(lots);
+      return List.of(
+        new KeyValue("id", group.id().toString()),
+        new KeyValue("name", i18NStringMapper.mapToApi(group.name())),
+        new KeyValue("vehicleParking", string)
+      );
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/StadtnaviVehicleParkingPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/StadtnaviVehicleParkingPropertyMapper.java
@@ -1,11 +1,12 @@
 package org.opentripplanner.ext.vectortiles.layers.vehicleparkings;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import org.json.simple.JSONObject;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
 import org.opentripplanner.framework.i18n.I18NStringMapper;
+import org.opentripplanner.framework.json.ObjectMappers;
 import org.opentripplanner.inspector.vector.KeyValue;
 import org.opentripplanner.model.calendar.openinghours.OsmOpeningHoursSupport;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
@@ -13,6 +14,7 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 
 public class StadtnaviVehicleParkingPropertyMapper extends PropertyMapper<VehicleParking> {
 
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.ignoringExtraFields();
   private final DigitransitVehicleParkingPropertyMapper digitransitMapper;
   private final I18NStringMapper i18NStringMapper;
 
@@ -57,13 +59,13 @@ public class StadtnaviVehicleParkingPropertyMapper extends PropertyMapper<Vehicl
       return List.of();
     }
 
-    var json = new JSONObject();
+    var json = OBJECT_MAPPER.createObjectNode();
     json.put("bicyclePlaces", places.getBicycleSpaces());
     json.put("carPlaces", places.getCarSpaces());
     json.put("wheelchairAccessibleCarPlaces", places.getWheelchairAccessibleCarSpaces());
 
     return List.of(
-      new KeyValue(key, JSONObject.toJSONString(json)),
+      new KeyValue(key, json.toString()),
       new KeyValue(subKey(key, "bicyclePlaces"), places.getBicycleSpaces()),
       new KeyValue(subKey(key, "carPlaces"), places.getCarSpaces()),
       new KeyValue(


### PR DESCRIPTION
### Summary

The vector tiles code uses the json-simple library to convert data into JSON format. This library has been released last in 2012 and of course duplicates the functionality of our other JSON library, Jackson.

In the interest of keeping the dependencies as low as possible, I'm removing it and replacing all the uses with Jackson.

### Unit tests

I added new tests for the station mapper and updated other tests where the JSON functionality was used. The stop layer test was split into two: one for the regular one and another one for the realtime layer.

### Documentation

None, because it is just refactoring.
