### PR TITLE
Don't use elevation data directly for ways with cutting=*, location=underground or indoor=yes tags in the default mapper

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
@@ -613,7 +613,10 @@ class DefaultMapper implements OsmTagMapper {
     // slope overrides
     props.setSlopeOverride(new BestMatchSpecifier("bridge=*"), true);
     props.setSlopeOverride(new BestMatchSpecifier("embankment=*"), true);
+    props.setSlopeOverride(new BestMatchSpecifier("cutting=*"), true);
     props.setSlopeOverride(new BestMatchSpecifier("tunnel=*"), true);
+    props.setSlopeOverride(new BestMatchSpecifier("location=underground"), true);
+    props.setSlopeOverride(new BestMatchSpecifier("indoor=yes"), true);
   }
 
   public void populateNotesAndNames(WayPropertySet props) {

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.openstreetmap.tagmapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
@@ -187,6 +188,15 @@ public class DefaultMapperTest {
     assertEquals(ALL, useSidepathBackwardProps.getPermission());
     assertEquals(0.98, useSidepathBackwardProps.bicycleSafety().forward(), epsilon);
     assertEquals(4.9, useSidepathBackwardProps.bicycleSafety().back(), epsilon);
+  }
+
+  @Test
+  void slopeOverrides() {
+    var regular = WayTestData.southeastLaBonitaWay();
+    assertFalse(wps.getSlopeOverride(regular));
+
+    var indoor = WayTestData.southeastLaBonitaWay().addTag("indoor", "yes");
+    assertTrue(wps.getSlopeOverride(indoor));
   }
 
   /**


### PR DESCRIPTION
### Summary

Copies over the rules from Norway mapper for disabling the elevation usage for the for the following tag value combinations to the default mapper as well:

    cutting=*
    location=underground
    indoor=yes


### Issue

Related to https://github.com/opentripplanner/OpenTripPlanner/issues/6092

### Unit tests

Added some

### Documentation

Not needed

### Changelog

From title
