### PR TITLE
Add `Leg.type` to GTFS GraphQL API

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -266,8 +266,7 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
 
   @Override
   public DataFetcher<GraphQLLegType> type() {
-    return environment ->
-      LegTypeMapper.map(getSource(environment));
+    return environment -> LegTypeMapper.map(getSource(environment));
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -9,6 +9,8 @@ import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLLegType;
+import org.opentripplanner.apis.gtfs.mapping.LegTypeMapper;
 import org.opentripplanner.apis.gtfs.mapping.NumberMapper;
 import org.opentripplanner.ext.restapi.mapping.LocalDateMapper;
 import org.opentripplanner.ext.ridehailing.model.RideEstimate;
@@ -260,6 +262,12 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
   @Override
   public DataFetcher<Trip> trip() {
     return environment -> getSource(environment).getTrip();
+  }
+
+  @Override
+  public DataFetcher<GraphQLLegType> type() {
+    return environment ->
+      LegTypeMapper.map(getSource(environment));
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -524,6 +524,8 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<Trip> trip();
 
+    public DataFetcher<org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLLegType> type();
+
     public DataFetcher<Boolean> walkingBike();
   }
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -1268,6 +1268,12 @@ public class GraphQLTypes {
     }
   }
 
+  public enum GraphQLLegType {
+    FLEX,
+    SCHEDULED_TRANSIT,
+    STREET,
+  }
+
   public static class GraphQLLocalDateRangeInput {
 
     private java.time.LocalDate end;

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -125,4 +125,5 @@ config:
     FareMedium: org.opentripplanner.model.fare.FareMedium#FareMedium
     RiderCategory: org.opentripplanner.model.fare.RiderCategory#RiderCategory
     StopPosition: org.opentripplanner.apis.gtfs.model.StopPosition#StopPosition
+    LegType: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLLegType
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapper.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapper.java
@@ -6,6 +6,9 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.StreetLeg;
 
+/**
+ * Extracts the type enum from a leg.
+ */
 public class LegTypeMapper {
 
   public static GraphQLTypes.GraphQLLegType map(Leg source) {

--- a/src/main/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapper.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.apis.gtfs.mapping;
 
-import javax.annotation.Nonnull;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.ext.flex.FlexibleTransitLeg;
 import org.opentripplanner.model.plan.Leg;
@@ -9,8 +8,6 @@ import org.opentripplanner.model.plan.StreetLeg;
 
 public class LegTypeMapper {
 
-
-  @Nonnull
   public static GraphQLTypes.GraphQLLegType map(Leg source) {
     return switch (source) {
       case StreetLeg ignored -> GraphQLTypes.GraphQLLegType.STREET;

--- a/src/main/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapper.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapper.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.apis.gtfs.mapping;
+
+import javax.annotation.Nonnull;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.ext.flex.FlexibleTransitLeg;
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.model.plan.ScheduledTransitLeg;
+import org.opentripplanner.model.plan.StreetLeg;
+
+public class LegTypeMapper {
+
+
+  @Nonnull
+  public static GraphQLTypes.GraphQLLegType map(Leg source) {
+    return switch (source) {
+      case StreetLeg ignored -> GraphQLTypes.GraphQLLegType.STREET;
+      case FlexibleTransitLeg ignored -> GraphQLTypes.GraphQLLegType.FLEX;
+      case ScheduledTransitLeg ignored -> GraphQLTypes.GraphQLLegType.SCHEDULED_TRANSIT;
+      default -> throw new IllegalStateException("Unhandled leg type: " + source);
+    };
+  }
+}

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -738,7 +738,7 @@ type Leg {
   "The Place where the leg ends."
   to: Place!
   "Whether this leg is a transit leg or not."
-  transitLeg: Boolean @deprecated(reason: "Use `type` instead.")
+  transitLeg: Boolean @deprecated(reason : "Use `type` instead.")
   "For transit legs, the trip that is used for traversing the leg. For non-transit legs, `null`."
   trip: Trip
   "What the type of the leg is."

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -741,6 +741,8 @@ type Leg {
   transitLeg: Boolean
   "For transit legs, the trip that is used for traversing the leg. For non-transit legs, `null`."
   trip: Trip
+  "What the type of the leg is."
+  type: LegType!
   "Whether this leg is walking with a bike."
   walkingBike: Boolean
 }
@@ -2884,6 +2886,18 @@ enum ItineraryFilterDebugProfile {
   LIST_ALL
   "By default, the debug itinerary filters is turned off."
   OFF
+}
+
+enum LegType {
+  """
+  Leg is on a flexible trip that uses flexible time windows, areas or groups of stops. This may or may not be classed
+  as transit, depending the type of service.
+  """
+  FLEX
+  "Leg is on a transit vehicle like bus, train or ferry which follows a published schedule, potentially with added real time information."
+  SCHEDULED_TRANSIT
+  "Leg traverses the street network, for example by walking to a stop, using a rental scooter or driving."
+  STREET
 }
 
 "Identifies whether this stop represents a stop or station."

--- a/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -738,7 +738,7 @@ type Leg {
   "The Place where the leg ends."
   to: Place!
   "Whether this leg is a transit leg or not."
-  transitLeg: Boolean
+  transitLeg: Boolean @deprecated(reason: "Use `type` instead.")
   "For transit legs, the trip that is used for traversing the leg. For non-transit legs, `null`."
   trip: Trip
   "What the type of the leg is."

--- a/src/test/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapperTest.java
@@ -20,5 +20,4 @@ class LegTypeMapperTest implements PlanTestConstants {
     var busLeg = TestItineraryBuilder.newItinerary(A).bus(1, T11_00, T11_30, B).build().firstLeg();
     assertEquals(GraphQLLegType.SCHEDULED_TRANSIT, LegTypeMapper.map(busLeg));
   }
-
 }

--- a/src/test/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapperTest.java
+++ b/src/test/java/org/opentripplanner/apis/gtfs/mapping/LegTypeMapperTest.java
@@ -1,0 +1,24 @@
+package org.opentripplanner.apis.gtfs.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLLegType;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.TestItineraryBuilder;
+
+class LegTypeMapperTest implements PlanTestConstants {
+
+  @Test
+  void flex() {
+    var flexLeg = TestItineraryBuilder.newItinerary(A).flex(T11_00, T11_30, B).build().firstLeg();
+    assertEquals(GraphQLLegType.FLEX, LegTypeMapper.map(flexLeg));
+  }
+
+  @Test
+  void transit() {
+    var busLeg = TestItineraryBuilder.newItinerary(A).bus(1, T11_00, T11_30, B).build().firstLeg();
+    assertEquals(GraphQLLegType.SCHEDULED_TRANSIT, LegTypeMapper.map(busLeg));
+  }
+
+}

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -199,9 +199,13 @@ public class TestItineraryBuilder implements PlanTestConstants {
     int legCost = 0;
     StopTime fromStopTime = new StopTime();
     fromStopTime.setStop(lastPlace.stop);
+    fromStopTime.setFlexWindowStart(start);
+    fromStopTime.setFlexWindowStart(end);
 
     StopTime toStopTime = new StopTime();
     toStopTime.setStop(to.stop);
+    toStopTime.setFlexWindowStart(start);
+    toStopTime.setFlexWindowEnd(end);
 
     Trip trip = trip("1", route("flex").build());
 

--- a/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-extended.json
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/expectations/plan-extended.json
@@ -17,6 +17,7 @@
           "walkTime" : 20,
           "legs" : [
             {
+              "type" : "STREET",
               "mode" : "WALK",
               "start" : {
                 "scheduledTime" : "2020-02-02T11:00:00Z",
@@ -67,6 +68,7 @@
               "accessibilityScore" : null
             },
             {
+              "type" : "SCHEDULED_TRANSIT",
               "mode" : "BUS",
               "start" : {
                 "scheduledTime" : "2020-02-02T10:51:00Z",
@@ -157,6 +159,7 @@
               "accessibilityScore" : null
             },
             {
+              "type" : "SCHEDULED_TRANSIT",
               "mode" : "RAIL",
               "start" : {
                 "scheduledTime" : "2020-02-02T11:20:00Z",
@@ -267,6 +270,7 @@
               "accessibilityScore" : null
             },
             {
+              "type" : "STREET",
               "mode" : "CAR",
               "start" : {
                 "scheduledTime" : "2020-02-02T11:50:00Z",

--- a/src/test/resources/org/opentripplanner/apis/gtfs/queries/plan-extended.graphql
+++ b/src/test/resources/org/opentripplanner/apis/gtfs/queries/plan-extended.graphql
@@ -26,6 +26,7 @@
       walkDistance
       walkTime
       legs {
+        type
         mode
         start {
           scheduledTime


### PR DESCRIPTION
### Summary

@miles-grant-ibigroup would like to have an unambiguous way to tell if a leg is a flex leg or not. The IBI frontend is currently using a heuristic that uses booking notices and pick up types. These things are not required for GTFS flex so currently there is no way to achieve this.

We have the `isTransit` boolean on `Leg` but I don't think this is good design. For that reason I'm introducing a new enum which tells client what the leg really is.

### Unit tests

:heavy_check_mark: 

### Documentation

:heavy_check_mark: 