### PR TITLE
Fix debug client after breaking change in dependency graphql-request

### DIFF
--- a/client-next/src/hooks/useServerInfo.ts
+++ b/client-next/src/hooks/useServerInfo.ts
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 import { graphql } from '../gql';
 import { request } from 'graphql-request'; // eslint-disable-line import/no-unresolved
 import { QueryType } from '../gql/graphql.ts';
-
-const endpoint = import.meta.env.VITE_API_URL;
+import { getApiUrl } from '../util/getApiUrl.ts';
 
 const query = graphql(`
   query serverInfo {
@@ -22,7 +21,7 @@ export const useServerInfo = () => {
   const [data, setData] = useState<QueryType | null>(null);
   useEffect(() => {
     const fetchData = async () => {
-      setData((await request(endpoint, query)) as QueryType);
+      setData((await request(getApiUrl(), query)) as QueryType);
     };
     fetchData();
   }, []);

--- a/client-next/src/hooks/useTripQuery.ts
+++ b/client-next/src/hooks/useTripQuery.ts
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { graphql } from '../gql';
 import { request } from 'graphql-request'; // eslint-disable-line import/no-unresolved
 import { QueryType, TripQueryVariables } from '../gql/graphql.ts';
-
-const endpoint = import.meta.env.VITE_API_URL;
+import { getApiUrl } from '../util/getApiUrl.ts';
 
 /**
   General purpose trip query document for debugging trip searches
@@ -96,9 +95,9 @@ export const useTripQuery: TripQueryHook = (variables) => {
         if (variables) {
           setLoading(true);
           if (pageCursor) {
-            setData((await request(endpoint, query, { ...variables, pageCursor })) as QueryType);
+            setData((await request(getApiUrl(), query, { ...variables, pageCursor })) as QueryType);
           } else {
-            setData((await request(endpoint, query, variables)) as QueryType);
+            setData((await request(getApiUrl(), query, variables)) as QueryType);
           }
           setLoading(false);
         } else {

--- a/client-next/src/util/getApiUrl.ts
+++ b/client-next/src/util/getApiUrl.ts
@@ -1,0 +1,12 @@
+const endpoint = import.meta.env.VITE_API_URL;
+
+export const getApiUrl = () => {
+  try {
+    // the URL constructor will throw exception if endpoint is not a valid URL,
+    // e.g. if it is a relative path
+    new URL(endpoint);
+    return endpoint;
+  } catch (e) {
+    return `${window.location.origin}${endpoint}`;
+  }
+};


### PR DESCRIPTION
Debug client is broken if VITE_API_URL is a relative path (which it is by default). This is due to a breaking change in v7.0.0 of graphql-request, which I overlooked when approving the upgrade: https://github.com/jasonkuhrt/graphql-request/releases/tag/7.0.0

This PR checks validity of VITE_API_URL by passing it to the URL constructor. If exception is thrown, we prefix it with the window's origin (which used to be the default behavior).

~~I still need to test this PR~~ Tested locally.