### PR TITLE
Use correct HEAD request when fetching HTTP headers

### DIFF
--- a/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
+++ b/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -76,7 +77,7 @@ public class OtpHttpClient {
     Map<String, String> requestHeaderValues
   ) {
     return executeAndMapWithResponseHandler(
-      new HttpGet(uri),
+      new HttpHead(uri),
       timeout,
       requestHeaderValues,
       response -> {

--- a/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
+++ b/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
@@ -91,9 +91,6 @@ public class OtpHttpClient {
 
           return Collections.emptyList();
         }
-        if (response.getEntity() == null || response.getEntity().getContent() == null) {
-          throw new OtpHttpClientException("HTTP request failed: empty response");
-        }
         return Arrays.stream(response.getHeaders()).toList();
       }
     );


### PR DESCRIPTION
### Summary

When working with large downloads in build-config.json I noticed that starting up OTP was quite slow and using a lot of bandwidth before the graph build, and therefore download, even started.

I traced it down to a problematic method that was supposed to fetch HTTP headers but instead downloaded the entire file.

The Javadoc clearly states that a HEAD request should be executed but the in the acutal implementation this is not the case: https://github.com/opentripplanner/OpenTripPlanner/blob/dc4cdb81ea15c8d0195a6e2f8928a51ece461608/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java#L70-L73

### Unit tests

I could write a test spinning up a HTTP server, but I don't think we want that.