### PR TITLE
Minor cleanup of some OSM classes

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -241,6 +241,7 @@ public class OSMWithTags {
    * Returns a name-like value for an entity (if one exists). The otp: namespaced tags are created
    * by {@link OsmModule}
    */
+  @Nullable
   public I18NString getAssumedName() {
     if (tags == null) {
       return null;
@@ -273,10 +274,6 @@ public class OSMWithTags {
    * other language found in OSM tag.
    */
   public Map<String, String> generateI18NForPattern(String pattern) {
-    if (pattern == null) {
-      return null;
-    }
-
     Map<String, StringBuffer> i18n = new HashMap<>();
     i18n.put(null, new StringBuffer());
     Matcher matcher = Pattern.compile("\\{(.*?)}").matcher(pattern);
@@ -290,17 +287,15 @@ public class OSMWithTags {
       String defKey = matcher.group(1);
       // scan all translated tags
       Map<String, String> i18nTags = getTagsByPrefix(defKey);
-      if (i18nTags != null) {
-        for (Map.Entry<String, String> kv : i18nTags.entrySet()) {
-          if (!kv.getKey().equals(defKey)) {
-            String lang = kv.getKey().substring(defKey.length() + 1);
-            if (!i18n.containsKey(lang)) i18n.put(lang, new StringBuffer(i18n.get(null)));
-          }
+      for (Map.Entry<String, String> kv : i18nTags.entrySet()) {
+        if (!kv.getKey().equals(defKey)) {
+          String lang = kv.getKey().substring(defKey.length() + 1);
+          if (!i18n.containsKey(lang)) i18n.put(lang, new StringBuffer(i18n.get(null)));
         }
       }
       // get the simple value (eg: description=...)
       String defTag = getTag(defKey);
-      if (defTag == null && i18nTags != null && i18nTags.size() != 0) {
+      if (defTag == null && !i18nTags.isEmpty()) {
         defTag = i18nTags.values().iterator().next();
       }
       // get the translated value, if exists
@@ -318,16 +313,13 @@ public class OSMWithTags {
     return out;
   }
 
-  public Map<String, String> getTagsByPrefix(String prefix) {
+  private Map<String, String> getTagsByPrefix(String prefix) {
     Map<String, String> out = new HashMap<>();
     for (Map.Entry<String, String> entry : tags.entrySet()) {
       String k = entry.getKey();
       if (k.equals(prefix) || k.startsWith(prefix + ":")) {
         out.put(k, entry.getValue());
       }
-    }
-    if (out.isEmpty()) {
-      return null;
     }
 
     return out;
@@ -502,6 +494,7 @@ public class OSMWithTags {
     this.creativeName = creativeName;
   }
 
+  @Nullable
   public String url() {
     return null;
   }

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/NoteProperties.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/NoteProperties.java
@@ -13,9 +13,9 @@ public class NoteProperties {
 
   private static final Pattern patternMatcher = Pattern.compile("\\{(.*?)}");
 
-  public String notePattern;
+  private final String notePattern;
 
-  public StreetNoteMatcher noteMatcher;
+  private final StreetNoteMatcher noteMatcher;
 
   public NoteProperties(String notePattern, StreetNoteMatcher noteMatcher) {
     this.notePattern = notePattern;

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
@@ -227,7 +227,6 @@ public class OSMWithTagsTest {
     osmTags.addTag("wheelchair:description", "Wheelchair description EN");
     osmTags.addTag("wheelchair:description:fr", "Wheelchair description FR");
 
-    assertNull(osmTags.generateI18NForPattern(null));
     Map<String, String> expected = new HashMap<>();
 
     expected.put(null, "");


### PR DESCRIPTION
### Summary
Small cleanup. Pure refactoring.

- Add `@Nullable` to some nullable return values.
- `generateI18NForPattern()` will never be called with a null value in practice, so I removed the null check.
- `getTagsByPrefix()` didn't need to return null so I removed that case.

### Issue

See #6048 

### Unit tests

No tests for this.