### PR TITLE
Fix comparison of feedId

### DIFF
--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -126,7 +126,7 @@ public class Timetable implements Serializable {
 
   public TripTimes getTripTimes(FeedScopedId tripId) {
     for (TripTimes tt : tripTimes) {
-      if (tt.getTrip().getId() == tripId) {
+      if (tt.getTrip().getId().equals(tripId)) {
         return tt;
       }
     }

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -67,6 +67,12 @@ public class TimetableTest {
   }
 
   @Test
+  public void getGetTripTimes() {
+    var tt = timetable.getTripTimes(new FeedScopedId(feedId, TRIP_ID));
+    assertNotNull(tt);
+  }
+
+  @Test
   public void tripNotFoundInPattern() {
     // non-existing trip
     var tripDescriptorBuilder = tripDescriptorBuilder("b");


### PR DESCRIPTION
### Summary

Change comparison of feedId in Triptimes to use `.equals()` instead of `==`. In practice it doesn't cause any issues currently, but the current code is dangerous since anyone using this method will expect structural comparison.

Discussion:
There was some concern raised that the original code might use `==` for performance reasons. But for that case there is a method `getTripTimes(Trip trip)` that uses referential equality and then we could change the performance critical code to use that method instead.

### Unit tests

Added a unit test to illustrate the issue.

### Bumping the serialization version id

Nope
