### PR TITLE
Discourage instead of ban cycling on use_sidepath ways and do the same for walking on foot=use_sidepath

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
@@ -106,20 +106,6 @@ public class OSMWay extends OSMWithTags {
   }
 
   /**
-   * Returns true if bikes must use sidepath in forward direction
-   */
-  public boolean isForwardDirectionSidepath() {
-    return "use_sidepath".equals(getTag("bicycle:forward"));
-  }
-
-  /**
-   * Returns true if bikes must use sidepath in reverse direction
-   */
-  public boolean isReverseDirectionSidepath() {
-    return "use_sidepath".equals(getTag("bicycle:backward"));
-  }
-
-  /**
    * Some cycleways allow contraflow biking.
    */
   public boolean isOpposableCycleway() {
@@ -182,18 +168,6 @@ public class OSMWay extends OSMWithTags {
         permissionsFront = permissionsFront.add(StreetTraversalPermission.BICYCLE);
         permissionsBack = permissionsBack.add(StreetTraversalPermission.BICYCLE);
       }
-    }
-
-    //This needs to be after adding permissions for oneway:bicycle=no
-    //removes bicycle permission when bicycles need to use sidepath
-    //TAG: bicycle:forward=use_sidepath
-    if (isForwardDirectionSidepath()) {
-      permissionsFront = permissionsFront.remove(StreetTraversalPermission.BICYCLE);
-    }
-
-    //TAG bicycle:backward=use_sidepath
-    if (isReverseDirectionSidepath()) {
-      permissionsBack = permissionsBack.remove(StreetTraversalPermission.BICYCLE);
     }
 
     if (isOpposableCycleway()) {

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -391,14 +391,10 @@ public class OSMWithTags {
   /**
    * Returns true if bikes are explicitly denied access.
    * <p>
-   * bicycle is denied if bicycle:no, bicycle:dismount, bicycle:license or bicycle:use_sidepath
+   * bicycle is denied if bicycle:no, bicycle:dismount or bicycle:license.
    */
   public boolean isBicycleExplicitlyDenied() {
-    return (
-      isTagDeniedAccess("bicycle") ||
-      "dismount".equals(getTag("bicycle")) ||
-      "use_sidepath".equals(getTag("bicycle"))
-    );
+    return (isTagDeniedAccess("bicycle") || "dismount".equals(getTag("bicycle")));
   }
 
   /**

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
@@ -624,6 +624,9 @@ class DefaultMapper implements OsmTagMapper {
     props.setMixinProperties("foot=discouraged", ofWalkSafety(3));
     props.setMixinProperties("bicycle=discouraged", ofBicycleSafety(3));
 
+    props.setMixinProperties("foot=use_sidepath", ofWalkSafety(5));
+    props.setMixinProperties("bicycle=use_sidepath", ofBicycleSafety(5));
+
     populateNotesAndNames(props);
 
     // slope overrides

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
@@ -168,8 +168,6 @@ class FinlandMapper implements OsmTagMapper {
     // We don't need to set bicycle safety as cycling is not currently allowed on these ways.
     props.setMixinProperties("bicycle=use_sidepath", ofWalkSafety(5));
 
-    props.setMixinProperties("foot=use_sidepath", ofWalkSafety(8));
-
     // Automobile speeds in Finland.
     // General speed limit is 80kph unless signs says otherwise.
     props.defaultCarSpeed = 22.22f;

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.openstreetmap.tagmapping;
 
+import static org.opentripplanner.openstreetmap.wayproperty.MixinPropertiesBuilder.ofWalkSafety;
 import static org.opentripplanner.openstreetmap.wayproperty.WayPropertiesBuilder.withModes;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
 import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
@@ -162,6 +163,12 @@ class FinlandMapper implements OsmTagMapper {
     // Remove Helsinki city center service tunnel network from graph
     props.setProperties("highway=service;tunnel=yes;access=destination", withModes(NONE));
     props.setProperties("highway=service;access=destination", withModes(ALL).bicycleSafety(1.1));
+
+    // Typically if this tag is used on a way, there is also a better option for walking.
+    // We don't need to set bicycle safety as cycling is not currently allowed on these ways.
+    props.setMixinProperties("bicycle=use_sidepath", ofWalkSafety(5));
+
+    props.setMixinProperties("foot=use_sidepath", ofWalkSafety(8));
 
     // Automobile speeds in Finland.
     // General speed limit is 80kph unless signs says otherwise.

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
@@ -93,21 +93,6 @@ public class OSMWayTest {
   }
 
   @Test
-  void testIsOneDirectionSidepath() {
-    OSMWay way = new OSMWay();
-    assertFalse(way.isForwardDirectionSidepath());
-    assertFalse(way.isReverseDirectionSidepath());
-
-    way.addTag("bicycle:forward", "use_sidepath");
-    assertTrue(way.isForwardDirectionSidepath());
-    assertFalse(way.isReverseDirectionSidepath());
-
-    way.addTag("bicycle:backward", "use_sidepath");
-    assertTrue(way.isForwardDirectionSidepath());
-    assertTrue(way.isReverseDirectionSidepath());
-  }
-
-  @Test
   void testIsOpposableCycleway() {
     OSMWay way = new OSMWay();
     assertFalse(way.isOpposableCycleway());

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
@@ -136,7 +136,7 @@ public class OSMWithTagsTest {
       assertFalse(tags.isBicycleExplicitlyDenied(), "bicycle=" + allowedValue);
     }
 
-    for (var deniedValue : List.of("no", "dismount", "license", "use_sidepath")) {
+    for (var deniedValue : List.of("no", "dismount", "license")) {
       tags.addTag("bicycle", deniedValue);
       assertTrue(tags.isBicycleExplicitlyDenied(), "bicycle=" + deniedValue);
     }

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapperTest.java
@@ -147,6 +147,48 @@ public class DefaultMapperTest {
     assertEquals(2.94, discouragedProps.bicycleSafety().forward(), epsilon);
   }
 
+  @Test
+  void footUseSidepath() {
+    var regular = WayTestData.pedestrianTunnel();
+    var props = wps.getDataForWay(regular);
+    assertEquals(PEDESTRIAN_AND_BICYCLE, props.getPermission());
+    assertEquals(1, props.walkSafety().forward());
+
+    var useSidepath = WayTestData.pedestrianTunnel().addTag("foot", "use_sidepath");
+    var useSidepathProps = wps.getDataForWay(useSidepath);
+    assertEquals(PEDESTRIAN_AND_BICYCLE, useSidepathProps.getPermission());
+    assertEquals(5, useSidepathProps.walkSafety().forward());
+  }
+
+  @Test
+  void bicycleUseSidepath() {
+    var regular = WayTestData.southeastLaBonitaWay();
+    var props = wps.getDataForWay(regular);
+    assertEquals(ALL, props.getPermission());
+    assertEquals(.98, props.bicycleSafety().forward());
+
+    var useSidepath = WayTestData.southeastLaBonitaWay().addTag("bicycle", "use_sidepath");
+    var useSidepathProps = wps.getDataForWay(useSidepath);
+    assertEquals(ALL, useSidepathProps.getPermission());
+    assertEquals(4.9, useSidepathProps.bicycleSafety().forward(), epsilon);
+
+    var useSidepathForward = WayTestData
+      .southeastLaBonitaWay()
+      .addTag("bicycle:forward", "use_sidepath");
+    var useSidepathForwardProps = wps.getDataForWay(useSidepathForward);
+    assertEquals(ALL, useSidepathForwardProps.getPermission());
+    assertEquals(4.9, useSidepathForwardProps.bicycleSafety().forward(), epsilon);
+    assertEquals(0.98, useSidepathForwardProps.bicycleSafety().back(), epsilon);
+
+    var useSidepathBackward = WayTestData
+      .southeastLaBonitaWay()
+      .addTag("bicycle:backward", "use_sidepath");
+    var useSidepathBackwardProps = wps.getDataForWay(useSidepathBackward);
+    assertEquals(ALL, useSidepathBackwardProps.getPermission());
+    assertEquals(0.98, useSidepathBackwardProps.bicycleSafety().forward(), epsilon);
+    assertEquals(4.9, useSidepathBackwardProps.bicycleSafety().back(), epsilon);
+  }
+
   /**
    * Test that two values are within epsilon of each other.
    */

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapperTest.java
@@ -168,7 +168,7 @@ public class FinlandMapperTest {
     assertEquals(8, wps.getDataForWay(wayWithBicycleSidePath).walkSafety().forward(), epsilon);
     OSMWithTags wayWithFootSidePath = new OSMWithTags();
     wayWithFootSidePath.addTag("foot", "use_sidepath");
-    assertEquals(12.8, wps.getDataForWay(wayWithFootSidePath).walkSafety().forward(), epsilon);
+    assertEquals(8, wps.getDataForWay(wayWithFootSidePath).walkSafety().forward(), epsilon);
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapperTest.java
@@ -162,6 +162,13 @@ public class FinlandMapperTest {
       wps.getDataForWay(wayWithMixinsAndCustomSafety).walkSafety().forward(),
       epsilon
     );
+
+    OSMWithTags wayWithBicycleSidePath = new OSMWithTags();
+    wayWithBicycleSidePath.addTag("bicycle", "use_sidepath");
+    assertEquals(8, wps.getDataForWay(wayWithBicycleSidePath).walkSafety().forward(), epsilon);
+    OSMWithTags wayWithFootSidePath = new OSMWithTags();
+    wayWithFootSidePath.addTag("foot", "use_sidepath");
+    assertEquals(12.8, wps.getDataForWay(wayWithFootSidePath).walkSafety().forward(), epsilon);
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySetTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySetTest.java
@@ -256,65 +256,6 @@ class WayPropertySetTest {
         assertTrue(permissionPair.main().allowsNothing());*/
     }
 
-    @Test
-    void testSidepathPermissions() {
-      OSMWay way = new OSMWay();
-      way.addTag("bicycle", "use_sidepath");
-      way.addTag("highway", "primary");
-      way.addTag("lanes", "2");
-      way.addTag("maxspeed", "70");
-      way.addTag("oneway", "yes");
-      var permissionPair = getWayProperties(way);
-
-      assertFalse(permissionPair.main().allows(StreetTraversalPermission.BICYCLE));
-      assertFalse(permissionPair.back().allows(StreetTraversalPermission.BICYCLE));
-
-      assertTrue(permissionPair.main().allows(StreetTraversalPermission.CAR));
-      assertFalse(permissionPair.back().allows(StreetTraversalPermission.CAR));
-
-      way = new OSMWay();
-      way.addTag("bicycle:forward", "use_sidepath");
-      way.addTag("highway", "tertiary");
-      permissionPair = getWayProperties(way);
-
-      assertFalse(permissionPair.main().allows(StreetTraversalPermission.BICYCLE));
-      assertTrue(permissionPair.back().allows(StreetTraversalPermission.BICYCLE));
-
-      assertTrue(permissionPair.main().allows(StreetTraversalPermission.CAR));
-      assertTrue(permissionPair.back().allows(StreetTraversalPermission.CAR));
-
-      way = new OSMWay();
-      way.addTag("bicycle:backward", "use_sidepath");
-      way.addTag("highway", "tertiary");
-      permissionPair = getWayProperties(way);
-
-      assertTrue(permissionPair.main().allows(StreetTraversalPermission.BICYCLE));
-      assertFalse(permissionPair.back().allows(StreetTraversalPermission.BICYCLE));
-
-      assertTrue(permissionPair.main().allows(StreetTraversalPermission.CAR));
-      assertTrue(permissionPair.back().allows(StreetTraversalPermission.CAR));
-
-      way = new OSMWay();
-      way.addTag("highway", "tertiary");
-      way.addTag("oneway", "yes");
-      way.addTag("oneway:bicycle", "no");
-      permissionPair = getWayProperties(way);
-
-      assertTrue(permissionPair.main().allows(StreetTraversalPermission.BICYCLE));
-      assertTrue(permissionPair.back().allows(StreetTraversalPermission.BICYCLE));
-
-      assertTrue(permissionPair.main().allows(StreetTraversalPermission.CAR));
-      assertFalse(permissionPair.back().allows(StreetTraversalPermission.CAR));
-
-      way.addTag("bicycle:forward", "use_sidepath");
-      permissionPair = getWayProperties(way);
-      assertFalse(permissionPair.main().allows(StreetTraversalPermission.BICYCLE));
-      assertTrue(permissionPair.back().allows(StreetTraversalPermission.BICYCLE));
-
-      assertTrue(permissionPair.main().allows(StreetTraversalPermission.CAR));
-      assertFalse(permissionPair.back().allows(StreetTraversalPermission.CAR));
-    }
-
     private StreetTraversalPermissionPair getWayProperties(OSMWay way) {
       WayPropertySet wayPropertySet = new WayPropertySet();
       WayProperties wayData = wayPropertySet.getDataForWay(way);


### PR DESCRIPTION
### Summary

Cycling on bicycle=use_sidepath is no longer banned but discouraged with safety values. foot=use_sidepath has no same effect for walking. For Finland mapper, also walking is discouraged when bicycle=use_sidepath is used.

This fixes some occurances where we get a route through a road with cars with walking even though there is a walking path close to the road that is tagged to the car road in OSM with either foot=use_sidepath or bicycle=use_sidepath.

For example https://www.openstreetmap.org/way/574874058

![before](https://github.com/opentripplanner/OpenTripPlanner/assets/24825005/cee6c229-e7e7-49a4-8e96-4e03dd8e3dc9)
![after](https://github.com/opentripplanner/OpenTripPlanner/assets/24825005/acb55296-88c8-4dac-b5ac-7ffd6410fd20)



### Issue

No issue as minor OSM mapper change.

### Unit tests

Updated tests

### Documentation

No need to update

### Changelog

From title
