### PR TITLE
Use transit editor service in SIRI timetable snapshot source

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
@@ -78,7 +78,7 @@ class AddedTripBuilderTest {
 
   private final Deduplicator DEDUPLICATOR = new Deduplicator();
   private final TransitModel TRANSIT_MODEL = new TransitModel(STOP_MODEL, DEDUPLICATOR);
-  private TransitEditorService TRANSIT_SERVICE;
+  private TransitEditorService transitService;
   private EntityResolver ENTITY_RESOLVER;
 
   @BeforeEach
@@ -103,7 +103,7 @@ class AddedTripBuilderTest {
 
     // Create transit model index
     TRANSIT_MODEL.index();
-    TRANSIT_SERVICE = new DefaultTransitService(TRANSIT_MODEL);
+    transitService = new DefaultTransitService(TRANSIT_MODEL);
 
     // Create the entity resolver only after the model has been indexed
     ENTITY_RESOLVER =
@@ -113,7 +113,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTrip() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -242,7 +242,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripOnAddedRoute() {
     var firstAddedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -268,7 +268,7 @@ class AddedTripBuilderTest {
     var tripId2 = TransitModelForTest.id("TRIP_ID_2");
 
     var secondAddedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       tripId2,
@@ -319,7 +319,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripOnExistingRoute() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -350,7 +350,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripWithoutReplacedRoute() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -393,7 +393,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripFailOnMissingServiceId() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -448,7 +448,7 @@ class AddedTripBuilderTest {
     );
 
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -487,7 +487,7 @@ class AddedTripBuilderTest {
         .build()
     );
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -534,7 +534,7 @@ class AddedTripBuilderTest {
         .build()
     );
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_SERVICE,
+      transitService,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,

--- a/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
@@ -35,6 +35,7 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.spi.UpdateError;
 import uk.org.siri.siri20.VehicleModesEnumeration;
@@ -77,6 +78,7 @@ class AddedTripBuilderTest {
 
   private final Deduplicator DEDUPLICATOR = new Deduplicator();
   private final TransitModel TRANSIT_MODEL = new TransitModel(STOP_MODEL, DEDUPLICATOR);
+  private TransitEditorService TRANSIT_SERVICE;
   private EntityResolver ENTITY_RESOLVER;
 
   @BeforeEach
@@ -101,6 +103,7 @@ class AddedTripBuilderTest {
 
     // Create transit model index
     TRANSIT_MODEL.index();
+    TRANSIT_SERVICE = new DefaultTransitService(TRANSIT_MODEL);
 
     // Create the entity resolver only after the model has been indexed
     ENTITY_RESOLVER =
@@ -110,7 +113,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTrip() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -239,7 +242,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripOnAddedRoute() {
     var firstAddedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -265,7 +268,7 @@ class AddedTripBuilderTest {
     var tripId2 = TransitModelForTest.id("TRIP_ID_2");
 
     var secondAddedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       tripId2,
@@ -316,7 +319,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripOnExistingRoute() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -347,7 +350,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripWithoutReplacedRoute() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -390,7 +393,7 @@ class AddedTripBuilderTest {
   @Test
   void testAddedTripFailOnMissingServiceId() {
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -445,7 +448,7 @@ class AddedTripBuilderTest {
     );
 
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -484,7 +487,7 @@ class AddedTripBuilderTest {
         .build()
     );
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,
@@ -531,7 +534,7 @@ class AddedTripBuilderTest {
         .build()
     );
     var addedTrip = new AddedTripBuilder(
-      TRANSIT_MODEL,
+      TRANSIT_SERVICE,
       ENTITY_RESOLVER,
       AbstractTransitEntity::getId,
       TRIP_ID,

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -34,6 +34,7 @@ import org.opentripplanner.routing.stoptimes.StopTimesHelper;
 import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
+import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
 import org.opentripplanner.transit.model.network.Route;
@@ -181,6 +182,10 @@ public class DefaultTransitService implements TransitEditorService {
     return this.transitModelIndex.getRouteForId(id);
   }
 
+  /**
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   * this when doing the issue #3030.
+   */
   @Override
   public void addRoutes(Route route) {
     this.transitModelIndex.addRoutes(route);
@@ -259,6 +264,15 @@ public class DefaultTransitService implements TransitEditorService {
     return this.transitModelIndex.getTripForId().get(id);
   }
 
+  /**
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   * this when doing the issue #3030.
+   */
+  @Override
+  public void addTripForId(FeedScopedId tripId, Trip trip) {
+    transitModelIndex.getTripForId().put(tripId, trip);
+  }
+
   @Override
   public Collection<Trip> getAllTrips() {
     OTPRequestTimeoutException.checkForTimeout();
@@ -276,6 +290,15 @@ public class DefaultTransitService implements TransitEditorService {
     return this.transitModelIndex.getPatternForTrip().get(trip);
   }
 
+  /**
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   * this when doing the issue #3030.
+   */
+  @Override
+  public void addPatternForTrip(Trip trip, TripPattern pattern) {
+    transitModelIndex.getPatternForTrip().put(trip, pattern);
+  }
+
   @Override
   public TripPattern getPatternForTrip(Trip trip, LocalDate serviceDate) {
     TripPattern realtimePattern = getRealtimeAddedTripPattern(trip.getId(), serviceDate);
@@ -289,6 +312,15 @@ public class DefaultTransitService implements TransitEditorService {
   public Collection<TripPattern> getPatternsForRoute(Route route) {
     OTPRequestTimeoutException.checkForTimeout();
     return this.transitModelIndex.getPatternsForRoute().get(route);
+  }
+
+  /**
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   * this when doing the issue #3030.
+   */
+  @Override
+  public void addPatternsForRoute(Route route, TripPattern pattern) {
+    transitModelIndex.getPatternsForRoute().put(route, pattern);
   }
 
   @Override
@@ -475,6 +507,15 @@ public class DefaultTransitService implements TransitEditorService {
     return transitModelIndex.getTripOnServiceDateById().get(datedServiceJourneyId);
   }
 
+  /**
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   * this when doing the issue #3030.
+   */
+  @Override
+  public void addTripOnServiceDateById(FeedScopedId id, TripOnServiceDate tripOnServiceDate) {
+    transitModelIndex.getTripOnServiceDateById().put(id, tripOnServiceDate);
+  }
+
   @Override
   public Collection<TripOnServiceDate> getAllTripOnServiceDates() {
     return transitModelIndex.getTripOnServiceDateForTripAndDay().values();
@@ -485,6 +526,29 @@ public class DefaultTransitService implements TransitEditorService {
     TripIdAndServiceDate tripIdAndServiceDate
   ) {
     return transitModelIndex.getTripOnServiceDateForTripAndDay().get(tripIdAndServiceDate);
+  }
+
+  /**
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   * this when doing the issue #3030.
+   */
+  @Override
+  public void addTripOnServiceDateForTripAndDay(
+    TripIdAndServiceDate tripIdAndServiceDate,
+    TripOnServiceDate tripOnServiceDate
+  ) {
+    transitModelIndex
+      .getTripOnServiceDateForTripAndDay()
+      .put(tripIdAndServiceDate, tripOnServiceDate);
+  }
+
+  /**
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   * this when doing the issue #3030.
+   */
+  @Override
+  public FeedScopedId getOrCreateServiceIdForDate(LocalDate serviceDate) {
+    return transitModel.getOrCreateServiceIdForDate(serviceDate);
   }
 
   @Override
@@ -577,6 +641,11 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public List<TransitMode> getModesOfStopLocation(StopLocation stop) {
     return sortByOccurrenceAndReduce(getPatternModesOfStop(stop)).toList();
+  }
+
+  @Override
+  public Deduplicator getDeduplicator() {
+    return transitModel.getDeduplicator();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
@@ -1,10 +1,16 @@
 package org.opentripplanner.transit.service;
 
+import java.time.LocalDate;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 
 /**
  * Entry point for requests (both read-only and read-write) towards the transit API.
@@ -14,9 +20,24 @@ public interface TransitEditorService extends TransitService {
 
   void addFeedInfo(FeedInfo info);
 
+  void addPatternForTrip(Trip trip, TripPattern pattern);
+
+  void addPatternsForRoute(Route route, TripPattern pattern);
+
   void addRoutes(Route route);
 
   void addTransitMode(TransitMode mode);
+
+  void addTripForId(FeedScopedId tripId, Trip trip);
+
+  void addTripOnServiceDateById(FeedScopedId id, TripOnServiceDate tripOnServiceDate);
+
+  void addTripOnServiceDateForTripAndDay(
+    TripIdAndServiceDate tripIdAndServiceDate,
+    TripOnServiceDate tripOnServiceDate
+  );
+
+  FeedScopedId getOrCreateServiceIdForDate(LocalDate serviceDate);
 
   void setTransitLayer(TransitLayer transitLayer);
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -254,8 +254,6 @@ public class TransitModel implements Serializable {
    * Get or create a serviceId for a given date. This method is used when a new trip is added from a
    * realtime data update. It make sure the date is in the existing transit service period.
    * <p>
-   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
-   *           - this when doing the issue #3030.
    *
    * @param serviceDate service date for the added service id
    * @return service-id for date if it exist or is created. If the given service date is outside the

--- a/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
@@ -126,10 +126,6 @@ public class TransitModelIndex {
     return routeForId.get(id);
   }
 
-  /**
-   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
-   *           - this when doing the issue #3030.
-   */
   public void addRoutes(Route route) {
     routeForId.put(route.getId(), route);
   }

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -25,6 +25,7 @@ import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
+import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
 import org.opentripplanner.transit.model.network.Route;
@@ -231,4 +232,6 @@ public interface TransitService {
    * So, if more patterns of mode BUS than RAIL visit the stop, the result will be [BUS,RAIL].
    */
   List<TransitMode> getModesOfStopLocation(StopLocation stop);
+
+  Deduplicator getDeduplicator();
 }


### PR DESCRIPTION
### Summary

As detailed in #5965, some Transit model indexes are modified concurrently in the real-time updaters without proper synchronization, causing data inconsistencies in reader threads.
This PR aims at refactoring the code to better identify and document the root causes of these concurrency issues.
This PR does not fix these concurrency issues.

Another goal of this PR is to bring the code closer to the target design (immutable transit model) [where the transit model is updated exclusively through a  TransitEditorService](https://github.com/entur/OpenTripPlanner/blob/otp2_refactor_transit_model/src/main/java/org/opentripplanner/transit/model/package.md#services-and-its-context)

The classes `SiriTimetableSnapshotSource` and `AddedTripBuilder` currently have direct access to the collections in the `TransitModelIndex`. This makes it difficult to identify where and when the indexes are modified.
By comparison the class `TimetableSnapshotSource` (GTFS updaters) uses `TransitEditorService`, thus modifying the transit model through a well-defined interface.

This PR refactors `SiriTimetableSnapshotSource` to remove direct access to the `TransitModel` and `TransitModelIndex` and channels all write operations through the `TransitEditorService`

**Note**: both in `TimetableSnapshotSource` and `SiriTimetableSnapshotSource`, the `TransitEditorService` is instantiated once at application construction time. This is problematic since the `DefaultTransitService` holds a reference to a fixed `TimetableSnapshot` (see `DefaultTransitService.lazyGetTimeTableSnapShot()` ) that does not reflect subsequent real-time changes.
In practice this does not cause any consistency issue (as of today) since none of the methods that rely on TimetableSnapshot is called in the updaters.
This should however be addressed so that the updaters use a consistent view of the real-time data through the TransitEditorService: a TimetableSnapshot created right before the updaters apply the updates would be more up-to-date, but it would still not reflect the uncommitted changes in the current TimetableSnapshot buffer.

### Issue

Relates to #3030, #5965

### Unit tests

Updated unit tests.

### Documentation

No
