### PR TITLE
Timetable snapshot code cleanup

### DIFF
--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -278,7 +278,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
             return null;
           }
 
-          if (transitService.hasRealtimeAddedTripPatterns()) {
+          if (transitService.hasRealtimeModifiedTripPatterns()) {
             return getTripTimeOnDatesForPatternAtStopIncludingTripsWithSkippedStops(
               pattern,
               stop,
@@ -562,7 +562,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
   ) {
     return originalPattern
       .scheduledTripsAsStream()
-      .map(trip -> transitService.getRealtimeAddedTripPattern(trip.getId(), date))
+      .map(trip -> transitService.getRealtimeModifiedTripPattern(trip.getId(), date))
       .filter(tripPattern ->
         tripPattern != null && tripPattern.isModifiedFromTripPatternWithEqualStops(originalPattern)
       );

--- a/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -278,7 +278,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
             return null;
           }
 
-          if (transitService.hasRealtimeModifiedTripPatterns()) {
+          if (transitService.hasNewTripPatternsForModifiedTrips()) {
             return getTripTimeOnDatesForPatternAtStopIncludingTripsWithSkippedStops(
               pattern,
               stop,
@@ -562,7 +562,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
   ) {
     return originalPattern
       .scheduledTripsAsStream()
-      .map(trip -> transitService.getRealtimeModifiedTripPattern(trip.getId(), date))
+      .map(trip -> transitService.getNewTripPatternForModifiedTrip(trip.getId(), date))
       .filter(tripPattern ->
         tripPattern != null && tripPattern.isModifiedFromTripPatternWithEqualStops(originalPattern)
       );

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -357,7 +357,6 @@ public class TimetableSnapshot {
     return commit(null, false);
   }
 
-  @SuppressWarnings("unchecked")
   public TimetableSnapshot commit(TransitLayerUpdater transitLayerUpdater, boolean force) {
     if (readOnly) {
       throw new ConcurrentModificationException("This TimetableSnapshot is read-only.");
@@ -483,7 +482,7 @@ public class TimetableSnapshot {
       SortedSet<Timetable> sortedTimetables = timetables.get(pattern);
       SortedSet<Timetable> toKeepTimetables = new TreeSet<>(new SortedTimetableComparator());
       for (Timetable timetable : sortedTimetables) {
-        if (serviceDate.compareTo(timetable.getServiceDate()) < 0) {
+        if (serviceDate.isBefore(timetable.getServiceDate())) {
           toKeepTimetables.add(timetable);
         } else {
           modified = true;
@@ -505,7 +504,7 @@ public class TimetableSnapshot {
       iterator.hasNext();
     ) {
       TripIdAndServiceDate tripIdAndServiceDate = iterator.next().getKey();
-      if (serviceDate.compareTo(tripIdAndServiceDate.serviceDate()) >= 0) {
+      if (!serviceDate.isBefore(tripIdAndServiceDate.serviceDate())) {
         iterator.remove();
         modified = true;
       }

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -227,7 +227,7 @@ public class TimetableSnapshot {
     return getByNullableKey(id, realtimeAddedRoutes);
   }
 
-  public Collection<Route> getAllRealTimeAddedRoutes() {
+  public Collection<Route> listRealTimeAddedRoutes() {
     return Collections.unmodifiableCollection(realtimeAddedRoutes.values());
   }
 
@@ -239,7 +239,7 @@ public class TimetableSnapshot {
     return getByNullableKey(id, realTimeAddedTrips);
   }
 
-  public Collection<Trip> getAllRealTimeAddedTrips() {
+  public Collection<Trip> listRealTimeAddedTrips() {
     return Collections.unmodifiableCollection(realTimeAddedTrips.values());
   }
 
@@ -276,7 +276,7 @@ public class TimetableSnapshot {
     return getByNullableKey(tripIdAndServiceDate, realTimeAddedTripOnServiceDateForTripAndDay);
   }
 
-  public Collection<? extends TripOnServiceDate> getAllRealTimeAddedTripOnServiceDate() {
+  public Collection<? extends TripOnServiceDate> listRealTimeAddedTripOnServiceDate() {
     return Collections.unmodifiableCollection(realTimeAddedTripOnServiceDateForTripAndDay.values());
   }
 

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -297,7 +297,7 @@ public class TimetableSnapshot {
    * @return whether the update was actually applied
    */
   public Result<UpdateSuccess, UpdateError> update(RealTimeTripUpdate realTimeTripUpdate) {
-    validateReadOnly();
+    validateNotReadOnly();
 
     TripPattern pattern = realTimeTripUpdate.pattern();
     LocalDate serviceDate = realTimeTripUpdate.serviceDate();
@@ -364,7 +364,7 @@ public class TimetableSnapshot {
   }
 
   public TimetableSnapshot commit(TransitLayerUpdater transitLayerUpdater, boolean force) {
-    validateReadOnly();
+    validateNotReadOnly();
 
     if (!force && !this.isDirty()) {
       return null;
@@ -398,7 +398,7 @@ public class TimetableSnapshot {
    * @param feedId feed id to clear the snapshot for
    */
   public void clear(String feedId) {
-    validateReadOnly();
+    validateNotReadOnly();
     // Clear all data from snapshot.
     boolean timetablesWereCleared = clearTimetables(feedId);
     boolean newTripPatternsForModifiedTripsWereCleared = clearNewTripPatternsForModifiedTrips(
@@ -422,7 +422,7 @@ public class TimetableSnapshot {
    * message and an attempt was made to re-associate it with its originally scheduled trip pattern.
    */
   public boolean revertTripToScheduledTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
-    validateReadOnly();
+    validateNotReadOnly();
 
     boolean success = false;
 
@@ -473,7 +473,7 @@ public class TimetableSnapshot {
    * @return true if any data has been modified and false if no purging has happened.
    */
   public boolean purgeExpiredData(LocalDate serviceDate) {
-    validateReadOnly();
+    validateNotReadOnly();
 
     boolean modified = false;
     for (Iterator<TripPattern> it = timetables.keySet().iterator(); it.hasNext();) {
@@ -604,7 +604,7 @@ public class TimetableSnapshot {
     dirty = true;
   }
 
-  private void validateReadOnly() {
+  private void validateNotReadOnly() {
     if (readOnly) {
       throw new ConcurrentModificationException("This TimetableSnapshot is read-only.");
     }

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -291,7 +291,7 @@ public class StopTimesHelper {
     TripPattern pattern,
     TransitService transitService
   ) {
-    final TripPattern replacement = transitService.getRealtimeAddedTripPattern(
+    final TripPattern replacement = transitService.getRealtimeModifiedTripPattern(
       trip.getId(),
       serviceDate
     );

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -291,7 +291,7 @@ public class StopTimesHelper {
     TripPattern pattern,
     TransitService transitService
   ) {
-    final TripPattern replacement = transitService.getRealtimeModifiedTripPattern(
+    final TripPattern replacement = transitService.getNewTripPatternForModifiedTrip(
       trip.getId(),
       serviceDate
     );

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -339,7 +339,7 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public TripPattern getPatternForTrip(Trip trip, LocalDate serviceDate) {
-    TripPattern realtimePattern = getRealtimeModifiedTripPattern(trip.getId(), serviceDate);
+    TripPattern realtimePattern = getNewTripPatternForModifiedTrip(trip.getId(), serviceDate);
     if (realtimePattern != null) {
       return realtimePattern;
     }
@@ -520,21 +520,21 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public TripPattern getRealtimeModifiedTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
+  public TripPattern getNewTripPatternForModifiedTrip(FeedScopedId tripId, LocalDate serviceDate) {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot == null) {
       return null;
     }
-    return currentSnapshot.getRealtimeModifiedTripPattern(tripId, serviceDate);
+    return currentSnapshot.getNewTripPatternForModifiedTrip(tripId, serviceDate);
   }
 
   @Override
-  public boolean hasRealtimeModifiedTripPatterns() {
+  public boolean hasNewTripPatternsForModifiedTrips() {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot == null) {
       return false;
     }
-    return currentSnapshot.hasRealtimeModifiedTripPatterns();
+    return currentSnapshot.hasNewTripPatternsForModifiedTrips();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -339,7 +339,7 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public TripPattern getPatternForTrip(Trip trip, LocalDate serviceDate) {
-    TripPattern realtimePattern = getRealtimeAddedTripPattern(trip.getId(), serviceDate);
+    TripPattern realtimePattern = getRealtimeModifiedTripPattern(trip.getId(), serviceDate);
     if (realtimePattern != null) {
       return realtimePattern;
     }
@@ -520,21 +520,21 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public TripPattern getRealtimeAddedTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
+  public TripPattern getRealtimeModifiedTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot == null) {
       return null;
     }
-    return currentSnapshot.getRealtimeAddedTripPattern(tripId, serviceDate);
+    return currentSnapshot.getRealtimeModifiedTripPattern(tripId, serviceDate);
   }
 
   @Override
-  public boolean hasRealtimeAddedTripPatterns() {
+  public boolean hasRealtimeModifiedTripPatterns() {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot == null) {
       return false;
     }
-    return currentSnapshot.hasRealtimeAddedTripPatterns();
+    return currentSnapshot.hasRealtimeModifiedTripPatterns();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -306,7 +306,7 @@ public class DefaultTransitService implements TransitEditorService {
     if (currentSnapshot != null) {
       return new CollectionsView<>(
         transitModelIndex.getTripForId().values(),
-        currentSnapshot.getAllRealTimeAddedTrips()
+        currentSnapshot.listRealTimeAddedTrips()
       );
     }
     return Collections.unmodifiableCollection(transitModelIndex.getTripForId().values());
@@ -319,7 +319,7 @@ public class DefaultTransitService implements TransitEditorService {
     if (currentSnapshot != null) {
       return new CollectionsView<>(
         transitModelIndex.getAllRoutes(),
-        currentSnapshot.getAllRealTimeAddedRoutes()
+        currentSnapshot.listRealTimeAddedRoutes()
       );
     }
     return Collections.unmodifiableCollection(transitModelIndex.getAllRoutes());
@@ -570,7 +570,7 @@ public class DefaultTransitService implements TransitEditorService {
     if (currentSnapshot != null) {
       return new CollectionsView<>(
         transitModelIndex.getTripOnServiceDateForTripAndDay().values(),
-        currentSnapshot.getAllRealTimeAddedTripOnServiceDate()
+        currentSnapshot.listRealTimeAddedTripOnServiceDate()
       );
     }
     return Collections.unmodifiableCollection(

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -234,12 +234,12 @@ public interface TransitService {
    * this date (that is: it is still using its scheduled trip pattern for this date).
    */
   @Nullable
-  TripPattern getRealtimeAddedTripPattern(FeedScopedId tripId, LocalDate serviceDate);
+  TripPattern getRealtimeModifiedTripPattern(FeedScopedId tripId, LocalDate serviceDate);
 
   /**
-   * Return true if at least one trip pattern has been created by a real-time update.
+   * Return true if at least one trip pattern has been modified by a real-time update.
    */
-  boolean hasRealtimeAddedTripPatterns();
+  boolean hasRealtimeModifiedTripPatterns();
 
   TripOnServiceDate getTripOnServiceDateForTripAndDay(TripIdAndServiceDate tripIdAndServiceDate);
 

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -234,12 +234,12 @@ public interface TransitService {
    * this date (that is: it is still using its scheduled trip pattern for this date).
    */
   @Nullable
-  TripPattern getRealtimeModifiedTripPattern(FeedScopedId tripId, LocalDate serviceDate);
+  TripPattern getNewTripPatternForModifiedTrip(FeedScopedId tripId, LocalDate serviceDate);
 
   /**
    * Return true if at least one trip pattern has been modified by a real-time update.
    */
-  boolean hasRealtimeModifiedTripPatterns();
+  boolean hasNewTripPatternsForModifiedTrips();
 
   TripOnServiceDate getTripOnServiceDateForTripAndDay(TripIdAndServiceDate tripIdAndServiceDate);
 

--- a/src/main/java/org/opentripplanner/updater/siri/SiriFuzzyTripMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/siri/SiriFuzzyTripMatcher.java
@@ -87,7 +87,7 @@ public class SiriFuzzyTripMatcher {
     EstimatedVehicleJourney journey,
     EntityResolver entityResolver,
     BiFunction<TripPattern, LocalDate, Timetable> getCurrentTimetable,
-    BiFunction<FeedScopedId, LocalDate, TripPattern> getRealtimeModifiedTripPattern
+    BiFunction<FeedScopedId, LocalDate, TripPattern> getNewTripPatternForModifiedTrip
   ) {
     List<CallWrapper> calls = CallWrapper.of(journey);
 
@@ -136,7 +136,7 @@ public class SiriFuzzyTripMatcher {
       calls,
       entityResolver,
       getCurrentTimetable,
-      getRealtimeModifiedTripPattern
+      getNewTripPatternForModifiedTrip
     );
   }
 
@@ -259,7 +259,7 @@ public class SiriFuzzyTripMatcher {
     List<CallWrapper> calls,
     EntityResolver entityResolver,
     BiFunction<TripPattern, LocalDate, Timetable> getCurrentTimetable,
-    BiFunction<FeedScopedId, LocalDate, TripPattern> getRealtimeModifiedTripPattern
+    BiFunction<FeedScopedId, LocalDate, TripPattern> getNewTripPatternForModifiedTrip
   ) {
     var journeyFirstStop = entityResolver.resolveQuay(calls.getFirst().getStopPointRef());
     var journeyLastStop = entityResolver.resolveQuay(calls.getLast().getStopPointRef());
@@ -282,12 +282,12 @@ public class SiriFuzzyTripMatcher {
         continue;
       }
 
-      var realTimeModifiedTripPattern = getRealtimeModifiedTripPattern.apply(
+      var newTripPatternForModifiedTrip = getNewTripPatternForModifiedTrip.apply(
         trip.getId(),
         serviceDate
       );
-      TripPattern tripPattern = realTimeModifiedTripPattern != null
-        ? realTimeModifiedTripPattern
+      TripPattern tripPattern = newTripPatternForModifiedTrip != null
+        ? newTripPatternForModifiedTrip
         : transitService.getPatternForTrip(trip);
 
       var firstStop = tripPattern.firstStop();

--- a/src/main/java/org/opentripplanner/updater/siri/SiriFuzzyTripMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/siri/SiriFuzzyTripMatcher.java
@@ -87,7 +87,7 @@ public class SiriFuzzyTripMatcher {
     EstimatedVehicleJourney journey,
     EntityResolver entityResolver,
     BiFunction<TripPattern, LocalDate, Timetable> getCurrentTimetable,
-    BiFunction<FeedScopedId, LocalDate, TripPattern> getRealtimeAddedTripPattern
+    BiFunction<FeedScopedId, LocalDate, TripPattern> getRealtimeModifiedTripPattern
   ) {
     List<CallWrapper> calls = CallWrapper.of(journey);
 
@@ -136,7 +136,7 @@ public class SiriFuzzyTripMatcher {
       calls,
       entityResolver,
       getCurrentTimetable,
-      getRealtimeAddedTripPattern
+      getRealtimeModifiedTripPattern
     );
   }
 
@@ -259,7 +259,7 @@ public class SiriFuzzyTripMatcher {
     List<CallWrapper> calls,
     EntityResolver entityResolver,
     BiFunction<TripPattern, LocalDate, Timetable> getCurrentTimetable,
-    BiFunction<FeedScopedId, LocalDate, TripPattern> getRealtimeAddedTripPattern
+    BiFunction<FeedScopedId, LocalDate, TripPattern> getRealtimeModifiedTripPattern
   ) {
     var journeyFirstStop = entityResolver.resolveQuay(calls.getFirst().getStopPointRef());
     var journeyLastStop = entityResolver.resolveQuay(calls.getLast().getStopPointRef());
@@ -282,9 +282,12 @@ public class SiriFuzzyTripMatcher {
         continue;
       }
 
-      var realTimeAddedTripPattern = getRealtimeAddedTripPattern.apply(trip.getId(), serviceDate);
-      TripPattern tripPattern = realTimeAddedTripPattern != null
-        ? realTimeAddedTripPattern
+      var realTimeModifiedTripPattern = getRealtimeModifiedTripPattern.apply(
+        trip.getId(),
+        serviceDate
+      );
+      TripPattern tripPattern = realTimeModifiedTripPattern != null
+        ? realTimeModifiedTripPattern
         : transitService.getPatternForTrip(trip);
 
       var firstStop = tripPattern.firstStop();

--- a/src/main/java/org/opentripplanner/updater/siri/SiriTimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/siri/SiriTimetableSnapshotSource.java
@@ -244,7 +244,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         estimatedVehicleJourney,
         entityResolver,
         this::getCurrentTimetable,
-        snapshotManager::getRealtimeModifiedTripPattern
+        snapshotManager::getNewTripPatternForModifiedTrip
       );
 
       if (tripAndPattern == null) {

--- a/src/main/java/org/opentripplanner/updater/siri/SiriTimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/siri/SiriTimetableSnapshotSource.java
@@ -244,7 +244,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         estimatedVehicleJourney,
         entityResolver,
         this::getCurrentTimetable,
-        snapshotManager::getRealtimeAddedTripPattern
+        snapshotManager::getRealtimeModifiedTripPattern
       );
 
       if (tripAndPattern == null) {

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -118,8 +118,8 @@ public final class TimetableSnapshotManager {
    * @return trip pattern created by the updater; null if pattern has not been changed for this trip.
    */
   @Nullable
-  public TripPattern getRealtimeAddedTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
-    return buffer.getRealtimeAddedTripPattern(tripId, serviceDate);
+  public TripPattern getRealtimeModifiedTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
+    return buffer.getRealtimeModifiedTripPattern(tripId, serviceDate);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -118,8 +118,8 @@ public final class TimetableSnapshotManager {
    * @return trip pattern created by the updater; null if pattern has not been changed for this trip.
    */
   @Nullable
-  public TripPattern getRealtimeModifiedTripPattern(FeedScopedId tripId, LocalDate serviceDate) {
-    return buffer.getRealtimeModifiedTripPattern(tripId, serviceDate);
+  public TripPattern getNewTripPatternForModifiedTrip(FeedScopedId tripId, LocalDate serviceDate) {
+    return buffer.getNewTripPatternForModifiedTrip(tripId, serviceDate);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -294,7 +294,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     FeedScopedId tripId,
     LocalDate serviceDate
   ) {
-    final TripPattern pattern = snapshotManager.getRealtimeAddedTripPattern(tripId, serviceDate);
+    final TripPattern pattern = snapshotManager.getRealtimeModifiedTripPattern(tripId, serviceDate);
     if (
       !isPreviouslyAddedTrip(tripId, pattern, serviceDate) ||
       (
@@ -946,7 +946,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   ) {
     boolean cancelledAddedTrip = false;
 
-    final TripPattern pattern = snapshotManager.getRealtimeAddedTripPattern(tripId, serviceDate);
+    final TripPattern pattern = snapshotManager.getRealtimeModifiedTripPattern(tripId, serviceDate);
     if (isPreviouslyAddedTrip(tripId, pattern, serviceDate)) {
       // Cancel trip times for this trip in this pattern
       final Timetable timetable = snapshotManager.resolve(pattern, serviceDate);

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -294,7 +294,10 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     FeedScopedId tripId,
     LocalDate serviceDate
   ) {
-    final TripPattern pattern = snapshotManager.getRealtimeModifiedTripPattern(tripId, serviceDate);
+    final TripPattern pattern = snapshotManager.getNewTripPatternForModifiedTrip(
+      tripId,
+      serviceDate
+    );
     if (
       !isPreviouslyAddedTrip(tripId, pattern, serviceDate) ||
       (
@@ -946,7 +949,10 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   ) {
     boolean cancelledAddedTrip = false;
 
-    final TripPattern pattern = snapshotManager.getRealtimeModifiedTripPattern(tripId, serviceDate);
+    final TripPattern pattern = snapshotManager.getNewTripPatternForModifiedTrip(
+      tripId,
+      serviceDate
+    );
     if (isPreviouslyAddedTrip(tripId, pattern, serviceDate)) {
       // Cancel trip times for this trip in this pattern
       final Timetable timetable = snapshotManager.resolve(pattern, serviceDate);

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -250,7 +250,7 @@ public class TimetableSnapshotSourceTest {
 
     // New trip pattern
     {
-      final TripPattern newTripPattern = snapshot.getRealtimeAddedTripPattern(
+      final TripPattern newTripPattern = snapshot.getRealtimeModifiedTripPattern(
         new FeedScopedId(feedId, modifiedTripId),
         SERVICE_DATE
       );

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -250,7 +250,7 @@ public class TimetableSnapshotSourceTest {
 
     // New trip pattern
     {
-      final TripPattern newTripPattern = snapshot.getRealtimeModifiedTripPattern(
+      final TripPattern newTripPattern = snapshot.getNewTripPatternForModifiedTrip(
         new FeedScopedId(feedId, modifiedTripId),
         SERVICE_DATE
       );

--- a/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
@@ -88,7 +88,7 @@ class SkippedTest implements RealtimeTestConstants {
     // stoptime updates have gone through
     var snapshot = env.getTimetableSnapshot();
 
-    assertNull(snapshot.getRealtimeModifiedTripPattern(id(TRIP_2_ID), SERVICE_DATE));
+    assertNull(snapshot.getNewTripPatternForModifiedTrip(id(TRIP_2_ID), SERVICE_DATE));
 
     assertNewTripTimesIsUpdated(env, TRIP_2_ID);
 

--- a/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/moduletests/delay/SkippedTest.java
@@ -88,7 +88,7 @@ class SkippedTest implements RealtimeTestConstants {
     // stoptime updates have gone through
     var snapshot = env.getTimetableSnapshot();
 
-    assertNull(snapshot.getRealtimeAddedTripPattern(id(TRIP_2_ID), SERVICE_DATE));
+    assertNull(snapshot.getRealtimeModifiedTripPattern(id(TRIP_2_ID), SERVICE_DATE));
 
     assertNewTripTimesIsUpdated(env, TRIP_2_ID);
 


### PR DESCRIPTION
### Summary

Code clean-up and documentation/clarification in TimetableSnapshot:
- Clarify the name and purpose of the realTimeAdded* and realTimeModified*  indexes: realTimeAdded* indexes contains data related to added trips (extra journeys), while realTimeModified* indexes contains data related to modified trips (that is: pre-existing scheduled trips modified by a real-time update).
- Align getter names with the project naming convention.
- Minor code clean-up.

### Issue

#6048

### Unit tests

No

### Documentation

No
