### PR TITLE
SiriTimetableSnapshot tests

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriEtBuilder.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriEtBuilder.java
@@ -1,0 +1,262 @@
+package org.opentripplanner.ext.siri;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opentripplanner.DateTimeHelper;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.StopLocation;
+import uk.org.siri.siri20.DatedVehicleJourneyRef;
+import uk.org.siri.siri20.EstimatedCall;
+import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
+import uk.org.siri.siri20.EstimatedVehicleJourney;
+import uk.org.siri.siri20.EstimatedVersionFrameStructure;
+import uk.org.siri.siri20.LineRef;
+import uk.org.siri.siri20.OperatorRefStructure;
+import uk.org.siri.siri20.QuayRefStructure;
+import uk.org.siri.siri20.RecordedCall;
+import uk.org.siri.siri20.StopAssignmentStructure;
+import uk.org.siri.siri20.StopPointRef;
+import uk.org.siri.siri20.VehicleJourneyRef;
+
+/**
+ * This is a helper class for constucting Siri ET messages to use in tests.
+ */
+public class SiriEtBuilder {
+
+  private final EstimatedVehicleJourney evj;
+  private final DateTimeHelper dateTimeHelper;
+
+  public SiriEtBuilder(DateTimeHelper dateTimeHelper) {
+    this.dateTimeHelper = dateTimeHelper;
+    this.evj = new EstimatedVehicleJourney();
+
+    // Set default values
+    evj.setMonitored(true);
+  }
+
+  public List<EstimatedTimetableDeliveryStructure> buildEstimatedTimetableDeliveries() {
+    var versionFrame = new EstimatedVersionFrameStructure();
+    versionFrame.getEstimatedVehicleJourneies().add(evj);
+
+    var etd = new EstimatedTimetableDeliveryStructure();
+    etd.getEstimatedJourneyVersionFrames().add(versionFrame);
+    return List.of(etd);
+  }
+
+  public SiriEtBuilder withCancellation(boolean canceled) {
+    evj.setCancellation(canceled);
+    return this;
+  }
+
+  public SiriEtBuilder withMonitored(boolean monitored) {
+    evj.setMonitored(monitored);
+    return this;
+  }
+
+  public SiriEtBuilder withIsExtraJourney(boolean isExtraJourney) {
+    evj.setExtraJourney(isExtraJourney);
+    return this;
+  }
+
+  public SiriEtBuilder withDatedVehicleJourneyRef(String datedServiceJourneyId) {
+    var ref = new DatedVehicleJourneyRef();
+    ref.setValue(datedServiceJourneyId);
+    evj.setDatedVehicleJourneyRef(ref);
+    return this;
+  }
+
+  public SiriEtBuilder withEstimatedVehicleJourneyCode(String estimatedVehicleJourneyCode) {
+    evj.setEstimatedVehicleJourneyCode(estimatedVehicleJourneyCode);
+    return this;
+  }
+
+  public SiriEtBuilder withOperatorRef(String operatorRef) {
+    var ref = new OperatorRefStructure();
+    ref.setValue(operatorRef);
+    evj.setOperatorRef(ref);
+    return this;
+  }
+
+  public SiriEtBuilder withLineRef(String lineRef) {
+    var ref = new LineRef();
+    ref.setValue(lineRef);
+    evj.setLineRef(ref);
+    return this;
+  }
+
+  public SiriEtBuilder withRecordedCalls(
+    Function<RecordedCallsBuilder, RecordedCallsBuilder> producer
+  ) {
+    if (evj.getEstimatedCalls() != null) {
+      // If we call this after estimatedCalls, the ordering will be messed up
+      throw new RuntimeException(
+        "You need to call withRecordedCalls() before withEstimatedCalls()"
+      );
+    }
+    var builder = new RecordedCallsBuilder(dateTimeHelper, 0);
+
+    builder = producer.apply(builder);
+
+    var calls = new EstimatedVehicleJourney.RecordedCalls();
+    builder.build().forEach(call -> calls.getRecordedCalls().add(call));
+    evj.setRecordedCalls(calls);
+    return this;
+  }
+
+  public SiriEtBuilder withEstimatedCalls(
+    Function<EstimatedCallsBuilder, EstimatedCallsBuilder> producer
+  ) {
+    int offset = evj.getRecordedCalls() == null
+      ? 0
+      : evj.getRecordedCalls().getRecordedCalls().size();
+    var builder = new EstimatedCallsBuilder(dateTimeHelper, offset);
+
+    builder = producer.apply(builder);
+
+    var calls = new EstimatedVehicleJourney.EstimatedCalls();
+    builder.build().forEach(call -> calls.getEstimatedCalls().add(call));
+    evj.setEstimatedCalls(calls);
+    return this;
+  }
+
+  public SiriEtBuilder withVehicleJourneyRef(String id) {
+    var ref = new VehicleJourneyRef();
+    ref.setValue(id);
+    evj.setVehicleJourneyRef(ref);
+    return this;
+  }
+
+  public static class RecordedCallsBuilder {
+
+    private final ArrayList<RecordedCall> calls;
+    private final int orderOffset;
+    private final DateTimeHelper dateTimeHelper;
+
+    public RecordedCallsBuilder(DateTimeHelper dateTimeHelper, int orderOffset) {
+      this.dateTimeHelper = dateTimeHelper;
+      this.orderOffset = orderOffset;
+      this.calls = new ArrayList<>();
+    }
+
+    public RecordedCallsBuilder call(StopLocation stop) {
+      var call = new RecordedCall();
+      call.setOrder(BigInteger.valueOf(orderOffset + calls.size()));
+
+      var ref = new StopPointRef();
+      ref.setValue(stop.getId().getId());
+      call.setStopPointRef(ref);
+
+      calls.add(call);
+      return this;
+    }
+
+    public RecordedCallsBuilder arriveAimedActual(String aimedTime, String actualTime) {
+      var call = calls.getLast();
+      call.setAimedArrivalTime(dateTimeHelper.zonedDateTime(aimedTime));
+      call.setActualArrivalTime(dateTimeHelper.zonedDateTime(actualTime));
+      return this;
+    }
+
+    public RecordedCallsBuilder departAimedActual(String aimedTime, String actualTime) {
+      var call = calls.getLast();
+      call.setAimedDepartureTime(dateTimeHelper.zonedDateTime(aimedTime));
+      call.setActualDepartureTime(dateTimeHelper.zonedDateTime(actualTime));
+      return this;
+    }
+
+    public RecordedCallsBuilder withIsExtraCall(boolean extra) {
+      var call = calls.getLast();
+      call.setExtraCall(extra);
+      return this;
+    }
+
+    public RecordedCallsBuilder withIsCancellation(boolean cancel) {
+      var call = calls.getLast();
+      call.setCancellation(cancel);
+      return this;
+    }
+
+    public List<RecordedCall> build() {
+      return calls;
+    }
+  }
+
+  public static class EstimatedCallsBuilder {
+
+    private final ArrayList<EstimatedCall> calls;
+    private final int orderOffset;
+    private final DateTimeHelper dateTimeHelper;
+
+    public EstimatedCallsBuilder(DateTimeHelper dateTimeHelper, int orderOffset) {
+      this.dateTimeHelper = dateTimeHelper;
+      this.orderOffset = orderOffset;
+      this.calls = new ArrayList<>();
+    }
+
+    public EstimatedCallsBuilder call(StopLocation stop) {
+      var call = new EstimatedCall();
+      call.setOrder(BigInteger.valueOf(orderOffset + calls.size()));
+
+      var ref = new StopPointRef();
+      ref.setValue(stop.getId().getId());
+      call.setStopPointRef(ref);
+
+      calls.add(call);
+      return this;
+    }
+
+    public EstimatedCallsBuilder arriveAimedExpected(String aimedTime, String expectedTime) {
+      var call = calls.getLast();
+      call.setAimedArrivalTime(dateTimeHelper.zonedDateTime(aimedTime));
+      call.setExpectedArrivalTime(dateTimeHelper.zonedDateTime(expectedTime));
+      return this;
+    }
+
+    public EstimatedCallsBuilder departAimedExpected(String aimedTime, String expectedTime) {
+      var call = calls.getLast();
+      call.setAimedDepartureTime(dateTimeHelper.zonedDateTime(aimedTime));
+      call.setExpectedDepartureTime(dateTimeHelper.zonedDateTime(expectedTime));
+      return this;
+    }
+
+    public EstimatedCallsBuilder withIsExtraCall(boolean extra) {
+      var call = calls.getLast();
+      call.setExtraCall(extra);
+      return this;
+    }
+
+    public EstimatedCallsBuilder withIsCancellation(boolean cancel) {
+      var call = calls.getLast();
+      call.setCancellation(cancel);
+      return this;
+    }
+
+    public EstimatedCallsBuilder withArrivalStopAssignment(
+      RegularStop aimedQuay,
+      @Nullable RegularStop expectedQuay
+    ) {
+      var stopAssignmentStructure = new StopAssignmentStructure();
+
+      var aimed = new QuayRefStructure();
+      aimed.setValue(aimedQuay.getId().getId());
+      stopAssignmentStructure.setAimedQuayRef(aimed);
+
+      if (expectedQuay != null) {
+        var expected = new QuayRefStructure();
+        expected.setValue(expectedQuay.getId().getId());
+        stopAssignmentStructure.setExpectedQuayRef(expected);
+      }
+
+      var call = calls.getLast();
+      call.setArrivalStopAssignment(stopAssignmentStructure);
+      return this;
+    }
+
+    public List<EstimatedCall> build() {
+      return calls;
+    }
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
@@ -1,0 +1,523 @@
+package org.opentripplanner.ext.siri;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.DateTimeHelper;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.model.PickDrop;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.calendar.CalendarServiceData;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.Station;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.model.timetable.TripTimesFactory;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.updater.TimetableSnapshotSourceParameters;
+import org.opentripplanner.updater.spi.UpdateError;
+import org.opentripplanner.updater.spi.UpdateResult;
+import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
+
+class SiriTimetableSnapshotSourceTest {
+
+  // TODO testcases:
+  // Error case: Et message contains a call for stop that is not expected and is not marked as
+  //   extra call. This silently works currently by ignoring the extra call, but should probably fail.
+
+  @Test
+  void testCancelTrip() {
+    var env = new RealtimeTestEnvironment();
+
+    assertEquals(RealTimeState.SCHEDULED, env.getTripTimesForTrip(env.trip1).getRealTimeState());
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef(env.trip1.getId().getId())
+      .withCancellation(true)
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertEquals(1, result.successful());
+    assertEquals(RealTimeState.CANCELED, env.getTripTimesForTrip(env.trip1).getRealTimeState());
+  }
+
+  @Test
+  void testAddJourney() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withEstimatedVehicleJourneyCode("newJourney")
+      .withIsExtraJourney(true)
+      .withOperatorRef(env.operator1Id.getId())
+      .withLineRef(env.route1Id.getId())
+      .withRecordedCalls(builder -> builder.call(env.stopC1).departAimedActual("00:01", "00:02"))
+      .withEstimatedCalls(builder -> builder.call(env.stopD1).arriveAimedExpected("00:03", "00:04"))
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertEquals(1, result.successful());
+    var tripTimes = env.getTripTimesForTrip("newJourney");
+    assertEquals(RealTimeState.ADDED, tripTimes.getRealTimeState());
+    assertEquals(2 * 60, tripTimes.getDepartureTime(0));
+    assertEquals(4 * 60, tripTimes.getDepartureTime(1));
+  }
+
+  @Test
+  void testReplaceJourney() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withEstimatedVehicleJourneyCode("newJourney")
+      .withIsExtraJourney(true)
+      // replace trip1
+      .withVehicleJourneyRef(env.trip1.getId().getId())
+      .withOperatorRef(env.operator1Id.getId())
+      .withLineRef(env.route1Id.getId())
+      .withRecordedCalls(builder -> builder.call(env.stopA1).departAimedActual("00:01", "00:02"))
+      .withEstimatedCalls(builder -> builder.call(env.stopC1).arriveAimedExpected("00:03", "00:04"))
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertEquals(1, result.successful());
+
+    var tripTimes = env.getTripTimesForTrip("newJourney");
+    var pattern = env.getPatternForTrip(env.id("newJourney"));
+    assertEquals(RealTimeState.ADDED, tripTimes.getRealTimeState());
+    assertEquals(2 * 60, tripTimes.getDepartureTime(0));
+    assertEquals(4 * 60, tripTimes.getDepartureTime(1));
+    assertEquals(env.stopA1.getId(), pattern.getStop(0).getId());
+    assertEquals(env.stopC1.getId(), pattern.getStop(1).getId());
+
+    var originalTripTimes = env.getTripTimesForTrip(env.trip1);
+    assertEquals(RealTimeState.SCHEDULED, originalTripTimes.getRealTimeState());
+  }
+
+  /**
+   * Update calls without changing the pattern
+   */
+  @Test
+  void testUpdateJourney() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef(env.trip1.getId().getId())
+      .withRecordedCalls(builder ->
+        builder.call(env.stopA1).departAimedActual("00:00:11", "00:00:15")
+      )
+      .withEstimatedCalls(builder ->
+        builder.call(env.stopB1).arriveAimedExpected("00:00:20", "00:00:25")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertEquals(1, result.successful());
+
+    var tripTimes = env.getTripTimesForTrip(env.trip1);
+    assertEquals(RealTimeState.UPDATED, tripTimes.getRealTimeState());
+    assertEquals(11, tripTimes.getScheduledDepartureTime(0));
+    assertEquals(15, tripTimes.getDepartureTime(0));
+    assertEquals(20, tripTimes.getScheduledArrivalTime(1));
+    assertEquals(25, tripTimes.getArrivalTime(1));
+  }
+
+  /**
+   * Change quay on a trip
+   */
+  @Test
+  void testChangeQuay() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef(env.trip1.getId().getId())
+      .withRecordedCalls(builder ->
+        builder.call(env.stopA1).departAimedActual("00:00:11", "00:00:15")
+      )
+      .withEstimatedCalls(builder ->
+        builder.call(env.stopB2).arriveAimedExpected("00:00:20", "00:00:33")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertEquals(1, result.successful());
+
+    var pattern = env.getPatternForTrip(env.trip1.getId());
+    var tripTimes = env.getTripTimesForTrip(env.trip1);
+    assertEquals(RealTimeState.MODIFIED, tripTimes.getRealTimeState());
+    assertEquals(11, tripTimes.getScheduledDepartureTime(0));
+    assertEquals(15, tripTimes.getDepartureTime(0));
+    assertEquals(20, tripTimes.getScheduledArrivalTime(1));
+    assertEquals(33, tripTimes.getArrivalTime(1));
+    assertEquals(env.stopB2, pattern.getStop(1));
+  }
+
+  @Test
+  void testCancelStop() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef(env.trip2.getId().getId())
+      .withEstimatedCalls(builder ->
+        builder
+          .call(env.stopA1)
+          .departAimedExpected("00:01:01", "00:01:01")
+          .call(env.stopB1)
+          .withIsCancellation(true)
+          .call(env.stopC1)
+          .arriveAimedExpected("00:01:30", "00:01:30")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertEquals(1, result.successful());
+
+    var pattern = env.getPatternForTrip(env.trip2.getId());
+
+    assertEquals(PickDrop.SCHEDULED, pattern.getAlightType(0));
+    assertEquals(PickDrop.CANCELLED, pattern.getAlightType(1));
+    assertEquals(PickDrop.SCHEDULED, pattern.getAlightType(2));
+  }
+
+  // Ignore this for now since it isn't supported
+  // TODO: support this
+  // @Test
+  void testAddStop() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef(env.trip1.getId().getId())
+      .withRecordedCalls(builder ->
+        builder.call(env.stopA1).departAimedActual("00:00:11", "00:00:15")
+      )
+      .withEstimatedCalls(builder ->
+        builder
+          .call(env.stopD1)
+          .withIsExtraCall(true)
+          .arriveAimedExpected("00:00:19", "00:00:20")
+          .departAimedExpected("00:00:24", "00:00:25")
+          .call(env.stopB1)
+          .arriveAimedExpected("00:00:20", "00:00:33")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertEquals(1, result.successful());
+
+    var pattern = env.getPatternForTrip(env.trip1.getId());
+    var tripTimes = env.getTripTimesForTrip(env.trip1);
+    assertEquals(RealTimeState.MODIFIED, tripTimes.getRealTimeState());
+    assertEquals(11, tripTimes.getScheduledDepartureTime(0));
+    assertEquals(15, tripTimes.getDepartureTime(0));
+
+    // Should it work to get the scheduled times from an extra call?
+    assertEquals(19, tripTimes.getScheduledArrivalTime(1));
+    assertEquals(24, tripTimes.getScheduledDepartureTime(1));
+
+    assertEquals(20, tripTimes.getDepartureTime(1));
+    assertEquals(25, tripTimes.getDepartureTime(1));
+
+    assertEquals(20, tripTimes.getScheduledArrivalTime(2));
+    assertEquals(33, tripTimes.getArrivalTime(2));
+    assertEquals(List.of(env.stopA1, env.stopD1, env.stopB1), pattern.getStops());
+  }
+
+  /////////////////
+  // Error cases //
+  /////////////////
+
+  @Test
+  void testNotMonitored() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withMonitored(false)
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertFailure(result, UpdateError.UpdateErrorType.NOT_MONITORED);
+  }
+
+  @Test
+  void testReplaceJourneyWithoutEstimatedVehicleJourneyCode() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef("newJourney")
+      .withIsExtraJourney(true)
+      .withVehicleJourneyRef(env.trip1.getId().getId())
+      .withOperatorRef(env.operator1Id.getId())
+      .withLineRef(env.route1Id.getId())
+      .withEstimatedCalls(builder ->
+        builder
+          .call(env.stopA1)
+          .departAimedExpected("00:01", "00:02")
+          .call(env.stopC1)
+          .arriveAimedExpected("00:03", "00:04")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    // TODO: this should have a more specific error type
+    assertFailure(result, UpdateError.UpdateErrorType.UNKNOWN);
+  }
+
+  @Test
+  void testNegativeHopTime() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef(env.trip1.getId().getId())
+      .withRecordedCalls(builder ->
+        builder
+          .call(env.stopA1)
+          .departAimedActual("00:00:11", "00:00:15")
+          .call(env.stopB1)
+          .arriveAimedActual("00:00:20", "00:00:14")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertFailure(result, UpdateError.UpdateErrorType.NEGATIVE_HOP_TIME);
+  }
+
+  @Test
+  void testNegativeDwellTime() {
+    var env = new RealtimeTestEnvironment();
+
+    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+      .withDatedVehicleJourneyRef(env.trip2.getId().getId())
+      .withRecordedCalls(builder ->
+        builder
+          .call(env.stopA1)
+          .departAimedActual("00:01:01", "00:01:01")
+          .call(env.stopB1)
+          .arriveAimedActual("00:01:10", "00:01:13")
+          .departAimedActual("00:01:11", "00:01:12")
+          .call(env.stopB1)
+          .arriveAimedActual("00:01:20", "00:01:20")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = env.applyEstimatedTimetable(updates);
+
+    assertFailure(result, UpdateError.UpdateErrorType.NEGATIVE_DWELL_TIME);
+  }
+
+  private void assertFailure(UpdateResult result, UpdateError.UpdateErrorType errorType) {
+    assertEquals(result.failures().keySet(), Set.of(errorType));
+  }
+
+  private static class RealtimeTestEnvironment {
+
+    private final TransitModelForTest testModel = TransitModelForTest.of();
+    public final ZoneId timeZone = ZoneId.of(TransitModelForTest.TIME_ZONE_ID);
+    public final Station stationA = testModel.station("A").build();
+    public final Station stationB = testModel.station("B").build();
+    public final Station stationC = testModel.station("C").build();
+    public final Station stationD = testModel.station("D").build();
+    public final RegularStop stopA1 = testModel.stop("A1").withParentStation(stationA).build();
+    public final RegularStop stopB1 = testModel.stop("B1").withParentStation(stationB).build();
+    public final RegularStop stopB2 = testModel.stop("B2").withParentStation(stationB).build();
+    public final RegularStop stopC1 = testModel.stop("C1").withParentStation(stationC).build();
+    public final RegularStop stopD1 = testModel.stop("D1").withParentStation(stationD).build();
+    public final StopModel stopModel = testModel
+      .stopModelBuilder()
+      .withRegularStop(stopA1)
+      .withRegularStop(stopB1)
+      .withRegularStop(stopB2)
+      .withRegularStop(stopC1)
+      .withRegularStop(stopD1)
+      .build();
+
+    public final LocalDate serviceDate = LocalDate.of(2024, 5, 8);
+    public TransitModel transitModel;
+    public SiriTimetableSnapshotSource snapshotSource;
+
+    public final FeedScopedId operator1Id = TransitModelForTest.id("TestOperator1");
+    public final FeedScopedId route1Id = TransitModelForTest.id("TestRoute1");
+    public Trip trip1;
+    public Trip trip2;
+
+    public final DateTimeHelper dateTimeHelper = new DateTimeHelper(timeZone, serviceDate);
+
+    public RealtimeTestEnvironment() {
+      transitModel = new TransitModel(stopModel, new Deduplicator());
+      transitModel.initTimeZone(timeZone);
+      transitModel.addAgency(TransitModelForTest.AGENCY);
+
+      Route route1 = TransitModelForTest.route(route1Id).build();
+
+      trip1 =
+        createTrip(
+          "TestTrip1",
+          route1,
+          List.of(new Stop(stopA1, 10, 11), new Stop(stopB1, 20, 21))
+        );
+      trip2 =
+        createTrip(
+          "TestTrip2",
+          route1,
+          List.of(new Stop(stopA1, 60, 61), new Stop(stopB1, 70, 71), new Stop(stopC1, 80, 81))
+        );
+
+      CalendarServiceData calendarServiceData = new CalendarServiceData();
+      var cal_id = TransitModelForTest.id("CAL_1");
+      calendarServiceData.putServiceDatesForServiceId(
+        cal_id,
+        List.of(serviceDate.minusDays(1), serviceDate, serviceDate.plusDays(1))
+      );
+      transitModel.getServiceCodes().put(cal_id, 0);
+      transitModel.updateCalendarServiceData(true, calendarServiceData, DataImportIssueStore.NOOP);
+
+      transitModel.index();
+
+      var parameters = new TimetableSnapshotSourceParameters(Duration.ZERO, false);
+      snapshotSource = new SiriTimetableSnapshotSource(parameters, transitModel);
+    }
+
+    private record Stop(RegularStop stop, int arrivalTime, int departureTime) {}
+
+    private Trip createTrip(String id, Route route, List<Stop> stops) {
+      var trip = Trip.of(id(id)).withRoute(route).build();
+
+      var tripOnServiceDate = TripOnServiceDate
+        .of(trip.getId())
+        .withTrip(trip)
+        .withServiceDate(serviceDate)
+        .build();
+
+      transitModel.addTripOnServiceDate(tripOnServiceDate.getId(), tripOnServiceDate);
+
+      var stopTimes = IntStream
+        .range(0, stops.size())
+        .mapToObj(i -> {
+          var stop = stops.get(i);
+          return createStopTime(trip, i, stop.stop(), stop.arrivalTime(), stop.departureTime());
+        })
+        .collect(Collectors.toList());
+
+      TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, null);
+
+      final TripPattern pattern = TransitModelForTest
+        .tripPattern(id + "Pattern", route)
+        .withStopPattern(TransitModelForTest.stopPattern(stops.stream().map(Stop::stop).toList()))
+        .build();
+      pattern.add(tripTimes);
+
+      transitModel.addTripPattern(pattern.getId(), pattern);
+
+      return trip;
+    }
+
+    public FeedScopedId id(String id) {
+      return TransitModelForTest.id(id);
+    }
+
+    /**
+     * Returns a new fresh TransitService
+     */
+    public TransitService getTransitService() {
+      return new DefaultTransitService(transitModel);
+    }
+
+    public EntityResolver getEntityResolver() {
+      return new EntityResolver(getTransitService(), getFeedId());
+    }
+
+    public TripPattern getPatternForTrip(FeedScopedId tripId) {
+      return getPatternForTrip(tripId, serviceDate);
+    }
+
+    public TripPattern getPatternForTrip(FeedScopedId tripId, LocalDate serviceDate) {
+      var transitService = getTransitService();
+      var trip = transitService.getTripOnServiceDateById(tripId);
+      return transitService.getPatternForTrip(trip.getTrip(), serviceDate);
+    }
+
+    /**
+     * Find the current TripTimes for a trip id on the default serviceDate
+     */
+    public TripTimes getTripTimesForTrip(Trip trip) {
+      return getTripTimesForTrip(trip.getId(), serviceDate);
+    }
+
+    /**
+     * Find the current TripTimes for a trip id on the default serviceDate
+     */
+    public TripTimes getTripTimesForTrip(String id) {
+      return getTripTimesForTrip(id(id), serviceDate);
+    }
+
+    /**
+     * Find the current TripTimes for a trip id on a serviceDate
+     */
+    public TripTimes getTripTimesForTrip(FeedScopedId tripId, LocalDate serviceDate) {
+      var transitService = getTransitService();
+      var trip = transitService.getTripOnServiceDateById(tripId);
+      var pattern = transitService.getPatternForTrip(trip.getTrip(), serviceDate);
+      var timetable = transitService.getTimetableForTripPattern(pattern, serviceDate);
+      return timetable.getTripTimes(tripId);
+    }
+
+    public DateTimeHelper getDateTimeHelper() {
+      return dateTimeHelper;
+    }
+
+    private StopTime createStopTime(
+      Trip trip,
+      int stopSequence,
+      StopLocation stop,
+      int arrivalTime,
+      int departureTime
+    ) {
+      var st = new StopTime();
+      st.setTrip(trip);
+      st.setStopSequence(stopSequence);
+      st.setStop(stop);
+      st.setArrivalTime(arrivalTime);
+      st.setDepartureTime(departureTime);
+      return st;
+    }
+
+    public String getFeedId() {
+      return TransitModelForTest.FEED_ID;
+    }
+
+    public UpdateResult applyEstimatedTimetable(List<EstimatedTimetableDeliveryStructure> updates) {
+      return this.snapshotSource.applyEstimatedTimetable(
+          null,
+          getEntityResolver(),
+          getFeedId(),
+          false,
+          updates
+        );
+    }
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
@@ -503,10 +503,10 @@ class SiriTimetableSnapshotSourceTest {
      */
     public TripTimes getTripTimesForTrip(FeedScopedId tripId, LocalDate serviceDate) {
       var transitService = getTransitService();
-      var trip = transitService.getTripOnServiceDateById(tripId);
-      var pattern = transitService.getPatternForTrip(trip.getTrip(), serviceDate);
+      var trip = transitService.getTripOnServiceDateById(tripId).getTrip();
+      var pattern = transitService.getPatternForTrip(trip, serviceDate);
       var timetable = transitService.getTimetableForTripPattern(pattern, serviceDate);
-      return timetable.getTripTimes(tripId);
+      return timetable.getTripTimes(trip);
     }
 
     public DateTimeHelper getDateTimeHelper() {

--- a/src/ext/java/org/opentripplanner/ext/siri/EntityResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/EntityResolver.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Operator;
@@ -207,6 +208,7 @@ public class EntityResolver {
     return transitService.getOperatorForId(resolveId(operatorRef));
   }
 
+  @Nullable
   public LocalDate resolveServiceDate(EstimatedVehicleJourney vehicleJourney) {
     if (vehicleJourney.getFramedVehicleJourneyRef() != null) {
       var dataFrame = vehicleJourney.getFramedVehicleJourneyRef().getDataFrameRef();
@@ -227,15 +229,18 @@ public class EntityResolver {
       }
     }
 
-    ZonedDateTime date = CallWrapper.of(vehicleJourney).get(0).getAimedDepartureTime();
-
-    if (date == null) {
+    var datetime = CallWrapper
+      .of(vehicleJourney)
+      .stream()
+      .findFirst()
+      .map(CallWrapper::getAimedDepartureTime);
+    if (datetime.isEmpty()) {
       return null;
     }
 
     var daysOffset = calculateDayOffset(vehicleJourney);
 
-    return date.toLocalDate().minusDays(daysOffset);
+    return datetime.get().toLocalDate().minusDays(daysOffset);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/framework/time/DateUtils.java
+++ b/src/main/java/org/opentripplanner/framework/time/DateUtils.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,7 @@ public class DateUtils {
    * Returns a Date object based on input date and time parameters Defaults to today / now (when
    * date / time are null)
    */
+  @Nullable
   public static ZonedDateTime toZonedDateTime(String date, String time, ZoneId tz) {
     //LOG.debug("JVM default timezone is {}", TimeZone.getDefault());
     LOG.debug("Parsing date {} and time {}", date, time);
@@ -179,7 +181,18 @@ public class DateUtils {
     }
   }
 
-  private static LocalTime parseTime(String time) {
+  /**
+   * Parse a time string on different formats:
+   *
+   * <pre>
+   * Hour Minute Second      "10:02:03"
+   * Hour Minute             "10:02"
+   * Seconds past midningt   "3600"
+   * AM / PM                 "11:30 PM"
+   * </pre>
+   */
+  @Nullable
+  public static LocalTime parseTime(String time) {
     boolean amPm = false;
     int addHours = 0;
     int hour = 0, min = 0, sec = 0;

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -126,7 +126,7 @@ public class Timetable implements Serializable {
 
   public TripTimes getTripTimes(FeedScopedId tripId) {
     for (TripTimes tt : tripTimes) {
-      if (tt.getTrip().getId() == tripId) {
+      if (tt.getTrip().getId().equals(tripId)) {
         return tt;
       }
     }

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -126,7 +126,7 @@ public class Timetable implements Serializable {
 
   public TripTimes getTripTimes(FeedScopedId tripId) {
     for (TripTimes tt : tripTimes) {
-      if (tt.getTrip().getId().equals(tripId)) {
+      if (tt.getTrip().getId() == tripId) {
         return tt;
       }
     }

--- a/src/test/java/org/opentripplanner/DateTimeHelper.java
+++ b/src/test/java/org/opentripplanner/DateTimeHelper.java
@@ -1,0 +1,30 @@
+package org.opentripplanner;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.opentripplanner.framework.time.DateUtils;
+
+public class DateTimeHelper {
+
+  private final ZoneId zone;
+  private final LocalDate defaultDate;
+
+  public DateTimeHelper(ZoneId zone, LocalDate defaultDate) {
+    this.zone = zone;
+    this.defaultDate = defaultDate;
+  }
+
+  /**
+   * Create a zoned datetime from a time string using the default date and timezone
+   *
+   * @throws IllegalArgumentException if we can't parse the string as a time.
+   */
+  public ZonedDateTime zonedDateTime(String timeString) {
+    var time = DateUtils.parseTime(timeString);
+    if (time == null) {
+      throw new IllegalArgumentException("Invalid time format");
+    }
+    return defaultDate.atTime(time).atZone(zone);
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -229,9 +229,13 @@ public class TransitModelForTest {
   }
 
   public static StopPattern stopPattern(RegularStop... stops) {
-    var builder = StopPattern.create(stops.length);
-    for (int i = 0; i < stops.length; i++) {
-      builder.stops.with(i, stops[i]);
+    return stopPattern(Arrays.asList(stops));
+  }
+
+  public static StopPattern stopPattern(List<RegularStop> stops) {
+    var builder = StopPattern.create(stops.size());
+    for (int i = 0; i < stops.size(); i++) {
+      builder.stops.with(i, stops.get(i));
       builder.pickups.with(i, PickDrop.SCHEDULED);
       builder.dropoffs.with(i, PickDrop.SCHEDULED);
     }


### PR DESCRIPTION
This PR is part of the realtime refactor work.

It mainly contains tests for SiriTimetableSnapshotSource. The purpose is to:
1) Verify that the transit model is updated correctly given different siri ET messages.
2) Make it easier to refactor the realtime behaviour without breaking functionality.
3) Document existing behaviour.

Currently the tests are on a pretty high level and basically generate Siri ET messages, apply them using SiriTimetableSnapshotSource and then verify the changes to the realtime parts of the transit model.

There are also two minor bugfixes:
- ~~Comparison of feedId in timetable.~~ (moved this to a separate PR)
- NPE fix in `EntityResolver.resolveServiceDate()` when the list of calls is empty.