### PR TITLE
Move expensive `WGS84_XY` constant setup into ElevationModule

### DIFF
--- a/src/main/java/org/opentripplanner/framework/geometry/GeometryUtils.java
+++ b/src/main/java/org/opentripplanner/framework/geometry/GeometryUtils.java
@@ -10,8 +10,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.geojson.GeoJsonObject;
 import org.geojson.LngLatAlt;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.referencing.CRS;
 import org.locationtech.jts.algorithm.ConvexHull;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
@@ -28,29 +26,11 @@ import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.locationtech.jts.linearref.LengthLocationMap;
 import org.locationtech.jts.linearref.LinearLocation;
 import org.locationtech.jts.linearref.LocationIndexedLine;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GeometryUtils {
 
-  private static final Logger LOG = LoggerFactory.getLogger(GeometryUtils.class);
-
   private static final CoordinateSequenceFactory csf = new PackedCoordinateSequenceFactory();
   private static final GeometryFactory gf = new GeometryFactory(csf);
-
-  /** A shared copy of the WGS84 CRS with longitude-first axis order. */
-  public static final CoordinateReferenceSystem WGS84_XY;
-
-  static {
-    try {
-      WGS84_XY = CRS.getAuthorityFactory(true).createCoordinateReferenceSystem("EPSG:4326");
-    } catch (Exception ex) {
-      LOG.error("Unable to create longitude-first WGS84 CRS", ex);
-      throw new RuntimeException(
-        "Could not create longitude-first WGS84 coordinate reference system."
-      );
-    }
-  }
 
   public static <T> Geometry makeConvexHull(
     Collection<T> collection,

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -63,16 +63,15 @@ public class ElevationModule implements GraphBuilderModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElevationModule.class);
   /**
-   * A shared copy of the WGS84 CRS with longitude-first axis order. This constant used
-   * to be defined in a shared utility class but since it's slow to initialize, it was move here.
-   * See https://github.com/opentripplanner/OpenTripPlanner/pull/5786
-   * */
+   * The WGS84 CRS with longitude-first axis order. The first time a CRS lookup is 
+   * performed is surprisingly expensive (around 500ms), apparently due to  initializing
+   * an HSQLDB JDBC connection. For this reason, the constant is defined in this 
+   * narrower scope rather than a shared utility class, where it was seen to incur the
+   * initialization cost in a broader range of tests than is necessary.
+   */
   private static final CoordinateReferenceSystem WGS84_XY;
 
   static {
-    // looking up the CRS is surprisingly expensive (~500ms) and should therefore not done
-    // in shared utility class
-    // https://github.com/opentripplanner/OpenTripPlanner/pull/5786
     try {
       WGS84_XY = CRS.getAuthorityFactory(true).createCoordinateReferenceSystem("EPSG:4326");
     } catch (Exception ex) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -63,7 +63,7 @@ public class ElevationModule implements GraphBuilderModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElevationModule.class);
   /** A shared copy of the WGS84 CRS with longitude-first axis order. */
-  public static final CoordinateReferenceSystem WGS84_XY;
+  private static final CoordinateReferenceSystem WGS84_XY;
 
   static {
     try {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -63,9 +63,9 @@ public class ElevationModule implements GraphBuilderModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElevationModule.class);
   /**
-   * The WGS84 CRS with longitude-first axis order. The first time a CRS lookup is 
+   * The WGS84 CRS with longitude-first axis order. The first time a CRS lookup is
    * performed is surprisingly expensive (around 500ms), apparently due to  initializing
-   * an HSQLDB JDBC connection. For this reason, the constant is defined in this 
+   * an HSQLDB JDBC connection. For this reason, the constant is defined in this
    * narrower scope rather than a shared utility class, where it was seen to incur the
    * initialization cost in a broader range of tests than is necessary.
    */

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -62,10 +62,17 @@ import org.slf4j.LoggerFactory;
 public class ElevationModule implements GraphBuilderModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElevationModule.class);
-  /** A shared copy of the WGS84 CRS with longitude-first axis order. */
+  /**
+   * A shared copy of the WGS84 CRS with longitude-first axis order. This constant used
+   * to be defined in a shared utility class but since it's slow to initialize, it was move here.
+   * See https://github.com/opentripplanner/OpenTripPlanner/pull/5786
+   * */
   private static final CoordinateReferenceSystem WGS84_XY;
 
   static {
+    // looking up the CRS is surprisingly expensive (~500ms) and should therefore not done
+    // in shared utility class
+    // https://github.com/opentripplanner/OpenTripPlanner/pull/5786
     try {
       WGS84_XY = CRS.getAuthorityFactory(true).createCoordinateReferenceSystem("EPSG:4326");
     } catch (Exception ex) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -20,13 +20,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.geotools.api.coverage.Coverage;
 import org.geotools.api.coverage.PointOutsideCoverageException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.geometry.Position2D;
+import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.framework.geometry.EncodedPolyline;
-import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.framework.lang.IntUtils;
 import org.opentripplanner.framework.logging.ProgressTracker;
@@ -61,6 +62,19 @@ import org.slf4j.LoggerFactory;
 public class ElevationModule implements GraphBuilderModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElevationModule.class);
+  /** A shared copy of the WGS84 CRS with longitude-first axis order. */
+  public static final CoordinateReferenceSystem WGS84_XY;
+
+  static {
+    try {
+      WGS84_XY = CRS.getAuthorityFactory(true).createCoordinateReferenceSystem("EPSG:4326");
+    } catch (Exception ex) {
+      LOG.error("Unable to create longitude-first WGS84 CRS", ex);
+      throw new RuntimeException(
+        "Could not create longitude-first WGS84 coordinate reference system."
+      );
+    }
+  }
 
   /** The elevation data to be used in calculating elevations. */
   private final ElevationGridCoverageFactory gridCoverageFactory;
@@ -564,7 +578,7 @@ public class ElevationModule implements GraphBuilderModule {
       // GeoTIFFs in various projections. Note that GeoTools defaults to strict EPSG axis ordering of (lat, long)
       // for DefaultGeographicCRS.WGS84, but OTP is using (long, lat) throughout and assumes unprojected DEM
       // rasters to also use (long, lat).
-      coverage.evaluate(new Position2D(GeometryUtils.WGS84_XY, x, y), values);
+      coverage.evaluate(new Position2D(WGS84_XY, x, y), values);
     } catch (PointOutsideCoverageException e) {
       nPointsOutsideDEM.incrementAndGet();
       throw e;


### PR DESCRIPTION
### Summary


When profiling something else, I noticed during test setup `GeometryUtils` takes up to 500ms to initialize. That is because it does quite an expensive lookup of a coordinate reference system in a HSQL embedded database.

![Screenshot from 2024-04-04 16-45-42](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/47d97371-a827-4fbc-8b4b-6d5c1ddaa576)
![Screenshot from 2024-04-04 16-45-25](https://github.com/opentripplanner/OpenTripPlanner/assets/151346/55326780-e366-48be-990a-24fae6207720)

Why is this bad?

I strive to write tests that execute quite quickly so having 500ms startup time for a test is a reason for me to investigate. If I move the initialization into `ElevationModule` investigating slow tests will be less noisy.