### PR TITLE
Fix handling of missing aimed departure time

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriEtBuilder.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriEtBuilder.java
@@ -248,21 +248,23 @@ public class SiriEtBuilder {
 
     public EstimatedCallsBuilder arriveAimedExpected(String aimedTime, String expectedTime) {
       var call = calls.getLast();
-      call.setAimedArrivalTime(aimedTime == null ? null : dateTimeHelper.zonedDateTime(aimedTime));
-      call.setExpectedArrivalTime(
-        expectedTime == null ? null : dateTimeHelper.zonedDateTime(expectedTime)
-      );
+      if (aimedTime != null) {
+        call.setAimedArrivalTime(dateTimeHelper.zonedDateTime(aimedTime));
+      }
+      if (expectedTime != null) {
+        call.setExpectedArrivalTime(dateTimeHelper.zonedDateTime(expectedTime));
+      }
       return this;
     }
 
     public EstimatedCallsBuilder departAimedExpected(String aimedTime, String expectedTime) {
       var call = calls.getLast();
-      call.setAimedDepartureTime(
-        aimedTime == null ? null : dateTimeHelper.zonedDateTime(aimedTime)
-      );
-      call.setExpectedDepartureTime(
-        expectedTime == null ? null : dateTimeHelper.zonedDateTime(expectedTime)
-      );
+      if (aimedTime != null) {
+        call.setAimedDepartureTime(dateTimeHelper.zonedDateTime(aimedTime));
+      }
+      if (expectedTime != null) {
+        call.setExpectedDepartureTime(dateTimeHelper.zonedDateTime(expectedTime));
+      }
       return this;
     }
 

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriEtBuilder.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriEtBuilder.java
@@ -159,7 +159,9 @@ public class SiriEtBuilder {
 
     public FramedVehicleJourneyRefStructure build() {
       DataFrameRefStructure dataFrameRefStructure = new DataFrameRefStructure();
-      dataFrameRefStructure.setValue(DateTimeFormatter.ISO_LOCAL_DATE.format(serviceDate));
+      if (serviceDate != null) {
+        dataFrameRefStructure.setValue(DateTimeFormatter.ISO_LOCAL_DATE.format(serviceDate));
+      }
       FramedVehicleJourneyRefStructure framedVehicleJourneyRefStructure = new FramedVehicleJourneyRefStructure();
       framedVehicleJourneyRefStructure.setDataFrameRef(dataFrameRefStructure);
       framedVehicleJourneyRefStructure.setDatedVehicleJourneyRef(vehicleJourneyRef);
@@ -246,7 +248,10 @@ public class SiriEtBuilder {
       return this;
     }
 
-    public EstimatedCallsBuilder arriveAimedExpected(String aimedTime, String expectedTime) {
+    public EstimatedCallsBuilder arriveAimedExpected(
+      @Nullable String aimedTime,
+      @Nullable String expectedTime
+    ) {
       var call = calls.getLast();
       if (aimedTime != null) {
         call.setAimedArrivalTime(dateTimeHelper.zonedDateTime(aimedTime));
@@ -257,7 +262,10 @@ public class SiriEtBuilder {
       return this;
     }
 
-    public EstimatedCallsBuilder departAimedExpected(String aimedTime, String expectedTime) {
+    public EstimatedCallsBuilder departAimedExpected(
+      @Nullable String aimedTime,
+      @Nullable String expectedTime
+    ) {
       var call = calls.getLast();
       if (aimedTime != null) {
         call.setAimedDepartureTime(dateTimeHelper.zonedDateTime(aimedTime));

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
@@ -588,7 +588,8 @@ class SiriTimetableSnapshotSourceTest {
     public UpdateResult applyEstimatedTimetableWithFuzzyMatcher(
       List<EstimatedTimetableDeliveryStructure> updates
     ) {
-      return applyEstimatedTimetable(updates, SiriFuzzyTripMatcher.of(getTransitService()));
+      SiriFuzzyTripMatcher siriFuzzyTripMatcher = new SiriFuzzyTripMatcher(getTransitService());
+      return applyEstimatedTimetable(updates, siriFuzzyTripMatcher);
     }
 
     private UpdateResult applyEstimatedTimetable(

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.DateTimeHelper;
@@ -41,15 +40,10 @@ import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
 
 class SiriTimetableSnapshotSourceTest {
 
-  private RealtimeTestEnvironment env;
-
-  @BeforeEach
-  void setUp() {
-    env = new RealtimeTestEnvironment();
-  }
-
   @Test
   void testCancelTrip() {
+    var env = new RealtimeTestEnvironment();
+
     assertEquals(RealTimeState.SCHEDULED, env.getTripTimesForTrip(env.trip1).getRealTimeState());
 
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
@@ -65,6 +59,8 @@ class SiriTimetableSnapshotSourceTest {
 
   @Test
   void testAddJourney() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withEstimatedVehicleJourneyCode("newJourney")
       .withIsExtraJourney(true)
@@ -85,6 +81,8 @@ class SiriTimetableSnapshotSourceTest {
 
   @Test
   void testReplaceJourney() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withEstimatedVehicleJourneyCode("newJourney")
       .withIsExtraJourney(true)
@@ -117,6 +115,8 @@ class SiriTimetableSnapshotSourceTest {
    */
   @Test
   void testUpdateJourneyWithDatedVehicleJourneyRef() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = updatedJourneyBuilder(env)
       .withDatedVehicleJourneyRef(env.trip1.getId().getId())
       .buildEstimatedTimetableDeliveries();
@@ -130,6 +130,8 @@ class SiriTimetableSnapshotSourceTest {
    */
   @Test
   void testUpdateJourneyWithFramedVehicleJourneyRef() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = updatedJourneyBuilder(env)
       .withFramedVehicleJourneyRef(builder ->
         builder.withServiceDate(env.serviceDate).withVehicleJourneyRef(env.trip1.getId().getId())
@@ -145,6 +147,8 @@ class SiriTimetableSnapshotSourceTest {
    */
   @Test
   void testUpdateJourneyWithoutJourneyRef() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = updatedJourneyBuilder(env).buildEstimatedTimetableDeliveries();
     var result = env.applyEstimatedTimetable(updates);
     assertEquals(0, result.successful());
@@ -155,6 +159,8 @@ class SiriTimetableSnapshotSourceTest {
    */
   @Test
   void testUpdateJourneyWithFuzzyMatching() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = updatedJourneyBuilder(env).buildEstimatedTimetableDeliveries();
     var result = env.applyEstimatedTimetableWithFuzzyMatcher(updates);
     assertEquals(1, result.successful());
@@ -167,6 +173,8 @@ class SiriTimetableSnapshotSourceTest {
    */
   @Test
   void testUpdateJourneyWithFuzzyMatchingAndMissingAimedDepartureTime() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withFramedVehicleJourneyRef(builder ->
         builder.withServiceDate(env.serviceDate).withVehicleJourneyRef("XXX")
@@ -189,6 +197,8 @@ class SiriTimetableSnapshotSourceTest {
    */
   @Test
   void testChangeQuay() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef(env.trip1.getId().getId())
       .withRecordedCalls(builder ->
@@ -215,6 +225,8 @@ class SiriTimetableSnapshotSourceTest {
 
   @Test
   void testCancelStop() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef(env.trip2.getId().getId())
       .withEstimatedCalls(builder ->
@@ -243,6 +255,8 @@ class SiriTimetableSnapshotSourceTest {
   @Test
   @Disabled("Not supported yet")
   void testAddStop() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef(env.trip1.getId().getId())
       .withRecordedCalls(builder ->
@@ -287,6 +301,8 @@ class SiriTimetableSnapshotSourceTest {
 
   @Test
   void testNotMonitored() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withMonitored(false)
       .buildEstimatedTimetableDeliveries();
@@ -298,6 +314,8 @@ class SiriTimetableSnapshotSourceTest {
 
   @Test
   void testReplaceJourneyWithoutEstimatedVehicleJourneyCode() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef("newJourney")
       .withIsExtraJourney(true)
@@ -321,6 +339,8 @@ class SiriTimetableSnapshotSourceTest {
 
   @Test
   void testNegativeHopTime() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef(env.trip1.getId().getId())
       .withRecordedCalls(builder ->
@@ -339,6 +359,8 @@ class SiriTimetableSnapshotSourceTest {
 
   @Test
   void testNegativeDwellTime() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef(env.trip2.getId().getId())
       .withRecordedCalls(builder ->
@@ -362,6 +384,8 @@ class SiriTimetableSnapshotSourceTest {
   @Test
   @Disabled("Not supported yet")
   void testExtraUnknownStop() {
+    var env = new RealtimeTestEnvironment();
+
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef(env.trip1.getId().getId())
       .withEstimatedCalls(builder ->

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
@@ -152,6 +152,7 @@ class SiriTimetableSnapshotSourceTest {
     var updates = updatedJourneyBuilder(env).buildEstimatedTimetableDeliveries();
     var result = env.applyEstimatedTimetable(updates);
     assertEquals(0, result.successful());
+    assertFailure(result, UpdateError.UpdateErrorType.TRIP_NOT_FOUND);
   }
 
   /**
@@ -190,6 +191,7 @@ class SiriTimetableSnapshotSourceTest {
 
     var result = env.applyEstimatedTimetableWithFuzzyMatcher(updates);
     assertEquals(0, result.successful(), "Should fail gracefully");
+    assertFailure(result, UpdateError.UpdateErrorType.NO_FUZZY_TRIP_MATCH);
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -116,10 +116,6 @@ public class SiriFuzzyTripMatcher {
     }
 
     if (calls.getFirst().getAimedDepartureTime() == null) {
-      LOG.warn(
-        "Missing aimed departure time on first stop for estimated vehicle journey '{}'",
-        DebugString.of(journey)
-      );
       return null;
     }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -65,7 +65,10 @@ public class SiriFuzzyTripMatcher {
     return instance;
   }
 
-  private SiriFuzzyTripMatcher(TransitService transitService) {
+  /**
+   * Constructor with package access for tests only.
+   */
+  SiriFuzzyTripMatcher(TransitService transitService) {
     this.transitService = transitService;
     initCache(this.transitService);
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.calendar.CalendarService;
@@ -98,6 +99,7 @@ public class SiriFuzzyTripMatcher {
   /**
    * Matches EstimatedVehicleJourney to a set of possible Trips based on tripId
    */
+  @Nullable
   public TripAndPattern match(
     EstimatedVehicleJourney journey,
     EntityResolver entityResolver,
@@ -110,6 +112,14 @@ public class SiriFuzzyTripMatcher {
       return null;
     }
 
+    if (calls.getFirst().getAimedDepartureTime() == null) {
+      LOG.warn(
+        "Missing aimed departure time on first stop for estimated vehicle journey '{}'",
+        DebugString.of(journey)
+      );
+      return null;
+    }
+
     Set<Trip> trips = null;
     if (
       journey.getVehicleRef() != null &&
@@ -119,7 +129,7 @@ public class SiriFuzzyTripMatcher {
     }
 
     if (trips == null || trips.isEmpty()) {
-      CallWrapper lastStop = calls.get(calls.size() - 1);
+      CallWrapper lastStop = calls.getLast();
       String lastStopPoint = lastStop.getStopPointRef();
       ZonedDateTime arrivalTime = lastStop.getAimedArrivalTime() != null
         ? lastStop.getAimedArrivalTime()
@@ -269,20 +279,21 @@ public class SiriFuzzyTripMatcher {
   /**
    * Finds the correct trip based on OTP-ServiceDate and SIRI-DepartureTime
    */
-  private TripAndPattern getTripAndPatternForJourney(
+  @Nullable
+  TripAndPattern getTripAndPatternForJourney(
     Set<Trip> trips,
     List<CallWrapper> calls,
     EntityResolver entityResolver,
     BiFunction<TripPattern, LocalDate, Timetable> getCurrentTimetable,
     BiFunction<FeedScopedId, LocalDate, TripPattern> getRealtimeAddedTripPattern
   ) {
-    var journeyFirstStop = entityResolver.resolveQuay(calls.get(0).getStopPointRef());
-    var journeyLastStop = entityResolver.resolveQuay(calls.get(calls.size() - 1).getStopPointRef());
+    var journeyFirstStop = entityResolver.resolveQuay(calls.getFirst().getStopPointRef());
+    var journeyLastStop = entityResolver.resolveQuay(calls.getLast().getStopPointRef());
     if (journeyFirstStop == null || journeyLastStop == null) {
       return null;
     }
 
-    ZonedDateTime date = calls.get(0).getAimedDepartureTime();
+    ZonedDateTime date = calls.getFirst().getAimedDepartureTime();
     LocalDate serviceDate = date.toLocalDate();
 
     int departureInSecondsSinceMidnight = ServiceDateUtils.secondsSinceStartOfService(
@@ -359,7 +370,7 @@ public class SiriFuzzyTripMatcher {
     }
 
     if (results.size() == 1) {
-      return results.get(0);
+      return results.getFirst();
     } else if (results.size() > 1) {
       // Multiple possible matches - check if lineRef/routeId matches
       if (
@@ -376,7 +387,7 @@ public class SiriFuzzyTripMatcher {
       }
 
       // Line does not match any routeId - return first result.
-      return results.get(0);
+      return results.getFirst();
     }
 
     return null;


### PR DESCRIPTION
### Summary

As detailed in #5864 , some SIRI updates fail with a NullPointerException. The root cause is a missing aimed departure date on the first call in the estimated vehicle journey (mandatory field in the Nordic SIRI profile).
This PR: 
- improve the error message when  aimed departure date is missing on the first call.
- add test coverage for additional use cases (SIRI updates matched by framed vehicle journey ref, fuzzy-matching)

**Note**: the null-check on aimed departure date is moved early enough in the process to provide context for the error message, but without changing the outcome.

**Note**: the SIRI test framework is extended to support:
-  the creation of  invalid SIRI messages (missing mandatory date fields),
-  the creation of  SIRI messages matched by framed vehicle journey ref,
-  the testing of fuzzy-matching.

### Issue

Closes #5864

### Unit tests

Added unit tests

### Documentation

No

