### PR TITLE
Introduce RealtimeUpdateContext

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
@@ -176,8 +176,9 @@ class RealtimeResolverTest {
     transitModel.updateCalendarServiceData(true, calendarServiceData, DataImportIssueStore.NOOP);
     transitModel.index();
 
-    var alertService = new TransitAlertServiceImpl(transitModel);
     return new DefaultTransitService(transitModel) {
+      final TransitAlertService alertService = new TransitAlertServiceImpl(transitModel);
+
       @Override
       public TransitAlertService getTransitAlertService() {
         return alertService;

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -65,8 +65,9 @@ public class RealtimeStopsLayerTest {
     var transitModel = new TransitModel(new StopModel(), deduplicator);
     transitModel.initTimeZone(ZoneIds.HELSINKI);
     transitModel.index();
-    var alertService = new TransitAlertServiceImpl(transitModel);
     var transitService = new DefaultTransitService(transitModel) {
+      final TransitAlertService alertService = new TransitAlertServiceImpl(transitModel);
+
       @Override
       public TransitAlertService getTransitAlertService() {
         return alertService;

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -133,7 +133,13 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     return snapshotManager.getTimetableSnapshot();
   }
 
-  private TimetableSnapshot getTimetableSnapshotBuffer() {
+  /**
+   * @return the current timetable snapshot buffer that contains pending changes (not yet published
+   * in a snapshot).
+   * This should be used in the context of an updater to build a TransitEditorService that sees all
+   * the changes applied so far by real-time updates.
+   */
+  public TimetableSnapshot getTimetableSnapshotBuffer() {
     return snapshotManager.getTimetableSnapshotBuffer();
   }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/AsyncEstimatedTimetableProcessor.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/AsyncEstimatedTimetableProcessor.java
@@ -33,11 +33,12 @@ public class AsyncEstimatedTimetableProcessor {
    * @return a future indicating when the changes are applied.
    */
   public Future<?> processSiriData(ServiceDelivery serviceDelivery) {
-    return saveResultOnGraph.execute((graph, transitModel) ->
+    return saveResultOnGraph.execute(context ->
       updateResultConsumer.accept(
         estimatedTimetableHandler.applyUpdate(
           serviceDelivery.getEstimatedTimetableDeliveries(),
-          UpdateIncrementality.DIFFERENTIAL
+          UpdateIncrementality.DIFFERENTIAL,
+          context
         )
       )
     );

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -16,7 +16,6 @@ import java.util.function.Consumer;
 import javax.xml.stream.XMLStreamException;
 import org.apache.hc.core5.net.URIBuilder;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.spi.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.trip.UpdateIncrementality;
@@ -40,10 +39,9 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
 
   public SiriAzureETUpdater(
     SiriAzureETUpdaterParameters config,
-    TransitModel transitModel,
     SiriTimetableSnapshotSource snapshotSource
   ) {
-    super(config, transitModel);
+    super(config);
     this.fromDateTime = config.getFromDateTime();
     this.snapshotSource = snapshotSource;
     this.recordMetrics = TripUpdateMetrics.streaming(config);
@@ -98,10 +96,10 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
   }
 
   private Future<?> processMessage(List<EstimatedTimetableDeliveryStructure> updates) {
-    return super.saveResultOnGraph.execute((graph, transitModel) -> {
+    return super.saveResultOnGraph.execute(context -> {
       var result = snapshotSource.applyEstimatedTimetable(
-        fuzzyTripMatcher(),
-        entityResolver(),
+        fuzzyTripMatching() ? context.siriFuzzyTripMatcher() : null,
+        context.entityResolver(feedId),
         feedId,
         UpdateIncrementality.DIFFERENTIAL,
         updates

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -36,18 +36,11 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
   private final LocalDate toDateTime;
 
   public SiriAzureSXUpdater(SiriAzureSXUpdaterParameters config, TransitModel transitModel) {
-    super(config, transitModel);
+    super(config);
     this.fromDateTime = config.getFromDateTime();
     this.toDateTime = config.getToDateTime();
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
-    this.updateHandler =
-      new SiriAlertsUpdateHandler(
-        feedId,
-        transitModel,
-        transitAlertService,
-        fuzzyTripMatcher(),
-        Duration.ZERO
-      );
+    this.updateHandler = new SiriAlertsUpdateHandler(feedId, transitAlertService, Duration.ZERO);
   }
 
   @Override
@@ -123,7 +116,7 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
   }
 
   private Future<?> processMessage(ServiceDelivery siriSx) {
-    return super.saveResultOnGraph.execute((graph, transitModel) -> updateHandler.update(siriSx));
+    return super.saveResultOnGraph.execute(context -> updateHandler.update(siriSx, context));
   }
 
   private void processHistory(ServiceDelivery siri) {

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/google/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/google/SiriETGooglePubsubUpdater.java
@@ -5,8 +5,6 @@ import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.ext.siri.updater.AsyncEstimatedTimetableProcessor;
 import org.opentripplanner.ext.siri.updater.AsyncEstimatedTimetableSource;
 import org.opentripplanner.ext.siri.updater.EstimatedTimetableHandler;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -27,7 +25,6 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
 
   public SiriETGooglePubsubUpdater(
     SiriETGooglePubsubUpdaterParameters config,
-    TransitModel transitModel,
     SiriTimetableSnapshotSource timetableSnapshotSource
   ) {
     configRef = config.configRef();
@@ -46,7 +43,6 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
       new EstimatedTimetableHandler(
         timetableSnapshotSource,
         config.fuzzyTripMatching(),
-        new DefaultTransitService(transitModel),
         config.feedId()
       );
 

--- a/src/main/java/org/opentripplanner/updater/DefaultRealTimeUpdateContext.java
+++ b/src/main/java/org/opentripplanner/updater/DefaultRealTimeUpdateContext.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.updater;
+
+import org.opentripplanner.ext.siri.EntityResolver;
+import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
+import org.opentripplanner.model.TimetableSnapshot;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitService;
+
+public class DefaultRealTimeUpdateContext implements RealTimeUpdateContext {
+
+  private final Graph graph;
+  private final TransitService transitService;
+  private SiriFuzzyTripMatcher siriFuzzyTripMatcher;
+
+  public DefaultRealTimeUpdateContext(
+    Graph graph,
+    TransitModel transitModel,
+    TimetableSnapshot timetableSnapshotBuffer
+  ) {
+    this.graph = graph;
+    this.transitService = new DefaultTransitService(transitModel, timetableSnapshotBuffer);
+  }
+
+  /**
+   * Constructor for unit tests only.
+   */
+  public DefaultRealTimeUpdateContext(Graph graph, TransitModel transitModel) {
+    this(graph, transitModel, null);
+  }
+
+  @Override
+  public Graph graph() {
+    return graph;
+  }
+
+  @Override
+  public TransitService transitService() {
+    return transitService;
+  }
+
+  @Override
+  public synchronized SiriFuzzyTripMatcher siriFuzzyTripMatcher() {
+    if (siriFuzzyTripMatcher == null) {
+      siriFuzzyTripMatcher = new SiriFuzzyTripMatcher(transitService);
+    }
+    return siriFuzzyTripMatcher;
+  }
+
+  @Override
+  public GtfsRealtimeFuzzyTripMatcher gtfsRealtimeFuzzyTripMatcher() {
+    return new GtfsRealtimeFuzzyTripMatcher(transitService);
+  }
+
+  @Override
+  public EntityResolver entityResolver(String feedId) {
+    return new EntityResolver(transitService, feedId);
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/GraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/GraphWriterRunnable.java
@@ -1,8 +1,5 @@
 package org.opentripplanner.updater;
 
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.transit.service.TransitModel;
-
 /**
  * The graph should only be modified by a runnable implementing this interface, executed by the
  * GraphUpdaterManager. A few notes: - Don't spend more time in this runnable than necessary, it
@@ -16,5 +13,5 @@ public interface GraphWriterRunnable {
   /**
    * This function is executed to modify the graph.
    */
-  void run(Graph graph, TransitModel transitModel);
+  void run(RealTimeUpdateContext context);
 }

--- a/src/main/java/org/opentripplanner/updater/RealTimeUpdateContext.java
+++ b/src/main/java/org/opentripplanner/updater/RealTimeUpdateContext.java
@@ -1,0 +1,45 @@
+package org.opentripplanner.updater;
+
+import org.opentripplanner.ext.siri.EntityResolver;
+import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitService;
+
+/**
+ * Give access to the transit data and street model in the context of a real-time updater.
+ * The services exposed should be used only from the GraphWriter thread.
+ */
+public interface RealTimeUpdateContext {
+  /**
+   * Return the street model (graph).
+   */
+  Graph graph();
+
+  /**
+   * Return a transit service that can look up both scheduled and real-time data.
+   * The transit service has access to all real-time updates applied so far,
+   * including those not yet committed in a published snapshot.
+   */
+  TransitService transitService();
+
+  /**
+   * Return a SIRI fuzzy trip matcher that can look up both scheduled and real-time data.
+   * The SIRI fuzzy trip matcher has access to all real-time updates applied so far,
+   * including those not yet committed in a published snapshot.
+   */
+  SiriFuzzyTripMatcher siriFuzzyTripMatcher();
+
+  /**
+   * Return a GTFS-RT fuzzy trip matcher that can look up both scheduled and real-time data.
+   * The GTFS-RT fuzzy trip matcher has access to all real-time updates applied so far,
+   * including those not yet committed in a published snapshot.
+   */
+  GtfsRealtimeFuzzyTripMatcher gtfsRealtimeFuzzyTripMatcher();
+
+  /**
+   * Return an entity resolver that can look up both scheduled and real-time data.
+   * The entity resolver has access to all real-time updates applied so far,
+   * including those not yet committed in a published snapshot.
+   */
+  EntityResolver entityResolver(String feedId);
+}

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -333,6 +333,16 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     return snapshotManager.getTimetableSnapshot();
   }
 
+  /**
+   * @return the current timetable snapshot buffer that contains pending changes (not yet published
+   * in a snapshot).
+   * This should be used in the context of an updater to build a TransitEditorService that sees all
+   * the changes applied so far by real-time updates.
+   */
+  public TimetableSnapshot getTimetableSnapshotBuffer() {
+    return snapshotManager.getTimetableSnapshotBuffer();
+  }
+
   private static void logUpdateResult(
     String feedId,
     Map<ScheduleRelationship, Integer> failuresByRelationship,

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -335,9 +335,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
   /**
    * @return the current timetable snapshot buffer that contains pending changes (not yet published
-   * in a snapshot).
-   * This should be used in the context of an updater to build a TransitEditorService that sees all
-   * the changes applied so far by real-time updates.
+   * in a snapshot). This should be used in the context of an updater to build  a TransitEditorService
+   * that sees all the changes applied so far by real-time updates.
    */
   public TimetableSnapshot getTimetableSnapshotBuffer() {
     return snapshotManager.getTimetableSnapshotBuffer();

--- a/src/main/java/org/opentripplanner/updater/trip/TripUpdateGraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TripUpdateGraphWriterRunnable.java
@@ -4,10 +4,8 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
-import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
+import org.opentripplanner.updater.RealTimeUpdateContext;
 import org.opentripplanner.updater.spi.UpdateResult;
 
 class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
@@ -19,7 +17,7 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
    */
   private final List<TripUpdate> updates;
 
-  private final GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
+  private final boolean fuzzyTripMatching;
 
   private final BackwardsDelayPropagationType backwardsDelayPropagationType;
 
@@ -29,7 +27,7 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
 
   TripUpdateGraphWriterRunnable(
     TimetableSnapshotSource snapshotSource,
-    GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
+    boolean fuzzyTripMatching,
     BackwardsDelayPropagationType backwardsDelayPropagationType,
     UpdateIncrementality updateIncrementality,
     List<TripUpdate> updates,
@@ -37,7 +35,7 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
     Consumer<UpdateResult> sendMetrics
   ) {
     this.snapshotSource = snapshotSource;
-    this.fuzzyTripMatcher = fuzzyTripMatcher;
+    this.fuzzyTripMatching = fuzzyTripMatching;
     this.backwardsDelayPropagationType = backwardsDelayPropagationType;
     this.updateIncrementality = updateIncrementality;
     this.updates = Objects.requireNonNull(updates);
@@ -46,9 +44,9 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
   }
 
   @Override
-  public void run(Graph graph, TransitModel transitModel) {
+  public void run(RealTimeUpdateContext context) {
     var result = snapshotSource.applyTripUpdates(
-      fuzzyTripMatcher,
+      fuzzyTripMatching ? context.gtfsRealtimeFuzzyTripMatcher() : null,
       backwardsDelayPropagationType,
       updateIncrementality,
       updates,

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
@@ -5,13 +5,12 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.RealTimeUpdateContext;
 import org.opentripplanner.updater.spi.DataSource;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -73,7 +72,7 @@ public class VehicleParkingAvailabilityUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void run(Graph graph, TransitModel ignored) {
+    public void run(RealTimeUpdateContext context) {
       updates.forEach(this::handleUpdate);
     }
 

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
@@ -23,8 +23,8 @@ import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.RealTimeUpdateContext;
 import org.opentripplanner.updater.spi.DataSource;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -98,14 +98,14 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void run(Graph graph, TransitModel transitModel) {
+    public void run(RealTimeUpdateContext context) {
       // Apply stations to graph
       /* Add any new park and update space available for existing parks */
       Set<VehicleParking> toAdd = new HashSet<>();
       Set<VehicleParking> toLink = new HashSet<>();
       Set<VehicleParking> toRemove = new HashSet<>();
 
-      var vehicleParkingHelper = new VehicleParkingHelper(graph);
+      var vehicleParkingHelper = new VehicleParkingHelper(context.graph());
 
       for (VehicleParking updatedVehicleParking : updatedVehicleParkings) {
         var operational = updatedVehicleParking.getState().equals(VehicleParkingState.OPERATIONAL);
@@ -133,7 +133,7 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
           tempEdgesByPark.get(oldVehicleParking).forEach(DisposableEdgeCollection::disposeEdges);
           verticesByPark
             .get(oldVehicleParking)
-            .forEach(v -> removeVehicleParkingEdgesFromGraph(v, graph));
+            .forEach(v -> removeVehicleParkingEdgesFromGraph(v, context.graph()));
           verticesByPark.remove(oldVehicleParking);
         }
 

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionUpdaterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionUpdaterRunnable.java
@@ -3,22 +3,46 @@ package org.opentripplanner.updater.vehicle_position;
 import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
 import java.util.List;
 import java.util.Objects;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.transit.service.TransitModel;
+import java.util.Set;
+import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
+import org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig;
 import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.RealTimeUpdateContext;
 
-public record VehiclePositionUpdaterRunnable(
-  List<VehiclePosition> updates,
-  RealtimeVehiclePatternMatcher matcher
-)
-  implements GraphWriterRunnable {
-  public VehiclePositionUpdaterRunnable {
-    Objects.requireNonNull(updates);
-    Objects.requireNonNull(matcher);
+public class VehiclePositionUpdaterRunnable implements GraphWriterRunnable {
+
+  private final List<VehiclePosition> updates;
+  private final RealtimeVehicleRepository realtimeVehicleRepository;
+  private final String feedId;
+  private final boolean fuzzyTripMatching;
+  private final Set<VehiclePositionsUpdaterConfig.VehiclePositionFeature> vehiclePositionFeatures;
+
+  public VehiclePositionUpdaterRunnable(
+    RealtimeVehicleRepository realtimeVehicleRepository,
+    Set<VehiclePositionsUpdaterConfig.VehiclePositionFeature> vehiclePositionFeatures,
+    String feedId,
+    boolean fuzzyTripMatching,
+    List<VehiclePosition> updates
+  ) {
+    this.updates = Objects.requireNonNull(updates);
+    this.feedId = feedId;
+    this.realtimeVehicleRepository = realtimeVehicleRepository;
+    this.fuzzyTripMatching = fuzzyTripMatching;
+    this.vehiclePositionFeatures = vehiclePositionFeatures;
   }
 
   @Override
-  public void run(Graph graph, TransitModel transitModel) {
+  public void run(RealTimeUpdateContext context) {
+    RealtimeVehiclePatternMatcher matcher = new RealtimeVehiclePatternMatcher(
+      feedId,
+      context.transitService()::getTripForId,
+      context.transitService()::getPatternForTrip,
+      context.transitService()::getPatternForTrip,
+      realtimeVehicleRepository,
+      context.transitService().getTimeZone(),
+      fuzzyTripMatching ? context.gtfsRealtimeFuzzyTripMatcher() : null,
+      vehiclePositionFeatures
+    );
     // Apply new vehicle positions
     matcher.applyRealtimeVehicleUpdates(updates);
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -15,7 +15,6 @@ import org.opentripplanner.framework.logging.Throttle;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.framework.time.TimeUtils;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.linking.DisposableEdgeCollection;
 import org.opentripplanner.routing.linking.LinkingDirection;
 import org.opentripplanner.routing.linking.VertexLinker;
@@ -32,8 +31,8 @@ import org.opentripplanner.street.model.vertex.VertexFactory;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.RealTimeUpdateContext;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.UpdaterConstructionException;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -156,10 +155,10 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void run(Graph graph, TransitModel transitModel) {
+    public void run(RealTimeUpdateContext context) {
       // Apply stations to graph
       Set<FeedScopedId> stationSet = new HashSet<>();
-      var vertexFactory = new VertexFactory(graph);
+      var vertexFactory = new VertexFactory(context.graph());
 
       /* add any new stations and update vehicle counts for existing stations */
       for (VehicleRentalPlace station : stations) {
@@ -239,7 +238,9 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
         latestModifiedEdges.forEach(StreetEdge::removeRentalExtension);
 
-        var updater = new GeofencingVertexUpdater(graph.getStreetIndex()::getEdgesForEnvelope);
+        var updater = new GeofencingVertexUpdater(
+          context.graph().getStreetIndex()::getEdgesForEnvelope
+        );
         latestModifiedEdges = updater.applyGeofencingZones(geofencingZones);
         latestAppliedGeofencingZones = geofencingZones;
 

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -191,7 +191,7 @@ public abstract class GtfsTest {
     gtfsBundle.setFeedId(feedId);
     List<GtfsBundle> gtfsBundleList = Collections.singletonList(gtfsBundle);
 
-    alertsUpdateHandler = new AlertsUpdateHandler();
+    alertsUpdateHandler = new AlertsUpdateHandler(false);
     var deduplicator = new Deduplicator();
     graph = new Graph(deduplicator);
     transitModel = new TransitModel(new StopModel(), deduplicator);
@@ -234,7 +234,7 @@ public abstract class GtfsTest {
         feedId.getId()
       );
       timetableSnapshotSource.flushBuffer();
-      alertsUpdateHandler.update(feedMessage);
+      alertsUpdateHandler.update(feedMessage, null);
     } catch (Exception exception) {}
   }
 }

--- a/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
+++ b/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
@@ -35,7 +35,7 @@ public class AlertsUpdateHandlerTest {
 
   @BeforeEach
   public void setUp() {
-    handler = new AlertsUpdateHandler();
+    handler = new AlertsUpdateHandler(false);
     handler.setFeedId("1");
     handler.setEarlyStart(5);
     handler.setTransitAlertService(service);
@@ -531,7 +531,7 @@ public class AlertsUpdateHandlerTest {
       .setHeader(GtfsRealtime.FeedHeader.newBuilder().setGtfsRealtimeVersion("2.0"))
       .addEntity(GtfsRealtime.FeedEntity.newBuilder().setAlert(alert).setId("1"))
       .build();
-    handler.update(message);
+    handler.update(message, null);
     Collection<TransitAlert> alerts = service.getAllAlerts();
     assertEquals(1, alerts.size());
     return alerts.iterator().next();

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
@@ -18,6 +18,7 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 import org.opentripplanner.standalone.config.routerconfig.updaters.VehicleParkingUpdaterConfig;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.DefaultRealTimeUpdateContext;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.spi.DataSource;
@@ -118,14 +119,18 @@ class VehicleParkingAvailabilityUpdaterTest {
 
       private static final Graph GRAPH = new Graph();
       private static final TransitModel TRANSIT_MODEL = new TransitModel();
+      public static final DefaultRealTimeUpdateContext REAL_TIME_UPDATE_CONTEXT = new DefaultRealTimeUpdateContext(
+        GRAPH,
+        TRANSIT_MODEL
+      );
 
       public GraphUpdaterMock(List<GraphUpdater> updaters) {
-        super(GRAPH, TRANSIT_MODEL, updaters);
+        super(REAL_TIME_UPDATE_CONTEXT, updaters);
       }
 
       @Override
       public Future<?> execute(GraphWriterRunnable runnable) {
-        runnable.run(GRAPH, TRANSIT_MODEL);
+        runnable.run(REAL_TIME_UPDATE_CONTEXT);
         return Futures.immediateVoidFuture();
       }
     }

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -21,6 +21,7 @@ import org.opentripplanner.street.model.edge.StreetVehicleParkingLink;
 import org.opentripplanner.street.model.edge.VehicleParkingEdge;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.DefaultRealTimeUpdateContext;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.spi.DataSource;
@@ -30,8 +31,9 @@ class VehicleParkingUpdaterTest {
 
   private DataSource<VehicleParking> dataSource;
   private Graph graph;
-
   private TransitModel transitModel;
+  private DefaultRealTimeUpdateContext realTimeUpdateContext;
+
   private VehicleParkingUpdater vehicleParkingUpdater;
 
   @BeforeEach
@@ -41,6 +43,7 @@ class VehicleParkingUpdaterTest {
     graphData.initGraph();
     graph = graphData.getGraph();
     transitModel = graphData.getTransitModel();
+    realTimeUpdateContext = new DefaultRealTimeUpdateContext(graph, transitModel);
 
     dataSource = (DataSource<VehicleParking>) Mockito.mock(DataSource.class);
     when(dataSource.update()).thenReturn(true);
@@ -268,12 +271,12 @@ class VehicleParkingUpdaterTest {
     class GraphUpdaterMock extends GraphUpdaterManager {
 
       public GraphUpdaterMock(Graph graph, TransitModel transitModel, List<GraphUpdater> updaters) {
-        super(graph, transitModel, updaters);
+        super(realTimeUpdateContext, updaters);
       }
 
       @Override
       public Future<?> execute(GraphWriterRunnable runnable) {
-        runnable.run(graph, transitModel);
+        runnable.run(realTimeUpdateContext);
         return Futures.immediateVoidFuture();
       }
     }

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
@@ -16,6 +16,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.DefaultRealTimeUpdateContext;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.spi.HttpHeaders;
@@ -45,7 +46,7 @@ class VehicleRentalUpdaterTest {
   static class MockManager extends GraphUpdaterManager {
 
     public MockManager(VehicleRentalUpdater updater) {
-      super(new Graph(), new TransitModel(), List.of(updater));
+      super(new DefaultRealTimeUpdateContext(new Graph(), new TransitModel()), List.of(updater));
     }
 
     @Override


### PR DESCRIPTION
### Summary

Real-time updaters use instances of `TransitService` to look up transit data. Currently these instances are created at construction time.
This is problematic since `TransitService` instances maintain a reference to a frozen version of the `TimetableSnapshot` that is not updated after construction.
As of today this does not cause any issue, since the real-time updaters update directly the collections in `TransitModelIndex`, and the `TransitService` looks up data in `TransitModelIndex`.

However #6007 changes this behavior by storing the real-time updates in indexes in `TimetableSnapshot`, making previous real-time updates invisible from the real-time updaters.
Among other regressions, this prevents the `EntityResolver` from identifying already created extra journeys, and leads to the creation of duplicated trips.

This PR refactors the real-time updaters so that they use `TransitService` instances that refer to the `TimetableSnapshot` buffer, thus giving access to all applied real-time updates (including uncommitted ones).

This PR is a prerequisite for https://github.com/opentripplanner/OpenTripPlanner/pull/6007
This PR supersedes https://github.com/opentripplanner/OpenTripPlanner/pull/6018 

**Note**: the refactoring consists in:
- Modifying the `GraphWriterRunnable` interface so that it accepts a `RealTimeUpdateContext` as a parameter.
`RealTimeUpdateContext` gives access to a transit service that points to the `TimetableSnapshot` buffer. Other entities exposed in this interface (`EntityResolver`, `SiriFuzzyTripMatcher`, `GtfsRealtimeFuzzyTripMatcher`) are also aware of the latest applied real-time update.
- Refactoring the real-time updaters in order to make use of the instances of `TransitService`, `EntityResolver`, `SiriFuzzyTripMatcher`, `GtfsRealtimeFuzzyTripMatcher` provided by the `RealTimeUpdateContext`,  exclusively in the context of a `GraphWriterRunnable` (where it is safe to do so).

**Note**: the `SiriFuzzyTripMatcher` is now instantiated only once in the `RealTimeUpdateContext`, making it possible to remove the static singleton logic that made it difficult to test.

**Note**: The SIRI-SX and Alert updaters still make use of a TransitModel instance. In practice they just need access to the `StopModel`, which is (currently) immutable. These updaters could be refactored in a follow-up PR to use only the `StopModel` instead of the `TransitModel`, making the intent clearer.


### Issue
No

### Unit tests

Added unit tests,
Updated unit tests.

### Documentation
No

