### PR TITLE
fix(orca-fares): allow senior fares with cash

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -134,7 +134,7 @@ public class OrcaFareServiceTest {
   void calculateFareForSingleAgency() {
     List<Leg> rides = List.of(getLeg(COMM_TRANS_AGENCY_ID, "400", 0));
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE);
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE);
+    calculateFare(rides, FareType.senior, TWO_DOLLARS);
     calculateFare(rides, FareType.youth, ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, TWO_DOLLARS);
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE);
@@ -154,7 +154,7 @@ public class OrcaFareServiceTest {
       getLeg(COMM_TRANS_AGENCY_ID, 2)
     );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(3));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(3));
+    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.plus(usDollars(2.25f)));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(
       rides,
@@ -164,7 +164,7 @@ public class OrcaFareServiceTest {
     calculateFare(
       rides,
       FareType.electronicRegular,
-      DEFAULT_TEST_RIDE_PRICE.plus(DEFAULT_TEST_RIDE_PRICE)
+      DEFAULT_TEST_RIDE_PRICE.times(2)
     );
     calculateFare(rides, FareType.electronicSenior, DEFAULT_TEST_RIDE_PRICE.plus(usDollars(1.25f)));
     calculateFare(rides, FareType.electronicYouth, Money.ZERO_USD);
@@ -200,7 +200,7 @@ public class OrcaFareServiceTest {
     );
 
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(2));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(2));
+    calculateFare(rides, FareType.senior, TWO_DOLLARS);
     calculateFare(rides, FareType.youth, ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, TWO_DOLLARS);
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE.times(2));
@@ -227,7 +227,7 @@ public class OrcaFareServiceTest {
     calculateFare(
       rides,
       FareType.senior,
-      DEFAULT_TEST_RIDE_PRICE.times(2).plus(usDollars(.50f)).plus(HALF_FERRY_FARE)
+      ONE_DOLLAR.plus(ONE_DOLLAR).plus(HALF_FERRY_FARE).plus(usDollars(0.5f))
     );
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     // We don't get any fares for the skagit transit leg below here because they don't accept ORCA (electronic)
@@ -263,7 +263,7 @@ public class OrcaFareServiceTest {
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 270)
     );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(3));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(3));
+    calculateFare(rides, FareType.senior, usDollars(3));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(3));
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE.times(3));
@@ -286,7 +286,7 @@ public class OrcaFareServiceTest {
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 149)
     );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(2));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(2));
+    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.plus(ONE_DOLLAR));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, DEFAULT_TEST_RIDE_PRICE.plus(ONE_DOLLAR));
     calculateFare(
@@ -305,7 +305,7 @@ public class OrcaFareServiceTest {
   void calculateFareForKitsapFastFerry() {
     List<Leg> rides = List.of(getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "404", "east"));
     calculateFare(rides, regular, TWO_DOLLARS);
-    calculateFare(rides, FareType.senior, TWO_DOLLARS);
+    calculateFare(rides, FareType.senior, ONE_DOLLAR);
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, ONE_DOLLAR);
     calculateFare(rides, FareType.electronicRegular, TWO_DOLLARS);
@@ -314,7 +314,7 @@ public class OrcaFareServiceTest {
 
     rides = List.of(getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "404", "west"));
     calculateFare(rides, regular, usDollars(10f));
-    calculateFare(rides, FareType.senior, usDollars(10f));
+    calculateFare(rides, FareType.senior, usDollars(5f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(5f));
     calculateFare(rides, FareType.electronicRegular, usDollars(10f));
@@ -349,7 +349,7 @@ public class OrcaFareServiceTest {
       getLeg(SOUND_TRANSIT_AGENCY_ID, "S Line", 100, "King Street Station", "Auburn Station")
     );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(2));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(2));
+    calculateFare(rides, FareType.senior, TWO_DOLLARS);
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, ORCA_SPECIAL_FARE);
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE);
@@ -364,7 +364,7 @@ public class OrcaFareServiceTest {
   void calculateWaterTaxiFares() {
     List<Leg> rides = List.of(getLeg(KC_METRO_AGENCY_ID, "973", 1));
     calculateFare(rides, regular, WEST_SEATTLE_WATER_TAXI_CASH_FARE);
-    calculateFare(rides, FareType.senior, WEST_SEATTLE_WATER_TAXI_CASH_FARE);
+    calculateFare(rides, FareType.senior, usDollars(2.50f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(3.75f));
     calculateFare(rides, FareType.electronicRegular, usDollars(5f));
@@ -374,7 +374,7 @@ public class OrcaFareServiceTest {
     rides = List.of(getLeg(KC_METRO_AGENCY_ID, "975", 1));
 
     calculateFare(rides, regular, VASHON_WATER_TAXI_CASH_FARE);
-    calculateFare(rides, FareType.senior, VASHON_WATER_TAXI_CASH_FARE);
+    calculateFare(rides, FareType.senior, usDollars(3f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(4.50f));
     calculateFare(rides, FareType.electronicRegular, usDollars(5.75f));
@@ -395,8 +395,7 @@ public class OrcaFareServiceTest {
       getLeg(KC_METRO_AGENCY_ID, "550", 240)
     );
     calculateFare(rides, regular, usDollars(9.75f));
-    // Sound Transit does not accept senior fares in cash
-    calculateFare(rides, FareType.senior, usDollars(9.75f));
+    calculateFare(rides, FareType.senior, usDollars(3.00f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(3f));
     calculateFare(rides, FareType.electronicRegular, usDollars(9.75f));
@@ -410,7 +409,7 @@ public class OrcaFareServiceTest {
         getLeg(PIERCE_COUNTY_TRANSIT_AGENCY_ID, "501", 60)
       );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(2));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(2));
+    calculateFare(rides, FareType.senior, TWO_DOLLARS);
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(1f));
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE);
@@ -430,7 +429,7 @@ public class OrcaFareServiceTest {
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 132)
     );
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE.times(4));
-    calculateFare(rides, FareType.senior, DEFAULT_TEST_RIDE_PRICE.times(4));
+    calculateFare(rides, FareType.senior, usDollars(4.25f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(1.25f));
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE.times(2));
@@ -442,12 +441,12 @@ public class OrcaFareServiceTest {
   void calculateTransferExtension() {
     List<Leg> rides = List.of(
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "Kitsap Fast Ferry", "east"), // 2.00
-      getLeg(KC_METRO_AGENCY_ID, 100), // Default ride price, extends transfer
+      getLeg(KC_METRO_AGENCY_ID, 100), // Default ride price, extends transfer for regular fare
       getLeg(KITSAP_TRANSIT_AGENCY_ID, 150, 4, "Kitsap Fast Ferry", "west") // 10.00
     );
     var regularFare = usDollars(2.00f).plus(DEFAULT_TEST_RIDE_PRICE).plus(usDollars(10f));
     calculateFare(rides, regular, regularFare);
-    calculateFare(rides, FareType.senior, regularFare);
+    calculateFare(rides, FareType.senior, usDollars(7f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
     calculateFare(rides, FareType.electronicSpecial, usDollars(6f));
     calculateFare(rides, FareType.electronicRegular, usDollars(10f)); // transfer extended on second leg

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -161,11 +161,7 @@ public class OrcaFareServiceTest {
       FareType.electronicSpecial,
       DEFAULT_TEST_RIDE_PRICE.plus(usDollars(1.25f))
     );
-    calculateFare(
-      rides,
-      FareType.electronicRegular,
-      DEFAULT_TEST_RIDE_PRICE.times(2)
-    );
+    calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE.times(2));
     calculateFare(rides, FareType.electronicSenior, DEFAULT_TEST_RIDE_PRICE.plus(usDollars(1.25f)));
     calculateFare(rides, FareType.electronicYouth, Money.ZERO_USD);
   }

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -352,10 +352,10 @@ public class OrcaFareService extends DefaultFareService {
     var regularFare = getRegularFare(fareType, rideType, defaultFare, leg);
     // Many agencies only provide senior discount if using ORCA
     return switch (rideType) {
-      case COMM_TRANS_LOCAL_SWIFT -> usesOrca(fareType) ? optionalUSD(1.25f) : regularFare;
-      case COMM_TRANS_COMMUTER_EXPRESS -> usesOrca(fareType) ? optionalUSD(2f) : regularFare;
+      case COMM_TRANS_LOCAL_SWIFT -> optionalUSD(1.25f);
+      case COMM_TRANS_COMMUTER_EXPRESS -> optionalUSD(2f);
       case SKAGIT_TRANSIT, WHATCOM_LOCAL, SKAGIT_LOCAL -> optionalUSD(0.5f);
-      case EVERETT_TRANSIT -> usesOrca(fareType) ? optionalUSD(0.5f) : regularFare;
+      case EVERETT_TRANSIT -> optionalUSD(0.5f);
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND,
         SOUND_TRANSIT,
         SOUND_TRANSIT_BUS,
@@ -365,14 +365,10 @@ public class OrcaFareService extends DefaultFareService {
         KC_METRO,
         PIERCE_COUNTY_TRANSIT,
         SEATTLE_STREET_CAR,
-        KITSAP_TRANSIT -> fareType.equals(FareType.electronicSenior)
-        ? optionalUSD(1f)
-        : regularFare;
-      case KC_WATER_TAXI_VASHON_ISLAND -> usesOrca(fareType) ? optionalUSD(3f) : regularFare;
-      case KC_WATER_TAXI_WEST_SEATTLE -> usesOrca(fareType) ? optionalUSD(2.5f) : regularFare;
-      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> fareType.equals(FareType.electronicSenior)
-        ? optionalUSD(5f)
-        : regularFare;
+        KITSAP_TRANSIT -> optionalUSD(1f);
+      case KC_WATER_TAXI_VASHON_ISLAND -> optionalUSD(3f);
+      case KC_WATER_TAXI_WEST_SEATTLE -> optionalUSD(2.5f);
+      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> optionalUSD(5f);
       // Discount specific to Skagit transit and not Orca.
       case WASHINGTON_STATE_FERRIES -> Optional.of(
         getWashingtonStateFerriesFare(route.getLongName(), fareType, defaultFare)


### PR DESCRIPTION
### Summary

This fixes senior fares not being allowed with cash. It was thought that senior discount was only allowed with an ORCA card, but that wasn't correct. 
