### PR TITLE
Add feed publisher name and url to GTFS GraphQL API

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLIndex.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLIndex.java
@@ -129,7 +129,6 @@ class GtfsGraphQLIndex {
         .type(typeWiring.build(DepartureRowImpl.class))
         .type(typeWiring.build(elevationProfileComponentImpl.class))
         .type(typeWiring.build(FeedImpl.class))
-        .type(typeWiring.build(FeedImpl.class))
         .type(typeWiring.build(GeometryImpl.class))
         .type(typeWiring.build(ItineraryImpl.class))
         .type(typeWiring.build(LegImpl.class))

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
@@ -64,6 +64,22 @@ public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
     return this::getSource;
   }
 
+  @Override
+  public DataFetcher<String> publisherName() {
+    return environment -> {
+      String id = getSource(environment);
+      return getTransitService(environment).getFeedInfo(id).getPublisherName();
+    };
+  }
+
+  @Override
+  public DataFetcher<String> publisherUrl() {
+    return environment -> {
+      String id = getSource(environment);
+      return getTransitService(environment).getFeedInfo(id).getPublisherUrl();
+    };
+  }
+
   private List<Agency> getAgencies(DataFetchingEnvironment environment) {
     String id = getSource(environment);
     return getTransitService(environment)

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
@@ -13,6 +13,7 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.organization.FeedPublisher;
 import org.opentripplanner.transit.service.TransitService;
 
 public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
@@ -65,18 +66,13 @@ public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
   }
 
   @Override
-  public DataFetcher<String> publisherName() {
+  public DataFetcher<Object> publisher() {
     return environment -> {
       String id = getSource(environment);
-      return getTransitService(environment).getFeedInfo(id).getPublisherName();
-    };
-  }
-
-  @Override
-  public DataFetcher<String> publisherUrl() {
-    return environment -> {
-      String id = getSource(environment);
-      return getTransitService(environment).getFeedInfo(id).getPublisherUrl();
+      return new FeedPublisher(
+        getTransitService(environment).getFeedInfo(id).getPublisherName(),
+        getTransitService(environment).getFeedInfo(id).getPublisherUrl()
+      );
     };
   }
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
@@ -9,11 +9,11 @@ import java.util.stream.Collectors;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.gtfs.model.FeedPublisher;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.organization.Agency;
-import org.opentripplanner.transit.model.organization.FeedPublisher;
 import org.opentripplanner.transit.service.TransitService;
 
 public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
@@ -66,7 +66,7 @@ public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
   }
 
   @Override
-  public DataFetcher<Object> publisher() {
+  public DataFetcher<FeedPublisher> publisher() {
     return environment -> {
       String id = getSource(environment);
       return new FeedPublisher(

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -381,9 +381,14 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<String> feedId();
 
-    public DataFetcher<String> publisherName();
+    public DataFetcher<Object> publisher();
+  }
 
-    public DataFetcher<String> publisherUrl();
+  /** Feed publisher information */
+  public interface GraphQLFeedPublisher {
+    public DataFetcher<String> name();
+
+    public DataFetcher<String> url();
   }
 
   public interface GraphQLGeometry {

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -380,6 +380,10 @@ public class GraphQLDataFetchers {
     public DataFetcher<Iterable<TransitAlert>> alerts();
 
     public DataFetcher<String> feedId();
+
+    public DataFetcher<String> publisherName();
+
+    public DataFetcher<String> publisherUrl();
   }
 
   public interface GraphQLGeometry {

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -20,6 +20,7 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLOccupancyStat
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRelativeDirection;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRoutingErrorCode;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTransitMode;
+import org.opentripplanner.apis.gtfs.model.FeedPublisher;
 import org.opentripplanner.apis.gtfs.model.RideHailingProvider;
 import org.opentripplanner.apis.gtfs.model.StopPosition;
 import org.opentripplanner.apis.gtfs.model.TripOccupancy;
@@ -381,7 +382,7 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<String> feedId();
 
-    public DataFetcher<Object> publisher();
+    public DataFetcher<FeedPublisher> publisher();
   }
 
   /** Feed publisher information */

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -56,6 +56,7 @@ config:
     elevationProfileComponent: org.opentripplanner.model.plan.ElevationProfile.Step
     Emissions: org.opentripplanner.model.plan.Emissions#Emissions
     Feed: String
+    FeedPublisher: org.opentripplanner.apis.gtfs.model.FeedPublisher#FeedPublisher
     Geometry: org.locationtech.jts.geom.Geometry#Geometry
     InputField: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLInputField#GraphQLInputField
     Itinerary: org.opentripplanner.model.plan.Itinerary#Itinerary

--- a/src/main/java/org/opentripplanner/apis/gtfs/model/FeedPublisher.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/model/FeedPublisher.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.model.organization;
+package org.opentripplanner.apis.gtfs.model;
 
 import java.util.Objects;
 

--- a/src/main/java/org/opentripplanner/transit/model/organization/FeedPublisher.java
+++ b/src/main/java/org/opentripplanner/transit/model/organization/FeedPublisher.java
@@ -1,0 +1,10 @@
+package org.opentripplanner.transit.model.organization;
+
+import java.util.Objects;
+
+public record FeedPublisher(String name, String url) {
+  public FeedPublisher {
+    Objects.requireNonNull(name);
+    Objects.requireNonNull(url);
+  }
+}

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -974,6 +974,18 @@ type fareComponent {
     routes: [Route] @deprecated
 }
 
+
+"""
+Feed publisher information
+"""
+type FeedPublisher {
+    """Name of feed publisher"""
+    name: String!
+
+    """Web address of feed publisher"""
+    url: String!
+}
+
 """
 A feed provides routing data (stops, routes, timetables, etc.) from one or more public transport agencies.
 """
@@ -984,11 +996,8 @@ type Feed {
     """List of agencies which provide data to this feed"""
     agencies: [Agency]
 
-    """Name of feed publisher"""
-    publisherName: String!
-
-    """Web address of feed publisher"""
-    publisherUrl: String!
+    """publisher"""
+    publisher: FeedPublisher!
 
     """
     Alerts relevant for the feed.

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -984,6 +984,12 @@ type Feed {
     """List of agencies which provide data to this feed"""
     agencies: [Agency]
 
+    """Name of feed publisher"""
+    publisherName: String!
+
+    """Web address of feed publisher"""
+    publisherUrl: String!
+
     """
     Alerts relevant for the feed.
     """

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -996,7 +996,7 @@ type Feed {
     """List of agencies which provide data to this feed"""
     agencies: [Agency]
 
-    """publisher"""
+    "The publisher of the input transit data."
     publisher: FeedPublisher
 
     """

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -997,7 +997,7 @@ type Feed {
     agencies: [Agency]
 
     """publisher"""
-    publisher: FeedPublisher!
+    publisher: FeedPublisher
 
     """
     Alerts relevant for the feed.

--- a/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -43,6 +43,7 @@ import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.model.Grams;
+import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.ItineraryFares;
@@ -84,6 +85,7 @@ import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.BikeAccess;
 import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
@@ -150,6 +152,18 @@ class GraphQLIntegrationTest {
     pattern.add(tripTimes);
 
     transitModel.addTripPattern(id("pattern-1"), pattern);
+
+    var feedId = "testfeed";
+    var feedInfo = FeedInfo.dummyForTest(feedId);
+    transitModel.addFeedInfo(feedInfo);
+
+    var agency = Agency
+      .of(new FeedScopedId(feedId, "agency-xx"))
+      .withName("speedtransit")
+      .withUrl("www.otp-foo.bar")
+      .withTimezone("Europe/Berlin")
+      .build();
+    transitModel.addAgency(agency);
 
     transitModel.initTimeZone(ZoneIds.BERLIN);
     transitModel.index();

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
@@ -1,0 +1,16 @@
+{
+  "data" : {
+    "feeds" : [
+      {
+        "agencies" : [
+          {
+            "name" : "speedtransit",
+            "url" : "www.otp-foo.bar"
+          }
+        ],
+        "publisherUrl" : "www.z.org",
+        "publisherName" : "publisher"
+      }
+    ]
+  }
+}

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
@@ -8,8 +8,10 @@
             "url" : "www.otp-foo.bar"
           }
         ],
-        "publisherUrl" : "www.z.org",
-        "publisherName" : "publisher"
+        "publisher" : {
+          "name" : "publisher",
+          "url" : "www.z.org"
+        }
       }
     ]
   }

--- a/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
@@ -1,0 +1,10 @@
+{
+    feeds {
+        agencies {
+	    name
+	    url
+	}
+	publisherUrl
+	publisherName
+    }
+}

--- a/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
@@ -4,7 +4,9 @@
 	    name
 	    url
 	}
-	publisherUrl
-	publisherName
+	publisher {
+	    name
+	    url
+        }
     }
 }


### PR DESCRIPTION
### Summary

Add fetchers for FeedInfo publisherName and publisherUrl information.

### Unit tests

Feedinfo test query added.

### Documentation

In gtfs graphql schema.

