### PR TITLE
debug client: update the map cursor when interactive

### DIFF
--- a/client/src/components/MapView/MapView.tsx
+++ b/client/src/components/MapView/MapView.tsx
@@ -12,7 +12,7 @@ import { TripPattern, TripQuery, TripQueryVariables } from '../../gql/graphql.ts
 import { NavigationMarkers } from './NavigationMarkers.tsx';
 import { LegLines } from './LegLines.tsx';
 import { useMapDoubleClick } from './useMapDoubleClick.ts';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { ContextMenuPopup } from './ContextMenuPopup.tsx';
 import { GeometryPropertyPopup } from './GeometryPropertyPopup.tsx';
 import DebugLayerControl from './LayerControl.tsx';
@@ -37,6 +37,9 @@ export function MapView({
   const onMapDoubleClick = useMapDoubleClick({ tripQueryVariables, setTripQueryVariables });
   const [showContextPopup, setShowContextPopup] = useState<LngLat | null>(null);
   const [showPropsPopup, setShowPropsPopup] = useState<PopupData | null>(null);
+  const [cursor, setCursor] = useState<string>('auto');
+  const onMouseEnter = useCallback(() => setCursor('pointer'), []);
+  const onMouseLeave = useCallback(() => setCursor('auto'), []);
   const showFeaturePropPopup = (
     e: MapMouseEvent & {
       features?: MapGeoJSONFeature[] | undefined;
@@ -76,6 +79,9 @@ export function MapView({
         // it's unfortunate that you have to list these layers here.
         // maybe there is a way around it: https://github.com/visgl/react-map-gl/discussions/2343
         interactiveLayerIds={['regular-stop', 'area-stop', 'group-stop', 'parking-vertex', 'vertex', 'edge', 'link']}
+        cursor={cursor}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         onClick={showFeaturePropPopup}
         // put lat/long in URL and pan to it on page reload
         hash={true}
@@ -86,6 +92,7 @@ export function MapView({
       >
         <NavigationControl position="top-left" />
         <NavigationMarkers
+          setCursor={setCursor}
           tripQueryVariables={tripQueryVariables}
           setTripQueryVariables={setTripQueryVariables}
           loading={loading}

--- a/client/src/components/MapView/NavigationMarkers.tsx
+++ b/client/src/components/MapView/NavigationMarkers.tsx
@@ -4,10 +4,12 @@ import markerFlagStart from '../../static/img/marker-flag-start-shadowed.png';
 import markerFlagEnd from '../../static/img/marker-flag-end-shadowed.png';
 
 export function NavigationMarkers({
+  setCursor,
   tripQueryVariables,
   setTripQueryVariables,
   loading,
 }: {
+  setCursor: (cursor: string) => void;
   tripQueryVariables: TripQueryVariables;
   setTripQueryVariables: (variables: TripQueryVariables) => void;
   loading: boolean;
@@ -19,7 +21,9 @@ export function NavigationMarkers({
           draggable
           latitude={tripQueryVariables.from.coordinates?.latitude}
           longitude={tripQueryVariables.from.coordinates?.longitude}
+          onDragStart={() => setCursor('grabbing')}
           onDragEnd={(e) => {
+            setCursor('auto');
             if (!loading) {
               setTripQueryVariables({
                 ...tripQueryVariables,
@@ -37,7 +41,9 @@ export function NavigationMarkers({
           draggable
           latitude={tripQueryVariables.to.coordinates?.latitude}
           longitude={tripQueryVariables.to.coordinates?.longitude}
+          onDragStart={() => setCursor('grabbing')}
           onDragEnd={(e) => {
+            setCursor('auto');
             if (!loading) {
               setTripQueryVariables({
                 ...tripQueryVariables,


### PR DESCRIPTION
### Summary

Add map cursors to the debug client to indicate what is interactive:
 - `pointer` when an item is clickable (part of an interactive layer)
    ![image](https://github.com/user-attachments/assets/d7f792a0-db08-4024-829b-df8b58138a31)
 - `grab` when an item may be dragged
   ![image](https://github.com/user-attachments/assets/9c8bc03e-fcbb-416c-a58c-125f95e78391)
 - `grabbing` while dragging an item
   ![image](https://github.com/user-attachments/assets/54c1d1ea-692e-4f9e-b249-e2eae4bb5e7b)
