### PR TITLE
Add mapper for GTFS GraphQL real time state

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -10,6 +10,7 @@ import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.mapping.NumberMapper;
+import org.opentripplanner.apis.gtfs.mapping.RealtimeStateMapper;
 import org.opentripplanner.ext.restapi.mapping.LocalDateMapper;
 import org.opentripplanner.ext.ridehailing.model.RideEstimate;
 import org.opentripplanner.ext.ridehailing.model.RideHailingLeg;
@@ -191,10 +192,10 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
   }
 
   @Override
-  public DataFetcher<String> realtimeState() {
+  public DataFetcher<GraphQLTypes.GraphQLRealtimeState> realtimeState() {
     return environment -> {
       var state = getSource(environment).getRealTimeState();
-      return (state != null) ? state.name() : null;
+      return RealtimeStateMapper.map(state);
     };
   }
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StoptimeImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StoptimeImpl.java
@@ -3,10 +3,11 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.gtfs.mapping.RealtimeStateMapper;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripTimeOnDate;
-import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 public class StoptimeImpl implements GraphQLDataFetchers.GraphQLStoptime {
@@ -67,11 +68,11 @@ public class StoptimeImpl implements GraphQLDataFetchers.GraphQLStoptime {
   }
 
   @Override
-  public DataFetcher<String> realtimeState() {
+  public DataFetcher<GraphQLTypes.GraphQLRealtimeState> realtimeState() {
     return environment ->
       getSource(environment).isCanceledEffectively()
-        ? RealTimeState.CANCELED.name()
-        : getSource(environment).getRealTimeState().name();
+        ? GraphQLTypes.GraphQLRealtimeState.CANCELED
+        : RealtimeStateMapper.map(getSource(environment).getRealTimeState());
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -18,6 +18,7 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertSeverity
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLBikesAllowed;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLInputField;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLOccupancyStatus;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRealtimeState;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRelativeDirection;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRoutingErrorCode;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTransitMode;
@@ -504,7 +505,7 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<Boolean> realTime();
 
-    public DataFetcher<String> realtimeState();
+    public DataFetcher<GraphQLRealtimeState> realtimeState();
 
     public DataFetcher<Boolean> rentedBike();
 
@@ -1082,7 +1083,7 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<Integer> realtimeDeparture();
 
-    public DataFetcher<String> realtimeState();
+    public DataFetcher<GraphQLRealtimeState> realtimeState();
 
     public DataFetcher<Integer> scheduledArrival();
 

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -84,7 +84,7 @@ config:
     PlanConnection: graphql.execution.DataFetcherResult<org.opentripplanner.routing.api.response.RoutingResponse>
     PlanEdge: graphql.relay.DefaultEdge#DefaultEdge<Itinerary>
     PlanPageInfo: org.opentripplanner.apis.gtfs.model.PlanPageInfo#PlanPageInfo
-    RealtimeState: String
+    RealtimeState: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRealtimeState#GraphQLRealtimeState
     RelativeDirection: org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLRelativeDirection#GraphQLRelativeDirection
     Route: org.opentripplanner.transit.model.network.Route#Route
     RoutingError: org.opentripplanner.routing.api.response.RoutingError#RoutingError

--- a/src/main/java/org/opentripplanner/apis/gtfs/mapping/RealtimeStateMapper.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/mapping/RealtimeStateMapper.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.apis.gtfs.mapping;
+
+import javax.annotation.Nullable;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
+
+/**
+ * Maps from the internal model to the API one.
+ */
+public class RealtimeStateMapper {
+
+  public static GraphQLTypes.GraphQLRealtimeState map(@Nullable RealTimeState state) {
+    if (state == null) return null;
+    return switch (state) {
+      case SCHEDULED -> GraphQLTypes.GraphQLRealtimeState.SCHEDULED;
+      case UPDATED -> GraphQLTypes.GraphQLRealtimeState.UPDATED;
+      case CANCELED, DELETED -> GraphQLTypes.GraphQLRealtimeState.CANCELED;
+      case ADDED -> GraphQLTypes.GraphQLRealtimeState.ADDED;
+      case MODIFIED -> GraphQLTypes.GraphQLRealtimeState.MODIFIED;
+    };
+  }
+}


### PR DESCRIPTION
### Summary

After #6045 was merged I realised that we should have a proper mapper for the realtime state since this forces you to correctly deal with all enum types.

Case in point, the current code would break with the real time state `DELETED`. I've mapped it to `CANCELLED`.

### Issue

None.

### Unit tests

None.
