### PR TITLE
Compute accessibility score for walking legs only

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.FieldSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
@@ -63,15 +62,17 @@ class DecorateWithAccessibilityScoreTest implements PlanTestConstants {
     itinerary.getLegs().forEach(l -> assertNotNull(l.accessibilityScore()));
   }
 
-  private static final List<Function<TestItineraryBuilder, TestItineraryBuilder>> nonWalkingCases = List.of(
-    b -> b.bicycle(10, 20, B),
-    b -> b.drive(10, 20, B),
-    b -> b.rentedBicycle(10, 20, B)
-  );
+  private static List<Function<TestItineraryBuilder, TestItineraryBuilder>> nonWalkingCases() {
+    return List.of(
+      b -> b.bicycle(10, 20, B),
+      b -> b.drive(10, 20, B),
+      b -> b.rentedBicycle(10, 20, B)
+    );
+  }
 
-  @FieldSource("nonWalkingCases")
+  @MethodSource("nonWalkingCases")
   @ParameterizedTest
-  void onlyWalking(Function<TestItineraryBuilder, TestItineraryBuilder> modifier) {
+  void noScoreForNonWalking(Function<TestItineraryBuilder, TestItineraryBuilder> modifier) {
     var itinerary = modifier.apply(newItinerary(A, 0)).build();
     DECORATOR.decorate(itinerary);
     assertNull(itinerary.getAccessibilityScore());

--- a/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
@@ -2,20 +2,27 @@ package org.opentripplanner.ext.accessibilityscore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.FieldSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.TestItineraryBuilder;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
 
-public class DecorateWithAccessibilityScoreTest implements PlanTestConstants {
+class DecorateWithAccessibilityScoreTest implements PlanTestConstants {
 
   private static final int ID = 1;
+  private static final DecorateWithAccessibilityScore DECORATOR = new DecorateWithAccessibilityScore(
+    WheelchairPreferences.DEFAULT.maxSlope()
+  );
 
   static List<Arguments> accessibilityScoreTestCase() {
     return List.of(
@@ -48,17 +55,26 @@ public class DecorateWithAccessibilityScoreTest implements PlanTestConstants {
 
   @ParameterizedTest
   @MethodSource("accessibilityScoreTestCase")
-  public void accessibilityScoreTest(Itinerary itinerary, float expectedAccessibilityScore) {
-    var filter = new DecorateWithAccessibilityScore(WheelchairPreferences.DEFAULT.maxSlope());
-
-    filter.decorate(itinerary);
+  void accessibilityScoreTest(Itinerary itinerary, float expectedAccessibilityScore) {
+    DECORATOR.decorate(itinerary);
 
     assertEquals(expectedAccessibilityScore, itinerary.getAccessibilityScore());
 
-    itinerary
-      .getLegs()
-      .forEach(l -> {
-        assertNotNull(l.accessibilityScore());
-      });
+    itinerary.getLegs().forEach(l -> assertNotNull(l.accessibilityScore()));
+  }
+
+  private static final List<Function<TestItineraryBuilder, TestItineraryBuilder>> nonWalkingCases = List.of(
+    b -> b.bicycle(10, 20, B),
+    b -> b.drive(10, 20, B),
+    b -> b.rentedBicycle(10, 20, B)
+  );
+
+  @FieldSource("nonWalkingCases")
+  @ParameterizedTest
+  void onlyWalking(Function<TestItineraryBuilder, TestItineraryBuilder> modifier) {
+    var itinerary = modifier.apply(newItinerary(A, 0)).build();
+    DECORATOR.decorate(itinerary);
+    assertNull(itinerary.getAccessibilityScore());
+    itinerary.getLegs().forEach(l -> assertNull(l.accessibilityScore()));
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScore.java
+++ b/src/ext/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScore.java
@@ -116,7 +116,7 @@ public record DecorateWithAccessibilityScore(double wheelchairMaxSlope)
       .map(leg -> {
         if (leg instanceof ScheduledTransitLeg transitLeg) {
           return transitLeg.withAccessibilityScore(compute(transitLeg));
-        } else if (leg instanceof StreetLeg streetLeg) {
+        } else if (leg instanceof StreetLeg streetLeg && leg.isWalkingLeg()) {
           return streetLeg.withAccessibilityScore(compute(streetLeg));
         } else {
           return leg;


### PR DESCRIPTION
### Summary

I changes the computation of the sandbox accessibility score so that it's only computed for walking and transit legs but not cycling, driving or scootering.

### Unit tests

:heavy_check_mark: