### PR TITLE
Remove write access to the transit layer from the transit editor service

### DIFF
--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -515,11 +515,6 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public void setTransitLayer(TransitLayer transitLayer) {
-    this.transitModel.setTransitLayer(transitLayer);
-  }
-
-  @Override
   public CalendarService getCalendarService() {
     return this.transitModel.getCalendarService();
   }

--- a/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.transit.service;
 
 import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -17,6 +16,4 @@ public interface TransitEditorService extends TransitService {
   void addRoutes(Route route);
 
   void addTransitMode(TransitMode mode);
-
-  void setTransitLayer(TransitLayer transitLayer);
 }


### PR DESCRIPTION

### Summary

The transit editor service allows today to set a new transit layer on the transit model.
This is not used anywhere in the code and obscures the lifecycle of the transit layer (the transit layer is created at application construction time and never changed afterwards).
This PR removes this dead code.

### Issue

No

### Unit tests
No

### Documentation

No

