### PR TITLE
Refactor NearbyStopsFinder to follow strategy pattern

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/MinMap.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/MinMap.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.graph_builder.module;
+package org.opentripplanner.graph_builder.module.nearbystops;
 
 import java.util.HashMap;
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinder.java
@@ -7,8 +7,8 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.street.model.vertex.Vertex;
 
 /**
- * This class contains code for finding nearby stops from a given vertex. It is being used by access
- * and egress searches as well as transfer generation.
+ * Interface for finding nearby stops from a given vertex. It is used by access
+ * and egress searches, and in transfer generation.
  */
 public interface NearbyStopFinder {
   /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinder.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.graph_builder.module.nearbystops;
+
+import java.util.Collection;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.street.model.vertex.Vertex;
+
+/**
+ * This class contains code for finding nearby stops from a given vertex. It is being used by access
+ * and egress searches as well as transfer generation.
+ */
+public interface NearbyStopFinder {
+  /**
+   * Return all stops within a certain distance from the given vertex.
+   */
+  Collection<NearbyStop> findNearbyStops(
+    Vertex vertex,
+    RouteRequest routingRequest,
+    StreetRequest streetRequest,
+    boolean reverseDirection
+  );
+}

--- a/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/PatternConsideringNearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/PatternConsideringNearbyStopFinder.java
@@ -1,0 +1,94 @@
+package org.opentripplanner.graph_builder.module.nearbystops;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
+import org.opentripplanner.ext.flex.trip.FlexTrip;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitService;
+
+public class PatternConsideringNearbyStopFinder implements NearbyStopFinder {
+
+  private final NearbyStopFinder delegateNearbyStopFinder;
+  private final TransitService transitService;
+
+  public PatternConsideringNearbyStopFinder(
+    TransitService transitService,
+    NearbyStopFinder delegateNearbyStopFinder
+  ) {
+    this.transitService = transitService;
+    this.delegateNearbyStopFinder = delegateNearbyStopFinder;
+  }
+
+  /**
+   * Find all unique nearby stops that are the closest stop on some trip pattern or flex trip. Note
+   * that the result will include the origin vertex if it is an instance of StopVertex. This is
+   * intentional: we don't want to return the next stop down the line for trip patterns that pass
+   * through the origin vertex. Taking the patterns into account reduces the number of transfers
+   * significantly compared to simple traverse-duration-constrained all-to-all stop linkage.
+   */
+  @Override
+  public List<NearbyStop> findNearbyStops(
+    Vertex vertex,
+    RouteRequest routingRequest,
+    StreetRequest streetRequest,
+    boolean reverseDirection
+  ) {
+    /* Track the closest stop on each pattern passing nearby. */
+    MinMap<TripPattern, NearbyStop> closestStopForPattern = new MinMap<>();
+
+    /* Track the closest stop on each flex trip nearby. */
+    MinMap<FlexTrip<?, ?>, NearbyStop> closestStopForFlexTrip = new MinMap<>();
+
+    /* Iterate over nearby stops via the street network or using straight-line distance. */
+    for (NearbyStop nearbyStop : delegateNearbyStopFinder.findNearbyStops(
+      vertex,
+      routingRequest,
+      streetRequest,
+      reverseDirection
+    )) {
+      StopLocation ts1 = nearbyStop.stop;
+
+      if (ts1 instanceof RegularStop) {
+        /* Consider this destination stop as a candidate for every trip pattern passing through it. */
+        for (TripPattern pattern : transitService.getPatternsForStop(ts1)) {
+          if (
+            reverseDirection
+              ? pattern.canAlight(nearbyStop.stop)
+              : pattern.canBoard(nearbyStop.stop)
+          ) {
+            closestStopForPattern.putMin(pattern, nearbyStop);
+          }
+        }
+      }
+
+      if (OTPFeature.FlexRouting.isOn()) {
+        for (FlexTrip<?, ?> trip : transitService.getFlexIndex().getFlexTripsByStop(ts1)) {
+          if (
+            reverseDirection
+              ? trip.isAlightingPossible(nearbyStop.stop)
+              : trip.isBoardingPossible(nearbyStop.stop)
+          ) {
+            closestStopForFlexTrip.putMin(trip, nearbyStop);
+          }
+        }
+      }
+    }
+
+    /* Make a transfer from the origin stop to each destination stop that was the closest stop on any pattern. */
+    Set<NearbyStop> uniqueStops = new HashSet<>();
+    uniqueStops.addAll(closestStopForFlexTrip.values());
+    uniqueStops.addAll(closestStopForPattern.values());
+    // TODO: don't convert to list
+    return uniqueStops.stream().toList();
+  }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StraightLineNearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StraightLineNearbyStopFinder.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.graph_builder.module.nearbystops;
+
+import java.time.Duration;
+import java.util.List;
+import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.preference.WalkPreferences;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.routing.graphfinder.DirectGraphFinder;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.transit.service.TransitService;
+
+public class StraightLineNearbyStopFinder implements NearbyStopFinder {
+
+  private final Duration durationLimit;
+  private final DirectGraphFinder directGraphFinder;
+
+  public StraightLineNearbyStopFinder(TransitService transitService, Duration durationLimit) {
+    this.durationLimit = durationLimit;
+
+    // We need to accommodate straight line distance (in meters) but when streets are present we
+    // use an earliest arrival search, which optimizes on time. Ideally we'd specify in meters,
+    // but we don't have much of a choice here. Use the default walking speed to convert.
+    this.directGraphFinder = new DirectGraphFinder(transitService::findRegularStops);
+  }
+
+  /**
+   * Find nearby stops using straight line distance.
+   */
+  @Override
+  public List<NearbyStop> findNearbyStops(
+    Vertex vertex,
+    RouteRequest routingRequest,
+    StreetRequest streetRequest,
+    boolean reverseDirection
+  ) {
+    return findNearbyStopsViaDirectTransfers(vertex);
+  }
+
+  private List<NearbyStop> findNearbyStopsViaDirectTransfers(Vertex vertex) {
+    // It make sense for the directGraphFinder to use meters as a limit, so we convert first
+    double limitMeters = durationLimit.toSeconds() * WalkPreferences.DEFAULT.speed();
+    Coordinate c0 = vertex.getCoordinate();
+    return directGraphFinder.findClosestStops(c0, limitMeters);
+  }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.graph_builder.module;
+package org.opentripplanner.graph_builder.module.nearbystops;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -7,24 +7,19 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.spi.SkipEdgeStrategy;
 import org.opentripplanner.astar.strategy.ComposingSkipEdgeStrategy;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
 import org.opentripplanner.astar.strategy.MaxCountSkipEdgeStrategy;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
-import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
-import org.opentripplanner.routing.api.request.preference.WalkPreferences;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.graphfinder.DirectGraphFinder;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
@@ -38,139 +33,40 @@ import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.request.StreetSearchRequestMapper;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.strategy.DominanceFunctions;
-import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.RegularStop;
-import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TransitService;
 
-/**
- * This class contains code for finding nearby stops from a given vertex. It is being used by access
- * and egress searches as well as transfer generation.
- */
-public class NearbyStopFinder {
-
-  public final boolean useStreets;
-
-  private final TransitService transitService;
+public class StreetNearbyStopFinder implements NearbyStopFinder {
 
   private final Duration durationLimit;
   private final int maxStopCount;
   private final DataOverlayContext dataOverlayContext;
 
-  private DirectGraphFinder directGraphFinder;
-
   /**
    * Construct a NearbyStopFinder for the given graph and search radius.
-   *
-   * @param useStreets if true, search via the street network instead of using straight-line
-   *                   distance.
    */
-  public NearbyStopFinder(
-    TransitService transitService,
+  public StreetNearbyStopFinder(
     Duration durationLimit,
     int maxStopCount,
-    DataOverlayContext dataOverlayContext,
-    boolean useStreets
+    DataOverlayContext dataOverlayContext
   ) {
-    this.transitService = transitService;
     this.dataOverlayContext = dataOverlayContext;
-    this.useStreets = useStreets;
     this.durationLimit = durationLimit;
     this.maxStopCount = maxStopCount;
-
-    if (!useStreets) {
-      // We need to accommodate straight line distance (in meters) but when streets are present we
-      // use an earliest arrival search, which optimizes on time. Ideally we'd specify in meters,
-      // but we don't have much of a choice here. Use the default walking speed to convert.
-      this.directGraphFinder = new DirectGraphFinder(transitService::findRegularStops);
-    }
-  }
-
-  /**
-   * Find all unique nearby stops that are the closest stop on some trip pattern or flex trip. Note
-   * that the result will include the origin vertex if it is an instance of StopVertex. This is
-   * intentional: we don't want to return the next stop down the line for trip patterns that pass
-   * through the origin vertex.
-   * Taking the patterns into account reduces the number of transfers significantly compared to
-   * simple traverse-duration-constrained all-to-all stop linkage.
-   */
-  public Set<NearbyStop> findNearbyStopsConsideringPatterns(
-    Vertex vertex,
-    RouteRequest routingRequest,
-    StreetRequest streetRequest,
-    boolean reverseDirection
-  ) {
-    /* Track the closest stop on each pattern passing nearby. */
-    MinMap<TripPattern, NearbyStop> closestStopForPattern = new MinMap<>();
-
-    /* Track the closest stop on each flex trip nearby. */
-    MinMap<FlexTrip<?, ?>, NearbyStop> closestStopForFlexTrip = new MinMap<>();
-
-    /* Iterate over nearby stops via the street network or using straight-line distance, depending on the graph. */
-    for (NearbyStop nearbyStop : findNearbyStops(
-      vertex,
-      routingRequest,
-      streetRequest,
-      reverseDirection
-    )) {
-      StopLocation ts1 = nearbyStop.stop;
-
-      if (ts1 instanceof RegularStop) {
-        /* Consider this destination stop as a candidate for every trip pattern passing through it. */
-        for (TripPattern pattern : transitService.getPatternsForStop(ts1)) {
-          if (
-            reverseDirection
-              ? pattern.canAlight(nearbyStop.stop)
-              : pattern.canBoard(nearbyStop.stop)
-          ) {
-            closestStopForPattern.putMin(pattern, nearbyStop);
-          }
-        }
-      }
-
-      if (OTPFeature.FlexRouting.isOn()) {
-        for (FlexTrip<?, ?> trip : transitService.getFlexIndex().getFlexTripsByStop(ts1)) {
-          if (
-            reverseDirection
-              ? trip.isAlightingPossible(nearbyStop.stop)
-              : trip.isBoardingPossible(nearbyStop.stop)
-          ) {
-            closestStopForFlexTrip.putMin(trip, nearbyStop);
-          }
-        }
-      }
-    }
-
-    /* Make a transfer from the origin stop to each destination stop that was the closest stop on any pattern. */
-    Set<NearbyStop> uniqueStops = new HashSet<>();
-    uniqueStops.addAll(closestStopForFlexTrip.values());
-    uniqueStops.addAll(closestStopForPattern.values());
-    return uniqueStops;
   }
 
   /**
    * Return all stops within a certain radius of the given vertex, using network distance along
-   * streets. Use the correct method depending on whether the graph has street data or not. If the
-   * origin vertex is a StopVertex, the result will include it; this characteristic is essential for
-   * associating the correct stop with each trip pattern in the vicinity.
+   * streets. If the origin vertex is a StopVertex, the result will include it; this characteristic
+   * is essential for associating the correct stop with each trip pattern in the vicinity.
    */
-  public List<NearbyStop> findNearbyStops(
+  @Override
+  public Collection<NearbyStop> findNearbyStops(
     Vertex vertex,
     RouteRequest routingRequest,
     StreetRequest streetRequest,
     boolean reverseDirection
   ) {
-    if (useStreets) {
-      return findNearbyStopsViaStreets(
-        Set.of(vertex),
-        reverseDirection,
-        routingRequest,
-        streetRequest
-      );
-    } else {
-      return findNearbyStopsViaDirectTransfers(vertex);
-    }
+    return findNearbyStops(Set.of(vertex), reverseDirection, routingRequest, streetRequest);
   }
 
   /**
@@ -181,7 +77,7 @@ public class NearbyStopFinder {
    * @param reverseDirection if true the paths returned instead originate at the nearby stops and
    *                         have the originVertex as the destination
    */
-  public List<NearbyStop> findNearbyStopsViaStreets(
+  public Collection<NearbyStop> findNearbyStops(
     Set<Vertex> originVertices,
     boolean reverseDirection,
     RouteRequest request,
@@ -262,18 +158,14 @@ public class NearbyStopFinder {
     return stopsFound;
   }
 
-  private List<NearbyStop> findNearbyStopsViaDirectTransfers(Vertex vertex) {
-    // It make sense for the directGraphFinder to use meters as a limit, so we convert first
-    double limitMeters = durationLimit.toSeconds() * WalkPreferences.DEFAULT.speed();
-    Coordinate c0 = vertex.getCoordinate();
-    return directGraphFinder.findClosestStops(c0, limitMeters);
-  }
-
   private SkipEdgeStrategy<State, Edge> getSkipEdgeStrategy() {
     var durationSkipEdgeStrategy = new DurationSkipEdgeStrategy(durationLimit);
 
     if (maxStopCount > 0) {
-      var strategy = new MaxCountSkipEdgeStrategy<>(maxStopCount, NearbyStopFinder::hasReachedStop);
+      var strategy = new MaxCountSkipEdgeStrategy<>(
+        maxStopCount,
+        StreetNearbyStopFinder::hasReachedStop
+      );
       return new ComposingSkipEdgeStrategy<>(strategy, durationSkipEdgeStrategy);
     }
     return durationSkipEdgeStrategy;
@@ -328,10 +220,9 @@ public class NearbyStopFinder {
    * can dominate those that can thereby leading to zero found stops when this predicate is used with
    * the {@link MaxCountSkipEdgeStrategy}.
    * <p>
-   * An example of this would be an egress/reverse search with a very high walk reluctance where
-   * the states that speculatively rent a vehicle move the walk states down the A* priority queue
-   * until the required number of stops are reached to abort the search, leading to zero egress
-   * results.
+   * An example of this would be an egress/reverse search with a very high walk reluctance where the
+   * states that speculatively rent a vehicle move the walk states down the A* priority queue until
+   * the required number of stops are reached to abort the search, leading to zero egress results.
    */
   public static boolean hasReachedStop(State state) {
     return state.getVertex() instanceof TransitStopVertex && state.isFinal();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -247,7 +247,6 @@ public class TransitRouter {
     var nearbyStops = AccessEgressRouter.streetSearch(
       accessRequest,
       temporaryVerticesContainer,
-      serverContext.transitService(),
       streetRequest,
       serverContext.dataOverlayContext(accessRequest),
       type.isEgress(),

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
@@ -2,10 +2,9 @@ package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
-import org.opentripplanner.graph_builder.module.NearbyStopFinder;
+import org.opentripplanner.graph_builder.module.nearbystops.StreetNearbyStopFinder;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -31,7 +30,6 @@ public class AccessEgressRouter {
   public static Collection<NearbyStop> streetSearch(
     RouteRequest request,
     TemporaryVerticesContainer verticesContainer,
-    TransitService transitService,
     StreetRequest streetRequest,
     DataOverlayContext dataOverlayContext,
     boolean fromTarget,
@@ -39,14 +37,12 @@ public class AccessEgressRouter {
     int maxStopCount
   ) {
     OTPRequestTimeoutException.checkForTimeout();
-    NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(
-      transitService,
+    var nearbyStopFinder = new StreetNearbyStopFinder(
       durationLimit,
       maxStopCount,
-      dataOverlayContext,
-      true
+      dataOverlayContext
     );
-    List<NearbyStop> nearbyStopList = nearbyStopFinder.findNearbyStopsViaStreets(
+    Collection<NearbyStop> nearbyStopList = nearbyStopFinder.findNearbyStops(
       fromTarget ? verticesContainer.getToVertices() : verticesContainer.getFromVertices(),
       fromTarget,
       request,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
@@ -37,7 +37,6 @@ public class DirectFlexRouter {
       Collection<NearbyStop> accessStops = AccessEgressRouter.streetSearch(
         request,
         temporaryVertices,
-        serverContext.transitService(),
         request.journey().direct(),
         serverContext.dataOverlayContext(request),
         false,
@@ -47,7 +46,6 @@ public class DirectFlexRouter {
       Collection<NearbyStop> egressStops = AccessEgressRouter.streetSearch(
         request,
         temporaryVertices,
-        serverContext.transitService(),
         request.journey().direct(),
         serverContext.dataOverlayContext(request),
         true,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
@@ -37,7 +37,6 @@ public class FlexAccessEgressRouter {
       ? AccessEgressRouter.streetSearch(
         request,
         verticesContainer,
-        transitService,
         new StreetRequest(StreetMode.WALK),
         dataOverlayContext,
         false,
@@ -50,7 +49,6 @@ public class FlexAccessEgressRouter {
       ? AccessEgressRouter.streetSearch(
         request,
         verticesContainer,
-        transitService,
         new StreetRequest(StreetMode.WALK),
         dataOverlayContext,
         true,

--- a/src/test/java/org/opentripplanner/astar/strategy/MaxCountSkipEdgeStrategyTest.java
+++ b/src/test/java/org/opentripplanner/astar/strategy/MaxCountSkipEdgeStrategyTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.graph_builder.module.NearbyStopFinder;
+import org.opentripplanner.graph_builder.module.nearbystops.StreetNearbyStopFinder;
 import org.opentripplanner.street.search.state.TestStateBuilder;
 
 class MaxCountSkipEdgeStrategyTest {
@@ -12,7 +12,7 @@ class MaxCountSkipEdgeStrategyTest {
   @Test
   void countStops() {
     var state = TestStateBuilder.ofWalking().stop().build();
-    var strategy = new MaxCountSkipEdgeStrategy<>(1, NearbyStopFinder::hasReachedStop);
+    var strategy = new MaxCountSkipEdgeStrategy<>(1, StreetNearbyStopFinder::hasReachedStop);
     assertFalse(strategy.shouldSkipEdge(state, null));
     assertTrue(strategy.shouldSkipEdge(state, null));
   }
@@ -20,7 +20,7 @@ class MaxCountSkipEdgeStrategyTest {
   @Test
   void doNotCountStop() {
     var state = TestStateBuilder.ofWalking().build();
-    var strategy = new MaxCountSkipEdgeStrategy<>(1, NearbyStopFinder::hasReachedStop);
+    var strategy = new MaxCountSkipEdgeStrategy<>(1, StreetNearbyStopFinder::hasReachedStop);
     assertFalse(strategy.shouldSkipEdge(state, null));
     assertFalse(strategy.shouldSkipEdge(state, null));
     assertFalse(strategy.shouldSkipEdge(state, null));
@@ -30,7 +30,7 @@ class MaxCountSkipEdgeStrategyTest {
   void nonFinalState() {
     var state = TestStateBuilder.ofScooterRentalArriveBy().stop().build();
     assertFalse(state.isFinal());
-    var strategy = new MaxCountSkipEdgeStrategy<>(1, NearbyStopFinder::hasReachedStop);
+    var strategy = new MaxCountSkipEdgeStrategy<>(1, StreetNearbyStopFinder::hasReachedStop);
     assertFalse(strategy.shouldSkipEdge(state, null));
   }
 }


### PR DESCRIPTION
### Summary

This PR is a pure refactor and shouldn't change any behaviour.

The NearbyStopsFinder has three different behaviours depending on two different parameters:
- Default street search, used if the graph has a street network.
- Straight line search, used if the graph doesn't have a street network.
- A special search considering TripPatterns that is used in conjunction with one of the above. Used if the `ConsiderPatternsForDirectTransfers` feature is enabled.

The different branches makes the code difficult to understand and difficult to test. This PR refactors this code to use the strategy pattern by extracting a common interface and having one class for each behaviour.

This work is in preparation of some work I need to do on access/egress search as part of #5848.

### Unit tests

Unfortunately there is no tests for this piece of code. I would like to add some in a follow-up PR. 

### Documentation

I added and updated javadoc.

### Bumping the serialization version id

Nope
