### PR TITLE
Remove non-standard trip fare ID

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/restapi/mapping/TripMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/restapi/mapping/TripMapper.java
@@ -31,7 +31,6 @@ public class TripMapper {
     api.shapeId = FeedScopedIdMapper.mapToApi(obj.getShapeId());
     api.wheelchairAccessible = WheelchairAccessibilityMapper.mapToApi(obj.getWheelchairBoarding());
     api.bikesAllowed = BikeAccessMapper.mapToApi(obj.getBikesAllowed());
-    api.fareId = obj.getGtfsFareId();
 
     return api;
   }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -60,7 +60,6 @@ class TripMapper {
     lhs.withShapeId(AgencyAndIdMapper.mapAgencyAndId(rhs.getShapeId()));
     lhs.withWheelchairBoarding(WheelchairAccessibilityMapper.map(rhs.getWheelchairAccessible()));
     lhs.withBikesAllowed(BikeAccessMapper.mapForTrip(rhs));
-    lhs.withGtfsFareId(rhs.getFareId());
 
     return lhs.build();
   }

--- a/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
@@ -36,7 +36,6 @@ public final class Trip extends AbstractTransitEntity<Trip, TripBuilder> impleme
   private final Accessibility wheelchairBoarding;
 
   private final String gtfsBlockId;
-  private final String gtfsFareId;
 
   private final String netexInternalPlanningCode;
   private final TripAlteration netexAlteration;
@@ -65,7 +64,6 @@ public final class Trip extends AbstractTransitEntity<Trip, TripBuilder> impleme
     this.headsign = builder.getHeadsign();
     this.shapeId = builder.getShapeId();
     this.gtfsBlockId = builder.getGtfsBlockId();
-    this.gtfsFareId = builder.getGtfsFareId();
     this.netexInternalPlanningCode = builder.getNetexInternalPlanningCode();
   }
 
@@ -149,12 +147,6 @@ public final class Trip extends AbstractTransitEntity<Trip, TripBuilder> impleme
     return gtfsBlockId;
   }
 
-  /** Custom extension for KCM to specify a fare per-trip */
-  @Nullable
-  public String getGtfsFareId() {
-    return gtfsFareId;
-  }
-
   /**
    * Internal code (non-public identifier) for the journey (e.g. train- or trip number from the
    * planners' tool). This is kept to ensure compatibility with legacy planning systems. In NeTEx
@@ -209,8 +201,7 @@ public final class Trip extends AbstractTransitEntity<Trip, TripBuilder> impleme
       Objects.equals(this.direction, other.direction) &&
       Objects.equals(this.bikesAllowed, other.bikesAllowed) &&
       Objects.equals(this.wheelchairBoarding, other.wheelchairBoarding) &&
-      Objects.equals(this.netexAlteration, other.netexAlteration) &&
-      Objects.equals(this.gtfsFareId, other.gtfsFareId)
+      Objects.equals(this.netexAlteration, other.netexAlteration)
     );
   }
 

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripBuilder.java
@@ -23,7 +23,6 @@ public class TripBuilder extends AbstractEntityBuilder<Trip, TripBuilder> {
   private BikeAccess bikesAllowed;
   private Accessibility wheelchairBoarding;
   private String gtfsBlockId;
-  private String gtfsFareId;
   private String netexInternalPlanningCode;
   private TripAlteration netexAlteration;
 
@@ -47,7 +46,6 @@ public class TripBuilder extends AbstractEntityBuilder<Trip, TripBuilder> {
     this.bikesAllowed = original.getBikesAllowed();
     this.wheelchairBoarding = original.getWheelchairBoarding();
     this.netexInternalPlanningCode = original.getNetexInternalPlanningCode();
-    this.gtfsFareId = original.getGtfsFareId();
   }
 
   public Operator getOperator() {
@@ -173,15 +171,6 @@ public class TripBuilder extends AbstractEntityBuilder<Trip, TripBuilder> {
 
   public TripBuilder withNetexAlteration(TripAlteration netexAlteration) {
     this.netexAlteration = netexAlteration;
-    return this;
-  }
-
-  public String getGtfsFareId() {
-    return gtfsFareId;
-  }
-
-  public TripBuilder withGtfsFareId(String gtfsFareId) {
-    this.gtfsFareId = gtfsFareId;
     return this;
   }
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -23,7 +23,6 @@ public class TripMapperTest {
   private static final int BIKES_ALLOWED = 1;
   private static final String BLOCK_ID = "Block Id";
   private static final int DIRECTION_ID = 1;
-  private static final String FARE_ID = "Fare Id";
   private static final String TRIP_HEADSIGN = "Trip Headsign";
   private static final String TRIP_SHORT_NAME = "Trip Short Name";
 
@@ -46,7 +45,6 @@ public class TripMapperTest {
     TRIP.setBikesAllowed(BIKES_ALLOWED);
     TRIP.setBlockId(BLOCK_ID);
     TRIP.setDirectionId(Integer.toString(DIRECTION_ID));
-    TRIP.setFareId(FARE_ID);
     TRIP.setRoute(data.route);
     TRIP.setServiceId(AGENCY_AND_ID);
     TRIP.setShapeId(AGENCY_AND_ID);
@@ -69,7 +67,6 @@ public class TripMapperTest {
     assertEquals("A:1", result.getId().toString());
     assertEquals(BLOCK_ID, result.getGtfsBlockId());
     assertEquals(Direction.INBOUND, result.getDirection());
-    assertEquals(FARE_ID, result.getGtfsFareId());
     assertNotNull(result.getRoute());
     assertEquals("A:1", result.getServiceId().toString());
     assertEquals("A:1", result.getShapeId().toString());
@@ -91,7 +88,6 @@ public class TripMapperTest {
     assertNotNull(result.getRoute());
 
     assertNull(result.getGtfsBlockId());
-    assertNull(result.getGtfsFareId());
     assertNull(result.getServiceId());
     assertNull(result.getShapeId());
     assertNull(result.getHeadsign());

--- a/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
@@ -26,7 +26,6 @@ class TripTest {
   private static final BikeAccess BIKE_ACCESS = BikeAccess.ALLOWED;
   private static final TransitMode TRANSIT_MODE = TransitMode.BUS;
   private static final String BLOCK_ID = "blockId";
-  private static final String FARE_ID = "fareId";
   private static final TripAlteration TRIP_ALTERATION = TripAlteration.CANCELLATION;
   private static final String NETEX_SUBMODE_NAME = "submode";
   private static final SubMode NETEX_SUBMODE = SubMode.of(NETEX_SUBMODE_NAME);
@@ -46,7 +45,6 @@ class TripTest {
     .withBikesAllowed(BIKE_ACCESS)
     .withMode(TRANSIT_MODE)
     .withGtfsBlockId(BLOCK_ID)
-    .withGtfsFareId(FARE_ID)
     .withNetexAlteration(TRIP_ALTERATION)
     .withNetexSubmode(NETEX_SUBMODE_NAME)
     .withNetexInternalPlanningCode(NETEX_INTERNAL_PLANNING_CODE)
@@ -88,7 +86,6 @@ class TripTest {
     assertEquals(BIKE_ACCESS, copy.getBikesAllowed());
     assertEquals(TRANSIT_MODE, copy.getMode());
     assertEquals(BLOCK_ID, copy.getGtfsBlockId());
-    assertEquals(FARE_ID, copy.getGtfsFareId());
     assertEquals(TRIP_ALTERATION, copy.getNetexAlteration());
     assertEquals(NETEX_SUBMODE, copy.getNetexSubMode());
     assertEquals(NETEX_INTERNAL_PLANNING_CODE, copy.getNetexInternalPlanningCode());
@@ -115,7 +112,6 @@ class TripTest {
     assertFalse(subject.sameAs(subject.copy().withBikesAllowed(BikeAccess.NOT_ALLOWED).build()));
     assertFalse(subject.sameAs(subject.copy().withMode(TransitMode.RAIL).build()));
     assertFalse(subject.sameAs(subject.copy().withGtfsBlockId("X").build()));
-    assertFalse(subject.sameAs(subject.copy().withGtfsFareId("X").build()));
     assertFalse(
       subject.sameAs(subject.copy().withNetexAlteration(TripAlteration.REPLACED).build())
     );


### PR DESCRIPTION
### Summary

Today I noticed that there is a field on `Trip` which appears to be both non-standard and unused: the fare ID.

It's not used internally and only exposed through the REST API. I think it's fair to remove it.