### PR TITLE
Cluster consolidated stops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -691,6 +691,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <version>1.4.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit</artifactId>
             <version>1.3.0</version>

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationRepository;
+import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationService;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -160,8 +162,12 @@ class LuceneIndexTest {
         );
       }
     };
-    index = new LuceneIndex(transitService);
-    mapper = new StopClusterMapper(transitService);
+    var stopConsolidationService = new DefaultStopConsolidationService(
+      new DefaultStopConsolidationRepository(),
+      transitModel
+    );
+    index = new LuceneIndex(transitService, stopConsolidationService);
+    mapper = new StopClusterMapper(transitService, stopConsolidationService);
   }
 
   @Test

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/StopClusterMapperTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/StopClusterMapperTest.java
@@ -1,0 +1,57 @@
+package org.opentripplanner.ext.geocoder;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationRepository;
+import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationService;
+import org.opentripplanner.ext.stopconsolidation.model.ConsolidatedStopGroup;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
+
+class StopClusterMapperTest {
+
+  private static final TransitModelForTest TEST_MODEL = TransitModelForTest.of();
+  private static final RegularStop STOP_A = TEST_MODEL.stop("A").build();
+  private static final RegularStop STOP_B = TEST_MODEL.stop("B").build();
+  private static final RegularStop STOP_C = TEST_MODEL.stop("C").build();
+  private static final List<RegularStop> STOPS = List.of(STOP_A, STOP_B, STOP_C);
+  private static final StopModel STOP_MODEL = TEST_MODEL
+    .stopModelBuilder()
+    .withRegularStops(STOPS)
+    .build();
+  private static final TransitModel TRANSIT_MODEL = new TransitModel(
+    STOP_MODEL,
+    new Deduplicator()
+  );
+  private static final List<StopLocation> LOCATIONS = STOPS
+    .stream()
+    .map(StopLocation.class::cast)
+    .toList();
+
+  @Test
+  void clusterConsolidatedStops() {
+    var repo = new DefaultStopConsolidationRepository();
+    repo.addGroups(List.of(new ConsolidatedStopGroup(STOP_A.getId(), List.of(STOP_B.getId()))));
+
+    var service = new DefaultStopConsolidationService(repo, TRANSIT_MODEL);
+    var mapper = new StopClusterMapper(new DefaultTransitService(TRANSIT_MODEL), service);
+
+    var clusters = mapper.generateStopClusters(LOCATIONS, List.of());
+
+    var expected = new LuceneStopCluster(
+      STOP_A.getId().toString(),
+      List.of(STOP_B.getId().toString()),
+      List.of(STOP_A.getName(), STOP_B.getName()),
+      List.of(STOP_A.getCode(), STOP_B.getCode()),
+      new StopCluster.Coordinate(STOP_A.getLat(), STOP_A.getLon())
+    );
+    assertThat(clusters).contains(expected);
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
@@ -3,7 +3,6 @@ package org.opentripplanner.ext.geocoder;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
@@ -28,21 +27,7 @@ public class GeocoderResource {
   private final OtpServerRequestContext serverContext;
 
   public GeocoderResource(@Context OtpServerRequestContext requestContext) {
-    serverContext = requestContext;
-  }
-
-  /**
-   * This class is only here for backwards-compatibility. It will be removed in the future.
-   */
-  @Path("/routers/{ignoreRouterId}/geocode")
-  public static class GeocoderResourceOldPath extends GeocoderResource {
-
-    public GeocoderResourceOldPath(
-      @Context OtpServerRequestContext serverContext,
-      @PathParam("ignoreRouterId") String ignore
-    ) {
-      super(serverContext);
-    }
+    luceneIndex = Objects.requireNonNull(requestContext.lucenceIndex());
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
@@ -81,8 +81,7 @@ public class GeocoderResource {
   }
 
   private Collection<SearchResult> queryStopLocations(String query, boolean autocomplete) {
-    return
-      luceneIndex
+    return luceneIndex
       .queryStopLocations(query, autocomplete)
       .map(sl ->
         new SearchResult(
@@ -96,8 +95,7 @@ public class GeocoderResource {
   }
 
   private Collection<? extends SearchResult> queryStations(String query, boolean autocomplete) {
-    return
-      luceneIndex
+    return luceneIndex
       .queryStopLocationGroups(query, autocomplete)
       .map(sc ->
         new SearchResult(

--- a/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
@@ -24,10 +24,10 @@ import org.opentripplanner.transit.model.site.StopLocation;
 @Produces(MediaType.APPLICATION_JSON)
 public class GeocoderResource {
 
-  private final OtpServerRequestContext serverContext;
+  private final LuceneIndex luceneIndex;
 
   public GeocoderResource(@Context OtpServerRequestContext requestContext) {
-    luceneIndex = Objects.requireNonNull(requestContext.lucenceIndex());
+    luceneIndex = requestContext.lucenceIndex();
   }
 
   /**
@@ -56,7 +56,7 @@ public class GeocoderResource {
   @GET
   @Path("stopClusters")
   public Response stopClusters(@QueryParam("query") String query) {
-    var clusters = LuceneIndex.forServer(serverContext).queryStopClusters(query).toList();
+    var clusters = luceneIndex.queryStopClusters(query).toList();
 
     return Response.status(Response.Status.OK).entity(clusters).build();
   }
@@ -81,8 +81,8 @@ public class GeocoderResource {
   }
 
   private Collection<SearchResult> queryStopLocations(String query, boolean autocomplete) {
-    return LuceneIndex
-      .forServer(serverContext)
+    return
+      luceneIndex
       .queryStopLocations(query, autocomplete)
       .map(sl ->
         new SearchResult(
@@ -96,8 +96,8 @@ public class GeocoderResource {
   }
 
   private Collection<? extends SearchResult> queryStations(String query, boolean autocomplete) {
-    return LuceneIndex
-      .forServer(serverContext)
+    return
+      luceneIndex
       .queryStopLocationGroups(query, autocomplete)
       .map(sc ->
         new SearchResult(

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
@@ -40,6 +41,7 @@ import org.apache.lucene.search.suggest.document.ContextSuggestField;
 import org.apache.lucene.search.suggest.document.FuzzyCompletionQuery;
 import org.apache.lucene.search.suggest.document.SuggestIndexSearcher;
 import org.apache.lucene.store.ByteBuffersDirectory;
+import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -68,9 +70,12 @@ public class LuceneIndex implements Serializable {
   private final SuggestIndexSearcher searcher;
   private final StopClusterMapper stopClusterMapper;
 
-  public LuceneIndex(TransitService transitService) {
+  public LuceneIndex(
+    TransitService transitService,
+    @Nullable StopConsolidationService stopConsolidationService
+  ) {
     this.transitService = transitService;
-    this.stopClusterMapper = new StopClusterMapper(transitService);
+    this.stopClusterMapper = new StopClusterMapper(transitService, stopConsolidationService);
 
     LOG.info("Creating geocoder lucene index");
 

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -46,8 +46,12 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopLocationsGroup;
 import org.opentripplanner.transit.service.TransitService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LuceneIndex implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LuceneIndex.class);
 
   private static final String TYPE = "type";
   private static final String ID = "id";

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -69,6 +69,8 @@ public class LuceneIndex implements Serializable {
     this.transitService = transitService;
     this.stopClusterMapper = new StopClusterMapper(transitService);
 
+    LOG.info("Creating geocoder lucene index");
+
     this.analyzer =
       new PerFieldAnalyzerWrapper(
         new StandardAnalyzer(),

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -77,8 +77,6 @@ public class LuceneIndex implements Serializable {
     this.transitService = transitService;
     this.stopClusterMapper = new StopClusterMapper(transitService, stopConsolidationService);
 
-    LOG.info("Creating geocoder lucene index");
-
     this.analyzer =
       new PerFieldAnalyzerWrapper(
         new StandardAnalyzer(),

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -42,7 +42,6 @@ import org.apache.lucene.search.suggest.document.SuggestIndexSearcher;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopLocationsGroup;
@@ -144,18 +143,6 @@ public class LuceneIndex implements Serializable {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  public static synchronized LuceneIndex forServer(OtpServerRequestContext serverContext) {
-    var graph = serverContext.graph();
-    var existingIndex = graph.getLuceneIndex();
-    if (existingIndex != null) {
-      return existingIndex;
-    }
-
-    var newIndex = new LuceneIndex(serverContext.transitService());
-    graph.setLuceneIndex(newIndex);
-    return newIndex;
   }
 
   public Stream<StopLocation> queryStopLocations(String query, boolean autocomplete) {

--- a/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
@@ -35,7 +35,7 @@ class StopClusterMapper {
 
   StopClusterMapper(
     TransitService transitService,
-    StopConsolidationService stopConsolidationService
+    @Nullable StopConsolidationService stopConsolidationService
   ) {
     this.transitService = transitService;
     this.stopConsolidationService = stopConsolidationService;

--- a/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.geocoder;
 import static org.opentripplanner.ext.geocoder.StopCluster.LocationType.STATION;
 import static org.opentripplanner.ext.geocoder.StopCluster.LocationType.STOP;
 
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.List;
@@ -10,6 +11,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
+import org.opentripplanner.ext.stopconsolidation.model.StopReplacement;
 import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
@@ -28,9 +31,14 @@ import org.opentripplanner.transit.service.TransitService;
 class StopClusterMapper {
 
   private final TransitService transitService;
+  private final StopConsolidationService stopConsolidationService;
 
-  StopClusterMapper(TransitService transitService) {
+  StopClusterMapper(
+    TransitService transitService,
+    StopConsolidationService stopConsolidationService
+  ) {
     this.transitService = transitService;
+    this.stopConsolidationService = stopConsolidationService;
   }
 
   /**
@@ -45,16 +53,67 @@ class StopClusterMapper {
     Collection<StopLocation> stopLocations,
     Collection<StopLocationsGroup> stopLocationsGroups
   ) {
+    var stopClusters = buildStopClusters(stopLocations);
+    var stationClusters = buildStationClusters(stopLocationsGroups);
+    var consolidatedStopClusters = buildConsolidatedStopClusters();
+
+    return Iterables.concat(stopClusters, stationClusters, consolidatedStopClusters);
+  }
+
+  private Iterable<LuceneStopCluster> buildConsolidatedStopClusters() {
+    var multiMap = stopConsolidationService
+      .replacements()
+      .stream()
+      .collect(
+        ImmutableListMultimap.toImmutableListMultimap(
+          StopReplacement::primary,
+          StopReplacement::secondary
+        )
+      );
+    return multiMap
+      .keySet()
+      .stream()
+      .map(primary -> {
+        var secondaryIds = multiMap.get(primary);
+        var secondaries = secondaryIds.stream().map(transitService::getStopLocation).toList();
+        var codes = ListUtils.combine(
+          ListUtils.ofNullable(primary.getCode()),
+          getCodes(secondaries)
+        );
+        var names = ListUtils.combine(
+          ListUtils.ofNullable(primary.getName()),
+          getNames(secondaries)
+        );
+
+        return new LuceneStopCluster(
+          primary.getId().toString(),
+          secondaryIds.stream().map(id -> id.toString()).toList(),
+          names,
+          codes,
+          toCoordinate(primary.getCoordinate())
+        );
+      })
+      .toList();
+  }
+
+  private static List<LuceneStopCluster> buildStationClusters(
+    Collection<StopLocationsGroup> stopLocationsGroups
+  ) {
+    return stopLocationsGroups.stream().map(StopClusterMapper::map).toList();
+  }
+
+  private List<LuceneStopCluster> buildStopClusters(Collection<StopLocation> stopLocations) {
     List<StopLocation> stops = stopLocations
       .stream()
       // remove stop locations without a parent station
       .filter(sl -> sl.getParentStation() == null)
+      .filter(sl -> !stopConsolidationService.isPartOfConsolidatedStop(sl))
       // stops without a name (for example flex areas) are useless for searching, so we remove them, too
       .filter(sl -> sl.getName() != null)
       .toList();
 
     // if they are very close to each other and have the same name, only one is chosen (at random)
-    var deduplicatedStops = stops
+    return stops
       .stream()
       .collect(
         Collectors.groupingBy(sl ->
@@ -66,9 +125,6 @@ class StopClusterMapper {
       .map(group -> map(group).orElse(null))
       .filter(Objects::nonNull)
       .toList();
-    var stations = stopLocationsGroups.stream().map(StopClusterMapper::map).toList();
-
-    return Iterables.concat(deduplicatedStops, stations);
   }
 
   private static LuceneStopCluster map(StopLocationsGroup g) {

--- a/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
@@ -75,7 +75,11 @@ class StopClusterMapper {
       .stream()
       .map(primary -> {
         var secondaryIds = multiMap.get(primary);
-        var secondaries = secondaryIds.stream().map(transitService::getStopLocation).toList();
+        var secondaries = secondaryIds
+          .stream()
+          .map(transitService::getStopLocation)
+          .filter(Objects::nonNull)
+          .toList();
         var codes = ListUtils.combine(
           ListUtils.ofNullable(primary.getCode()),
           getCodes(secondaries)

--- a/src/ext/java/org/opentripplanner/ext/geocoder/configure/GeocoderModule.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/configure/GeocoderModule.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.ext.geocoder.configure;
+
+import dagger.Module;
+import dagger.Provides;
+import jakarta.inject.Singleton;
+import javax.annotation.Nullable;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.transit.service.TransitService;
+
+/**
+ * This module converts the ride hailing configurations into ride hailing services to be used by the
+ * application context.
+ */
+@Module
+public class GeocoderModule {
+
+  @Provides
+  @Singleton
+  @Nullable
+  LuceneIndex luceneIndex(TransitService service) {
+    if (OTPFeature.SandboxAPIGeocoder.isOn()) {
+      return new LuceneIndex(service);
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/geocoder/configure/GeocoderModule.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/configure/GeocoderModule.java
@@ -5,12 +5,12 @@ import dagger.Provides;
 import jakarta.inject.Singleton;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
+import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
- * This module converts the ride hailing configurations into ride hailing services to be used by the
- * application context.
+ * This module builds the lucene geocoder based on the whether the feature flag is
  */
 @Module
 public class GeocoderModule {
@@ -18,9 +18,12 @@ public class GeocoderModule {
   @Provides
   @Singleton
   @Nullable
-  LuceneIndex luceneIndex(TransitService service) {
+  LuceneIndex luceneIndex(
+    TransitService service,
+    @Nullable StopConsolidationService stopConsolidationService
+  ) {
     if (OTPFeature.SandboxAPIGeocoder.isOn()) {
-      return new LuceneIndex(service);
+      return new LuceneIndex(service, stopConsolidationService);
     } else {
       return null;
     }

--- a/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationService.java
+++ b/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationService.java
@@ -43,4 +43,6 @@ public interface StopConsolidationService {
    * For a given stop id return the primary stop if it is part of a consolidated stop group.
    */
   Optional<StopLocation> primaryStop(FeedScopedId id);
+
+  boolean isPartOfConsolidatedStop(StopLocation sl);
 }

--- a/src/ext/java/org/opentripplanner/ext/stopconsolidation/internal/DefaultStopConsolidationService.java
+++ b/src/ext/java/org/opentripplanner/ext/stopconsolidation/internal/DefaultStopConsolidationService.java
@@ -68,6 +68,11 @@ public class DefaultStopConsolidationService implements StopConsolidationService
   }
 
   @Override
+  public boolean isPartOfConsolidatedStop(StopLocation sl) {
+    return isSecondaryStop(sl) || isPrimaryStop(sl);
+  }
+
+  @Override
   public boolean isActive() {
     return !repo.groups().isEmpty();
   }

--- a/src/main/java/org/opentripplanner/apis/APIEndpoints.java
+++ b/src/main/java/org/opentripplanner/apis/APIEndpoints.java
@@ -61,8 +61,6 @@ public class APIEndpoints {
     addIfEnabled(SandboxAPIMapboxVectorTilesApi, VectorTilesResource.class);
     addIfEnabled(SandboxAPIParkAndRideApi, ParkAndRideResource.class);
     addIfEnabled(SandboxAPIGeocoder, GeocoderResource.class);
-    // scheduled to be removed and only here for backwards compatibility
-    addIfEnabled(SandboxAPIGeocoder, GeocoderResource.GeocoderResourceOldPath.class);
 
     // scheduled to be removed
     addIfEnabled(APIBikeRental, BikeRental.class);

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -16,7 +16,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
-import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.framework.geometry.CompactElevationProfile;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.model.calendar.openinghours.OpeningHoursCalendarService;
@@ -136,7 +135,6 @@ public class Graph implements Serializable {
    * creating the data overlay context when routing.
    */
   public DataOverlayParameterBindings dataOverlayParameterBindings;
-  private LuceneIndex luceneIndex;
 
   @Inject
   public Graph(
@@ -382,14 +380,6 @@ public class Graph implements Serializable {
 
   public void setFareService(FareService fareService) {
     this.fareService = fareService;
-  }
-
-  public LuceneIndex getLuceneIndex() {
-    return luceneIndex;
-  }
-
-  public void setLuceneIndex(LuceneIndex luceneIndex) {
-    this.luceneIndex = luceneIndex;
   }
 
   private void indexIfNotIndexed(StopModel stopModel) {

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
@@ -8,6 +8,7 @@ import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.ext.emissions.EmissionsService;
 import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.framework.application.OTPFeature;
@@ -136,4 +137,7 @@ public interface OtpServerRequestContext {
       )
     );
   }
+
+  @Nullable
+  LuceneIndex lucenceIndex();
 }

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -179,7 +179,8 @@ public class ConstructApplication {
     }
 
     if (OTPFeature.SandboxAPIGeocoder.isOn()) {
-      LOG.info("Creating debug client geocoder lucene index");
+      LOG.info("Initializing geocoder");
+      this.factory.luceneIndex();
     }
   }
 

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -5,7 +5,6 @@ import javax.annotation.Nullable;
 import org.opentripplanner.apis.transmodel.TransmodelAPI;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.ext.emissions.EmissionsDataModel;
-import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationRepository;
 import org.opentripplanner.framework.application.LogMDCSupport;
 import org.opentripplanner.framework.application.OTPFeature;
@@ -181,7 +180,6 @@ public class ConstructApplication {
 
     if (OTPFeature.SandboxAPIGeocoder.isOn()) {
       LOG.info("Creating debug client geocoder lucene index");
-      LuceneIndex.forServer(createServerContext());
     }
   }
 

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
@@ -6,6 +6,8 @@ import jakarta.inject.Singleton;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.emissions.EmissionsDataModel;
 import org.opentripplanner.ext.emissions.EmissionsServiceModule;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
+import org.opentripplanner.ext.geocoder.configure.GeocoderModule;
 import org.opentripplanner.ext.interactivelauncher.configuration.InteractiveLauncherModule;
 import org.opentripplanner.ext.ridehailing.configure.RideHailingServicesModule;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationRepository;
@@ -56,6 +58,7 @@ import org.opentripplanner.visualizer.GraphVisualizer;
     StopConsolidationServiceModule.class,
     InteractiveLauncherModule.class,
     StreetLimitationParametersServiceModule.class,
+    GeocoderModule.class,
   }
 )
 public interface ConstructApplicationFactory {
@@ -86,6 +89,9 @@ public interface ConstructApplicationFactory {
   StopConsolidationRepository stopConsolidationRepository();
 
   StreetLimitationParameters streetLimitationParameters();
+
+  @Nullable
+  LuceneIndex luceneIndex();
 
   @Component.Builder
   interface Builder {

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationModule.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationModule.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.ext.emissions.EmissionsService;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.interactivelauncher.api.LauncherRequestDecorator;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
@@ -40,7 +41,8 @@ public class ConstructApplicationModule {
     StreetLimitationParametersService streetLimitationParametersService,
     @Nullable TraverseVisitor<?, ?> traverseVisitor,
     EmissionsService emissionsService,
-    LauncherRequestDecorator launcherRequestDecorator
+    LauncherRequestDecorator launcherRequestDecorator,
+    @Nullable LuceneIndex luceneIndex
   ) {
     var defaultRequest = launcherRequestDecorator.intercept(routerConfig.routingRequestDefaults());
 
@@ -60,7 +62,8 @@ public class ConstructApplicationModule {
       rideHailingServices,
       stopConsolidationService,
       streetLimitationParametersService,
-      traverseVisitor
+      traverseVisitor,
+      luceneIndex
     );
   }
 

--- a/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -134,7 +134,8 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
       stopConsolidationService,
       streetLimitationParametersService,
       flexParameters,
-      traverseVisitor, luceneIndex
+      traverseVisitor,
+      luceneIndex
     );
   }
 

--- a/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.ext.emissions.EmissionsService;
 import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.inspector.raster.TileRendererManager;
@@ -49,6 +50,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   private final EmissionsService emissionsService;
   private final StopConsolidationService stopConsolidationService;
   private final StreetLimitationParametersService streetLimitationParametersService;
+  private final LuceneIndex luceneIndex;
 
   /**
    * Make sure all mutable components are copied/cloned before calling this constructor.
@@ -70,7 +72,8 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     StopConsolidationService stopConsolidationService,
     StreetLimitationParametersService streetLimitationParametersService,
     FlexParameters flexParameters,
-    TraverseVisitor traverseVisitor
+    TraverseVisitor traverseVisitor,
+    @Nullable LuceneIndex luceneIndex
   ) {
     this.graph = graph;
     this.transitService = transitService;
@@ -89,6 +92,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     this.emissionsService = emissionsService;
     this.stopConsolidationService = stopConsolidationService;
     this.streetLimitationParametersService = streetLimitationParametersService;
+    this.luceneIndex = luceneIndex;
   }
 
   /**
@@ -110,7 +114,8 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     List<RideHailingService> rideHailingServices,
     @Nullable StopConsolidationService stopConsolidationService,
     StreetLimitationParametersService streetLimitationParametersService,
-    @Nullable TraverseVisitor traverseVisitor
+    @Nullable TraverseVisitor traverseVisitor,
+    @Nullable LuceneIndex luceneIndex
   ) {
     return new DefaultServerRequestContext(
       graph,
@@ -129,7 +134,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
       stopConsolidationService,
       streetLimitationParametersService,
       flexParameters,
-      traverseVisitor
+      traverseVisitor, luceneIndex
     );
   }
 
@@ -233,6 +238,12 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   @Override
   public VectorTileConfig vectorTileConfig() {
     return vectorTileConfig;
+  }
+
+  @Nullable
+  @Override
+  public LuceneIndex lucenceIndex() {
+    return luceneIndex;
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/TestServerContext.java
+++ b/src/test/java/org/opentripplanner/TestServerContext.java
@@ -55,7 +55,7 @@ public class TestServerContext {
       List.of(),
       null,
       createStreetLimitationParametersService(),
-      null
+      null, null
     );
     creatTransitLayerForRaptor(transitModel, routerConfig.transitTuningConfig());
     return context;

--- a/src/test/java/org/opentripplanner/TestServerContext.java
+++ b/src/test/java/org/opentripplanner/TestServerContext.java
@@ -55,7 +55,8 @@ public class TestServerContext {
       List.of(),
       null,
       createStreetLimitationParametersService(),
-      null, null
+      null,
+      null
     );
     creatTransitLayerForRaptor(transitModel, routerConfig.transitTuningConfig());
     return context;

--- a/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
@@ -15,12 +15,10 @@ import graphql.schema.DataFetchingEnvironmentImpl;
 import io.micrometer.core.instrument.Metrics;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -146,7 +144,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
           List.of(),
           null,
           new DefaultStreetLimitationParametersService(new StreetLimitationParameters()),
-          null
+          null, null
         ),
         null,
         transitService

--- a/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
@@ -144,7 +144,8 @@ public class TripRequestMapperTest implements PlanTestConstants {
           List.of(),
           null,
           new DefaultStreetLimitationParametersService(new StreetLimitationParameters()),
-          null, null
+          null,
+          null
         ),
         null,
         transitService

--- a/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -121,7 +121,8 @@ public class SpeedTest {
         List.of(),
         null,
         TestServerContext.createStreetLimitationParametersService(),
-        null, null
+        null,
+        null
       );
     // Creating transitLayerForRaptor should be integrated into the TransitModel, but for now
     // we do it manually here

--- a/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -121,7 +121,7 @@ public class SpeedTest {
         List.of(),
         null,
         TestServerContext.createStreetLimitationParametersService(),
-        null
+        null, null
       );
     // Creating transitLayerForRaptor should be integrated into the TransitModel, but for now
     // we do it manually here


### PR DESCRIPTION
### Summary

This connects two sandbox features with each other: IBI's consolidated stops and and the geocoder.

In order to do this, the `LuceneIndex` was moved out of the Graph and into a Dagger module which instantiates it (or not) based on the feature flags.

cc @miles-grant-ibigroup 

### Unit tests

I added a unit test.

Most importantly, it adds a dependency on the assertion library `truth` by Google which allows you to write assertions against collections (among other things) which have very helpful error messages, like this:

```
value of           : generateStopClusters(...)
expected to contain: LuceneStopCluster[primaryId=F:A, secondaryIds=[F:B], names=[A, B], codes=[A], coordinate=Coordinate[lat=60.0, lon=10.0]]
but was            : [LuceneStopCluster[primaryId=F:C, secondaryIds=[], names=[C], codes=[C], coordinate=Coordinate[lat=60.0, lon=10.0]], LuceneStopCluster[primaryId=F:A, secondaryIds=[F:B], names=[A, B], codes=[A, B], coordinate=Coordinate[lat=60.0, lon=10.0]]]
```