### PR TITLE
Fix duration parsing error handling

### DIFF
--- a/src/test/java/org/opentripplanner/routing/api/request/framework/LinearFunctionSerializationTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/framework/LinearFunctionSerializationTest.java
@@ -36,6 +36,8 @@ class LinearFunctionSerializationTest {
            3h + 5.111 t   ||       3h  |   5.1
             7m + 10.1 x   ||       7m  |  10.0
           PT7s + 10.1 x   ||       7s  |  10.0
+          0.1 + 10.1 x   ||       0s  |  10.0
+          0.5 + 10.1 x   ||       1s  |  10.0
         """
     );
   }
@@ -53,7 +55,7 @@ class LinearFunctionSerializationTest {
   }
 
   @Test
-  void parseEmtpy() {
+  void parseEmpty() {
     assertEquals(Optional.empty(), LinearFunctionSerialization.parse(null, fail()));
     assertEquals(Optional.empty(), LinearFunctionSerialization.parse("", fail()));
     assertEquals(Optional.empty(), LinearFunctionSerialization.parse(" \r\n", fail()));
@@ -75,6 +77,15 @@ class LinearFunctionSerializationTest {
       () -> LinearFunctionSerialization.parse("foo", fail())
     );
     assertEquals("Unable to parse function: 'foo'", ex.getMessage());
+  }
+
+  @Test
+  void parseIllegalDuration() {
+    var ex = assertThrows(
+      IllegalArgumentException.class,
+      () -> LinearFunctionSerialization.parse("600ss + 1.3 t", fail())
+    );
+    assertEquals("Unable to parse duration: '600ss'", ex.getMessage());
   }
 
   private static BiFunction<Duration, Double, ?> fail() {


### PR DESCRIPTION

### Summary

A request that specifies a time penalty with an incorrect duration format:
```
accessEgressPenalty: [{
      streetMode: flexible
      timePenalty: "600ss + 1.3 t"
      costFactor: 1.3
    }],

```
fails with an HTTP 500 error:

```

"Text cannot be parsed to a Duration: '600ss' java.time.format.DateTimeParseException: Text cannot be parsed to a Duration: '600ss'
	at org.opentripplanner.framework.time.DurationUtils.duration(DurationUtils.java:121)
	at org.opentripplanner.routing.api.request.framework.LinearFunctionSerialization.parse(LinearFunctionSerialization.java:68)
	at org.opentripplanner.apis.transmodel.model.scalars.DoubleFunctionFactory$1.parseValue(DoubleFunctionFactory.java:59)
	at org.opentripplanner.apis.transmodel.model.scalars.DoubleFunctionFactory$1.parseLiteral(DoubleFunctionFactory.java:73)
	at org.opentripplanner.apis.transmodel.model.scalars.DoubleFunctionFactory$1.parseLiteral(DoubleFunctionFactory.java:40)

```

This PR fixes exception handling so that the parsing error is reported as a client error:
```

{
  "errors": [
    {
      "message": "Unable to parse duration: '600ss'",
      "locations": [],
      "extensions": {
        "classification": "BadRequestError"
      }
    }
  ]
}
```

**Note**: the parsing logic is moved to a private method `LinearFunctionSerialization.parseDecimalSecondsOrDuration()`. This method should probably not be promoted to the class `DurationUtils`: it is used solely to fix a backward compatibility issue (see #5304).

### Issue

No

### Documentation

No

