### PR TITLE
Add nicer assertions to SiriTimetableSnapshotSourceTest

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSourceTest.java
@@ -157,7 +157,7 @@ class SiriTimetableSnapshotSourceTest {
     var updates = updatedJourneyBuilder(env).buildEstimatedTimetableDeliveries();
     var result = env.applyEstimatedTimetable(updates);
     assertEquals(0, result.successful());
-    assertFailure(result, UpdateError.UpdateErrorType.TRIP_NOT_FOUND);
+    assertFailure(UpdateError.UpdateErrorType.TRIP_NOT_FOUND, result);
   }
 
   /**
@@ -196,7 +196,7 @@ class SiriTimetableSnapshotSourceTest {
 
     var result = env.applyEstimatedTimetableWithFuzzyMatcher(updates);
     assertEquals(0, result.successful(), "Should fail gracefully");
-    assertFailure(result, UpdateError.UpdateErrorType.NO_FUZZY_TRIP_MATCH);
+    assertFailure(UpdateError.UpdateErrorType.NO_FUZZY_TRIP_MATCH, result);
   }
 
   /**
@@ -296,7 +296,7 @@ class SiriTimetableSnapshotSourceTest {
 
     var result = env.applyEstimatedTimetable(updates);
 
-    assertFailure(result, UpdateError.UpdateErrorType.NOT_MONITORED);
+    assertFailure(UpdateError.UpdateErrorType.NOT_MONITORED, result);
   }
 
   @Test
@@ -321,7 +321,7 @@ class SiriTimetableSnapshotSourceTest {
     var result = env.applyEstimatedTimetable(updates);
 
     // TODO: this should have a more specific error type
-    assertFailure(result, UpdateError.UpdateErrorType.UNKNOWN);
+    assertFailure(UpdateError.UpdateErrorType.UNKNOWN, result);
   }
 
   @Test
@@ -341,7 +341,7 @@ class SiriTimetableSnapshotSourceTest {
 
     var result = env.applyEstimatedTimetable(updates);
 
-    assertFailure(result, UpdateError.UpdateErrorType.NEGATIVE_HOP_TIME);
+    assertFailure(UpdateError.UpdateErrorType.NEGATIVE_HOP_TIME, result);
   }
 
   @Test
@@ -364,7 +364,7 @@ class SiriTimetableSnapshotSourceTest {
 
     var result = env.applyEstimatedTimetable(updates);
 
-    assertFailure(result, UpdateError.UpdateErrorType.NEGATIVE_DWELL_TIME);
+    assertFailure(UpdateError.UpdateErrorType.NEGATIVE_DWELL_TIME, result);
   }
 
   // TODO: support this
@@ -390,11 +390,11 @@ class SiriTimetableSnapshotSourceTest {
 
     var result = env.applyEstimatedTimetable(updates);
 
-    assertFailure(result, UpdateError.UpdateErrorType.INVALID_STOP_SEQUENCE);
+    assertFailure(UpdateError.UpdateErrorType.INVALID_STOP_SEQUENCE, result);
   }
 
-  private void assertFailure(UpdateResult result, UpdateError.UpdateErrorType errorType) {
-    assertEquals(result.failures().keySet(), Set.of(errorType));
+  private void assertFailure(UpdateError.UpdateErrorType expectedError, UpdateResult result) {
+    assertEquals(Set.of(expectedError), result.failures().keySet());
   }
 
   private static SiriEtBuilder updatedJourneyBuilder(RealtimeTestEnvironment env) {

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripTimesStringBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripTimesStringBuilder.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.transit.model.timetable;
+
+import java.util.ArrayList;
+import org.opentripplanner.framework.time.TimeUtils;
+import org.opentripplanner.transit.model.network.TripPattern;
+
+public class TripTimesStringBuilder {
+
+  /**
+   * This encodes the trip times and information about stops in a readable way in order to simplify
+   * testing/debugging. The format of the outputput string is:
+   *
+   * <pre>
+   * REALTIME_STATE | stop1 [FLAGS] arrivalTime departureTime | stop2 ...
+   *
+   * Where flags are:
+   * C: Canceled
+   * R: Recorded
+   * PI: Prediction Inaccurate
+   * ND: No Data
+   * </pre>
+   *
+   * @throws IllegalStateException if TripTimes does not match the TripPattern
+   */
+  public static String encodeTripTimes(TripTimes tripTimes, TripPattern pattern) {
+    var stops = pattern.getStops();
+
+    if (tripTimes.getNumStops() != stops.size()) {
+      throw new IllegalArgumentException(
+        "TripTimes and TripPattern have different number of stops"
+      );
+    }
+
+    StringBuilder s = new StringBuilder(tripTimes.getRealTimeState().toString());
+    for (int i = 0; i < tripTimes.getNumStops(); i++) {
+      var depart = tripTimes.getDepartureTime(i);
+      var arrive = tripTimes.getArrivalTime(i);
+      var flags = new ArrayList<String>();
+      if (tripTimes.isCancelledStop(i)) {
+        flags.add("C");
+      }
+      if (tripTimes.isRecordedStop(i)) {
+        flags.add("R");
+      }
+      if (tripTimes.isPredictionInaccurate(i)) {
+        flags.add("PI");
+      }
+      if (tripTimes.isNoDataStop(i)) {
+        flags.add("ND");
+      }
+
+      s.append(" | ").append(stops.get(i).getName());
+      if (!flags.isEmpty()) {
+        s.append(" [").append(String.join(",", flags)).append("]");
+      }
+      s
+        .append(" ")
+        .append(TimeUtils.timeToStrCompact(arrive))
+        .append(" ")
+        .append(TimeUtils.timeToStrCompact(depart));
+    }
+    return s.toString();
+  }
+}


### PR DESCRIPTION
### Summary

Inspired by the raptor module tests I wanted to make the assertions easier to work with in SiriTimetableSnapshotSourceTest.

The previous assertions were pretty verbose since you had to assert each call by itself. Now you can write something along the lines:

```
  assertEquals(
      "UPDATED | A1 0:00:15 0:00:15 | B1 0:00:25 0:00:25",
      env.getRealtimeTimetable(env.trip1)
  );
```

instead of this:

```
    var tripTimes = env.getTripTimesForTrip(env.trip1);
    assertEquals(RealTimeState.UPDATED, tripTimes.getRealTimeState());
    assertEquals(11, tripTimes.getArrivalTime(0));
    assertEquals(15, tripTimes.getDepartureTime(0));
    assertEquals(20, tripTimes.getDepartureTime(1));
    assertEquals(25, tripTimes.getArrivalTime(1));
```

There are a lot of open PRs touching this piece of code so there might be some conflicts. But since this makes it easier to write these tests I thought it might be worth creating this PR anyway.

### Documentation

Added a little bit of documentation
