### PR TITLE
Add full ISO times and colours to debug UI 

### DIFF
--- a/client/src/components/ItineraryList/ItineraryHeaderContent.tsx
+++ b/client/src/components/ItineraryList/ItineraryHeaderContent.tsx
@@ -45,6 +45,7 @@ export function ItineraryHeaderContent({
         }}
       />
       <div
+        title={tripPattern.expectedStartTime}
         className="itinerary-header-itinerary-time"
         style={{
           left: `${leftPx - TIME_BOX_WIDTH}px`,
@@ -65,6 +66,7 @@ export function ItineraryHeaderContent({
       ))}
 
       <div
+        title={tripPattern.expectedEndTime}
         className="itinerary-header-itinerary-time"
         style={{
           left: `${leftPx + widthPx + 2}px`,

--- a/client/src/components/ItineraryList/LegTime.tsx
+++ b/client/src/components/ItineraryList/LegTime.tsx
@@ -11,11 +11,15 @@ export function LegTime({
 }) {
   return aimedTime !== expectedTime ? (
     <>
-      <span style={{ color: 'red' }}>{formatTime(expectedTime, 'short')}</span>
-      <span style={{ textDecoration: 'line-through' }}>{formatTime(aimedTime, 'short')}</span>
+      <span title={expectedTime} style={{ color: 'red' }}>
+        {formatTime(expectedTime, 'short')}
+      </span>
+      <span title={aimedTime} style={{ textDecoration: 'line-through' }}>
+        {formatTime(aimedTime, 'short')}
+      </span>
     </>
   ) : (
-    <span>
+    <span title={expectedTime}>
       {formatTime(expectedTime, 'short')}
       {hasRealtime && <span> (on time)</span>}
     </span>

--- a/client/src/components/ItineraryList/useHeaderLegContentStyleCalculations.ts
+++ b/client/src/components/ItineraryList/useHeaderLegContentStyleCalculations.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { isTransitMode } from '../../util/isTransitMode.ts';
-import { getColorForMode } from '../../util/getColorForMode.ts';
+import { getColorForLeg } from '../../util/getColorForLeg.ts';
 import { generateTextColor } from '../../util/generateTextColor.ts';
 import { Leg } from '../../gql/graphql.ts';
 
@@ -27,7 +27,7 @@ export function useHeaderLegContentStyleCalculations(
   const showPublicCode =
     widthPx > 40 && isTransitMode(leg.mode) && leg.line?.publicCode && leg.line.publicCode.length <= 6;
 
-  const modeColor = getColorForMode(leg.mode);
+  const modeColor = getColorForLeg(leg);
   const legTextColor = useMemo(() => generateTextColor(modeColor), [modeColor]);
 
   return { widthPx, leftPx, legTextColor, modeColor, showPublicCode };

--- a/client/src/components/MapView/LegLines.tsx
+++ b/client/src/components/MapView/LegLines.tsx
@@ -1,7 +1,7 @@
 import { TripPattern } from '../../gql/graphql.ts';
 import { Layer, Source } from 'react-map-gl';
 import { decode } from '@googlemaps/polyline-codec';
-import { getColorForMode } from '../../util/getColorForMode.ts';
+import { getColorForLeg } from '../../util/getColorForLeg.ts';
 
 export function LegLines({ tripPattern }: { tripPattern?: TripPattern }) {
   return (
@@ -28,7 +28,7 @@ export function LegLines({ tripPattern }: { tripPattern?: TripPattern }) {
                   'line-cap': 'round',
                 }}
                 paint={{
-                  'line-color': getColorForMode(leg.mode),
+                  'line-color': getColorForLeg(leg),
                   'line-width': 5,
                 }}
               />

--- a/client/src/static/query/tripQuery.tsx
+++ b/client/src/static/query/tripQuery.tsx
@@ -64,6 +64,9 @@ export const query = graphql(`
             publicCode
             name
             id
+            presentation {
+              colour
+            }
           }
           authority {
             name

--- a/client/src/util/getColorForLeg.ts
+++ b/client/src/util/getColorForLeg.ts
@@ -1,6 +1,6 @@
-import { Mode } from '../gql/graphql.ts';
+import { Leg, Mode } from '../gql/graphql.ts';
 
-export const getColorForMode = function (mode: Mode) {
+const getColorForMode = function (mode: Mode) {
   if (mode === Mode.Foot) return '#191616';
   if (mode === Mode.Bicycle) return '#5076D9';
   if (mode === Mode.Scooter) return '#253664';
@@ -18,4 +18,15 @@ export const getColorForMode = function (mode: Mode) {
   if (mode === Mode.Monorail) return '#81304C';
   if (mode === Mode.Taxi) return '#81304C';
   return '#aaa';
+};
+
+/**
+ * Extract a line color from a leg. If there isn't on given by its line property use fallback colors.
+ */
+export const getColorForLeg = function (leg: Leg) {
+  if (leg.line?.presentation?.colour) {
+    return `#${leg.line.presentation.colour}`;
+  } else {
+    return getColorForMode(leg.mode);
+  }
 };

--- a/client/src/util/getColorForLeg.ts
+++ b/client/src/util/getColorForLeg.ts
@@ -21,7 +21,7 @@ const getColorForMode = function (mode: Mode) {
 };
 
 /**
- * Extract a line color from a leg. If there isn't on given by its line property use fallback colors.
+ * Extract a line color from a leg. If there isn't one given by its line, this method returns a fallback color.
  */
 export const getColorForLeg = function (leg: Leg) {
   if (leg.line?.presentation?.colour) {


### PR DESCRIPTION
### Summary

This is a quality of life improvement for the debug UI:

- adds the full ISO date time to the `title` property, so it shows up on hover
- uses the line's colours when visualising legs and their geometries

![Screenshot from 2024-09-19 09-50-53](https://github.com/user-attachments/assets/f6a86bd4-0f0f-421d-8104-24e3d636e155)