### PR TITLE
Remove reference to TimetableSnapshot in TransitModelIndex

### DIFF
--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -169,6 +169,7 @@ public class TransitModel implements Serializable {
     }
   }
 
+  @Nullable
   public TimetableSnapshot getTimetableSnapshot() {
     return timetableSnapshotProvider == null
       ? null

--- a/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import org.opentripplanner.ext.flex.FlexIndex;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.framework.application.OTPFeature;
-import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
@@ -152,24 +151,6 @@ public class TransitModelIndex {
       .stream()
       .flatMap(TripPattern::scheduledTripsAsStream)
       .collect(Collectors.toList());
-  }
-
-  /**
-   * Returns all the patterns for a specific stop. If timetableSnapshot is included, new patterns
-   * added by realtime updates are added to the collection. A set is used here because trip patterns
-   * that were updated by realtime data is both part of the TransitModelIndex and the TimetableSnapshot.
-   */
-  public Collection<TripPattern> getPatternsForStop(
-    StopLocation stop,
-    TimetableSnapshot timetableSnapshot
-  ) {
-    Set<TripPattern> tripPatterns = new HashSet<>(getPatternsForStop(stop));
-
-    if (timetableSnapshot != null) {
-      tripPatterns.addAll(timetableSnapshot.getPatternsForStop(stop));
-    }
-
-    return tripPatterns;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -93,8 +93,16 @@ public interface TransitService {
 
   Set<Route> getRoutesForStop(StopLocation stop);
 
+  /**
+   * Return all the scheduled trip patterns for a specific stop
+   * (not taking into account real-time updates).
+   */
   Collection<TripPattern> getPatternsForStop(StopLocation stop);
 
+  /**
+   * Returns all the patterns for a specific stop. If includeRealtimeUpdates is set, new patterns
+   * added by realtime updates are added to the collection.
+   */
   Collection<TripPattern> getPatternsForStop(StopLocation stop, boolean includeRealtimeUpdates);
 
   Collection<Trip> getTripsForStop(StopLocation stop);
@@ -127,8 +135,16 @@ public interface TransitService {
 
   Collection<Route> getAllRoutes();
 
+  /**
+   * Return the scheduled trip pattern for a given trip (not taking into account real-time updates)
+   */
   TripPattern getPatternForTrip(Trip trip);
 
+  /**
+   * Return the trip pattern for a given trip on a service date. The real-time updated version
+   * is returned if it exists, otherwise the scheduled trip pattern is returned.
+   *
+   */
   TripPattern getPatternForTrip(Trip trip, LocalDate serviceDate);
 
   Collection<TripPattern> getPatternsForRoute(Route route);
@@ -167,6 +183,10 @@ public interface TransitService {
 
   GroupOfRoutes getGroupOfRoutesForId(FeedScopedId id);
 
+  /**
+   * Return the timetable for a given trip pattern and date, taking into account real-time updates.
+   * If no real-times update are applied, fall back to scheduled data.
+   */
   Timetable getTimetableForTripPattern(TripPattern tripPattern, LocalDate serviceDate);
 
   TripPattern getRealtimeAddedTripPattern(FeedScopedId tripId, LocalDate serviceDate);


### PR DESCRIPTION
### Summary

`TimetableSnapshot` is used:
* in real-time updaters to apply real-time updates,
* in the `TransitService` to get a unified view of the transit model (scheduled data + real-time updates).

`TimetableSnapshot` is a complex concept and it is desirable to limit its use to these 2 set of classes.

This PR refactor `DefaultTransitService` and `TransitModelIndex` to removes references to  `TimetableSnapshot` in `TransitModelIndex`.

### Issue

No

### Unit tests

Added unit test.

### Documentation

Updated Javadoc