### PR TITLE
Add OTP request timeout GraphQL instrumentation

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/OTPRequestTimeoutInstrumentation.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/OTPRequestTimeoutInstrumentation.java
@@ -1,0 +1,36 @@
+package org.opentripplanner.apis.transmodel;
+
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.noOp;
+
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import java.util.concurrent.atomic.AtomicLong;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A GraphQL instrumentation that periodically checks the OTP request interruption status while the
+ * query is being processed.
+ */
+public class OTPRequestTimeoutInstrumentation implements Instrumentation {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OTPRequestTimeoutInstrumentation.class);
+
+  private final AtomicLong fieldFetchCounter = new AtomicLong();
+
+  @Override
+  public InstrumentationContext<Object> beginFieldFetch(
+    InstrumentationFieldFetchParameters parameters,
+    InstrumentationState state
+  ) {
+    long fetched = fieldFetchCounter.incrementAndGet();
+    if (fetched % 100000 == 0) {
+      LOG.debug("Fetched {} fields", fetched);
+      OTPRequestTimeoutException.checkForTimeout();
+    }
+    return noOp();
+  }
+}

--- a/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
@@ -79,7 +79,10 @@ class TransmodelGraph {
   }
 
   private static Instrumentation createInstrumentation(int maxResolves, Iterable<Tag> tracingTags) {
-    Instrumentation instrumentation = new MaxQueryComplexityInstrumentation(maxResolves);
+    Instrumentation instrumentation = new ChainedInstrumentation(
+      new MaxQueryComplexityInstrumentation(maxResolves),
+      new OTPRequestTimeoutInstrumentation()
+    );
 
     if (OTPFeature.ActuatorAPI.isOn()) {
       instrumentation =


### PR DESCRIPTION
### Summary

The OTP request timeout feature provides a way to periodically check if the thread running an API request has been interrupted at a higher level (web server level).
This allows for cancelling long-running queries.
However this assumes that the running query will touch the code that checks for the interruption status.
While this works well for trip planning queries, other categories of query may never touch the check points.

This PR adds an extra level of protection by checking periodically the OTP request timeout status at the GraphQL level, while data is being fetched.

### Issue
No.

### Unit tests

No.

### Documentation

No.
