### PR TITLE
Handle NeTEx `any` version

### DIFF
--- a/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -26,7 +26,11 @@ public class NetexVersionHelper {
    * increasing integer. A bigger value indicate a later version.
    */
   public static int versionOf(EntityInVersionStructure e) {
-    return Integer.parseInt(e.getVersion());
+    if(e.getVersion().equals("any")){
+      return 1;
+    } else{
+      return Integer.parseInt(e.getVersion());
+    }
   }
 
   /**

--- a/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -16,7 +16,13 @@ import org.rutebanken.netex.model.ValidBetween;
  */
 public class NetexVersionHelper {
 
+  /**
+   * @see NetexVersionHelper#versionOf(EntityInVersionStructure)
+   */
   private static final String ANY = "any";
+  /**
+   * A special value that represents an unknown version.
+   */
   private static final int UNKNOWN_VERSION = -1;
 
   /**
@@ -27,6 +33,11 @@ public class NetexVersionHelper {
   /**
    * According to the <b>Norwegian Netex profile</b> the version number must be a positive
    * increasing integer. A bigger value indicates a later version.
+   * However, the special value "any" is also supported and returns a constant meaning "unknown".
+   * The EPIP profile at
+   * http://netex.uk/netex/doc/2019.05.07-v1.1_FinalDraft/prCEN_TS_16614-PI_Profile_FV_%28E%29-2019-Final-Draft-v3.pdf (page 33)
+   * defines this as follows: "Use "any" if the VERSION is unknown (note that this will trigger NeTEx's
+   * XML automatic consistency check)."
    */
   public static int versionOf(EntityInVersionStructure e) {
     if (e.getVersion().equals(ANY)) {

--- a/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -16,6 +16,9 @@ import org.rutebanken.netex.model.ValidBetween;
  */
 public class NetexVersionHelper {
 
+  private static final String ANY = "any";
+  private static final int UNKNOWN_VERSION = -1;
+
   /**
    * private constructor to prevent instantiation of utility class
    */
@@ -23,12 +26,12 @@ public class NetexVersionHelper {
 
   /**
    * According to the <b>Norwegian Netex profile</b> the version number must be a positive
-   * increasing integer. A bigger value indicate a later version.
+   * increasing integer. A bigger value indicates a later version.
    */
   public static int versionOf(EntityInVersionStructure e) {
-    if(e.getVersion().equals("any")){
-      return 1;
-    } else{
+    if (e.getVersion().equals(ANY)) {
+      return UNKNOWN_VERSION;
+    } else {
       return Integer.parseInt(e.getVersion());
     }
   }
@@ -38,7 +41,7 @@ public class NetexVersionHelper {
    * elements exist in the collection {@code -1} is returned.
    */
   public static int latestVersionIn(Collection<? extends EntityInVersionStructure> list) {
-    return list.stream().mapToInt(NetexVersionHelper::versionOf).max().orElse(-1);
+    return list.stream().mapToInt(NetexVersionHelper::versionOf).max().orElse(UNKNOWN_VERSION);
   }
 
   /**

--- a/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
+++ b/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
@@ -19,32 +19,39 @@ import org.junit.jupiter.api.Test;
 import org.rutebanken.netex.model.EntityInVersionStructure;
 import org.rutebanken.netex.model.ValidBetween;
 
-public class NetexVersionHelperTest {
+class NetexVersionHelperTest {
 
   private static final EntityInVersionStructure E_VER_1 = new EntityInVersionStructure()
     .withVersion("1");
   private static final EntityInVersionStructure E_VER_2 = new EntityInVersionStructure()
     .withVersion("2");
+  private static final EntityInVersionStructure E_VER_ANY = new EntityInVersionStructure()
+    .withVersion("any");
 
   @Test
-  public void versionOfTest() {
+  void versionOfTest() {
     assertEquals(1, versionOf(E_VER_1));
   }
 
   @Test
-  public void latestVersionInTest() {
+  void any() {
+    assertEquals(-1, versionOf(E_VER_ANY));
+  }
+
+  @Test
+  void latestVersionInTest() {
     assertEquals(2, latestVersionIn(Arrays.asList(E_VER_1, E_VER_2)));
     assertEquals(-1, latestVersionIn(Collections.emptyList()));
   }
 
   @Test
-  public void lastestVersionedElementInTest() {
+  void lastestVersionedElementInTest() {
     assertEquals(E_VER_2, latestVersionedElementIn(Arrays.asList(E_VER_1, E_VER_2)));
     assertNull(latestVersionedElementIn(Collections.emptyList()));
   }
 
   @Test
-  public void comparingVersionTest() {
+  void comparingVersionTest() {
     // Given a comparator (subject under test)
     Comparator<EntityInVersionStructure> subject = comparingVersion();
     // And a entity with version as the E_VER_1 entity
@@ -62,7 +69,7 @@ public class NetexVersionHelperTest {
   }
 
   @Test
-  public void testFirstRelevantDateTime() {
+  void testFirstRelevantDateTime() {
     var may1st = LocalDateTime.of(2021, MAY, 1, 14, 0);
     var may2nd = LocalDateTime.of(2021, MAY, 2, 14, 0);
     var may3rd = LocalDateTime.of(2021, MAY, 3, 14, 0);


### PR DESCRIPTION
### Summary

NeTEx allows the version of an entity to use the special string `any` which is defined as follows:

> Use "any" if the VERSION is unknown (note that this will trigger NeTEx's XML automatic consistency check).

@vpaturet has said that in they Entur pipeline an `any` value is converted to `0` before it reaches OTP.

For this reason, I am adding some special logic to the version parser that uses a fallback for this case. The fallback value existed previously and communicates the fact that the version is unknown.

### Issue

https://github.com/noi-techpark/odh-mentor-otp/issues/191

Relates to #3640 

### Unit tests

Added.

### Documentation

Javadoc.