### PR TITLE
Remove service date from cache key of SiriTripPatternCache

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -285,8 +285,7 @@ public class SiriRealTimeTripUpdateAdapter {
       pattern = tripUpdate.addedTripPattern();
     } else {
       // Get cached trip pattern or create one if it doesn't exist yet
-      pattern = tripPatternCache.getOrCreateTripPattern(tripUpdate.stopPattern(), trip
-      );
+      pattern = tripPatternCache.getOrCreateTripPattern(tripUpdate.stopPattern(), trip);
     }
 
     // Add new trip times to buffer, making protective copies as needed. Bubble success/error up.

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -285,10 +285,7 @@ public class SiriRealTimeTripUpdateAdapter {
       pattern = tripUpdate.addedTripPattern();
     } else {
       // Get cached trip pattern or create one if it doesn't exist yet
-      pattern = tripPatternCache.getOrCreateTripPattern(
-        tripUpdate.stopPattern(),
-        trip,
-        serviceDate
+      pattern = tripPatternCache.getOrCreateTripPattern(tripUpdate.stopPattern(), trip
       );
     }
 

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriTripPatternCache.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriTripPatternCache.java
@@ -28,9 +28,12 @@ import org.opentripplanner.transit.model.timetable.Trip;
  */
 class SiriTripPatternCache {
 
-  // TODO RT_AB: Improve documentation. This seems to be the primary collection of added
-  //   TripPatterns, with other collections serving as indexes. Similar to TripPatternCache.cache
-  //   in the GTFS version of this class, but with service date as part of the key.
+  /**
+   * We cache the trip pattern based on the stop pattern only in order to de-duplicate them.
+   * <p>
+   * Note that we don't really have a definition which properties are really part of the trip
+   * pattern and several pattern keys are used in different parts of OTP.
+   */
   private final Map<StopPattern, TripPattern> cache = new HashMap<>();
 
   // TODO RT_AB: generalize this so we can generate IDs for SIRI or GTFS-RT sources.


### PR DESCRIPTION
### Summary

In today's real time meeting we talked about the indexing of trip patterns in the `SiriTripPatternCache` and we came to the following conclusion:

- we don't really know why the cache key contains the service date
- even though we are uneasy about it, @vpaturet agreed to just try it out on Entur's staging system to find out if there are negative consequences

### Issue

#4002