### PR TITLE
Document and validate timeRange GraphQL parameter

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.apis.transmodel.model.stop;
 
+import static org.opentripplanner.apis.transmodel.support.GqlUtil.getPositiveNonNullIntegerArgument;
+
 import graphql.Scalars;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
@@ -299,8 +301,8 @@ public class QuayType {
             Integer departuresPerLineAndDestinationDisplay = environment.getArgument(
               "numberOfDeparturesPerLineAndDestinationDisplay"
             );
-            Integer timeRangeInput = environment.getArgument("timeRange");
-            Duration timeRange = Duration.ofSeconds(timeRangeInput.longValue());
+            int timeRangeInput = getPositiveNonNullIntegerArgument(environment, "timeRange");
+            Duration timeRange = Duration.ofSeconds(timeRangeInput);
             StopLocation stop = environment.getSource();
 
             JourneyWhiteListed whiteListed = new JourneyWhiteListed(environment);

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
@@ -216,6 +216,9 @@ public class QuayType {
             GraphQLArgument
               .newArgument()
               .name("timeRange")
+              .description(
+                "Duration in seconds from start time to search forward for estimated calls. Must be a positive value. Default value is 24 hours"
+              )
               .type(Scalars.GraphQLInt)
               .defaultValue(24 * 60 * 60)
               .build()

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
@@ -290,6 +290,9 @@ public class StopPlaceType {
             GraphQLArgument
               .newArgument()
               .name("timeRange")
+              .description(
+                "Duration in seconds from start time to search forward for estimated calls. Must be a positive value. Default value is 24 hours"
+              )
               .type(Scalars.GraphQLInt)
               .defaultValue(24 * 60 * 60)
               .build()

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
@@ -358,7 +358,7 @@ public class StopPlaceType {
               "numberOfDeparturesPerLineAndDestinationDisplay"
             );
             int timeRangeInput = getPositiveNonNullIntegerArgument(environment, "timeRange");
-            Duration timeRage = Duration.ofSeconds(timeRangeInput);
+            Duration timeRange = Duration.ofSeconds(timeRangeInput);
 
             MonoOrMultiModalStation monoOrMultiModalStation = environment.getSource();
             JourneyWhiteListed whiteListed = new JourneyWhiteListed(environment);
@@ -375,7 +375,7 @@ public class StopPlaceType {
                 getTripTimesForStop(
                   singleStop,
                   startTime,
-                  timeRage,
+                  timeRange,
                   arrivalDeparture,
                   includeCancelledTrips,
                   numberOfDepartures,
@@ -420,7 +420,7 @@ public class StopPlaceType {
   public static Stream<TripTimeOnDate> getTripTimesForStop(
     StopLocation stop,
     Instant startTimeSeconds,
-    Duration timeRage,
+    Duration timeRange,
     ArrivalDeparture arrivalDeparture,
     boolean includeCancelledTrips,
     int numberOfDepartures,
@@ -435,7 +435,7 @@ public class StopPlaceType {
     List<StopTimesInPattern> stopTimesInPatterns = transitService.stopTimesForStop(
       stop,
       startTimeSeconds,
-      timeRage,
+      timeRange,
       numberOfDepartures,
       arrivalDeparture,
       includeCancelledTrips

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.transmodel.model.stop;
 
 import static java.lang.Boolean.TRUE;
+import static org.opentripplanner.apis.transmodel.support.GqlUtil.getPositiveNonNullIntegerArgument;
 
 import graphql.Scalars;
 import graphql.schema.DataFetchingEnvironment;
@@ -356,8 +357,8 @@ public class StopPlaceType {
             Integer departuresPerLineAndDestinationDisplay = environment.getArgument(
               "numberOfDeparturesPerLineAndDestinationDisplay"
             );
-            Integer timeRangeInput = environment.getArgument("timeRange");
-            Duration timeRage = Duration.ofSeconds(timeRangeInput.longValue());
+            int timeRangeInput = getPositiveNonNullIntegerArgument(environment, "timeRange");
+            Duration timeRage = Duration.ofSeconds(timeRangeInput);
 
             MonoOrMultiModalStation monoOrMultiModalStation = environment.getSource();
             JourneyWhiteListed whiteListed = new JourneyWhiteListed(environment);

--- a/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
@@ -103,6 +103,25 @@ public class GqlUtil {
     return environment.containsArgument(name) && environment.getArgument(name) != null;
   }
 
+  /**
+   * Return the integer value of the argument or throw an exception if the value is null
+   * or strictly negative.
+   * This should generally be handled at the GraphQL schema level,
+   * but must sometimes be implemented programmatically to preserve backward compatibility.
+   */
+  public static int getPositiveNonNullIntegerArgument(
+    DataFetchingEnvironment environment,
+    String argumentName
+  ) {
+    Integer argumentValue = environment.getArgument(argumentName);
+    if (argumentValue == null || argumentValue < 0) {
+      throw new IllegalArgumentException(
+        "The argument '" + argumentName + "' should be a non-null positive value: " + argumentValue
+      );
+    }
+    return argumentValue;
+  }
+
   public static <T> List<T> listOfNullSafe(T element) {
     return element == null ? List.of() : List.of(element);
   }

--- a/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -571,6 +571,7 @@ type Quay implements PlaceInterface {
     omitNonBoarding: Boolean = false @deprecated(reason : "Non-functional. Use arrivalDeparture instead."),
     "DateTime for when to fetch estimated calls from. Default value is current time"
     startTime: DateTime,
+    "Duration in seconds from start time to search forward for estimated calls. Must be a positive value. Default value is 24 hours"
     timeRange: Int = 86400,
     "Parameters for indicating the only authorities and/or lines or quays to list estimatedCalls for"
     whiteListed: InputWhiteListed,
@@ -1132,6 +1133,7 @@ type StopPlace implements PlaceInterface {
     numberOfDeparturesPerLineAndDestinationDisplay: Int,
     "DateTime for when to fetch estimated calls from. Default value is current time"
     startTime: DateTime,
+    "Duration in seconds from start time to search forward for estimated calls. Must be a positive value. Default value is 24 hours"
     timeRange: Int = 86400,
     "Parameters for indicating the only authorities and/or lines or quays to list estimatedCalls for"
     whiteListed: InputWhiteListed,

--- a/src/test/java/org/opentripplanner/apis/transmodel/support/GqlUtilTest.java
+++ b/src/test/java/org/opentripplanner/apis/transmodel/support/GqlUtilTest.java
@@ -2,11 +2,14 @@ package org.opentripplanner.apis.transmodel.support;
 
 import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import graphql.ExecutionInput;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
+import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -14,6 +17,7 @@ import org.junit.jupiter.api.Test;
 public class GqlUtilTest {
 
   static final ExecutionContext executionContext;
+  private static final String TEST_ARGUMENT = "testArgument";
 
   static {
     ExecutionInput executionInput = ExecutionInput
@@ -27,6 +31,54 @@ public class GqlUtilTest {
         .executionInput(executionInput)
         .executionId(ExecutionId.from("GqlUtilTest"))
         .build();
+  }
+
+  @Test
+  void testGetPositiveNonNullIntegerArgumentWithStrictlyPositiveValue() {
+    var env = buildEnvWithTestValue(1);
+    assertEquals(1, GqlUtil.getPositiveNonNullIntegerArgument(env, TEST_ARGUMENT));
+  }
+
+  @Test
+  void testGetPositiveNonNullIntegerArgumentWithZeroValue() {
+    var env = buildEnvWithTestValue(0);
+    assertEquals(0, GqlUtil.getPositiveNonNullIntegerArgument(env, TEST_ARGUMENT));
+  }
+
+  @Test
+  void testGetPositiveNonNullIntegerArgumentWithNegativeValue() {
+    var env = buildEnvWithTestValue(-1);
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> GqlUtil.getPositiveNonNullIntegerArgument(env, TEST_ARGUMENT)
+    );
+  }
+
+  @Test
+  void testGetPositiveNonNullIntegerArgumentWithNullValue() {
+    var env = buildEnvWithTestValue(null);
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> GqlUtil.getPositiveNonNullIntegerArgument(env, TEST_ARGUMENT)
+    );
+  }
+
+  @Test
+  void testGetPositiveNonNullIntegerArgumentWithoutValue() {
+    var env = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(executionContext).build();
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> GqlUtil.getPositiveNonNullIntegerArgument(env, TEST_ARGUMENT)
+    );
+  }
+
+  private static DataFetchingEnvironment buildEnvWithTestValue(Integer value) {
+    Map<String, Object> argsMap = new HashMap<>();
+    argsMap.put(TEST_ARGUMENT, value);
+    return DataFetchingEnvironmentImpl
+      .newDataFetchingEnvironment(executionContext)
+      .arguments(argsMap)
+      .build();
   }
 
   @Test


### PR DESCRIPTION

### Summary

The timeRange parameter in the TransModel GraphQL API lacks documentation and validation logic.
It fails with a non-descriptive error message when provided with a null value:

```
"Exception while fetching data (/stopPlace/estimatedCalls) : Cannot invoke "java.lang.Integer.longValue()" because "timeRangeInput" is null
java.lang.NullPointerException: Cannot invoke "java.lang.Integer.longValue()" because "timeRangeInput" is null
	at org.opentripplanner.apis.transmodel.model.stop.StopPlaceType.lambda$create$17(StopPlaceType.java:360)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:329)
```
	
or a negative value:

```
	Exception while fetching data (/stopPlace/estimatedCalls) : 2024-04-27 < 2024-04-28
java.lang.IllegalArgumentException: 2024-04-27 < 2024-04-28
	at java.base/java.time.LocalDate.datesUntil(LocalDate.java:1717)
	at org.opentripplanner.routing.stoptimes.StopTimesHelper.listTripTimeShortsForPatternAtStop(StopTimesHelper.java:203)
	at org.opentripplanner.routing.stoptimes.StopTimesHelper.stopTimesForStop(StopTimesHelper.java:65)
	at org.opentripplanner.transit.service.DefaultTransitService.stopTimesForStop(DefaultTransitService.java:325)
	at org.opentripplanner.apis.transmodel.model.stop.StopPlaceType.getTripTimesForStop(StopPlaceType.java:434)
	at org.opentripplanner.apis.transmodel.model.stop.StopPlaceType.lambda$create$16(StopPlaceType.java:374)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
	at java.base/java.util.HashMap$KeySpliterator.tryAdvance(HashMap.java:1736)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.opentripplanner.apis.transmodel.model.stop.StopPlaceType.lambda$create$17(StopPlaceType.java:396)
	at graphql.execution.ExecutionStrategy.invokeDataFetcher(ExecutionStrategy.java:329)	
```

This PR documents the purpose of this parameter, its boundaries and add validation logic with an explicit error message:
```
"errors": [
    {
      "message": "Exception while fetching data (/stopPlace/estimatedCalls) : The argument 'timeRange' should be a non-null positive value: null",
```

### Issue
No.

### Unit tests

Added unit tests

### Documentation

Updated documentation
