### PR TITLE
Enforce non-null coordinates on multimodal station

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/MultiModalStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/MultiModalStationMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -21,6 +22,7 @@ class MultiModalStationMapper {
     this.idFactory = idFactory;
   }
 
+  @Nullable
   MultiModalStation map(StopPlace stopPlace, Collection<Station> childStations) {
     MultiModalStationBuilder multiModalStation = MultiModalStation
       .of(idFactory.createId(stopPlace.getId()))
@@ -34,13 +36,13 @@ class MultiModalStationMapper {
     if (coordinate == null) {
       issueStore.add(
         "MultiModalStationWithoutCoordinates",
-        "MultiModal station {} does not contain any coordinates.",
+        "MultiModal station %s does not contain any coordinates.",
         multiModalStation.getId()
       );
+      return null;
     } else {
       multiModalStation.withCoordinate(coordinate);
+      return multiModalStation.build();
     }
-
-    return multiModalStation.build();
   }
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -332,8 +332,9 @@ public class NetexMapper {
         .getStationsByMultiModalStationRfs()
         .get(multiModalStopPlace.getId());
       var multiModalStation = mapper.map(multiModalStopPlace, stations);
-
-      transitBuilder.stopModel().withMultiModalStation(multiModalStation);
+      if (multiModalStation != null) {
+        transitBuilder.stopModel().withMultiModalStation(multiModalStation);
+      }
     }
   }
 

--- a/src/main/java/org/opentripplanner/transit/model/site/MultiModalStation.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/MultiModalStation.java
@@ -37,11 +37,11 @@ public class MultiModalStation
     super(builder.getId());
     // Required fields
     this.childStations = Objects.requireNonNull(builder.childStations());
+    this.coordinate = Objects.requireNonNull(builder.coordinate());
     this.name = I18NString.assertHasValue(builder.name());
 
     // Optional fields
     // TODO Make required
-    this.coordinate = builder.coordinate();
     this.code = builder.code();
     this.description = builder.description();
     this.url = builder.url();

--- a/src/test/java/org/opentripplanner/netex/mapping/MultiModalStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/MultiModalStationMapperTest.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.netex.mapping;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
+import org.opentripplanner.netex.NetexTestDataSupport;
+import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.rutebanken.netex.model.StopPlace;
+
+class MultiModalStationMapperTest {
+
+  @Test
+  void testMissingCoordinates() {
+    DataImportIssueStore dataIssueStore = new DefaultDataImportIssueStore();
+    FeedScopedIdFactory feedScopeIdFactory = new FeedScopedIdFactory(TransitModelForTest.FEED_ID);
+    MultiModalStationMapper multiModalStationMapper = new MultiModalStationMapper(
+      dataIssueStore,
+      feedScopeIdFactory
+    );
+    StopPlace stopPlace = new StopPlace();
+    stopPlace.setId(NetexTestDataSupport.STOP_PLACE_ID);
+    Assertions.assertNull(multiModalStationMapper.map(stopPlace, List.of()));
+    Assertions.assertEquals(1, dataIssueStore.listIssues().size());
+    Assertions.assertEquals(
+      "MultiModalStationWithoutCoordinates",
+      dataIssueStore.listIssues().getFirst().getType()
+    );
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/MultiModalStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/MultiModalStationMapperTest.java
@@ -1,7 +1,8 @@
 package org.opentripplanner.netex.mapping;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
@@ -22,9 +23,9 @@ class MultiModalStationMapperTest {
     );
     StopPlace stopPlace = new StopPlace();
     stopPlace.setId(NetexTestDataSupport.STOP_PLACE_ID);
-    Assertions.assertNull(multiModalStationMapper.map(stopPlace, List.of()));
-    Assertions.assertEquals(1, dataIssueStore.listIssues().size());
-    Assertions.assertEquals(
+    assertNull(multiModalStationMapper.map(stopPlace, List.of()));
+    assertEquals(1, dataIssueStore.listIssues().size());
+    assertEquals(
       "MultiModalStationWithoutCoordinates",
       dataIssueStore.listIssues().getFirst().getType()
     );

--- a/src/test/java/org/opentripplanner/transit/model/site/MultiModalStationTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/MultiModalStationTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -26,6 +27,7 @@ class MultiModalStationTest {
     .of(TransitModelForTest.id(ID))
     .withName(NAME)
     .withChildStations(CHILD_STATIONS)
+    .withCoordinate(new WgsCoordinate(1, 1))
     .build();
 
   @Test


### PR DESCRIPTION
### Summary

When querying a multimodal station without coordinates through the GraphQL API, the call fails with a NullPointerException:

```

Exception while fetching data (/trip/tripPatterns[0]/legs[5]/intermediateEstimatedCalls[7]/quay/stopPlace) : Cannot invoke "org.opentripplanner.framework.geometry.WgsCoordinate.latitude()" because the return value of "org.opentripplanner.transit.model.site.StopLocationsGroup.getCoordinate()" is null
java.lang.NullPointerException: Cannot invoke "org.opentripplanner.framework.geometry.WgsCoordinate.latitude()" because the return value of "org.opentripplanner.transit.model.site.StopLocationsGroup.getCoordinate()" is null
	at org.opentripplanner.transit.model.site.StopLocationsGroup.getLat(StopLocationsGroup.java:25)
	at org.opentripplanner.apis.transmodel.model.stop.MonoOrMultiModalStation.<init>(MonoOrMultiModalStation.java:59)
	at org.opentripplanner.apis.transmodel.model.stop.MonoOrMultiModalStation.<init>(MonoOrMultiModalStation.java:53)
	at org.opentripplanner.apis.transmodel.model.stop.QuayType.lambda$create$4(QuayType.java:125)
```

This PR ensures that multimodal stations without coordinates are ignored during graph building.

### Issue

No

### Unit tests

Updated unit tests

### Documentation

No
