### PR TITLE
Make naming of stopTransferCosts/stopBoardAlightCosts consistent

### DIFF
--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -744,7 +744,7 @@ but we want to calculate the transfers always from OSM data.
 Should there be some preference or aversion for transfers at stops that are part of a station.
 
 This parameter sets the generic level of preference. What is the actual cost can be changed
-with the `stopTransferCost` parameter in the router configuration.
+with the `stopBoardAlightDuringTransferCost` parameter in the router configuration.
 
 
 <h3 id="islandPruning_adaptivePruningDistance">adaptivePruningDistance</h3>
@@ -993,7 +993,7 @@ but we want to calculate the transfers always from OSM data.
 Should there be some preference or aversion for transfers at stops that are part of a station. Overrides the value specified in `gtfsDefaults`.
 
 This parameter sets the generic level of preference. What is the actual cost can be changed
-with the `stopTransferCost` parameter in the router configuration.
+with the `stopBoardAlightDuringTransferCost` parameter in the router configuration.
 
 
 <h3 id="tf_1_groupFilePattern">groupFilePattern</h3>

--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -947,7 +947,7 @@ The wait time is used to prevent *back-travel*, the `backTravelWaitTimeFactor` i
 
 Add an extra board- and alight-cost for prioritized stops.
 
-A stopBoardAlightCosts is added to the generalized-cost during routing. But this cost
+A stopBoardAlightTransferCosts is added to the generalized-cost during routing. But this cost
 cannot be too high, because that would add extra cost to the transfer, and favor other
 alternative paths. But, when optimizing transfers, we do not have to take other paths
 into consideration and can *boost* the stop-priority-cost to allow transfers to

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -61,7 +61,7 @@ A full list of them can be found in the [RouteRequest](RouteRequest.md).
 |       [minWindow](#transit_dynamicSearchWindow_minWindow)                                 |       `duration`      | The constant minimum duration for a raptor-search-window.                                             | *Optional* | `"PT40M"`     |  2.2  |
 |       [stepMinutes](#transit_dynamicSearchWindow_stepMinutes)                             |       `integer`       | Used to set the steps the search-window is rounded to.                                                | *Optional* | `10`          |  2.1  |
 |    [pagingSearchWindowAdjustments](#transit_pagingSearchWindowAdjustments)                |      `duration[]`     | The provided array of durations is used to increase the search-window for the next/previous page.     | *Optional* |               |   na  |
-|    [stopTransferCost](#transit_stopTransferCost)                                          | `enum map of integer` | Use this to set a stop transfer cost for the given transfer priority                                  | *Optional* |               |  2.0  |
+|    [stopBoardAlightDuringTransferCost](#transit_stopBoardAlightDuringTransferCost)        | `enum map of integer` | Costs for boarding and alighting during transfers at stops with a given transfer priority.            | *Optional* |               |  2.0  |
 |    [transferCacheRequests](#transit_transferCacheRequests)                                |       `object[]`      | Routing requests to use for pre-filling the stop-to-stop transfer cache.                              | *Optional* |               |  2.3  |
 | transmodelApi                                                                             |        `object`       | Configuration for the Transmodel GraphQL API.                                                         | *Optional* |               |  2.1  |
 |    [hideFeedId](#transmodelApi_hideFeedId)                                                |       `boolean`       | Hide the FeedId in all API output, and add it to input.                                               | *Optional* | `false`       |   na  |
@@ -358,19 +358,21 @@ previous page cursor. See JavaDoc for [TransitTuningParameters#pagingSearchWindo
 for more info."
 
 
-<h3 id="transit_stopTransferCost">stopTransferCost</h3>
+<h3 id="transit_stopBoardAlightDuringTransferCost">stopBoardAlightDuringTransferCost</h3>
 
 **Since version:** `2.0` ∙ **Type:** `enum map of integer` ∙ **Cardinality:** `Optional`   
 **Path:** /transit   
 **Enum keys:** `discouraged` | `allowed` | `recommended` | `preferred`
 
-Use this to set a stop transfer cost for the given transfer priority
+Costs for boarding and alighting during transfers at stops with a given transfer priority.
 
-The cost is applied to boarding and alighting at all stops. All stops have a transfer cost priority
-set, the default is `allowed`. The `stopTransferCost` parameter is optional, but if listed all
+This cost is applied **both to boarding and alighting** at stops during transfers. All stops have a transfer cost priority
+set, the default is `allowed`. The `stopBoardAlightDuringTransferCost` parameter is optional, but if listed all
 values must be set.
 
-If not set the `stopTransferCost` is ignored. This is only available for NeTEx imported Stops.
+When a transfer occurs at the same stop, the cost will be applied twice since the cost is both for boarding and alighting,
+
+If not set the `stopBoardAlightDuringTransferCost` is ignored. This is only available for NeTEx imported Stops.
 
 The cost is a scalar, but is equivalent to the felt cost of riding a transit trip for 1 second.
 
@@ -382,7 +384,7 @@ The cost is a scalar, but is equivalent to the felt cost of riding a transit tri
 | `preferred`   | The best place to do transfers. Should be set to `0`(zero).                                   | int  |
 
 Use values in a range from `0` to `100 000`. **All key/value pairs are required if the
-`stopTransferCost` is listed.**
+`stopBoardAlightDuringTransferCost` is listed.**
 
 
 <h3 id="transit_transferCacheRequests">transferCacheRequests</h3>
@@ -608,7 +610,7 @@ Used to group requests when monitoring OTP.
       "minWindow" : "1h",
       "maxWindow" : "5h"
     },
-    "stopTransferCost" : {
+    "stopBoardAlightDuringTransferCost" : {
       "DISCOURAGED" : 1500,
       "ALLOWED" : 75,
       "RECOMMENDED" : 30,

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -366,13 +366,15 @@ for more info."
 
 Costs for boarding and alighting during transfers at stops with a given transfer priority.
 
-This cost is applied **both to boarding and alighting** at stops during transfers. All stops have a transfer cost priority
-set, the default is `allowed`. The `stopBoardAlightDuringTransferCost` parameter is optional, but if listed all
-values must be set.
+This cost is applied **both to boarding and alighting** at stops during transfers. All stops have a
+transfer cost priority set, the default is `allowed`. The `stopBoardAlightDuringTransferCost`
+parameter is optional, but if listed all values must be set.
 
-When a transfer occurs at the same stop, the cost will be applied twice since the cost is both for boarding and alighting,
+When a transfer occurs at the same stop, the cost will be applied twice since the cost is both for
+boarding and alighting,
 
-If not set the `stopBoardAlightDuringTransferCost` is ignored. This is only available for NeTEx imported Stops.
+If not set the `stopBoardAlightDuringTransferCost` is ignored. This is only available for NeTEx
+imported Stops.
 
 The cost is a scalar, but is equivalent to the felt cost of riding a transit trip for 1 second.
 

--- a/docs/examples/entur/router-config.json
+++ b/docs/examples/entur/router-config.json
@@ -91,7 +91,7 @@
       "minWindow" : "1h",
       "maxWindow" : "5h"
     },
-    "stopTransferCost" : {
+    "stopBoardAlightDuringTransferCost" : {
       "DISCOURAGED" : 1500,
       "ALLOWED" : 75,
       "RECOMMENDED" : 30,

--- a/docs/examples/skanetrafiken/router-config.json
+++ b/docs/examples/skanetrafiken/router-config.json
@@ -15,7 +15,7 @@
       "24h",
       "0h"
     ],
-    "stopTransferCost": {
+    "stopBoardAlightDuringTransferCost": {
       "DISCOURAGED": 3000,
       "ALLOWED": 150,
       "RECOMMENDED": 60,

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -61,6 +61,7 @@ public class Timetable implements Serializable {
 
   private final List<FrequencyEntry> frequencyEntries = new ArrayList<>();
 
+  @Nullable
   private final LocalDate serviceDate;
 
   /** Construct an empty Timetable. */

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -146,7 +146,7 @@ public class TransitRouter {
         requestTransitDataProvider.stopNameResolver(),
         serverContext.transitService().getTransferService(),
         requestTransitDataProvider,
-        transitLayer.getStopBoardAlightCosts(),
+        transitLayer.getStopBoardAlightTransferCosts(),
         request.preferences().transfer().optimization(),
         raptorRequest.multiCriteria()
       );

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
@@ -48,7 +48,11 @@ public class TransitLayer {
 
   private final TransferIndexGenerator transferIndexGenerator;
 
-  private final int[] stopBoardAlightCosts;
+  /**
+   * @see #getStopBoardAlightTransferCosts()
+   */
+  @Nullable
+  private final int[] stopBoardAlightTransferCosts;
 
   /**
    * Makes a shallow copy of the TransitLayer, except for the tripPatternsForDate, where a shallow
@@ -65,7 +69,7 @@ public class TransitLayer {
       transitLayer.transferCache,
       transitLayer.constrainedTransfers,
       transitLayer.transferIndexGenerator,
-      transitLayer.stopBoardAlightCosts
+      transitLayer.stopBoardAlightTransferCosts
     );
   }
 
@@ -78,7 +82,7 @@ public class TransitLayer {
     RaptorRequestTransferCache transferCache,
     ConstrainedTransfersForPatterns constrainedTransfers,
     TransferIndexGenerator transferIndexGenerator,
-    int[] stopBoardAlightCosts
+    @Nullable int[] stopBoardAlightTransferCosts
   ) {
     this.tripPatternsRunningOnDate = new HashMap<>(tripPatternsRunningOnDate);
     this.transfersByStopIndex = transfersByStopIndex;
@@ -88,7 +92,7 @@ public class TransitLayer {
     this.transferCache = transferCache;
     this.constrainedTransfers = constrainedTransfers;
     this.transferIndexGenerator = transferIndexGenerator;
-    this.stopBoardAlightCosts = stopBoardAlightCosts;
+    this.stopBoardAlightTransferCosts = stopBoardAlightTransferCosts;
   }
 
   @Nullable
@@ -166,8 +170,13 @@ public class TransitLayer {
     return transferIndexGenerator;
   }
 
-  public int[] getStopBoardAlightCosts() {
-    return stopBoardAlightCosts;
+  /**
+   * Costs for both boarding and alighting at a given stop during transfer. Note that this is in
+   * raptor centi-second units.
+   */
+  @Nullable
+  public int[] getStopBoardAlightTransferCosts() {
+    return stopBoardAlightTransferCosts;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
@@ -48,9 +48,6 @@ public class TransitLayer {
 
   private final TransferIndexGenerator transferIndexGenerator;
 
-  /**
-   * @see #getStopBoardAlightTransferCosts()
-   */
   @Nullable
   private final int[] stopBoardAlightTransferCosts;
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitTuningParameters.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitTuningParameters.java
@@ -13,7 +13,7 @@ public interface TransitTuningParameters {
    * These tuning parameters are typically used in unit tests. The values are:
    * <pre>
    * enableStopTransferPriority : true
-   * stopTransferCost : {
+   * stopBoardAlightDuringTransferCost : {
    *   DISCOURAGED:  3600  (equivalent of 1 hour penalty)
    *   ALLOWED:        60  (60 seconds penalty)
    *   RECOMMENDED:    20  (20 seconds penalty)
@@ -28,7 +28,7 @@ public interface TransitTuningParameters {
     }
 
     @Override
-    public Integer stopTransferCost(StopTransferPriority key) {
+    public Integer stopBoardAlightDuringTransferCost(StopTransferPriority key) {
       switch (key) {
         case DISCOURAGED:
           return 3600;
@@ -70,10 +70,11 @@ public interface TransitTuningParameters {
   boolean enableStopTransferPriority();
 
   /**
-   * The stop transfer cost for the given {@link StopTransferPriority}. The cost applied to boarding
-   * and alighting all stops with the given priority.
+   * The stop board alight transfer cost for the given {@link StopTransferPriority}. The cost
+   * applied during transfers to <b>both boarding and alighting</b> of stops with the given
+   * priority.
    */
-  Integer stopTransferCost(StopTransferPriority key);
+  Integer stopBoardAlightDuringTransferCost(StopTransferPriority key);
 
   /**
    * The maximum number of transfer RouteRequests for which the pre-calculated transfers should be

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/CostCalculatorFactory.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/CostCalculatorFactory.java
@@ -1,16 +1,17 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.cost;
 
+import javax.annotation.Nullable;
 import org.opentripplanner.raptor.spi.RaptorCostCalculator;
 
 public class CostCalculatorFactory {
 
   public static <T extends DefaultTripSchedule> RaptorCostCalculator<T> createCostCalculator(
     GeneralizedCostParameters generalizedCostParameters,
-    int[] stopBoardAlightCosts
+    @Nullable int[] stopBoardAlightTransferCosts
   ) {
     RaptorCostCalculator<T> calculator = new DefaultCostCalculator<>(
       generalizedCostParameters,
-      stopBoardAlightCosts
+      stopBoardAlightTransferCosts
     );
 
     if (generalizedCostParameters.wheelchairEnabled()) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
@@ -19,22 +19,28 @@ public final class DefaultCostCalculator<T extends DefaultTripSchedule>
   private final int boardAndTransferCost;
   private final int waitFactor;
   private final FactorStrategy transitFactors;
-  private final int[] stopTransferCost;
+
+  /**
+   * Costs for boarding and alighting at a given stop during transfer.
+   * See TransitLayer.getStopBoardAlightTransferCosts()
+   */
+  @Nullable
+  private final int[] stopBoardAlightTransferCosts;
 
   /**
    * Cost unit: SECONDS - The unit for all input parameters are in the OTP TRANSIT model cost unit
    * (in Raptor the unit for cost is centi-seconds).
    *
-   * @param stopTransferCost Unit centi-seconds. This parameter is used "as-is" and not transformed
-   *                      into the Raptor cast unit to avoid the transformation for each request.
-   *                      Use {@code null} to ignore stop cost.
+   * @param stopBoardAlightTransferCosts Unit centi-seconds. This parameter is used "as-is" and not
+   *                      transformed into the Raptor cast unit to avoid the transformation for each
+   *                      request. Use {@code null} to ignore stop cost.
    */
   public DefaultCostCalculator(
     int boardCost,
     int transferCost,
     double waitReluctanceFactor,
     @Nullable double[] transitReluctanceFactors,
-    @Nullable int[] stopTransferCost
+    @Nullable int[] stopBoardAlightTransferCosts
   ) {
     this.boardCostOnly = RaptorCostConverter.toRaptorCost(boardCost);
     this.transferCostOnly = RaptorCostConverter.toRaptorCost(transferCost);
@@ -46,16 +52,19 @@ public final class DefaultCostCalculator<T extends DefaultTripSchedule>
         ? new SingleValueFactorStrategy(GeneralizedCostParameters.DEFAULT_TRANSIT_RELUCTANCE)
         : new IndexBasedFactorStrategy(transitReluctanceFactors);
 
-    this.stopTransferCost = stopTransferCost;
+    this.stopBoardAlightTransferCosts = stopBoardAlightTransferCosts;
   }
 
-  public DefaultCostCalculator(GeneralizedCostParameters params, int[] stopTransferCost) {
+  public DefaultCostCalculator(
+    GeneralizedCostParameters params,
+    @Nullable int[] stopBoardAlightTransferCosts
+  ) {
     this(
       params.boardCost(),
       params.transferCost(),
       params.waitReluctanceFactor(),
       params.transitReluctanceFactors(),
-      stopTransferCost
+      stopBoardAlightTransferCosts
     );
   }
 
@@ -108,8 +117,8 @@ public final class DefaultCostCalculator<T extends DefaultTripSchedule>
 
     // Add transfer cost on all alighting events.
     // If it turns out to be the last one this cost will be removed during costEgress phase.
-    if (stopTransferCost != null) {
-      cost += stopTransferCost[toStop];
+    if (stopBoardAlightTransferCosts != null) {
+      cost += stopBoardAlightTransferCosts[toStop];
     }
 
     return cost;
@@ -134,7 +143,9 @@ public final class DefaultCostCalculator<T extends DefaultTripSchedule>
       // Remove cost that was added during alighting similar as we do in the costEgress() method
       int fixedCost = transitFactors.minFactor() * minTravelTime;
 
-      return stopTransferCost == null ? fixedCost : fixedCost - stopTransferCost[fromStop];
+      return stopBoardAlightTransferCosts == null
+        ? fixedCost
+        : fixedCost - stopBoardAlightTransferCosts[fromStop];
     }
   }
 
@@ -142,12 +153,12 @@ public final class DefaultCostCalculator<T extends DefaultTripSchedule>
   public int costEgress(RaptorAccessEgress egress) {
     if (egress.hasRides()) {
       return egress.c1() + transferCostOnly;
-    } else if (stopTransferCost != null) {
+    } else if (stopBoardAlightTransferCosts != null) {
       // Remove cost that was added during alighting.
       // We do not want to add this cost on last alighting since it should only be applied on transfers
       // It has to be done here because during alighting we do not know yet if it will be
       // a transfer or not.
-      return egress.c1() - stopTransferCost[egress.stop()];
+      return egress.c1() - stopBoardAlightTransferCosts[egress.stop()];
     } else {
       return egress.c1();
     }
@@ -171,8 +182,8 @@ public final class DefaultCostCalculator<T extends DefaultTripSchedule>
     cost += firstBoarding ? boardCostOnly : boardAndTransferCost;
 
     // If it's first boarding event then it is not a transfer
-    if (stopTransferCost != null && !firstBoarding) {
-      cost += stopTransferCost[boardStop];
+    if (stopBoardAlightTransferCosts != null && !firstBoarding) {
+      cost += stopBoardAlightTransferCosts[boardStop];
     }
     return cost;
   }
@@ -210,8 +221,9 @@ public final class DefaultCostCalculator<T extends DefaultTripSchedule>
       // For a guaranteed transfer we skip board- and transfer-cost
       final int boardWaitTime = boardTime - prevArrivalTime;
 
-      // StopTransferCost is NOT added to the cost here. This is because a trip-to-trip constrained transfer take
-      // precedence over stop-to-stop transfer priority (NeTEx station transfer priority).
+      // StopBoardAlightTransferCost is NOT added to the cost here. This is because a trip-to-trip
+      // constrained transfer take precedence over stop-to-stop transfer priority (NeTEx station
+      // transfer priority).
       return waitFactor * boardWaitTime;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.Transfer;
@@ -103,7 +104,7 @@ public class TransitLayerMapper {
       transferCache,
       constrainedTransfers,
       transferIndexGenerator,
-      createStopTransferCosts(stopModel, tuningParameters)
+      createStopBoardAlightTransferCosts(stopModel, tuningParameters)
     );
   }
 
@@ -179,19 +180,23 @@ public class TransitLayerMapper {
   }
 
   /**
-   * Create static board/alight cost for Raptor to include for each stop.
+   * Create static board/alight cost for Raptor to apply during transfer
    */
-  static int[] createStopTransferCosts(StopModel stops, TransitTuningParameters tuningParams) {
+  @Nullable
+  static int[] createStopBoardAlightTransferCosts(
+    StopModel stops,
+    TransitTuningParameters tuningParams
+  ) {
     if (!tuningParams.enableStopTransferPriority()) {
       return null;
     }
-    int[] stopTransferCosts = new int[stops.stopIndexSize()];
+    int[] stopBoardAlightTransferCosts = new int[stops.stopIndexSize()];
 
     for (int i = 0; i < stops.stopIndexSize(); ++i) {
       StopTransferPriority priority = stops.stopByIndex(i).getPriority();
-      int domainCost = tuningParams.stopTransferCost(priority);
-      stopTransferCosts[i] = RaptorCostConverter.toRaptorCost(domainCost);
+      int domainCost = tuningParams.stopBoardAlightDuringTransferCost(priority);
+      stopBoardAlightTransferCosts[i] = RaptorCostConverter.toRaptorCost(domainCost);
     }
-    return stopTransferCosts;
+    return stopBoardAlightTransferCosts;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -104,7 +104,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
     this.generalizedCostCalculator =
       CostCalculatorFactory.createCostCalculator(
         mcCostParams,
-        transitLayer.getStopBoardAlightCosts()
+        transitLayer.getStopBoardAlightTransferCosts()
       );
 
     this.slackProvider =

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/api/TransferOptimizationParameters.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/api/TransferOptimizationParameters.java
@@ -35,9 +35,10 @@ public interface TransferOptimizationParameters {
   double minSafeWaitTimeFactor();
 
   /**
-   * Use this to add an extra board- and alight-cost for (none) prioritized stops. A {@code
-   * stopBoardAlightCosts} is added to the generalized-cost during routing. But, this cost cannot be
-   * too high, because that would add extra cost to the transfer, and favor other alternative paths.
+   * Use this to add an extra board- and alight-cost for (non) prioritized stops. A {@code
+   * stopBoardAlightTransferCosts} is added to the generalized-cost during routing. But, this cost
+   * cannot be too high, because that would add extra cost to the transfer, and favor other
+   * alternative paths.
    * But, when optimizing transfers, we do not have to take other paths into consideration and can
    * "boost" the stop-priority-cost to allow transfers to take place at a preferred stop.
    * <p>

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/configure/TransferOptimizationServiceConfigurator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/configure/TransferOptimizationServiceConfigurator.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.algorithm.transferoptimization.configure;
 
 import java.util.function.IntFunction;
+import javax.annotation.Nullable;
 import org.opentripplanner.model.transfer.TransferService;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.raptor.api.path.RaptorStopNameResolver;
@@ -28,7 +29,10 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
   private final RaptorStopNameResolver stopNameResolver;
   private final TransferService transferService;
   private final RaptorTransitDataProvider<T> transitDataProvider;
-  private final int[] stopBoardAlightCosts;
+
+  @Nullable
+  private final int[] stopBoardAlightTransferCosts;
+
   private final TransferOptimizationParameters config;
   private final MultiCriteriaRequest<T> multiCriteriaRequest;
 
@@ -37,7 +41,7 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
     RaptorStopNameResolver stopNameResolver,
     TransferService transferService,
     RaptorTransitDataProvider<T> transitDataProvider,
-    int[] stopBoardAlightCosts,
+    int[] stopBoardAlightTransferCosts,
     TransferOptimizationParameters config,
     MultiCriteriaRequest<T> multiCriteriaRequest
   ) {
@@ -45,7 +49,7 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
     this.stopNameResolver = stopNameResolver;
     this.transferService = transferService;
     this.transitDataProvider = transitDataProvider;
-    this.stopBoardAlightCosts = stopBoardAlightCosts;
+    this.stopBoardAlightTransferCosts = stopBoardAlightTransferCosts;
     this.config = config;
     this.multiCriteriaRequest = multiCriteriaRequest;
   }
@@ -60,7 +64,7 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
     RaptorStopNameResolver stopNameResolver,
     TransferService transferService,
     RaptorTransitDataProvider<T> transitDataProvider,
-    int[] stopBoardAlightCosts,
+    @Nullable int[] stopBoardAlightTransferCosts,
     TransferOptimizationParameters config,
     MultiCriteriaRequest<T> multiCriteriaRequest
   ) {
@@ -69,7 +73,7 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
       stopNameResolver,
       transferService,
       transitDataProvider,
-      stopBoardAlightCosts,
+      stopBoardAlightTransferCosts,
       config,
       multiCriteriaRequest
     )
@@ -113,7 +117,7 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
       costCalculator,
       transitDataProvider.slackProvider(),
       transferWaitTimeCostCalculator,
-      stopBoardAlightCosts,
+      stopBoardAlightTransferCosts,
       config.extraStopBoardAlightCostsFactor(),
       createFilter(),
       stopNameResolver

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
@@ -33,6 +33,7 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
   @Nullable
   private final TransferWaitTimeCostCalculator waitTimeCostCalculator;
 
+  @Nullable
   private final StopPriorityCostCalculator stopPriorityCostCalculator;
 
   private int transferPriorityCost = TransferConstraint.ZERO_COST;
@@ -44,15 +45,18 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
     RaptorCostCalculator<T> costCalculator,
     int iterationDepartureTime,
     TransferWaitTimeCostCalculator waitTimeCostCalculator,
-    int[] stopBoardAlightCosts,
+    @Nullable int[] stopBoardAlightTransferCosts,
     double extraStopBoardAlightCostsFactor,
     RaptorStopNameResolver stopNameResolver
   ) {
     super(slackProvider, iterationDepartureTime, costCalculator, stopNameResolver, null);
     this.waitTimeCostCalculator = waitTimeCostCalculator;
     this.stopPriorityCostCalculator =
-      (stopBoardAlightCosts != null && extraStopBoardAlightCostsFactor > 0.01)
-        ? new StopPriorityCostCalculator(extraStopBoardAlightCostsFactor, stopBoardAlightCosts)
+      (stopBoardAlightTransferCosts != null && extraStopBoardAlightCostsFactor > 0.01)
+        ? new StopPriorityCostCalculator(
+          extraStopBoardAlightCostsFactor,
+          stopBoardAlightTransferCosts
+        )
         : null;
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/StopPriorityCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/StopPriorityCostCalculator.java
@@ -1,22 +1,29 @@
 package org.opentripplanner.routing.algorithm.transferoptimization.model;
 
 import org.opentripplanner.framework.lang.IntUtils;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 
 /**
- * This calculator is used to give the stop-priority-cost a boost, by multiplying it with a {@code
- * factor}.
+ * This class calculates an extra stop priority cost by using the stop-board-alight-transfer-cost
+ * and boosting it by multiplying it with a {@code factor}.
  */
 public class StopPriorityCostCalculator {
 
-  private final int[] stopTransferCost;
-  private final double extraStopTransferCostFactor;
+  /**
+   * @see TransitLayer#getStopBoardAlightTransferCosts()
+   */
+  private final int[] stopBoardAlightTransferCosts;
+  private final double extraStopBoardAlightCostFactor;
 
-  StopPriorityCostCalculator(double extraStopTransferCostFactor, int[] stopTransferCost) {
-    this.stopTransferCost = stopTransferCost;
-    this.extraStopTransferCostFactor = extraStopTransferCostFactor;
+  StopPriorityCostCalculator(
+    double extraStopBoardAlightCostFactor,
+    int[] stopBoardAlightTransferCosts
+  ) {
+    this.stopBoardAlightTransferCosts = stopBoardAlightTransferCosts;
+    this.extraStopBoardAlightCostFactor = extraStopBoardAlightCostFactor;
   }
 
   int extraStopPriorityCost(int stop) {
-    return IntUtils.round(stopTransferCost[stop] * extraStopTransferCostFactor);
+    return IntUtils.round(stopBoardAlightTransferCosts[stop] * extraStopBoardAlightCostFactor);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.opentripplanner.raptor.api.model.RaptorConstants;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.raptor.api.path.RaptorPath;
 import org.opentripplanner.raptor.api.path.RaptorStopNameResolver;
@@ -16,6 +15,7 @@ import org.opentripplanner.raptor.api.path.TransferPathLeg;
 import org.opentripplanner.raptor.api.path.TransitPathLeg;
 import org.opentripplanner.raptor.spi.RaptorCostCalculator;
 import org.opentripplanner.raptor.spi.RaptorSlackProvider;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.transferoptimization.api.OptimizedPath;
 import org.opentripplanner.routing.algorithm.transferoptimization.model.OptimizedPathTail;
 import org.opentripplanner.routing.algorithm.transferoptimization.model.PathTailFilter;
@@ -78,8 +78,11 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
   @Nullable
   private final TransferWaitTimeCostCalculator waitTimeCostCalculator;
 
+  /**
+   * @see TransitLayer#getStopBoardAlightTransferCosts()
+   */
   @Nullable
-  private final int[] stopBoardAlightCosts;
+  private final int[] stopBoardAlightTransferCosts;
 
   private final double extraStopBoardAlightCostsFactor;
 
@@ -88,7 +91,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
     RaptorCostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider,
     @Nullable TransferWaitTimeCostCalculator waitTimeCostCalculator,
-    int[] stopBoardAlightCosts,
+    @Nullable int[] stopBoardAlightTransferCosts,
     double extraStopBoardAlightCostsFactor,
     PathTailFilter<T> filter,
     RaptorStopNameResolver stopNameTranslator
@@ -97,7 +100,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
     this.costCalculator = costCalculator;
     this.slackProvider = slackProvider;
     this.waitTimeCostCalculator = waitTimeCostCalculator;
-    this.stopBoardAlightCosts = stopBoardAlightCosts;
+    this.stopBoardAlightTransferCosts = stopBoardAlightTransferCosts;
     this.extraStopBoardAlightCostsFactor = extraStopBoardAlightCostsFactor;
     this.filter = filter;
     this.stopNameTranslator = stopNameTranslator;
@@ -139,7 +142,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
         costCalculator,
         iterationDepartureTime,
         waitTimeCostCalculator,
-        stopBoardAlightCosts,
+        stopBoardAlightTransferCosts,
         extraStopBoardAlightCostsFactor,
         stopNameTranslator
       )

--- a/src/main/java/org/opentripplanner/standalone/config/buildconfig/GtfsConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/buildconfig/GtfsConfig.java
@@ -74,7 +74,7 @@ public class GtfsConfig {
           .description(
             """
             This parameter sets the generic level of preference. What is the actual cost can be changed
-            with the `stopTransferCost` parameter in the router configuration.
+            with the `stopBoardAlightDuringTransferCost` parameter in the router configuration.
             """
           )
           .docDefaultValue(docDefaults.stationTransferPreference())

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/TransitRoutingConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/TransitRoutingConfig.java
@@ -31,7 +31,7 @@ public final class TransitRoutingConfig implements RaptorTuningParameters, Trans
   private final List<RouteRequest> transferCacheRequests;
   private final List<Duration> pagingSearchWindowAdjustments;
 
-  private final Map<StopTransferPriority, Integer> stopTransferCost;
+  private final Map<StopTransferPriority, Integer> stopBoardAlightDuringTransferCost;
   private final Duration maxSearchWindow;
   private final DynamicSearchWindowCoefficients dynamicSearchWindowCoefficients;
 
@@ -114,18 +114,24 @@ no extra threads are started and the search is done in one thread.
         )
         .asInt(dft.searchThreadPoolSize());
     // Dynamic Search Window
-    this.stopTransferCost =
+    this.stopBoardAlightDuringTransferCost =
       c
-        .of("stopTransferCost")
+        .of("stopBoardAlightDuringTransferCost")
         .since(V2_0)
-        .summary("Use this to set a stop transfer cost for the given transfer priority")
+        .summary(
+          "Costs for boarding and alighting during transfers at stops with a given transfer priority."
+        )
         .description(
           """
-The cost is applied to boarding and alighting at all stops. All stops have a transfer cost priority
-set, the default is `allowed`. The `stopTransferCost` parameter is optional, but if listed all 
-values must be set.
+This cost is applied **both to boarding and alighting** at stops during transfers. All stops have a
+transfer cost priority set, the default is `allowed`. The `stopBoardAlightDuringTransferCost`
+parameter is optional, but if listed all values must be set.
+
+When a transfer occurs at the same stop, the cost will be applied twice since the cost is both for
+boarding and alighting,
           
-If not set the `stopTransferCost` is ignored. This is only available for NeTEx imported Stops.
+If not set the `stopBoardAlightDuringTransferCost` is ignored. This is only available for NeTEx
+imported Stops.
           
 The cost is a scalar, but is equivalent to the felt cost of riding a transit trip for 1 second.
           
@@ -137,7 +143,7 @@ The cost is a scalar, but is equivalent to the felt cost of riding a transit tri
 | `preferred`   | The best place to do transfers. Should be set to `0`(zero).                                   | int  |
           
 Use values in a range from `0` to `100 000`. **All key/value pairs are required if the 
-`stopTransferCost` is listed.**
+`stopBoardAlightDuringTransferCost` is listed.**
 """
         )
         .asEnumMapAllKeysRequired(StopTransferPriority.class, Integer.class);
@@ -250,12 +256,12 @@ for more info."
 
   @Override
   public boolean enableStopTransferPriority() {
-    return stopTransferCost != null;
+    return stopBoardAlightDuringTransferCost != null;
   }
 
   @Override
-  public Integer stopTransferCost(StopTransferPriority key) {
-    return stopTransferCost.get(key);
+  public Integer stopBoardAlightDuringTransferCost(StopTransferPriority key) {
+    return stopBoardAlightDuringTransferCost.get(key);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/TransferConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/TransferConfig.java
@@ -144,7 +144,7 @@ package documentation.
           .summary("Add an extra board- and alight-cost for prioritized stops.")
           .description(
             """
-            A stopBoardAlightCosts is added to the generalized-cost during routing. But this cost
+            A stopBoardAlightTransferCosts is added to the generalized-cost during routing. But this cost
             cannot be too high, because that would add extra cost to the transfer, and favor other
             alternative paths. But, when optimizing transfers, we do not have to take other paths
             into consideration and can *boost* the stop-priority-cost to allow transfers to

--- a/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
+++ b/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
@@ -66,7 +66,7 @@ public class TestTransitData
   private final List<ConstrainedTransfer> constrainedTransfers = new ArrayList<>();
   private final GeneralizedCostParametersBuilder costParamsBuilder = GeneralizedCostParameters.of();
 
-  private final int[] stopBoardAlightCosts = new int[NUM_STOPS];
+  private final int[] stopBoardAlightTransferCosts = new int[NUM_STOPS];
 
   private RaptorSlackProvider slackProvider = SLACK_PROVIDER;
 
@@ -106,7 +106,7 @@ public class TestTransitData
   public RaptorCostCalculator<TestTripSchedule> multiCriteriaCostCalculator() {
     return CostCalculatorFactory.createCostCalculator(
       costParamsBuilder.build(),
-      stopBoardAlightCost()
+      stopBoardAlightTransferCosts()
     );
   }
 
@@ -302,8 +302,8 @@ public class TestTransitData
     return this;
   }
 
-  public TestTransitData withStopBoardAlightCost(int stop, int boardAlightCost) {
-    stopBoardAlightCosts[stop] = boardAlightCost;
+  public TestTransitData withStopBoardAlightTransferCost(int stop, int boardAlightTransferCost) {
+    stopBoardAlightTransferCosts[stop] = boardAlightTransferCost;
     return this;
   }
 
@@ -357,9 +357,9 @@ public class TestTransitData
 
   /* private methods */
 
-  private int[] stopBoardAlightCost() {
+  private int[] stopBoardAlightTransferCosts() {
     // Not implemented, no test for this yet.
-    return stopBoardAlightCosts;
+    return stopBoardAlightTransferCosts;
   }
 
   private void expandNumOfStops(int stopIndex) {

--- a/src/test/java/org/opentripplanner/raptor/moduletests/B05_EgressStopBoardAlightTransferCostTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/B05_EgressStopBoardAlightTransferCostTest.java
@@ -22,10 +22,10 @@ import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 /**
  * FEATURE UNDER TEST
  * <p>
- * This verifies that the stopTransferCost is not applied for egress legs. If this is not correctly
- * handled by the heuristics optimization, the cheapest journey could be discarded.
+ * This verifies that the stopBoardAlightTransferCost is not applied for egress legs. If this is not
+ * correctly handled by the heuristics optimization, the cheapest journey could be discarded.
  */
-public class B05_EgressStopTransferCostTest implements RaptorTestConstants {
+public class B05_EgressStopBoardAlightTransferCostTest implements RaptorTestConstants {
 
   private final TestTransitData data = new TestTransitData();
   private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
@@ -40,7 +40,7 @@ public class B05_EgressStopTransferCostTest implements RaptorTestConstants {
       .withRoute(route("R2", STOP_C, STOP_D).withTimetable(schedule("0:18, 0:20")));
 
     data.mcCostParamsBuilder().transferCost(0).boardCost(0);
-    data.withStopBoardAlightCost(STOP_D, 60000);
+    data.withStopBoardAlightTransferCost(STOP_D, 60000);
 
     requestBuilder
       .searchParams()
@@ -61,7 +61,7 @@ public class B05_EgressStopTransferCostTest implements RaptorTestConstants {
       .add(
         multiCriteria(),
         // We should get both the fastest and the c1-cheapest results
-        // The stopTransferCost should not be applied to the egress leg from STOP_D
+        // The stopBoardAlightTransferCost should not be applied to the egress leg from STOP_D
         "B ~ BUS R1 0:10 0:14 ~ C ~ Walk 5m [0:10 0:19 9m Tₓ0 C₁840]",
         "B ~ BUS R1 0:10 0:14 ~ C ~ BUS R2 0:18 0:20 ~ D ~ Walk 20s [0:10 0:20:20 10m20s Tₓ1 C₁640]"
       )

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapperTest.java
@@ -42,8 +42,8 @@ class TransitLayerMapperTest {
   private final List<StopLocation> STOPS = Arrays.asList(STOP_0, STOP_1, STOP_2, STOP_3, STOP_4);
 
   @Test
-  public void createStopTransferCosts() {
-    int[] result = TransitLayerMapper.createStopTransferCosts(
+  public void createStopBoardAlightTransferCosts() {
+    int[] result = TransitLayerMapper.createStopBoardAlightTransferCosts(
       new StopModelMock(STOPS),
       TransitTuningParameters.FOR_TEST
     );

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
@@ -53,14 +53,14 @@ class OptimizedPathTailTest implements RaptorTestConstants {
    *  Extra cost = (30.0 + 2 * 10.0) * 2.0 = $100.00
    *  </pre>
    */
-  private final int[] stopBoardAlightCost = new int[] { 0, 0, 3000, 0, 1000, 0 };
+  private final int[] stopBoardAlightTransferCosts = new int[] { 0, 0, 3000, 0, 1000, 0 };
 
   private final OptimizedPathTail<TestTripSchedule> subject = new OptimizedPathTail<>(
     SLACK_PROVIDER,
     BasicPathTestCase.C1_CALCULATOR,
     0,
     waitTimeCalc,
-    stopBoardAlightCost,
+    stopBoardAlightTransferCosts,
     2.0,
     this::stopIndexToName
   );

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -171,7 +171,7 @@
       "minWindow": "1h",
       "maxWindow": "5h"
     },
-    "stopTransferCost": {
+    "stopBoardAlightDuringTransferCost": {
       "DISCOURAGED": 1500,
       "ALLOWED": 75,
       "RECOMMENDED": 30,

--- a/test/performance/norway/speed-test-config.json
+++ b/test/performance/norway/speed-test-config.json
@@ -31,7 +31,7 @@
       // stepMinutes: 10
       // stepMinutes: 10
     },
-    "stopTransferCost": {
+    "stopBoardAlightDuringTransferCost": {
       "DISCOURAGED": 86400,
       "ALLOWED": 3000,
       "RECOMMENDED": 300,

--- a/test/performance/skanetrafiken/speed-test-config.json
+++ b/test/performance/skanetrafiken/speed-test-config.json
@@ -7,7 +7,7 @@
     "dynamicSearchWindow": {
       "maxWindow": "24h"
     },
-    "stopTransferCost": {
+    "stopBoardAlightDuringTransferCost": {
       "DISCOURAGED": 3000,
       "ALLOWED": 150,
       "RECOMMENDED": 60,

--- a/test/performance/switzerland/speed-test-config.json
+++ b/test/performance/switzerland/speed-test-config.json
@@ -31,7 +31,7 @@
       // stepMinutes: 10
       // stepMinutes: 10
     },
-    "stopTransferCost": {
+    "stopBoardAlightDuringTransferCost": {
       "DISCOURAGED": 86400,
       "ALLOWED": 3000,
       "RECOMMENDED": 300,


### PR DESCRIPTION
### Summary

The stop-specific costs that are applied for boarding and alighting during transfers is poorly named as discussed in #5783. The list is inconistently named throughout the code and is sometimes called `stopTransferCosts` and sometimes `stopBoardAlightCosts`. But neither of these names capture the behaviour that it is applied both for boarding and alighting but only during transfers.

This PR fixes this by renaming it to `stopBoardAlightTransferCost` as suggested in #5783. While the new name is not obvious, at least it will prompt readers of the code to read the documentation.

The router configuration parameter `stopTransferCost` that is used to map netex stop priorities to costs is renamed to `stopBoardAlightDuringTransferCost`. I'm not 100% sure about this name and am open to other suggestions.

I also tried to clarify the documentation for this parameter.