### PR TITLE
Implement `hashCode` for `Money` class

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/basic/Money.java
+++ b/src/main/java/org/opentripplanner/transit/model/basic/Money.java
@@ -206,4 +206,9 @@ public class Money implements Comparable<Money>, Serializable {
       return false;
     }
   }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(currency, amount);
+  }
 }

--- a/src/test/java/org/opentripplanner/routing/core/MoneyTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/MoneyTest.java
@@ -102,4 +102,9 @@ class MoneyTest {
   void serializable() {
     assertInstanceOf(Serializable.class, oneDollar);
   }
+
+  @Test
+  void equalHashCode() {
+    assertEquals(Money.usDollars(5).hashCode(), Money.usDollars(5).hashCode());
+  }
 }


### PR DESCRIPTION
### Summary

I found a rather embarrassing bug where the vehicle parking updater would randomly add and remove parking lots. This was due to the fact that `equals` and `hashCode` in `VehicleParking` were not symetric.

I traced it down to `Money` not having implemented `hashCode`. :flushed: 

### Unit tests

:heavy_check_mark: 