### PR TITLE
Move rounding of WgsCoordinate from constructor to factory method

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/ridehailing/RideHailingAccessShifter.java
+++ b/src/ext/java/org/opentripplanner/ext/ridehailing/RideHailingAccessShifter.java
@@ -121,7 +121,7 @@ public class RideHailingAccessShifter {
     try {
       var service = services.get(0);
       var arrivalTimeOpt = service
-        .arrivalTimes(new WgsCoordinate(req.from().getCoordinate()), req.wheelchair())
+        .arrivalTimes(WgsCoordinate.normalized(req.from().getCoordinate()), req.wheelchair())
         .stream()
         .min(Comparator.comparing(ArrivalTime::duration));
 

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/bikeep/BikeepUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/bikeep/BikeepUpdater.java
@@ -34,7 +34,7 @@ public class BikeepUpdater extends GenericJsonDataSource<VehicleParking> {
   protected VehicleParking parseElement(JsonNode jsonNode) {
     try {
       var coords = jsonNode.path("geometry").path("coordinates");
-      var coordinate = new WgsCoordinate(coords.get(1).asDouble(), coords.get(0).asDouble());
+      var coordinate = WgsCoordinate.normalized(coords.get(1).asDouble(), coords.get(0).asDouble());
 
       var props = jsonNode.path("properties");
       var vehicleParkId = new FeedScopedId(params.feedId(), props.path("code").asText());

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubToVehicleParkingGroupMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslHubToVehicleParkingGroupMapper.java
@@ -57,7 +57,7 @@ public class HslHubToVehicleParkingGroupMapper {
       var vehicleParkingGroup = VehicleParkingGroup
         .of(hubId)
         .withName(name)
-        .withCoordinate(new WgsCoordinate(geometry.getCentroid()))
+        .withCoordinate(WgsCoordinate.normalized(geometry.getCentroid()))
         .build();
       var vehicleParkingIds = getVehicleParkingIds((ArrayNode) jsonNode.get("facilityIds"), hubId);
       if (vehicleParkingIds == null) {

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
@@ -114,7 +114,7 @@ public class HslParkToVehicleParkingMapper {
         .id(vehicleParkId)
         .name(name)
         .state(state)
-        .coordinate(new WgsCoordinate(geometry.getCentroid()))
+        .coordinate(WgsCoordinate.normalized(geometry.getCentroid()))
         .capacity(capacity)
         .bicyclePlaces(bicyclePlaces)
         .carPlaces(carPlaces)
@@ -125,7 +125,7 @@ public class HslParkToVehicleParkingMapper {
           builder
             .entranceId(new FeedScopedId(feedId, vehicleParkId.getId() + "/entrance"))
             .name(name)
-            .coordinate(new WgsCoordinate(geometry.getCentroid()))
+            .coordinate(WgsCoordinate.normalized(geometry.getCentroid()))
             .walkAccessible(true)
             .carAccessible(carPlaces || wheelChairAccessiblePlaces)
         )

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/noi/NoiUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/noi/NoiUpdater.java
@@ -42,7 +42,7 @@ public class NoiUpdater extends GenericJsonDataSource<VehicleParking> {
     var name = new NonLocalizedString(jsonNode.path("name").asText());
     double lat = jsonNode.path("lat").asDouble();
     double lon = jsonNode.path("lon").asDouble();
-    var coordinate = new WgsCoordinate(lat, lon);
+    var coordinate = WgsCoordinate.normalized(lat, lon);
     VehicleParking.VehicleParkingEntranceCreator entrance = builder ->
       builder
         .entranceId(new FeedScopedId(params.feedId(), vehicleParkId.getId() + "/entrance"))

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
@@ -75,7 +75,7 @@ abstract class ParkAPIUpdater extends GenericJsonDataSource<VehicleParking> {
       builder
         .entranceId(new FeedScopedId(feedId, vehicleParkId.getId() + "/entrance"))
         .name(new NonLocalizedString(jsonNode.path("name").asText()))
-        .coordinate(new WgsCoordinate(y, x))
+        .coordinate(WgsCoordinate.normalized(y, x))
         .walkAccessible(true)
         .carAccessible(true);
 
@@ -101,7 +101,7 @@ abstract class ParkAPIUpdater extends GenericJsonDataSource<VehicleParking> {
       .id(vehicleParkId)
       .name(new NonLocalizedString(jsonNode.path("name").asText()))
       .state(state)
-      .coordinate(new WgsCoordinate(y, x))
+      .coordinate(WgsCoordinate.normalized(y, x))
       .openingHoursCalendar(parseOpeningHours(jsonNode.path("opening_hours"), vehicleParkId))
       .detailsUrl(jsonNode.has("url") ? jsonNode.get("url").asText() : null)
       .imageUrl(jsonNode.has("image_url") ? jsonNode.get("image_url").asText() : null)

--- a/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
+++ b/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
@@ -29,43 +29,66 @@ public final class WgsCoordinate implements Serializable {
     DoubleUtils.requireInRange(latitude, LAT_MIN, LAT_MAX, "latitude");
     DoubleUtils.requireInRange(longitude, LON_MIN, LON_MAX, "longitude");
 
-    // Normalize coordinates to precision around ~ 1 centimeters (7 decimals)
-    this.latitude = DoubleUtils.roundTo7Decimals(latitude);
-    this.longitude = DoubleUtils.roundTo7Decimals(longitude);
+    this.latitude = latitude;
+    this.longitude = longitude;
   }
 
   public WgsCoordinate(Point point) {
     Objects.requireNonNull(point);
-    this.latitude = DoubleUtils.roundTo7Decimals(point.getY());
-    this.longitude = DoubleUtils.roundTo7Decimals(point.getX());
+    DoubleUtils.requireInRange(point.getY(), LAT_MIN, LAT_MAX, "latitude");
+    DoubleUtils.requireInRange(point.getX(), LON_MIN, LON_MAX, "longitude");
+
+    this.latitude = point.getY();
+    this.longitude = point.getX();
   }
 
   public WgsCoordinate(Coordinate coordinate) {
     Objects.requireNonNull(coordinate);
-    this.latitude = DoubleUtils.roundTo7Decimals(coordinate.getY());
-    this.longitude = DoubleUtils.roundTo7Decimals(coordinate.getX());
+    DoubleUtils.requireInRange(coordinate.getY(), LAT_MIN, LAT_MAX, "latitude");
+    DoubleUtils.requireInRange(coordinate.getX(), LON_MIN, LON_MAX, "longitude");
+
+    this.latitude = coordinate.getY();
+    this.longitude = coordinate.getX();
   }
 
   /**
-   * Unlike the constructor this factory method retuns {@code null} if both {@code lat} and {@code
-   * lon} is {@code null}.
+   * Creates a coordinate where latitude/longitude are rounded to 7 decimal places. This gives a
+   * precicion of ~ 1 centimeters. Higher precision than this is generally not needed inside OTP.
    */
-  public static WgsCoordinate creatOptionalCoordinate(Double latitude, Double longitude) {
-    if (latitude == null && longitude == null) {
-      return null;
-    }
-
-    // Set coordinate is both lat and lon exist
-    if (latitude != null && longitude != null) {
-      return new WgsCoordinate(latitude, longitude);
-    }
-    throw new IllegalArgumentException(
-      "Both 'latitude' and 'longitude' must have a value or both must be 'null'."
+  public static WgsCoordinate normalized(double latitude, double longitude) {
+    return new WgsCoordinate(
+      DoubleUtils.roundTo7Decimals(latitude),
+      DoubleUtils.roundTo7Decimals(longitude)
     );
   }
 
   /**
-   * Find the mean coordinate between the given set of {@code coordinates}.
+   * Creates a coordinate where latitude/longitude are rounded to 7 decimal places. This gives a
+   * precicion of ~ 1 centimeters. Higher precision than this is generally not needed inside OTP.
+   */
+  public static WgsCoordinate normalized(Coordinate coordinate) {
+    Objects.requireNonNull(coordinate);
+    return new WgsCoordinate(
+      DoubleUtils.roundTo7Decimals(coordinate.getY()),
+      DoubleUtils.roundTo7Decimals(coordinate.getX())
+    );
+  }
+
+  /**
+   * Creates a coordinate where latitude/longitude are rounded to 7 decimal places. This gives a
+   * precicion of ~ 1 centimeters. Higher precision than this is generally not needed inside OTP.
+   */
+  public static WgsCoordinate normalized(Point point) {
+    Objects.requireNonNull(point);
+    return new WgsCoordinate(
+      DoubleUtils.roundTo7Decimals(point.getY()),
+      DoubleUtils.roundTo7Decimals(point.getX())
+    );
+  }
+
+  /**
+   * Find the mean coordinate between the given set of {@code coordinates}. Result will be normalized
+   * to 7 decimal places.
    */
   public static WgsCoordinate mean(Collection<WgsCoordinate> coordinates) {
     if (coordinates.isEmpty()) {
@@ -86,7 +109,7 @@ public final class WgsCoordinate implements Serializable {
       longitude += c.longitude();
     }
 
-    return new WgsCoordinate(latitude / n, longitude / n);
+    return WgsCoordinate.normalized(latitude / n, longitude / n);
   }
 
   public double latitude() {

--- a/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
+++ b/src/main/java/org/opentripplanner/framework/geometry/WgsCoordinate.java
@@ -13,42 +13,26 @@ import org.opentripplanner.framework.tostring.ValueObjectToStringBuilder;
  * <p>
  * This is a ValueObject (design pattern).
  */
-public final class WgsCoordinate implements Serializable {
-
+public record WgsCoordinate(double latitude, double longitude) implements Serializable {
   public static final WgsCoordinate GREENWICH = new WgsCoordinate(51.48, 0d);
   private static final double LAT_MIN = -90;
   private static final double LAT_MAX = 90;
   private static final double LON_MIN = -180;
   private static final double LON_MAX = 180;
 
-  private final double latitude;
-  private final double longitude;
-
-  public WgsCoordinate(double latitude, double longitude) {
+  public WgsCoordinate {
     // Verify coordinates are in range
     DoubleUtils.requireInRange(latitude, LAT_MIN, LAT_MAX, "latitude");
     DoubleUtils.requireInRange(longitude, LON_MIN, LON_MAX, "longitude");
-
-    this.latitude = latitude;
-    this.longitude = longitude;
   }
 
-  public WgsCoordinate(Point point) {
-    Objects.requireNonNull(point);
-    DoubleUtils.requireInRange(point.getY(), LAT_MIN, LAT_MAX, "latitude");
-    DoubleUtils.requireInRange(point.getX(), LON_MIN, LON_MAX, "longitude");
-
-    this.latitude = point.getY();
-    this.longitude = point.getX();
-  }
-
-  public WgsCoordinate(Coordinate coordinate) {
+  /**
+   * Create a WgsCoordinate from a given jts Coordinate. There is no rounding of the latitude or
+   * longitude values.
+   */
+  public static WgsCoordinate of(Coordinate coordinate) {
     Objects.requireNonNull(coordinate);
-    DoubleUtils.requireInRange(coordinate.getY(), LAT_MIN, LAT_MAX, "latitude");
-    DoubleUtils.requireInRange(coordinate.getX(), LON_MIN, LON_MAX, "longitude");
-
-    this.latitude = coordinate.getY();
-    this.longitude = coordinate.getX();
+    return new WgsCoordinate(coordinate.getY(), coordinate.getX());
   }
 
   /**
@@ -110,14 +94,6 @@ public final class WgsCoordinate implements Serializable {
     }
 
     return WgsCoordinate.normalized(latitude / n, longitude / n);
-  }
-
-  public double latitude() {
-    return latitude;
-  }
-
-  public double longitude() {
-    return longitude;
   }
 
   /** Return OTP domain coordinate as JTS GeoTools Library coordinate. */

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -84,7 +84,7 @@ class ParkingProcessor {
             )
           )
           .name(creativeName)
-          .coordinate(new WgsCoordinate(node.getCoordinate()))
+          .coordinate(WgsCoordinate.normalized(node.getCoordinate()))
           .walkAccessible(true)
           .carAccessible(isCarParkAndRide);
 
@@ -304,7 +304,7 @@ class ParkingProcessor {
           )
         )
         .name(vehicleParkingName)
-        .coordinate(new WgsCoordinate(group.union.getInteriorPoint()))
+        .coordinate(WgsCoordinate.normalized(group.union.getInteriorPoint()))
         // setting the vertex to null signals the rest of the build process that this needs to be linked to the street network
         .vertex(null)
         .walkAccessible(true)
@@ -383,7 +383,7 @@ class ParkingProcessor {
       .builder()
       .id(id)
       .name(creativeName)
-      .coordinate(new WgsCoordinate(coordinate))
+      .coordinate(WgsCoordinate.normalized(coordinate))
       .tags(tags)
       .detailsUrl(entity.getTag("website"))
       .openingHoursCalendar(openingHours)
@@ -464,7 +464,7 @@ class ParkingProcessor {
             )
           )
           .name(entranceName)
-          .coordinate(new WgsCoordinate(access.vertex().getCoordinate()))
+          .coordinate(WgsCoordinate.normalized(access.vertex().getCoordinate()))
           .vertex(access.vertex())
           .walkAccessible(access.vertex().isConnectedToWalkingEdge())
           .carAccessible(access.vertex().isConnectedToDriveableEdge())

--- a/src/main/java/org/opentripplanner/gtfs/mapping/WgsCoordinateMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/WgsCoordinateMapper.java
@@ -7,7 +7,7 @@ class WgsCoordinateMapper {
 
   static WgsCoordinate mapToDomain(Stop stop) {
     if (stop.isLatSet() && stop.isLonSet()) {
-      return new WgsCoordinate(stop.getLat(), stop.getLon());
+      return WgsCoordinate.normalized(stop.getLat(), stop.getLon());
     }
     if (!stop.isLatSet() && !stop.isLonSet()) {
       return null;

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -68,20 +68,13 @@ public class Place {
   }
 
   public static Place normal(Double lat, Double lon, I18NString name) {
-    return new Place(
-      name,
-      WgsCoordinate.creatOptionalCoordinate(lat, lon),
-      VertexType.NORMAL,
-      null,
-      null,
-      null
-    );
+    return new Place(name, creatOptionalCoordinate(lat, lon), VertexType.NORMAL, null, null, null);
   }
 
   public static Place normal(Vertex vertex, I18NString name) {
     return new Place(
       name,
-      WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
+      creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
       VertexType.NORMAL,
       null,
       null,
@@ -107,7 +100,7 @@ public class Place {
     // coordinates.
     return new Place(
       name,
-      WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
+      creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
       VertexType.TRANSIT,
       stop,
       null,
@@ -118,7 +111,7 @@ public class Place {
   public static Place forVehicleRentalPlace(VehicleRentalPlaceVertex vertex) {
     return new Place(
       vertex.getName(),
-      WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
+      creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
       VertexType.VEHICLERENTAL,
       null,
       vertex.getStation(),
@@ -140,7 +133,7 @@ public class Place {
       .hasRealTimeDataForMode(traverseMode, request.wheelchair());
     return new Place(
       vertex.getName(),
-      WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
+      creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
       VertexType.VEHICLEPARKING,
       null,
       null,
@@ -193,5 +186,23 @@ public class Place {
       .addObj("vehicleRentalPlace", vehicleRentalPlace)
       .addObj("vehicleParkingEntrance", vehicleParkingWithEntrance)
       .toString();
+  }
+
+  /**
+   * Unlike the constructor this factory method retuns {@code null} if both {@code lat} and {@code
+   * lon} is {@code null}.
+   */
+  private static WgsCoordinate creatOptionalCoordinate(Double latitude, Double longitude) {
+    if (latitude == null && longitude == null) {
+      return null;
+    }
+
+    // Set coordinate is both lat and lon exist
+    if (latitude != null && longitude != null) {
+      return WgsCoordinate.normalized(latitude, longitude);
+    }
+    throw new IllegalArgumentException(
+      "Both 'latitude' and 'longitude' must have a value or both must be 'null'."
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
@@ -26,6 +26,9 @@ class WgsCoordinateMapper {
       throw new IllegalArgumentException("Coordinate is not valid: " + loc);
     }
     // Location is safe to process
-    return new WgsCoordinate(loc.getLatitude().doubleValue(), loc.getLongitude().doubleValue());
+    return WgsCoordinate.normalized(
+      loc.getLatitude().doubleValue(),
+      loc.getLongitude().doubleValue()
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
@@ -544,7 +544,7 @@ public class StatesToWalkStepsMapper {
     return WalkStep
       .builder()
       .withDirectionText(en.getName())
-      .withStartLocation(new WgsCoordinate(backState.getVertex().getCoordinate()))
+      .withStartLocation(WgsCoordinate.normalized(backState.getVertex().getCoordinate()))
       .withBogusName(en.hasBogusName())
       .withAngle(DirectionUtils.getFirstAngle(forwardState.getBackEdge().getGeometry()))
       .withWalkingBike(forwardState.isBackWalkingBike())

--- a/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -212,8 +212,9 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
    * @see org.opentripplanner.framework.geometry.WgsCoordinate#sameLocation(WgsCoordinate)
    **/
   public boolean sameLocation(Vertex other) {
-    return new WgsCoordinate(getLat(), getLon())
-      .sameLocation(new WgsCoordinate(other.getLat(), other.getLon()));
+    return WgsCoordinate
+      .normalized(getLat(), getLon())
+      .sameLocation(WgsCoordinate.normalized(other.getLat(), other.getLon()));
   }
 
   public boolean rentalTraversalBanned(State currentState) {

--- a/src/main/java/org/opentripplanner/transit/model/site/AreaStopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/AreaStopBuilder.java
@@ -70,7 +70,7 @@ public class AreaStopBuilder extends AbstractEntityBuilder<AreaStop, AreaStopBui
 
   public AreaStopBuilder withGeometry(Geometry geometry) {
     this.geometry = geometry;
-    this.centroid = new WgsCoordinate(geometry.getCentroid());
+    this.centroid = WgsCoordinate.normalized(geometry.getCentroid());
     return this;
   }
 

--- a/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
@@ -94,7 +94,7 @@ public class GroupStopBuilder extends AbstractEntityBuilder<GroupStop, GroupStop
     newGeometries[numGeometries] = location.getGeometry();
 
     geometry = new GeometryCollection(newGeometries, GeometryUtils.getGeometryFactory());
-    centroid = new WgsCoordinate(geometry.getCentroid());
+    centroid = WgsCoordinate.normalized(geometry.getCentroid());
 
     return this;
   }

--- a/src/main/java/org/opentripplanner/transit/model/site/StationBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/StationBuilder.java
@@ -70,7 +70,7 @@ public class StationBuilder extends AbstractEntityBuilder<Station, StationBuilde
   }
 
   public StationBuilder withCoordinate(double latitude, double longitude) {
-    this.coordinate = new WgsCoordinate(latitude, longitude);
+    this.coordinate = WgsCoordinate.normalized(latitude, longitude);
     return this;
   }
 

--- a/src/main/java/org/opentripplanner/transit/model/site/StationElementBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/StationElementBuilder.java
@@ -78,7 +78,7 @@ public abstract class StationElementBuilder<
   }
 
   public B withCoordinate(double latitude, double longitude) {
-    this.coordinate = new WgsCoordinate(latitude, longitude);
+    this.coordinate = WgsCoordinate.normalized(latitude, longitude);
     return instance();
   }
 

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
@@ -214,7 +214,7 @@ public class RealtimeVehiclePatternMatcher {
     if (vehiclePositionFeatures.contains(POSITION) && vehiclePosition.hasPosition()) {
       var position = vehiclePosition.getPosition();
       newVehicle.withCoordinates(
-        new WgsCoordinate(position.getLatitude(), position.getLongitude())
+        WgsCoordinate.normalized(position.getLatitude(), position.getLongitude())
       );
 
       if (position.hasSpeed()) {

--- a/src/test/java/org/opentripplanner/framework/geometry/WgsCoordinateTest.java
+++ b/src/test/java/org/opentripplanner/framework/geometry/WgsCoordinateTest.java
@@ -15,7 +15,7 @@ public class WgsCoordinateTest {
 
   @Test
   void normalize() {
-    WgsCoordinate c = new WgsCoordinate(1.123456789, 2.987654321);
+    WgsCoordinate c = WgsCoordinate.normalized(1.123456789, 2.987654321);
     assertEquals(1.1234568, c.latitude());
     assertEquals(2.9876543, c.longitude());
   }
@@ -29,21 +29,21 @@ public class WgsCoordinateTest {
 
   @Test
   void testCoordinateEquals() {
-    WgsCoordinate a = new WgsCoordinate(5.000_000_3, 3.0);
+    WgsCoordinate a = WgsCoordinate.normalized(5.000_000_3, 3.0);
 
     // Test latitude
-    WgsCoordinate sameLatitudeUpper = new WgsCoordinate(5.000_000_349, 3.0);
-    WgsCoordinate sameLatitudeLower = new WgsCoordinate(5.000_000_250, 3.0);
-    WgsCoordinate differentLatitude = new WgsCoordinate(5.000_000_350, 3.0);
+    WgsCoordinate sameLatitudeUpper = WgsCoordinate.normalized(5.000_000_349, 3.0);
+    WgsCoordinate sameLatitudeLower = WgsCoordinate.normalized(5.000_000_250, 3.0);
+    WgsCoordinate differentLatitude = WgsCoordinate.normalized(5.000_000_350, 3.0);
 
     assertTrue(a.sameLocation(sameLatitudeUpper));
     assertTrue(a.sameLocation(sameLatitudeLower));
     assertFalse(a.sameLocation(differentLatitude));
 
     // Test longitude
-    WgsCoordinate sameLongitudeUpper = new WgsCoordinate(5.000_000_3, 3.000_000_049);
-    WgsCoordinate sameLongitudeLover = new WgsCoordinate(5.000_000_3, 2.999_999_95);
-    WgsCoordinate differentLongitude = new WgsCoordinate(5.000_000_30, 3.000_000_05);
+    WgsCoordinate sameLongitudeUpper = WgsCoordinate.normalized(5.000_000_3, 3.000_000_049);
+    WgsCoordinate sameLongitudeLover = WgsCoordinate.normalized(5.000_000_3, 2.999_999_95);
+    WgsCoordinate differentLongitude = WgsCoordinate.normalized(5.000_000_30, 3.000_000_05);
 
     assertTrue(a.sameLocation(sameLongitudeUpper));
     assertTrue(a.sameLocation(sameLongitudeLover));

--- a/src/test/java/org/opentripplanner/framework/geometry/WgsCoordinateTest.java
+++ b/src/test/java/org/opentripplanner/framework/geometry/WgsCoordinateTest.java
@@ -107,7 +107,7 @@ public class WgsCoordinateTest {
 
   @Test
   void roundingTo10m() {
-    var hamburg = new WgsCoordinate(Coordinates.HAMBURG);
+    var hamburg = WgsCoordinate.of(Coordinates.HAMBURG);
     var rounded = hamburg.roundToApproximate10m();
     assertEquals(10.0003, rounded.longitude());
     assertEquals(53.5566, rounded.latitude());
@@ -115,7 +115,7 @@ public class WgsCoordinateTest {
 
   @Test
   void roundingTo100m() {
-    var hamburg = new WgsCoordinate(Coordinates.HAMBURG);
+    var hamburg = WgsCoordinate.of(Coordinates.HAMBURG);
     var rounded = hamburg.roundToApproximate100m();
     assertEquals(10, rounded.longitude());
     assertEquals(53.557, rounded.latitude());

--- a/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
@@ -119,7 +119,7 @@ class StreetLinkerModuleTest {
       stop =
         builder
           .regularStop(id("platform-1"))
-          .withCoordinate(new WgsCoordinate(KONGSBERG_PLATFORM_1))
+          .withCoordinate(WgsCoordinate.of(KONGSBERG_PLATFORM_1))
           .build();
       builder.withRegularStop(stop);
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
@@ -48,7 +48,7 @@ public class VehicleParkingLinkingTest {
     var parking = StreetModelForTest
       .vehicleParking()
       .entrance(builder ->
-        builder.entranceId(id("1")).coordinate(new WgsCoordinate(A.getCoordinate())).vertex(A)
+        builder.entranceId(id("1")).coordinate(WgsCoordinate.of(A.getCoordinate())).vertex(A)
       )
       .build();
     var parkingVertex = vertexFactory.vehicleParkingEntrance(parking);
@@ -128,14 +128,14 @@ public class VehicleParkingLinkingTest {
       .entrance(builder ->
         builder
           .entranceId(id("Entrance-1"))
-          .coordinate(new WgsCoordinate(A.getCoordinate()))
+          .coordinate(WgsCoordinate.of(A.getCoordinate()))
           .vertex(A)
           .walkAccessible(true)
       )
       .entrance(builder ->
         builder
           .entranceId(id("Entrance-2"))
-          .coordinate(new WgsCoordinate(B.getCoordinate()))
+          .coordinate(WgsCoordinate.of(B.getCoordinate()))
           .vertex(B)
           .walkAccessible(true)
       )
@@ -163,7 +163,7 @@ public class VehicleParkingLinkingTest {
       .entrance(builder ->
         builder
           .entranceId(id("Entrance-1"))
-          .coordinate(new WgsCoordinate(A.getCoordinate()))
+          .coordinate(WgsCoordinate.of(A.getCoordinate()))
           .vertex(A)
           .walkAccessible(true)
       )

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -429,7 +429,7 @@ public abstract class GraphRoutingTest {
         builder
           .entranceId(TransitModelForTest.id(id))
           .name(new NonLocalizedString(id))
-          .coordinate(new WgsCoordinate(streetVertex.getCoordinate()))
+          .coordinate(WgsCoordinate.of(streetVertex.getCoordinate()))
           .vertex(streetVertex)
           .carAccessible(carAccessible)
           .walkAccessible(walkAccessible);


### PR DESCRIPTION
### Summary

This is part 1 of some changes to the coordinate classes.

This PR converts the `WgsCoordinate` into a record and changes the default constructor to not round the coordinates to 7 decimal places. If you want the rounding behaviour you instead call the `WgsCoordinate.normalized(lat, lon)` factory method.

The main reason for this change is that we want to change a lot of code to start using the `WgsCoordinate` class without having to change the behaviour of the existing code.

This code is mostly a refactor. But there are some changes in behaviour:
- Now the `WgsCoordinate.of(Coordinate)` and `WgsCoordinate.of(Point)` constructors will throw exceptions if the lat/lon is out of bounds.
- I didn't update all creations of the WgsCoordinate to use the normalizing factory method. A lot of test code is doing `new WgsCoordinate(1, 2)`, i left those as they are.

### Issue

See #6013 

### Unit tests

I updated some test code in the WgsCoordinateTest according to the new behaviour.

### Documentation

I added javadoc to the new factory methods.

### Bumping the serialization version id

Converting the WgsCoordinate into a record will probably change the serialization.
