### PR TITLE
Add links for Debug UI to GraphiQL

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,3 +1,3 @@
 VITE_API_URL=/otp/transmodel/v3
 VITE_DEBUG_STYLE_URL=/otp/routers/default/inspector/vectortile/style.json
-
+VITE_GRAPHIQL_URL=/graphiql?flavor=transmodel

--- a/client/.env.development
+++ b/client/.env.development
@@ -1,2 +1,3 @@
 VITE_API_URL=http://localhost:8080/otp/transmodel/v3
 VITE_DEBUG_STYLE_URL=http://localhost:8080/otp/routers/default/inspector/vectortile/style.json
+VITE_GRAPHIQL_URL=http://localhost:8080/graphiql?flavor=transmodel

--- a/client/src/components/ItineraryList/ItineraryGraphiQLAuthorityLink.tsx
+++ b/client/src/components/ItineraryList/ItineraryGraphiQLAuthorityLink.tsx
@@ -1,0 +1,25 @@
+import { authorityQueryAsString } from '../../static/query/authorityQuery.tsx';
+import { Maybe } from '../../gql/graphql.ts';
+const graphiQLUrl = import.meta.env.VITE_GRAPHIQL_URL;
+
+export function ItineraryGraphiQLAuthorityLink({
+  legId,
+  legName,
+}: {
+  legId: string | undefined;
+  legName: Maybe<string> | undefined;
+}) {
+  const queryID = { id: legId };
+  const formattedQuery = encodeURIComponent(authorityQueryAsString);
+  const formattedQueryID = encodeURIComponent(JSON.stringify(queryID));
+
+  return (
+    <a
+      href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedQueryID}
+      target={'_blank'}
+      rel={'noreferrer'}
+    >
+      {legName}
+    </a>
+  );
+}

--- a/client/src/components/ItineraryList/ItineraryGraphiQLLineLink.tsx
+++ b/client/src/components/ItineraryList/ItineraryGraphiQLLineLink.tsx
@@ -1,0 +1,18 @@
+import { lineQueryAsString } from '../../static/query/lineQuery.tsx';
+const graphiQLUrl = import.meta.env.VITE_GRAPHIQL_URL;
+
+export function ItineraryGraphiQLLineLink({ legId, legName }: { legId: string; legName: string }) {
+  const queryID = { id: legId };
+  const formattedQuery = encodeURIComponent(lineQueryAsString);
+  const formattedQueryID = encodeURIComponent(JSON.stringify(queryID));
+
+  return (
+    <a
+      href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedQueryID}
+      target={'_blank'}
+      rel={'noreferrer'}
+    >
+      {legName}
+    </a>
+  );
+}

--- a/client/src/components/ItineraryList/ItineraryGraphiQLQuayLink.tsx
+++ b/client/src/components/ItineraryList/ItineraryGraphiQLQuayLink.tsx
@@ -1,0 +1,25 @@
+import { quayQueryAsString } from '../../static/query/quayQuery.tsx';
+import { Maybe } from '../../gql/graphql.ts';
+const graphiQLUrl = import.meta.env.VITE_GRAPHIQL_URL;
+
+export function ItineraryGraphiQLQuayLink({
+  legId,
+  legName,
+}: {
+  legId: string | undefined;
+  legName: Maybe<string> | undefined;
+}) {
+  const queryID = { id: legId };
+  const formattedQuery = encodeURIComponent(quayQueryAsString);
+  const formattedQueryID = encodeURIComponent(JSON.stringify(queryID));
+
+  return (
+    <a
+      href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedQueryID}
+      target={'_blank'}
+      rel={'noreferrer'}
+    >
+      {legName}
+    </a>
+  );
+}

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -32,6 +32,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
             <a
               title={leg.line?.id}
               target={'_blank'}
+              rel={'noreferrer'}
               href={graphiQLUrl + '&query=' + formattedLineQuery + '&variables=' + formattedLineID}
             >
               {leg.line.publicCode} {leg.toEstimatedCall?.destinationDisplay?.frontText}
@@ -45,6 +46,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
             <a
               title={leg.fromPlace.quay?.id}
               target={'_blank'}
+              rel={'noreferrer'}
               href={
                 graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedFromPlaceID
               }
@@ -58,6 +60,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
           <a
             title={leg.toPlace.quay?.id}
             target={'_blank'}
+            rel={'noreferrer'}
             href={graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedToPlaceID}
           >
             {leg.toPlace.name}

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -47,9 +47,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
               title={leg.fromPlace.quay?.id}
               target={'_blank'}
               rel={'noreferrer'}
-              href={
-                graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedFromPlaceID
-              }
+              href={graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedFromPlaceID}
             >
               {leg.fromPlace.name}
             </a>{' '}

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -3,20 +3,11 @@ import { LegTime } from './LegTime.tsx';
 import { formatDistance } from '../../util/formatDistance.ts';
 import { formatDuration } from '../../util/formatDuration.ts';
 import { InterchangeInfo } from './InterchangeInfo.tsx';
-import { quayQueryAsString } from '../../static/query/quayQuery.tsx';
-import { lineQueryAsString } from '../../static/query/lineQuery.tsx';
-const graphiQLUrl = import.meta.env.VITE_GRAPHIQL_URL;
+import { ItineraryGraphiQLLineLink } from './ItineraryGraphiQLLineLink.tsx';
+import { ItineraryGraphiQLQuayLink } from './ItineraryGraphiQLQuayLink.tsx';
+import { ItineraryGraphiQLAuthorityLink } from './ItineraryGraphiQLAuthorityLink.tsx';
 
 export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean }) {
-  const lineID = { id: leg.line?.id };
-  const fromPlaceID = { id: leg.fromPlace.quay?.id };
-  const toPlaceID = { id: leg.toPlace.quay?.id };
-  const formattedQuayQuery = encodeURIComponent(quayQueryAsString);
-  const formattedLineQuery = encodeURIComponent(lineQueryAsString);
-  const formattedLineID = encodeURIComponent(JSON.stringify(lineID));
-  const formattedFromPlaceID = encodeURIComponent(JSON.stringify(fromPlaceID));
-  const formattedToPlaceID = encodeURIComponent(JSON.stringify(toPlaceID));
-
   return (
     <div className="itinerary-leg-details">
       <div className="times">
@@ -29,41 +20,20 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
         <b>{leg.mode}</b>{' '}
         {leg.line && (
           <>
-            <a
-              title={leg.line?.id}
-              target={'_blank'}
-              rel={'noreferrer'}
-              href={graphiQLUrl + '&query=' + formattedLineQuery + '&variables=' + formattedLineID}
-            >
-              {leg.line.publicCode} {leg.toEstimatedCall?.destinationDisplay?.frontText}
-            </a>
-            , {leg.authority?.name}
+            <ItineraryGraphiQLLineLink
+              legId={leg.line?.id}
+              legName={leg.line.publicCode + ' ' + leg.toEstimatedCall?.destinationDisplay?.frontText}
+            />
+            , <ItineraryGraphiQLAuthorityLink legId={leg.authority?.id} legName={leg.authority?.name} />
           </>
         )}{' '}
         {leg.mode !== Mode.Foot && (
           <>
             <br />
-            <a
-              title={leg.fromPlace.quay?.id}
-              target={'_blank'}
-              rel={'noreferrer'}
-              href={graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedFromPlaceID}
-            >
-              {leg.fromPlace.name}
-            </a>{' '}
-            →{' '}
+            <ItineraryGraphiQLQuayLink legId={leg.fromPlace.quay?.id} legName={leg.fromPlace.name} /> →{' '}
           </>
         )}{' '}
-        {!isLast && (
-          <a
-            title={leg.toPlace.quay?.id}
-            target={'_blank'}
-            rel={'noreferrer'}
-            href={graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedToPlaceID}
-          >
-            {leg.toPlace.name}
-          </a>
-        )}
+        {!isLast && <ItineraryGraphiQLQuayLink legId={leg.toPlace.quay?.id} legName={leg.toPlace.name} />}
       </div>
     </div>
   );

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -3,8 +3,20 @@ import { LegTime } from './LegTime.tsx';
 import { formatDistance } from '../../util/formatDistance.ts';
 import { formatDuration } from '../../util/formatDuration.ts';
 import { InterchangeInfo } from './InterchangeInfo.tsx';
+import { quayQueryAsString } from '../../static/query/quayQuery.tsx';
+import { lineQueryAsString } from '../../static/query/lineQuery.tsx';
+const graphiQLUrl = import.meta.env.VITE_GRAPHIQL_URL;
 
 export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean }) {
+  const lineID = { id: leg.line?.id };
+  const fromPlaceID = { id: leg.fromPlace.quay?.id };
+  const toPlaceID = { id: leg.toPlace.quay?.id };
+  const formattedQuayQuery = encodeURIComponent(quayQueryAsString);
+  const formattedLineQuery = encodeURIComponent(lineQueryAsString);
+  const formattedLineID = encodeURIComponent(JSON.stringify(lineID));
+  const formattedFromPlaceID = encodeURIComponent(JSON.stringify(fromPlaceID));
+  const formattedToPlaceID = encodeURIComponent(JSON.stringify(toPlaceID));
+
   return (
     <div className="itinerary-leg-details">
       <div className="times">
@@ -17,19 +29,40 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
         <b>{leg.mode}</b>{' '}
         {leg.line && (
           <>
-            <u>
+            <a
+              title={leg.line?.id}
+              target={'_blank'}
+              href={graphiQLUrl + '&query=' + formattedLineQuery + '&variables=' + formattedLineID}
+            >
               {leg.line.publicCode} {leg.toEstimatedCall?.destinationDisplay?.frontText}
-            </u>
+            </a>
             , {leg.authority?.name}
           </>
         )}{' '}
         {leg.mode !== Mode.Foot && (
           <>
             <br />
-            <u title={leg.fromPlace.quay?.id}>{leg.fromPlace.name}</u> →{' '}
+            <a
+              title={leg.fromPlace.quay?.id}
+              target={'_blank'}
+              href={
+                graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedFromPlaceID
+              }
+            >
+              {leg.fromPlace.name}
+            </a>{' '}
+            →{' '}
           </>
         )}{' '}
-        {!isLast && <u title={leg.toPlace.quay?.id}>{leg.toPlace.name}</u>}
+        {!isLast && (
+          <a
+            title={leg.toPlace.quay?.id}
+            target={'_blank'}
+            href={graphiQLUrl + '&query=' + formattedQuayQuery + '&variables=' + formattedToPlaceID}
+          >
+            {leg.toPlace.name}
+          </a>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/SearchBar/GraphiQLRouteButton.tsx
+++ b/client/src/components/SearchBar/GraphiQLRouteButton.tsx
@@ -1,0 +1,25 @@
+import { Button } from 'react-bootstrap';
+import { TripQueryVariables } from '../../gql/graphql.ts';
+import { queryAsString } from '../../static/query/tripQuery.tsx';
+
+function GraphiQLRouteButton({ tripQueryVariables }: { tripQueryVariables: TripQueryVariables }) {
+  const formattedVariables = encodeURIComponent(JSON.stringify(tripQueryVariables));
+  const formattedQuery = encodeURIComponent(queryAsString);
+
+  return (
+    <div className="search-bar-route-button-wrapper">
+      <Button
+        href={
+          'https://otp2debug.dev.entur.org/graphiql?flavor=transmodel&query=' +
+          formattedQuery +
+          '&variables=' +
+          formattedVariables
+        }
+        target={'_blank'}
+      >
+        GraphQL
+      </Button>
+    </div>
+  );
+}
+export default GraphiQLRouteButton;

--- a/client/src/components/SearchBar/GraphiQLRouteButton.tsx
+++ b/client/src/components/SearchBar/GraphiQLRouteButton.tsx
@@ -9,10 +9,7 @@ function GraphiQLRouteButton({ tripQueryVariables }: { tripQueryVariables: TripQ
 
   return (
     <div className="search-bar-route-button-wrapper">
-      <Button
-        href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedVariables}
-        target={'_blank'}
-      >
+      <Button href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedVariables} target={'_blank'}>
         GraphQL
       </Button>
     </div>

--- a/client/src/components/SearchBar/GraphiQLRouteButton.tsx
+++ b/client/src/components/SearchBar/GraphiQLRouteButton.tsx
@@ -1,6 +1,7 @@
 import { Button } from 'react-bootstrap';
 import { TripQueryVariables } from '../../gql/graphql.ts';
 import { queryAsString } from '../../static/query/tripQuery.tsx';
+const graphiQLUrl = import.meta.env.VITE_GRAPHIQL_URL;
 
 function GraphiQLRouteButton({ tripQueryVariables }: { tripQueryVariables: TripQueryVariables }) {
   const formattedVariables = encodeURIComponent(JSON.stringify(tripQueryVariables));
@@ -9,12 +10,7 @@ function GraphiQLRouteButton({ tripQueryVariables }: { tripQueryVariables: TripQ
   return (
     <div className="search-bar-route-button-wrapper">
       <Button
-        href={
-          'https://otp2debug.dev.entur.org/graphiql?flavor=transmodel&query=' +
-          formattedQuery +
-          '&variables=' +
-          formattedVariables
-        }
+        href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedVariables}
         target={'_blank'}
       >
         GraphQL

--- a/client/src/components/SearchBar/GraphiQLRouteButton.tsx
+++ b/client/src/components/SearchBar/GraphiQLRouteButton.tsx
@@ -10,7 +10,7 @@ function GraphiQLRouteButton({ tripQueryVariables }: { tripQueryVariables: TripQ
   return (
     <div className="search-bar-route-button-wrapper">
       <Button href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedVariables} target={'_blank'}>
-        GraphQL
+        GraphiQL
       </Button>
     </div>
   );

--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -15,6 +15,7 @@ import Navbar from 'react-bootstrap/Navbar';
 import { ServerInfoTooltip } from './ServerInfoTooltip.tsx';
 import { useRef, useState } from 'react';
 import logo from '../../static/img/otp-logo.svg';
+import GraphiQLRouteButton from './GraphiQLRouteButton.tsx';
 
 type SearchBarProps = {
   onRoute: () => void;
@@ -61,6 +62,7 @@ export function SearchBar({ onRoute, tripQueryVariables, setTripQueryVariables, 
           Route
         </Button>
       </div>
+      <GraphiQLRouteButton tripQueryVariables={tripQueryVariables}></GraphiQLRouteButton>
     </div>
   );
 }

--- a/client/src/hooks/useTripQuery.ts
+++ b/client/src/hooks/useTripQuery.ts
@@ -1,96 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { graphql } from '../gql';
 import { request } from 'graphql-request'; // eslint-disable-line import/no-unresolved
 import { QueryType, TripQueryVariables } from '../gql/graphql.ts';
 import { getApiUrl } from '../util/getApiUrl.ts';
+import { query } from '../static/query/tripQuery.tsx';
 
 /**
   General purpose trip query document for debugging trip searches
-  TODO: should live in a separate file, and split into fragments for readability
  */
-const query = graphql(`
-  query trip(
-    $from: Location!
-    $to: Location!
-    $arriveBy: Boolean
-    $dateTime: DateTime
-    $numTripPatterns: Int
-    $searchWindow: Int
-    $modes: Modes
-    $itineraryFiltersDebug: ItineraryFilterDebugProfile
-    $pageCursor: String
-  ) {
-    trip(
-      from: $from
-      to: $to
-      arriveBy: $arriveBy
-      dateTime: $dateTime
-      numTripPatterns: $numTripPatterns
-      searchWindow: $searchWindow
-      modes: $modes
-      itineraryFilters: { debug: $itineraryFiltersDebug }
-      pageCursor: $pageCursor
-    ) {
-      previousPageCursor
-      nextPageCursor
-      tripPatterns {
-        aimedStartTime
-        aimedEndTime
-        expectedEndTime
-        expectedStartTime
-        duration
-        distance
-        legs {
-          id
-          mode
-          aimedStartTime
-          aimedEndTime
-          expectedEndTime
-          expectedStartTime
-          realtime
-          distance
-          duration
-          fromPlace {
-            name
-            quay {
-              id
-            }
-          }
-          toPlace {
-            name
-            quay {
-              id
-            }
-          }
-          toEstimatedCall {
-            destinationDisplay {
-              frontText
-            }
-          }
-          line {
-            publicCode
-            name
-          }
-          authority {
-            name
-          }
-          pointsOnLink {
-            points
-          }
-          interchangeTo {
-            staySeated
-          }
-          interchangeFrom {
-            staySeated
-          }
-        }
-        systemNotices {
-          tag
-        }
-      }
-    }
-  }
-`);
 
 type TripQueryHook = (
   variables?: TripQueryVariables,
@@ -126,6 +42,5 @@ export const useTripQuery: TripQueryHook = (variables) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [variables?.from, variables?.to]);
-
   return [data, loading, callback];
 };

--- a/client/src/static/query/authorityQuery.tsx
+++ b/client/src/static/query/authorityQuery.tsx
@@ -1,0 +1,13 @@
+import { graphql } from '../../gql';
+import { print } from 'graphql/index';
+
+export const query = graphql(`
+  query authority($id: String!) {
+    authority(id: $id) {
+      name
+      id
+    }
+  }
+`);
+
+export const authorityQueryAsString = print(query);

--- a/client/src/static/query/lineQuery.tsx
+++ b/client/src/static/query/lineQuery.tsx
@@ -1,0 +1,13 @@
+import { graphql } from '../../gql';
+import { print } from 'graphql/index';
+
+export const query = graphql(`
+  query line($id: ID!) {
+    line(id: $id) {
+      name
+      publicCode
+    }
+  }
+`);
+
+export const lineQueryAsString = print(query);

--- a/client/src/static/query/quayQuery.tsx
+++ b/client/src/static/query/quayQuery.tsx
@@ -1,0 +1,15 @@
+import { graphql } from '../../gql';
+import { print } from 'graphql/index';
+
+export const query = graphql(`
+  query quay($id: String!) {
+    quay(id: $id) {
+      stopPlace {
+        id
+        name
+      }
+    }
+  }
+`);
+
+export const quayQueryAsString = print(query);

--- a/client/src/static/query/tripQuery.tsx
+++ b/client/src/static/query/tripQuery.tsx
@@ -67,6 +67,7 @@ export const query = graphql(`
           }
           authority {
             name
+            id
           }
           pointsOnLink {
             points

--- a/client/src/static/query/tripQuery.tsx
+++ b/client/src/static/query/tripQuery.tsx
@@ -1,0 +1,88 @@
+import { graphql } from '../../gql';
+import { print } from 'graphql/index';
+
+export const query = graphql(`
+  query trip(
+    $from: Location!
+    $to: Location!
+    $arriveBy: Boolean
+    $dateTime: DateTime
+    $numTripPatterns: Int
+    $searchWindow: Int
+    $modes: Modes
+    $itineraryFiltersDebug: ItineraryFilterDebugProfile
+    $pageCursor: String
+  ) {
+    trip(
+      from: $from
+      to: $to
+      arriveBy: $arriveBy
+      dateTime: $dateTime
+      numTripPatterns: $numTripPatterns
+      searchWindow: $searchWindow
+      modes: $modes
+      itineraryFilters: { debug: $itineraryFiltersDebug }
+      pageCursor: $pageCursor
+    ) {
+      previousPageCursor
+      nextPageCursor
+      tripPatterns {
+        aimedStartTime
+        aimedEndTime
+        expectedEndTime
+        expectedStartTime
+        duration
+        distance
+        legs {
+          id
+          mode
+          aimedStartTime
+          aimedEndTime
+          expectedEndTime
+          expectedStartTime
+          realtime
+          distance
+          duration
+          fromPlace {
+            name
+            quay {
+              id
+            }
+          }
+          toPlace {
+            name
+            quay {
+              id
+            }
+          }
+          toEstimatedCall {
+            destinationDisplay {
+              frontText
+            }
+          }
+          line {
+            publicCode
+            name
+          }
+          authority {
+            name
+          }
+          pointsOnLink {
+            points
+          }
+          interchangeTo {
+            staySeated
+          }
+          interchangeFrom {
+            staySeated
+          }
+        }
+        systemNotices {
+          tag
+        }
+      }
+    }
+  }
+`);
+
+export const queryAsString = print(query);

--- a/client/src/static/query/tripQuery.tsx
+++ b/client/src/static/query/tripQuery.tsx
@@ -63,6 +63,7 @@ export const query = graphql(`
           line {
             publicCode
             name
+            id
           }
           authority {
             name


### PR DESCRIPTION
### Summary

This feature provides the following new functionality for the debug client:
A new button that when pressed will take the parameters set and create a GraphQL trip query that opens in GraphiQL.
Links in the leg lists will now take you to GraphQL queries in GraphiQL for the different entities.

### Issue
This should resolve issue 1. and 2. listen under this: https://github.com/opentripplanner/OpenTripPlanner/issues/5330#issuecomment-2273311110 issue.

