### PR TITLE
Update Google Pubsub updater configuration

### DIFF
--- a/doc-templates/sandbox/siri/SiriGooglePubSubUpdater.md
+++ b/doc-templates/sandbox/siri/SiriGooglePubSubUpdater.md
@@ -1,0 +1,29 @@
+# Siri-ET Google PubSub Updater
+
+Support for consuming SIRI-ET messages over a Google Cloud PubSub subscription.
+Similarly to the SIRI-ET HTTP updater, this updater is developed to support the Nordic SIRI profile
+which is a subset of the SIRI specification.
+
+## Contact Info
+Entur, Norway
+https://entur.no/
+
+## Documentation
+
+This updater consumes SIRI real time information over an asynchronous publisher/subscriber feed
+provided by a Google Cloud PubSub topic.
+
+For more documentation see
+the [Entur Real-Time Data](https://developer.entur.org/pages-real-time-intro) documentation and
+the [Norwegian SIRI profile](https://enturas.atlassian.net/wiki/spaces/PUBLIC/pages/637370420/Norwegian+SIRI+profile)
+.
+
+## Configuration
+
+To enable the SIRI-ET Google PubSub updater you need to add it to the updaters section
+of the `router-config.json`.
+
+### Siri-ET via Google PubSub
+
+<!-- INSERT: siri-et-google-pubsub-updater -->
+

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -860,6 +860,17 @@ Used to group requests when monitoring OTP.
       }
     },
     {
+      "type" : "siri-et-google-pubsub-updater",
+      "feedId" : "feed_id",
+      "reconnectPeriod" : "5s",
+      "initialGetDataTimeout" : "1m20s",
+      "topicProjectName" : "google_pubsub_topic_project_name",
+      "subscriptionProjectName" : "google_pubsub_subscription_project_name",
+      "topicName" : "estimated_timetables",
+      "dataInitializationUrl" : "https://example.com/some/path",
+      "fuzzyTripMatching" : true
+    },
+    {
       "type" : "vehicle-parking",
       "feedId" : "bikeep",
       "sourceType" : "bikeep",

--- a/docs/examples/entur/router-config.json
+++ b/docs/examples/entur/router-config.json
@@ -123,8 +123,9 @@
     {
       "type": "siri-et-google-pubsub-updater",
       "feedId": "EN",
-      "projectName": "entur-ror",
+      "topicProjectName": "entur-anshar",
       "topicName": "estimated_timetables",
+      "subscriptionProjectName": "entur-otp2",
       "dataInitializationUrl": "https://example.com"
     },
     // SIRI ET updater

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -320,36 +320,36 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 | Config Parameter                 |       Type      | Summary                                                                      |  Req./Opt. | Default Value | Since |
 |----------------------------------|:---------------:|------------------------------------------------------------------------------|:----------:|---------------|:-----:|
 | type = "vehicle-parking"         |      `enum`     | The type of the updater.                                                     | *Required* |               |  1.5  |
-| [feedId](#u__13__feedId)         |     `string`    | The id of the data source, which will be the prefix of the parking lot's id. | *Required* |               |  2.2  |
+| [feedId](#u__14__feedId)         |     `string`    | The id of the data source, which will be the prefix of the parking lot's id. | *Required* |               |  2.2  |
 | frequency                        |    `duration`   | How often to update the source.                                              | *Optional* | `"PT1M"`      |  2.6  |
-| [sourceType](#u__13__sourceType) |      `enum`     | The source of the vehicle updates.                                           | *Required* |               |  2.2  |
+| [sourceType](#u__14__sourceType) |      `enum`     | The source of the vehicle updates.                                           | *Required* |               |  2.2  |
 | url                              |      `uri`      | URL of the locations endpoint.                                               | *Required* |               |  2.6  |
-| [headers](#u__13__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.   | *Optional* |               |  2.6  |
+| [headers](#u__14__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.   | *Optional* |               |  2.6  |
 
 
 #### Details
 
-<h4 id="u__13__feedId">feedId</h4>
+<h4 id="u__14__feedId">feedId</h4>
 
 **Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
-**Path:** /updaters/[13] 
+**Path:** /updaters/[14] 
 
 The id of the data source, which will be the prefix of the parking lot's id.
 
 This will end up in the API responses as the feed id of of the parking lot.
 
-<h4 id="u__13__sourceType">sourceType</h4>
+<h4 id="u__14__sourceType">sourceType</h4>
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
-**Path:** /updaters/[13]   
+**Path:** /updaters/[14]   
 **Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep`
 
 The source of the vehicle updates.
 
-<h4 id="u__13__headers">headers</h4>
+<h4 id="u__14__headers">headers</h4>
 
 **Since version:** `2.6` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
-**Path:** /updaters/[13] 
+**Path:** /updaters/[14] 
 
 HTTP headers to add to the request. Any header key, value can be inserted.
 

--- a/docs/sandbox/siri/SiriGooglePubSubUpdater.md
+++ b/docs/sandbox/siri/SiriGooglePubSubUpdater.md
@@ -1,0 +1,118 @@
+# Siri-ET Google PubSub Updater
+
+Support for consuming SIRI-ET messages over a Google Cloud PubSub subscription.
+Similarly to the SIRI-ET HTTP updater, this updater is developed to support the Nordic SIRI profile
+which is a subset of the SIRI specification.
+
+## Contact Info
+Entur, Norway
+https://entur.no/
+
+## Documentation
+
+This updater consumes SIRI real time information over an asynchronous publisher/subscriber feed
+provided by a Google Cloud PubSub topic.
+
+For more documentation see
+the [Entur Real-Time Data](https://developer.entur.org/pages-real-time-intro) documentation and
+the [Norwegian SIRI profile](https://enturas.atlassian.net/wiki/spaces/PUBLIC/pages/637370420/Norwegian+SIRI+profile)
+.
+
+## Configuration
+
+To enable the SIRI-ET Google PubSub updater you need to add it to the updaters section
+of the `router-config.json`.
+
+### Siri-ET via Google PubSub
+
+<!-- siri-et-google-pubsub-updater BEGIN -->
+<!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
+
+| Config Parameter                                           |    Type    | Summary                                                                          |  Req./Opt. | Default Value | Since |
+|------------------------------------------------------------|:----------:|----------------------------------------------------------------------------------|:----------:|---------------|:-----:|
+| type = "siri-et-google-pubsub-updater"                     |   `enum`   | The type of the updater.                                                         | *Required* |               |  1.5  |
+| [dataInitializationUrl](#u__13__dataInitializationUrl)     |  `string`  | URL used to download over HTTP the recent history of SIRI-ET messages.           | *Optional* |               |   na  |
+| feedId                                                     |  `string`  | The ID of the feed to apply the updates to.                                      | *Optional* |               |   na  |
+| fuzzyTripMatching                                          |  `boolean` | If the trips should be matched fuzzily.                                          | *Optional* | `false`       |   na  |
+| [initialGetDataTimeout](#u__13__initialGetDataTimeout)     | `duration` | Timeout for retrieving the recent history of SIRI-ET messages.                   | *Optional* | `"PT30S"`     |   na  |
+| [reconnectPeriod](#u__13__reconnectPeriod)                 | `duration` | Wait this amount of time before trying to reconnect to the PubSub subscription.  | *Optional* | `"PT30S"`     |   na  |
+| [subscriptionProjectName](#u__13__subscriptionProjectName) |  `string`  | The Google Cloud project that hosts the PubSub subscription.                     | *Required* |               |   na  |
+| topicName                                                  |  `string`  | The name of the PubSub topic that publishes the updates.                         | *Required* |               |   na  |
+| topicProjectName                                           |  `string`  | The Google Cloud project that hosts the PubSub topic that publishes the updates. | *Required* |               |   na  |
+
+
+##### Parameter details
+
+<h4 id="u__13__dataInitializationUrl">dataInitializationUrl</h4>
+
+**Since version:** `na` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
+**Path:** /updaters/[13] 
+
+URL used to download over HTTP the recent history of SIRI-ET messages.
+
+Optionally the updater can download the recent history of SIRI-ET messages from this URL.
+If this parameter is set, the updater will be marked as initialized (primed) only when
+the message history is fully downloaded and applied.
+
+
+<h4 id="u__13__initialGetDataTimeout">initialGetDataTimeout</h4>
+
+**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT30S"`   
+**Path:** /updaters/[13] 
+
+Timeout for retrieving the recent history of SIRI-ET messages.
+
+When trying to fetch the message history over HTTP, the updater will wait this amount
+of time for the connection to be established.
+If the connection times out, the updater will retry indefinitely with exponential backoff.
+
+
+<h4 id="u__13__reconnectPeriod">reconnectPeriod</h4>
+
+**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT30S"`   
+**Path:** /updaters/[13] 
+
+Wait this amount of time before trying to reconnect to the PubSub subscription.
+
+In case of a network error, the updater will try periodically to reconnect to the
+Google PubSub subscription.
+
+
+<h4 id="u__13__subscriptionProjectName">subscriptionProjectName</h4>
+
+**Since version:** `na` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[13] 
+
+The Google Cloud project that hosts the PubSub subscription.
+
+During startup, the updater creates a PubSub subscription that listens
+to the PubSub topic that publishes SIRI-ET updates.
+This parameter specifies in which Google Cloud project the subscription will be created.
+The topic and the subscription can be hosted in two different projects.
+
+
+
+
+##### Example configuration
+
+```JSON
+// router-config.json
+{
+  "updaters" : [
+    {
+      "type" : "siri-et-google-pubsub-updater",
+      "feedId" : "feed_id",
+      "reconnectPeriod" : "5s",
+      "initialGetDataTimeout" : "1m20s",
+      "topicProjectName" : "google_pubsub_topic_project_name",
+      "subscriptionProjectName" : "google_pubsub_subscription_project_name",
+      "topicName" : "estimated_timetables",
+      "dataInitializationUrl" : "https://example.com/some/path",
+      "fuzzyTripMatching" : true
+    }
+  ]
+}
+```
+
+<!-- siri-et-google-pubsub-updater END -->
+

--- a/docs/sandbox/siri/SiriGooglePubSubUpdater.md
+++ b/docs/sandbox/siri/SiriGooglePubSubUpdater.md
@@ -31,21 +31,21 @@ of the `router-config.json`.
 | Config Parameter                                           |    Type    | Summary                                                                          |  Req./Opt. | Default Value | Since |
 |------------------------------------------------------------|:----------:|----------------------------------------------------------------------------------|:----------:|---------------|:-----:|
 | type = "siri-et-google-pubsub-updater"                     |   `enum`   | The type of the updater.                                                         | *Required* |               |  1.5  |
-| [dataInitializationUrl](#u__13__dataInitializationUrl)     |  `string`  | URL used to download over HTTP the recent history of SIRI-ET messages.           | *Optional* |               |   na  |
-| feedId                                                     |  `string`  | The ID of the feed to apply the updates to.                                      | *Optional* |               |   na  |
-| fuzzyTripMatching                                          |  `boolean` | If the trips should be matched fuzzily.                                          | *Optional* | `false`       |   na  |
-| [initialGetDataTimeout](#u__13__initialGetDataTimeout)     | `duration` | Timeout for retrieving the recent history of SIRI-ET messages.                   | *Optional* | `"PT30S"`     |   na  |
-| [reconnectPeriod](#u__13__reconnectPeriod)                 | `duration` | Wait this amount of time before trying to reconnect to the PubSub subscription.  | *Optional* | `"PT30S"`     |   na  |
-| [subscriptionProjectName](#u__13__subscriptionProjectName) |  `string`  | The Google Cloud project that hosts the PubSub subscription.                     | *Required* |               |   na  |
-| topicName                                                  |  `string`  | The name of the PubSub topic that publishes the updates.                         | *Required* |               |   na  |
-| topicProjectName                                           |  `string`  | The Google Cloud project that hosts the PubSub topic that publishes the updates. | *Required* |               |   na  |
+| [dataInitializationUrl](#u__13__dataInitializationUrl)     |  `string`  | URL used to download over HTTP the recent history of SIRI-ET messages.           | *Optional* |               |  2.1  |
+| feedId                                                     |  `string`  | The ID of the feed to apply the updates to.                                      | *Optional* |               |  2.1  |
+| fuzzyTripMatching                                          |  `boolean` | If the trips should be matched fuzzily.                                          | *Optional* | `false`       |  2.1  |
+| [initialGetDataTimeout](#u__13__initialGetDataTimeout)     | `duration` | Timeout for retrieving the recent history of SIRI-ET messages.                   | *Optional* | `"PT30S"`     |  2.1  |
+| [reconnectPeriod](#u__13__reconnectPeriod)                 | `duration` | Wait this amount of time before trying to reconnect to the PubSub subscription.  | *Optional* | `"PT30S"`     |  2.1  |
+| [subscriptionProjectName](#u__13__subscriptionProjectName) |  `string`  | The Google Cloud project that hosts the PubSub subscription.                     | *Required* |               |  2.1  |
+| topicName                                                  |  `string`  | The name of the PubSub topic that publishes the updates.                         | *Required* |               |  2.1  |
+| topicProjectName                                           |  `string`  | The Google Cloud project that hosts the PubSub topic that publishes the updates. | *Required* |               |  2.1  |
 
 
 ##### Parameter details
 
 <h4 id="u__13__dataInitializationUrl">dataInitializationUrl</h4>
 
-**Since version:** `na` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
+**Since version:** `2.1` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[13] 
 
 URL used to download over HTTP the recent history of SIRI-ET messages.
@@ -57,7 +57,7 @@ the message history is fully downloaded and applied.
 
 <h4 id="u__13__initialGetDataTimeout">initialGetDataTimeout</h4>
 
-**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT30S"`   
+**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT30S"`   
 **Path:** /updaters/[13] 
 
 Timeout for retrieving the recent history of SIRI-ET messages.
@@ -69,7 +69,7 @@ If the connection times out, the updater will retry indefinitely with exponentia
 
 <h4 id="u__13__reconnectPeriod">reconnectPeriod</h4>
 
-**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT30S"`   
+**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT30S"`   
 **Path:** /updaters/[13] 
 
 Wait this amount of time before trying to reconnect to the PubSub subscription.
@@ -80,7 +80,7 @@ Google PubSub subscription.
 
 <h4 id="u__13__subscriptionProjectName">subscriptionProjectName</h4>
 
-**Since version:** `na` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
+**Since version:** `2.1` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[13] 
 
 The Google Cloud project that hosts the PubSub subscription.

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/google/SiriETGooglePubsubUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/google/SiriETGooglePubsubUpdaterParameters.java
@@ -10,15 +10,12 @@ import org.opentripplanner.updater.trip.UrlUpdaterParameters;
 public record SiriETGooglePubsubUpdaterParameters(
   @Nonnull String configRef,
   @Nullable String feedId,
-  String type,
-  @Deprecated String projectName,
   String subscriptionProjectName,
   String topicProjectName,
   String topicName,
   @Nullable String dataInitializationUrl,
   Duration reconnectPeriod,
   Duration initialGetDataTimeout,
-  boolean purgeExpiredData,
   boolean fuzzyTripMatching
 )
   implements UrlUpdaterParameters {
@@ -26,16 +23,6 @@ public record SiriETGooglePubsubUpdaterParameters(
   public static Duration INITIAL_GET_DATA_TIMEOUT = Duration.ofSeconds(30);
 
   public SiriETGooglePubsubUpdaterParameters {
-    Objects.requireNonNull(type);
-
-    if (subscriptionProjectName == null && topicProjectName == null) {
-      // New config-parameters not yet in use
-      // TODO: Remove deprecated `projectName` when config is updated
-      Objects.requireNonNull(projectName);
-      subscriptionProjectName = projectName;
-      topicProjectName = projectName;
-    }
-
     Objects.requireNonNull(subscriptionProjectName);
     Objects.requireNonNull(topicProjectName);
     Objects.requireNonNull(topicName);
@@ -50,14 +37,11 @@ public record SiriETGooglePubsubUpdaterParameters(
       .of(SiriETGooglePubsubUpdaterParameters.class)
       .addObj("configRef", configRef, null)
       .addObj("feedId", feedId, null)
-      .addObj("type", type)
-      .addObj("projectName", projectName)
-      .addObj("subscriptionProjectName", subscriptionProjectName, projectName)
-      .addObj("topicProjectName", topicProjectName, projectName)
+      .addObj("subscriptionProjectName", subscriptionProjectName)
+      .addObj("topicProjectName", topicProjectName)
       .addObj("topicName", topicName)
       .addDuration("reconnectPeriod", reconnectPeriod, RECONNECT_PERIOD)
       .addDuration("initialGetDataTimeout", initialGetDataTimeout, INITIAL_GET_DATA_TIMEOUT)
-      .addBoolIfTrue("purgeExpiredData", purgeExpiredData)
       .addBoolIfTrue("fuzzyTripMatching", fuzzyTripMatching)
       .addObj("dataInitializationUrl", dataInitializationUrl, null)
       .toString();

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETGooglePubsubUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETGooglePubsubUpdaterConfig.java
@@ -12,17 +12,74 @@ public class SiriETGooglePubsubUpdaterConfig {
   public static SiriETGooglePubsubUpdaterParameters create(String configRef, NodeAdapter c) {
     return new SiriETGooglePubsubUpdaterParameters(
       configRef,
-      c.of("feedId").since(NA).summary("TODO").asString(null),
-      c.of("type").since(NA).summary("TODO").asString(),
-      c.of("projectName").since(NA).summary("TODO").asString(null), // TODO: Remove (deprecated)
-      c.of("subscriptionProjectName").since(NA).summary("TODO").asString(null), // TODO: Set as required
-      c.of("topicProjectName").since(NA).summary("TODO").asString(null), // TODO: Set as required
-      c.of("topicName").since(NA).summary("TODO").asString(),
-      c.of("dataInitializationUrl").since(NA).summary("TODO").asString(null),
-      c.of("reconnectPeriod").since(NA).summary("TODO").asDuration(RECONNECT_PERIOD),
-      c.of("initialGetDataTimeout").since(NA).summary("TODO").asDuration(INITIAL_GET_DATA_TIMEOUT),
-      c.of("purgeExpiredData").since(NA).summary("TODO").asBoolean(false),
-      c.of("fuzzyTripMatching").since(NA).summary("TODO").asBoolean(false)
+      c
+        .of("feedId")
+        .since(NA)
+        .summary("The ID of the feed to apply the updates to.")
+        .asString(null),
+      c
+        .of("subscriptionProjectName")
+        .since(NA)
+        .summary("The Google Cloud project that hosts the PubSub subscription.")
+        .description(
+          """
+        During startup, the updater creates a PubSub subscription that listens
+        to the PubSub topic that publishes SIRI-ET updates.
+        This parameter specifies in which Google Cloud project the subscription will be created.
+        The topic and the subscription can be hosted in two different projects.
+        """
+        )
+        .asString(),
+      c
+        .of("topicProjectName")
+        .since(NA)
+        .summary("The Google Cloud project that hosts the PubSub topic that publishes the updates.")
+        .asString(),
+      c
+        .of("topicName")
+        .since(NA)
+        .summary("The name of the PubSub topic that publishes the updates.")
+        .asString(),
+      c
+        .of("dataInitializationUrl")
+        .since(NA)
+        .summary("URL used to download over HTTP the recent history of SIRI-ET messages.")
+        .description(
+          """
+          Optionally the updater can download the recent history of SIRI-ET messages from this URL.
+          If this parameter is set, the updater will be marked as initialized (primed) only when
+          the message history is fully downloaded and applied.
+          """
+        )
+        .asString(null),
+      c
+        .of("reconnectPeriod")
+        .since(NA)
+        .summary("Wait this amount of time before trying to reconnect to the PubSub subscription.")
+        .description(
+          """
+            In case of a network error, the updater will try periodically to reconnect to the
+            Google PubSub subscription.
+            """
+        )
+        .asDuration(RECONNECT_PERIOD),
+      c
+        .of("initialGetDataTimeout")
+        .since(NA)
+        .summary("Timeout for retrieving the recent history of SIRI-ET messages.")
+        .description(
+          """
+          When trying to fetch the message history over HTTP, the updater will wait this amount
+          of time for the connection to be established.
+          If the connection times out, the updater will retry indefinitely with exponential backoff.
+          """
+        )
+        .asDuration(INITIAL_GET_DATA_TIMEOUT),
+      c
+        .of("fuzzyTripMatching")
+        .since(NA)
+        .summary("If the trips should be matched fuzzily.")
+        .asBoolean(false)
     );
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETGooglePubsubUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETGooglePubsubUpdaterConfig.java
@@ -2,7 +2,7 @@ package org.opentripplanner.standalone.config.routerconfig.updaters;
 
 import static org.opentripplanner.ext.siri.updater.google.SiriETGooglePubsubUpdaterParameters.INITIAL_GET_DATA_TIMEOUT;
 import static org.opentripplanner.ext.siri.updater.google.SiriETGooglePubsubUpdaterParameters.RECONNECT_PERIOD;
-import static org.opentripplanner.standalone.config.framework.json.OtpVersion.NA;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
 
 import org.opentripplanner.ext.siri.updater.google.SiriETGooglePubsubUpdaterParameters;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
@@ -14,12 +14,12 @@ public class SiriETGooglePubsubUpdaterConfig {
       configRef,
       c
         .of("feedId")
-        .since(NA)
+        .since(V2_1)
         .summary("The ID of the feed to apply the updates to.")
         .asString(null),
       c
         .of("subscriptionProjectName")
-        .since(NA)
+        .since(V2_1)
         .summary("The Google Cloud project that hosts the PubSub subscription.")
         .description(
           """
@@ -32,17 +32,17 @@ public class SiriETGooglePubsubUpdaterConfig {
         .asString(),
       c
         .of("topicProjectName")
-        .since(NA)
+        .since(V2_1)
         .summary("The Google Cloud project that hosts the PubSub topic that publishes the updates.")
         .asString(),
       c
         .of("topicName")
-        .since(NA)
+        .since(V2_1)
         .summary("The name of the PubSub topic that publishes the updates.")
         .asString(),
       c
         .of("dataInitializationUrl")
-        .since(NA)
+        .since(V2_1)
         .summary("URL used to download over HTTP the recent history of SIRI-ET messages.")
         .description(
           """
@@ -54,7 +54,7 @@ public class SiriETGooglePubsubUpdaterConfig {
         .asString(null),
       c
         .of("reconnectPeriod")
-        .since(NA)
+        .since(V2_1)
         .summary("Wait this amount of time before trying to reconnect to the PubSub subscription.")
         .description(
           """
@@ -65,7 +65,7 @@ public class SiriETGooglePubsubUpdaterConfig {
         .asDuration(RECONNECT_PERIOD),
       c
         .of("initialGetDataTimeout")
-        .since(NA)
+        .since(V2_1)
         .summary("Timeout for retrieving the recent history of SIRI-ET messages.")
         .description(
           """
@@ -77,7 +77,7 @@ public class SiriETGooglePubsubUpdaterConfig {
         .asDuration(INITIAL_GET_DATA_TIMEOUT),
       c
         .of("fuzzyTripMatching")
-        .since(NA)
+        .since(V2_1)
         .summary("If the trips should be matched fuzzily.")
         .asBoolean(false)
     );

--- a/src/test/java/org/opentripplanner/generate/doc/SiriGooglePubSubConfigDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/SiriGooglePubSubConfigDocTest.java
@@ -23,34 +23,29 @@ import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 @GeneratesDocumentation
-public class UpdaterConfigDocTest {
+public class SiriGooglePubSubConfigDocTest {
 
-  private static final File TEMPLATE = new File(TEMPLATE_ROOT, "UpdaterConfig.md");
-  private static final File OUT_FILE = new File(DOCS_ROOT, "UpdaterConfig.md");
+  private static final File TEMPLATE = new File(
+    TEMPLATE_ROOT,
+    "sandbox/siri/SiriGooglePubSubUpdater.md"
+  );
+  private static final File OUT_FILE = new File(
+    DOCS_ROOT,
+    "sandbox/siri/SiriGooglePubSubUpdater.md"
+  );
 
   private static final String ROUTER_CONFIG_PATH = "standalone/config/" + ROUTER_CONFIG_FILENAME;
-  private static final Set<String> SKIP_UPDATERS = Set.of(
-    "siri-azure-sx-updater",
-    "siri-azure-et-updater",
-    "vehicle-parking",
-    "siri-et-updater",
-    "siri-et-google-pubsub-updater",
-    "siri-sx-updater"
-  );
+  private static final Set<String> INCLUDE_UPDATERS = Set.of("siri-et-google-pubsub-updater");
   private static final SkipNodes SKIP_NODES = SkipNodes.of().build();
   public static final ObjectMapper mapper = new ObjectMapper();
 
   /**
-   * NOTE! This test updates the {@code docs/Configuration.md} document based on the latest
-   * version of the code. The following is auto generated:
-   * <ul>
-   *   <li>The configuration type table</li>
-   *   <li>The list of OTP features</li>
-   * </ul>
+   * NOTE! This test updates the {@code docs/sandbox/SiriGooglePubSubUpdater.md} document based on the latest
+   * version of the code.
    */
   @Test
-  public void updateRouterConfigurationDoc() {
-    NodeAdapter node = readBuildConfig();
+  public void updateSiriDoc() {
+    NodeAdapter node = readUpdaterConfig();
 
     // Read and close input file (same as output file)
     String template = readFile(TEMPLATE);
@@ -60,7 +55,7 @@ public class UpdaterConfigDocTest {
       var child = node.child(childName);
       var type = child.typeQualifier();
 
-      if (!SKIP_UPDATERS.contains(type)) {
+      if (INCLUDE_UPDATERS.contains(type)) {
         template = replaceSection(template, type, updaterDoc(child));
       }
     }
@@ -69,7 +64,7 @@ public class UpdaterConfigDocTest {
     assertFileEquals(original, OUT_FILE);
   }
 
-  private NodeAdapter readBuildConfig() {
+  private NodeAdapter readUpdaterConfig() {
     var json = jsonNodeFromResource(ROUTER_CONFIG_PATH);
     var conf = new RouterConfig(json, ROUTER_CONFIG_PATH, false);
     return conf.asNodeAdapter().child("updaters");

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -421,6 +421,18 @@
         "timeout": 300000
       }
     },
+    // SIRI ET Google Pubsub updater
+    {
+      "type": "siri-et-google-pubsub-updater",
+      "feedId": "feed_id",
+      "reconnectPeriod": "5s",
+      "initialGetDataTimeout": "1m20s",
+      "topicProjectName": "google_pubsub_topic_project_name",
+      "subscriptionProjectName": "google_pubsub_subscription_project_name",
+      "topicName": "estimated_timetables",
+      "dataInitializationUrl": "https://example.com/some/path",
+      "fuzzyTripMatching": true
+    },
     {
       "type": "vehicle-parking",
       "feedId": "bikeep",


### PR DESCRIPTION
### Summary

This PR:
- removes unused parameters in the Google PubSub SIRI updater,
- documents the parameters,
- adds a dedicated markdown page for this updater.


**Removed parameters:**
- the parameter `projectName` is deprecated and removed. It is replaced by the now-mandatory parameters `topicProjectName` and `subscriptionProjectName`
- the parameter `purgeExpiredData` is managed in the section `timetableUpdates` . It does not need to be specified in this updater.
- the parameter `type` is managed by the configuration framework. It does not need to be specified in this updater.

### Issue

No

### Unit tests

Updated documentation test

### Documentation

Updated documentation

