### PR TITLE
Rental vehicle map layer should show vehicle availability

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/VehicleRentalLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/VehicleRentalLayerTest.java
@@ -38,6 +38,7 @@ public class VehicleRentalLayerTest {
     assertEquals("A:B", map.get("id"));
     assertEquals("BICYCLE", map.get("formFactor"));
     assertEquals("A", map.get("network"));
+    assertEquals(true, map.get("pickupAllowed"));
     assertNull(map.get("name"));
   }
 

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/DigitransitRentalVehiclePropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/DigitransitRentalVehiclePropertyMapper.java
@@ -15,6 +15,7 @@ public class DigitransitRentalVehiclePropertyMapper extends PropertyMapper<Vehic
     var items = new ArrayList<KeyValue>();
     items.addAll(getFeedScopedIdAndNetwork(place));
     items.add(new KeyValue("formFactor", place.vehicleType.formFactor.toString()));
+    items.add(new KeyValue("isAllowPickup", place.isAllowPickup()));
     return items;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/DigitransitRentalVehiclePropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/DigitransitRentalVehiclePropertyMapper.java
@@ -15,7 +15,7 @@ public class DigitransitRentalVehiclePropertyMapper extends PropertyMapper<Vehic
     var items = new ArrayList<KeyValue>();
     items.addAll(getFeedScopedIdAndNetwork(place));
     items.add(new KeyValue("formFactor", place.vehicleType.formFactor.toString()));
-    items.add(new KeyValue("isAllowPickup", place.isAllowPickup()));
+    items.add(new KeyValue("pickupAllowed", place.isAllowPickup()));
     return items;
   }
 }


### PR DESCRIPTION
### Summary

Added isAllowPickup value to rental vehicle map layer return values as a user might not want to see disabled vehicles on map.

### Issue
Disabled vehicles are shown on the map with no way to distinguish them from the available ones.

### Tests
Added the new value to VehicleRentalLayerTest.