### PR TITLE
Rename TripTimeShort to TripTimeOnDate in method and class names

### DIFF
--- a/src/main/java/org/opentripplanner/apis/transmodel/model/TripTimeOnDateHelper.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/TripTimeOnDateHelper.java
@@ -12,16 +12,16 @@ import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 
-public class TripTimeShortHelper {
+public class TripTimeOnDateHelper {
 
   /** Utility class with private constructor to prevent instantiation. */
-  private TripTimeShortHelper() {}
+  private TripTimeOnDateHelper() {}
 
   /**
    * Find trip time short for the from place in transit leg, or null.
    */
   @Nullable
-  public static TripTimeOnDate getTripTimeShortForFromPlace(Leg leg) {
+  public static TripTimeOnDate getTripTimeOnDateForFromPlace(Leg leg) {
     if (!leg.isScheduledTransitLeg()) {
       return null;
     }
@@ -49,7 +49,7 @@ public class TripTimeShortHelper {
    * Find trip time short for the to place in transit leg, or null.
    */
   @Nullable
-  public static TripTimeOnDate getTripTimeShortForToPlace(Leg leg) {
+  public static TripTimeOnDate getTripTimeOnDateForToPlace(Leg leg) {
     if (!leg.isScheduledTransitLeg()) {
       return null;
     }
@@ -77,7 +77,7 @@ public class TripTimeShortHelper {
   /**
    * Find trip time shorts for all stops for the full trip of a leg.
    */
-  public static List<TripTimeOnDate> getAllTripTimeShortsForLegsTrip(Leg leg) {
+  public static List<TripTimeOnDate> getAllTripTimeOnDatesForLegsTrip(Leg leg) {
     if (!leg.isScheduledTransitLeg()) {
       return List.of();
     }
@@ -96,7 +96,7 @@ public class TripTimeShortHelper {
   /**
    * Find trip time shorts for all intermediate stops for a leg.
    */
-  public static List<TripTimeOnDate> getIntermediateTripTimeShortsForLeg(Leg leg) {
+  public static List<TripTimeOnDate> getIntermediateTripTimeOnDatesForLeg(Leg leg) {
     if (!leg.isScheduledTransitLeg()) {
       return List.of();
     }

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/plan/JourneyWhiteListed.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/plan/JourneyWhiteListed.java
@@ -60,10 +60,10 @@ public class JourneyWhiteListed {
     if (authorityIds.isEmpty() && lineIds.isEmpty()) {
       return stream;
     }
-    return stream.filter(it -> isTripTimeShortAcceptable(it, authorityIds, lineIds));
+    return stream.filter(it -> isTripTimeOnDateAcceptable(it, authorityIds, lineIds));
   }
 
-  private static boolean isTripTimeShortAcceptable(
+  private static boolean isTripTimeOnDateAcceptable(
     TripTimeOnDate tts,
     Collection<FeedScopedId> authorityIds,
     Collection<FeedScopedId> lineIds

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/plan/LegType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/plan/LegType.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opentripplanner.apis.transmodel.model.EnumTypes;
 import org.opentripplanner.apis.transmodel.model.TransmodelTransportSubmode;
-import org.opentripplanner.apis.transmodel.model.TripTimeShortHelper;
+import org.opentripplanner.apis.transmodel.model.TripTimeOnDateHelper;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.framework.geometry.EncodedPolyline;
 import org.opentripplanner.model.plan.Leg;
@@ -271,7 +271,7 @@ public class LegType {
           .withDirective(gqlUtil.timingData)
           .description("EstimatedCall for the quay where the leg originates.")
           .type(estimatedCallType)
-          .dataFetcher(env -> TripTimeShortHelper.getTripTimeShortForFromPlace(env.getSource()))
+          .dataFetcher(env -> TripTimeOnDateHelper.getTripTimeOnDateForFromPlace(env.getSource()))
           .build()
       )
       .field(
@@ -281,7 +281,7 @@ public class LegType {
           .withDirective(gqlUtil.timingData)
           .description("EstimatedCall for the quay where the leg ends.")
           .type(estimatedCallType)
-          .dataFetcher(env -> TripTimeShortHelper.getTripTimeShortForToPlace(env.getSource()))
+          .dataFetcher(env -> TripTimeOnDateHelper.getTripTimeOnDateForToPlace(env.getSource()))
           .build()
       )
       .field(
@@ -358,7 +358,7 @@ public class LegType {
           )
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(estimatedCallType))))
           .dataFetcher(env ->
-            TripTimeShortHelper.getIntermediateTripTimeShortsForLeg(env.getSource())
+            TripTimeOnDateHelper.getIntermediateTripTimeOnDatesForLeg(env.getSource())
           )
           .build()
       )
@@ -371,7 +371,8 @@ public class LegType {
             "For ride legs, all estimated calls for the service journey. For non-ride legs, empty list."
           )
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(estimatedCallType))))
-          .dataFetcher(env -> TripTimeShortHelper.getAllTripTimeShortsForLegsTrip(env.getSource()))
+          .dataFetcher(env -> TripTimeOnDateHelper.getAllTripTimeOnDatesForLegsTrip(env.getSource())
+          )
           .build()
       )
       //                .field(GraphQLFieldDefinition.newFieldDefinition()

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
@@ -355,7 +355,7 @@ public class EstimatedCallType {
   }
 
   /**
-   * Resolves all AlertPatches that are relevant for the supplied TripTimeShort.
+   * Resolves all AlertPatches that are relevant for the supplied TripTimeOnDate.
    */
   private static Collection<TransitAlert> getAllRelevantAlerts(
     TripTimeOnDate tripTimeOnDate,

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import org.opentripplanner.apis.transmodel.model.EnumTypes;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
-import org.opentripplanner.routing.TripTimesShortHelper;
+import org.opentripplanner.routing.TripTimeOnDateHelper;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
@@ -149,7 +149,7 @@ public class DatedServiceJourneyType {
           )
           .dataFetcher(environment -> {
             TripOnServiceDate tripOnServiceDate = tripOnServiceDate(environment);
-            return TripTimesShortHelper.getTripTimesShort(
+            return TripTimeOnDateHelper.getTripTimeOnDates(
               GqlUtil.getTransitService(environment),
               tripOnServiceDate.getTrip(),
               tripOnServiceDate.getServiceDate()

--- a/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -20,7 +20,7 @@ import org.opentripplanner.apis.transmodel.model.TransmodelTransportSubmode;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.framework.geometry.EncodedPolyline;
 import org.opentripplanner.model.TripTimeOnDate;
-import org.opentripplanner.routing.TripTimesShortHelper;
+import org.opentripplanner.routing.TripTimeOnDateHelper;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -273,7 +273,7 @@ public class ServiceJourneyType {
               .ofNullable(environment.getArgument("date"))
               .map(LocalDate.class::cast)
               .orElse(LocalDate.now(GqlUtil.getTransitService(environment).getTimeZone()));
-            return TripTimesShortHelper.getTripTimesShort(
+            return TripTimeOnDateHelper.getTripTimeOnDates(
               GqlUtil.getTransitService(environment),
               trip(environment),
               serviceDate

--- a/src/main/java/org/opentripplanner/model/StopTimesInPattern.java
+++ b/src/main/java/org/opentripplanner/model/StopTimesInPattern.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.opentripplanner.transit.model.network.TripPattern;
 
 /**
- * Some stopTimes all in the same pattern. TripTimeShort should probably be renamed StopTimeShort
+ * Some stopTimes all in the same pattern.
  */
 public class StopTimesInPattern {
 

--- a/src/main/java/org/opentripplanner/routing/TripTimeOnDateHelper.java
+++ b/src/main/java/org/opentripplanner/routing/TripTimeOnDateHelper.java
@@ -14,11 +14,11 @@ import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TripTimesShortHelper {
+public class TripTimeOnDateHelper {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TripTimesShortHelper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TripTimeOnDateHelper.class);
 
-  public static List<TripTimeOnDate> getTripTimesShort(
+  public static List<TripTimeOnDate> getTripTimeOnDates(
     TransitService transitService,
     Trip trip,
     LocalDate serviceDate
@@ -37,7 +37,7 @@ public class TripTimesShortHelper {
       timetable = transitService.getTimetableForTripPattern(pattern, serviceDate);
     }
 
-    // This check is made here to avoid changing TripTimeShort.fromTripTimes
+    // This check is made here to avoid changing TripTimeOnDate.fromTripTimes
     TripTimes times = timetable.getTripTimes(trip);
     if (
       !transitService.getServiceCodesRunningForDate(serviceDate).contains(times.getServiceCode())

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -62,7 +62,7 @@ public class StopTimesHelper {
     Collection<TripPattern> patterns = transitService.getPatternsForStop(stop, true);
 
     for (TripPattern pattern : patterns) {
-      Queue<TripTimeOnDate> pq = listTripTimeShortsForPatternAtStop(
+      Queue<TripTimeOnDate> pq = listTripTimeOnDatesForPatternAtStop(
         transitService,
         stop,
         pattern,
@@ -154,7 +154,7 @@ public class StopTimesHelper {
     ArrivalDeparture arrivalDeparture,
     boolean includeCancellations
   ) {
-    Queue<TripTimeOnDate> pq = listTripTimeShortsForPatternAtStop(
+    Queue<TripTimeOnDate> pq = listTripTimeOnDatesForPatternAtStop(
       transitService,
       stop,
       pattern,
@@ -184,7 +184,7 @@ public class StopTimesHelper {
     return result;
   }
 
-  private static Queue<TripTimeOnDate> listTripTimeShortsForPatternAtStop(
+  private static Queue<TripTimeOnDate> listTripTimeOnDatesForPatternAtStop(
     TransitService transitService,
     StopLocation stop,
     TripPattern pattern,


### PR DESCRIPTION
### Summary

The class initially named `TripTimeShort` was renamed to `TripTimeOnDate`, but the method names and class names that refer to it were not updated, which is confusing.
This PR replaces all references to `TripTimeShort` by `TripTimeOnDate`.

**Note**: there are 2 related classes `APITripTimeShort` and `ApiPatternShort` in the REST API that are left untouched.

### Issue
No

### Unit tests
No

### Documentation
No
