### PR TITLE
Add wheelchairAccessibility enabled true to docs

### DIFF
--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -29,6 +29,7 @@ If you want to allow trips and stops of unknown wheelchair-accessibility then ad
 {
   "routingDefaults": {
     "wheelchairAccessibility": {
+      "enabled": true,
       "trip": {
         "onlyConsiderAccessible": false,
         "unknownCost": 600,

--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -1255,6 +1255,7 @@ include stairs as a last result.
       "extraStopBoardAlightCostsFactor" : 8.0
     },
     "wheelchairAccessibility" : {
+      "enabled": true,
       "trip" : {
         "onlyConsiderAccessible" : false,
         "unknownCost" : 600,


### PR DESCRIPTION
### Summary

The example `wheelchairAccessibility` configs don't include `"enabled": true`, which is required for any other `wheelchairAccessibility` configurations to work. The docs are misleading without it as anyone copying them won't have wheelchair accessibility enabled.