### PR TITLE
Add geometry for `EscalatorEdge`

### DIFF
--- a/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.street.model.edge;
 
 import javax.annotation.Nonnull;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedString;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -34,6 +36,11 @@ public class EscalatorEdge extends Edge {
       s1.incrementWalkDistance(getDistanceMeters());
       return s1.makeStateArray();
     } else return State.empty();
+  }
+
+  @Override
+  public LineString getGeometry() {
+    return GeometryUtils.makeLineString(fromv.getCoordinate(), tov.getCoordinate());
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/street/model/edge/EscalatorEdgeTest.java
+++ b/src/test/java/org/opentripplanner/street/model/edge/EscalatorEdgeTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.edge;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
@@ -42,7 +43,7 @@ class EscalatorEdgeTest {
     var edge = EscalatorEdge.createEscalatorEdge(from, to, 10);
     var req = StreetSearchRequest.of().withMode(StreetMode.BIKE);
     var res = edge.traverse(new State(from, req.build()));
-    assertEquals(res.length, 0);
+    assertThat(res).isEmpty();
   }
 
   @Test
@@ -50,7 +51,7 @@ class EscalatorEdgeTest {
     var edge = EscalatorEdge.createEscalatorEdge(from, to, 10);
     var req = StreetSearchRequest.of().withMode(StreetMode.WALK).withWheelchair(true);
     var res = edge.traverse(new State(from, req.build()));
-    assertEquals(res.length, 0);
+    assertThat(res).isEmpty();
   }
 
   @Test
@@ -58,5 +59,11 @@ class EscalatorEdgeTest {
     var edge = EscalatorEdge.createEscalatorEdge(from, to, 10);
     assertEquals("Rolltreppe", edge.getName().toString(Locale.GERMANY));
     assertEquals("escalator", edge.getName().toString(Locale.ENGLISH));
+  }
+
+  @Test
+  void geometry() {
+    var edge = EscalatorEdge.createEscalatorEdge(from, to, 10);
+    assertThat(edge.getGeometry().getCoordinates()).isNotEmpty();
   }
 }


### PR DESCRIPTION
### Summary

When I debugged a problem inside a station, I noticed that escalators are not shown in the new debug UI. This is because they don't have a geometry.

For this reason, this PR adds one that is generated on the fly.