### PR TITLE
Add Iceland to the list of deployments [ci skip]

### DIFF
--- a/doc/user/Deployments.md
+++ b/doc/user/Deployments.md
@@ -79,6 +79,7 @@ The following are known deployments of OTP in a government- or agency-sponsored 
 * **Lower Saxony, Germany** The [VBN](https://www.vbn.de/en/) transportation authority offers an [OTP instance](https://www.vbn.de/en/service/developer-information/opendata-and-openservice) as alternative to the [Hafas](https://www.hacon.de/en/portfolio/information-ticketing/#section_8294) passenger information system.
 * **Leipzig, Germany** As of summer 2020 [Leipzig Move](https://leipzig-move.de/) has been using
   OpenTripPlanner.
+* **Iceland (nationwide)** – [Strætó](https://www.straeto.is/en) has used OTP from  2015.  
 
 ## Independent Production
 


### PR DESCRIPTION
### Summary

This add the Iceland (nationwide) travelplanner to the list of deployments. They are currently using OTP 1, but have plans to migrate to OTP 2. They have used OTP since 2015.

### Issue

Not relevant.


### Unit tests

Not relevant.


### Documentation

✅  Deployment doc updated


### Changelog

Not relevant


### Bumping the serialization version id

Not relevant
