### PR TITLE
Add progress log to HTTP downloads

### DIFF
--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -88,8 +88,8 @@ class HttpsDataSourceMetadata {
     return ToStringBuilder
       .of(this.getClass())
       .addObj("contentType", contentType)
-      .addStr("contentLength", FileSizeToTextConverter.fileSizeToString(contentLength))
-      .addObj("lastModified", lastModified)
+      .addObj("contentLength", FileSizeToTextConverter.fileSizeToString(contentLength))
+      .addObj("lastModified", Instant.ofEpochMilli(lastModified).toString())
       .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -9,6 +9,7 @@ import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.opentripplanner.datastore.api.DataSource;
+import org.opentripplanner.framework.text.FileSizeToTextConverter;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 
 /**
@@ -87,7 +88,7 @@ class HttpsDataSourceMetadata {
     return ToStringBuilder
       .of(this.getClass())
       .addObj("contentType", contentType)
-      .addObj("contentLength", contentLength)
+      .addStr("contentLength", FileSizeToTextConverter.fileSizeToString(contentLength))
       .addObj("lastModified", lastModified)
       .toString();
   }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpsDataSourceRepository implements DataSourceRepository {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HttpsFileDataSource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HttpsDataSourceRepository.class);
 
   private static final Duration HTTP_HEAD_REQUEST_TIMEOUT = Duration.ofSeconds(20);
 

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -14,6 +14,7 @@ import org.opentripplanner.datastore.file.DirectoryDataSource;
 import org.opentripplanner.datastore.file.ZipFileDataSource;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
+import org.opentripplanner.framework.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +90,13 @@ final class HttpsFileDataSource implements DataSource {
         throw new IllegalStateException(e.getLocalizedMessage(), e);
       }
     } else {
-      return in;
+      return ProgressTracker.track(
+        "Downloading %s".formatted(uri.toString()),
+        1000,
+        size(),
+        in,
+        m -> LOG.info(m)
+      );
     }
   }
 


### PR DESCRIPTION
### Summary

This adds a progress log for HTTP downloads which give you a bit of visibillity when OTP does large downloads.

### Issue

:x: 

### Unit tests

:x: 