### PR TITLE
De-emphasize mailing list in landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,12 +60,7 @@ your own OTP instance, the best place to start is the [Basic Tutorial](Basic-Tut
 
 # Getting help
 
-The fastest way to get help is to use our [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner)
-where most of the core developers are.
-You can also send questions and comments to the [mailing list](http://groups.google.com/group/opentripplanner-users)
-or file bug reports via the Github [issue tracker](https://github.com/openplans/OpenTripPlanner/issues). 
-Note that the issue tracker is not intended for support questions or discussions. Please use the
-chat or the mailing list instead.
+The fastest way to get help is to use our [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner) where most of the core developers are. Bug reports may be filed via the Github [issue tracker](https://github.com/openplans/OpenTripPlanner/issues). The issue tracker is not intended for support questions or discussions. Please use the chat for this purpose. The OpenTripPlanner [mailing list](http://groups.google.com/group/opentripplanner-users) is treated as a legacy communications channel and used almost exclusively for project announcements. Again, please direct development and support discussions to the Gitter chat.
 
 # Financial and In-Kind Support
 


### PR DESCRIPTION
My understanding is that a decision was made to use the mailing list only for announcements, and the Gitter chat for all other support and discussion. We are still getting questions posted to the mailing list, which then requires someone to reply encouraging the person to use Gitter, which means the whole list will receive these questions and response emails. I went looking for why this was happening, and see that the landing page of the docs still says "The fastest way to get help is to use our Gitter chat room where most of the core developers are. You can also send questions and comments to the mailing list...". This PR changes the part about the mailing list to say it's used only for announcements.
