### PR TITLE
Add back GraphQL data fetcher error logging

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLIndex.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLIndex.java
@@ -83,6 +83,7 @@ import org.opentripplanner.apis.gtfs.datafetchers.serviceTimeRangeImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.stepImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.stopAtDistanceImpl;
 import org.opentripplanner.apis.gtfs.model.StopPosition;
+import org.opentripplanner.apis.support.graphql.LoggingDataFetcherExceptionHandler;
 import org.opentripplanner.ext.actuator.MicrometerGraphQLInstrumentation;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.concurrent.OtpRequestThreadFactory;
@@ -210,7 +211,11 @@ class GtfsGraphQLIndex {
         );
     }
 
-    GraphQL graphQL = GraphQL.newGraphQL(indexSchema).instrumentation(instrumentation).build();
+    GraphQL graphQL = GraphQL
+      .newGraphQL(indexSchema)
+      .instrumentation(instrumentation)
+      .defaultDataFetcherExceptionHandler(new LoggingDataFetcherExceptionHandler())
+      .build();
 
     if (variables == null) {
       variables = new HashMap<>();

--- a/src/main/java/org/opentripplanner/apis/support/graphql/LoggingDataFetcherExceptionHandler.java
+++ b/src/main/java/org/opentripplanner/apis/support/graphql/LoggingDataFetcherExceptionHandler.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.apis.transmodel;
+package org.opentripplanner.apis.support.graphql;
 
 import graphql.ExceptionWhileDataFetching;
 import graphql.execution.SimpleDataFetcherExceptionHandler;

--- a/src/main/java/org/opentripplanner/apis/transmodel/LoggingDataFetcherExceptionHandler.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/LoggingDataFetcherExceptionHandler.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.apis.transmodel;
+
+import graphql.ExceptionWhileDataFetching;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Log a warning message when an exception occurs in a data fetcher.
+ */
+public class LoggingDataFetcherExceptionHandler extends SimpleDataFetcherExceptionHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+    LoggingDataFetcherExceptionHandler.class
+  );
+
+  @Override
+  protected void logException(ExceptionWhileDataFetching error, Throwable exception) {
+    LOG.warn(error.getMessage(), exception);
+  }
+}

--- a/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
@@ -130,6 +130,7 @@ class TransmodelGraph {
       .newGraphQL(indexSchema)
       .instrumentation(instrumentation)
       .queryExecutionStrategy(executionStrategy)
+      .defaultDataFetcherExceptionHandler(new LoggingDataFetcherExceptionHandler())
       .build();
   }
 

--- a/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.opentripplanner.apis.support.graphql.LoggingDataFetcherExceptionHandler;
 import org.opentripplanner.apis.transmodel.support.AbortOnUnprocessableRequestExecutionStrategy;
 import org.opentripplanner.apis.transmodel.support.ExecutionResultMapper;
 import org.opentripplanner.ext.actuator.MicrometerGraphQLInstrumentation;

--- a/src/main/java/org/opentripplanner/apis/transmodel/support/AbortOnUnprocessableRequestExecutionStrategy.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/support/AbortOnUnprocessableRequestExecutionStrategy.java
@@ -5,7 +5,7 @@ import graphql.execution.ExecutionStrategyParameters;
 import graphql.schema.DataFetchingEnvironment;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
-import org.opentripplanner.apis.transmodel.LoggingDataFetcherExceptionHandler;
+import org.opentripplanner.apis.support.graphql.LoggingDataFetcherExceptionHandler;
 import org.opentripplanner.apis.transmodel.ResponseTooLargeException;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.logging.ProgressTracker;

--- a/src/main/java/org/opentripplanner/apis/transmodel/support/AbortOnUnprocessableRequestExecutionStrategy.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/support/AbortOnUnprocessableRequestExecutionStrategy.java
@@ -5,6 +5,7 @@ import graphql.execution.ExecutionStrategyParameters;
 import graphql.schema.DataFetchingEnvironment;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
+import org.opentripplanner.apis.transmodel.LoggingDataFetcherExceptionHandler;
 import org.opentripplanner.apis.transmodel.ResponseTooLargeException;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.logging.ProgressTracker;
@@ -30,6 +31,10 @@ public class AbortOnUnprocessableRequestExecutionStrategy
     LOG_STEPS,
     -1
   );
+
+  public AbortOnUnprocessableRequestExecutionStrategy() {
+    super(new LoggingDataFetcherExceptionHandler());
+  }
 
   @Override
   protected <T> CompletableFuture<T> handleFetchingException(

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -83,7 +83,6 @@
   <logger name="com.amazonaws" level="info"/>
   <logger name="org.apache.hc" level="info" />
   <logger name="com.conveyal" level="info"/>
-  <logger name="notprivacysafe.graphql" level="off" />
 
   <!-- Avoid printing info messages about calendars when building graph -->
   <logger name="org.onebusaway.gtfs.impl.calendar.CalendarServiceDataFactoryImpl" level="warn" />
@@ -94,6 +93,11 @@
   <logger name="org.glassfish.grizzly" level="info" />
   <!-- Suppress info logs from azure packages -->
   <logger name="com.azure" level="warn" />
+
+  <!--Log errors in GraphQL data fetchers for the TransModel API. This is disabled by default
+     Set it to "warn" to log these errors.
+  -->
+  <logger name="org.opentripplanner.apis.transmodel.LoggingDataFetcherExceptionHandler" level="off" />
 
   <!-- If you want to debug realtime updates set these loggers to debug -->
   <logger name="org.opentripplanner.updater.trip.TimetableSnapshotSource" level="info" />

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -94,10 +94,10 @@
   <!-- Suppress info logs from azure packages -->
   <logger name="com.azure" level="warn" />
 
-  <!--Log errors in GraphQL data fetchers for the TransModel API. This is disabled by default
+  <!--Log errors in GraphQL data fetchers. This is disabled by default.
      Set it to "warn" to log these errors.
   -->
-  <logger name="org.opentripplanner.apis.transmodel.LoggingDataFetcherExceptionHandler" level="off" />
+  <logger name="org.opentripplanner.apis.support.graphql.LoggingDataFetcherExceptionHandler" level="off" />
 
   <!-- If you want to debug realtime updates set these loggers to debug -->
   <logger name="org.opentripplanner.updater.trip.TimetableSnapshotSource" level="info" />


### PR DESCRIPTION
### Summary

GraphQL Java v22 removed support for logging errors in data fetchers (see https://github.com/graphql-java/graphql-java/pull/3403). This used to be controlled through the `notprivacysafe.graphql` logger.
This PR adds back this feature by creating a custom DataFetcherExceptionHandler that logs at WARN level all errors thrown from data fetchers.
This applies to the Transmodel API and the GTFS API.

The logger is disabled by default in the logback.xml file shipped with OTP (as was the case with  `notprivacysafe.graphql`)

### Issue
No

### Unit tests

No

### Documentation

No

