### PR TITLE
Realtime stops vectortile layer checks whether there are stoptimes on the service day

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -46,6 +46,7 @@ public class RealtimeStopsLayerTest {
         .withName(name)
         .withDescription(desc)
         .withCoordinate(50, 10)
+        .withTimeZone(ZoneIds.HELSINKI)
         .build();
     stop2 =
       StopModel
@@ -54,6 +55,7 @@ public class RealtimeStopsLayerTest {
         .withName(name)
         .withDescription(desc)
         .withCoordinate(51, 10)
+        .withTimeZone(ZoneIds.HELSINKI)
         .build();
   }
 
@@ -100,5 +102,6 @@ public class RealtimeStopsLayerTest {
     assertEquals("name", map.get("name"));
     assertEquals("desc", map.get("desc"));
     assertEquals(true, map.get("closedByServiceAlert"));
+    assertEquals(true, map.get("noServiceOnServiceDay"));
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -102,6 +102,6 @@ public class RealtimeStopsLayerTest {
     assertEquals("name", map.get("name"));
     assertEquals("desc", map.get("desc"));
     assertEquals(true, map.get("closedByServiceAlert"));
-    assertEquals(true, map.get("noServiceOnServiceDay"));
+    assertEquals(false, map.get("servicesRunningOnServiceDay"));
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -102,6 +102,6 @@ public class RealtimeStopsLayerTest {
     assertEquals("name", map.get("name"));
     assertEquals("desc", map.get("desc"));
     assertEquals(true, map.get("closedByServiceAlert"));
-    assertEquals(false, map.get("servicesRunningOnServiceDay"));
+    assertEquals(false, map.get("servicesRunningOnServiceDate"));
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.vectortiles.layers.stops;
 import static org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper.getBaseKeyValues;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -10,6 +11,7 @@ import org.opentripplanner.apis.support.mapping.PropertyMapper;
 import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.framework.i18n.I18NStringMapper;
 import org.opentripplanner.inspector.vector.KeyValue;
+import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -32,10 +34,19 @@ public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<Regula
       .stream()
       .anyMatch(alert -> alert.noServiceAt(currentTime));
 
+    var serviceDate = LocalDate.ofInstant(currentTime, transitService.getTimeZone());
+    boolean stopTimesExist = transitService
+      .getStopTimesForStop(stop, serviceDate, ArrivalDeparture.BOTH, true)
+      .stream()
+      .anyMatch(stopTime -> stopTime.times.size() > 0);
+
     Collection<KeyValue> sharedKeyValues = getBaseKeyValues(stop, i18NStringMapper, transitService);
     return ListUtils.combine(
       sharedKeyValues,
-      List.of(new KeyValue("closedByServiceAlert", noServiceAlert))
+      List.of(
+        new KeyValue("closedByServiceAlert", noServiceAlert),
+        new KeyValue("noServiceOnServiceDay", !stopTimesExist)
+      )
     );
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -34,7 +34,7 @@ public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<Regula
       .stream()
       .anyMatch(alert -> alert.noServiceAt(currentTime));
 
-    var serviceDate = LocalDate.ofInstant(currentTime, transitService.getTimeZone());
+    var serviceDate = LocalDate.now(transitService.getTimeZone());
     boolean stopTimesExist = transitService
       .getStopTimesForStop(stop, serviceDate, ArrivalDeparture.BOTH, true)
       .stream()

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -45,7 +45,7 @@ public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<Regula
       sharedKeyValues,
       List.of(
         new KeyValue("closedByServiceAlert", noServiceAlert),
-        new KeyValue("servicesRunningOnServiceDay", stopTimesExist)
+        new KeyValue("servicesRunningOnServiceDate", stopTimesExist)
       )
     );
   }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -45,7 +45,7 @@ public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<Regula
       sharedKeyValues,
       List.of(
         new KeyValue("closedByServiceAlert", noServiceAlert),
-        new KeyValue("noServiceOnServiceDay", !stopTimesExist)
+        new KeyValue("servicesRunningOnServiceDay", stopTimesExist)
       )
     );
   }


### PR DESCRIPTION
## PR Instructions

### Summary

A badge needs to be displayed on the map for stops without traffic on the service day. The vectortile layer for realtime stops checks if stop times exist for a particular stop and returns the result.

### Issue

- A badge needs to be displayed on the map for stops without traffic on the service day. 

### Unit tests

- Added the new value to the RealtimeStopsLayerTest.
- Functionality was manually verified.


