### PR TITLE
Fix parsing of GBFS feeds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -674,7 +674,7 @@
         <dependency>
             <groupId>org.mobilitydata</groupId>
             <artifactId>gbfs-java-model</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.7</version>
         </dependency>
 
         <!-- TESTING -->

--- a/src/test/resources/gbfs/lillestrombysykkel/gbfs.json
+++ b/src/test/resources/gbfs/lillestrombysykkel/gbfs.json
@@ -6,6 +6,10 @@
     "nb": {
       "feeds": [
         {
+          "name": "gbfs",
+          "url": "file:src/test/resources/gbfs/lillestrombysykkel/gbfs.json"
+        },
+        {
           "name": "system_information",
           "url": "file:src/test/resources/gbfs/lillestrombysykkel/system_information.json"
         },


### PR DESCRIPTION
### Summary

When the GBFS model moved to MobilityData an inadvertent change was made to the implementing class mapper, so gbfs.json pointed to the generated class for v2.3, which does not work. The upgrade includes https://github.com/MobilityData/gbfs-json-schema/pull/129 which reverts to the original behavior of mapping to the hand-written class.

### Issue

Closes #5889  

### Unit tests

Test case courtesy of @leonardehrenfried (https://github.com/ibi-group/OpenTripPlanner/commit/ff938e31573837df9bf770ecfd0ebe3857b6cffb)