### PR TITLE
Debug client itinerary list style improvements

### DIFF
--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -10,14 +10,9 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
       <div className="times">
         {formatDistance(leg.distance)}, {formatDuration(leg.duration)}
       </div>
-
-        <InterchangeInfo leg={leg} />
-        <LegTime
-          aimedTime={leg.aimedStartTime}
-          expectedTime={leg.expectedStartTime}
-          hasRealtime={leg.realtime}
-        /> - <LegTime aimedTime={leg.aimedEndTime} expectedTime={leg.expectedEndTime} hasRealtime={leg.realtime} />
-
+      <InterchangeInfo leg={leg} />
+      <LegTime aimedTime={leg.aimedStartTime} expectedTime={leg.expectedStartTime} hasRealtime={leg.realtime} /> -{' '}
+      <LegTime aimedTime={leg.aimedEndTime} expectedTime={leg.expectedEndTime} hasRealtime={leg.realtime} />
       <div className="mode">
         <b>{leg.mode}</b>{' '}
         {leg.line && (
@@ -28,11 +23,10 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
             , {leg.authority?.name}
           </>
         )}{' '}
-
         {leg.mode !== Mode.Foot && (
           <>
-            <br/>
-              <u title={leg.fromPlace.quay?.id}>{leg.fromPlace.name}</u> →{' '}
+            <br />
+            <u title={leg.fromPlace.quay?.id}>{leg.fromPlace.name}</u> →{' '}
           </>
         )}{' '}
         {!isLast && <u title={leg.toPlace.quay?.id}>{leg.toPlace.name}</u>}

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -10,14 +10,14 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
       <div className="times">
         {formatDistance(leg.distance)}, {formatDuration(leg.duration)}
       </div>
-      <div>
+
         <InterchangeInfo leg={leg} />
         <LegTime
           aimedTime={leg.aimedStartTime}
           expectedTime={leg.expectedStartTime}
           hasRealtime={leg.realtime}
         /> - <LegTime aimedTime={leg.aimedEndTime} expectedTime={leg.expectedEndTime} hasRealtime={leg.realtime} />
-      </div>
+
       <div className="mode">
         <b>{leg.mode}</b>{' '}
         {leg.line && (
@@ -28,10 +28,11 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
             , {leg.authority?.name}
           </>
         )}{' '}
-        <div></div>
+
         {leg.mode !== Mode.Foot && (
           <>
-            <u title={leg.fromPlace.quay?.id}>{leg.fromPlace.name}</u> →{' '}
+            <br/>
+              <u title={leg.fromPlace.quay?.id}>{leg.fromPlace.name}</u> →{' '}
           </>
         )}{' '}
         {!isLast && <u title={leg.toPlace.quay?.id}>{leg.toPlace.name}</u>}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -86,7 +86,7 @@
 }
 
 .itinerary-leg-details .mode {
-  margin-top: 10px;
+  margin-top: 2px;
 }
 
 .itinerary-header-itinerary-number {


### PR DESCRIPTION

### Summary

Update to the OTP Debug client.
Removed some spacing in the itinerary list to make the view more compact. 

### Issue
https://github.com/opentripplanner/OpenTripPlanner/issues/5330#issuecomment-2273311110

This is to address the following:
UX - Less line spacing on expanded legs to make it easier to compare two itineraries.

The code is only some simple css and html changes to make the element more compact. See screenshots of before and after.
![after](https://github.com/user-attachments/assets/7f634e4d-717e-43da-a183-e07a25be2e91)
![before](https://github.com/user-attachments/assets/27b8b0ad-3483-45ce-93de-40747dcbaa38)


