### PR TITLE
Fix trip duplication in Graph Builder DSJ mapping

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -392,9 +392,12 @@ class TripPatternMapper {
     JourneyPattern_VersionStructure journeyPattern,
     ServiceJourney serviceJourney
   ) {
-    return tripMapper.mapServiceJourney(
-      serviceJourney,
-      () -> findTripHeadsign(journeyPattern, serviceJourney)
+    return deduplicator.deduplicateObject(
+      Trip.class,
+      tripMapper.mapServiceJourney(
+        serviceJourney,
+        () -> findTripHeadsign(journeyPattern, serviceJourney)
+      )
     );
   }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -67,7 +67,7 @@ class TripPatternMapper {
 
   private final ReadOnlyHierarchicalMap<String, Route> routeById;
 
-  private final Multimap<String, ServiceJourney> serviceJourniesByPatternId = ArrayListMultimap.create();
+  private final Multimap<String, ServiceJourney> serviceJourneysByPatternId = ArrayListMultimap.create();
 
   private final ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById;
 
@@ -152,12 +152,12 @@ class TripPatternMapper {
     this.serviceJourneyById = serviceJourneyById;
     // Index service journey by pattern id
     for (ServiceJourney sj : serviceJourneyById.localValues()) {
-      this.serviceJourniesByPatternId.put(sj.getJourneyPatternRef().getValue().getRef(), sj);
+      this.serviceJourneysByPatternId.put(sj.getJourneyPatternRef().getValue().getRef(), sj);
     }
   }
 
   Optional<TripPatternMapperResult> mapTripPattern(JourneyPattern_VersionStructure journeyPattern) {
-    Collection<ServiceJourney> serviceJourneys = serviceJourniesByPatternId.get(
+    Collection<ServiceJourney> serviceJourneys = serviceJourneysByPatternId.get(
       journeyPattern.getId()
     );
 

--- a/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -40,6 +40,7 @@ import org.rutebanken.netex.model.RouteRefStructure;
 import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
 import org.rutebanken.netex.model.ServiceAlterationEnumeration;
 import org.rutebanken.netex.model.ServiceJourney;
+import org.rutebanken.netex.model.ServiceJourneyRefStructure;
 import org.rutebanken.netex.model.StopPointInJourneyPattern;
 import org.rutebanken.netex.model.StopPointInJourneyPatternRefStructure;
 import org.rutebanken.netex.model.TimetabledPassingTime;
@@ -50,9 +51,11 @@ import org.rutebanken.netex.model.Vias_RelStructure;
 public class NetexTestDataSample {
 
   public static final String SERVICE_JOURNEY_ID = "RUT:ServiceJourney:1";
+  public static final String DATED_SERVICE_JOURNEY_ID_1 = "RUT:DatedServiceJourney:1";
+  public static final String DATED_SERVICE_JOURNEY_ID_2 = "RUT:DatedServiceJourney:2";
   public static final List<String> DATED_SERVICE_JOURNEY_ID = List.of(
-    "RUT:DatedServiceJourney:1",
-    "RUT:DatedServiceJourney:2"
+    DATED_SERVICE_JOURNEY_ID_1,
+    DATED_SERVICE_JOURNEY_ID_2
   );
   public static final List<String> OPERATING_DAYS = List.of("2022-02-28", "2022-02-29");
   private static final DayType EVERYDAY = new DayType()
@@ -174,6 +177,11 @@ public class NetexTestDataSample {
 
         DatedServiceJourney datedServiceJourney = new DatedServiceJourney()
           .withId(DATED_SERVICE_JOURNEY_ID.get(i))
+          .withJourneyRef(
+            List.of(
+              MappingSupport.createWrappedRef(SERVICE_JOURNEY_ID, ServiceJourneyRefStructure.class)
+            )
+          )
           .withServiceAlteration(ServiceAlterationEnumeration.PLANNED)
           .withOperatingDayRef(new OperatingDayRefStructure().withRef(operatingDay.getId()));
 
@@ -216,6 +224,15 @@ public class NetexTestDataSample {
 
   public HierarchicalMapById<ServiceJourney> getServiceJourneyById() {
     return serviceJourneyById;
+  }
+
+  public DatedServiceJourney getDatedServiceJourneyById(String id) {
+    return datedServiceJourneyBySjId
+      .values()
+      .stream()
+      .filter(datedServiceJourney -> datedServiceJourney.getId().equals(id))
+      .findFirst()
+      .orElse(null);
   }
 
   public ServiceJourney getServiceJourney() {


### PR DESCRIPTION
### Summary

As detailed in #5793, querying passing times for a replaced DatedServiceJourney fails currently with a NullPointerException.  

The root cause is the creation of a duplicated Trip object during graph building when resolving the reference to the ServiceJourney associated with a replaced DatedServiceJourney.
Since looking up a given Trip in a Timetable is based on object identity rather than object equality (see https://github.com/opentripplanner/OpenTripPlanner/blob/d15e61655f485f4f1b8c9de1e5c2468444b9f8f5/src/main/java/org/opentripplanner/model/Timetable.java#L119), the lookup fails and leads to a NullPointerException.

The issue can be solved by using a deduplicator when creating the Trip object during graph building.

### Issue

Close #5793 

### Unit tests

Added unit test.

### Documentation

No

### Changelog
