### PR TITLE
Fix incorrect mapping of flex safe duration offset

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -81,7 +81,7 @@ class TripMapper {
     if (rhs.getSafeDurationFactor() == null && rhs.getSafeDurationOffset() == null) {
       return Optional.empty();
     } else {
-      var offset = Duration.ofSeconds(rhs.getSafeDurationOffset().longValue());
+      var offset = Duration.ofMinutes(rhs.getSafeDurationOffset().longValue());
       return Optional.of(TimePenalty.of(offset, rhs.getSafeDurationFactor().doubleValue()));
     }
   }

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -122,12 +123,12 @@ public class TripMapperTest {
     var flexTrip = new Trip();
     flexTrip.setId(new AgencyAndId("1", "1"));
     flexTrip.setSafeDurationFactor(1.5);
-    flexTrip.setSafeDurationOffset(600d);
+    flexTrip.setSafeDurationOffset(60d);
     flexTrip.setRoute(new GtfsTestData().route);
     var mapper = defaultTripMapper();
     var mapped = mapper.map(flexTrip);
     var penalty = mapper.flexSafeTimePenalties().get(mapped);
     assertEquals(1.5f, penalty.coefficient());
-    assertEquals(600, penalty.constant().toSeconds());
+    assertEquals(Duration.ofHours(1), penalty.constant());
   }
 }


### PR DESCRIPTION
### Summary

During #5796 I made a mistake by interpreting the safe_duration_offset as a number of seconds. The spec clearly states though that it's a number of _minutes_.

### Issue

https://github.com/MobilityData/gtfs-flex/pull/79

### Unit tests

Updated.