### PR TITLE
Adding route type 8 for GTFS mapping

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
@@ -70,6 +70,7 @@ public class TransitModeMapper {
       case 5 -> TransitMode.CABLE_CAR;
       case 6 -> TransitMode.GONDOLA;
       case 7 -> TransitMode.FUNICULAR;
+      case 8 -> TransitMode.AIRPLANE;
       case 11 -> TransitMode.TROLLEYBUS;
       case 12 -> TransitMode.MONORAIL;
       default -> throw new IllegalArgumentException("unknown gtfs route type " + routeType);


### PR DESCRIPTION
### Summary

Some GTFS use route type 8 for air planes (example with **KorriGo company** and the **Finist'Air** route : https://www.korrigo.bzh/ftp/OPENDATA/KORRIGOBRET.gtfs.zip)

![image](https://github.com/user-attachments/assets/7ecadd5c-74e0-4a69-aaef-2dfdda90743e)
### Issue

Currently, the route type is not recognized and cause a `java.lang.IllegalArgumentException` when we try to build the `graph.org` file.
```
01:48:28.503 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.Vehicle
01:48:28.506 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.Facility
01:48:28.509 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.FacilityPropertyDefinition
01:48:28.510 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.FacilityProperty
01:48:28.513 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.RouteNameException
01:48:28.520 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.DirectionNameException
01:48:28.523 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.WrongWayConcurrency
01:48:28.524 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.DirectionEntry
01:48:28.525 INFO [main]  (GtfsModule.java:327) Reading entity: org.onebusaway.gtfs.model.AlternateStopNameException
01:48:29.350 ERROR [main]  (OTPMain.java:60) An uncaught error occurred inside OTP: unknown gtfs route type 8
java.lang.IllegalArgumentException: unknown gtfs route type 8
        at org.opentripplanner.gtfs.mapping.TransitModeMapper.mapMode(TransitModeMapper.java:75)
        at org.opentripplanner.gtfs.mapping.RouteMapper.doMap(RouteMapper.java:67)
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1228)
        at org.opentripplanner.gtfs.mapping.RouteMapper.map(RouteMapper.java:43)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1787)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at org.opentripplanner.framework.collection.MapUtils.mapToList(MapUtils.java:32)
        at org.opentripplanner.gtfs.mapping.RouteMapper.map(RouteMapper.java:38)
        at org.opentripplanner.gtfs.mapping.GTFSToOtpTransitServiceMapper.mapStopTripAndRouteDataIntoBuilder(GTFSToOtpTransitServiceMapper.java:158)
        at org.opentripplanner.gtfs.graphbuilder.GtfsModule.buildGraph(GtfsModule.java:142)
        at org.opentripplanner.graph_builder.GraphBuilder.run(GraphBuilder.java:194)
        at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:141)
        at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:55)
01:48:29.381 INFO [server-shutdown-info]  (OtpStartupInfo.java:43) OTP SHUTTING DOWN (version: 2.5.0, ser.ver.id: 148, commit: b301ea7c70f2ce7bb22c7f8e7fba6f8654cea3a5, branch: master)
```
Changes only apply for this GTFS thought, I haven't found any yet that can represent that issue, the French government GTFS validator tools also doesn't recognize it (https://transport.data.gouv.fr/validation/264103?issue_type=InvalidRouteType&token=5de99fd5-1fb8-4a0c-b9ee-08b458bba59b#issues)

![image](https://github.com/user-attachments/assets/fc3ef0cd-a7d5-4e1c-a15b-1eb49a15bb3a)

But considering that these switch conditions are "original", it shouldn't be a problem for OpenTripPlanner to use this route type.
