### PR TITLE
Upgrade Codecov action and use token [ci skip]

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -51,9 +51,11 @@ jobs:
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner'
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v4
         with:
           files: target/site/jacoco/jacoco.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
       - name: Deploy to Github Package Registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Set up Maven
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: stCarolas/setup-maven@v.4.5
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.8.2
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Archive travel results file
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.location }}-travelSearch-results.csv
           path: test/performance/${{ matrix.location }}/travelSearch-results.csv


### PR DESCRIPTION
The old Codcov Github Action is being phase out so I'm using the new one which requires a token.