### PR TITLE
Remove unused Siri code

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -1,22 +1,13 @@
 package org.opentripplanner.ext.siri;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multimaps;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.RegularStop;
-import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Threadsafe mechanism for tracking any TripPatterns added to the graph via SIRI realtime messages.
@@ -39,22 +30,10 @@ import org.slf4j.LoggerFactory;
  */
 public class SiriTripPatternCache {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SiriTripPatternCache.class);
-
   // TODO RT_AB: Improve documentation. This seems to be the primary collection of added
   //   TripPatterns, with other collections serving as indexes. Similar to TripPatternCache.cache
   //   in the GTFS version of this class, but with service date as part of the key.
   private final Map<StopPatternServiceDateKey, TripPattern> cache = new HashMap<>();
-
-  // TODO RT_AB: Improve documentation. This field appears to be an index that exists only in the
-  //   SIRI version of this class (i.e. this version and not the older TripPatternCache that
-  //   handles GTFS-RT). This index appears to be tailored for use by the Transmodel GraphQL APIs.
-  private final ListMultimap<StopLocation, TripPattern> patternsForStop = Multimaps.synchronizedListMultimap(
-    ArrayListMultimap.create()
-  );
-
-  // TODO RT_AB: clarify name and add documentation to this field.
-  private final Map<TripServiceDateKey, TripPattern> updatedTripPatternsForTripCache = new HashMap<>();
 
   // TODO RT_AB: generalize this so we can generate IDs for SIRI or GTFS-RT sources.
   private final SiriTripPatternIdGenerator tripPatternIdGenerator;
@@ -128,84 +107,7 @@ public class SiriTripPatternCache {
       cache.put(key, tripPattern);
     }
 
-    /*
-     When the StopPattern is first modified (e.g. change of platform), then updated (or vice
-     versa), the stopPattern is altered, and the StopPattern-object for the different states will
-     not be equal.
-
-     This causes both tripPatterns to be added to all unchanged stops along the route, which again
-     causes duplicate results in departureRow-searches (one departure for "updated", one for
-     "modified").
-
-     Full example:
-          Planned stops: Stop 1 - Platform 1, Stop 2 - Platform 1
-
-          StopPattern #rt1: "updated" stopPattern cached in 'patternsForStop':
-              - Stop 1, Platform 1
-              	- StopPattern #rt1
-              - Stop 2, Platform 1
-              	- StopPattern #rt1
-
-          "modified" stopPattern: Stop 1 - Platform 1, Stop 2 - Platform 2
-
-          StopPattern #rt2: "modified" stopPattern cached in 'patternsForStop' will then be:
-              - Stop 1, Platform 1
-              	- StopPattern #rt1, StopPattern #rt2
-              - Stop 2, Platform 1
-              	- StopPattern #rt1
-              - Stop 2, Platform 2
-              	- StopPattern #rt2
-
-     Therefore, we must clean up the duplicates by deleting the previously added (and thus
-     outdated) tripPattern for all affected stops. In example above, "StopPattern #rt1" should be
-     removed from all stops.
-
-     TODO RT_AB: review why this particular case is handled in an ad-hoc manner. It seems like all
-       such indexes should be constantly rebuilt and versioned along with the TimetableSnapshot.
-    */
-    TripServiceDateKey tripServiceDateKey = new TripServiceDateKey(trip, serviceDate);
-    if (updatedTripPatternsForTripCache.containsKey(tripServiceDateKey)) {
-      // Remove previously added TripPatterns for the trip currently being updated - if the stopPattern does not match
-      TripPattern cachedTripPattern = updatedTripPatternsForTripCache.get(tripServiceDateKey);
-      if (cachedTripPattern != null && !tripPattern.stopPatternIsEqual(cachedTripPattern)) {
-        int sizeBefore = patternsForStop.values().size();
-        long t1 = System.currentTimeMillis();
-        patternsForStop.values().removeAll(Arrays.asList(cachedTripPattern));
-        int sizeAfter = patternsForStop.values().size();
-
-        LOG.debug(
-          "Removed outdated TripPattern for {} stops in {} ms - tripId: {}",
-          (sizeBefore - sizeAfter),
-          (System.currentTimeMillis() - t1),
-          trip.getId()
-        );
-        // TODO: Also remove previously updated - now outdated - TripPattern from cache ?
-        // cache.remove(new StopPatternServiceDateKey(cachedTripPattern.stopPattern, serviceDate));
-      }
-    }
-
-    // To make these trip patterns visible for departureRow searches.
-    for (var stop : tripPattern.getStops()) {
-      if (!patternsForStop.containsEntry(stop, tripPattern)) {
-        patternsForStop.put(stop, tripPattern);
-      }
-    }
-
-    // Cache the last added tripPattern that has been used to update a specific trip
-    updatedTripPatternsForTripCache.put(tripServiceDateKey, tripPattern);
-
     return tripPattern;
-  }
-
-  /**
-   * Returns any new TripPatterns added by real time information for a given stop.
-   * TODO RT_AB: this appears to be currently unused. Perhaps remove it if the API has changed.
-   *
-   * @param stop the stop
-   * @return list of TripPatterns created by real time sources for the stop.
-   */
-  public List<TripPattern> getAddedTripPatternsForStop(RegularStop stop) {
-    return patternsForStop.get(stop);
   }
 }
 
@@ -241,35 +143,5 @@ class StopPatternServiceDateKey {
     }
     StopPatternServiceDateKey that = (StopPatternServiceDateKey) thatObject;
     return (this.stopPattern.equals(that.stopPattern) && this.serviceDate.equals(that.serviceDate));
-  }
-}
-
-/**
- * An alternative key for looking up realtime-added TripPatterns by trip and service date instead
- * of stop pattern and service date. Must define hashcode and equals to confer semantic identity.
- * TODO RT_AB: verify whether one map is considered the definitive collection and the other an index.
- */
-class TripServiceDateKey {
-
-  Trip trip;
-  LocalDate serviceDate;
-
-  public TripServiceDateKey(Trip trip, LocalDate serviceDate) {
-    this.trip = trip;
-    this.serviceDate = serviceDate;
-  }
-
-  @Override
-  public int hashCode() {
-    return trip.hashCode() + serviceDate.hashCode();
-  }
-
-  @Override
-  public boolean equals(Object thatObject) {
-    if (!(thatObject instanceof TripServiceDateKey)) {
-      return false;
-    }
-    TripServiceDateKey that = (TripServiceDateKey) thatObject;
-    return (this.trip.equals(that.trip) && this.serviceDate.equals(that.serviceDate));
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHelper.java
@@ -7,19 +7,14 @@ import java.time.ZonedDateTime;
 import java.util.UUID;
 import javax.xml.stream.XMLStreamException;
 import org.rutebanken.siri20.util.SiriXml;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.org.siri.siri20.EstimatedTimetableRequestStructure;
 import uk.org.siri.siri20.MessageQualifierStructure;
 import uk.org.siri.siri20.RequestorRef;
 import uk.org.siri.siri20.ServiceRequest;
 import uk.org.siri.siri20.Siri;
 import uk.org.siri.siri20.SituationExchangeRequestStructure;
-import uk.org.siri.siri20.VehicleMonitoringRequestStructure;
 
 public class SiriHelper {
-
-  private static final Logger LOG = LoggerFactory.getLogger(SiriHelper.class);
 
   public static Siri unmarshal(InputStream is) throws JAXBException, XMLStreamException {
     return SiriXml.parseXml(is);
@@ -27,16 +22,6 @@ public class SiriHelper {
 
   public static String createSXServiceRequestAsXml(String requestorRef) throws JAXBException {
     Siri request = createSXServiceRequest(requestorRef);
-    return SiriXml.toXml(request);
-  }
-
-  public static String createVMServiceRequestAsXml(String requestorRef) throws JAXBException {
-    Siri request = createVMServiceRequest(requestorRef);
-    return SiriXml.toXml(request);
-  }
-
-  public static String createETServiceRequestAsXml(String requestorRef) throws JAXBException {
-    Siri request = createETServiceRequest(requestorRef, null);
     return SiriXml.toXml(request);
   }
 
@@ -101,31 +86,6 @@ public class SiriHelper {
 
     etRequest.setMessageIdentifier(messageIdentifier);
     serviceRequest.getEstimatedTimetableRequests().add(etRequest);
-
-    request.setServiceRequest(serviceRequest);
-
-    return request;
-  }
-
-  private static Siri createVMServiceRequest(String requestorRefValue) {
-    Siri request = createSiriObject();
-
-    ServiceRequest serviceRequest = new ServiceRequest();
-    serviceRequest.setRequestTimestamp(ZonedDateTime.now());
-
-    RequestorRef requestorRef = new RequestorRef();
-    requestorRef.setValue(requestorRefValue);
-    serviceRequest.setRequestorRef(requestorRef);
-
-    VehicleMonitoringRequestStructure vmRequest = new VehicleMonitoringRequestStructure();
-    vmRequest.setRequestTimestamp(ZonedDateTime.now());
-    vmRequest.setVersion("2.0");
-
-    MessageQualifierStructure messageIdentifier = new MessageQualifierStructure();
-    messageIdentifier.setValue(UUID.randomUUID().toString());
-
-    vmRequest.setMessageIdentifier(messageIdentifier);
-    serviceRequest.getVehicleMonitoringRequests().add(vmRequest);
 
     request.setServiceRequest(serviceRequest);
 


### PR DESCRIPTION
### Summary

While I was investigating how to handle cancellations for Siri and GTFS (for later unification) I stumbled over a peculiar piece of complicated logic that appears to be completely unused: keeping the pattern -> stop relationship of realtime-added patterns in `SiriTripPatternCache`.

It seems that once upon a time the API was directly requesting some information from the cache but the method `getAddedTripPatternsForStop` is now completely unused. 

I believe that it can be removed.

The best way to review this, would be to look at the code yourself and start removing the dead code to see what else can also be removed.

### Issue

#4816