### PR TITLE
Add trace log for HTTP error responses

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/ridehailing/service/uber/UberService.java
+++ b/src/ext/java/org/opentripplanner/ext/ridehailing/service/uber/UberService.java
@@ -79,7 +79,7 @@ public class UberService extends CachingRideHailingService {
     this.timeEstimateUri = timeEstimateUri;
     this.bannedTypes = bannedTypes;
     this.wheelchairAccessibleProductId = wheelchairAccessibleProductId;
-    this.otpHttpClient = new OtpHttpClient();
+    this.otpHttpClient = new OtpHttpClient(LOG);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/ridehailing/service/uber/UberService.java
+++ b/src/ext/java/org/opentripplanner/ext/ridehailing/service/uber/UberService.java
@@ -25,6 +25,7 @@ import org.opentripplanner.ext.ridehailing.service.oauth.OAuthService;
 import org.opentripplanner.ext.ridehailing.service.oauth.UrlEncodedOAuthService;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.json.ObjectMappers;
 import org.opentripplanner.transit.model.basic.Money;
 import org.slf4j.Logger;
@@ -79,7 +80,7 @@ public class UberService extends CachingRideHailingService {
     this.timeEstimateUri = timeEstimateUri;
     this.bannedTypes = bannedTypes;
     this.wheelchairAccessibleProductId = wheelchairAccessibleProductId;
-    this.otpHttpClient = new OtpHttpClient(LOG);
+    this.otpHttpClient = new OtpHttpClientFactory().create(LOG);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -312,7 +312,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   }
 
   private ByteString fetchInitialData() {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
       return otpHttpClient.getAndMap(
         dataInitializationUrl,
         initialGetDataTimeout,

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -28,7 +28,7 @@ import org.opentripplanner.ext.siri.EntityResolver;
 import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.framework.application.ApplicationShutdownSupport;
-import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.retry.OtpRetry;
 import org.opentripplanner.framework.retry.OtpRetryBuilder;
 import org.opentripplanner.framework.text.FileSizeToTextConverter;
@@ -312,7 +312,8 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   }
 
   private ByteString fetchInitialData() {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
+    try (OtpHttpClientFactory otpHttpClientFactory = new OtpHttpClientFactory()) {
+      var otpHttpClient = otpHttpClientFactory.create(LOG);
       return otpHttpClient.getAndMap(
         dataInitializationUrl,
         initialGetDataTimeout,

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
@@ -4,6 +4,7 @@ import jakarta.xml.bind.JAXBException;
 import java.time.Duration;
 import java.util.Optional;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,7 @@ public class SiriHttpLoader implements SiriLoader {
     this.timeout = timeout;
     this.requestHeaders = requestHeaders;
     this.previewInterval = previewInterval;
-    this.otpHttpClient = new OtpHttpClient(timeout, timeout, LOG);
+    this.otpHttpClient = new OtpHttpClientFactory(timeout, timeout).create(LOG);
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHttpLoader.java
@@ -35,7 +35,7 @@ public class SiriHttpLoader implements SiriLoader {
     this.timeout = timeout;
     this.requestHeaders = requestHeaders;
     this.previewInterval = previewInterval;
-    this.otpHttpClient = new OtpHttpClient(timeout, timeout);
+    this.otpHttpClient = new OtpHttpClient(timeout, timeout, LOG);
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -25,7 +25,7 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.opentripplanner.ext.siri.EntityResolver;
 import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.framework.application.ApplicationShutdownSupport;
-import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
@@ -206,7 +206,8 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   protected Optional<ServiceDelivery> fetchInitialSiriData(URI uri) {
     var headers = HttpHeaders.of().acceptApplicationXML().build().asMap();
 
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
+    try (OtpHttpClientFactory otpHttpClientFactory = new OtpHttpClientFactory()) {
+      var otpHttpClient = otpHttpClientFactory.create(LOG);
       var t1 = System.currentTimeMillis();
       var siriOptional = otpHttpClient.executeAndMapOptional(
         new HttpGet(uri),

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -206,7 +206,7 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   protected Optional<ServiceDelivery> fetchInitialSiriData(URI uri) {
     var headers = HttpHeaders.of().acceptApplicationXML().build().asMap();
 
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
       var t1 = System.currentTimeMillis();
       var siriOptional = otpHttpClient.executeAndMapOptional(
         new HttpGet(uri),

--- a/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
@@ -23,7 +23,7 @@ public class SmooveBikeRentalDataSource
   extends GenericJsonDataSource<VehicleRentalPlace>
   implements VehicleRentalDatasource {
 
-  private static final Logger log = LoggerFactory.getLogger(SmooveBikeRentalDataSource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SmooveBikeRentalDataSource.class);
 
   public static final String DEFAULT_NETWORK_NAME = "smoove";
 
@@ -33,7 +33,7 @@ public class SmooveBikeRentalDataSource
   private final RentalVehicleType vehicleType;
 
   public SmooveBikeRentalDataSource(SmooveBikeRentalDataSourceParameters config) {
-    this(config, new OtpHttpClient());
+    this(config, new OtpHttpClient(LOG));
   }
 
   public SmooveBikeRentalDataSource(
@@ -76,7 +76,7 @@ public class SmooveBikeRentalDataSource
       station.longitude = Double.parseDouble(coordinates[1].trim());
     } catch (NumberFormatException e) {
       // E.g. coordinates is empty
-      log.warn("Error parsing bike rental station {}", station.id, e);
+      LOG.warn("Error parsing bike rental station {}", station.id, e);
       return null;
     }
     if (!node.path("style").asText().equals("Station on")) {

--- a/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
@@ -33,14 +34,14 @@ public class SmooveBikeRentalDataSource
   private final RentalVehicleType vehicleType;
 
   public SmooveBikeRentalDataSource(SmooveBikeRentalDataSourceParameters config) {
-    this(config, new OtpHttpClient(LOG));
+    this(config, new OtpHttpClientFactory());
   }
 
   public SmooveBikeRentalDataSource(
     SmooveBikeRentalDataSourceParameters config,
-    OtpHttpClient otpHttpClient
+    OtpHttpClientFactory otpHttpClientFactory
   ) {
-    super(config.url(), "result", config.httpHeaders(), otpHttpClient);
+    super(config.url(), "result", config.httpHeaders(), otpHttpClientFactory.create(LOG));
     networkName = config.getNetwork(DEFAULT_NETWORK_NAME);
     vehicleType = RentalVehicleType.getDefaultType(networkName);
     overloadingAllowed = config.overloadingAllowed();

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/bikely/BikelyUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/bikely/BikelyUpdater.java
@@ -44,7 +44,7 @@ public class BikelyUpdater implements DataSource<VehicleParking> {
     .put("lonMax", 0)
     .put("latMin", 0)
     .put("latMax", 0);
-  private final OtpHttpClient httpClient = new OtpHttpClient();
+  private final OtpHttpClient httpClient = new OtpHttpClient(LOG);
   private final BikelyUpdaterParameters parameters;
   private List<VehicleParking> lots;
 

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/bikely/BikelyUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/bikely/BikelyUpdater.java
@@ -15,6 +15,7 @@ import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.LocalizedString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.json.ObjectMappers;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
@@ -44,7 +45,7 @@ public class BikelyUpdater implements DataSource<VehicleParking> {
     .put("lonMax", 0)
     .put("latMin", 0)
     .put("latMax", 0);
-  private final OtpHttpClient httpClient = new OtpHttpClient(LOG);
+  private final OtpHttpClient httpClient = new OtpHttpClientFactory().create(LOG);
   private final BikelyUpdaterParameters parameters;
   private List<VehicleParking> lots;
 

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientException;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingGroup;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -31,12 +32,13 @@ public class HslFacilitiesDownloader {
   public HslFacilitiesDownloader(
     String url,
     String jsonParsePath,
-    BiFunction<JsonNode, Map<FeedScopedId, VehicleParkingGroup>, VehicleParking> facilitiesParser
+    BiFunction<JsonNode, Map<FeedScopedId, VehicleParkingGroup>, VehicleParking> facilitiesParser,
+    OtpHttpClientFactory otpHttpClientFactory
   ) {
     this.url = url;
     this.jsonParsePath = jsonParsePath;
     this.facilitiesParser = facilitiesParser;
-    this.otpHttpClient = new OtpHttpClient(LOG);
+    this.otpHttpClient = otpHttpClientFactory.create(LOG);
   }
 
   public List<VehicleParking> downloadFacilities(

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslFacilitiesDownloader.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public class HslFacilitiesDownloader {
 
-  private static final Logger log = LoggerFactory.getLogger(HslFacilitiesDownloader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HslFacilitiesDownloader.class);
   private static final ObjectMapper mapper = new ObjectMapper();
 
   private final String jsonParsePath;
@@ -36,14 +36,14 @@ public class HslFacilitiesDownloader {
     this.url = url;
     this.jsonParsePath = jsonParsePath;
     this.facilitiesParser = facilitiesParser;
-    this.otpHttpClient = new OtpHttpClient();
+    this.otpHttpClient = new OtpHttpClient(LOG);
   }
 
   public List<VehicleParking> downloadFacilities(
     Map<FeedScopedId, VehicleParkingGroup> hubForPark
   ) {
     if (url == null) {
-      log.warn("Cannot download updates, because url is null!");
+      LOG.warn("Cannot download updates, because url is null!");
       return null;
     }
 
@@ -55,17 +55,17 @@ public class HslFacilitiesDownloader {
           try {
             return parseJSON(is, hubForPark);
           } catch (IllegalArgumentException e) {
-            log.warn("Error parsing facilities from {}", url, e);
+            LOG.warn("Error parsing facilities from {}", url, e);
           } catch (JsonProcessingException e) {
-            log.warn("Error parsing facilities from {} (bad JSON of some sort)", url, e);
+            LOG.warn("Error parsing facilities from {} (bad JSON of some sort)", url, e);
           } catch (IOException e) {
-            log.warn("Error reading facilities from {}", url, e);
+            LOG.warn("Error reading facilities from {}", url, e);
           }
           return null;
         }
       );
     } catch (OtpHttpClientException e) {
-      log.warn("Failed to get data from url {}", url);
+      LOG.warn("Failed to get data from url {}", url);
       return null;
     }
   }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientException;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingGroup;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.slf4j.Logger;
@@ -29,12 +30,13 @@ public class HslHubsDownloader {
   public HslHubsDownloader(
     String url,
     String jsonParsePath,
-    Function<JsonNode, Map<FeedScopedId, VehicleParkingGroup>> hubsParser
+    Function<JsonNode, Map<FeedScopedId, VehicleParkingGroup>> hubsParser,
+    OtpHttpClientFactory otpHttpClientFactory
   ) {
     this.url = url;
     this.jsonParsePath = jsonParsePath;
     this.hubsParser = hubsParser;
-    otpHttpClient = new OtpHttpClient(LOG);
+    otpHttpClient = otpHttpClientFactory.create(LOG);
   }
 
   public Map<FeedScopedId, VehicleParkingGroup> downloadHubs() {

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubsDownloader.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class HslHubsDownloader {
 
-  private static final Logger log = LoggerFactory.getLogger(HslHubsDownloader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HslHubsDownloader.class);
   private static final ObjectMapper mapper = new ObjectMapper();
 
   private final String jsonParsePath;
@@ -34,12 +34,12 @@ public class HslHubsDownloader {
     this.url = url;
     this.jsonParsePath = jsonParsePath;
     this.hubsParser = hubsParser;
-    otpHttpClient = new OtpHttpClient();
+    otpHttpClient = new OtpHttpClient(LOG);
   }
 
   public Map<FeedScopedId, VehicleParkingGroup> downloadHubs() {
     if (url == null) {
-      log.warn("Cannot download updates, because url is null!");
+      LOG.warn("Cannot download updates, because url is null!");
       return null;
     }
     try {
@@ -50,17 +50,17 @@ public class HslHubsDownloader {
           try {
             return parseJSON(is);
           } catch (IllegalArgumentException e) {
-            log.warn("Error parsing hubs from {}", url, e);
+            LOG.warn("Error parsing hubs from {}", url, e);
           } catch (JsonProcessingException e) {
-            log.warn("Error parsing hubs from {} (bad JSON of some sort)", url, e);
+            LOG.warn("Error parsing hubs from {} (bad JSON of some sort)", url, e);
           } catch (IOException e) {
-            log.warn("Error reading hubs from {}", url, e);
+            LOG.warn("Error reading hubs from {}", url, e);
           }
           return null;
         }
       );
     } catch (OtpHttpClientException e) {
-      log.warn("Failed to get data from url {}", url);
+      LOG.warn("Failed to get data from url {}", url);
       return null;
     }
   }

--- a/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -61,7 +61,7 @@ public class VehicleRentalServiceDirectoryFetcher {
     }
 
     int maxHttpConnections = sources.size();
-    var otpHttpClient = new OtpHttpClient(maxHttpConnections);
+    var otpHttpClient = new OtpHttpClient(maxHttpConnections, LOG);
 
     var serviceDirectory = new VehicleRentalServiceDirectoryFetcher(
       vertexLinker,
@@ -154,7 +154,7 @@ public class VehicleRentalServiceDirectoryFetcher {
   private static JsonNode listSources(VehicleRentalServiceDirectoryFetcherParameters parameters) {
     JsonNode node;
     URI url = parameters.getUrl();
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
       node = otpHttpClient.getAndMapAsJsonNode(url, Map.of(), new ObjectMapper());
     } catch (OtpHttpClientException e) {
       LOG.warn("Error fetching list of vehicle rental endpoints from {}", url, e);

--- a/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
-import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientException;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.json.JsonUtils;
 import org.opentripplanner.routing.linking.VertexLinker;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
@@ -35,16 +35,16 @@ public class VehicleRentalServiceDirectoryFetcher {
 
   private final VertexLinker vertexLinker;
   private final VehicleRentalRepository repository;
-  private final OtpHttpClient otpHttpClient;
+  private final OtpHttpClientFactory otpHttpClientFactory;
 
   public VehicleRentalServiceDirectoryFetcher(
     VertexLinker vertexLinker,
     VehicleRentalRepository repository,
-    OtpHttpClient otpHttpClient
+    OtpHttpClientFactory otpHttpClientFactory
   ) {
     this.vertexLinker = vertexLinker;
     this.repository = repository;
-    this.otpHttpClient = otpHttpClient;
+    this.otpHttpClientFactory = otpHttpClientFactory;
   }
 
   public static List<GraphUpdater> createUpdatersFromEndpoint(
@@ -61,12 +61,12 @@ public class VehicleRentalServiceDirectoryFetcher {
     }
 
     int maxHttpConnections = sources.size();
-    var otpHttpClient = new OtpHttpClient(maxHttpConnections, LOG);
+    var otpHttpClientFactory = new OtpHttpClientFactory(maxHttpConnections);
 
     var serviceDirectory = new VehicleRentalServiceDirectoryFetcher(
       vertexLinker,
       repository,
-      otpHttpClient
+      otpHttpClientFactory
     );
     return serviceDirectory.createUpdatersFromEndpoint(parameters, sources);
   }
@@ -146,7 +146,7 @@ public class VehicleRentalServiceDirectoryFetcher {
 
     var dataSource = VehicleRentalDataSourceFactory.create(
       vehicleRentalParameters.sourceParameters(),
-      otpHttpClient
+      otpHttpClientFactory
     );
     return new VehicleRentalUpdater(vehicleRentalParameters, dataSource, vertexLinker, repository);
   }
@@ -154,7 +154,8 @@ public class VehicleRentalServiceDirectoryFetcher {
   private static JsonNode listSources(VehicleRentalServiceDirectoryFetcherParameters parameters) {
     JsonNode node;
     URI url = parameters.getUrl();
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
+    try {
+      var otpHttpClient = new OtpHttpClientFactory().create(LOG);
       node = otpHttpClient.getAndMapAsJsonNode(url, Map.of(), new ObjectMapper());
     } catch (OtpHttpClientException e) {
       LOG.warn("Error fetching list of vehicle rental endpoints from {}", url, e);

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -11,7 +11,7 @@ import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.base.DataSourceRepository;
 import org.opentripplanner.datastore.file.ZipStreamDataSourceDecorator;
-import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +79,8 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   }
 
   protected List<Header> getHttpHeaders(URI uri) {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
+    try (OtpHttpClientFactory otpHttpClientFactory = new OtpHttpClientFactory()) {
+      var otpHttpClient = otpHttpClientFactory.create(LOG);
       return otpHttpClient.getHeaders(uri, HTTP_HEAD_REQUEST_TIMEOUT, Map.of());
     }
   }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -12,11 +12,15 @@ import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.base.DataSourceRepository;
 import org.opentripplanner.datastore.file.ZipStreamDataSourceDecorator;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This data store accesses files in read-only mode over HTTPS.
  */
 public class HttpsDataSourceRepository implements DataSourceRepository {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpsFileDataSource.class);
 
   private static final Duration HTTP_HEAD_REQUEST_TIMEOUT = Duration.ofSeconds(20);
 
@@ -75,7 +79,7 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   }
 
   protected List<Header> getHttpHeaders(URI uri) {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try (OtpHttpClient otpHttpClient = new OtpHttpClient(LOG)) {
       return otpHttpClient.getHeaders(uri, HTTP_HEAD_REQUEST_TIMEOUT, Map.of());
     }
   }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -13,6 +13,8 @@ import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.file.DirectoryDataSource;
 import org.opentripplanner.datastore.file.ZipFileDataSource;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is a wrapper around an HTTPS resource.
@@ -21,6 +23,8 @@ import org.opentripplanner.framework.io.OtpHttpClient;
  * .gz).
  */
 final class HttpsFileDataSource implements DataSource {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpsFileDataSource.class);
 
   private static final Duration HTTP_GET_REQUEST_TIMEOUT = Duration.ofSeconds(20);
   private final URI uri;
@@ -35,7 +39,7 @@ final class HttpsFileDataSource implements DataSource {
     this.uri = uri;
     this.type = type;
     this.httpsDataSourceMetadata = httpsDataSourceMetadata;
-    otpHttpClient = new OtpHttpClient();
+    otpHttpClient = new OtpHttpClient(LOG);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -13,6 +13,7 @@ import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.file.DirectoryDataSource;
 import org.opentripplanner.datastore.file.ZipFileDataSource;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ final class HttpsFileDataSource implements DataSource {
     this.uri = uri;
     this.type = type;
     this.httpsDataSourceMetadata = httpsDataSourceMetadata;
-    otpHttpClient = new OtpHttpClient(LOG);
+    otpHttpClient = new OtpHttpClientFactory().create(LOG);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public class JsonDataListDownloader<T> {
 
-  private static final Logger log = LoggerFactory.getLogger(JsonDataListDownloader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(JsonDataListDownloader.class);
   private final String jsonParsePath;
   private final Map<String, String> headers;
   private final Function<JsonNode, T> elementParser;
@@ -30,7 +30,7 @@ public class JsonDataListDownloader<T> {
     @Nonnull Function<JsonNode, T> elementParser,
     @Nonnull Map<String, String> headers
   ) {
-    this(url, jsonParsePath, elementParser, headers, new OtpHttpClient());
+    this(url, jsonParsePath, elementParser, headers, new OtpHttpClient(LOG));
   }
 
   public JsonDataListDownloader(
@@ -49,7 +49,7 @@ public class JsonDataListDownloader<T> {
 
   public List<T> download() {
     if (url == null) {
-      log.warn("Cannot download updates, because url is null!");
+      LOG.warn("Cannot download updates, because url is null!");
       return null;
     }
     try {
@@ -60,17 +60,17 @@ public class JsonDataListDownloader<T> {
           try {
             return parseJSON(is);
           } catch (IllegalArgumentException e) {
-            log.warn("Error parsing bike rental feed from {}", url, e);
+            LOG.warn("Error parsing bike rental feed from {}", url, e);
           } catch (JsonProcessingException e) {
-            log.warn("Error parsing bike rental feed from {} (bad JSON of some sort)", url, e);
+            LOG.warn("Error parsing bike rental feed from {} (bad JSON of some sort)", url, e);
           } catch (IOException e) {
-            log.warn("Error reading bike rental feed from {}", url, e);
+            LOG.warn("Error reading bike rental feed from {}", url, e);
           }
           return null;
         }
       );
     } catch (OtpHttpClientException e) {
-      log.warn("Failed to get data from url {}", url);
+      LOG.warn("Failed to get data from url {}", url);
       return null;
     }
   }
@@ -111,7 +111,7 @@ public class JsonDataListDownloader<T> {
           out.add(parsedElement);
         }
       } catch (Exception e) {
-        log.error("Could not process element in JSON list downloaded from {}", url, e);
+        LOG.error("Could not process element in JSON list downloaded from {}", url, e);
       }
     }
     return out;

--- a/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
@@ -60,11 +60,11 @@ public class JsonDataListDownloader<T> {
           try {
             return parseJSON(is);
           } catch (IllegalArgumentException e) {
-            LOG.warn("Error parsing bike rental feed from {}", url, e);
+            LOG.warn("Error parsing feed from {}", url, e);
           } catch (JsonProcessingException e) {
-            LOG.warn("Error parsing bike rental feed from {} (bad JSON of some sort)", url, e);
+            LOG.warn("Error parsing feed from {} (bad JSON of some sort)", url, e);
           } catch (IOException e) {
-            LOG.warn("Error reading bike rental feed from {}", url, e);
+            LOG.warn("Error reading feed from {}", url, e);
           }
           return null;
         }

--- a/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/framework/io/JsonDataListDownloader.java
@@ -30,7 +30,7 @@ public class JsonDataListDownloader<T> {
     @Nonnull Function<JsonNode, T> elementParser,
     @Nonnull Map<String, String> headers
   ) {
-    this(url, jsonParsePath, elementParser, headers, new OtpHttpClient(LOG));
+    this(url, jsonParsePath, elementParser, headers, new OtpHttpClientFactory().create(LOG));
   }
 
   public JsonDataListDownloader(

--- a/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
+++ b/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
@@ -20,14 +20,9 @@ import java.util.stream.Collectors;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
-import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
@@ -35,11 +30,7 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
-import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
-import org.apache.hc.core5.pool.PoolReusePolicy;
-import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 
@@ -52,107 +43,26 @@ import org.slf4j.Logger;
  * <h3>Exception management</h3>
  * Exceptions thrown during network operations or response mapping are wrapped in
  * {@link OtpHttpClientException}
- * <h3>Timeout configuration</h3>
- * The same timeout value is applied to the following parameters:
- * <ul>
- *  <li>Connection request timeout: the maximum waiting time for leasing a connection in the
- *  connection pool.
- *  <li>Connect timeout: the maximum waiting time for the first packet received from the server.
- *  <li>Socket timeout: the maximum waiting time between two packets received from the server.
- * </ul>
- * The default timeout is set to 5 seconds.
- * <h3>Connection time-to-live</h3>
- * Maximum time an HTTP connection can stay in the connection pool before being closed.
- * Note that HTTP 1.1 and HTTP/2 rely on persistent connections and the HTTP server is allowed to
- * close idle connections at any time.
- * The default connection time-to-live is set to 1 minute.
  * <h3>Resource management</h3>
- * It is recommended to use the <code>getAndMapXXX</code> and <code>postAndMapXXX</code> methods
- * in this class since they
- * ensure that the underlying network resources are properly released.
- * The method {@link #getAsInputStream} gives access to an input stream on the body response but
- * requires the caller to close this stream. For most use cases, this method is not recommended .
- * <h3>Connection Pooling</h3>
- * The connection pool holds by default a maximum of 25 connections, with maximum 5 connections
- * per host.
+ * It is recommended to use the <code>getAndMapXXX</code> and <code>postAndMapXXX</code> methods in
+ * this class since they ensure that the underlying network resources are properly released. The
+ * method {@link #getAsInputStream} gives access to an input stream on the body response but
+ * requires the caller to close this stream. For most use cases, this method is not recommended.
  *
  * <h3>Thread-safety</h3>
  * Instances of this class are thread-safe.
  */
-public class OtpHttpClient implements AutoCloseable {
-
-  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
-
-  private static final Duration DEFAULT_TTL = Duration.ofMinutes(1);
-
-  /**
-   * see {@link PoolingHttpClientConnectionManager#DEFAULT_MAX_TOTAL_CONNECTIONS}
-   */
-  public static final int DEFAULT_MAX_TOTAL_CONNECTIONS = 25;
+public class OtpHttpClient {
 
   private final CloseableHttpClient httpClient;
 
   private final Logger log;
 
   /**
-   * Creates an HTTP client with default timeout, default connection time-to-live and default max
-   * number of connections.
-   */
-  public OtpHttpClient(Logger logger) {
-    this(DEFAULT_TIMEOUT, DEFAULT_TTL, logger);
-  }
-
-  /**
-   * Creates an HTTP client with default timeout, default connection time-to-live and the given max
-   * number of connections.
-   */
-  public OtpHttpClient(int maxConnections, Logger logger) {
-    this(DEFAULT_TIMEOUT, DEFAULT_TTL, maxConnections, logger);
-  }
-
-  /**
-   * Creates an HTTP client the given timeout and connection time-to-live and the default max
-   * number of connections.
-   */
-  public OtpHttpClient(Duration timeout, Duration connectionTtl, Logger logger) {
-    this(timeout, connectionTtl, DEFAULT_MAX_TOTAL_CONNECTIONS, logger);
-  }
-
-  /**
    * Creates an HTTP client with custom configuration.
    */
-  private OtpHttpClient(
-    Duration timeout,
-    Duration connectionTtl,
-    int maxConnections,
-    Logger logger
-  ) {
-    Objects.requireNonNull(timeout);
-    Objects.requireNonNull(connectionTtl);
-
-    PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder
-      .create()
-      .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(Timeout.of(timeout)).build())
-      .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.STRICT)
-      .setConnPoolPolicy(PoolReusePolicy.LIFO)
-      .setMaxConnTotal(maxConnections)
-      .setDefaultConnectionConfig(
-        ConnectionConfig
-          .custom()
-          .setSocketTimeout(Timeout.of(timeout))
-          .setConnectTimeout(Timeout.of(timeout))
-          .setTimeToLive(TimeValue.of(connectionTtl))
-          .build()
-      )
-      .build();
-
-    HttpClientBuilder httpClientBuilder = HttpClients
-      .custom()
-      .setUserAgent("OpenTripPlanner")
-      .setConnectionManager(connectionManager)
-      .setDefaultRequestConfig(requestConfig(timeout));
-
-    httpClient = httpClientBuilder.build();
+  OtpHttpClient(CloseableHttpClient httpClient, Logger logger) {
+    this.httpClient = httpClient;
     log = logger;
   }
 
@@ -355,15 +265,6 @@ public class OtpHttpClient implements AutoCloseable {
         return Optional.of(mapResponse(response, contentMapper));
       }
     );
-  }
-
-  @Override
-  public void close() {
-    try {
-      httpClient.close();
-    } catch (IOException e) {
-      throw new OtpHttpClientException(e);
-    }
   }
 
   /**

--- a/src/main/java/org/opentripplanner/framework/io/OtpHttpClientFactory.java
+++ b/src/main/java/org/opentripplanner/framework/io/OtpHttpClientFactory.java
@@ -1,0 +1,137 @@
+package org.opentripplanner.framework.io;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import org.apache.hc.core5.pool.PoolReusePolicy;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+
+/**
+ * Factory for creating {@link OtpHttpClient} instances. These instances will share the same
+ * {@link CloseableHttpClient} instance.
+ *
+ * <h3>Timeout configuration</h3>
+ * The same timeout value is applied to the following parameters:
+ * <ul>
+ *  <li>Connection request timeout: the maximum waiting time for leasing a connection in the
+ *  connection pool.
+ *  <li>Connect timeout: the maximum waiting time for the first packet received from the server.
+ *  <li>Socket timeout: the maximum waiting time between two packets received from the server.
+ * </ul>
+ * The default timeout is set to 5 seconds.
+ * <h3>Connection time-to-live</h3>
+ * Maximum time an HTTP connection can stay in the connection pool before being closed.
+ * Note that HTTP 1.1 and HTTP/2 rely on persistent connections and the HTTP server is allowed to
+ * close idle connections at any time.
+ * The default connection time-to-live is set to 1 minute.
+ * <h3>Connection Pooling</h3>
+ * The connection pool holds by default a maximum of 25 connections, with maximum 5 connections
+ * per host.
+ *
+ * <h3>Thread-safety</h3>
+ * Instances of this class are thread-safe.
+ */
+public class OtpHttpClientFactory implements AutoCloseable {
+
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+  private static final Duration DEFAULT_TTL = Duration.ofMinutes(1);
+
+  /**
+   * see {@link PoolingHttpClientConnectionManager#DEFAULT_MAX_TOTAL_CONNECTIONS}
+   */
+  public static final int DEFAULT_MAX_TOTAL_CONNECTIONS = 25;
+
+  private final CloseableHttpClient httpClient;
+
+  /**
+   * Creates an HTTP client with default timeout, default connection time-to-live and default max
+   * number of connections.
+   */
+  public OtpHttpClientFactory() {
+    this(DEFAULT_TIMEOUT, DEFAULT_TTL);
+  }
+
+  /**
+   * Creates an HTTP client with default timeout, default connection time-to-live and the given max
+   * number of connections.
+   */
+  public OtpHttpClientFactory(int maxConnections) {
+    this(DEFAULT_TIMEOUT, DEFAULT_TTL, maxConnections);
+  }
+
+  /**
+   * Creates an HTTP client the given timeout and connection time-to-live and the default max
+   * number of connections.
+   */
+  public OtpHttpClientFactory(Duration timeout, Duration connectionTtl) {
+    this(timeout, connectionTtl, DEFAULT_MAX_TOTAL_CONNECTIONS);
+  }
+
+  /**
+   * Creates an HTTP client with custom configuration.
+   */
+  private OtpHttpClientFactory(Duration timeout, Duration connectionTtl, int maxConnections) {
+    Objects.requireNonNull(timeout);
+    Objects.requireNonNull(connectionTtl);
+
+    PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder
+      .create()
+      .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(Timeout.of(timeout)).build())
+      .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.STRICT)
+      .setConnPoolPolicy(PoolReusePolicy.LIFO)
+      .setMaxConnTotal(maxConnections)
+      .setDefaultConnectionConfig(
+        ConnectionConfig
+          .custom()
+          .setSocketTimeout(Timeout.of(timeout))
+          .setConnectTimeout(Timeout.of(timeout))
+          .setTimeToLive(TimeValue.of(connectionTtl))
+          .build()
+      )
+      .build();
+
+    HttpClientBuilder httpClientBuilder = HttpClients
+      .custom()
+      .setUserAgent("OpenTripPlanner")
+      .setConnectionManager(connectionManager)
+      .setDefaultRequestConfig(requestConfig(timeout));
+
+    httpClient = httpClientBuilder.build();
+  }
+
+  public OtpHttpClient create(Logger logger) {
+    return new OtpHttpClient(httpClient, logger);
+  }
+
+  @Override
+  public void close() {
+    try {
+      httpClient.close();
+    } catch (IOException e) {
+      throw new OtpHttpClientException(e);
+    }
+  }
+
+  /**
+   * Configures the request with a custom timeout.
+   */
+  private static RequestConfig requestConfig(Duration timeout) {
+    return RequestConfig
+      .custom()
+      .setResponseTimeout(Timeout.of(timeout))
+      .setConnectionRequestTimeout(Timeout.of(timeout))
+      .build();
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -50,7 +50,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
     this.updateHandler.setFeedId(config.feedId());
     this.updateHandler.setTransitAlertService(transitAlertService);
     this.updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
-    this.otpHttpClient = new OtpHttpClient();
+    this.otpHttpClient = new OtpHttpClient(LOG);
     LOG.info("Creating real-time alert updater running every {}: {}", pollingPeriod(), url);
   }
 

--- a/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.alert;
 import com.google.transit.realtime.GtfsRealtime.FeedMessage;
 import java.net.URI;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
@@ -50,7 +51,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
     this.updateHandler.setFeedId(config.feedId());
     this.updateHandler.setTransitAlertService(transitAlertService);
     this.updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
-    this.otpHttpClient = new OtpHttpClient(LOG);
+    this.otpHttpClient = new OtpHttpClientFactory().create(LOG);
     LOG.info("Creating real-time alert updater running every {}: {}", pollingPeriod(), url);
   }
 

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -28,6 +28,8 @@ import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdater;
 import org.opentripplanner.updater.vehicle_position.PollingVehiclePositionUpdater;
 import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater;
 import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataSourceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Sets up and starts all the graph updaters.
@@ -37,6 +39,8 @@ import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataS
  * GraphUpdaterManager.
  */
 public class UpdaterConfigurator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UpdaterConfigurator.class);
 
   private final Graph graph;
   private final TransitModel transitModel;
@@ -137,7 +141,7 @@ public class UpdaterConfigurator {
 
     if (!updatersParameters.getVehicleRentalParameters().isEmpty()) {
       int maxHttpConnections = updatersParameters.getVehicleRentalParameters().size();
-      OtpHttpClient otpHttpClient = new OtpHttpClient(maxHttpConnections);
+      OtpHttpClient otpHttpClient = new OtpHttpClient(maxHttpConnections, LOG);
       for (var configItem : updatersParameters.getVehicleRentalParameters()) {
         var source = VehicleRentalDataSourceFactory.create(
           configItem.sourceParameters(),

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -10,7 +10,7 @@ import org.opentripplanner.ext.siri.updater.azure.SiriAzureETUpdater;
 import org.opentripplanner.ext.siri.updater.azure.SiriAzureSXUpdater;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.VehicleRentalServiceDirectoryFetcher;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
-import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.model.calendar.openinghours.OpeningHoursCalendarService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
@@ -141,11 +141,11 @@ public class UpdaterConfigurator {
 
     if (!updatersParameters.getVehicleRentalParameters().isEmpty()) {
       int maxHttpConnections = updatersParameters.getVehicleRentalParameters().size();
-      OtpHttpClient otpHttpClient = new OtpHttpClient(maxHttpConnections, LOG);
+      var otpHttpClientFactory = new OtpHttpClientFactory(maxHttpConnections);
       for (var configItem : updatersParameters.getVehicleRentalParameters()) {
         var source = VehicleRentalDataSourceFactory.create(
           configItem.sourceParameters(),
-          otpHttpClient
+          otpHttpClientFactory
         );
         updaters.add(
           new VehicleRentalUpdater(configItem, source, graph.getLinker(), vehicleRentalRepository)

--- a/src/main/java/org/opentripplanner/updater/spi/GenericJsonDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/spi/GenericJsonDataSource.java
@@ -15,7 +15,7 @@ public abstract class GenericJsonDataSource<T> implements DataSource<T> {
   protected List<T> updates = List.of();
 
   protected GenericJsonDataSource(String url, String jsonParsePath, HttpHeaders headers) {
-    this(url, jsonParsePath, headers, new OtpHttpClient());
+    this(url, jsonParsePath, headers, new OtpHttpClient(LOG));
   }
 
   protected GenericJsonDataSource(

--- a/src/main/java/org/opentripplanner/updater/spi/GenericJsonDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/spi/GenericJsonDataSource.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import org.opentripplanner.framework.io.JsonDataListDownloader;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,7 +16,7 @@ public abstract class GenericJsonDataSource<T> implements DataSource<T> {
   protected List<T> updates = List.of();
 
   protected GenericJsonDataSource(String url, String jsonParsePath, HttpHeaders headers) {
-    this(url, jsonParsePath, headers, new OtpHttpClient(LOG));
+    this(url, jsonParsePath, headers, new OtpHttpClientFactory().create(LOG));
   }
 
   protected GenericJsonDataSource(

--- a/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
@@ -33,7 +33,7 @@ public class GtfsRealtimeTripUpdateSource {
     this.url = config.url();
     this.headers = HttpHeaders.of().acceptProtobuf().add(config.headers()).build();
     MfdzRealtimeExtensions.registerAllExtensions(registry);
-    otpHttpClient = new OtpHttpClient();
+    otpHttpClient = new OtpHttpClient(LOG);
   }
 
   public List<TripUpdate> getUpdates() {

--- a/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.slf4j.Logger;
@@ -33,7 +34,7 @@ public class GtfsRealtimeTripUpdateSource {
     this.url = config.url();
     this.headers = HttpHeaders.of().acceptProtobuf().add(config.headers()).build();
     MfdzRealtimeExtensions.registerAllExtensions(registry);
-    otpHttpClient = new OtpHttpClient(LOG);
+    otpHttpClient = new OtpHttpClientFactory().create(LOG);
   }
 
   public List<TripUpdate> getUpdates() {

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
@@ -33,7 +33,7 @@ public class GtfsRealtimeHttpVehiclePositionSource {
   public GtfsRealtimeHttpVehiclePositionSource(URI url, HttpHeaders headers) {
     this.url = url;
     this.headers = HttpHeaders.of().acceptProtobuf().add(headers).build();
-    this.otpHttpClient = new OtpHttpClient();
+    this.otpHttpClient = new OtpHttpClient(LOG);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientException;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.slf4j.Logger;
@@ -33,7 +34,7 @@ public class GtfsRealtimeHttpVehiclePositionSource {
   public GtfsRealtimeHttpVehiclePositionSource(URI url, HttpHeaders headers) {
     this.url = url;
     this.headers = HttpHeaders.of().acceptProtobuf().add(headers).build();
-    this.otpHttpClient = new OtpHttpClient(LOG);
+    this.otpHttpClient = new OtpHttpClientFactory().create(LOG);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
@@ -13,6 +13,7 @@ import org.entur.gbfs.v2_3.gbfs.GBFSFeedName;
 import org.entur.gbfs.v2_3.gbfs.GBFSFeeds;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientException;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.opentripplanner.updater.spi.UpdaterConstructionException;
 import org.slf4j.Logger;
@@ -98,7 +99,7 @@ public class GbfsFeedLoader {
   }
 
   GbfsFeedLoader(String url, HttpHeaders httpHeaders, String languageCode) {
-    this(url, httpHeaders, languageCode, new OtpHttpClient(LOG));
+    this(url, httpHeaders, languageCode, new OtpHttpClientFactory().create(LOG));
   }
 
   /**

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
@@ -98,7 +98,7 @@ public class GbfsFeedLoader {
   }
 
   GbfsFeedLoader(String url, HttpHeaders httpHeaders, String languageCode) {
-    this(url, httpHeaders, languageCode, new OtpHttpClient());
+    this(url, httpHeaders, languageCode, new OtpHttpClient(LOG));
   }
 
   /**

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
@@ -16,6 +16,7 @@ import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
 import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleTypes;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -46,10 +47,10 @@ class GbfsVehicleRentalDataSource implements VehicleRentalDatasource {
 
   public GbfsVehicleRentalDataSource(
     GbfsVehicleRentalDataSourceParameters parameters,
-    OtpHttpClient otpHttpClient
+    OtpHttpClientFactory otpHttpClientFactory
   ) {
     this.params = parameters;
-    this.otpHttpClient = otpHttpClient;
+    this.otpHttpClient = otpHttpClientFactory.create(LOG);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/VehicleRentalDataSourceFactory.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/VehicleRentalDataSourceFactory.java
@@ -2,7 +2,7 @@ package org.opentripplanner.updater.vehicle_rental.datasources;
 
 import org.opentripplanner.ext.smoovebikerental.SmooveBikeRentalDataSource;
 import org.opentripplanner.ext.smoovebikerental.SmooveBikeRentalDataSourceParameters;
-import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.updater.vehicle_rental.datasources.params.GbfsVehicleRentalDataSourceParameters;
 import org.opentripplanner.updater.vehicle_rental.datasources.params.VehicleRentalDataSourceParameters;
 
@@ -10,7 +10,7 @@ public class VehicleRentalDataSourceFactory {
 
   public static VehicleRentalDatasource create(
     VehicleRentalDataSourceParameters source,
-    OtpHttpClient otpHttpClient
+    OtpHttpClientFactory otpHttpClientFactory
   ) {
     return switch (source.sourceType()) {
       // There used to be a lot more updaters and corresponding config variables here, but since
@@ -20,11 +20,11 @@ public class VehicleRentalDataSourceFactory {
       // and become the point of contact for the community.
       case GBFS -> new GbfsVehicleRentalDataSource(
         (GbfsVehicleRentalDataSourceParameters) source,
-        otpHttpClient
+        otpHttpClientFactory
       );
       case SMOOVE -> new SmooveBikeRentalDataSource(
         (SmooveBikeRentalDataSourceParameters) source,
-        otpHttpClient
+        otpHttpClientFactory
       );
     };
   }

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoaderTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoaderTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.updater.spi.HttpHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This tests that {@link GbfsFeedLoader} handles loading of different versions of GBFS correctly,
@@ -90,7 +92,11 @@ class GbfsFeedLoaderTest {
   @Test
   @Disabled
   void fetchAllPublicFeeds() {
-    try (OtpHttpClient otpHttpClient = new OtpHttpClient()) {
+    try (
+      OtpHttpClient otpHttpClient = new OtpHttpClient(
+        LoggerFactory.getLogger(GbfsFeedLoaderTest.class)
+      )
+    ) {
       List<Exception> exceptions = otpHttpClient.getAndMap(
         URI.create("https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv"),
         Map.of(),

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoaderTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoaderTest.java
@@ -28,9 +28,8 @@ import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
 import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleTypes;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.updater.spi.HttpHeaders;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -92,11 +91,10 @@ class GbfsFeedLoaderTest {
   @Test
   @Disabled
   void fetchAllPublicFeeds() {
-    try (
-      OtpHttpClient otpHttpClient = new OtpHttpClient(
+    try (OtpHttpClientFactory otpHttpClientFactory = new OtpHttpClientFactory()) {
+      var otpHttpClient = otpHttpClientFactory.create(
         LoggerFactory.getLogger(GbfsFeedLoaderTest.class)
-      )
-    ) {
+      );
       List<Exception> exceptions = otpHttpClient.getAndMap(
         URI.create("https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv"),
         Map.of(),

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
@@ -10,21 +10,17 @@ import java.util.List;
 import java.util.Map;
 import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.opentripplanner.updater.vehicle_rental.datasources.params.GbfsVehicleRentalDataSourceParameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This tests the mapping between data coming from a {@link GbfsFeedLoader} to OTP station models.
  */
 class GbfsVehicleRentalDataSourceTest {
-
-  private static final Logger LOG = LoggerFactory.getLogger(GbfsVehicleRentalDataSourceTest.class);
 
   @Test
   void makeStationFromV22() {
@@ -38,7 +34,7 @@ class GbfsVehicleRentalDataSourceTest {
         false,
         false
       ),
-      new OtpHttpClient(LOG)
+      new OtpHttpClientFactory()
     );
 
     dataSource.setup();
@@ -129,7 +125,7 @@ class GbfsVehicleRentalDataSourceTest {
         true,
         false
       ),
-      new OtpHttpClient(LOG)
+      new OtpHttpClientFactory()
     );
 
     dataSource.setup();
@@ -171,7 +167,7 @@ class GbfsVehicleRentalDataSourceTest {
         false,
         true
       ),
-      new OtpHttpClient(LOG)
+      new OtpHttpClientFactory()
     );
 
     dataSource.setup();

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
@@ -16,11 +16,15 @@ import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.opentripplanner.updater.vehicle_rental.datasources.params.GbfsVehicleRentalDataSourceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This tests the mapping between data coming from a {@link GbfsFeedLoader} to OTP station models.
  */
 class GbfsVehicleRentalDataSourceTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GbfsVehicleRentalDataSourceTest.class);
 
   @Test
   void makeStationFromV22() {
@@ -34,7 +38,7 @@ class GbfsVehicleRentalDataSourceTest {
         false,
         false
       ),
-      new OtpHttpClient()
+      new OtpHttpClient(LOG)
     );
 
     dataSource.setup();
@@ -125,7 +129,7 @@ class GbfsVehicleRentalDataSourceTest {
         true,
         false
       ),
-      new OtpHttpClient()
+      new OtpHttpClient(LOG)
     );
 
     dataSource.setup();
@@ -167,7 +171,7 @@ class GbfsVehicleRentalDataSourceTest {
         false,
         true
       ),
-      new OtpHttpClient()
+      new OtpHttpClient(LOG)
     );
 
     dataSource.setup();


### PR DESCRIPTION
### Summary

Removes OtpHttpClient's own logger and passes in loggers from where it's used from. Adds a trace log for http responses in case there is an error response coming from an external API.

### Issue

closes #5761

### Unit tests

New tests will not be added.

### Documentation

Not needed

### Changelog

Not sure if needed
