### PR TITLE
Don't expose mutable tripOnServiceDates in TransitModel

### DIFF
--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -69,7 +69,7 @@ public class NetexModule implements GraphBuilderModule {
         );
         transitBuilder.limitServiceDays(transitPeriodLimit);
         for (var tripOnServiceDate : transitBuilder.getTripOnServiceDates().values()) {
-          transitModel.getTripOnServiceDates().put(tripOnServiceDate.getId(), tripOnServiceDate);
+          transitModel.addTripOnServiceDate(tripOnServiceDate.getId(), tripOnServiceDate);
         }
         calendarServiceData.add(transitBuilder.buildCalendarServiceData());
 

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -371,8 +371,9 @@ public class TransitModel implements Serializable {
     return tripPatternForId.get(id);
   }
 
-  public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDates() {
-    return tripOnServiceDates;
+  public void addTripOnServiceDate(FeedScopedId id, TripOnServiceDate tripOnServiceDate) {
+    invalidateIndex();
+    tripOnServiceDates.put(id, tripOnServiceDate);
   }
 
   /**

--- a/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -87,16 +87,14 @@ class ScheduledTransitLegReferenceTest {
     calendarServiceData.putServiceDatesForServiceId(tripPattern.getId(), List.of(SERVICE_DATE));
     transitModel.updateCalendarServiceData(true, calendarServiceData, DataImportIssueStore.NOOP);
 
-    transitModel
-      .getTripOnServiceDates()
-      .put(
-        TRIP_ON_SERVICE_DATE_ID,
-        TripOnServiceDate
-          .of(TRIP_ON_SERVICE_DATE_ID)
-          .withTrip(trip)
-          .withServiceDate(SERVICE_DATE)
-          .build()
-      );
+    transitModel.addTripOnServiceDate(
+      TRIP_ON_SERVICE_DATE_ID,
+      TripOnServiceDate
+        .of(TRIP_ON_SERVICE_DATE_ID)
+        .withTrip(trip)
+        .withServiceDate(SERVICE_DATE)
+        .build()
+    );
 
     transitModel.index();
 


### PR DESCRIPTION
### Summary

Just a minor cleanup to not expose a mutable map and instead provide `TransitModel.addTripOnServiceDate()`

Encapsulation, loose coupling etc.