### PR TITLE
fix(orca-fares): remove fare attributes with no rules

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/FareRuleSetTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/FareRuleSetTest.java
@@ -69,16 +69,7 @@ class FareRuleSetTest {
     var trips = Set.of(new FeedScopedId("feed", "trip1"));
     var zones = Set.of("zone1");
     assertTrue(
-      fareRuleSet.matches(
-        "A",
-        "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
-        0,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("A", "B", Set.of(), Set.of(), Set.of(), 0, Duration.ZERO, Duration.ZERO)
     );
     assertTrue(
       fareRuleSet.matches(
@@ -98,28 +89,10 @@ class FareRuleSetTest {
   void testMatchesWithOriginDestination() {
     fareRuleSet.addOriginDestination("A", "B");
     assertTrue(
-      fareRuleSet.matches(
-        "A",
-        "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
-        0,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("A", "B", Set.of(), Set.of(), Set.of(), 0, Duration.ZERO, Duration.ZERO)
     );
     assertFalse(
-      fareRuleSet.matches(
-        "B",
-        "C",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
-        0,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("B", "C", Set.of(), Set.of(), Set.of(), 0, Duration.ZERO, Duration.ZERO)
     );
   }
 
@@ -131,28 +104,10 @@ class FareRuleSetTest {
     fareRuleSet.addContains("Zone1");
     fareRuleSet.addContains("Zone2");
     assertTrue(
-      fareRuleSet.matches(
-        "A",
-        "B",
-        zones,
-        new HashSet<>(),
-        new HashSet<>(),
-        0,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("A", "B", zones, Set.of(), Set.of(), 0, Duration.ZERO, Duration.ZERO)
     );
     assertFalse(
-      fareRuleSet.matches(
-        "A",
-        "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
-        0,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("A", "B", Set.of(), Set.of(), Set.of(), 0, Duration.ZERO, Duration.ZERO)
     );
   }
 
@@ -164,24 +119,15 @@ class FareRuleSetTest {
     routes.add(routeId);
     fareRuleSet.addRoute(routeId);
     assertTrue(
-      fareRuleSet.matches(
-        "A",
-        "B",
-        new HashSet<>(),
-        routes,
-        new HashSet<>(),
-        0,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("A", "B", Set.of(), routes, Set.of(), 0, Duration.ZERO, Duration.ZERO)
     );
     assertFalse(
       fareRuleSet.matches(
         "A",
         "B",
-        new HashSet<>(),
+        Set.of(),
         Set.of(otherRouteId),
-        new HashSet<>(),
+        Set.of(),
         0,
         Duration.ZERO,
         Duration.ZERO
@@ -192,28 +138,10 @@ class FareRuleSetTest {
   @Test
   void testMatchesWithTransfers() {
     assertTrue(
-      fareRuleSet.matches(
-        "A",
-        "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
-        1,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("A", "B", Set.of(), Set.of(), Set.of(), 1, Duration.ZERO, Duration.ZERO)
     );
     assertFalse(
-      fareRuleSet.matches(
-        "A",
-        "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
-        2,
-        Duration.ZERO,
-        Duration.ZERO
-      )
+      fareRuleSet.matches("A", "B", Set.of(), Set.of(), Set.of(), 2, Duration.ZERO, Duration.ZERO)
     );
   }
 
@@ -223,9 +151,9 @@ class FareRuleSetTest {
       fareRuleSet.matches(
         "A",
         "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
+        Set.of(),
+        Set.of(),
+        Set.of(),
         0,
         Duration.ofSeconds(7000),
         Duration.ZERO
@@ -235,9 +163,9 @@ class FareRuleSetTest {
       fareRuleSet.matches(
         "A",
         "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
+        Set.of(),
+        Set.of(),
+        Set.of(),
         0,
         Duration.ofSeconds(8000),
         Duration.ZERO
@@ -259,9 +187,9 @@ class FareRuleSetTest {
       journeyRuleSet.matches(
         "A",
         "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
+        Set.of(),
+        Set.of(),
+        Set.of(),
         0,
         Duration.ZERO,
         Duration.ofSeconds(7000)
@@ -271,9 +199,9 @@ class FareRuleSetTest {
       journeyRuleSet.matches(
         "A",
         "B",
-        new HashSet<>(),
-        new HashSet<>(),
-        new HashSet<>(),
+        Set.of(),
+        Set.of(),
+        Set.of(),
         0,
         Duration.ZERO,
         Duration.ofSeconds(8000)

--- a/src/ext-test/java/org/opentripplanner/ext/fares/FareRuleSetTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/FareRuleSetTest.java
@@ -1,0 +1,294 @@
+package org.opentripplanner.ext.fares;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.model.FareAttribute;
+import org.opentripplanner.ext.fares.model.FareRuleSet;
+import org.opentripplanner.transit.model.basic.Money;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+class FareRuleSetTest {
+
+  private FareRuleSet fareRuleSet;
+  static final Money TWO_FIFTY = Money.usDollars(2.50f);
+
+  @BeforeEach
+  void setUp() {
+    FeedScopedId id = new FeedScopedId("feed", "fare1");
+    FareAttribute fareAttribute = FareAttribute
+      .of(id)
+      .setPrice(TWO_FIFTY)
+      .setPaymentMethod(1)
+      .setTransfers(1)
+      .setTransferDuration(7200)
+      .build();
+    fareRuleSet = new FareRuleSet(fareAttribute);
+  }
+
+  @Test
+  void testHasNoRules() {
+    assertFalse(fareRuleSet.hasRules());
+  }
+
+  @Test
+  void testAddOriginDestination() {
+    fareRuleSet.addOriginDestination("A", "B");
+    assertTrue(fareRuleSet.hasRules());
+  }
+
+  @Test
+  void testAddRouteOriginDestination() {
+    fareRuleSet.addRouteOriginDestination("Route1", "A", "B");
+    assertTrue(fareRuleSet.hasRules());
+    assertEquals(1, fareRuleSet.getRouteOriginDestinations().size());
+  }
+
+  @Test
+  void testAddContains() {
+    fareRuleSet.addContains("Zone1");
+    assertTrue(fareRuleSet.hasRules());
+    assertEquals(1, fareRuleSet.getContains().size());
+  }
+
+  @Test
+  void testAddRoute() {
+    FeedScopedId routeId = new FeedScopedId("feed", "route1");
+    fareRuleSet.addRoute(routeId);
+    assertTrue(fareRuleSet.hasRules());
+    assertEquals(1, fareRuleSet.getRoutes().size());
+  }
+
+  @Test
+  void testMatchesWithNoRules() {
+    var routes = Set.of(new FeedScopedId("feed", "route1"));
+    var trips = Set.of(new FeedScopedId("feed", "trip1"));
+    var zones = Set.of("zone1");
+    assertTrue(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+    assertTrue(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        zones,
+        routes,
+        trips,
+        0,
+        Duration.ofMinutes(100),
+        Duration.ofMinutes(100)
+      )
+    );
+  }
+
+  @Test
+  void testMatchesWithOriginDestination() {
+    fareRuleSet.addOriginDestination("A", "B");
+    assertTrue(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+    assertFalse(
+      fareRuleSet.matches(
+        "B",
+        "C",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+  }
+
+  @Test
+  void testMatchesWithContains() {
+    Set<String> zones = new HashSet<>();
+    zones.add("Zone1");
+    zones.add("Zone2");
+    fareRuleSet.addContains("Zone1");
+    fareRuleSet.addContains("Zone2");
+    assertTrue(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        zones,
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+    assertFalse(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+  }
+
+  @Test
+  void testMatchesWithRoutes() {
+    Set<FeedScopedId> routes = new HashSet<>();
+    FeedScopedId routeId = new FeedScopedId("feed", "route1");
+    FeedScopedId otherRouteId = new FeedScopedId("feed", "route2");
+    routes.add(routeId);
+    fareRuleSet.addRoute(routeId);
+    assertTrue(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        routes,
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+    assertFalse(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        Set.of(otherRouteId),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+  }
+
+  @Test
+  void testMatchesWithTransfers() {
+    assertTrue(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        1,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+    assertFalse(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        2,
+        Duration.ZERO,
+        Duration.ZERO
+      )
+    );
+  }
+
+  @Test
+  void testMatchesWithTransferDuration() {
+    assertTrue(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ofSeconds(7000),
+        Duration.ZERO
+      )
+    );
+    assertFalse(
+      fareRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ofSeconds(8000),
+        Duration.ZERO
+      )
+    );
+  }
+
+  @Test
+  void testMatchesWithJourneyDuration() {
+    FareAttribute journeyFare = FareAttribute
+      .of(new FeedScopedId("feed", "journey"))
+      .setPrice(Money.usDollars(3.00f))
+      .setPaymentMethod(1)
+      .setJourneyDuration(7200)
+      .build();
+    FareRuleSet journeyRuleSet = new FareRuleSet(journeyFare);
+
+    assertTrue(
+      journeyRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ofSeconds(7000)
+      )
+    );
+    assertFalse(
+      journeyRuleSet.matches(
+        "A",
+        "B",
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        0,
+        Duration.ZERO,
+        Duration.ofSeconds(8000)
+      )
+    );
+  }
+
+  @Test
+  void testAgencyMethods() {
+    assertFalse(fareRuleSet.hasAgencyDefined());
+    assertNull(fareRuleSet.getAgency());
+
+    FeedScopedId agencyId = new FeedScopedId("feed", "agency1");
+    fareRuleSet.setAgency(agencyId);
+    assertTrue(fareRuleSet.hasAgencyDefined());
+    assertEquals(agencyId, fareRuleSet.getAgency());
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceFactory.java
@@ -92,7 +92,7 @@ public class DefaultFareServiceFactory implements FareServiceFactory {
       FareRuleSet fareRule = fareRuleSet.get(id);
       if (fareRule == null) {
         // Should never happen by design
-        LOG.error("Inexistant fare ID in fare rule: " + id);
+        LOG.error("Nonexistent fare ID in fare rule: " + id);
         continue;
       }
       String contains = rule.getContainsId();

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareFactory.java
@@ -24,6 +24,8 @@ public class OrcaFareFactory extends DefaultFareServiceFactory {
   @Override
   public void processGtfs(FareRulesData fareRuleService, OtpTransitService transitService) {
     fillFareRules(fareRuleService.fareAttributes(), fareRuleService.fareRules(), regularFareRules);
+    // ORCA agencies don't rely on fare attributes without rules, so let's remove them.
+    regularFareRules.entrySet().removeIf(entry -> !entry.getValue().hasRules());
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/fares/model/FareRuleSet.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/model/FareRuleSet.java
@@ -40,6 +40,15 @@ public class FareRuleSet implements Serializable {
     return routeOriginDestinations;
   }
 
+  public boolean hasRules() {
+    return (
+      !routes.isEmpty() ||
+      !originDestinations.isEmpty() ||
+      !routeOriginDestinations.isEmpty() ||
+      !contains.isEmpty()
+    );
+  }
+
   public void addContains(String containsId) {
     contains.add(containsId);
   }

--- a/src/ext/java/org/opentripplanner/ext/fares/model/FareRuleSet.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/model/FareRuleSet.java
@@ -40,6 +40,10 @@ public class FareRuleSet implements Serializable {
     return routeOriginDestinations;
   }
 
+  /**
+   * Determine whether the FareRuleSet has any rules added.
+   * @return True if any rules have been added.
+   */
   public boolean hasRules() {
     return (
       !routes.isEmpty() ||
@@ -69,6 +73,19 @@ public class FareRuleSet implements Serializable {
     return fareAttribute;
   }
 
+  /**
+   * Determines whether the FareRuleSet matches against a set of itinerary parameters
+   * based on the added rules and fare attribute
+   * @param startZone Origin zone
+   * @param endZone End zone
+   * @param zonesVisited A set containing the names of zones visited on the fare
+   * @param routesVisited A set containing the route IDs visited
+   * @param tripsVisited [Not implemented] A set containing the trip IDs visited
+   * @param transfersUsed Number of transfers already used
+   * @param tripTime Time from beginning of first leg to beginning of current leg to be evaluated
+   * @param journeyTime Total journey time from beginning of first leg to end of current leg
+   * @return True if this FareAttribute should apply to this leg
+   */
   public boolean matches(
     String startZone,
     String endZone,


### PR DESCRIPTION
### Summary

ORCA agencies have occasionally left in fare attributes with no associated rules. OTP will match these against any leg, and if the fare is lower than the correct fare, it will take priority. There does not seem to be a well defined behavior for this edge case in the GTFS spec, but to avoid changing the behavior of OTP in general, I have added a one liner to remove these fare attributes lacking rules when using the ORCA fare module.

### Unit tests

I'm not sure how to test this or if it's necessary, since this change happened in the ORCA fare factory which is untested.