### PR TITLE
Add an option to hardcode TileJSON tiles URL by providing a header in requests

### DIFF
--- a/doc-templates/sandbox/MapboxVectorTilesApi.md
+++ b/doc-templates/sandbox/MapboxVectorTilesApi.md
@@ -220,3 +220,4 @@ key, and a function to create the mapper, with a `Graph` object as a parameter, 
 - 2024-01-22: Make `basePath` configurable [#5627](https://github.com/opentripplanner/OpenTripPlanner/pull/5627)
 - 2024-02-27: Add layer for flex zones [#5704](https://github.com/opentripplanner/OpenTripPlanner/pull/5704)
 - 2024-03-25: Add layer for realtime stops [#5743](https://github.com/opentripplanner/OpenTripPlanner/pull/5743)
+- 2024-08-26: Add support for hardcoding tilejson tiles URL in requests [#6021](https://github.com/opentripplanner/OpenTripPlanner/pull/6021)

--- a/doc-templates/sandbox/MapboxVectorTilesApi.md
+++ b/doc-templates/sandbox/MapboxVectorTilesApi.md
@@ -164,6 +164,13 @@ For each layer, the configuration includes:
 
 <!-- INSERT: parameters -->
 
+### Configuring tilejson tiles URL
+
+Sometimes the requests to OTP come through a proxy which rewrites the request's host and/or path.
+Therefore, the tiles endpoint url in the TileJSON file can be configured to not just be derived from
+the request's URL seen by OTP by either configuring `basePath` in the router-config.json or by sending
+in a hardcoded URL in `X-OTP-Tilejson-Url` header in the requests which fetch the TileJSON file.
+
 ### Extending
 
 If more generic layers are created for this API, the code should be moved out from the sandbox, into 

--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -259,6 +259,13 @@ Currently `Digitransit` is supported for all layer types.
 
 <!-- parameters END -->
 
+### Configuring tilejson tiles URL
+
+Sometimes the requests to OTP come through a proxy which rewrites the request's host and/or path.
+Therefore, the tiles endpoint url in the TileJSON file can be configured to not just be derived from
+the request's URL seen by OTP by either configuring `basePath` in the router-config.json or by sending
+in a hardcoded URL in `X-OTP-Tilejson-Url` header in the requests which fetch the TileJSON file.
+
 ### Extending
 
 If more generic layers are created for this API, the code should be moved out from the sandbox, into 

--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -315,3 +315,4 @@ key, and a function to create the mapper, with a `Graph` object as a parameter, 
 - 2024-01-22: Make `basePath` configurable [#5627](https://github.com/opentripplanner/OpenTripPlanner/pull/5627)
 - 2024-02-27: Add layer for flex zones [#5704](https://github.com/opentripplanner/OpenTripPlanner/pull/5704)
 - 2024-03-25: Add layer for realtime stops [#5743](https://github.com/opentripplanner/OpenTripPlanner/pull/5743)
+- 2024-08-26: Add support for hardcoding tilejson tiles URL in requests [#6021](https://github.com/opentripplanner/OpenTripPlanner/pull/6021)

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
@@ -28,4 +28,25 @@ class VectorTilesResourceTest {
       tileJson.tiles[0]
     );
   }
+
+  @Test
+  void tileJsonWithHardcodedUrl() {
+    // the Grizzly request is awful to instantiate, using Mockito
+    var grizzlyRequest = Mockito.mock(Request.class);
+    var resource = new VectorTilesResource(
+      TestServerContext.createServerContext(new Graph(), new TransitModel()),
+      grizzlyRequest,
+      "default"
+    );
+    var req = HttpForTest.containerRequest();
+    req.header(
+      "X-OTP-Tilejson-Url",
+      "https://example.com/vectorTiles/layer1,layer2/{z}/{x}/{y}.pbf"
+    );
+    var tileJson = resource.getTileJson(req.getUriInfo(), req, "layer1,layer2");
+    assertEquals(
+      "https://example.com/vectorTiles/layer1,layer2/{z}/{x}/{y}.pbf",
+      tileJson.tiles[0]
+    );
+  }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -86,15 +86,19 @@ public class VectorTilesResource {
 
     List<String> rLayers = Arrays.asList(requestedLayers.split(","));
 
-    var url = serverContext
-      .vectorTileConfig()
-      .basePath()
-      .map(overrideBasePath ->
-        TileJson.urlFromOverriddenBasePath(uri, headers, overrideBasePath, rLayers)
-      )
-      .orElseGet(() ->
-        TileJson.urlWithDefaultPath(uri, headers, rLayers, ignoreRouterId, "vectorTiles")
-      );
+    var hardcodedUrl = headers.getHeaderString("X-OTP-Tilejson-Url");
+
+    var url = hardcodedUrl != null
+      ? hardcodedUrl
+      : serverContext
+        .vectorTileConfig()
+        .basePath()
+        .map(overrideBasePath ->
+          TileJson.urlFromOverriddenBasePath(uri, headers, overrideBasePath, rLayers)
+        )
+        .orElseGet(() ->
+          TileJson.urlWithDefaultPath(uri, headers, rLayers, ignoreRouterId, "vectorTiles")
+        );
 
     return serverContext
       .vectorTileConfig()


### PR DESCRIPTION
### Summary

The request URL that OTP knows differs in many ways from what the users use through the Digitransit APIs. Therefore, we need to control the tiles URL in the TileJSON file on a request basis through a header. This PR introduces `X-OTP-Tilejson-Url` to achieve that.

### Issue

Minor sandbox addition, no issue.

### Unit tests

Added tests.

### Documentation

Updated documentation.

### Changelog

Sandbox changelog will be updated.
