### PR TITLE
SIRI-FM vehicle parking updates

### DIFF
--- a/doc-templates/VehicleParking.md
+++ b/doc-templates/VehicleParking.md
@@ -54,7 +54,7 @@ The SIRI-FM updater works slightly differently from the others in that it only u
 of parking but does not create new lots in realtime.
 
 The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile
-requires SIRI 2.1.
+which requires SIRI 2.1.
 
 <!-- INSERT: siri-fm -->
 

--- a/doc-templates/VehicleParking.md
+++ b/doc-templates/VehicleParking.md
@@ -50,7 +50,7 @@ All updaters have the following parameters in common:
 
 ## SIRI-FM
 
-The SIRI-FM updaters works slighly differently from the others in that it only updates the availability
+The SIRI-FM updater works slightly differently from the others in that it only updates the availability
 of parking but does not create new lots in realtime.
 
 The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile

--- a/doc-templates/VehicleParking.md
+++ b/doc-templates/VehicleParking.md
@@ -53,7 +53,8 @@ All updaters have the following parameters in common:
 The SIRI-FM updaters works slighly differently from the other in that it only updates the availability
 of parking but does not create new lots in realtime.
 
-The data source must conform to the [Italian SIRI-FM](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf) profile.
+The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile
+requires SIRI 2.1.
 
 <!-- INSERT: siri-fm -->
 

--- a/doc-templates/VehicleParking.md
+++ b/doc-templates/VehicleParking.md
@@ -50,7 +50,7 @@ All updaters have the following parameters in common:
 
 ## SIRI-FM
 
-The SIRI-FM updaters works slighly differently from the other in that it only updates the availability
+The SIRI-FM updaters works slighly differently from the others in that it only updates the availability
 of parking but does not create new lots in realtime.
 
 The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile

--- a/doc-templates/VehicleParking.md
+++ b/doc-templates/VehicleParking.md
@@ -48,6 +48,15 @@ All updaters have the following parameters in common:
 
 <!-- INSERT: bikeep -->
 
+## SIRI-FM
+
+The SIRI-FM updaters works slighly differently from the other in that it only updates the availability
+of parking but does not create new lots in realtime.
+
+The data source must conform to the [Italian SIRI-FM](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf) profile.
+
+<!-- INSERT: siri-fm -->
+
 ## Changelog
 
 - Create initial sandbox implementation (January 2022, [#3796](https://github.com/opentripplanner/OpenTripPlanner/pull/3796))

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -875,6 +875,12 @@ Used to group requests when monitoring OTP.
       "feedId" : "bikeep",
       "sourceType" : "bikeep",
       "url" : "https://services.bikeep.com/location/v1/public-areas/no-baia-mobility/locations"
+    },
+    {
+      "type" : "vehicle-parking",
+      "feedId" : "parking",
+      "sourceType" : "siri-fm",
+      "url" : "https://transmodel.api.opendatahub.com/siri-lite/fm/parking"
     }
   ],
   "rideHailingServices" : [

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -375,7 +375,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 ## SIRI-FM
 
-The SIRI-FM updaters works slighly differently from the others in that it only updates the availability
+The SIRI-FM updater works slightly differently from the others in that it only updates the availability
 of parking but does not create new lots in realtime.
 
 The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -378,7 +378,8 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 The SIRI-FM updaters works slighly differently from the other in that it only updates the availability
 of parking but does not create new lots in realtime.
 
-The data source must conform to the [Italian SIRI-FM](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf) profile.
+The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile
+requires SIRI 2.1.
 
 <!-- siri-fm BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
@@ -422,7 +423,8 @@ URL of the SIRI-FM Light endpoint.
 SIRI Light means that it must be available as a HTTP GET request rather than the usual
 SIRI request mechanism of HTTP POST.
 
-The contents must also conform to the [Italian SIRI profile](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf).
+The contents must also conform to the [Italian SIRI profile](https://github.com/5Tsrl/siri-italian-profile)
+which requires SIRI 2.1.
 
 
 <h4 id="u__15__headers">headers</h4>

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -379,7 +379,7 @@ The SIRI-FM updater works slightly differently from the others in that it only u
 of parking but does not create new lots in realtime.
 
 The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile
-requires SIRI 2.1.
+which requires SIRI 2.1.
 
 <!-- siri-fm BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -375,7 +375,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 ## SIRI-FM
 
-The SIRI-FM updaters works slighly differently from the other in that it only updates the availability
+The SIRI-FM updaters works slighly differently from the others in that it only updates the availability
 of parking but does not create new lots in realtime.
 
 The data source must conform to the [Italian SIRI-FM](https://github.com/5Tsrl/siri-italian-profile) profile

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -55,7 +55,7 @@ All updaters have the following parameters in common:
 
 The id of the data source, which will be the prefix of the parking lot's id.
 
-This will end up in the API responses as the feed id of of the parking lot.
+This will end up in the API responses as the feed id of the parking lot.
 
 <h4 id="u__2__sourceType">sourceType</h4>
 
@@ -125,7 +125,7 @@ Used for converting abstract opening hours into concrete points in time.
 
 The id of the data source, which will be the prefix of the parking lot's id.
 
-This will end up in the API responses as the feed id of of the parking lot.
+This will end up in the API responses as the feed id of the parking lot.
 
 <h4 id="u__3__sourceType">sourceType</h4>
 
@@ -210,7 +210,7 @@ Tags to add to the parking lots.
 
 The id of the data source, which will be the prefix of the parking lot's id.
 
-This will end up in the API responses as the feed id of of the parking lot.
+This will end up in the API responses as the feed id of the parking lot.
 
 <h4 id="u__4__sourceType">sourceType</h4>
 
@@ -275,7 +275,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 The id of the data source, which will be the prefix of the parking lot's id.
 
-This will end up in the API responses as the feed id of of the parking lot.
+This will end up in the API responses as the feed id of the parking lot.
 
 <h4 id="u__5__sourceType">sourceType</h4>
 
@@ -336,7 +336,7 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 
 The id of the data source, which will be the prefix of the parking lot's id.
 
-This will end up in the API responses as the feed id of of the parking lot.
+This will end up in the API responses as the feed id of the parking lot.
 
 <h4 id="u__14__sourceType">sourceType</h4>
 
@@ -372,6 +372,85 @@ HTTP headers to add to the request. Any header key, value can be inserted.
 ```
 
 <!-- bikeep END -->
+
+## SIRI-FM
+
+The SIRI-FM updaters works slighly differently from the other in that it only updates the availability
+of parking but does not create new lots in realtime.
+
+The data source must conform to the [Italian SIRI-FM](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf) profile.
+
+<!-- siri-fm BEGIN -->
+<!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
+
+| Config Parameter                 |       Type      | Summary                                                                      |  Req./Opt. | Default Value | Since |
+|----------------------------------|:---------------:|------------------------------------------------------------------------------|:----------:|---------------|:-----:|
+| type = "vehicle-parking"         |      `enum`     | The type of the updater.                                                     | *Required* |               |  1.5  |
+| [feedId](#u__15__feedId)         |     `string`    | The id of the data source, which will be the prefix of the parking lot's id. | *Required* |               |  2.2  |
+| frequency                        |    `duration`   | How often to update the source.                                              | *Optional* | `"PT1M"`      |  2.6  |
+| [sourceType](#u__15__sourceType) |      `enum`     | The source of the vehicle updates.                                           | *Required* |               |  2.2  |
+| [url](#u__15__url)               |      `uri`      | URL of the SIRI-FM Light endpoint.                                           | *Required* |               |  2.6  |
+| [headers](#u__15__headers)       | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.   | *Optional* |               |  2.6  |
+
+
+#### Details
+
+<h4 id="u__15__feedId">feedId</h4>
+
+**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[15] 
+
+The id of the data source, which will be the prefix of the parking lot's id.
+
+This will end up in the API responses as the feed id of the parking lot.
+
+<h4 id="u__15__sourceType">sourceType</h4>
+
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[15]   
+**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep` | `siri-fm`
+
+The source of the vehicle updates.
+
+<h4 id="u__15__url">url</h4>
+
+**Since version:** `2.6` ∙ **Type:** `uri` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[15] 
+
+URL of the SIRI-FM Light endpoint.
+
+SIRI Light means that it must be available as a HTTP GET request rather than the usual
+SIRI request mechanism of HTTP POST.
+
+The contents must also conform to the [Italian SIRI profile](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf).
+
+
+<h4 id="u__15__headers">headers</h4>
+
+**Since version:** `2.6` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
+**Path:** /updaters/[15] 
+
+HTTP headers to add to the request. Any header key, value can be inserted.
+
+
+
+##### Example configuration
+
+```JSON
+// router-config.json
+{
+  "updaters" : [
+    {
+      "type" : "vehicle-parking",
+      "feedId" : "parking",
+      "sourceType" : "siri-fm",
+      "url" : "https://transmodel.api.opendatahub.com/siri-lite/fm/parking"
+    }
+  ]
+}
+```
+
+<!-- siri-fm END -->
 
 ## Changelog
 

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -61,7 +61,7 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[2]   
-**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep`
+**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep` | `siri-fm`
 
 The source of the vehicle updates.
 
@@ -131,7 +131,7 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[3]   
-**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep`
+**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep` | `siri-fm`
 
 The source of the vehicle updates.
 
@@ -216,7 +216,7 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[4]   
-**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep`
+**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep` | `siri-fm`
 
 The source of the vehicle updates.
 
@@ -281,7 +281,7 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[5]   
-**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep`
+**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep` | `siri-fm`
 
 The source of the vehicle updates.
 
@@ -342,7 +342,7 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
 **Path:** /updaters/[14]   
-**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep`
+**Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely` | `noi-open-data-hub` | `bikeep` | `siri-fm`
 
 The source of the vehicle updates.
 

--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterTest.java
@@ -19,7 +19,7 @@ class SiriFmUpdaterTest {
       Duration.ofSeconds(30),
       HttpHeaders.empty()
     );
-    var updater = new SiriFmUpdater(parameters);
+    var updater = new SiriFmDatasource(parameters);
     updater.update();
     var updates = updater.getUpdates();
 

--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterTest.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.ext.vehicleparking.sirifm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.test.support.ResourceLoader;
+import org.opentripplanner.updater.spi.HttpHeaders;
+
+class SiriFmUpdaterTest {
+
+  @Test
+  void parse() {
+    var uri = ResourceLoader.of(this).uri("siri-fm.xml");
+    var parameters = new SiriFmUpdaterParameters(
+      "noi",
+      uri,
+      "noi",
+      Duration.ofSeconds(30),
+      HttpHeaders.empty()
+    );
+    var updater = new SiriFmUpdater(parameters);
+    updater.update();
+    var updates = updater.getUpdates();
+
+    assertEquals(4, updates.size());
+  }
+}

--- a/src/ext-test/resources/org/opentripplanner/ext/vehicleparking/sirifm/siri-fm.xml
+++ b/src/ext-test/resources/org/opentripplanner/ext/vehicleparking/sirifm/siri-fm.xml
@@ -1,0 +1,56 @@
+<Siri version="2.1"
+      xmlns="http://www.siri.org.uk/siri"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri">
+    <ServiceDelivery>
+        <ResponseTimestamp>2024-07-17T11:07:40Z</ResponseTimestamp>
+        <ProducerRef>RAP Alto Adige - Open Data Hub</ProducerRef>
+        <FacilityMonitoringDelivery>
+            <ResponseTimestamp>2024-07-17T11:07:40Z</ResponseTimestamp>
+            <ProducerRef>RAP Alto Adige - Open Data Hub</ProducerRef>
+            <FacilityCondition>
+                <FacilityRef>IT:ITH10:Parking:105</FacilityRef>
+                <FacilityStatus>
+                    <Status>available</Status>
+                </FacilityStatus>
+                <MonitoredCounting>
+                    <CountingType>presentCount</CountingType>
+                    <CountedFeatureUnit>bays</CountedFeatureUnit>
+                    <Count>33</Count>
+                </MonitoredCounting>
+            </FacilityCondition>
+            <FacilityCondition>
+                <FacilityRef>IT:ITH10:Parking:TRENTO_areaexsitviacanestrinip1</FacilityRef>
+                <FacilityStatus>
+                    <Status>notAvailable</Status>
+                </FacilityStatus>
+                <MonitoredCounting>
+                    <CountingType>presentCount</CountingType>
+                    <CountedFeatureUnit>bays</CountedFeatureUnit>
+                    <Count>300</Count>
+                </MonitoredCounting>
+            </FacilityCondition>
+            <FacilityCondition>
+                <FacilityRef>IT:ITH10:Parking:TRENTO_autosilobuonconsigliop3</FacilityRef>
+                <FacilityStatus>
+                    <Status>notAvailable</Status>
+                </FacilityStatus>
+                <MonitoredCounting>
+                    <CountingType>presentCount</CountingType>
+                    <CountedFeatureUnit>bays</CountedFeatureUnit>
+                    <Count>633</Count>
+                </MonitoredCounting>
+            </FacilityCondition>
+            <FacilityCondition>
+                <FacilityRef>IT:ITH10:Parking:TRENTO_cteviabomportop6</FacilityRef>
+                <FacilityStatus>
+                    <Status>notAvailable</Status>
+                </FacilityStatus>
+                <MonitoredCounting>
+                    <CountingType>presentCount</CountingType>
+                    <CountedFeatureUnit>bays</CountedFeatureUnit>
+                    <Count>250</Count>
+                </MonitoredCounting>
+            </FacilityCondition>
+        </FacilityMonitoringDelivery>
+    </ServiceDelivery>
+</Siri>

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/bikeep/BikeepUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/bikeep/BikeepUpdaterParameters.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.vehicleparking.bikeep;
 
+import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.FULL;
+
 import java.net.URI;
 import java.time.Duration;
 import org.opentripplanner.updater.spi.HttpHeaders;
@@ -21,5 +23,10 @@ public record BikeepUpdaterParameters(
   @Override
   public VehicleParkingSourceType sourceType() {
     return VehicleParkingSourceType.BIKEEP;
+  }
+
+  @Override
+  public UpdateType updateType() {
+    return FULL;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterParameters.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.vehicleparking.hslpark;
 
+import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.FULL;
+
 import java.time.Duration;
 import java.time.ZoneId;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingSourceType;
@@ -24,5 +26,10 @@ public record HslParkUpdaterParameters(
   @Override
   public Duration frequency() {
     return Duration.ofSeconds(utilizationsFrequencySec);
+  }
+
+  @Override
+  public UpdateType updateType() {
+    return FULL;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/noi/NoiUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/noi/NoiUpdaterParameters.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.vehicleparking.noi;
 
+import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.FULL;
+
 import java.net.URI;
 import java.time.Duration;
 import org.opentripplanner.updater.spi.HttpHeaders;
@@ -21,5 +23,10 @@ public record NoiUpdaterParameters(
   @Override
   public VehicleParkingSourceType sourceType() {
     return VehicleParkingSourceType.NOI_OPEN_DATA_HUB;
+  }
+
+  @Override
+  public UpdateType updateType() {
+    return FULL;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterParameters.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.vehicleparking.parkapi;
 
+import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.FULL;
+
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.List;
@@ -21,4 +23,9 @@ public record ParkAPIUpdaterParameters(
   VehicleParkingSourceType sourceType,
   ZoneId timeZone
 )
-  implements VehicleParkingUpdaterParameters {}
+  implements VehicleParkingUpdaterParameters {
+  @Override
+  public UpdateType updateType() {
+    return FULL;
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmDatasource.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmDatasource.java
@@ -21,15 +21,15 @@ import uk.org.siri.siri21.FacilityConditionStructure;
  * Parses SIRI 2.1 XML data into parking availability updates. The data needs to conform to the
  * Italian profile of SIRI-FM.
  */
-public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
+public class SiriFmDatasource implements DataSource<AvailabiltyUpdate> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SiriFmUpdater.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SiriFmDatasource.class);
   private final SiriFmUpdaterParameters params;
   private final OtpHttpClient httpClient;
   private final Map<String, String> headers;
   private List<AvailabiltyUpdate> updates = List.of();
 
-  public SiriFmUpdater(SiriFmUpdaterParameters parameters) {
+  public SiriFmDatasource(SiriFmUpdaterParameters parameters) {
     params = parameters;
     headers = HttpHeaders.of().acceptApplicationXML().add(parameters.httpHeaders()).build().asMap();
     httpClient = new OtpHttpClientFactory().create(LOG);
@@ -82,7 +82,6 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
       c.getMonitoredCountings().getFirst().getCountingType() == PRESENT_COUNT
     );
   }
-
 
   @Override
   public List<AvailabiltyUpdate> getUpdates() {

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
@@ -80,7 +80,7 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
   private AvailabiltyUpdate mapToUpdate(FacilityConditionStructure c) {
     var id = new FeedScopedId(params.feedId(), c.getFacilityRef().getValue());
     var available = c.getMonitoredCountings().getFirst().getCount().intValue();
-    return new AvailabiltyUpdate.AvailabilityUpdated(id, available);
+    return new AvailabiltyUpdate(id, available);
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
@@ -56,8 +56,6 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
 
   @Override
   public boolean update() {
-    LOG.error("RUNNING {}", this);
-
     updates =
       httpClient.getAndMap(
         params.url(),
@@ -92,7 +90,7 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
       c.getFacilityRef() != null &&
       c.getFacilityRef().getValue() != null &&
       c.getMonitoredCountings().size() == 1 &&
-      c.getMonitoredCountings().stream().anyMatch(mc -> mc.getCountingType() == PRESENT_COUNT)
+      c.getMonitoredCountings().getFirst().getCountingType() == PRESENT_COUNT
     );
   }
 

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
@@ -1,9 +1,14 @@
 package org.opentripplanner.ext.vehicleparking.sirifm;
 
 import java.util.List;
+import java.util.Map;
+import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.updater.spi.DataSource;
+import org.opentripplanner.updater.spi.HttpHeaders;
 import org.opentripplanner.updater.vehicle_parking.AvailabiltyUpdate;
+import org.rutebanken.siri20.util.SiriXml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,9 +16,14 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriFmUpdater.class);
   private final SiriFmUpdaterParameters params;
+  private final OtpHttpClient httpClient;
+  private final Map<String, String> headers;
+  private List<AvailabiltyUpdate> updates = List.of();
 
-  public SiriFmUpdater(SiriFmUpdaterParameters params) {
-    this.params = params;
+  public SiriFmUpdater(SiriFmUpdaterParameters parameters) {
+    params = parameters;
+    headers = HttpHeaders.of().acceptApplicationXML().add(parameters.httpHeaders()).build().asMap();
+    httpClient = new OtpHttpClientFactory().create(LOG);
   }
 
   @Override
@@ -27,11 +37,33 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
   @Override
   public boolean update() {
     LOG.error("RUNNING {}", this);
+
+    updates =
+      httpClient.getAndMap(
+        params.url(),
+        headers,
+        resp -> {
+          var siri = SiriXml.parseXml(resp);
+
+          var conditions = siri
+            .getServiceDelivery()
+            .getFacilityMonitoringDeliveries()
+            .stream()
+            .flatMap(d -> d.getFacilityConditions().stream())
+            .toList();
+
+          conditions.forEach(c -> {
+            LOG.error("{}", c.getFacilityRef().getValue());
+          });
+
+          return List.of();
+        }
+      );
     return true;
   }
 
   @Override
   public List<AvailabiltyUpdate> getUpdates() {
-    return List.of();
+    return updates;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
@@ -2,14 +2,10 @@ package org.opentripplanner.ext.vehicleparking.sirifm;
 
 import static uk.org.siri.siri21.CountingTypeEnumeration.PRESENT_COUNT;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
+import org.entur.siri21.util.SiriXml;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
@@ -20,8 +16,11 @@ import org.opentripplanner.updater.vehicle_parking.AvailabiltyUpdate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.siri.siri21.FacilityConditionStructure;
-import uk.org.siri.siri21.Siri;
 
+/**
+ * Parses SIRI 2.1 XML data into parking availability updates. The data needs to conform to the
+ * Italian profile of SIRI-FM.
+ */
 public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriFmUpdater.class);
@@ -29,16 +28,6 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
   private final OtpHttpClient httpClient;
   private final Map<String, String> headers;
   private List<AvailabiltyUpdate> updates = List.of();
-
-  private static final JAXBContext jaxbContext;
-
-  static {
-    try {
-      jaxbContext = JAXBContext.newInstance(Siri.class);
-    } catch (JAXBException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   public SiriFmUpdater(SiriFmUpdaterParameters parameters) {
     params = parameters;
@@ -61,7 +50,7 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
         params.url(),
         headers,
         resp -> {
-          var siri = parseXml(resp);
+          var siri = SiriXml.parseXml(resp);
 
           return Stream
             .ofNullable(siri.getServiceDelivery())
@@ -94,16 +83,6 @@ public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
     );
   }
 
-  private Siri parseXml(InputStream stream) {
-    try {
-      var xmlif = XMLInputFactory.newInstance();
-      var jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-      var streamReader = xmlif.createXMLStreamReader(stream);
-      return (Siri) jaxbUnmarshaller.unmarshal(streamReader);
-    } catch (JAXBException | XMLStreamException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   @Override
   public List<AvailabiltyUpdate> getUpdates() {

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdater.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.ext.vehicleparking.sirifm;
+
+import java.util.List;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
+import org.opentripplanner.updater.spi.DataSource;
+import org.opentripplanner.updater.vehicle_parking.AvailabiltyUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SiriFmUpdater implements DataSource<AvailabiltyUpdate> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SiriFmUpdater.class);
+  private final SiriFmUpdaterParameters params;
+
+  public SiriFmUpdater(SiriFmUpdaterParameters params) {
+    this.params = params;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(this.getClass())
+      .addStr("url", this.params.url().toString())
+      .toString();
+  }
+
+  @Override
+  public boolean update() {
+    LOG.error("RUNNING {}", this);
+    return true;
+  }
+
+  @Override
+  public List<AvailabiltyUpdate> getUpdates() {
+    return List.of();
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterParameters.java
@@ -1,18 +1,20 @@
-package org.opentripplanner.ext.vehicleparking.bikely;
+package org.opentripplanner.ext.vehicleparking.sirifm;
 
-import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.FULL;
+import static org.opentripplanner.updater.vehicle_parking.VehicleParkingSourceType.SIRI_FM;
+import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.AVAILABILITY;
 
 import java.net.URI;
 import java.time.Duration;
+import org.opentripplanner.ext.vehicleparking.noi.NoiUpdater;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingSourceType;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters;
 
 /**
- * Class that extends {@link VehicleParkingUpdaterParameters} with parameters required by
- * {@link BikelyUpdater}.
+ * Class that extends {@link VehicleParkingUpdaterParameters} with parameters required by {@link
+ * NoiUpdater}.
  */
-public record BikelyUpdaterParameters(
+public record SiriFmUpdaterParameters(
   String configRef,
   URI url,
   String feedId,
@@ -22,11 +24,11 @@ public record BikelyUpdaterParameters(
   implements VehicleParkingUpdaterParameters {
   @Override
   public VehicleParkingSourceType sourceType() {
-    return VehicleParkingSourceType.BIKELY;
+    return SIRI_FM;
   }
 
   @Override
   public UpdateType updateType() {
-    return FULL;
+    return AVAILABILITY;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/sirifm/SiriFmUpdaterParameters.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.ext.vehicleparking.sirifm;
 
 import static org.opentripplanner.updater.vehicle_parking.VehicleParkingSourceType.SIRI_FM;
-import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.AVAILABILITY;
+import static org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters.UpdateType.AVAILABILITY_ONLY;
 
 import java.net.URI;
 import java.time.Duration;
@@ -29,6 +29,6 @@ public record SiriFmUpdaterParameters(
 
   @Override
   public UpdateType updateType() {
-    return AVAILABILITY;
+    return AVAILABILITY_ONLY;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
@@ -239,21 +239,38 @@ public class VehicleParking implements Serializable {
       return false;
     }
 
-    switch (traverseMode) {
-      case BICYCLE:
-        return availability.getBicycleSpaces() != null;
-      case CAR:
+    return switch (traverseMode) {
+      case BICYCLE -> availability.getBicycleSpaces() != null;
+      case CAR -> {
         var places = wheelchairAccessibleCarPlaces
           ? availability.getWheelchairAccessibleCarSpaces()
           : availability.getCarSpaces();
-        return places != null;
-      default:
-        return false;
-    }
+        yield places != null;
+      }
+      default -> false;
+    };
   }
 
+  /**
+   * The only mutable method in this class: it allows to update the available parking spaces during
+   * real-time updates.
+   */
   public void updateAvailability(VehicleParkingSpaces vehicleParkingSpaces) {
     this.availability = vehicleParkingSpaces;
+  }
+
+  public void close() {
+    var builder = VehicleParkingSpaces.builder();
+    if (hasCarPlaces()) {
+      builder.carSpaces(0);
+    }
+    if (hasWheelchairAccessibleCarPlaces()) {
+      builder.wheelchairAccessibleCarSpaces(0);
+    }
+    if (hasBicyclePlaces()) {
+      builder.bicycleSpaces(0);
+    }
+    updateAvailability(builder.build());
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
@@ -97,7 +97,7 @@ public class VehicleParking implements Serializable {
   /**
    * The currently available spaces at this vehicle parking.
    */
-  private VehicleParkingSpaces availability;
+  private volatile VehicleParkingSpaces availability;
   /**
    * The vehicle parking group this parking belongs to.
    */
@@ -254,9 +254,13 @@ public class VehicleParking implements Serializable {
   /**
    * The only mutable method in this class: it allows to update the available parking spaces during
    * real-time updates.
+   * Since the entity is used both by writer threads (real-time updates) and reader threads
+   * (A* routing), the update process is synchronized.
    */
   public void updateAvailability(VehicleParkingSpaces vehicleParkingSpaces) {
-    this.availability = vehicleParkingSpaces;
+    synchronized (this) {
+      this.availability = vehicleParkingSpaces;
+    }
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
@@ -258,9 +258,7 @@ public class VehicleParking implements Serializable {
    * (A* routing), the update process is synchronized.
    */
   public void updateAvailability(VehicleParkingSpaces vehicleParkingSpaces) {
-    synchronized (this) {
-      this.availability = vehicleParkingSpaces;
-    }
+    this.availability = vehicleParkingSpaces;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
@@ -257,7 +257,7 @@ public class VehicleParking implements Serializable {
    * The only mutable method in this class: it allows to update the available parking spaces during
    * real-time updates.
    * Since the entity is used both by writer threads (real-time updates) and reader threads
-   * (A* routing), the update process is synchronized.
+   * (A* routing), the variable holding the information is marked as volatile.
    */
   public void updateAvailability(VehicleParkingSpaces vehicleParkingSpaces) {
     this.availability = vehicleParkingSpaces;

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
@@ -96,6 +96,8 @@ public class VehicleParking implements Serializable {
   private final List<VehicleParkingEntrance> entrances = new ArrayList<>();
   /**
    * The currently available spaces at this vehicle parking.
+   * <p>
+   * The volatile keyword is used to ensure safe publication by clearing CPU caches.
    */
   private volatile VehicleParkingSpaces availability;
   /**

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
@@ -259,20 +259,6 @@ public class VehicleParking implements Serializable {
     this.availability = vehicleParkingSpaces;
   }
 
-  public void close() {
-    var builder = VehicleParkingSpaces.builder();
-    if (hasCarPlaces()) {
-      builder.carSpaces(0);
-    }
-    if (hasWheelchairAccessibleCarPlaces()) {
-      builder.wheelchairAccessibleCarSpaces(0);
-    }
-    if (hasBicyclePlaces()) {
-      builder.bicycleSpaces(0);
-    }
-    updateAvailability(builder.build());
-  }
-
   @Override
   public int hashCode() {
     return Objects.hash(

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingService.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingService.java
@@ -21,13 +21,17 @@ public class VehicleParkingService implements Serializable {
 
   /**
    * To ensure that his is thread-safe, the set stored here should always be immutable.
+   * <p>
+   * The volatile keyword is used to ensure safe publication by clearing CPU caches.
    */
-  private Set<VehicleParking> vehicleParkings = Set.of();
+  private volatile Set<VehicleParking> vehicleParkings = Set.of();
 
   /**
    * To ensure that his is thread-safe, {@link ImmutableListMultimap} is used.
+   * <p>
+   * The volatile keyword is used to ensure safe publication by clearing CPU caches.
    */
-  private ImmutableListMultimap<VehicleParkingGroup, VehicleParking> vehicleParkingGroups = ImmutableListMultimap.of();
+  private volatile ImmutableListMultimap<VehicleParkingGroup, VehicleParking> vehicleParkingGroups = ImmutableListMultimap.of();
 
   /**
    * Does atomic update of {@link VehicleParking} and index of {@link VehicleParkingGroup} in this

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
@@ -112,7 +112,8 @@ public class VehicleParkingUpdaterConfig {
           SIRI Light means that it must be available as a HTTP GET request rather than the usual
           SIRI request mechanism of HTTP POST.
           
-          The contents must also conform to the [Italian SIRI profile](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf).
+          The contents must also conform to the [Italian SIRI profile](https://github.com/5Tsrl/siri-italian-profile)
+          which requires SIRI 2.1.
           """
           )
           .asUri(),

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
@@ -30,7 +30,7 @@ public class VehicleParkingUpdaterConfig {
       .of("feedId")
       .since(V2_2)
       .summary("The id of the data source, which will be the prefix of the parking lot's id.")
-      .description("This will end up in the API responses as the feed id of of the parking lot.")
+      .description("This will end up in the API responses as the feed id of the parking lot.")
       .asString();
     return switch (sourceType) {
       case HSL_PARK -> new HslParkUpdaterParameters(
@@ -103,7 +103,19 @@ public class VehicleParkingUpdaterConfig {
       );
       case SIRI_FM -> new SiriFmUpdaterParameters(
         updaterRef,
-        c.of("url").since(V2_6).summary("URL of the SIRI-FM Light endpoint.").asUri(),
+        c
+          .of("url")
+          .since(V2_6)
+          .summary("URL of the SIRI-FM Light endpoint.")
+          .description(
+            """
+          SIRI Light means that it must be available as a HTTP GET request rather than the usual
+          SIRI request mechanism of HTTP POST.
+          
+          The contents must also conform to the [Italian SIRI profile](https://github.com/noi-techpark/sta-nap-export/files/15302688/240502_SpecificaSIRI_v.1.0.3.pdf).
+          """
+          )
+          .asUri(),
         feedId,
         c
           .of("frequency")

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleParkingUpdaterConfig.java
@@ -13,6 +13,7 @@ import org.opentripplanner.ext.vehicleparking.bikely.BikelyUpdaterParameters;
 import org.opentripplanner.ext.vehicleparking.hslpark.HslParkUpdaterParameters;
 import org.opentripplanner.ext.vehicleparking.noi.NoiUpdaterParameters;
 import org.opentripplanner.ext.vehicleparking.parkapi.ParkAPIUpdaterParameters;
+import org.opentripplanner.ext.vehicleparking.sirifm.SiriFmUpdaterParameters;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingSourceType;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters;
@@ -92,6 +93,17 @@ public class VehicleParkingUpdaterConfig {
       case BIKEEP -> new BikeepUpdaterParameters(
         updaterRef,
         c.of("url").since(V2_6).summary("URL of the locations endpoint.").asUri(),
+        feedId,
+        c
+          .of("frequency")
+          .since(V2_6)
+          .summary("How often to update the source.")
+          .asDuration(Duration.ofMinutes(1)),
+        HttpHeadersConfig.headers(c, V2_6)
+      );
+      case SIRI_FM -> new SiriFmUpdaterParameters(
+        updaterRef,
+        c.of("url").since(V2_6).summary("URL of the SIRI-FM Light endpoint.").asUri(),
         feedId,
         c
           .of("frequency")

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -204,7 +204,7 @@ public class UpdaterConfigurator {
             )
           );
         }
-        case AVAILABILITY -> {
+        case AVAILABILITY_ONLY -> {
           var source = AvailabilityDatasourceFactory.create(configItem);
           updaters.add(
             new VehicleParkingAvailabilityUpdater(

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -190,7 +190,7 @@ public class UpdaterConfigurator {
     }
     for (var configItem : updatersParameters.getVehicleParkingUpdaterParameters()) {
       switch (configItem.updateType()) {
-        case AVAILABILITY -> {
+        case FULL -> {
           var source = VehicleParkingDataSourceFactory.create(
             configItem,
             openingHoursCalendarService
@@ -204,7 +204,7 @@ public class UpdaterConfigurator {
             )
           );
         }
-        case FULL -> {
+        case AVAILABILITY -> {
           var source = AvailabilityDatasourceFactory.create(configItem);
           updaters.add(
             new VehicleParkingAvailabilityUpdater(

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -32,8 +32,6 @@ import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdater;
 import org.opentripplanner.updater.vehicle_position.PollingVehiclePositionUpdater;
 import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater;
 import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataSourceFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Sets up and starts all the graph updaters.
@@ -43,8 +41,6 @@ import org.slf4j.LoggerFactory;
  * GraphUpdaterManager.
  */
 public class UpdaterConfigurator {
-
-  private static final Logger LOG = LoggerFactory.getLogger(UpdaterConfigurator.class);
 
   private final Graph graph;
   private final TransitModel transitModel;

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabilityDatasourceFactory.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabilityDatasourceFactory.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.updater.vehicle_parking;
 
-import org.opentripplanner.ext.vehicleparking.sirifm.SiriFmUpdater;
+import org.opentripplanner.ext.vehicleparking.sirifm.SiriFmDatasource;
 import org.opentripplanner.ext.vehicleparking.sirifm.SiriFmUpdaterParameters;
 import org.opentripplanner.updater.spi.DataSource;
 
@@ -11,7 +11,7 @@ public class AvailabilityDatasourceFactory {
 
   public static DataSource<AvailabiltyUpdate> create(VehicleParkingUpdaterParameters parameters) {
     return switch (parameters.sourceType()) {
-      case SIRI_FM -> new SiriFmUpdater((SiriFmUpdaterParameters) parameters);
+      case SIRI_FM -> new SiriFmDatasource((SiriFmUpdaterParameters) parameters);
       case PARK_API,
         BICYCLE_PARK_API,
         HSL_PARK,

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabilityDatasourceFactory.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabilityDatasourceFactory.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.updater.vehicle_parking;
+
+import org.opentripplanner.ext.vehicleparking.sirifm.SiriFmUpdater;
+import org.opentripplanner.ext.vehicleparking.sirifm.SiriFmUpdaterParameters;
+import org.opentripplanner.updater.spi.DataSource;
+
+/**
+ * Class that can be used to return a custom vehicle parking {@link DataSource}.
+ */
+public class AvailabilityDatasourceFactory {
+
+  public static DataSource<AvailabiltyUpdate> create(VehicleParkingUpdaterParameters parameters) {
+    return switch (parameters.sourceType()) {
+      case SIRI_FM -> new SiriFmUpdater((SiriFmUpdaterParameters) parameters);
+      case PARK_API,
+        BICYCLE_PARK_API,
+        HSL_PARK,
+        BIKEEP,
+        NOI_OPEN_DATA_HUB,
+        BIKELY -> throw new IllegalArgumentException("Cannot instantiate SIRI-FM data source");
+    };
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabiltyUpdate.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabiltyUpdate.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.updater.vehicle_parking;
+
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+public sealed interface AvailabiltyUpdate {
+  FeedScopedId vehicleParkingId();
+
+  record AvailabilityUpdated(FeedScopedId vehicleParkingId, int spacesAvailable)
+    implements AvailabiltyUpdate {}
+
+  record ParkingClosed(FeedScopedId vehicleParkingId) implements AvailabiltyUpdate {}
+}

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabiltyUpdate.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabiltyUpdate.java
@@ -1,5 +1,12 @@
 package org.opentripplanner.updater.vehicle_parking;
 
+import java.util.Objects;
+import org.opentripplanner.framework.lang.IntUtils;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
-public record AvailabiltyUpdate(FeedScopedId vehicleParkingId, int spacesAvailable) {}
+public record AvailabiltyUpdate(FeedScopedId vehicleParkingId, int spacesAvailable) {
+  public AvailabiltyUpdate {
+    Objects.requireNonNull(vehicleParkingId);
+    IntUtils.requireNotNegative(spacesAvailable);
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabiltyUpdate.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/AvailabiltyUpdate.java
@@ -2,11 +2,4 @@ package org.opentripplanner.updater.vehicle_parking;
 
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
-public sealed interface AvailabiltyUpdate {
-  FeedScopedId vehicleParkingId();
-
-  record AvailabilityUpdated(FeedScopedId vehicleParkingId, int spacesAvailable)
-    implements AvailabiltyUpdate {}
-
-  record ParkingClosed(FeedScopedId vehicleParkingId) implements AvailabiltyUpdate {}
-}
+public record AvailabiltyUpdate(FeedScopedId vehicleParkingId, int spacesAvailable) {}

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
@@ -51,10 +51,7 @@ public class VehicleParkingAvailabilityUpdater extends PollingGraphUpdater {
 
   @Override
   protected void runPolling() {
-    LOG.debug("Updating parking availability from {}", source);
-    if (!source.update()) {
-      LOG.debug("No updates");
-    } else {
+    if (source.update()) {
       var updates = source.getUpdates();
 
       var graphWriterRunnable = new UpdateAvailabilities(updates);

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
@@ -1,0 +1,114 @@
+package org.opentripplanner.updater.vehicle_parking;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.opentripplanner.framework.tostring.ToStringBuilder;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vehicle_parking.VehicleParking;
+import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
+import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.spi.DataSource;
+import org.opentripplanner.updater.spi.PollingGraphUpdater;
+import org.opentripplanner.updater.spi.WriteToGraphCallback;
+import org.opentripplanner.updater.vehicle_parking.AvailabiltyUpdate.AvailabilityUpdated;
+import org.opentripplanner.updater.vehicle_parking.AvailabiltyUpdate.ParkingClosed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Graph updater that dynamically sets availability information on vehicle parking lots. This
+ * updater fetches data from a single {@link DataSource<VehicleParking>}.
+ */
+public class VehicleParkingAvailabilityUpdater extends PollingGraphUpdater {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+    VehicleParkingAvailabilityUpdater.class
+  );
+  private final DataSource<AvailabiltyUpdate> source;
+  private WriteToGraphCallback saveResultOnGraph;
+
+  private final VehicleParkingService vehicleParkingService;
+
+  public VehicleParkingAvailabilityUpdater(
+    VehicleParkingUpdaterParameters parameters,
+    DataSource<AvailabiltyUpdate> source,
+    VehicleParkingService vehicleParkingService
+  ) {
+    super(parameters);
+    this.source = source;
+    this.vehicleParkingService = vehicleParkingService;
+
+    LOG.info("Creating vehicle-parking updater running every {}: {}", pollingPeriod(), source);
+  }
+
+  @Override
+  public void setup(WriteToGraphCallback writeToGraphCallback) {
+    this.saveResultOnGraph = writeToGraphCallback;
+  }
+
+  @Override
+  protected void runPolling() {
+    LOG.debug("Updating parking availability from {}", source);
+    if (!source.update()) {
+      LOG.debug("No updates");
+    } else {
+      var updates = source.getUpdates();
+
+      var graphWriterRunnable = new VehicleParkingGraphWriterRunnable(updates);
+      saveResultOnGraph.execute(graphWriterRunnable);
+    }
+  }
+
+  private class VehicleParkingGraphWriterRunnable implements GraphWriterRunnable {
+
+    private final List<AvailabiltyUpdate> updates;
+    private final Map<FeedScopedId, VehicleParking> parkingById;
+
+    private VehicleParkingGraphWriterRunnable(List<AvailabiltyUpdate> updates) {
+      this.updates = List.copyOf(updates);
+      this.parkingById =
+        vehicleParkingService
+          .getVehicleParkings()
+          .collect(Collectors.toUnmodifiableMap(VehicleParking::getId, Function.identity()));
+    }
+
+    @Override
+    public void run(Graph graph, TransitModel ignored) {
+      updates.forEach(this::handleUpdate);
+    }
+
+    private void handleUpdate(AvailabiltyUpdate update) {
+      if (!parkingById.containsKey(update.vehicleParkingId())) {
+        LOG.error(
+          "Parking with id {} does not exist. Skipping availability update.",
+          update.vehicleParkingId()
+        );
+      }
+      var parking = parkingById.get(update.vehicleParkingId());
+
+      switch (update) {
+        case ParkingClosed closed -> parking.close();
+        case AvailabilityUpdated availabilityUpdated -> {
+          var builder = VehicleParkingSpaces.builder();
+          if (parking.hasCarPlaces()) {
+            builder.carSpaces(availabilityUpdated.spacesAvailable());
+          }
+          if (parking.hasBicyclePlaces()) {
+            builder.bicycleSpaces(availabilityUpdated.spacesAvailable());
+          }
+          parking.updateAvailability(builder.build());
+        }
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.of(this.getClass()).addObj("source", source).toString();
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
@@ -88,20 +88,21 @@ public class VehicleParkingAvailabilityUpdater extends PollingGraphUpdater {
           "Parking with id {} does not exist. Skipping availability update.",
           update.vehicleParkingId()
         );
-      }
-      var parking = parkingById.get(update.vehicleParkingId());
+      } else {
+        var parking = parkingById.get(update.vehicleParkingId());
 
-      switch (update) {
-        case ParkingClosed closed -> parking.close();
-        case AvailabilityUpdated availabilityUpdated -> {
-          var builder = VehicleParkingSpaces.builder();
-          if (parking.hasCarPlaces()) {
-            builder.carSpaces(availabilityUpdated.spacesAvailable());
+        switch (update) {
+          case ParkingClosed closed -> parking.close();
+          case AvailabilityUpdated availabilityUpdated -> {
+            var builder = VehicleParkingSpaces.builder();
+            if (parking.hasCarPlaces()) {
+              builder.carSpaces(availabilityUpdated.spacesAvailable());
+            }
+            if (parking.hasBicyclePlaces()) {
+              builder.bicycleSpaces(availabilityUpdated.spacesAvailable());
+            }
+            parking.updateAvailability(builder.build());
           }
-          if (parking.hasBicyclePlaces()) {
-            builder.bicycleSpaces(availabilityUpdated.spacesAvailable());
-          }
-          parking.updateAvailability(builder.build());
         }
       }
     }

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
@@ -54,17 +54,17 @@ public class VehicleParkingAvailabilityUpdater extends PollingGraphUpdater {
     if (source.update()) {
       var updates = source.getUpdates();
 
-      var graphWriterRunnable = new UpdateAvailabilities(updates);
+      var graphWriterRunnable = new AvailabilityUpdater(updates);
       saveResultOnGraph.execute(graphWriterRunnable);
     }
   }
 
-  private class UpdateAvailabilities implements GraphWriterRunnable {
+  private class AvailabilityUpdater implements GraphWriterRunnable {
 
     private final List<AvailabiltyUpdate> updates;
     private final Map<FeedScopedId, VehicleParking> parkingById;
 
-    private UpdateAvailabilities(List<AvailabiltyUpdate> updates) {
+    private AvailabilityUpdater(List<AvailabiltyUpdate> updates) {
       this.updates = List.copyOf(updates);
       this.parkingById =
         vehicleParkingService

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
@@ -79,7 +79,7 @@ public class VehicleParkingAvailabilityUpdater extends PollingGraphUpdater {
 
     private void handleUpdate(AvailabiltyUpdate update) {
       if (!parkingById.containsKey(update.vehicleParkingId())) {
-        LOG.error(
+        LOG.warn(
           "Parking with id {} does not exist. Skipping availability update.",
           update.vehicleParkingId()
         );

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingDataSourceFactory.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingDataSourceFactory.java
@@ -42,6 +42,7 @@ public class VehicleParkingDataSourceFactory {
       case BIKELY -> new BikelyUpdater((BikelyUpdaterParameters) parameters);
       case NOI_OPEN_DATA_HUB -> new NoiUpdater((NoiUpdaterParameters) parameters);
       case BIKEEP -> new BikeepUpdater((BikeepUpdaterParameters) parameters);
+      case SIRI_FM -> throw new IllegalArgumentException("Cannot instantiate SIRI-FM data source");
     };
   }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingSourceType.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingSourceType.java
@@ -7,4 +7,5 @@ public enum VehicleParkingSourceType {
   BIKELY,
   NOI_OPEN_DATA_HUB,
   BIKEEP,
+  SIRI_FM,
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterParameters.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterParameters.java
@@ -8,4 +8,10 @@ import org.opentripplanner.updater.spi.PollingGraphUpdaterParameters;
  */
 public interface VehicleParkingUpdaterParameters extends PollingGraphUpdaterParameters {
   VehicleParkingSourceType sourceType();
+  UpdateType updateType();
+
+  enum UpdateType {
+    FULL,
+    AVAILABILITY,
+  }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterParameters.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterParameters.java
@@ -12,6 +12,6 @@ public interface VehicleParkingUpdaterParameters extends PollingGraphUpdaterPara
 
   enum UpdateType {
     FULL,
-    AVAILABILITY,
+    AVAILABILITY_ONLY,
   }
 }

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
@@ -2,10 +2,10 @@ package org.opentripplanner.updater.vehicle_parking;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.standalone.config.framework.json.JsonSupport.newNodeAdapterForTest;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 
 import com.google.common.util.concurrent.Futures;
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
@@ -15,6 +15,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
+import org.opentripplanner.standalone.config.routerconfig.updaters.VehicleParkingUpdaterConfig;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdaterManager;
@@ -24,27 +25,20 @@ import org.opentripplanner.updater.spi.GraphUpdater;
 
 class VehicleParkingAvailabilityUpdaterTest {
 
-  private static final VehicleParkingUpdaterParameters PARAMETERS = new VehicleParkingUpdaterParameters() {
-    @Override
-    public VehicleParkingSourceType sourceType() {
-      return VehicleParkingSourceType.SIRI_FM;
-    }
+  private static final VehicleParkingUpdaterParameters PARAMETERS = VehicleParkingUpdaterConfig.create(
+    "ref",
+    newNodeAdapterForTest(
+      """
+      {
+        "type" : "vehicle-parking",
+        "feedId" : "parking",
+        "sourceType" : "siri-fm",
+        "url" : "https://transmodel.api.opendatahub.com/siri-lite/fm/parking"
+      }
+    """
+    )
+  );
 
-    @Override
-    public UpdateType updateType() {
-      return UpdateType.AVAILABILITY_ONLY;
-    }
-
-    @Override
-    public Duration frequency() {
-      return Duration.ZERO;
-    }
-
-    @Override
-    public String configRef() {
-      return null;
-    }
-  };
   private static final FeedScopedId ID = id("parking1");
   private static final AvailabiltyUpdate DEFAULT_UPDATE = new AvailabiltyUpdate(ID, 8);
 

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
@@ -33,6 +33,7 @@ class VehicleParkingAvailabilityUpdaterTest {
         "type" : "vehicle-parking",
         "feedId" : "parking",
         "sourceType" : "siri-fm",
+        "frequency": "0s",
         "url" : "https://transmodel.api.opendatahub.com/siri-lite/fm/parking"
       }
     """

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
@@ -81,6 +81,7 @@ class VehicleParkingAvailabilityUpdaterTest {
     assertEquals(8, updated.getAvailability().getBicycleSpaces());
     assertNull(updated.getAvailability().getCarSpaces());
   }
+
   @Test
   void notFound() {
     var service = buildParkingService(VehicleParkingSpaces.builder().bicycleSpaces(15).build());

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
@@ -1,0 +1,108 @@
+package org.opentripplanner.updater.vehicle_parking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
+
+import com.google.common.util.concurrent.Futures;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vehicle_parking.VehicleParking;
+import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
+import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.GraphUpdaterManager;
+import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.spi.DataSource;
+import org.opentripplanner.updater.spi.GraphUpdater;
+
+class VehicleParkingAvailabilityUpdaterTest {
+
+  private static final VehicleParkingUpdaterParameters PARAMETERS = new VehicleParkingUpdaterParameters() {
+    @Override
+    public VehicleParkingSourceType sourceType() {
+      return VehicleParkingSourceType.SIRI_FM;
+    }
+
+    @Override
+    public UpdateType updateType() {
+      return UpdateType.AVAILABILITY_ONLY;
+    }
+
+    @Override
+    public Duration frequency() {
+      return Duration.ZERO;
+    }
+
+    @Override
+    public String configRef() {
+      return null;
+    }
+  };
+  private static final FeedScopedId ID = id("parking1");
+
+  @Test
+  void updateAvailability() {
+    var service = new VehicleParkingService();
+
+    var parking = VehicleParking
+      .builder()
+      .id(ID)
+      .name(I18NString.of("parking"))
+      .coordinate(WgsCoordinate.GREENWICH)
+      .carPlaces(true)
+      .capacity(VehicleParkingSpaces.builder().carSpaces(10).build())
+      .build();
+    service.updateVehicleParking(List.of(parking), List.of());
+
+    var updater = new VehicleParkingAvailabilityUpdater(PARAMETERS, new StubDatasource(), service);
+
+    runUpdaterOnce(updater);
+
+    var updated = service.getVehicleParkings().toList().getFirst();
+    assertEquals(ID, updated.getId());
+    assertEquals(8, updated.getAvailability().getCarSpaces());
+    assertNull(updated.getAvailability().getBicycleSpaces());
+  }
+
+  private void runUpdaterOnce(VehicleParkingAvailabilityUpdater updater) {
+    class GraphUpdaterMock extends GraphUpdaterManager {
+
+      private static final Graph GRAPH = new Graph();
+      private static final TransitModel TRANSIT_MODEL = new TransitModel();
+
+      public GraphUpdaterMock(List<GraphUpdater> updaters) {
+        super(GRAPH, TRANSIT_MODEL, updaters);
+      }
+
+      @Override
+      public Future<?> execute(GraphWriterRunnable runnable) {
+        runnable.run(GRAPH, TRANSIT_MODEL);
+        return Futures.immediateVoidFuture();
+      }
+    }
+
+    var graphUpdaterManager = new GraphUpdaterMock(List.of(updater));
+    graphUpdaterManager.startUpdaters();
+    graphUpdaterManager.stop(false);
+  }
+
+  private static class StubDatasource implements DataSource<AvailabiltyUpdate> {
+
+    @Override
+    public boolean update() {
+      return true;
+    }
+
+    @Override
+    public List<AvailabiltyUpdate> getUpdates() {
+      return List.of(new AvailabiltyUpdate(ID, 8));
+    }
+  }
+}

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -55,6 +55,11 @@ class VehicleParkingUpdaterTest {
       }
 
       @Override
+      public UpdateType updateType() {
+        return UpdateType.FULL;
+      }
+
+      @Override
       public Duration frequency() {
         return Duration.ZERO;
       }

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -438,6 +438,13 @@
       "feedId": "bikeep",
       "sourceType": "bikeep",
       "url": "https://services.bikeep.com/location/v1/public-areas/no-baia-mobility/locations"
+    },
+    // SIRI-FM vehicle parking updater
+    {
+      "type": "vehicle-parking",
+      "feedId": "parking",
+      "sourceType": "siri-fm",
+      "url": "https://transmodel.api.opendatahub.com/siri-lite/fm/parking"
     }
   ],
   "rideHailingServices": [


### PR DESCRIPTION
### Summary

Following up on #5946 this adds a vehicle parking updater that consumes SIRI-FM.

It introduces a new model for parking updates: rather than being able to add parking lots through a realtime updater, this only updates the availability.

We can discuss in the dev meetings, if these two update types should be handled in the same updater.

### Unit tests

Added.

For the time being, this is a draft as I want to wait until #5946 has been merged.