### PR TITLE
Fix conversion of parent station id in vector tiles

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
@@ -1,56 +1,60 @@
 package org.opentripplanner.ext.vectortiles.layers.stops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.vectortiles.layers.TestTransitService;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.TranslatedString;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
 public class StopsLayerTest {
 
-  private RegularStop stop;
+  private static final I18NString NAME_TRANSLATIONS = TranslatedString.getI18NString(
+    new HashMap<>() {
+      {
+        put(null, "name");
+        put("de", "nameDE");
+      }
+    },
+    false,
+    false
+  );
+  private static final I18NString DESC_TRANSLATIONS = TranslatedString.getI18NString(
+    new HashMap<>() {
+      {
+        put(null, "desc");
+        put("de", "descDE");
+      }
+    },
+    false,
+    false
+  );
 
-  @BeforeEach
-  public void setUp() {
-    var nameTranslations = TranslatedString.getI18NString(
-      new HashMap<>() {
-        {
-          put(null, "name");
-          put("de", "nameDE");
-        }
-      },
-      false,
-      false
-    );
-    var descTranslations = TranslatedString.getI18NString(
-      new HashMap<>() {
-        {
-          put(null, "desc");
-          put("de", "descDE");
-        }
-      },
-      false,
-      false
-    );
-    stop =
-      StopModel
-        .of()
-        .regularStop(new FeedScopedId("F", "name"))
-        .withName(nameTranslations)
-        .withDescription(descTranslations)
-        .withCoordinate(50, 10)
-        .build();
-  }
+  private static final Station STATION = Station
+    .of(id("station1"))
+    .withCoordinate(WgsCoordinate.GREENWICH)
+    .withName(I18NString.of("A Station"))
+    .build();
+  private static final RegularStop STOP = StopModel
+    .of()
+    .regularStop(new FeedScopedId("F", "name"))
+    .withName(NAME_TRANSLATIONS)
+    .withDescription(DESC_TRANSLATIONS)
+    .withCoordinate(50, 10)
+    .withParentStation(STATION)
+    .build();
 
   @Test
   public void digitransitStopPropertyMapperTest() {
@@ -65,12 +69,13 @@ public class StopsLayerTest {
     );
 
     Map<String, Object> map = new HashMap<>();
-    mapper.map(stop).forEach(o -> map.put(o.key(), o.value()));
+    mapper.map(STOP).forEach(o -> map.put(o.key(), o.value()));
 
     assertEquals("F:name", map.get("gtfsId"));
     assertEquals("name", map.get("name"));
     assertEquals("desc", map.get("desc"));
     assertEquals("[{\"gtfsType\":100}]", map.get("routes"));
+    assertEquals(STATION.getId().toString(), map.get("parentStation"));
   }
 
   @Test
@@ -86,7 +91,7 @@ public class StopsLayerTest {
     );
 
     Map<String, Object> map = new HashMap<>();
-    mapper.map(stop).forEach(o -> map.put(o.key(), o.value()));
+    mapper.map(STOP).forEach(o -> map.put(o.key(), o.value()));
 
     assertEquals("nameDE", map.get("name"));
     assertEquals("descDE", map.get("desc"));

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.vectortiles.layers.stops;
 
+import static org.opentripplanner.inspector.vector.KeyValue.kv;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
@@ -52,10 +54,7 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
       new KeyValue("desc", i18NStringMapper.mapToApi(stop.getDescription())),
       new KeyValue("type", getType(transitService, stop)),
       new KeyValue("routes", getRoutes(transitService, stop)),
-      new KeyValue(
-        "parentStation",
-        stop.getParentStation() != null ? stop.getParentStation().getId() : null
-      )
+      kv("parentStation", stop.getParentStation() != null ? stop.getParentStation().getId() : null)
     );
   }
 


### PR DESCRIPTION
### Summary

@miles-grant-ibigroup has reported that the field `parentId` is not correctly converted to a string in the vector tiles layer.
This was because the id was of type `FeedScopedId` and the vector tile library was silently ignoring it.

### Unit tests

Added.