### PR TITLE
Fix GTFS-Flex duration offset and factor parsing when only one of them is set

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -81,8 +81,13 @@ class TripMapper {
     if (rhs.getSafeDurationFactor() == null && rhs.getSafeDurationOffset() == null) {
       return Optional.empty();
     } else {
-      var offset = Duration.ofMinutes(rhs.getSafeDurationOffset().longValue());
-      return Optional.of(TimePenalty.of(offset, rhs.getSafeDurationFactor().doubleValue()));
+      var offset = rhs.getSafeDurationOffset() == null
+        ? Duration.ZERO
+        : Duration.ofMinutes(rhs.getSafeDurationOffset().longValue());
+      var factor = rhs.getSafeDurationFactor() == null
+        ? 1d
+        : rhs.getSafeDurationFactor().doubleValue();
+      return Optional.of(TimePenalty.of(offset, factor));
     }
   }
 }


### PR DESCRIPTION
## PR Instructions

### Summary

Currently, if only one of the `safe_duration_offset` or `safe_duration_factor` is set, OTP crashes.

This PR fixes that by providing default for the other one if only of them is set.

### Issue

No.

### Unit tests

Unit tests added.

### Documentation

No