### PR TITLE
Publish timetable snapshot in background

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -119,8 +119,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     LOG.debug("message contains {} trip updates", updates.size());
 
-    snapshotManager.purgeAndCommit();
-
     return UpdateResult.ofResults(results);
   }
 
@@ -328,6 +326,9 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     return success;
   }
 
+  /**
+   * Flush pending changes in the timetable snapshot buffer and publish a new snapshot.
+   */
   public void flushBuffer() {
     snapshotManager.purgeAndCommit();
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -129,6 +129,10 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     return snapshotManager.getTimetableSnapshot();
   }
 
+  private TimetableSnapshot getTimetableSnapshotBuffer() {
+    return snapshotManager.getTimetableSnapshotBuffer();
+  }
+
   private Result<UpdateSuccess, UpdateError> apply(
     EstimatedVehicleJourney journey,
     TransitEditorService transitService,
@@ -193,12 +197,9 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
    * Snapshot timetable is used as source if initialised, trip patterns scheduled timetable if not.
    */
   private Timetable getCurrentTimetable(TripPattern tripPattern, LocalDate serviceDate) {
-    TimetableSnapshot timetableSnapshot = getTimetableSnapshot();
-    if (timetableSnapshot != null) {
-      return timetableSnapshot.resolve(tripPattern, serviceDate);
-    }
-    return tripPattern.getScheduledTimetable();
+    return getTimetableSnapshotBuffer().resolve(tripPattern, serviceDate);
   }
+
 
   private Result<TripUpdate, UpdateError> handleModifiedTrip(
     @Nullable SiriFuzzyTripMatcher fuzzyTripMatcher,

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -57,7 +57,12 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
    */
   private final SiriTripPatternCache tripPatternCache;
 
-  private final TransitEditorService transitService;
+  /**
+   * Long-lived transit editor service that has access to the timetable snapshot buffer.
+   * This differs from the usual use case where the transit service refers to the latest published
+   * timetable snapshot.
+   */
+  private final TransitEditorService transitEditorService;
 
   private final TimetableSnapshotManager snapshotManager;
 
@@ -71,9 +76,10 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         parameters,
         () -> LocalDate.now(transitModel.getTimeZone())
       );
-    this.transitService = new DefaultTransitService(transitModel, getTimetableSnapshotBuffer());
+    this.transitEditorService =
+      new DefaultTransitService(transitModel, getTimetableSnapshotBuffer());
     this.tripPatternCache =
-      new SiriTripPatternCache(tripPatternIdGenerator, transitService::getPatternForTrip);
+      new SiriTripPatternCache(tripPatternIdGenerator, transitEditorService::getPatternForTrip);
 
     transitModel.initTimetableSnapshotProvider(this);
   }
@@ -112,7 +118,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         var journeys = estimatedJourneyVersion.getEstimatedVehicleJourneies();
         LOG.debug("Handling {} EstimatedVehicleJourneys.", journeys.size());
         for (EstimatedVehicleJourney journey : journeys) {
-          results.add(apply(journey, transitService, fuzzyTripMatcher, entityResolver));
+          results.add(apply(journey, transitEditorService, fuzzyTripMatcher, entityResolver));
         }
       }
     }
@@ -224,7 +230,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     if (trip != null) {
       // Found exact match
-      pattern = transitService.getPatternForTrip(trip);
+      pattern = transitEditorService.getPatternForTrip(trip);
     } else if (fuzzyTripMatcher != null) {
       // No exact match found - search for trips based on arrival-times/stop-patterns
       TripAndPattern tripAndPattern = fuzzyTripMatcher.match(
@@ -259,7 +265,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       pattern,
       estimatedVehicleJourney,
       serviceDate,
-      transitService.getTimeZone(),
+      transitEditorService.getTimeZone(),
       entityResolver
     )
       .build();
@@ -306,7 +312,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
   private boolean markScheduledTripAsDeleted(Trip trip, final LocalDate serviceDate) {
     boolean success = false;
 
-    final TripPattern pattern = transitService.getPatternForTrip(trip);
+    final TripPattern pattern = transitEditorService.getPatternForTrip(trip);
 
     if (pattern != null) {
       // Mark scheduled trip times for this trip in this pattern as deleted

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -102,11 +102,10 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     List<Result<UpdateSuccess, UpdateError>> results = new ArrayList<>();
 
-    snapshotManager.withLock(() -> {
-      if (incrementality == FULL_DATASET) {
-        // Remove all updates from the buffer
-        snapshotManager.clearBuffer(feedId);
-      }
+    if (incrementality == FULL_DATASET) {
+      // Remove all updates from the buffer
+      snapshotManager.clearBuffer(feedId);
+    }
 
       for (var etDelivery : updates) {
         for (var estimatedJourneyVersion : etDelivery.getEstimatedJourneyVersionFrames()) {
@@ -118,10 +117,9 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         }
       }
 
-      LOG.debug("message contains {} trip updates", updates.size());
+    LOG.debug("message contains {} trip updates", updates.size());
 
-      snapshotManager.purgeAndCommit();
-    });
+    snapshotManager.purgeAndCommit();
 
     return UpdateResult.ofResults(results);
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -327,4 +327,8 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     return success;
   }
+
+  public void flushBuffer() {
+    snapshotManager.purgeAndCommit();
+  }
 }

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -65,6 +65,11 @@ import org.slf4j.LoggerFactory;
  * up timetables on this class could conceivably be replaced with snapshotting entire views of the
  * transit network. It would also be possible to make the realtime version of Timetables or
  * TripTimes the primary view, and include references back to their scheduled versions.
+ * <p>
+ * Implementation note: when a snapshot is committed, the mutable state of this class is stored
+ * in final fields and completely initialized in the constructor. This provides an additional
+ * guarantee of safe-publication without synchronization.
+ * (see <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.5">final Field Semantics</a>)
  */
 public class TimetableSnapshot {
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -79,6 +79,14 @@ public class DefaultTransitService implements TransitEditorService {
     this.transitModelIndex = transitModel.getTransitModelIndex();
   }
 
+  public DefaultTransitService(
+    TransitModel transitModel,
+    TimetableSnapshot timetableSnapshotBuffer
+  ) {
+    this(transitModel);
+    this.timetableSnapshot = timetableSnapshotBuffer;
+  }
+
   @Override
   public Collection<String> getFeedIds() {
     return this.transitModel.getFeedIds();

--- a/src/main/java/org/opentripplanner/updater/spi/TimetableSnapshotFlush.java
+++ b/src/main/java/org/opentripplanner/updater/spi/TimetableSnapshotFlush.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.updater.spi;
+
+import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
+import org.opentripplanner.updater.trip.TimetableSnapshotSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Flush the timetable snapshot buffer by committing pending changes.
+ */
+public class TimetableSnapshotFlush implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TimetableSnapshotFlush.class);
+
+  private final SiriTimetableSnapshotSource siriTimetableSnapshotSource;
+  private final TimetableSnapshotSource gtfsTimetableSnapshotSource;
+
+  public TimetableSnapshotFlush(
+    SiriTimetableSnapshotSource siriTimetableSnapshotSource,
+    TimetableSnapshotSource gtfsTimetableSnapshotSource
+  ) {
+    this.siriTimetableSnapshotSource = siriTimetableSnapshotSource;
+    this.gtfsTimetableSnapshotSource = gtfsTimetableSnapshotSource;
+  }
+
+  @Override
+  public void run() {
+    LOG.debug("Flushing timetable snapshot buffer");
+    if (siriTimetableSnapshotSource != null) {
+      siriTimetableSnapshotSource.flushBuffer();
+    }
+    if (gtfsTimetableSnapshotSource != null) {
+      gtfsTimetableSnapshotSource.flushBuffer();
+    }
+    LOG.debug("Flushed timetable snapshot buffer");
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/spi/TimetableSnapshotFlush.java
+++ b/src/main/java/org/opentripplanner/updater/spi/TimetableSnapshotFlush.java
@@ -7,6 +7,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Flush the timetable snapshot buffer by committing pending changes.
+ * Exceptions occurring during the flush are caught and ignored: the scheduler can then retry
+ * the task later.
  */
 public class TimetableSnapshotFlush implements Runnable {
 
@@ -25,13 +27,17 @@ public class TimetableSnapshotFlush implements Runnable {
 
   @Override
   public void run() {
-    LOG.debug("Flushing timetable snapshot buffer");
-    if (siriTimetableSnapshotSource != null) {
-      siriTimetableSnapshotSource.flushBuffer();
+    try {
+      LOG.debug("Flushing timetable snapshot buffer");
+      if (siriTimetableSnapshotSource != null) {
+        siriTimetableSnapshotSource.flushBuffer();
+      }
+      if (gtfsTimetableSnapshotSource != null) {
+        gtfsTimetableSnapshotSource.flushBuffer();
+      }
+      LOG.debug("Flushed timetable snapshot buffer");
+    } catch (Throwable t) {
+      LOG.error("Error flushing timetable snapshot buffer", t);
     }
-    if (gtfsTimetableSnapshotSource != null) {
-      gtfsTimetableSnapshotSource.flushBuffer();
-    }
-    LOG.debug("Flushed timetable snapshot buffer");
   }
 }

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -90,6 +90,10 @@ public final class TimetableSnapshotManager {
     return snapshot;
   }
 
+  public TimetableSnapshot getTimetableSnapshotBuffer() {
+    return buffer;
+  }
+
   /**
    * Request a commit of the timetable snapshot.
    * <p>
@@ -154,6 +158,8 @@ public final class TimetableSnapshotManager {
   public void revertTripToScheduledTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
     buffer.revertTripToScheduledTripPattern(tripId, serviceDate);
   }
+
+
 
   /**
    * Remove realtime data from previous service dates from the snapshot. This is useful so that

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -102,7 +102,7 @@ public final class TimetableSnapshotManager {
    *
    * @param force Force the committing of a new snapshot even if the above conditions are not met.
    */
-  public void commitTimetableSnapshot(final boolean force) {
+  void commitTimetableSnapshot(final boolean force) {
     if (force || snapshotFrequencyThrottle.timeIsUp()) {
       if (force || buffer.isDirty()) {
         LOG.debug("Committing {}", buffer);

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -159,8 +159,6 @@ public final class TimetableSnapshotManager {
     buffer.revertTripToScheduledTripPattern(tripId, serviceDate);
   }
 
-
-
   /**
    * Remove realtime data from previous service dates from the snapshot. This is useful so that
    * instances that run for multiple days don't accumulate a lot of realtime data for past

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -82,6 +82,12 @@ public final class TimetableSnapshotManager {
     return snapshot.get();
   }
 
+  /**
+   * @return the current timetable snapshot buffer that contains pending changes (not yet published
+   * in a snapshot).
+   * This should be used in the context of an updater to build a TransitEditorService that sees all
+   * the changes applied so far by real-time updates.
+   */
   public TimetableSnapshot getTimetableSnapshotBuffer() {
     return buffer;
   }

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -119,7 +119,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     this.snapshotManager =
       new TimetableSnapshotManager(transitModel.getTransitLayerUpdater(), parameters, localDateNow);
     this.timeZone = transitModel.getTimeZone();
-    this.transitService = new DefaultTransitService(transitModel);
+    this.transitService =
+      new DefaultTransitService(transitModel, snapshotManager.getTimetableSnapshotBuffer());
     this.deduplicator = transitModel.getDeduplicator();
     this.serviceCodes = transitModel.getServiceCodes();
     this.localDateNow = localDateNow;

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -1097,4 +1097,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     CANCEL,
     DELETE,
   }
+
+  public void flushBuffer() {
+    snapshotManager.purgeAndCommit();
+  }
 }

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -269,8 +269,6 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       }
     }
 
-    snapshotManager.purgeAndCommit();
-
     var updateResult = UpdateResult.ofResults(results);
 
     if (updateIncrementality == FULL_DATASET) {

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -233,6 +233,7 @@ public abstract class GtfsTest {
         updates,
         feedId.getId()
       );
+      timetableSnapshotSource.flushBuffer();
       alertsUpdateHandler.update(feedMessage);
     } catch (Exception exception) {}
   }

--- a/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
+++ b/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
@@ -221,7 +221,6 @@ public final class RealtimeTestEnvironment {
   }
 
   public TimetableSnapshot getTimetableSnapshot() {
-    commitTimetableSnapshot();
     if (siriSource != null) {
       return siriSource.getTimetableSnapshot();
     } else {
@@ -285,13 +284,15 @@ public final class RealtimeTestEnvironment {
     UpdateIncrementality incrementality
   ) {
     Objects.requireNonNull(gtfsSource, "Test environment is configured for SIRI only");
-    return gtfsSource.applyTripUpdates(
+    UpdateResult updateResult = gtfsSource.applyTripUpdates(
       null,
       BackwardsDelayPropagationType.REQUIRED_NO_DATA,
       incrementality,
       updates,
       getFeedId()
     );
+    commitTimetableSnapshot();
+    return updateResult;
   }
 
   // private methods

--- a/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
+++ b/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
@@ -221,6 +221,7 @@ public final class RealtimeTestEnvironment {
   }
 
   public TimetableSnapshot getTimetableSnapshot() {
+    commitTimetableSnapshot();
     if (siriSource != null) {
       return siriSource.getTimetableSnapshot();
     } else {
@@ -300,7 +301,19 @@ public final class RealtimeTestEnvironment {
     boolean fuzzyMatching
   ) {
     Objects.requireNonNull(siriSource, "Test environment is configured for GTFS-RT only");
-    return getEstimatedTimetableHandler(fuzzyMatching).applyUpdate(updates, DIFFERENTIAL);
+    UpdateResult updateResult = getEstimatedTimetableHandler(fuzzyMatching)
+      .applyUpdate(updates, DIFFERENTIAL);
+    commitTimetableSnapshot();
+    return updateResult;
+  }
+
+  private void commitTimetableSnapshot() {
+    if (siriSource != null) {
+      siriSource.flushBuffer();
+    }
+    if (gtfsSource != null) {
+      gtfsSource.flushBuffer();
+    }
   }
 
   private Trip createTrip(String id, Route route, List<StopCall> stops) {

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotManagerTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotManagerTest.java
@@ -63,19 +63,16 @@ class TimetableSnapshotManagerTest {
 
   static Stream<Arguments> purgeExpiredDataTestCases() {
     return Stream.of(
-      // purgeExpiredData   maxSnapshotFrequency || snapshots PatternSnapshotA  PatternSnapshotB
-      Arguments.of(Boolean.TRUE, -1, NotSame, NotSame),
-      Arguments.of(Boolean.FALSE, -1, NotSame, Same),
-      Arguments.of(Boolean.TRUE, 1000, NotSame, NotSame),
-      Arguments.of(Boolean.FALSE, 1000, Same, Same)
+      // purgeExpiredData   || snapshots PatternSnapshotA  PatternSnapshotB
+      Arguments.of(Boolean.TRUE, NotSame, NotSame),
+      Arguments.of(Boolean.FALSE, NotSame, Same)
     );
   }
 
-  @ParameterizedTest(name = "purgeExpired: {0}, maxFrequency: {1}  ||  {2}  {3}")
+  @ParameterizedTest(name = "purgeExpired: {0} ||  {1}  {2}")
   @MethodSource("purgeExpiredDataTestCases")
   public void testPurgeExpiredData(
     boolean purgeExpiredData,
-    int maxSnapshotFrequency,
     SameAssert expSnapshots,
     SameAssert expPatternAeqB
   ) {
@@ -85,9 +82,7 @@ class TimetableSnapshotManagerTest {
 
     var snapshotManager = new TimetableSnapshotManager(
       null,
-      TimetableSnapshotSourceParameters.DEFAULT
-        .withPurgeExpiredData(purgeExpiredData)
-        .withMaxSnapshotFrequency(Duration.ofMillis(maxSnapshotFrequency)),
+      TimetableSnapshotSourceParameters.DEFAULT.withPurgeExpiredData(purgeExpiredData),
       clock::get
     );
 

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -83,28 +83,6 @@ public class TimetableSnapshotSourceTest {
   }
 
   @Test
-  public void testGetSnapshotWithMaxSnapshotFrequencyCleared() {
-    var updater = new TimetableSnapshotSource(
-      TimetableSnapshotSourceParameters.DEFAULT.withMaxSnapshotFrequency(Duration.ofMillis(-1)),
-      transitModel
-    );
-
-    final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
-
-    updater.applyTripUpdates(
-      TRIP_MATCHER_NOOP,
-      REQUIRED_NO_DATA,
-      DIFFERENTIAL,
-      List.of(CANCELLATION),
-      feedId
-    );
-
-    final TimetableSnapshot newSnapshot = updater.getTimetableSnapshot();
-    assertNotNull(newSnapshot);
-    assertNotSame(snapshot, newSnapshot);
-  }
-
-  @Test
   public void testHandleModifiedTrip() {
     // GIVEN
 
@@ -221,6 +199,7 @@ public class TimetableSnapshotSourceTest {
       List.of(tripUpdate),
       feedId
     );
+    updater.flushBuffer();
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();


### PR DESCRIPTION
### Summary

In the current implementation, the timetable snapshot can be committed:
- from the graph writer thread when applying updates (see https://github.com/opentripplanner/OpenTripPlanner/blob/8391674772e122e92cf940453d166a4ea44dadba/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java#L141)
- from reader threads when lazy-loading a snapshot (see https://github.com/opentripplanner/OpenTripPlanner/blob/359cb7368cc8942219c544981027d2d8b6c00e3e/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java#L518)

Committing the snapshot from a reader thread should be avoided: it delays the API call and it makes the implementation more complex and fragile due to synchronization between threads.

This PR modifies the snapshot lazy-loading logic so that it does not trigger a snapshot commit from reader threads.

This allows also to remove synchronization on the snapshot creation process since only the graph writer thread can modify the snapshot.
There is still a need for synchronizing the publishing of the new snapshot to guarantee that all changes that lead to the creation of the snapshot happens-before the publication. In the current implementation this is guaranteed by a volatile field. This PR makes use of the `ConcurrentPublished` mechanism to align with the publication mechanism used in the `TransitLayer`.

In addition to this, it makes it possible to construct a `TransitService` that reflects the current state of the buffer rather than the state of the latest published snapshot.
This is useful when used in the context of an updater, so that the `TransitService` can see pending changes.

A downside of committing snapshots only when applying updates is that, in case of throttling, the pending changes will be deferred until the next real-time message arrives, after the throttling period. This is not an issue with updaters that receive a steady flow of messages, but could be problematic with updaters that receive messages in batches followed by silent periods.
To cover this edge case, a periodic task `TimetableSnapshotFlush` commits pending changes, if any. In addition the updaters do not commit a snapshot after an update anymore, leaving `TimetableSnapshotFlush` the only place where a snapshot can be created. The throttling logic is removed from `TimetableSnapshotManager` 

### Issue

No

### Unit tests

No

### Documentation

No