### PR TITLE
Encapsulate transit model index

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
@@ -169,8 +169,7 @@ class AddedTripBuilderTest {
     assertEquals(route, pattern.getRoute());
     assertTrue(
       transitService
-        .getServiceCodesRunningForDate()
-        .get(SERVICE_DATE)
+        .getServiceCodesRunningForDate(SERVICE_DATE)
         .contains(TRANSIT_MODEL.getServiceCodes().get(trip.getServiceId())),
       "serviceId should be running on service date"
     );

--- a/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/AddedTripBuilderTest.java
@@ -154,37 +154,34 @@ class AddedTripBuilderTest {
     assertEquals(SubMode.of(SUB_MODE), route.getNetexSubmode(), "submode should be mapped");
     assertNotEquals(REPLACED_ROUTE, route, "Should not re-use replaced route");
 
-    // Assert transit model index
-    var transitModelIndex = TRANSIT_MODEL.getTransitModelIndex();
-    assertNotNull(transitModelIndex);
     assertEquals(
       route,
-      transitModelIndex.getRouteForId(TransitModelForTest.id(LINE_REF)),
+      transitService.getRouteForId(TransitModelForTest.id(LINE_REF)),
       "Route should be added to transit index"
     );
     assertEquals(
       trip,
-      transitModelIndex.getTripForId().get(TRIP_ID),
+      transitService.getTripForId(TRIP_ID),
       "Route should be added to transit index"
     );
-    var pattern = transitModelIndex.getPatternForTrip().get(trip);
+    var pattern = transitService.getPatternForTrip(trip);
     assertNotNull(pattern);
     assertEquals(route, pattern.getRoute());
     assertTrue(
-      transitModelIndex
+      transitService
         .getServiceCodesRunningForDate()
         .get(SERVICE_DATE)
         .contains(TRANSIT_MODEL.getServiceCodes().get(trip.getServiceId())),
       "serviceId should be running on service date"
     );
     assertNotNull(
-      transitModelIndex.getTripOnServiceDateById().get(TRIP_ID),
+      transitService.getTripOnServiceDateById(TRIP_ID),
       "TripOnServiceDate should be added to transit index by id"
     );
     assertNotNull(
-      transitModelIndex
-        .getTripOnServiceDateForTripAndDay()
-        .get(new TripIdAndServiceDate(TRIP_ID, SERVICE_DATE)),
+      transitService.getTripOnServiceDateForTripAndDay(
+        new TripIdAndServiceDate(TRIP_ID, SERVICE_DATE)
+      ),
       "TripOnServiceDate should be added to transit index for trip and day"
     );
 
@@ -299,10 +296,7 @@ class AddedTripBuilderTest {
     Route route = secondTrip.getRoute();
     assertSame(firstTrip.getRoute(), route, "route be reused from the first trip");
 
-    // Assert transit model index
-    var transitModelIndex = TRANSIT_MODEL.getTransitModelIndex();
-    assertNotNull(transitModelIndex);
-    assertEquals(2, transitModelIndex.getPatternsForRoute().get(route).size());
+    assertEquals(2, transitService.getPatternsForRoute(route).size());
 
     // Assert trip times
     var times = secondAddedTrip.successValue().tripTimes();

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -67,9 +67,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   @Override
   public void buildGraph() {
     /* Initialize transit model index which is needed by the nearby stop finder. */
-    if (transitModel.getTransitModelIndex() == null) {
-      transitModel.index();
-    }
+    transitModel.index();
 
     /* The linker will use streets if they are available, or straight-line distance otherwise. */
     NearbyStopFinder nearbyStopFinder = createNearbyStopFinder();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransfersMapper.java
@@ -6,7 +6,7 @@ import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.Transfer;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 
 class TransfersMapper {
 
@@ -14,7 +14,7 @@ class TransfersMapper {
    * Copy pre-calculated transfers from the original graph
    * @return a list where each element is a list of transfers for the corresponding stop index
    */
-  static List<List<Transfer>> mapTransfers(StopModel stopModel, TransitModel transitModel) {
+  static List<List<Transfer>> mapTransfers(StopModel stopModel, TransitService transitService) {
     List<List<Transfer>> transferByStopIndex = new ArrayList<>();
 
     for (int i = 0; i < stopModel.stopIndexSize(); ++i) {
@@ -26,7 +26,7 @@ class TransfersMapper {
 
       ArrayList<Transfer> list = new ArrayList<>();
 
-      for (PathTransfer pathTransfer : transitModel.getTransfersByStop(stop)) {
+      for (PathTransfer pathTransfer : transitService.getTransfersByStop(stop)) {
         if (pathTransfer.to instanceof RegularStop) {
           int toStopIndex = pathTransfer.to.getIndex();
           Transfer newTransfer;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
@@ -19,8 +19,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.constrainedtr
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
-import org.opentripplanner.transit.service.TransitModel;
-import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.transit.service.TransitEditorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +39,7 @@ public class TransitLayerUpdater {
 
   private static final Logger LOG = LoggerFactory.getLogger(TransitLayerUpdater.class);
 
-  private final TransitModel transitModel;
-  private final TransitService transitService;
+  private final TransitEditorService transitService;
 
   /**
    * Cache the TripPatternForDates indexed on the original TripPatterns in order to avoid this
@@ -57,8 +55,7 @@ public class TransitLayerUpdater {
 
   private final Map<LocalDate, Set<TripPatternForDate>> tripPatternsRunningOnDateMapCache = new HashMap<>();
 
-  public TransitLayerUpdater(TransitModel transitModel, TransitService transitService) {
-    this.transitModel = transitModel;
+  public TransitLayerUpdater(TransitEditorService transitService) {
     this.transitService = transitService;
   }
 
@@ -66,7 +63,7 @@ public class TransitLayerUpdater {
     Set<Timetable> updatedTimetables,
     Map<TripPattern, SortedSet<Timetable>> timetables
   ) {
-    if (!transitModel.hasRealtimeTransitLayer()) {
+    if (!transitService.hasRealtimeTransitLayer()) {
       return;
     }
 
@@ -74,7 +71,7 @@ public class TransitLayerUpdater {
 
     // Make a shallow copy of the realtime transit layer. Only the objects that are copied will be
     // changed during this update process.
-    TransitLayer realtimeTransitLayer = new TransitLayer(transitModel.getRealtimeTransitLayer());
+    TransitLayer realtimeTransitLayer = new TransitLayer(transitService.getRealtimeTransitLayer());
 
     // Instantiate a TripPatternForDateMapper with the new TripPattern mappings
     TripPatternForDateMapper tripPatternForDateMapper = new TripPatternForDateMapper(
@@ -225,7 +222,7 @@ public class TransitLayerUpdater {
 
     // Switch out the reference with the updated realtimeTransitLayer. This is synchronized to
     // guarantee that the reference is set after all the fields have been updated.
-    transitModel.setRealtimeTransitLayer(realtimeTransitLayer);
+    transitService.setRealtimeTransitLayer(realtimeTransitLayer);
 
     LOG.debug(
       "UPDATING {} tripPatterns took {} ms",

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import gnu.trove.set.TIntSet;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,6 +20,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,8 +41,7 @@ public class TransitLayerUpdater {
   private static final Logger LOG = LoggerFactory.getLogger(TransitLayerUpdater.class);
 
   private final TransitModel transitModel;
-
-  private final Map<LocalDate, TIntSet> serviceCodesRunningForDate;
+  private final TransitService transitService;
 
   /**
    * Cache the TripPatternForDates indexed on the original TripPatterns in order to avoid this
@@ -58,12 +57,9 @@ public class TransitLayerUpdater {
 
   private final Map<LocalDate, Set<TripPatternForDate>> tripPatternsRunningOnDateMapCache = new HashMap<>();
 
-  public TransitLayerUpdater(
-    TransitModel transitModel,
-    Map<LocalDate, TIntSet> serviceCodesRunningForDate
-  ) {
+  public TransitLayerUpdater(TransitModel transitModel, TransitService transitService) {
     this.transitModel = transitModel;
-    this.serviceCodesRunningForDate = serviceCodesRunningForDate;
+    this.transitService = transitService;
   }
 
   public void update(
@@ -82,7 +78,7 @@ public class TransitLayerUpdater {
 
     // Instantiate a TripPatternForDateMapper with the new TripPattern mappings
     TripPatternForDateMapper tripPatternForDateMapper = new TripPatternForDateMapper(
-      serviceCodesRunningForDate
+      transitService.getServiceCodesRunningForDate()
     );
 
     Set<LocalDate> datesToBeUpdated = new HashSet<>();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
@@ -41,7 +41,7 @@ public class TripPatternForDateMapper {
    * @param serviceCodesRunningForDate - READ ONLY
    */
   TripPatternForDateMapper(Map<LocalDate, TIntSet> serviceCodesRunningForDate) {
-    this.serviceCodesRunningForDate = Collections.unmodifiableMap(serviceCodesRunningForDate);
+    this.serviceCodesRunningForDate = serviceCodesRunningForDate;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -212,7 +212,7 @@ public class ConstructApplication {
     transitModel.setTransitLayer(TransitLayerMapper.map(tuningParameters, transitModel));
     transitModel.setRealtimeTransitLayer(new TransitLayer(transitModel.getTransitLayer()));
     transitModel.setTransitLayerUpdater(
-      new TransitLayerUpdater(transitModel, new DefaultTransitService(transitModel))
+      new TransitLayerUpdater(new DefaultTransitService(transitModel))
     );
   }
 

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -33,6 +33,7 @@ import org.opentripplanner.standalone.server.GrizzlyServer;
 import org.opentripplanner.standalone.server.OTPWebApplication;
 import org.opentripplanner.street.model.StreetLimitationParameters;
 import org.opentripplanner.street.model.elevation.ElevationUtils;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.configure.UpdaterConfigurator;
 import org.opentripplanner.visualizer.GraphVisualizer;
@@ -202,7 +203,7 @@ public class ConstructApplication {
     TransitModel transitModel,
     TransitTuningParameters tuningParameters
   ) {
-    if (!transitModel.hasTransit() || transitModel.getTransitModelIndex() == null) {
+    if (!transitModel.hasTransit() || !transitModel.isIndexed()) {
       LOG.warn(
         "Cannot create Raptor data, that requires the graph to have transit data and be indexed."
       );
@@ -211,10 +212,7 @@ public class ConstructApplication {
     transitModel.setTransitLayer(TransitLayerMapper.map(tuningParameters, transitModel));
     transitModel.setRealtimeTransitLayer(new TransitLayer(transitModel.getTransitLayer()));
     transitModel.setTransitLayerUpdater(
-      new TransitLayerUpdater(
-        transitModel,
-        transitModel.getTransitModelIndex().getServiceCodesRunningForDate()
-      )
+      new TransitLayerUpdater(transitModel, new DefaultTransitService(transitModel))
     );
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -596,6 +596,16 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
+  public void setRealtimeTransitLayer(TransitLayer realtimeTransitLayer) {
+    transitModel.setRealtimeTransitLayer(realtimeTransitLayer);
+  }
+
+  @Override
+  public boolean hasRealtimeTransitLayer() {
+    return transitModel.hasRealtimeTransitLayer();
+  }
+
+  @Override
   public CalendarService getCalendarService() {
     return this.transitModel.getCalendarService();
   }

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -657,6 +658,16 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public Deduplicator getDeduplicator() {
     return transitModel.getDeduplicator();
+  }
+
+  @Override
+  public Set<LocalDate> getAllServiceCodes() {
+    return Collections.unmodifiableSet(transitModelIndex.getServiceCodesRunningForDate().keySet());
+  }
+
+  @Override
+  public Map<LocalDate, TIntSet> getServiceCodesRunningForDate() {
+    return Collections.unmodifiableMap(transitModelIndex.getServiceCodesRunningForDate());
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
@@ -39,9 +39,22 @@ public interface TransitEditorService extends TransitService {
 
   FeedScopedId getOrCreateServiceIdForDate(LocalDate serviceDate);
 
+  /**
+   * Set the original, immutable, transit layer,
+   * based on scheduled data (not real-time data).
+   */
   void setTransitLayer(TransitLayer transitLayer);
 
+  /**
+   * Return true if a real-time transit layer is present.
+   * The real-time transit layer is optional,
+   * it is present only when real-time updaters are configured.
+   */
   boolean hasRealtimeTransitLayer();
 
+  /**
+   * Publish the latest snapshot of the real-time transit layer.
+   * Should be called only when creating a new TransitLayer, from the graph writer thread.
+   */
   void setRealtimeTransitLayer(TransitLayer realtimeTransitLayer);
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
@@ -40,4 +40,8 @@ public interface TransitEditorService extends TransitService {
   FeedScopedId getOrCreateServiceIdForDate(LocalDate serviceDate);
 
   void setTransitLayer(TransitLayer transitLayer);
+
+  boolean hasRealtimeTransitLayer();
+
+  void setRealtimeTransitLayer(TransitLayer realtimeTransitLayer);
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -539,8 +539,13 @@ public class TransitModel implements Serializable {
    * The caller is responsible for calling the {@link #index()} method if it is a
    * possibility that the index is not initialized (during graph build).
    */
-  public @Nullable TransitModelIndex getTransitModelIndex() {
+  @Nullable
+  TransitModelIndex getTransitModelIndex() {
     return index;
+  }
+
+  public boolean isIndexed() {
+    return index != null;
   }
 
   public boolean hasFlexTrips() {

--- a/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * For performance reasons these indexes are not part of the serialized state of the graph.
  * They are rebuilt at runtime after graph deserialization.
  */
-public class TransitModelIndex {
+class TransitModelIndex {
 
   private static final Logger LOG = LoggerFactory.getLogger(TransitModelIndex.class);
 
@@ -117,20 +117,20 @@ public class TransitModelIndex {
     LOG.info("Transit Model index init complete.");
   }
 
-  public Agency getAgencyForId(FeedScopedId id) {
+  Agency getAgencyForId(FeedScopedId id) {
     return agencyForId.get(id);
   }
 
-  public Route getRouteForId(FeedScopedId id) {
+  Route getRouteForId(FeedScopedId id) {
     return routeForId.get(id);
   }
 
-  public void addRoutes(Route route) {
+  void addRoutes(Route route) {
     routeForId.put(route.getId(), route);
   }
 
   /** Dynamically generate the set of Routes passing though a Stop on demand. */
-  public Set<Route> getRoutesForStop(StopLocation stop) {
+  Set<Route> getRoutesForStop(StopLocation stop) {
     Set<Route> routes = new HashSet<>();
     for (TripPattern p : getPatternsForStop(stop)) {
       routes.add(p.getRoute());
@@ -138,11 +138,11 @@ public class TransitModelIndex {
     return routes;
   }
 
-  public Collection<TripPattern> getPatternsForStop(StopLocation stop) {
+  Collection<TripPattern> getPatternsForStop(StopLocation stop) {
     return patternsForStopId.get(stop);
   }
 
-  public Collection<Trip> getTripsForStop(StopLocation stop) {
+  Collection<Trip> getTripsForStop(StopLocation stop) {
     return getPatternsForStop(stop)
       .stream()
       .flatMap(TripPattern::scheduledTripsAsStream)
@@ -152,43 +152,43 @@ public class TransitModelIndex {
   /**
    * Get a list of all operators spanning across all feeds.
    */
-  public Collection<Operator> getAllOperators() {
+  Collection<Operator> getAllOperators() {
     return getOperatorForId().values();
   }
 
-  public Map<FeedScopedId, Operator> getOperatorForId() {
+  Map<FeedScopedId, Operator> getOperatorForId() {
     return operatorForId;
   }
 
-  public Map<FeedScopedId, Trip> getTripForId() {
+  Map<FeedScopedId, Trip> getTripForId() {
     return tripForId;
   }
 
-  public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDateById() {
+  Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDateById() {
     return tripOnServiceDateById;
   }
 
-  public Map<TripIdAndServiceDate, TripOnServiceDate> getTripOnServiceDateForTripAndDay() {
+  Map<TripIdAndServiceDate, TripOnServiceDate> getTripOnServiceDateForTripAndDay() {
     return tripOnServiceDateForTripAndDay;
   }
 
-  public Collection<Route> getAllRoutes() {
+  Collection<Route> getAllRoutes() {
     return routeForId.values();
   }
 
-  public Map<Trip, TripPattern> getPatternForTrip() {
+  Map<Trip, TripPattern> getPatternForTrip() {
     return patternForTrip;
   }
 
-  public Multimap<Route, TripPattern> getPatternsForRoute() {
+  Multimap<Route, TripPattern> getPatternsForRoute() {
     return patternsForRoute;
   }
 
-  public Map<LocalDate, TIntSet> getServiceCodesRunningForDate() {
+  Map<LocalDate, TIntSet> getServiceCodesRunningForDate() {
     return serviceCodesRunningForDate;
   }
 
-  public FlexIndex getFlexIndex() {
+  FlexIndex getFlexIndex() {
     return flexIndex;
   }
 
@@ -229,11 +229,11 @@ public class TransitModelIndex {
     }
   }
 
-  public Multimap<GroupOfRoutes, Route> getRoutesForGroupOfRoutes() {
+  Multimap<GroupOfRoutes, Route> getRoutesForGroupOfRoutes() {
     return routesForGroupOfRoutes;
   }
 
-  public Map<FeedScopedId, GroupOfRoutes> getGroupOfRoutesForId() {
+  Map<FeedScopedId, GroupOfRoutes> getGroupOfRoutesForId() {
     return groupOfRoutesForId;
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -186,6 +186,10 @@ public interface TransitService {
 
   GroupOfRoutes getGroupOfRoutesForId(FeedScopedId id);
 
+  /**
+   * Return the timetable for a given trip pattern and date, taking into account real-time updates.
+   * If no real-times update are applied, fall back to scheduled data.
+   */
   @Nullable
   Timetable getTimetableForTripPattern(TripPattern tripPattern, LocalDate serviceDate);
 

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -8,8 +8,10 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.ext.flex.FlexIndex;
 import org.opentripplanner.model.FeedInfo;
@@ -184,10 +186,7 @@ public interface TransitService {
 
   GroupOfRoutes getGroupOfRoutesForId(FeedScopedId id);
 
-  /**
-   * Return the timetable for a given trip pattern and date, taking into account real-time updates.
-   * If no real-times update are applied, fall back to scheduled data.
-   */
+  @Nullable
   Timetable getTimetableForTripPattern(TripPattern tripPattern, LocalDate serviceDate);
 
   TripPattern getRealtimeAddedTripPattern(FeedScopedId tripId, LocalDate serviceDate);
@@ -254,4 +253,8 @@ public interface TransitService {
   List<TransitMode> getModesOfStopLocation(StopLocation stop);
 
   Deduplicator getDeduplicator();
+
+  Set<LocalDate> getAllServiceCodes();
+
+  Map<LocalDate, TIntSet> getServiceCodesRunningForDate();
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
@@ -99,8 +99,8 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
     Trip trip,
     LocalDate sd
   ) {
-    // TODO OTP2 RT_VP a new instance of DefaultTransitService must be created to retrieve
-    // the latest TimetableSnapshot
+    // a new instance of DefaultTransitService must be created to retrieve
+    // the current TimetableSnapshot
     return (new DefaultTransitService(transitModel)).getPatternForTrip(trip, sd);
   }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
@@ -45,6 +45,8 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
     super(params);
     this.vehiclePositionSource =
       new GtfsRealtimeHttpVehiclePositionSource(params.url(), params.headers());
+    // TODO Inject TransitService, do not create it here. We currently do not
+    //      support dagger injection in updaters, so this is ok for now.
     TransitService transitService = new DefaultTransitService(transitModel);
     var fuzzyTripMatcher = params.fuzzyTripMatching()
       ? new GtfsRealtimeFuzzyTripMatcher(transitService)

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
@@ -3,13 +3,13 @@ package org.opentripplanner.updater.vehicle_position;
 import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -45,18 +45,18 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
     super(params);
     this.vehiclePositionSource =
       new GtfsRealtimeHttpVehiclePositionSource(params.url(), params.headers());
-    var index = transitModel.getTransitModelIndex();
+    TransitService transitService = new DefaultTransitService(transitModel);
     var fuzzyTripMatcher = params.fuzzyTripMatching()
-      ? new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel))
+      ? new GtfsRealtimeFuzzyTripMatcher(transitService)
       : null;
     this.realtimeVehiclePatternMatcher =
       new RealtimeVehiclePatternMatcher(
         params.feedId(),
-        tripId -> index.getTripForId().get(tripId),
-        trip -> index.getPatternForTrip().get(trip),
+        transitService::getTripForId,
+        transitService::getPatternForTrip,
         (trip, date) -> getPatternIncludingRealtime(transitModel, trip, date),
         realtimeVehicleRepository,
-        transitModel.getTimeZone(),
+        transitService.getTimeZone(),
         fuzzyTripMatcher,
         params.vehiclePositionFeatures()
       );
@@ -99,9 +99,8 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
     Trip trip,
     LocalDate sd
   ) {
-    return Optional
-      .ofNullable(transitModel.getTimetableSnapshot())
-      .map(snapshot -> snapshot.getRealtimeAddedTripPattern(trip.getId(), sd))
-      .orElseGet(() -> transitModel.getTransitModelIndex().getPatternForTrip().get(trip));
+    // TODO OTP2 RT_VP a new instance of DefaultTransitService must be created to retrieve
+    // the latest TimetableSnapshot
+    return (new DefaultTransitService(transitModel)).getPatternForTrip(trip, sd);
   }
 }

--- a/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
+++ b/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
@@ -217,8 +217,7 @@ public final class RealtimeTestEnvironment {
   }
 
   public TripPattern getPatternForTrip(Trip trip) {
-    var transitService = getTransitService();
-    return transitService.getPatternForTrip(trip);
+    return getTransitService().getPatternForTrip(trip);
   }
 
   public TimetableSnapshot getTimetableSnapshot() {

--- a/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
+++ b/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
@@ -217,7 +217,8 @@ public final class RealtimeTestEnvironment {
   }
 
   public TripPattern getPatternForTrip(Trip trip) {
-    return transitModel.getTransitModelIndex().getPatternForTrip().get(trip);
+    var transitService = getTransitService();
+    return transitService.getPatternForTrip(trip);
   }
 
   public TimetableSnapshot getTimetableSnapshot() {

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -33,7 +33,9 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.TimetableSnapshotSourceParameters;
 
@@ -52,11 +54,13 @@ public class TimetableSnapshotSourceTest {
   private final GtfsRealtimeFuzzyTripMatcher TRIP_MATCHER_NOOP = null;
 
   private String feedId;
+  private TransitService transitService;
 
   @BeforeEach
   public void setUp() {
     TestOtpModel model = ConstantsForTests.buildGtfsGraph(ConstantsForTests.SIMPLE_GTFS);
     transitModel = model.transitModel();
+    transitService = new DefaultTransitService(transitModel);
 
     feedId = transitModel.getFeedIds().stream().findFirst().get();
   }
@@ -224,11 +228,8 @@ public class TimetableSnapshotSourceTest {
     // Original trip pattern
     {
       final FeedScopedId tripId = new FeedScopedId(feedId, modifiedTripId);
-      final Trip trip = transitModel.getTransitModelIndex().getTripForId().get(tripId);
-      final TripPattern originalTripPattern = transitModel
-        .getTransitModelIndex()
-        .getPatternForTrip()
-        .get(trip);
+      final Trip trip = transitService.getTripForId(tripId);
+      final TripPattern originalTripPattern = transitService.getPatternForTrip(trip);
 
       final Timetable originalTimetableForToday = snapshot.resolve(
         originalTripPattern,

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -50,11 +50,11 @@ public class TimetableSnapshotSourceTest {
   )
     .build();
   private TransitModel transitModel;
+  private TransitService transitService;
 
   private final GtfsRealtimeFuzzyTripMatcher TRIP_MATCHER_NOOP = null;
 
   private String feedId;
-  private TransitService transitService;
 
   @BeforeEach
   public void setUp() {
@@ -62,7 +62,7 @@ public class TimetableSnapshotSourceTest {
     transitModel = model.transitModel();
     transitService = new DefaultTransitService(transitModel);
 
-    feedId = transitModel.getFeedIds().stream().findFirst().get();
+    feedId = transitService.getFeedIds().stream().findFirst().get();
   }
 
   @Test
@@ -119,7 +119,7 @@ public class TimetableSnapshotSourceTest {
       tripDescriptorBuilder.setStartDate(ServiceDateUtils.asCompactString(SERVICE_DATE));
 
       final long midnightSecondsSinceEpoch = ServiceDateUtils
-        .asStartOfService(SERVICE_DATE, transitModel.getTimeZone())
+        .asStartOfService(SERVICE_DATE, transitService.getTimeZone())
         .toEpochSecond();
 
       final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();

--- a/src/test/java/org/opentripplanner/updater/trip/moduletests/addition/AddedTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/moduletests/addition/AddedTest.java
@@ -62,7 +62,7 @@ class AddedTest {
     assertEquals(TripUpdateBuilder.ROUTE_NAME, route.getName());
     assertEquals(TransitMode.RAIL, route.getMode());
 
-    var fromTransitModel = env.transitModel.getTransitModelIndex().getRouteForId(route.getId());
+    var fromTransitModel = env.getTransitService().getRouteForId(route.getId());
     assertEquals(fromTransitModel, route);
 
     assertEquals(PickDrop.CALL_AGENCY, pattern.getBoardType(0));
@@ -117,7 +117,7 @@ class AddedTest {
     var secondRoute = secondPattern.getRoute();
 
     assertSame(firstRoute, secondRoute);
-    assertNotNull(env.transitModel.getTransitModelIndex().getRouteForId(firstRoute.getId()));
+    assertNotNull(env.getTransitService().getRouteForId(firstRoute.getId()));
   }
 
   private TripPattern assertAddedTrip(String tripId, RealtimeTestEnvironment env) {

--- a/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/DelayedTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/DelayedTest.java
@@ -86,10 +86,7 @@ class DelayedTest {
 
     var snapshot = env.getTimetableSnapshot();
 
-    final TripPattern originalTripPattern = env.transitModel
-      .getTransitModelIndex()
-      .getPatternForTrip()
-      .get(env.trip2);
+    final TripPattern originalTripPattern = env.getTransitService().getPatternForTrip(env.trip2);
 
     var originalTimetableForToday = snapshot.resolve(originalTripPattern, SERVICE_DATE);
     var originalTimetableScheduled = snapshot.resolve(originalTripPattern, null);

--- a/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
@@ -13,9 +13,6 @@ import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
-import org.opentripplanner.transit.model.timetable.Trip;
-import org.opentripplanner.transit.model.timetable.TripTimes;
-import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.model.timetable.TripTimesStringBuilder;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
@@ -181,8 +178,7 @@ public class SkippedTest {
     RealtimeTestEnvironment env,
     FeedScopedId tripId
   ) {
-    var originalTripPattern = env.getTransitService()
-      .getPatternForTrip(env.trip2);
+    var originalTripPattern = env.getTransitService().getPatternForTrip(env.trip2);
     var snapshot = env.getTimetableSnapshot();
     var originalTimetableForToday = snapshot.resolve(originalTripPattern, SERVICE_DATE);
 

--- a/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
@@ -13,6 +13,9 @@ import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.model.timetable.TripTimesStringBuilder;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
@@ -132,8 +135,8 @@ public class SkippedTest {
     RealtimeTestEnvironment env,
     FeedScopedId tripId
   ) {
-    var trip = env.transitModel.getTransitModelIndex().getTripForId().get(tripId);
-    var originalTripPattern = env.transitModel.getTransitModelIndex().getPatternForTrip().get(trip);
+    var trip = env.getTransitService().getTripForId(tripId);
+    var originalTripPattern = env.getTransitService().getPatternForTrip(trip);
     var snapshot = env.getTimetableSnapshot();
     var originalTimetableForToday = snapshot.resolve(originalTripPattern, SERVICE_DATE);
     var originalTimetableScheduled = snapshot.resolve(originalTripPattern, null);
@@ -178,10 +181,8 @@ public class SkippedTest {
     RealtimeTestEnvironment env,
     FeedScopedId tripId
   ) {
-    var originalTripPattern = env.transitModel
-      .getTransitModelIndex()
-      .getPatternForTrip()
-      .get(env.trip2);
+    var originalTripPattern = env.getTransitService()
+      .getPatternForTrip(env.trip2);
     var snapshot = env.getTimetableSnapshot();
     var originalTimetableForToday = snapshot.resolve(originalTripPattern, SERVICE_DATE);
 


### PR DESCRIPTION
### Summary

This PR encapsulates the `TransitModelIndex` so that it is accessed only through the `TransitService`/`TransitEditorService` interfaces.

This prepares for further refactoring steps where the mutable state that is currently stored in the `TransitModelIndex`, the `TimetableSnapshot` and the `TransitLayer` will be handled in a more consistent and unified way.

This also brings the code closer to the target design (immutable transit model) where all transit model updates are performed through the `TransitEditorService`.

**Note**:
* The `TransitService` service should not provide direct read/write access to the underlying collections in the index. Ideally, all accessors should return an unmodifiable view of these collections. This is currently not always the case. This PR fixes this issue in a couple of accessor methods where it is easy to demonstrate that the access is indeed read-only. More accessors should be fixed in a follow-up PR.

* The content and semantic of `TransitLayer`, `TimetableSnapshot`, `TransitModelIndex` are not explicit in the current design, but it appears that:
   * `TransitLayer` is used only in Raptor and reflects all real-time updates
   * `TimetableSnapshot` is used in API calls and reflects all real-time updates
   * `TransitModelIndex`  is used in API calls and reflects scheduled data + initial state of extra journeys
(i.e: the only updates to the index are additions of new trips, no removal/modification. Subsequent changes in added trips are not applied to the index)


### Issue

No

### Unit tests

Updated unit tests

### Documentation

No
