### PR TITLE
doc: update `NamingConventions.md` reference [ci skip]

### DIFF
--- a/DEVELOPMENT_DECISION_RECORDS.md
+++ b/DEVELOPMENT_DECISION_RECORDS.md
@@ -16,7 +16,7 @@ tests. Expect to include some code cleanup as part of all PRs.
 ## Follow-Naming-Conventions
 
 Use established terminology from GTFS, NeTEx or the existing OTP code. Make sure the code is easy
-to read and understand. [Follow naming conventions](CODE_CONVENTIONS.md#naming-conventions) . 
+to read and understand. [Follow naming conventions](doc/dev/decisionrecords/NamingConventions.md#naming-conventions) . 
 
 
 ## Write-Code-Documentation - Use JavaDoc

--- a/doc/user/Developers-Guide.md
+++ b/doc/user/Developers-Guide.md
@@ -205,7 +205,7 @@ so they are a bit easier to maintain that way. The primary audience is also acti
 that have the code checked out locally.
 
  - [Architecture](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/ARCHITECTURE.md) 
- - [Code Conventions](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/CODE_CONVENTIONS.md)
+ - [Naming Conventions](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/dev/decisionrecords/NamingConventions.md)
  - [Development Decision Records](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/DEVELOPMENT_DECISION_RECORDS.md)
 
 


### PR DESCRIPTION
### Summary

Commit 27eb36ca5518866c71f1656bcf334f5c22a3f8a4 renamed `CODE_CONVENTIONS.md` to be `NamingConventions.md` and moved it to another location. This PR adjusts sources to changes.