### PR TITLE
Take realtime patterns into account when storing realtime vehicles

### DIFF
--- a/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -8,7 +8,6 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
@@ -35,6 +34,9 @@ public class DefaultRealtimeVehicleService
 
   @Override
   public void setRealtimeVehicles(TripPattern pattern, List<RealtimeVehicle> updates) {
+    if (pattern.getOriginalTripPattern() != null) {
+      pattern = pattern.getOriginalTripPattern();
+    }
     vehicles.put(pattern, List.copyOf(updates));
   }
 
@@ -45,6 +47,9 @@ public class DefaultRealtimeVehicleService
 
   @Override
   public List<RealtimeVehicle> getRealtimeVehicles(@Nonnull TripPattern pattern) {
+    if (pattern.getOriginalTripPattern() != null) {
+      pattern = pattern.getOriginalTripPattern();
+    }
     // the list is made immutable during insertion, so we can safely return them
     return vehicles.getOrDefault(pattern, List.of());
   }

--- a/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -32,6 +32,11 @@ public class DefaultRealtimeVehicleService
     this.transitService = transitService;
   }
 
+  /**
+   * Stores the relationship between a list of realtime vehicles with a pattern. If the pattern is
+   * a realtime-added one, then the original (scheduled) one is used as the key for the map storing
+   * the information.
+   */
   @Override
   public void setRealtimeVehicles(TripPattern pattern, List<RealtimeVehicle> updates) {
     if (pattern.getOriginalTripPattern() != null) {
@@ -45,6 +50,13 @@ public class DefaultRealtimeVehicleService
     vehicles.remove(pattern);
   }
 
+  /**
+   * Gets the realtime vehicles for a given pattern. If the pattern is a realtime-added one
+   * then the original (scheduled) one is used for the lookup instead, so you receive the correct
+   * result no matter if you use the realtime or static information.
+   *
+   * @see DefaultRealtimeVehicleService#setRealtimeVehicles(TripPattern, List)
+   */
   @Override
   public List<RealtimeVehicle> getRealtimeVehicles(@Nonnull TripPattern pattern) {
     if (pattern.getOriginalTripPattern() != null) {

--- a/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
+++ b/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
@@ -1,0 +1,55 @@
+package org.opentripplanner.service.realtimevehicles.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.framework.geometry.WgsCoordinate.GREENWICH;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.route;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.tripPattern;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.StopPattern;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
+
+class DefaultRealtimeVehicleServiceTest {
+
+  private static final Route ROUTE = route("r1").build();
+  private static final TransitModelForTest MODEL = TransitModelForTest.of();
+  private static final StopPattern STOP_PATTERN = TransitModelForTest.stopPattern(
+    MODEL.stop("1").build(),
+    MODEL.stop("2").build()
+  );
+  private static final TripPattern ORIGINAL = tripPattern("original", ROUTE)
+    .withStopPattern(STOP_PATTERN)
+    .build();
+  private static final Instant TIME = Instant.ofEpochSecond(1000);
+  private static final List<RealtimeVehicle> VEHICLES = List.of(
+    RealtimeVehicle.builder().withTime(TIME).withCoordinates(GREENWICH).build()
+  );
+
+  @Test
+  void originalPattern() {
+    var service = new DefaultRealtimeVehicleService(new DefaultTransitService(new TransitModel()));
+    service.setRealtimeVehicles(ORIGINAL, VEHICLES);
+    var updates = service.getRealtimeVehicles(ORIGINAL);
+    assertEquals(VEHICLES, updates);
+  }
+
+  @Test
+  void realtimeAddedPattern() {
+    var service = new DefaultRealtimeVehicleService(new DefaultTransitService(new TransitModel()));
+    var realtimePattern = tripPattern("realtime-added", ROUTE)
+      .withStopPattern(STOP_PATTERN)
+      .withOriginalTripPattern(ORIGINAL)
+      .withCreatedByRealtimeUpdater(true)
+      .build();
+    service.setRealtimeVehicles(realtimePattern, VEHICLES);
+    var updates = service.getRealtimeVehicles(ORIGINAL);
+    assertEquals(VEHICLES, updates);
+  }
+}


### PR DESCRIPTION
### Summary

When storing realtime vehicle positions by pattern the realtime added patterns are not taken into account correctly.

This PR uses the original pattern as the key for the storage map.

### Unit tests

Added.

### Documentation

Explained it in Javadoc.