### PR TITLE
Add stop position type to GTFS GraphQL API

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StoptimeImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StoptimeImpl.java
@@ -3,7 +3,7 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
-import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.mapping.TripPositionMapper;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.model.StopTime;
@@ -112,8 +112,8 @@ public class StoptimeImpl implements GraphQLDataFetchers.GraphQLStoptime {
   }
 
   @Override
-  public DataFetcher<GraphQLTripPosition> tripPosition() {
-    return environment -> TripPositionMapper.map(getSource(environment).positionInTrip());
+  public DataFetcher<GraphQLTypes.GraphQLStopPositionType> stopPositionType() {
+    return environment -> TripPositionMapper.map(getSource(environment).stopPositionType());
   }
 
   private TripTimeOnDate getSource(DataFetchingEnvironment environment) {

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StoptimeImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StoptimeImpl.java
@@ -3,6 +3,8 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition;
+import org.opentripplanner.apis.gtfs.mapping.TripPositionMapper;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripTimeOnDate;
@@ -107,6 +109,11 @@ public class StoptimeImpl implements GraphQLDataFetchers.GraphQLStoptime {
   @Override
   public DataFetcher<Trip> trip() {
     return environment -> getSource(environment).getTrip();
+  }
+
+  @Override
+  public DataFetcher<GraphQLTripPosition> tripPosition() {
+    return environment -> TripPositionMapper.map(getSource(environment).positionInTrip());
   }
 
   private TripTimeOnDate getSource(DataFetchingEnvironment environment) {

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -20,6 +20,7 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLOccupancyStat
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRelativeDirection;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRoutingErrorCode;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTransitMode;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition;
 import org.opentripplanner.apis.gtfs.model.RideHailingProvider;
 import org.opentripplanner.apis.gtfs.model.StopPosition;
 import org.opentripplanner.apis.gtfs.model.TripOccupancy;
@@ -1024,6 +1025,8 @@ public class GraphQLDataFetchers {
     public DataFetcher<Boolean> timepoint();
 
     public DataFetcher<Trip> trip();
+
+    public DataFetcher<GraphQLTripPosition> tripPosition();
   }
 
   /** Stoptimes grouped by pattern */

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -19,8 +19,8 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLInputField;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLOccupancyStatus;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRelativeDirection;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRoutingErrorCode;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopPositionType;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTransitMode;
-import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition;
 import org.opentripplanner.apis.gtfs.model.RideHailingProvider;
 import org.opentripplanner.apis.gtfs.model.StopPosition;
 import org.opentripplanner.apis.gtfs.model.TripOccupancy;
@@ -1022,11 +1022,11 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<Integer> stopPosition();
 
+    public DataFetcher<GraphQLStopPositionType> stopPositionType();
+
     public DataFetcher<Boolean> timepoint();
 
     public DataFetcher<Trip> trip();
-
-    public DataFetcher<GraphQLTripPosition> tripPosition();
   }
 
   /** Stoptimes grouped by pattern */

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -3114,6 +3114,12 @@ public class GraphQLTypes {
     TRIPS,
   }
 
+  public enum GraphQLStopPositionType {
+    FIRST,
+    LAST,
+    MIDDLE,
+  }
+
   public static class GraphQLStoptimeHeadsignArgs {
 
     private String language;
@@ -3300,12 +3306,6 @@ public class GraphQLTypes {
     ROUTE_TYPE,
     STOPS_ON_TRIP,
     TRIP,
-  }
-
-  public enum GraphQLTripPosition {
-    FIRST,
-    LAST,
-    MIDDLE,
   }
 
   public static class GraphQLVehicleParkingNameArgs {

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -3302,6 +3302,12 @@ public class GraphQLTypes {
     TRIP,
   }
 
+  public enum GraphQLTripPosition {
+    FIRST,
+    LAST,
+    MIDDLE,
+  }
+
   public static class GraphQLVehicleParkingNameArgs {
 
     private String language;

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -113,5 +113,5 @@ config:
     FareMedium: org.opentripplanner.model.fare.FareMedium#FareMedium
     RiderCategory: org.opentripplanner.model.fare.RiderCategory#RiderCategory
     StopPosition: org.opentripplanner.apis.gtfs.model.StopPosition#StopPosition
-    TripPosition: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition#GraphQLTripPosition
+    StopPositionType: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopPositionType#GraphQLStopPositionType
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -113,4 +113,5 @@ config:
     FareMedium: org.opentripplanner.model.fare.FareMedium#FareMedium
     RiderCategory: org.opentripplanner.model.fare.RiderCategory#RiderCategory
     StopPosition: org.opentripplanner.apis.gtfs.model.StopPosition#StopPosition
+    TripPosition: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition#GraphQLTripPosition
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/mapping/TripPositionMapper.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/mapping/TripPositionMapper.java
@@ -1,0 +1,15 @@
+package org.opentripplanner.apis.gtfs.mapping;
+
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition;
+import org.opentripplanner.model.PositionInTrip;
+
+public class TripPositionMapper {
+
+  public static GraphQLTripPosition map(PositionInTrip tripPosition) {
+    return switch (tripPosition) {
+      case FIRST -> GraphQLTripPosition.FIRST;
+      case MIDDLE -> GraphQLTripPosition.MIDDLE;
+      case LAST -> GraphQLTripPosition.LAST;
+    };
+  }
+}

--- a/src/main/java/org/opentripplanner/apis/gtfs/mapping/TripPositionMapper.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/mapping/TripPositionMapper.java
@@ -1,15 +1,15 @@
 package org.opentripplanner.apis.gtfs.mapping;
 
-import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTripPosition;
-import org.opentripplanner.model.PositionInTrip;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopPositionType;
+import org.opentripplanner.model.StopPositionType;
 
 public class TripPositionMapper {
 
-  public static GraphQLTripPosition map(PositionInTrip tripPosition) {
+  public static GraphQLStopPositionType map(StopPositionType tripPosition) {
     return switch (tripPosition) {
-      case FIRST -> GraphQLTripPosition.FIRST;
-      case MIDDLE -> GraphQLTripPosition.MIDDLE;
-      case LAST -> GraphQLTripPosition.LAST;
+      case FIRST -> GraphQLStopPositionType.FIRST;
+      case MIDDLE -> GraphQLStopPositionType.MIDDLE;
+      case LAST -> GraphQLStopPositionType.LAST;
     };
   }
 }

--- a/src/main/java/org/opentripplanner/model/PositionInTrip.java
+++ b/src/main/java/org/opentripplanner/model/PositionInTrip.java
@@ -1,0 +1,7 @@
+package org.opentripplanner.model;
+
+public enum PositionInTrip {
+  FIRST,
+  MIDDLE,
+  LAST,
+}

--- a/src/main/java/org/opentripplanner/model/StopPositionType.java
+++ b/src/main/java/org/opentripplanner/model/StopPositionType.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.model;
 
-public enum PositionInTrip {
+public enum StopPositionType {
   FIRST,
   MIDDLE,
   LAST,

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -269,13 +269,16 @@ public class TripTimeOnDate {
     return tripTimes.getDropOffBookingInfo(stopIndex);
   }
 
-  public PositionInTrip positionInTrip() {
+  /**
+   * If this stop time is the first or last of the trip, or any stop in between.
+   */
+  public StopPositionType stopPositionType() {
     if (stopIndex == 0) {
-      return PositionInTrip.FIRST;
+      return StopPositionType.FIRST;
     } else if (stopIndex == tripPattern.numberOfStops() - 1) {
-      return PositionInTrip.LAST;
+      return StopPositionType.LAST;
     } else {
-      return PositionInTrip.MIDDLE;
+      return StopPositionType.MIDDLE;
     }
   }
 }

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -268,4 +268,14 @@ public class TripTimeOnDate {
   public BookingInfo getDropOffBookingInfo() {
     return tripTimes.getDropOffBookingInfo(stopIndex);
   }
+
+  public PositionInTrip positionInTrip() {
+    if (stopIndex == 0) {
+      return PositionInTrip.FIRST;
+    } else if (stopIndex == tripPattern.numberOfStops() - 1) {
+      return PositionInTrip.LAST;
+    } else {
+      return PositionInTrip.MIDDLE;
+    }
+  }
 }

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -3929,8 +3929,13 @@ type StopOnTrip {
     trip: Trip!
 }
 
-enum TripPosition {
-    FIRST, MIDDLE, LAST
+enum StopPositionType {
+    "The stop time is the first stop on the trip."
+    FIRST,
+    "The stop time is neither the first nor the last stop on the trip."
+    MIDDLE,
+    "The stop time is the last stop on the trip."
+    LAST
 }
 
 """
@@ -3953,6 +3958,9 @@ type Stoptime {
     even generated.
     """
     stopPosition: Int
+
+    "If the stop time is the first or last in the trip, or neither of those."
+    stopPositionType: StopPositionType
 
     """
     Scheduled arrival time. Format: seconds since midnight of the departure date
@@ -4027,8 +4035,6 @@ type Stoptime {
     feed's language then returns wanted translation. Otherwise uses name from trip_headsign.txt.
     """
     language: String): String
-
-    tripPosition: TripPosition
 }
 
 """Stoptimes grouped by pattern"""

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -3929,6 +3929,10 @@ type StopOnTrip {
     trip: Trip!
 }
 
+enum TripPosition {
+    FIRST, MIDDLE, LAST
+}
+
 """
 Stoptime represents the time when a specific trip arrives to or departs from a specific stop.
 """
@@ -4023,6 +4027,8 @@ type Stoptime {
     feed's language then returns wanted translation. Otherwise uses name from trip_headsign.txt.
     """
     language: String): String
+
+    tripPosition: TripPosition
 }
 
 """Stoptimes grouped by pattern"""

--- a/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
+++ b/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
@@ -25,9 +25,9 @@ class TripTimeOnDateTest implements PlanTestConstants {
 
   @Test
   void tripPosition() {
-    assertEquals(PositionInTrip.FIRST, buildTripTimeOnDate(0).positionInTrip());
-    assertEquals(PositionInTrip.MIDDLE, buildTripTimeOnDate(1).positionInTrip());
-    assertEquals(PositionInTrip.LAST, buildTripTimeOnDate(2).positionInTrip());
+    assertEquals(StopPositionType.FIRST, buildTripTimeOnDate(0).stopPositionType());
+    assertEquals(StopPositionType.MIDDLE, buildTripTimeOnDate(1).stopPositionType());
+    assertEquals(StopPositionType.LAST, buildTripTimeOnDate(2).stopPositionType());
   }
 
   private static TripTimeOnDate buildTripTimeOnDate(int stopIndex) {

--- a/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
+++ b/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
@@ -14,6 +14,23 @@ class TripTimeOnDateTest implements PlanTestConstants {
 
   @Test
   void gtfsSequence() {
+    final var subject = buildTripTimeOnDate(2);
+
+    var seq = subject.getGtfsSequence();
+    assertEquals(30, seq);
+
+    var departure = LocalTime.ofSecondOfDay(subject.getScheduledDeparture());
+    assertEquals(LocalTime.of(11, 10), departure);
+  }
+
+  @Test
+  void tripPosition() {
+    assertEquals(PositionInTrip.FIRST, buildTripTimeOnDate(0).positionInTrip());
+    assertEquals(PositionInTrip.MIDDLE, buildTripTimeOnDate(1).positionInTrip());
+    assertEquals(PositionInTrip.LAST, buildTripTimeOnDate(2).positionInTrip());
+  }
+
+  private static TripTimeOnDate buildTripTimeOnDate(int stopIndex) {
     var testModel = TransitModelForTest.of();
     var pattern = testModel.pattern(TransitMode.BUS).build();
     var trip = TransitModelForTest.trip("123").build();
@@ -21,12 +38,6 @@ class TripTimeOnDateTest implements PlanTestConstants {
 
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
 
-    var subject = new TripTimeOnDate(tripTimes, 2, pattern);
-
-    var seq = subject.getGtfsSequence();
-    assertEquals(30, seq);
-
-    var departure = LocalTime.ofSecondOfDay(subject.getScheduledDeparture());
-    assertEquals(LocalTime.of(11, 10), departure);
+    return new TripTimeOnDate(tripTimes, stopIndex, pattern);
   }
 }

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/trips.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/trips.json
@@ -6,21 +6,21 @@
         "stoptimes" : [
           {
             "stopPosition" : 10,
+            "stopPositionType" : "FIRST",
             "scheduledArrival" : 39600,
-            "scheduledDeparture" : 39600,
-            "tripPosition" : "FIRST"
+            "scheduledDeparture" : 39600
           },
           {
             "stopPosition" : 20,
+            "stopPositionType" : "MIDDLE",
             "scheduledArrival" : 39900,
-            "scheduledDeparture" : 39900,
-            "tripPosition" : "MIDDLE"
+            "scheduledDeparture" : 39900
           },
           {
             "stopPosition" : 30,
+            "stopPositionType" : "LAST",
             "scheduledArrival" : 40200,
-            "scheduledDeparture" : 40200,
-            "tripPosition" : "LAST"
+            "scheduledDeparture" : 40200
           }
         ]
       }

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/trips.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/trips.json
@@ -1,0 +1,29 @@
+{
+  "data" : {
+    "trips" : [
+      {
+        "gtfsId" : "F:123",
+        "stoptimes" : [
+          {
+            "stopPosition" : 10,
+            "scheduledArrival" : 39600,
+            "scheduledDeparture" : 39600,
+            "tripPosition" : "FIRST"
+          },
+          {
+            "stopPosition" : 20,
+            "scheduledArrival" : 39900,
+            "scheduledDeparture" : 39900,
+            "tripPosition" : "MIDDLE"
+          },
+          {
+            "stopPosition" : 30,
+            "scheduledArrival" : 40200,
+            "scheduledDeparture" : 40200,
+            "tripPosition" : "LAST"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/org/opentripplanner/apis/gtfs/queries/trips.graphql
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/queries/trips.graphql
@@ -1,0 +1,11 @@
+query {
+    trips {
+        gtfsId
+        stoptimes {
+            stopPosition
+            scheduledArrival
+            scheduledDeparture
+            tripPosition
+        }
+    }
+}

--- a/src/test/resources/org/opentripplanner/apis/gtfs/queries/trips.graphql
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/queries/trips.graphql
@@ -3,9 +3,9 @@ query {
         gtfsId
         stoptimes {
             stopPosition
+            stopPositionType
             scheduledArrival
             scheduledDeparture
-            tripPosition
         }
     }
 }


### PR DESCRIPTION
### Summary

It adds a new field to the GTFS API which allows frontend developers to easily figure out if a stop time is the first, last or middle stop in a trip.

Why might you need this when you could just look at all stop times? In the nearby view (and perhaps others) when looking at the `DepartureRow` you see stop times in isolation without a trip. Here it would be nice if frontend developers could easily tell if it's the first or the last stop in a trip.

### Unit tests

Added.

### Documentation

Added.

cc @miles-grant-ibigroup 