### PR TITLE
Expose stop transfer priority in Transmodel API

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -22,6 +22,7 @@ import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.transit.model.basic.Accessibility;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.BikeAccess;
+import org.opentripplanner.transit.model.site.StopTransferPriority;
 import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.OccupancyStatus;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
@@ -133,11 +134,25 @@ public class EnumTypes {
 
   public static final GraphQLEnumType INTERCHANGE_WEIGHTING = GraphQLEnumType
     .newEnum()
+    .description("Deprecated. Use STOP_INTERCHANGE_PRIORITY")
     .name("InterchangeWeighting")
     .value("preferredInterchange", 2, "Highest priority interchange.")
     .value("recommendedInterchange", 1, "Second highest priority interchange.")
     .value("interchangeAllowed", 0, "Third highest priority interchange.")
     .value("noInterchange", -1, "Interchange not allowed.")
+    .build();
+
+  public static final GraphQLEnumType STOP_INTERCHANGE_PRIORITY = GraphQLEnumType
+    .newEnum()
+    .name("StopInterchangePriority")
+    .value("preferred", StopTransferPriority.PREFERRED, "Highest interchange priority.")
+    .value("recommended", StopTransferPriority.RECOMMENDED)
+    .value("allowed", StopTransferPriority.ALLOWED)
+    .value(
+      "discouraged",
+      StopTransferPriority.DISCOURAGED,
+      "This maps to 'interchangeNotAllowed' in NeTEx."
+    )
     .build();
 
   public static final GraphQLEnumType ITINERARY_FILTER_DEBUG_PROFILE = createFromDocumentedEnum(

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -145,13 +145,26 @@ public class EnumTypes {
   public static final GraphQLEnumType STOP_INTERCHANGE_PRIORITY = GraphQLEnumType
     .newEnum()
     .name("StopInterchangePriority")
-    .value("preferred", StopTransferPriority.PREFERRED, "Highest interchange priority.")
-    .value("recommended", StopTransferPriority.RECOMMENDED)
-    .value("allowed", StopTransferPriority.ALLOWED)
+    .value(
+      "preferred",
+      StopTransferPriority.PREFERRED,
+      "Preferred place to transfer, strongly recommended. NeTEx equivalent is PREFERRED_INTERCHANGE."
+    )
+    .value(
+      "recommended",
+      StopTransferPriority.RECOMMENDED,
+      "Recommended stop place. NeTEx equivalent is RECOMMENDED_INTERCHANGE."
+    )
+    .value(
+      "allowed",
+      StopTransferPriority.ALLOWED,
+      "Allow transfers from/to this stop. This is the default. NeTEx equivalent is INTERCHANGE_ALLOWED."
+    )
     .value(
       "discouraged",
       StopTransferPriority.DISCOURAGED,
-      "This maps to 'interchangeNotAllowed' in NeTEx."
+      "Block transfers from/to this stop. In OTP this is not a definitive block," +
+      " just a huge penalty is added to the cost function. NeTEx equivalent is NO_INTERCHANGE."
     )
     .build();
 

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/stop/MonoOrMultiModalStation.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/stop/MonoOrMultiModalStation.java
@@ -8,6 +8,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.site.StopTransferPriority;
 
 public class MonoOrMultiModalStation {
 
@@ -40,6 +41,8 @@ public class MonoOrMultiModalStation {
 
   private final MonoOrMultiModalStation parentStation;
 
+  private final StopTransferPriority priority;
+
   public MonoOrMultiModalStation(Station station, MultiModalStation parentStation) {
     this.id = station.getId();
     this.name = station.getName();
@@ -50,6 +53,7 @@ public class MonoOrMultiModalStation {
     this.url = station.getUrl();
     this.timezone = station.getTimezone();
     this.childStops = station.getChildStops();
+    this.priority = station.getPriority();
     this.parentStation = parentStation != null ? new MonoOrMultiModalStation(parentStation) : null;
   }
 
@@ -63,6 +67,7 @@ public class MonoOrMultiModalStation {
     this.url = multiModalStation.getUrl();
     this.timezone = null;
     this.childStops = multiModalStation.getChildStops();
+    this.priority = null;
     this.parentStation = null;
   }
 
@@ -100,6 +105,10 @@ public class MonoOrMultiModalStation {
 
   public Collection<StopLocation> getChildStops() {
     return childStops;
+  }
+
+  public StopTransferPriority getPriority() {
+    return priority;
   }
 
   public MonoOrMultiModalStation getParentStation() {

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
@@ -147,8 +147,20 @@ public class StopPlaceType {
           .description(
             "Relative weighting of this stop with regards to interchanges. NOT IMPLEMENTED"
           )
+          .deprecate("Not implemented. Use stopInterchangePriority")
           .type(EnumTypes.INTERCHANGE_WEIGHTING)
           .dataFetcher(environment -> 0)
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopInterchangePriority")
+          .description("Specify the priority of interchanges at this stop")
+          .type(EnumTypes.STOP_INTERCHANGE_PRIORITY)
+          .dataFetcher(environment ->
+            ((MonoOrMultiModalStation) environment.getSource()).getPriority()
+          )
           .build()
       )
       .field(

--- a/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1167,6 +1167,8 @@ type StopPlace implements PlaceInterface {
   ): [Quay] @timingData
   "Get all situations active for the stop place. Situations affecting individual quays are not returned, and should be fetched directly from the quay."
   situations: [PtSituationElement!]!
+  "Specify the priority of interchanges at this stop"
+  stopInterchangePriority: StopInterchangePriority
   tariffZones: [TariffZone]!
   timeZone: String
   "The transport modes of quays under this stop place."
@@ -1174,7 +1176,7 @@ type StopPlace implements PlaceInterface {
   "The transport submode serviced by this stop place."
   transportSubmode: [TransportSubmode]
   "Relative weighting of this stop with regards to interchanges. NOT IMPLEMENTED"
-  weighting: InterchangeWeighting
+  weighting: InterchangeWeighting @deprecated(reason : "Not implemented. Use stopInterchangePriority")
 }
 
 "List of coordinates between two stops as a polyline"
@@ -1531,6 +1533,7 @@ enum InterchangePriority {
   recommended
 }
 
+"Deprecated. Use STOP_INTERCHANGE_PRIORITY"
 enum InterchangeWeighting {
   "Third highest priority interchange."
   interchangeAllowed
@@ -1744,6 +1747,15 @@ enum StopCondition {
   requestStop
   "Situation applies when stop is the startpoint of the leg."
   startPoint
+}
+
+enum StopInterchangePriority {
+  allowed
+  "This maps to 'interchangeNotAllowed' in NeTEx."
+  discouraged
+  "Highest interchange priority."
+  preferred
+  recommended
 }
 
 enum StreetMode {

--- a/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1750,11 +1750,13 @@ enum StopCondition {
 }
 
 enum StopInterchangePriority {
+  "Allow transfers from/to this stop. This is the default. NeTEx equivalent is INTERCHANGE_ALLOWED."
   allowed
-  "This maps to 'interchangeNotAllowed' in NeTEx."
+  "Block transfers from/to this stop. In OTP this is not a definitive block, just a huge penalty is added to the cost function. NeTEx equivalent is NO_INTERCHANGE."
   discouraged
-  "Highest interchange priority."
+  "Preferred place to transfer, strongly recommended. NeTEx equivalent is PREFERRED_INTERCHANGE."
   preferred
+  "Recommended stop place. NeTEx equivalent is RECOMMENDED_INTERCHANGE."
   recommended
 }
 


### PR DESCRIPTION
### Summary

This PR exposes stop transfer priority in the TransModel API.
"Stop transfer priority" is used to specify the relative preference of a stop when several stops can be used for a transfer.
In the TransModel API `transfers` are referred to as `interchanges`.

The naming of the existing field `weighting` was confusing and the data fetching was never implemented (it returned always the same value)
It is replaced by `stopInterchangePriority` whose name matches more clearly the name `interchangePriority`, that is the  priority set on interchanges. 
The NeTEx enum values are also confusing, in particular `interchangeNotAllowed`. It is replaced by `discouraged` which matches the actual behaviour of OTP (not banning but discouraging the transfer at a given stop). 

### Issue
No

### Unit tests

No

### Documentation

Updated API documentation


