### PR TITLE
Upgrade OBA, remove camsys-apps.com from Maven repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -819,7 +819,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>3.2.2</version>
+            <version>3.2.3</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -533,11 +533,6 @@
             <name>Open Source Geospatial Foundation Repository</name>
             <url>https://repo.osgeo.org/repository/release/</url>
         </repository>
-        <repository>
-            <id>onebusaway-releases</id>
-            <name>Onebusaway Releases Repo</name>
-            <url>https://repo.camsys-apps.com/releases/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>
@@ -824,13 +819,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.4.17</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>3.2.2</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>


### PR DESCRIPTION
### Summary

One of the first actions as a maintainer was to deploy all OBA artifacts on Maven Central so the Maven Repo camsys-apps.com is no longer needed.

The main changes in the library code itself are 

- Removal of compatibility code for very old drafts of GTFS Flex
- Addition of cars_allowed

cc @villepihlava