### PR TITLE
Copy-on-write snapshot maps

### DIFF
--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/ImmutableSnapMap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/ImmutableSnapMap.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.framework.collection.snapshot;
+
+/**
+ * An unmodifiable mapping from keys to values, with one value per key.
+ * Reading is thread safe because contents are guaranteed to be unchanging.
+ */
+public interface ImmutableSnapMap<K, V> {
+  /** @return the value currently associated with the given key, or null if no mapping exists. */
+  V get(K key);
+
+  /** @return the number of mappings in this map instance. */
+  int size();
+
+  /**
+   * Efficiently create a modifiable copy of this map. Changes to that copy will NOT affect this
+   * source instance. Low-cost operation using deferred copy-on-write to reuse existing objects,
+   * minimizing allocations and copies.
+   * @return a mutable copy-on-write view of this map.
+   */
+  MutableSnapMap mutate();
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/ImmutableSnapMultimap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/ImmutableSnapMultimap.java
@@ -1,0 +1,18 @@
+package org.opentripplanner.framework.collection.snapshot;
+
+import java.util.Collection;
+
+/**
+ * This is similar to an ImmutableSnapMap but allows multiple mappings for the same key. Calling
+ * get with a particular key returns an unordered collection of values, rather than a single value.
+ */
+public interface ImmutableSnapMultimap<K, V> {
+  // TODO Collections.unmodifiableList(Arrays.asList()); and ensure arrays are private and CoW.
+  Collection<V> get(K key);
+
+  /** @return the number of mappings in this map (the number of values, not the number of keys). */
+  int size();
+
+  /** @see ImmutableSnapMap#mutate() */
+  MutableSnapMultimap mutate();
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/MapAdapter.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/MapAdapter.java
@@ -1,0 +1,52 @@
+package org.opentripplanner.framework.collection.snapshot;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// For comparing performance on typical workloads against the standard JDK HashMap in TESTING ONLY.
+public class MapAdapter<K, V> implements MutableSnapMap<K, V> {
+
+  private Map<K, V> map;
+
+  public MapAdapter(int size) {
+    map = new HashMap(size);
+  }
+
+  public MapAdapter() {
+    map = new HashMap();
+  }
+
+  public MapAdapter(Map<K, V> map) {
+    this.map = map;
+  }
+
+  @Override
+  public void put(K key, V value) {
+    map.put(key, value);
+  }
+
+  @Override
+  public void remove(K key) {
+    map.remove(key);
+  }
+
+  @Override
+  public ImmutableSnapMap snapshot() {
+    return new MapAdapter(Map.copyOf(map));
+  }
+
+  @Override
+  public V get(K key) {
+    return map.get(key);
+  }
+
+  @Override
+  public int size() {
+    return map.size();
+  }
+
+  @Override
+  public MutableSnapMap mutate() {
+    return new MapAdapter(new HashMap(map));
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/MutableSnapMap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/MutableSnapMap.java
@@ -1,0 +1,24 @@
+package org.opentripplanner.framework.collection.snapshot;
+
+/**
+ * Extends the ImmutableSnapMap interface to make it writable.
+ * For performance reasons, implementations of this interface are generally not thread safe and
+ * perform no locking or synchronization. All reads, writes, and snapshot generation on a particular
+ * instance should be performed from only a single thread at a time, with any necessary
+ * synchronization provided by the caller.
+ */
+public interface MutableSnapMap<K, V> extends ImmutableSnapMap<K, V> {
+  /** Add a new key-value mapping to this map. */
+  void put(K key, V value);
+
+  /** Remove the mapping for the given key, if any, from this map. */
+  void remove(K key);
+
+  /**
+   * Efficiently create an unmodifiable copy of this map, whose contents are unchanging and will
+   * not be affected by further changes to this instance. Implementations aim to reuse existing
+   * objects, avoiding allocations and copies.
+   * @return an unmodifiable and unchanging view of the mappings currently in this map.
+   */
+  ImmutableSnapMap snapshot();
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/MutableSnapMultimap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/MutableSnapMultimap.java
@@ -1,0 +1,10 @@
+package org.opentripplanner.framework.collection.snapshot;
+
+public interface MutableSnapMultimap<K, V> extends ImmutableSnapMultimap<K, V> {
+  void put(K key, V value);
+
+  // Do we even need removal, given how complicated it is to implement in the layered cases?
+  void remove(K key);
+
+  ImmutableSnapMultimap snapshot();
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/SnapMapTest.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/SnapMapTest.java
@@ -1,0 +1,147 @@
+package org.opentripplanner.framework.collection.snapshot;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Random;
+import java.util.function.Supplier;
+import org.opentripplanner.framework.collection.snapshot.impl.MutableHashSnapMap;
+
+// RUN WITH -ea JVM option to enable assertions
+public class SnapMapTest {
+
+  // Number of items in the map. POWER OF TWO ONLY for now.
+  private static final int N = 1024 * 1024 * 4;
+
+  // Number of replaced mappings, new mappings, and reads per snapshot publication cycle.
+  private static final int N_OVERWRITES = 400;
+  private static final int N_NEW_WRITES = 100;
+  private static final int N_REMOVALS = 10;
+  private static final int N_READS = 1000;
+
+  private interface MapSupplier extends Supplier<MutableSnapMap<String, String>> {}
+
+  public static void main(String[] args) {
+    // Use default capacity to test expansion and rehashing.
+    // Then use appropriate capacity to see how much faster it is without rehashing.
+    MapSupplier jdkSupplierDefaultCapacity = MapAdapter::new;
+    MapSupplier jdkSupplierPreparedCapacity = () -> new MapAdapter<>(N);
+    MapSupplier customSupplierDefaultCapacity = () -> MutableHashSnapMap.withDefaultCapacity();
+    MapSupplier customSupplierPreparedCapacity = () -> MutableHashSnapMap.withInitialCapacity(N);
+    MapSupplier mapSupplier = customSupplierDefaultCapacity;
+    while (true) {
+      simulatedWorkload(mapSupplier);
+      oneIteration(mapSupplier);
+    }
+  }
+
+  private static MutableSnapMap<String, String> makeFilledMutable(
+    int nMappings,
+    MapSupplier mapSupplier
+  ) {
+    long start = System.currentTimeMillis();
+    MutableSnapMap<String, String> map = mapSupplier.get();
+    for (int i = 0; i < nMappings; i++) {
+      String key = "K" + i;
+      String value = "V" + i;
+      map.put(key, value);
+    }
+    long end = System.currentTimeMillis();
+    System.out.println("Initialized mutable map in " + (end - start) + "ms");
+    return map;
+  }
+
+  public static void oneIteration(MapSupplier mapSupplier) {
+    MutableSnapMap<String, String> map = makeFilledMutable(N, mapSupplier);
+
+    // An immutable snapshot instance should be exactly the same size as the mutable one.
+    ImmutableSnapMap ss0 = map.snapshot();
+    assert map.size() == N;
+    assert ss0.size() == N;
+
+    for (int x = 0; x < 10; x++) {
+      long start = System.currentTimeMillis();
+      // Update mutable map with different values for the same keys, as well as some new keys.
+      final int M = N * 2;
+      for (int i = 0; i < M; i++) {
+        String key = "K" + i;
+        String value = "X" + (M - i);
+        map.put(key, value);
+      }
+      ImmutableSnapMap ss1 = map.snapshot();
+      assert ss0.size() == N;
+      assert ss1.size() == M;
+      assert map.size() == M;
+
+      map.put("K1000", "ABCDEF");
+      assert ss0.get("K1000").equals("V1000");
+      assert ss1.get("K1000").equals("X" + (M - 1000));
+      assert map.get("K1000").equals("ABCDEF");
+
+      MutableSnapMap mut = ss0.mutate();
+      mut.put("NEWKEY", "NEWVAL");
+      assert map.get("NEWKEY") == null;
+      assert ss0.get("NEWKEY") == null;
+      assert ss1.get("NEWKEY") == null;
+      assert mut.get("NEWKEY").equals("NEWVAL");
+
+      ImmutableSnapMap ss2 = mut.snapshot();
+      map.put("NEWKEY", "ANOTHERVAL");
+      assert ss2.get("NEWKEY").equals("NEWVAL");
+      assert ss2.get("NEWKEY").equals(mut.get("NEWKEY"));
+      assert ss0.get("NEWKEY") == null;
+      assert ss1.get("NEWKEY") == null;
+      assert map.get("NEWKEY") == "ANOTHERVAL";
+      map.remove("NEWKEY");
+      // TODO further testing of remove
+
+      long end = System.currentTimeMillis();
+      System.out.println(String.format("Inserted %d elements in %d milliseconds", M, end - start));
+    }
+  }
+
+  public static void simulatedWorkload(MapSupplier mapSupplier) {
+    Random random = new Random();
+    long start = System.currentTimeMillis();
+    Deque<ImmutableSnapMap> snapshotsInUse = new LinkedList<>();
+    // Use default capacity to test expansion and rehashing.
+    MutableSnapMap<String, String> buffer = makeFilledMutable(N, mapSupplier);
+    long sum = 0;
+    for (int i = 0; i <= 500; i++) {
+      ImmutableSnapMap<String, String> snapshot = buffer.snapshot();
+      snapshotsInUse.add(snapshot);
+      if (snapshotsInUse.size() > 3) {
+        snapshotsInUse.remove();
+      }
+      for (int r = 0; r < N_READS; r++) {
+        int x = random.nextInt(N);
+        String key = "K" + x;
+        String existing = snapshot.get(key);
+        sum += existing.hashCode(); // Prevent optimization.
+        assert existing != null && existing.endsWith(Integer.toString(x)); // Catch both V and OVERWRITE.
+      }
+      buffer = snapshot.mutate();
+      for (int w = 0; w < N_OVERWRITES; w++) {
+        int x = random.nextInt(N);
+        String key = "K" + x;
+        String value = "OVERWRITE" + x;
+        buffer.put(key, value);
+      }
+      for (int w = 0; w < N_NEW_WRITES; w++) {
+        int x = random.nextInt(N);
+        String key = "NEW KEY " + x;
+        String value = "NEW VAL " + x;
+        buffer.put(key, value);
+      }
+      for (int r = 0; r < N_REMOVALS; r++) {
+        // FIXME this is removing NEW KEY things that usually don't exist.
+        int x = random.nextInt(N);
+        String key = "NEW KEY " + x;
+        buffer.remove(key);
+      }
+      long elapsed = System.currentTimeMillis() - start;
+      if (i % 10 == 0 && i > 0) {
+        System.out.println(String.format("%d iterations, average time %d msec", i, elapsed / i));
+      }
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/ImmutableHashSnapMap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/ImmutableHashSnapMap.java
@@ -1,0 +1,109 @@
+package org.opentripplanner.framework.collection.snapshot.impl;
+
+import org.opentripplanner.framework.collection.snapshot.ImmutableSnapMap;
+import org.opentripplanner.framework.collection.snapshot.MutableSnapMap;
+
+/**
+ * The mutable version of this class is implemented as a subclass with additional methods.
+ * The type system thus enforces mutable / immutable behavior at compile time.
+ * The mutable version applies a copy-on-write strategy when any modifications are made.
+ *
+ * The immutable form can be created only as a snapshot from a mutable form.
+ * In that sense, the mutable form is like a builder.
+ *
+ * All costs of insertion, rehashing, protective copying etc. are to be incurred in the mutable
+ * version of this class. Creating a read-only snapshot should be a near-zero-cost operation.
+ * Creating a mutable copy should also be near-zero-cost until any changes actually happen.
+ *
+ * Sizes could be constrained to be 2*k for integer k, to optimize modulo operations. The table only
+ * needs to grow, and is expected to grow slowly between snapshots. It doesn't require any special
+ * logic for shrinking back down after removals.
+ *
+ * The hash table uses open addressing and linear probing. Keeping the array sizes at or above 2x
+ * the capacity should yield an average of 2 probes per lookup. The separate key and value arrays
+ * may be slightly worse for cache locality, but are more readable/maintainable than a single packed
+ * Object array. And it seems possible that they're actually better for locality when probing.
+ *
+ * It does not support null keys.
+ *
+ * Non-goals:
+ * This class will not implement the Map interface. It is not intended as a drop-in replacement for
+ * Map. No concessions are made for multithreaded write access. A mutable instance may only be
+ * written from one thread at a time. Snapshot creation is considered a write operation, and must be
+ * performed in a synchronized fashion with any other write operations (put and remove).
+ */
+public class ImmutableHashSnapMap<K, V> implements ImmutableSnapMap<K, V> {
+
+  protected static final int DEFAULT_INITIAL_CAPACITY = 32;
+  protected static final int EXPAND_FACTOR = 2;
+
+  protected int size;
+  protected int capacity;
+  protected K[] keys;
+  protected V[] vals;
+  protected int hashMask;
+
+  public ImmutableHashSnapMap() {
+    this(DEFAULT_INITIAL_CAPACITY);
+  }
+
+  // CAPACITY MUST BE A POWER OF TWO
+  public ImmutableHashSnapMap(int initialCapacity) {
+    setCapacityAndCreateArrays(initialCapacity);
+  }
+
+  /** Along with creating new empty arrays, (re)set size to zero. */
+  protected void setCapacityAndCreateArrays(int newCapacity) {
+    capacity = newCapacity;
+    final int arrayLength = capacity * EXPAND_FACTOR;
+    keys = (K[]) new Object[arrayLength];
+    vals = (V[]) new Object[arrayLength];
+    size = 0;
+    hashMask = arrayLength - 1; // All ones in least significant bits.
+  }
+
+  /** Protected shallow copy constructor, for internal use by this class and subclasses. */
+  protected ImmutableHashSnapMap(ImmutableHashSnapMap other) {
+    size = other.size;
+    capacity = other.capacity;
+    keys = (K[]) other.keys;
+    vals = (V[]) other.vals;
+    hashMask = other.hashMask;
+  }
+
+  public V get(K key) {
+    return vals[indexOf(key)];
+  }
+
+  public int size() {
+    return size;
+  }
+
+  public MutableSnapMap<K, V> mutate() {
+    return new MutableLayeredSnapMap<>(this);
+    // return new MutableHashSnapMap(this);
+  }
+
+  // This method was a hot spot taking 55% of run time when using a modulo operator.
+  // Bit masking is much faster.
+  protected int indexOf(K key) {
+    // Unsigned right shift will ensure hash is positive, as will bitwise-and with lower bits.
+    int index = key.hashCode() & hashMask;
+    // To terminate, this loop requires there to be at least one null entry in the keys array.
+    while (true) {
+      if (keys[index] == null || keys[index].equals(key)) {
+        return index;
+      }
+      // Neither the key nor an empty slot was found, try the next slot.
+      index += 1;
+      if (index == keys.length) {
+        index = 0;
+      }
+    }
+  }
+
+  /// Bulk Load Methods
+
+  // public ImmutableHashSnapMap fromKeyValuePairs ()
+
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/ImmutableHashSnapMultimap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/ImmutableHashSnapMultimap.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.framework.collection.snapshot.impl;
+
+import java.util.Collections;
+import java.util.List;
+import org.opentripplanner.framework.collection.snapshot.ImmutableSnapMultimap;
+import org.opentripplanner.framework.collection.snapshot.MutableSnapMap;
+import org.opentripplanner.framework.collection.snapshot.MutableSnapMultimap;
+
+/**
+ * Making this extend ImmutableHashSnapMap<K, List<V>> almost works, except that the mutate methods
+ * clash and we don't want to return a mutable view of the internal list objects. So instead do it
+ * by composition.
+ */
+public class ImmutableHashSnapMultimap<K, V> implements ImmutableSnapMultimap<K, V> {
+
+  // Currently this is the interface rather than a concrete type, so we can drop in layered
+  // implementations as needed. The mutable type is specified here because subclasses need the
+  // mutable methods and it's an implementation detail. Immutable implementations should never call
+  // the mutating methods of this field.
+  protected MutableSnapMap<K, List<V>> map;
+
+  // The size of the multimap (number of mappings) is different from that of the map
+  // (number of keys with mappings).
+  protected int size;
+
+  public ImmutableHashSnapMultimap() {
+    map = MutableHashSnapMap.withDefaultCapacity();
+  }
+
+  /**
+   * Protected shallow copy constructor, for internal use by this class and subclasses.
+   * WARNING: calling this constructor leaks the map, and requires caller to protectively copy
+   * anything it contains on any later writes.
+   */
+  protected ImmutableHashSnapMultimap(ImmutableHashSnapMultimap source) {
+    map = source.map;
+    size = source.size;
+  }
+
+  // WARNING: CAPACITY MUST BE A POWER OF TWO
+  // TODO add checks
+  public ImmutableHashSnapMultimap(int initialCapacity) {
+    map = MutableHashSnapMap.withInitialCapacity(initialCapacity);
+  }
+
+  public List<V> get(K key) {
+    List<V> ret = map.get(key);
+    if (ret == null) {
+      return Collections.EMPTY_LIST;
+    } else {
+      return Collections.unmodifiableList(ret);
+    }
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public MutableSnapMultimap<K, V> mutate() {
+    return new MutableHashSnapMultimap<>(this);
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/ImmutableLayeredSnapMap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/ImmutableLayeredSnapMap.java
@@ -1,0 +1,51 @@
+package org.opentripplanner.framework.collection.snapshot.impl;
+
+import org.opentripplanner.framework.collection.snapshot.ImmutableSnapMap;
+import org.opentripplanner.framework.collection.snapshot.MutableSnapMap;
+
+public class ImmutableLayeredSnapMap<K, V> implements ImmutableSnapMap<K, V> {
+
+  private static final Object REMOVED = new Object();
+
+  // The types of these fields are concrete implementations rather than interfaces to prevent deep
+  // nesting of layered instances. Using the concrete types also allows finer  manipulation of
+  // behavior and internals (signaling when protective copies are necessary).
+
+  protected final MutableHashSnapMap<K, Object> mutable;
+  protected final ImmutableHashSnapMap<K, V> immutable;
+  protected int nRemoved;
+
+  protected ImmutableLayeredSnapMap(
+    MutableHashSnapMap<K, Object> mutable,
+    ImmutableHashSnapMap<K, V> immutable,
+    int nRemoved
+  ) {
+    this.mutable = mutable;
+    this.immutable = immutable;
+    this.nRemoved = nRemoved;
+  }
+
+  @Override
+  public V get(K key) {
+    Object value = mutable.get(key);
+    if (value == REMOVED) {
+      return null;
+    }
+    if (value == null) {
+      return immutable.get(key);
+    }
+    return (V) value;
+  }
+
+  @Override
+  public int size() {
+    // FIXME handle cases where removed is overwritten with new value,
+    //  and where elements in one layer mask old ones.
+    return mutable.size() + immutable.size() - nRemoved;
+  }
+
+  @Override
+  public MutableSnapMap mutate() {
+    return new MutableLayeredSnapMap(new MutableHashSnapMap(mutable), immutable, nRemoved);
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableHashSnapMap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableHashSnapMap.java
@@ -1,0 +1,100 @@
+package org.opentripplanner.framework.collection.snapshot.impl;
+
+import org.opentripplanner.framework.collection.snapshot.MutableSnapMap;
+
+public class MutableHashSnapMap<K, V>
+  extends ImmutableHashSnapMap<K, V>
+  implements MutableSnapMap<K, V> {
+
+  private boolean needsProtectiveCopy = false;
+
+  /// Private and protected constructors. Called from public factory methods.
+
+  protected MutableHashSnapMap() {
+    super();
+  }
+
+  private MutableHashSnapMap(int initialCapacity) {
+    super(initialCapacity);
+  }
+
+  /** Create a mutable instance (builder) from either a mutable or immutable instance. */
+  protected MutableHashSnapMap(ImmutableHashSnapMap source) {
+    super(source);
+    needsProtectiveCopy = true; // Arrays alias those in some other snapshot, so can't be modified.
+  }
+
+  /// Internal implementation methods
+
+  // We may want to perform the protective copy on construction to avoid repeatedly incurring the
+  // cost of this function call. Should be profiled.
+  private void protectiveCopy() {
+    if (needsProtectiveCopy) {
+      keys = keys.clone();
+      vals = vals.clone();
+      needsProtectiveCopy = false;
+    }
+  }
+
+  private static final int DURATION_THRESHOLD_MSEC = 10;
+
+  private void expandAndRehash() {
+    long start = System.currentTimeMillis();
+    K[] oldKeys = keys;
+    V[] oldVals = vals;
+    setCapacityAndCreateArrays(capacity * 2);
+    for (int i = 0; i < oldKeys.length; i++) {
+      if (oldKeys[i] != null) {
+        put(oldKeys[i], oldVals[i]);
+      }
+    }
+    long duration = System.currentTimeMillis() - start;
+    if (duration >= DURATION_THRESHOLD_MSEC) {
+      System.out.println("Expanded capacity to " + capacity);
+      System.out.println("Rehashed in " + duration + " milliseconds");
+    }
+  }
+
+  /// Public interface: mutable extensions to immutable superclass
+
+  public void put(K key, V val) {
+    protectiveCopy();
+    int index = indexOf(key);
+    if (vals[index] == null) {
+      // Inserting a mapping, rather than replacing an existing one.
+      if (size >= capacity) {
+        expandAndRehash();
+        index = indexOf(key);
+      }
+      // Increment size after rehash, because rehash sets the size to the number of mappings.
+      size += 1;
+    }
+    keys[index] = key;
+    vals[index] = val;
+  }
+
+  public void remove(K key) {
+    final int index = indexOf(key);
+    if (keys[index] != null) {
+      protectiveCopy();
+      keys[index] = null;
+      vals[index] = null;
+      size -= 1;
+    }
+  }
+
+  public ImmutableHashSnapMap snapshot() {
+    this.needsProtectiveCopy = true;
+    return new ImmutableHashSnapMap(this);
+  }
+
+  /// Public factory methods.
+
+  public static MutableHashSnapMap withDefaultCapacity() {
+    return new MutableHashSnapMap();
+  }
+
+  public static MutableHashSnapMap withInitialCapacity(int initialCapacity) {
+    return new MutableHashSnapMap(initialCapacity);
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableHashSnapMultimap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableHashSnapMultimap.java
@@ -1,0 +1,72 @@
+package org.opentripplanner.framework.collection.snapshot.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.opentripplanner.framework.collection.snapshot.MutableSnapMultimap;
+
+/**
+ * Should this use some kind of snapshot set for the values? No, this can be a list multimap that
+ * accepts duplicate mappings.
+ */
+public class MutableHashSnapMultimap<K, V>
+  extends ImmutableHashSnapMultimap<K, V>
+  implements MutableSnapMultimap<K, V> {
+
+  // Track which lists we created, to avoid redundant copy-on-write between snapshots.
+  private Set<List<V>> ownedLists = new HashSet<>();
+
+  /// Private and protected constructors. Called from public factory methods.
+
+  private MutableHashSnapMultimap() {
+    super();
+  }
+
+  /** Capacity here means the number of keys, not number of mappings. */
+  private MutableHashSnapMultimap(int initialCapacity) {
+    super(initialCapacity);
+  }
+
+  /** Create a mutable instance (builder) from either a mutable or immutable source instance. */
+  protected MutableHashSnapMultimap(ImmutableHashSnapMultimap source) {
+    super(source); // FIXME need to call mutate() on delegate
+  }
+
+  /// Internal implementation methods
+
+  /// Public interface: mutable multimap extensions to immutable superclass
+
+  public void put(K key, V val) {
+    // No need to make top-level protective copy, that's done at construction.
+    List<V> list = map.get(key);
+    if (list == null) {
+      list = new ArrayList<>();
+      map.put(key, list);
+      ownedLists.add(list);
+    } else if (!ownedLists.contains(list)) {
+      list = new ArrayList<>(list);
+      ownedLists.add(list);
+    }
+    list.add(val);
+  }
+
+  public void remove(K key) {
+    throw new UnsupportedOperationException();
+  }
+
+  public ImmutableHashSnapMultimap snapshot() {
+    this.ownedLists.clear();
+    return new ImmutableHashSnapMultimap(this);
+  }
+
+  /// Public factory methods.
+
+  public static MutableHashSnapMultimap withDefaultCapacity() {
+    return new MutableHashSnapMultimap();
+  }
+
+  public static MutableHashSnapMultimap withInitialCapacity(int initialCapacity) {
+    return new MutableHashSnapMultimap(initialCapacity);
+  }
+}

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableHashSnapMultimap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableHashSnapMultimap.java
@@ -1,7 +1,10 @@
 package org.opentripplanner.framework.collection.snapshot.impl;
 
+import com.google.common.collect.Sets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import org.opentripplanner.framework.collection.snapshot.MutableSnapMultimap;
@@ -14,8 +17,10 @@ public class MutableHashSnapMultimap<K, V>
   extends ImmutableHashSnapMultimap<K, V>
   implements MutableSnapMultimap<K, V> {
 
-  // Track which lists we created, to avoid redundant copy-on-write between snapshots.
-  private Set<List<V>> ownedLists = new HashSet<>();
+  // Track which lists we created, to avoid redundant copy-on-write between snapshots. This is
+  // intentionally using identity (reference) equality instead of Set's default semantic equality.
+  // Guava Sets.newIdentityHashSet is just a facade for the approach here.
+  private Set<List<V>> ownedLists = Collections.newSetFromMap(new IdentityHashMap<>());
 
   /// Private and protected constructors. Called from public factory methods.
 

--- a/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableLayeredSnapMap.java
+++ b/src/main/java/org/opentripplanner/framework/collection/snapshot/impl/MutableLayeredSnapMap.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.framework.collection.snapshot.impl;
+
+import org.opentripplanner.framework.collection.snapshot.ImmutableSnapMap;
+import org.opentripplanner.framework.collection.snapshot.MutableSnapMap;
+
+public class MutableLayeredSnapMap<K, V>
+  extends ImmutableLayeredSnapMap<K, V>
+  implements MutableSnapMap<K, V> {
+
+  // TODO Can we just null the value for this purpose?
+  private static final Object REMOVED = new Object();
+
+  protected MutableLayeredSnapMap(
+    MutableHashSnapMap<K, Object> mutable,
+    ImmutableHashSnapMap<K, V> immutable,
+    int nRemoved
+  ) {
+    super(mutable, immutable, nRemoved);
+  }
+
+  protected MutableLayeredSnapMap(ImmutableHashSnapMap<K, V> immutableHashSnapMap) {
+    this(new MutableHashSnapMap<>(), immutableHashSnapMap, 0);
+  }
+
+  @Override
+  public void put(K key, V value) {
+    mutable.put(key, value);
+  }
+
+  @Override
+  public void remove(K key) {
+    // Two ways to do this: a special REMOVED object, or rehash all data into a new table on removal.
+    if (get(key) != null) {
+      mutable.put(key, REMOVED);
+      nRemoved += 1;
+    }
+  }
+
+  @Override
+  public ImmutableSnapMap snapshot() {
+    // Need to signal that a protective copy is needed. FIXME may be wrong.
+    // We should probably just make a protective copy immediately, every time mutate() is called.
+    // Maybe separate deferred and non-deferred copy classes.
+    mutable.snapshot();
+    return new ImmutableLayeredSnapMap(mutable, immutable, nRemoved);
+  }
+}


### PR DESCRIPTION
### Summary

As discussed in realtime cleanup meetings, this PR introduces some custom collection classes for use in snapshots of realtime data. It includes interfaces for mutable and immutable maps from keys to single values and from keys to collections of values (multimaps). These are not extensions or re-implementation of Java collections, they are custom-designed for our use case with very narrow functionality. Creating a mutable copy of an immutable map is done at near zero cost, and updates are accumulated in a smaller map layered on top of the existing immutable map until they become numerous enough to justify rehashing a full copy.

OTP realtime data includes a lot of maps serving as indexes into the transit schedules. So far, these maps have not been subject to the same multi-version snapshot system as the transit schedule data itself. This means the indexes and the data they index could get out of sync, or might appear to be out of sync in one request but aligned in another request. This situation has persisted largely because of the perception that making snapshots of these indexes will involve making full copies of huge maps several times per second, wasting a lot of memory bandwidth and incurring lag in publishing the snapshots for use in routing.

The map implementations here are intended to alleviate these concerns, allowing extremely frequent "copies" of large maps, which only incur costs when things are added to them, and even then incur much smaller costs than a complete copy.

### Tests

Some tests of basic functionality and speed are included, but in the form of a main method. These will need to be refactored into proper tests.

### Documentation

- Some Javadoc is included in the classes, but the design is likely to evolve as we experiment with using this in realtime snapshots. Javadoc and package documentation will be completed when it's clear the system is stabilizing.

Note: the initial version of this code was written by me, but was first drafted in another project with a permissive (MIT) license. If similar code appears elsewhere, it is likely not derived from OTP, but just shares a common ancestor.