### PR TITLE
Log the origin of a request that causes a transfer cache addition.

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
@@ -165,6 +165,10 @@ public class TransitLayer {
     return transferCache.get(transfersByStopIndex, request);
   }
 
+  public void initTransferCacheForRequest(RouteRequest request) {
+    transferCache.put(transfersByStopIndex, request);
+  }
+
   public RaptorRequestTransferCache getTransferCache() {
     return transferCache;
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRequestTransferCache.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRequestTransferCache.java
@@ -42,7 +42,7 @@ public class RaptorRequestTransferCache {
       cacheKey.request
     );
 
-    LOG.info("Adding request from config to cache: {}", cacheKey.options);
+    LOG.info("Initializing cache with request: {}", cacheKey.options);
     transferCache.put(cacheKey, raptorTransferIndex);
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRequestTransferCache.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRequestTransferCache.java
@@ -35,14 +35,20 @@ public class RaptorRequestTransferCache {
     return transferCache;
   }
 
+  public void put(List<List<Transfer>> transfersByStopIndex, RouteRequest request) {
+    final CacheKey cacheKey = new CacheKey(transfersByStopIndex, request);
+    final RaptorTransferIndex raptorTransferIndex = RaptorTransferIndex.create(
+      transfersByStopIndex,
+      cacheKey.request
+    );
+
+    LOG.info("Adding request from config to cache: {}", cacheKey.options);
+    transferCache.put(cacheKey, raptorTransferIndex);
+  }
+
   public RaptorTransferIndex get(List<List<Transfer>> transfersByStopIndex, RouteRequest request) {
     try {
-      return transferCache.get(
-        new CacheKey(
-          transfersByStopIndex,
-          StreetSearchRequestMapper.mapToTransferRequest(request).build()
-        )
-      );
+      return transferCache.get(new CacheKey(transfersByStopIndex, request));
     } catch (ExecutionException e) {
       throw new RuntimeException("Failed to get item from transfer cache", e);
     }
@@ -53,7 +59,7 @@ public class RaptorRequestTransferCache {
       @Override
       @Nonnull
       public RaptorTransferIndex load(@Nonnull CacheKey cacheKey) {
-        LOG.info("Adding request to cache: {}", cacheKey.options);
+        LOG.info("Adding runtime request to cache: {}", cacheKey.options);
         return RaptorTransferIndex.create(cacheKey.transfersByStopIndex, cacheKey.request);
       }
     };
@@ -65,10 +71,10 @@ public class RaptorRequestTransferCache {
     private final StreetSearchRequest request;
     private final StreetRelevantOptions options;
 
-    private CacheKey(List<List<Transfer>> transfersByStopIndex, StreetSearchRequest request) {
+    private CacheKey(List<List<Transfer>> transfersByStopIndex, RouteRequest request) {
       this.transfersByStopIndex = transfersByStopIndex;
-      this.request = request;
-      this.options = new StreetRelevantOptions(request);
+      this.request = StreetSearchRequestMapper.mapToTransferRequest(request).build();
+      this.options = new StreetRelevantOptions(this.request);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -233,7 +233,7 @@ public class ConstructApplication {
       LOG.info(progress.startMessage());
 
       transferCacheRequests.forEach(request -> {
-        transitModel.getTransitLayer().getRaptorTransfersForRequest(request);
+        transitModel.getTransitLayer().initTransferCacheForRequest(request);
 
         //noinspection Convert2MethodRef
         progress.step(s -> LOG.info(s));


### PR DESCRIPTION
### Summary

With this change it's possible to differentiate between entries added because of configuration and those from runtime requests, the latter being candidates for the former.

From config:
```
Initializing cache with request: StreetRelevantOptions{transferMode: WALK, walk: WalkPreferences{speed: 0.69, boardCost: $0}, street: StreetPreferences{accessEgress: AccessEgressPreferences{maxDuration: DurationForStreetMode{default:50m, WALK:48m10s}}, maxDirectDuration: DurationForStreetMode{default:1h1m40s, CAR:1d}}}
```

From runtime:
```
Adding runtime request to cache: StreetRelevantOptions{transferMode: WALK, street: StreetPreferences{accessEgress: AccessEgressPreferences{maxDuration: DurationForStreetMode{default:50m}}, maxDirectDuration: DurationForStreetMode{default:1h1m40s, CAR:1d}}}
```


### Issue

This makes it much easier to find and handle new transfer cache additions in the logs.

### Testing

Manually tested for both cases.
