### PR TITLE
Fix handling of null transport mode filter

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/mapping/FilterMapper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/mapping/FilterMapper.java
@@ -83,7 +83,7 @@ class FilterMapper {
     List<MainAndSubMode> tModes = new ArrayList<>();
     if (GqlUtil.hasArgument(environment, "modes")) {
       Map<String, Object> modesInput = environment.getArgument("modes");
-      if (modesInput.containsKey("transportModes")) {
+      if (modesInput.get("transportModes") != null) {
         List<Map<String, ?>> transportModes = (List<Map<String, ?>>) modesInput.get(
           "transportModes"
         );


### PR DESCRIPTION
### Summary

In the TransModel GraphQL API, the documentation of the "transportModes" filter states:

> 
The allowed modes for the transit part of the trip. Use an empty list to disallow transit for this search. If the element is not present or null, it will default to all transport modes.

In practice, specifying a null value for the filter triggers a NullPointerException:

```
Exception while fetching data (/trip) : Cannot invoke "java.util.List.isEmpty()" because "transportModes" is null
java.lang.NullPointerException: Cannot invoke "java.util.List.isEmpty()" because "transportModes" is null
	at org.opentripplanner.apis.transmodel.mapping.FilterMapper.mapFilterOldWay(FilterMapper.java:91)
	at org.opentripplanner.apis.transmodel.mapping.TripRequestMapper.createRequest(TripRequestMapper.java:109)
	at org.opentripplanner.apis.transmodel.TransmodelGraphQLPlanner.plan(TransmodelGraphQLPlanner.java:31)
```

This PR ensures that the filter behaves according to the documentation, that is:

* No filter: `modes: {}` --> all transport modes selected
* Null filter: `modes: {transportModes: null}` --> all transport modes selected
* Empty filter: `modes: {transportModes: []}` --> no transport mode selected

### Issue
No

### Unit tests

No

### Documentation

No
