### PR TITLE
Improve geocoder matches for numeric adjectives

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -135,7 +135,13 @@ class EnglishNgramAnalyzerTest {
     assertEquals(List.of(expected), result);
   }
 
-  public List<String> tokenize(String text) {
+  @Test
+  void wordBoundary() {
+    var result = tokenize("1stst");
+    assertEquals(List.of("1sts", "1stst", "stst"), result);
+  }
+
+  private List<String> tokenize(String text) {
     try (var analyzer = new EnglishNGramAnalyzer()) {
       List<String> result;
       TokenStream tokenStream;

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -82,6 +82,40 @@ class EnglishNgramAnalyzerTest {
     );
   }
 
+  @Test
+  void ampersand() throws IOException {
+    var analyzer = new EnglishNGramAnalyzer();
+    List<String> result = analyze("Meridian Ave N & N 148th St", analyzer);
+
+    assertEquals(
+      List.of(
+        "Meri",
+        "Merid",
+        "Meridi",
+        "Meridia",
+        "Meridian",
+        "erid",
+        "eridi",
+        "eridia",
+        "eridian",
+        "ridi",
+        "ridia",
+        "ridian",
+        "idia",
+        "idian",
+        "dian",
+        "Av",
+        "N",
+        "N",
+        "148t",
+        "148th",
+        "48th",
+        "St"
+      ),
+      result
+    );
+  }
+
   public List<String> analyze(String text, Analyzer analyzer) throws IOException {
     List<String> result = new ArrayList<>();
     TokenStream tokenStream = analyzer.tokenStream("name", text);

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -18,6 +17,7 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Alexanderplatz", analyzer);
 
+    //System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
         "Ale",
@@ -99,7 +99,6 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Meridian Ave N & N 148th St", analyzer);
 
-    System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
         "Mer",

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -17,9 +18,9 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Alexanderplatz", analyzer);
 
-    //System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
+        "Ale",
         "Alex",
         "Alexa",
         "Alexan",
@@ -27,6 +28,7 @@ class EnglishNgramAnalyzerTest {
         "Alexande",
         "Alexander",
         "Alexanderp",
+        "lex",
         "lexa",
         "lexan",
         "lexand",
@@ -34,6 +36,7 @@ class EnglishNgramAnalyzerTest {
         "lexander",
         "lexanderp",
         "lexanderpl",
+        "exa",
         "exan",
         "exand",
         "exande",
@@ -41,6 +44,7 @@ class EnglishNgramAnalyzerTest {
         "exanderp",
         "exanderpl",
         "exanderpla",
+        "xan",
         "xand",
         "xande",
         "xander",
@@ -48,6 +52,7 @@ class EnglishNgramAnalyzerTest {
         "xanderpl",
         "xanderpla",
         "xanderplat",
+        "and",
         "ande",
         "ander",
         "anderp",
@@ -55,27 +60,34 @@ class EnglishNgramAnalyzerTest {
         "anderpla",
         "anderplat",
         "anderplatz",
+        "nde",
         "nder",
         "nderp",
         "nderpl",
         "nderpla",
         "nderplat",
         "nderplatz",
+        "der",
         "derp",
         "derpl",
         "derpla",
         "derplat",
         "derplatz",
+        "erp",
         "erpl",
         "erpla",
         "erplat",
         "erplatz",
+        "rpl",
         "rpla",
         "rplat",
         "rplatz",
+        "pla",
         "plat",
         "platz",
+        "lat",
         "latz",
+        "atz",
         "Alexanderplatz"
       ),
       result
@@ -87,29 +99,39 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Meridian Ave N & N 148th St", analyzer);
 
+    System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
+        "Mer",
         "Meri",
         "Merid",
         "Meridi",
         "Meridia",
         "Meridian",
+        "eri",
         "erid",
         "eridi",
         "eridia",
         "eridian",
+        "rid",
         "ridi",
         "ridia",
         "ridian",
+        "idi",
         "idia",
         "idian",
+        "dia",
         "dian",
+        "ian",
         "Av",
         "N",
         "N",
+        "148",
         "148t",
         "148th",
+        "48t",
         "48th",
+        "8th",
         "St"
       ),
       result

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -98,6 +98,10 @@ class LuceneIndexTest {
     .withCoordinate(52.52277, 13.41046)
     .build();
 
+  static final RegularStop MERIDIAN_AVE = TEST_MODEL.stop("Meridian Ave N & N 148th").build();
+
+  static final RegularStop MERIDIAN_1 = TEST_MODEL.stop("Meridian N & Spencer").build();
+
   static LuceneIndex index;
 
   static StopClusterMapper mapper;
@@ -113,7 +117,9 @@ class LuceneIndexTest {
         LICHTERFELDE_OST_2,
         WESTHAFEN,
         ARTS_CENTER,
-        ARTHUR
+        ARTHUR,
+        MERIDIAN_AVE,
+        MERIDIAN_1
       )
       .forEach(stopModel::withRegularStop);
     List
@@ -294,6 +300,15 @@ class LuceneIndexTest {
       assertEquals(ALEXANDERPLATZ_STATION.getName().toString(), cluster.primary().name());
       assertEquals(List.of(StopClusterMapper.toAgency(BVG)), cluster.primary().agencies());
       assertEquals("A Publisher", cluster.primary().feedPublisher().name());
+    }
+
+    @Test
+    void numbers() {
+      var result = index
+        .queryStopClusters("Meridian Ave N & N 148")
+        .map(s -> s.primary().name())
+        .toList();
+      assertEquals(List.of("Meridian Ave N & N 148th", "Meridian N & Spencer"), result);
     }
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -305,7 +305,15 @@ class LuceneIndexTest {
 
     @ParameterizedTest
     @ValueSource(
-      strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148", "Meridian Ave N N 148" }
+      strings = {
+        "Meridian Ave N & N 148th",
+        "Meridian Ave N & N 148",
+        "Meridian Ave N N 148",
+        "Meridian Ave N 148",
+        "Meridian & N 148",
+        "Meridian Ave 148",
+        "Meridian Av 148",
+      }
     )
     void shortTokens(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -316,7 +316,7 @@ class LuceneIndexTest {
         "meridian av 148",
       }
     )
-    void shortTokens(String query) {
+    void numericAdjectives(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(
         Stream.of(MERIDIAN_AVE, MERIDIAN_N2, MERIDIAN_N1).map(s -> s.getName().toString()).toList(),

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -108,21 +108,21 @@ class LuceneIndexTest {
     .stop("Meridian N & Spencer")
     .withId(FeedScopedId.parse("pierce:13268"))
     .withCode("4168")
-    .withCoordinate(47.209366,-122.293999)
+    .withCoordinate(47.209366, -122.293999)
     .build();
 
   static final RegularStop MERIDIAN_N_2 = TEST_MODEL
     .stop("Meridian N & Spencer")
     .withId(FeedScopedId.parse("pierce:30976"))
     .withCode("4169")
-    .withCoordinate(47.209316,-122.293841)
+    .withCoordinate(47.209316, -122.293841)
     .build();
 
   static final RegularStop MERIDIAN_N_3 = TEST_MODEL
     .stop("N 205th St & Meridian Ave N")
     .withId(FeedScopedId.parse("commtrans:490"))
     .withCode("490")
-    .withCoordinate(47.209316,-122.293841)
+    .withCoordinate(47.777632, -122.3346)
     .build();
 
   static LuceneIndex index;
@@ -329,8 +329,14 @@ class LuceneIndexTest {
 
     @Test
     void number() {
-      var names = index.queryStopClusters("Meridian Ave N & N 148").map(c -> c.primary().name()).toList();
-      assertEquals(List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()), names);
+      var names = index
+        .queryStopClusters("Meridian Ave N & N 148")
+        .map(c -> c.primary().name())
+        .toList();
+      assertEquals(
+        List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()),
+        names
+      );
     }
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -259,7 +260,7 @@ class LuceneIndexTest {
     @Test
     void fuzzyStopClusters() {
       var result1 = index.queryStopClusters("arts").map(primaryId()).toList();
-      assertEquals(List.of(ARTS_CENTER.getId()), result1);
+      assertEquals(List.of(ARTS_CENTER.getId(), ARTHUR.getId()), result1);
     }
 
     @Test
@@ -327,14 +328,15 @@ class LuceneIndexTest {
       assertEquals("A Publisher", cluster.primary().feedPublisher().name());
     }
 
-    @Test
-    void number() {
-      var names = index
-        .queryStopClusters("Meridian Ave N & N 148")
-        .map(c -> c.primary().name())
-        .toList();
+    @ParameterizedTest
+    @ValueSource(strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148" })
+    void shortTokens(String query) {
+      var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(
-        List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()),
+        Stream
+          .of(MERIDIAN_AVE, MERIDIAN_N_3, MERIDIAN_N_1)
+          .map(s -> s.getName().toString())
+          .toList(),
         names
       );
     }

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -98,9 +97,33 @@ class LuceneIndexTest {
     .withCoordinate(52.52277, 13.41046)
     .build();
 
-  static final RegularStop MERIDIAN_AVE = TEST_MODEL.stop("Meridian Ave N & N 148th").build();
+  static final RegularStop MERIDIAN_AVE = TEST_MODEL
+    .stop("Meridian Ave N & N 148th St")
+    .withId(FeedScopedId.parse("kcm:16340"))
+    .withCode("16340")
+    .withCoordinate(47.736145, -122.33445)
+    .build();
 
-  static final RegularStop MERIDIAN_1 = TEST_MODEL.stop("Meridian N & Spencer").build();
+  static final RegularStop MERIDIAN_N_1 = TEST_MODEL
+    .stop("Meridian N & Spencer")
+    .withId(FeedScopedId.parse("pierce:13268"))
+    .withCode("4168")
+    .withCoordinate(47.209366,-122.293999)
+    .build();
+
+  static final RegularStop MERIDIAN_N_2 = TEST_MODEL
+    .stop("Meridian N & Spencer")
+    .withId(FeedScopedId.parse("pierce:30976"))
+    .withCode("4169")
+    .withCoordinate(47.209316,-122.293841)
+    .build();
+
+  static final RegularStop MERIDIAN_N_3 = TEST_MODEL
+    .stop("N 205th St & Meridian Ave N")
+    .withId(FeedScopedId.parse("commtrans:490"))
+    .withCode("490")
+    .withCoordinate(47.209316,-122.293841)
+    .build();
 
   static LuceneIndex index;
 
@@ -118,8 +141,10 @@ class LuceneIndexTest {
         WESTHAFEN,
         ARTS_CENTER,
         ARTHUR,
-        MERIDIAN_AVE,
-        MERIDIAN_1
+        MERIDIAN_N_1,
+        MERIDIAN_N_2,
+        MERIDIAN_N_3,
+        MERIDIAN_AVE
       )
       .forEach(stopModel::withRegularStop);
     List
@@ -303,16 +328,13 @@ class LuceneIndexTest {
     }
 
     @Test
-    void numbers() {
-      var result = index
-        .queryStopClusters("Meridian Ave N & N 148")
-        .map(s -> s.primary().name())
-        .toList();
-      assertEquals(List.of("Meridian Ave N & N 148th", "Meridian N & Spencer"), result);
+    void number() {
+      var names = index.queryStopClusters("Meridian Ave N & N 148").map(c -> c.primary().name()).toList();
+      assertEquals(List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()), names);
     }
   }
 
-  private static @Nonnull Function<StopCluster, FeedScopedId> primaryId() {
+  private static Function<StopCluster, FeedScopedId> primaryId() {
     return c -> c.primary().id();
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -329,7 +329,9 @@ class LuceneIndexTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148" })
+    @ValueSource(
+      strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148", "Meridian Ave N N 148" }
+    )
     void shortTokens(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -98,33 +98,9 @@ class LuceneIndexTest {
     .withCoordinate(52.52277, 13.41046)
     .build();
 
-  static final RegularStop MERIDIAN_AVE = TEST_MODEL
-    .stop("Meridian Ave N & N 148th St")
-    .withId(FeedScopedId.parse("kcm:16340"))
-    .withCode("16340")
-    .withCoordinate(47.736145, -122.33445)
-    .build();
-
-  static final RegularStop MERIDIAN_N_1 = TEST_MODEL
-    .stop("Meridian N & Spencer")
-    .withId(FeedScopedId.parse("pierce:13268"))
-    .withCode("4168")
-    .withCoordinate(47.209366, -122.293999)
-    .build();
-
-  static final RegularStop MERIDIAN_N_2 = TEST_MODEL
-    .stop("Meridian N & Spencer")
-    .withId(FeedScopedId.parse("pierce:30976"))
-    .withCode("4169")
-    .withCoordinate(47.209316, -122.293841)
-    .build();
-
-  static final RegularStop MERIDIAN_N_3 = TEST_MODEL
-    .stop("N 205th St & Meridian Ave N")
-    .withId(FeedScopedId.parse("commtrans:490"))
-    .withCode("490")
-    .withCoordinate(47.777632, -122.3346)
-    .build();
+  static final RegularStop MERIDIAN_AVE = TEST_MODEL.stop("Meridian Ave N & N 148th St").build();
+  static final RegularStop MERIDIAN_N1 = TEST_MODEL.stop("Meridian N & Spencer").build();
+  static final RegularStop MERIDIAN_N2 = TEST_MODEL.stop("N 205th St & Meridian Ave N").build();
 
   static LuceneIndex index;
 
@@ -142,9 +118,8 @@ class LuceneIndexTest {
         WESTHAFEN,
         ARTS_CENTER,
         ARTHUR,
-        MERIDIAN_N_1,
-        MERIDIAN_N_2,
-        MERIDIAN_N_3,
+        MERIDIAN_N1,
+        MERIDIAN_N2,
         MERIDIAN_AVE
       )
       .forEach(stopModel::withRegularStop);
@@ -335,10 +310,7 @@ class LuceneIndexTest {
     void shortTokens(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(
-        Stream
-          .of(MERIDIAN_AVE, MERIDIAN_N_3, MERIDIAN_N_1)
-          .map(s -> s.getName().toString())
-          .toList(),
+        Stream.of(MERIDIAN_AVE, MERIDIAN_N2, MERIDIAN_N1).map(s -> s.getName().toString()).toList(),
         names
       );
     }

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -310,6 +310,8 @@ class LuceneIndexTest {
         "Meridian Ave N & N 148",
         "Meridian Ave N N 148",
         "Meridian Ave N 148",
+        "Meridian & 148 N",
+        "148 N & Meridian",
         "Meridian & N 148",
         "Meridian Ave 148",
         "Meridian Av 148",

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -235,7 +235,7 @@ class LuceneIndexTest {
     @Test
     void fuzzyStopClusters() {
       var result1 = index.queryStopClusters("arts").map(primaryId()).toList();
-      assertEquals(List.of(ARTS_CENTER.getId(), ARTHUR.getId()), result1);
+      assertEquals(List.of(ARTS_CENTER.getId()), result1);
     }
 
     @Test
@@ -313,6 +313,7 @@ class LuceneIndexTest {
         "Meridian & N 148",
         "Meridian Ave 148",
         "Meridian Av 148",
+        "meridian av 148",
       }
     )
     void shortTokens(String query) {

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -25,7 +25,7 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
  */
 class EnglishNGramAnalyzer extends Analyzer {
 
-  // matches one or more numbers followed by the English suffixes "st", "nd", "rd", "th"
+  // Matches one or more numbers followed by the English suffixes "st", "nd", "rd", "th"
   private static final Pattern NUMBER_SUFFIX_PATTERN = Pattern.compile("(\\d+)(st|nd|rd|th)\\b");
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -26,7 +26,7 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
 class EnglishNGramAnalyzer extends Analyzer {
 
   // matches one or more numbers followed by the English suffixes "st", "nd", "rd", "th"
-  private static final Pattern NUMBER_SUFFIX_PATTERN = Pattern.compile("(\\d+)[st|nd|rd|th]+");
+  private static final Pattern NUMBER_SUFFIX_PATTERN = Pattern.compile("(\\d+)(st|nd|rd|th)\\b");
 
   @Override
   protected TokenStreamComponents createComponents(String fieldName) {

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -28,7 +28,7 @@ class EnglishNGramAnalyzer extends Analyzer {
     result = new StopFilter(result, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
     result = new PorterStemFilter(result);
     result = new CapitalizationFilter(result);
-    result = new NGramTokenFilter(result, 4, 10, true);
+    result = new NGramTokenFilter(result, 3, 10, true);
     return new TokenStreamComponents(src, result);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -1,14 +1,16 @@
 package org.opentripplanner.ext.geocoder;
 
+import java.util.regex.Pattern;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.en.EnglishPossessiveFilter;
 import org.apache.lucene.analysis.en.PorterStemFilter;
 import org.apache.lucene.analysis.miscellaneous.CapitalizationFilter;
 import org.apache.lucene.analysis.ngram.NGramTokenFilter;
+import org.apache.lucene.analysis.pattern.PatternReplaceFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 
 /**
@@ -17,18 +19,25 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
  * of a stop name can be matched efficiently.
  * <p>
  * For example the query of "exanderpl" will match the stop name "Alexanderplatz".
+ * <p>
+ * It also removes number suffixes in the American street names, like "147th Street", which will
+ * be tokenized to "147 Street".
  */
 class EnglishNGramAnalyzer extends Analyzer {
+
+  // matches one or more numbers followed by the English suffixes "st", "nd", "rd", "th"
+  private static final Pattern NUMBER_SUFFIX_PATTERN = Pattern.compile("(\\d+)[st|nd|rd|th]+");
 
   @Override
   protected TokenStreamComponents createComponents(String fieldName) {
     StandardTokenizer src = new StandardTokenizer();
     TokenStream result = new EnglishPossessiveFilter(src);
     result = new LowerCaseFilter(result);
+    result = new PatternReplaceFilter(result, NUMBER_SUFFIX_PATTERN, "$1", true);
     result = new StopFilter(result, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
     result = new PorterStemFilter(result);
     result = new CapitalizationFilter(result);
-    result = new NGramTokenFilter(result, 3, 10, true);
+    result = new NGramTokenFilter(result, 4, 10, true);
     return new TokenStreamComponents(src, result);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -288,7 +288,7 @@ public class LuceneIndex implements Serializable {
             }
           });
       } else {
-        var nameParser = new QueryParser(NAME, analyzer);
+        var nameParser = new QueryParser(NAME_NGRAM, analyzer);
         var nameQuery = nameParser.parse(searchTerms);
 
         var ngramNameQuery = new TermQuery(


### PR DESCRIPTION
### Summary

This PR improves the sandbox geocoder by shortening the minimal n-gram to 3 from 4.

This is so that the stop name of "Meridian Ave N & N 148th St" is matched when the users search for "Meridian Ave N & N 148". Previously "148th" would only be tokenised to "148t" but not "148".

~~This also changes one of the regression test cases: When you search for "arts" you now also get "arthur place" which before you didn't. @miles-grant-ibigroup said that this is fine.~~

### Unit tests

Added.