### PR TITLE
Add car rental to Transmodel street mode options

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,2 +1,3 @@
 VITE_API_URL=/otp/transmodel/v3
 VITE_DEBUG_STYLE_URL=/otp/routers/default/inspector/vectortile/style.json
+

--- a/client/README.md
+++ b/client/README.md
@@ -63,3 +63,4 @@ or add it to a new `.env.development.local` file (this file will be ignored by g
 In production mode, the default is to access OTP via the same origin as the client (see `.env`).
 This behavior can also be modified by changing the previously mentioned environment variable at
 build-time.
+

--- a/client/README.md
+++ b/client/README.md
@@ -63,4 +63,3 @@ or add it to a new `.env.development.local` file (this file will be ignored by g
 In production mode, the default is to access OTP via the same origin as the client (see `.env`).
 This behavior can also be modified by changing the previously mentioned environment variable at
 build-time.
-

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -435,6 +435,13 @@ public class EnumTypes {
       "This can include various taxi-services or kiss & ride."
     )
     .value(
+      "car_rental",
+      StreetMode.CAR_RENTAL,
+      "Walk to a car rental point along " +
+      "the road, drive to a drop-off point along the road, and walk the rest of the way. " +
+      "This can include car rental at fixed locations or free-floating services."
+    )
+    .value(
       "flexible",
       StreetMode.FLEXIBLE,
       "Walk to an eligible pickup area for " +

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -439,7 +439,7 @@ public class EnumTypes {
       StreetMode.CAR_RENTAL,
       "Walk to a car rental point along " +
       "the road, drive to a drop-off point along the road, and walk the rest of the way. " +
-      "This can include car rental at fixed locations or free-floating services."
+      "This can include car rentals at fixed locations or free-floating services."
     )
     .value(
       "flexible",

--- a/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1773,7 +1773,7 @@ enum StreetMode {
   car_park
   "Walk to a pickup point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include various taxi-services or kiss & ride."
   car_pickup
-  "Walk to a car rental point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include car rental at fixed locations or free-floating services."
+  "Walk to a car rental point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include car rentals at fixed locations or free-floating services."
   car_rental
   "Walk to an eligible pickup area for flexible transportation, ride to an eligible drop-off area and then walk the rest of the way."
   flexible

--- a/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -775,7 +775,7 @@ type QueryType {
   "Input type for executing a travel search for a trip between two locations. Returns trip patterns describing suggested alternatives for the trip."
   trip(
     "Time and cost penalty on access/egress modes."
-    accessEgressPenalty: [PenaltyForStreetMode!] = [{streetMode : car_park, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : flexible, timePenalty : "10m + 1.30 t", costFactor : 1.3}],
+    accessEgressPenalty: [PenaltyForStreetMode!] = [{streetMode : car_park, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : car_rental, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : flexible, timePenalty : "10m + 1.30 t", costFactor : 1.3}],
     "The alightSlack is the minimum extra time after exiting a public transport vehicle. This is the default value used, if not overridden by the 'alightSlackList'."
     alightSlackDefault: Int = 0,
     "List of alightSlack for a given set of modes. Defaults: []"
@@ -1773,6 +1773,8 @@ enum StreetMode {
   car_park
   "Walk to a pickup point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include various taxi-services or kiss & ride."
   car_pickup
+  "Walk to a car rental point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include car rental at fixed locations or free-floating services."
+  car_rental
   "Walk to an eligible pickup area for flexible transportation, ride to an eligible drop-off area and then walk the rest of the way."
   flexible
   "Walk only"


### PR DESCRIPTION
### Summary

Now that the new debug UI uses the Transmodel API @hbruch has reported that car rental is missing from its street modes.

This PR adds it.

It also makes a new line change in the `/client` folder in order to trigger a rebuild of the debug UI so that the GraphQL schema is also rebuild and the new item shows up in the debug UI.

