### PR TITLE
Remove unused field from TransitLayer

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,8 +50,6 @@ public class TransitLayer {
 
   private final StopModel stopModel;
 
-  private final ZoneId transitDataZoneId;
-
   private final RaptorRequestTransferCache transferCache;
 
   private ConstrainedTransfersForPatterns constrainedTransfers;
@@ -73,7 +70,6 @@ public class TransitLayer {
       transitLayer.transfersByStopIndex,
       transitLayer.transferService,
       transitLayer.stopModel,
-      transitLayer.transitDataZoneId,
       transitLayer.transferCache,
       transitLayer.constrainedTransfers,
       transitLayer.transferIndexGenerator,
@@ -86,7 +82,6 @@ public class TransitLayer {
     List<List<Transfer>> transfersByStopIndex,
     TransferService transferService,
     StopModel stopModel,
-    ZoneId transitDataZoneId,
     RaptorRequestTransferCache transferCache,
     ConstrainedTransfersForPatterns constrainedTransfers,
     TransferIndexGenerator transferIndexGenerator,
@@ -96,7 +91,6 @@ public class TransitLayer {
     this.transfersByStopIndex = transfersByStopIndex;
     this.transferService = transferService;
     this.stopModel = stopModel;
-    this.transitDataZoneId = transitDataZoneId;
     this.transferCache = transferCache;
     this.constrainedTransfers = constrainedTransfers;
     this.transferIndexGenerator = transferIndexGenerator;
@@ -115,16 +109,6 @@ public class TransitLayer {
    */
   public Collection<TripPatternForDate> getTripPatternsForRunningDate(LocalDate date) {
     return tripPatternsRunningOnDate.getOrDefault(date, List.of());
-  }
-
-  /**
-   * This is the time zone which is used for interpreting all local "service" times (in transfers,
-   * trip schedules and so on). This is the time zone of the internal OTP time - which is used in
-   * logging and debugging. This is independent of the time zone of imported data and of the time
-   * zone used on any API - it can be the same, but it does not need to.
-   */
-  public ZoneId getTransitDataZoneId() {
-    return transitDataZoneId;
   }
 
   public int getStopCount() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
@@ -103,7 +103,6 @@ public class TransitLayerMapper {
       transferByStopIndex,
       transitService.getTransferService(),
       stopModel,
-      transitService.getTimeZone(),
       transferCache,
       constrainedTransfers,
       transferIndexGenerator,

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
@@ -237,7 +237,6 @@ public class RaptorPathToItineraryMapperTest {
       null,
       null,
       null,
-      null,
       null
     );
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayerTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayerTest.java
@@ -65,7 +65,6 @@ class TransitLayerTest {
       null,
       null,
       null,
-      null,
       null
     );
     var runningOnDate = transitLayer.getTripPatternsRunningOnDateCopy(date);
@@ -89,7 +88,6 @@ class TransitLayerTest {
     var tripPatterns = List.of(tripPatternForDate);
     var transitLayer = new TransitLayer(
       Map.of(date, tripPatterns),
-      null,
       null,
       null,
       null,
@@ -124,7 +122,6 @@ class TransitLayerTest {
       null,
       null,
       null,
-      null,
       null
     );
     var startingOnDate = transitLayer.getTripPatternsOnServiceDateCopy(date);
@@ -147,7 +144,6 @@ class TransitLayerTest {
     );
     var transitLayer = new TransitLayer(
       Map.of(runningDate, List.of(tripPatternForDate)),
-      null,
       null,
       null,
       null,
@@ -181,7 +177,6 @@ class TransitLayerTest {
         entry(firstRunningDate, List.of(tripPatternForDate)),
         entry(secondRunningDate, List.of(tripPatternForDate))
       ),
-      null,
       null,
       null,
       null,


### PR DESCRIPTION
I noticed that there is a completely unused field in `TransitModel` which can be removed without replacement.