### PR TITLE
Small clean up of flex duration factor/offset

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexTripsMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexTripsMapperTest.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.ext.flex;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.graph_builder.issue.api.DataImportIssueStore.NOOP;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.service.StopModel;
+
+class FlexTripsMapperTest {
+
+  @Test
+  void defaultTimePenalty() {
+    var builder = new OtpTransitServiceBuilder(StopModel.of().build(), NOOP);
+    var stopTimes = List.of(stopTime(0), stopTime(1));
+    builder.getStopTimesSortedByTrip().addAll(stopTimes);
+    var trips = FlexTripsMapper.createFlexTrips(builder, NOOP);
+    assertEquals("[UnscheduledTrip{F:flex-1 timePenalty=(0s + 1.00 t)}]", trips.toString());
+  }
+
+  private static StopTime stopTime(int seq) {
+    var st = FlexStopTimesForTest.area("08:00", "18:00");
+    st.setTrip(TransitModelForTest.trip("flex-1").build());
+    st.setStopSequence(seq);
+    return st;
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPathTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPathTest.java
@@ -21,7 +21,7 @@ class FlexPathTest {
 
   static List<Arguments> cases() {
     return List.of(
-      Arguments.of(TimePenalty.ZERO, THIRTY_MINS_IN_SECONDS),
+      Arguments.of(TimePenalty.NONE, THIRTY_MINS_IN_SECONDS),
       Arguments.of(TimePenalty.of(Duration.ofMinutes(10), 1), 2400),
       Arguments.of(TimePenalty.of(Duration.ofMinutes(10), 1.5f), 3300),
       Arguments.of(TimePenalty.of(Duration.ZERO, 3), 5400)

--- a/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPathTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPathTest.java
@@ -30,8 +30,8 @@ class FlexPathTest {
 
   @ParameterizedTest
   @MethodSource("cases")
-  void calculate(TimePenalty mod, int expectedSeconds) {
-    var modified = PATH.withDurationModifier(mod);
+  void calculate(TimePenalty penalty, int expectedSeconds) {
+    var modified = PATH.withTimePenalty(penalty);
     assertEquals(expectedSeconds, modified.durationSeconds);
     assertEquals(LineStrings.SIMPLE, modified.getGeometry());
   }

--- a/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
@@ -1,10 +1,14 @@
-package org.opentripplanner.ext.flex;
+package org.opentripplanner.ext.flex.trip;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.opentripplanner.graph_builder.issue.api.DataImportIssueStore.NOOP;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.flex.FlexStopTimesForTest;
+import org.opentripplanner.ext.flex.FlexTripsMapper;
+import org.opentripplanner.ext.flex.flexpathcalculator.DirectFlexPathCalculator;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -18,7 +22,10 @@ class FlexTripsMapperTest {
     var stopTimes = List.of(stopTime(0), stopTime(1));
     builder.getStopTimesSortedByTrip().addAll(stopTimes);
     var trips = FlexTripsMapper.createFlexTrips(builder, NOOP);
-    assertEquals("[UnscheduledTrip{F:flex-1 timePenalty=(0s + 1.00 t)}]", trips.toString());
+    assertEquals("[UnscheduledTrip{F:flex-1}]", trips.toString());
+    var unscheduled = (UnscheduledTrip) trips.getFirst();
+    var unchanged = unscheduled.flexPathCalculator(new DirectFlexPathCalculator());
+    assertInstanceOf(DirectFlexPathCalculator.class, unchanged);
   }
 
   private static StopTime stopTime(int seq) {

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPath.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPath.java
@@ -41,12 +41,8 @@ public class FlexPath {
   /**
    * Returns an (immutable) copy of this path with the duration modified.
    */
-  public FlexPath withTimePenalty(TimePenalty mod) {
-    if (mod.isZero()) {
-      return this;
-    } else {
-      int updatedDuration = (int) mod.calculate(Duration.ofSeconds(durationSeconds)).toSeconds();
-      return new FlexPath(distanceMeters, updatedDuration, geometrySupplier);
-    }
+  public FlexPath withTimePenalty(TimePenalty penalty) {
+    int updatedDuration = (int) penalty.calculate(Duration.ofSeconds(durationSeconds)).toSeconds();
+    return new FlexPath(distanceMeters, updatedDuration, geometrySupplier);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPath.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPath.java
@@ -41,7 +41,7 @@ public class FlexPath {
   /**
    * Returns an (immutable) copy of this path with the duration modified.
    */
-  public FlexPath withDurationModifier(TimePenalty mod) {
+  public FlexPath withTimePenalty(TimePenalty mod) {
     if (mod.isZero()) {
       return this;
     } else {

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/TimePenaltyCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/TimePenaltyCalculator.java
@@ -11,11 +11,11 @@ import org.opentripplanner.street.model.vertex.Vertex;
 public class TimePenaltyCalculator implements FlexPathCalculator {
 
   private final FlexPathCalculator delegate;
-  private final TimePenalty factors;
+  private final TimePenalty penalty;
 
   public TimePenaltyCalculator(FlexPathCalculator delegate, TimePenalty penalty) {
     this.delegate = delegate;
-    this.factors = penalty;
+    this.penalty = penalty;
   }
 
   @Nullable
@@ -26,7 +26,7 @@ public class TimePenaltyCalculator implements FlexPathCalculator {
     if (path == null) {
       return null;
     } else {
-      return path.withDurationModifier(factors);
+      return path.withTimePenalty(penalty);
     }
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/TimePenaltyCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/TimePenaltyCalculator.java
@@ -5,8 +5,8 @@ import org.opentripplanner.routing.api.request.framework.TimePenalty;
 import org.opentripplanner.street.model.vertex.Vertex;
 
 /**
- * A calculator to delegates the main computation to another instance and applies a duration
- * modifier afterward.
+ * A calculator to delegates the main computation to another instance and applies a time penalty
+ * afterward.
  */
 public class TimePenaltyCalculator implements FlexPathCalculator {
 

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.flex.FlexServiceDate;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.TimePenaltyCalculator;
@@ -29,6 +30,7 @@ import org.opentripplanner.routing.api.request.framework.TimePenalty;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.standalone.config.sandbox.FlexConfig;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.framework.LogInfo;
 import org.opentripplanner.transit.model.framework.TransitBuilder;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -45,7 +47,9 @@ import org.opentripplanner.transit.model.site.StopLocation;
  * <p>
  * For a discussion of this behaviour see https://github.com/MobilityData/gtfs-flex/issues/76
  */
-public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBuilder> {
+public class UnscheduledTrip
+  extends FlexTrip<UnscheduledTrip, UnscheduledTripBuilder>
+  implements LogInfo {
 
   private static final Set<Integer> N_STOPS = Set.of(1, 2);
   private static final int INDEX_NOT_FOUND = -1;
@@ -152,6 +156,12 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
           config
         )
       );
+  }
+
+  @Nullable
+  @Override
+  public String logName() {
+    return "timePenalty=(%s)".formatted(timePenalty.toString());
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -166,7 +166,7 @@ public class UnscheduledTrip
 
   /**
    * Get the correct {@link FlexPathCalculator} depending on the {@code timePenalty}.
-   * If the modifier doesn't actually modify, we return the regular calculator.
+   * If the penalty would not change the result, we return the regular calculator.
    */
   protected FlexPathCalculator flexPathCalculator(FlexPathCalculator calculator) {
     if (timePenalty.modifies()) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.opentripplanner.ext.flex.FlexServiceDate;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.TimePenaltyCalculator;
@@ -30,7 +29,6 @@ import org.opentripplanner.routing.api.request.framework.TimePenalty;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.standalone.config.sandbox.FlexConfig;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.framework.LogInfo;
 import org.opentripplanner.transit.model.framework.TransitBuilder;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -47,9 +45,7 @@ import org.opentripplanner.transit.model.site.StopLocation;
  * <p>
  * For a discussion of this behaviour see https://github.com/MobilityData/gtfs-flex/issues/76
  */
-public class UnscheduledTrip
-  extends FlexTrip<UnscheduledTrip, UnscheduledTripBuilder>
-  implements LogInfo {
+public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBuilder> {
 
   private static final Set<Integer> N_STOPS = Set.of(1, 2);
   private static final int INDEX_NOT_FOUND = -1;
@@ -156,12 +152,6 @@ public class UnscheduledTrip
           config
         )
       );
-  }
-
-  @Nullable
-  @Override
-  public String logName() {
-    return "timePenalty=(%s)".formatted(timePenalty.toString());
   }
 
   /**

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -171,7 +171,7 @@ public class GTFSToOtpTransitServiceMapper {
 
     builder.getPathways().addAll(pathwayMapper.map(data.getAllPathways()));
     builder.getStopTimesSortedByTrip().addAll(stopTimeMapper.map(data.getAllStopTimes()));
-    builder.getFlexTimePenalty().putAll(tripMapper.flexSafeDurationModifiers());
+    builder.getFlexTimePenalty().putAll(tripMapper.flexSafeTimePenalties());
     builder.getTripsById().addAll(tripMapper.map(data.getAllTrips()));
 
     fareRulesBuilder.fareAttributes().addAll(fareAttributeMapper.map(data.getAllFareAttributes()));

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -18,7 +18,7 @@ class TripMapper {
   private final TranslationHelper translationHelper;
 
   private final Map<org.onebusaway.gtfs.model.Trip, Trip> mappedTrips = new HashMap<>();
-  private final Map<Trip, TimePenalty> flexSafeDurationModifiers = new HashMap<>();
+  private final Map<Trip, TimePenalty> flexSafeTimePenalties = new HashMap<>();
 
   TripMapper(
     RouteMapper routeMapper,
@@ -45,8 +45,8 @@ class TripMapper {
   /**
    * The map of flex duration factors per flex trip.
    */
-  Map<Trip, TimePenalty> flexSafeDurationModifiers() {
-    return flexSafeDurationModifiers;
+  Map<Trip, TimePenalty> flexSafeTimePenalties() {
+    return flexSafeTimePenalties;
   }
 
   private Trip doMap(org.onebusaway.gtfs.model.Trip rhs) {
@@ -73,11 +73,11 @@ class TripMapper {
     lhs.withBikesAllowed(BikeAccessMapper.mapForTrip(rhs));
 
     var trip = lhs.build();
-    mapSafeDurationModifier(rhs).ifPresent(f -> flexSafeDurationModifiers.put(trip, f));
+    mapSafeTimePenalty(rhs).ifPresent(f -> flexSafeTimePenalties.put(trip, f));
     return trip;
   }
 
-  private Optional<TimePenalty> mapSafeDurationModifier(org.onebusaway.gtfs.model.Trip rhs) {
+  private Optional<TimePenalty> mapSafeTimePenalty(org.onebusaway.gtfs.model.Trip rhs) {
     if (rhs.getSafeDurationFactor() == null && rhs.getSafeDurationOffset() == null) {
       return Optional.empty();
     } else {

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -94,7 +94,7 @@ public class OtpTransitServiceBuilder {
 
   private final TripStopTimes stopTimesByTrip = new TripStopTimes();
 
-  private final Map<Trip, TimePenalty> flexDurationFactors = new HashMap<>();
+  private final Map<Trip, TimePenalty> flexTimePenalties = new HashMap<>();
 
   private final EntityById<FareZone> fareZonesById = new DefaultEntityById<>();
 
@@ -214,7 +214,7 @@ public class OtpTransitServiceBuilder {
   }
 
   public Map<Trip, TimePenalty> getFlexTimePenalty() {
-    return flexDurationFactors;
+    return flexTimePenalties;
   }
 
   public EntityById<FareZone> getFareZonesById() {

--- a/src/main/java/org/opentripplanner/routing/api/request/framework/TimePenalty.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/framework/TimePenalty.java
@@ -7,6 +7,9 @@ import org.opentripplanner.framework.time.DurationUtils;
 public final class TimePenalty extends AbstractLinearFunction<Duration> {
 
   public static final TimePenalty ZERO = new TimePenalty(Duration.ZERO, 0.0);
+  /**
+   * An instance that doesn't actually apply a penalty and returns the duration unchanged.
+   */
   public static final TimePenalty NONE = new TimePenalty(Duration.ZERO, 1.0);
 
   private TimePenalty(Duration constant, double coefficient) {

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -126,8 +126,8 @@ public class TripMapperTest {
     flexTrip.setRoute(new GtfsTestData().route);
     var mapper = defaultTripMapper();
     var mapped = mapper.map(flexTrip);
-    var mod = mapper.flexSafeTimePenalties().get(mapped);
-    assertEquals(1.5f, mod.coefficient());
-    assertEquals(600, mod.constant().toSeconds());
+    var penalty = mapper.flexSafeTimePenalties().get(mapped);
+    assertEquals(1.5f, penalty.coefficient());
+    assertEquals(600, penalty.constant().toSeconds());
   }
 }

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -111,14 +111,14 @@ public class TripMapperTest {
   }
 
   @Test
-  void noFlexDurationModifier() {
+  void noFlexTimePenalty() {
     var mapper = defaultTripMapper();
     mapper.map(TRIP);
-    assertTrue(mapper.flexSafeDurationModifiers().isEmpty());
+    assertTrue(mapper.flexSafeTimePenalties().isEmpty());
   }
 
   @Test
-  void flexDurationModifier() {
+  void flexTimePenalty() {
     var flexTrip = new Trip();
     flexTrip.setId(new AgencyAndId("1", "1"));
     flexTrip.setSafeDurationFactor(1.5);
@@ -126,7 +126,7 @@ public class TripMapperTest {
     flexTrip.setRoute(new GtfsTestData().route);
     var mapper = defaultTripMapper();
     var mapped = mapper.map(flexTrip);
-    var mod = mapper.flexSafeDurationModifiers().get(mapped);
+    var mod = mapper.flexSafeTimePenalties().get(mapped);
     assertEquals(1.5f, mod.coefficient());
     assertEquals(600, mod.constant().toSeconds());
   }


### PR DESCRIPTION
### Summary

After merging of #5796 I realised that I missed a couple of renames where I still used the old name for time penalty (modifier, factors). This is fixed in this PR.

I also cleaned up the modifcation logic a bit: the check for `isZero` is no longer necessary as the default is a value that doesn't modify at all.

Lastly, I added a test that makes sure that the mapper sets the correct default value.