### PR TITLE
Inject updated TransitService in real-time updaters

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
@@ -176,8 +176,9 @@ class RealtimeResolverTest {
     transitModel.updateCalendarServiceData(true, calendarServiceData, DataImportIssueStore.NOOP);
     transitModel.index();
 
-    var alertService = new TransitAlertServiceImpl(transitModel);
     return new DefaultTransitService(transitModel) {
+      final TransitAlertService alertService = new TransitAlertServiceImpl(this);
+
       @Override
       public TransitAlertService getTransitAlertService() {
         return alertService;

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -83,11 +83,11 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       transitAlertService.getAllAlerts().clear();
     }
     if (alertsUpdateHandler == null) {
-      transitAlertService = new TransitAlertServiceImpl(transitModel);
+      transitAlertService = new TransitAlertServiceImpl(transitService);
       alertsUpdateHandler =
         new SiriAlertsUpdateHandler(
           FEED_ID,
-          transitModel,
+          transitService,
           transitAlertService,
           SiriFuzzyTripMatcher.of(transitService),
           Duration.ZERO

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -65,8 +65,9 @@ public class RealtimeStopsLayerTest {
     var transitModel = new TransitModel(new StopModel(), deduplicator);
     transitModel.initTimeZone(ZoneIds.HELSINKI);
     transitModel.index();
-    var alertService = new TransitAlertServiceImpl(transitModel);
     var transitService = new DefaultTransitService(transitModel) {
+      final TransitAlertService alertService = new TransitAlertServiceImpl(this);
+
       @Override
       public TransitAlertService getTransitAlertService() {
         return alertService;

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -20,8 +20,6 @@ import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.alertpatch.TransitAlertBuilder;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +65,7 @@ public class SiriAlertsUpdateHandler {
    */
   public SiriAlertsUpdateHandler(
     String feedId,
-    TransitModel transitModel,
+    TransitService transitService,
     TransitAlertService transitAlertService,
     SiriFuzzyTripMatcher siriFuzzyTripMatcher,
     Duration earlyStart
@@ -76,7 +74,6 @@ public class SiriAlertsUpdateHandler {
     this.transitAlertService = transitAlertService;
     this.earlyStart = earlyStart;
 
-    TransitService transitService = new DefaultTransitService(transitModel);
     this.affectsMapper = new AffectsMapper(feedId, siriFuzzyTripMatcher, transitService);
   }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -133,7 +133,13 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     return snapshotManager.getTimetableSnapshot();
   }
 
-  private TimetableSnapshot getTimetableSnapshotBuffer() {
+  /**
+   * @return the current timetable snapshot buffer that contains pending changes (not yet published
+   * in a snapshot).
+   * This should be used in the context of an updater to build a TransitEditorService that sees all
+   * the changes applied so far by real-time updates.
+   */
+  public TimetableSnapshot getTimetableSnapshotBuffer() {
     return snapshotManager.getTimetableSnapshotBuffer();
   }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -3,8 +3,7 @@ package org.opentripplanner.ext.siri.updater;
 import java.util.List;
 import java.util.function.Consumer;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateResult;
@@ -41,7 +40,7 @@ public class SiriETUpdater extends PollingGraphUpdater {
 
   public SiriETUpdater(
     SiriETUpdaterParameters config,
-    TransitModel transitModel,
+    TransitService transitService,
     SiriTimetableSnapshotSource timetableSnapshotSource
   ) {
     super(config);
@@ -62,7 +61,7 @@ public class SiriETUpdater extends PollingGraphUpdater {
       new EstimatedTimetableHandler(
         timetableSnapshotSource,
         config.fuzzyTripMatching(),
-        new DefaultTransitService(transitModel),
+        transitService,
         feedId
       );
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -11,8 +11,7 @@ import org.opentripplanner.framework.retry.OtpRetry;
 import org.opentripplanner.framework.retry.OtpRetryBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -45,7 +44,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   private final SiriHttpLoader siriHttpLoader;
   private final OtpRetry retry;
 
-  public SiriSXUpdater(SiriSXUpdaterParameters config, TransitModel transitModel) {
+  public SiriSXUpdater(SiriSXUpdaterParameters config, TransitService transitService) {
     super(config);
     // TODO: add options to choose different patch services
     this.url = config.url();
@@ -58,13 +57,13 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
     //Keeping original requestorRef use as base for updated requestorRef to be used in retries
     this.originalRequestorRef = requestorRef;
     this.blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
-    this.transitAlertService = new TransitAlertServiceImpl(transitModel);
+    this.transitAlertService = new TransitAlertServiceImpl(transitService);
     this.updateHandler =
       new SiriAlertsUpdateHandler(
         config.feedId(),
-        transitModel,
+        transitService,
         transitAlertService,
-        SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel)),
+        SiriFuzzyTripMatcher.of(transitService),
         config.earlyStart()
       );
     siriHttpLoader = new SiriHttpLoader(url, config.timeout(), config.requestHeaders());

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -26,8 +26,6 @@ import org.opentripplanner.ext.siri.EntityResolver;
 import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.framework.application.ApplicationShutdownSupport;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.spi.HttpHeaders;
@@ -69,7 +67,10 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
    */
   protected final int timeout;
 
-  public AbstractAzureSiriUpdater(SiriAzureUpdaterParameters config, TransitModel transitModel) {
+  public AbstractAzureSiriUpdater(
+    SiriAzureUpdaterParameters config,
+    TransitService transitService
+  ) {
     this.configRef = config.configRef();
     this.authenticationType = config.getAuthenticationType();
     this.fullyQualifiedNamespace = config.getFullyQualifiedNamespace();
@@ -80,7 +81,6 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
     this.feedId = config.feedId();
     this.autoDeleteOnIdle = config.getAutoDeleteOnIdle();
     this.prefetchCount = config.getPrefetchCount();
-    TransitService transitService = new DefaultTransitService(transitModel);
     this.entityResolver = new EntityResolver(transitService, feedId);
     this.fuzzyTripMatcher =
       config.isFuzzyTripMatching() ? SiriFuzzyTripMatcher.of(transitService) : null;

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 import javax.xml.stream.XMLStreamException;
 import org.apache.hc.core5.net.URIBuilder;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.trip.UpdateIncrementality;
@@ -40,10 +40,10 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
 
   public SiriAzureETUpdater(
     SiriAzureETUpdaterParameters config,
-    TransitModel transitModel,
+    TransitService transitService,
     SiriTimetableSnapshotSource snapshotSource
   ) {
-    super(config, transitModel);
+    super(config, transitService);
     this.fromDateTime = config.getFromDateTime();
     this.snapshotSource = snapshotSource;
     this.recordMetrics = TripUpdateMetrics.streaming(config);

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -18,7 +18,7 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.rutebanken.siri20.util.SiriXml;
 import org.slf4j.Logger;
@@ -35,15 +35,15 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
   private final LocalDate fromDateTime;
   private final LocalDate toDateTime;
 
-  public SiriAzureSXUpdater(SiriAzureSXUpdaterParameters config, TransitModel transitModel) {
-    super(config, transitModel);
+  public SiriAzureSXUpdater(SiriAzureSXUpdaterParameters config, TransitService transitService) {
+    super(config, transitService);
     this.fromDateTime = config.getFromDateTime();
     this.toDateTime = config.getToDateTime();
-    this.transitAlertService = new TransitAlertServiceImpl(transitModel);
+    this.transitAlertService = new TransitAlertServiceImpl(transitService);
     this.updateHandler =
       new SiriAlertsUpdateHandler(
         feedId,
-        transitModel,
+        transitService,
         transitAlertService,
         fuzzyTripMatcher(),
         Duration.ZERO

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/google/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/google/SiriETGooglePubsubUpdater.java
@@ -5,8 +5,7 @@ import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.ext.siri.updater.AsyncEstimatedTimetableProcessor;
 import org.opentripplanner.ext.siri.updater.AsyncEstimatedTimetableSource;
 import org.opentripplanner.ext.siri.updater.EstimatedTimetableHandler;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -27,7 +26,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
 
   public SiriETGooglePubsubUpdater(
     SiriETGooglePubsubUpdaterParameters config,
-    TransitModel transitModel,
+    TransitService transitService,
     SiriTimetableSnapshotSource timetableSnapshotSource
   ) {
     configRef = config.configRef();
@@ -46,7 +45,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
       new EstimatedTimetableHandler(
         timetableSnapshotSource,
         config.fuzzyTripMatching(),
-        new DefaultTransitService(transitModel),
+        transitService,
         config.feedId()
       );
 

--- a/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -13,7 +13,7 @@ import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.Direction;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * This is the primary implementation of TransitAlertService, which actually retains its own set
@@ -32,12 +32,12 @@ import org.opentripplanner.transit.service.TransitModel;
  */
 public class TransitAlertServiceImpl implements TransitAlertService {
 
-  private final TransitModel transitModel;
+  private final TransitService transitService;
 
   private Multimap<EntityKey, TransitAlert> alerts = HashMultimap.create();
 
-  public TransitAlertServiceImpl(TransitModel transitModel) {
-    this.transitModel = transitModel;
+  public TransitAlertServiceImpl(TransitService transitService) {
+    this.transitService = transitService;
   }
 
   @Override
@@ -85,8 +85,8 @@ public class TransitAlertServiceImpl implements TransitAlertService {
     }
     if (result.isEmpty()) {
       // Search for alerts on parent-stop
-      if (transitModel != null) {
-        var quay = transitModel.getStopModel().getRegularStop(stopId);
+      if (transitService != null) {
+        var quay = transitService.getRegularStop(stopId);
         if (quay != null) {
           // TODO - SIRI: Add alerts from parent- and multimodal-stops
           /*

--- a/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -7,8 +7,7 @@ import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.spi.HttpHeaders;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
@@ -33,15 +32,15 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
 
   public GtfsRealtimeAlertsUpdater(
     GtfsRealtimeAlertsUpdaterParameters config,
-    TransitModel transitModel
+    TransitService transitService
   ) {
     super(config);
     this.url = config.url();
     this.headers = HttpHeaders.of().acceptProtobuf().add(config.headers()).build();
-    TransitAlertService transitAlertService = new TransitAlertServiceImpl(transitModel);
+    TransitAlertService transitAlertService = new TransitAlertServiceImpl(transitService);
 
     var fuzzyTripMatcher = config.fuzzyTripMatching()
-      ? new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel))
+      ? new GtfsRealtimeFuzzyTripMatcher(transitService)
       : null;
 
     this.transitAlertService = transitAlertService;

--- a/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
@@ -17,8 +17,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.spi.UpdateResult;
@@ -66,7 +65,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
 
   public MqttGtfsRealtimeUpdater(
     MqttGtfsRealtimeUpdaterParameters parameters,
-    TransitModel transitModel,
+    TransitService transitService,
     TimetableSnapshotSource snapshotSource
   ) {
     this.configRef = parameters.configRef();
@@ -78,8 +77,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
     this.snapshotSource = snapshotSource;
     // Set properties of realtime data snapshot source
     if (parameters.getFuzzyTripMatching()) {
-      this.fuzzyTripMatcher =
-        new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
+      this.fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(transitService);
     }
     this.recordMetrics = TripUpdateMetrics.streaming(parameters);
     LOG.info("Creating streaming GTFS-RT TripUpdate updater subscribing to MQTT broker at {}", url);

--- a/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdater.java
@@ -4,8 +4,7 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.util.List;
 import java.util.function.Consumer;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.UpdateResult;
@@ -47,7 +46,7 @@ public class PollingTripUpdater extends PollingGraphUpdater {
 
   public PollingTripUpdater(
     PollingTripUpdaterParameters parameters,
-    TransitModel transitModel,
+    TransitService transitService,
     TimetableSnapshotSource snapshotSource
   ) {
     super(parameters);
@@ -57,8 +56,7 @@ public class PollingTripUpdater extends PollingGraphUpdater {
     this.backwardsDelayPropagationType = parameters.backwardsDelayPropagationType();
     this.snapshotSource = snapshotSource;
     if (parameters.fuzzyTripMatching()) {
-      this.fuzzyTripMatcher =
-        new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
+      this.fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(transitService);
     }
 
     this.recordMetrics = BatchTripUpdateMetrics.batch(parameters);

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -333,6 +333,16 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     return snapshotManager.getTimetableSnapshot();
   }
 
+  /**
+   * @return the current timetable snapshot buffer that contains pending changes (not yet published
+   * in a snapshot).
+   * This should be used in the context of an updater to build a TransitEditorService that sees all
+   * the changes applied so far by real-time updates.
+   */
+  public TimetableSnapshot getTimetableSnapshotBuffer() {
+    return snapshotManager.getTimetableSnapshotBuffer();
+  }
+
   private static void logUpdateResult(
     String feedId,
     Map<ScheduleRelationship, Integer> failuresByRelationship,

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -39,6 +39,7 @@ import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.TimetableSnapshotSourceParameters;
@@ -214,7 +215,7 @@ public abstract class GtfsTest {
           .withMaxSnapshotFrequency(Duration.ZERO),
         transitModel
       );
-    alertPatchServiceImpl = new TransitAlertServiceImpl(transitModel);
+    alertPatchServiceImpl = new TransitAlertServiceImpl(new DefaultTransitService(transitModel));
     alertsUpdateHandler.setTransitAlertService(alertPatchServiceImpl);
     alertsUpdateHandler.setFeedId(feedId.getId());
 

--- a/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -198,7 +198,7 @@ class GraphQLIntegrationTest {
 
     var busRoute = routes.stream().filter(r -> r.getMode().equals(BUS)).findFirst().get();
     TransitEditorService transitService = new DefaultTransitService(transitModel) {
-      private final TransitAlertService alertService = new TransitAlertServiceImpl(transitModel);
+      private final TransitAlertService alertService = new TransitAlertServiceImpl(this);
 
       @Override
       public List<TransitMode> getModesOfStopLocation(StopLocation stop) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/TransitAlertFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/TransitAlertFilterTest.java
@@ -12,6 +12,7 @@ import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 
 class TransitAlertFilterTest implements PlanTestConstants {
@@ -20,7 +21,9 @@ class TransitAlertFilterTest implements PlanTestConstants {
 
   @Test
   void testFilter() {
-    var transitAlertService = new TransitAlertServiceImpl(new TransitModel());
+    var transitAlertService = new TransitAlertServiceImpl(
+      new DefaultTransitService(new TransitModel())
+    );
     transitAlertService.setAlerts(
       List.of(
         TransitAlert

--- a/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
+++ b/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
@@ -25,13 +25,16 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 
 public class AlertsUpdateHandlerTest {
 
   private AlertsUpdateHandler handler;
 
-  private final TransitAlertService service = new TransitAlertServiceImpl(new TransitModel());
+  private final TransitAlertService service = new TransitAlertServiceImpl(
+    new DefaultTransitService(new TransitModel())
+  );
 
   @BeforeEach
   public void setUp() {


### PR DESCRIPTION
### Summary
Real-time updaters use instances of `TransitService` to look up transit data. Currently these instances are created at construction time.
This is problematic since `TransitService` instances maintain a reference to a frozen version of the `TimetableSnapshot` that is not updated after construction.
As of today this does not cause any issue, since the real-time updaters update directly the collections in `TransitModelIndex`, and the `TransitService` looks up data in `TransitModelIndex`.

However #6007 changes this behavior by storing the real-time updates in indexes in `TimetableSnapshot`, making previous real-time updates invisible from the real-time updaters.
Among other regressions, this prevents the `EntityResolver` from identifying already created extra journeys, and leads to the creation of duplicated trips.

This PR refactors the real-time updaters so that they use `TransitService` instances that refer to the `TimetableSnapshot` buffer, thus giving access to all applied real-time updates (including uncommitted ones).

This PR is a prerequisite for #6007

**Note**: the refactoring consists in:
* Modifying the constructors of the real-time updaters so that they accept a `TransitService` instead of a `TransitModel`.
* Modifying `UpdaterConfigurator` so that it injects in the updaters a  `TransitService` that points to the TimetableSnapshot buffer.

**Note**: This design is fragile, since there is no way to guarantee that the `TransitService` that points to the buffer will be used only from the GraphWriter thread (this is however the case in this PR) . Ideally this should be enforced. The fact that the `SiriFuzzyTripMatcher` is initialized statically makes things more difficult.

### Issue
No

### Unit tests
Added unit test.
Updated unit tests

### Documentation

No
