### PR TITLE
Make TransitModelIndex more immutable

### DIFF
--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -70,7 +70,7 @@ public class NetexModule implements GraphBuilderModule {
         );
         transitBuilder.limitServiceDays(transitPeriodLimit);
         for (var tripOnServiceDate : transitBuilder.getTripOnServiceDates().values()) {
-          transitModel.addTripOnServiceDate(tripOnServiceDate.getId(), tripOnServiceDate);
+          transitModel.addTripOnServiceDate(tripOnServiceDate);
         }
         calendarServiceData.add(transitBuilder.buildCalendarServiceData());
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -296,7 +296,7 @@ public class DefaultTransitService implements TransitEditorService {
   @Nullable
   @Override
   public Trip getScheduledTripForId(FeedScopedId id) {
-    return this.transitModelIndex.getTripForId().get(id);
+    return this.transitModelIndex.getTripForId(id);
   }
 
   @Override
@@ -305,11 +305,11 @@ public class DefaultTransitService implements TransitEditorService {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot != null) {
       return new CollectionsView<>(
-        transitModelIndex.getTripForId().values(),
+        transitModelIndex.getAllTrips(),
         currentSnapshot.listRealTimeAddedTrips()
       );
     }
-    return Collections.unmodifiableCollection(transitModelIndex.getTripForId().values());
+    return Collections.unmodifiableCollection(transitModelIndex.getAllTrips());
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -234,12 +234,12 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public Collection<Operator> getAllOperators() {
     OTPRequestTimeoutException.checkForTimeout();
-    return this.transitModelIndex.getAllOperators();
+    return this.transitModel.getOperators();
   }
 
   @Override
   public Operator getOperatorForId(FeedScopedId id) {
-    return this.transitModelIndex.getOperatorForId().get(id);
+    return this.transitModelIndex.getOperatorForId(id);
   }
 
   @Override
@@ -334,7 +334,7 @@ public class DefaultTransitService implements TransitEditorService {
         return realtimeAddedTripPattern;
       }
     }
-    return this.transitModelIndex.getPatternForTrip().get(trip);
+    return this.transitModelIndex.getPatternForTrip(trip);
   }
 
   @Override
@@ -491,18 +491,18 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public Collection<GroupOfRoutes> getGroupsOfRoutes() {
     OTPRequestTimeoutException.checkForTimeout();
-    return transitModelIndex.getRoutesForGroupOfRoutes().keySet();
+    return transitModelIndex.getAllGroupOfRoutes();
   }
 
   @Override
   public Collection<Route> getRoutesForGroupOfRoutes(GroupOfRoutes groupOfRoutes) {
     OTPRequestTimeoutException.checkForTimeout();
-    return transitModelIndex.getRoutesForGroupOfRoutes().get(groupOfRoutes);
+    return transitModelIndex.getRoutesForGroupOfRoutes(groupOfRoutes);
   }
 
   @Override
   public GroupOfRoutes getGroupOfRoutesForId(FeedScopedId id) {
-    return transitModelIndex.getGroupOfRoutesForId().get(id);
+    return transitModelIndex.getGroupOfRoutesForId(id);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -569,11 +569,11 @@ public class DefaultTransitService implements TransitEditorService {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot != null) {
       return new CollectionsView<>(
-        transitModel.getAllTripOnServiceDates(),
+        transitModel.getAllTripsOnServiceDates(),
         currentSnapshot.listRealTimeAddedTripOnServiceDate()
       );
     }
-    return Collections.unmodifiableCollection(transitModel.getAllTripOnServiceDates());
+    return transitModel.getAllTripsOnServiceDates();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -350,7 +350,7 @@ public class DefaultTransitService implements TransitEditorService {
   public Collection<TripPattern> getPatternsForRoute(Route route) {
     OTPRequestTimeoutException.checkForTimeout();
     Collection<TripPattern> tripPatterns = new HashSet<>(
-      transitModelIndex.getPatternsForRoute().get(route)
+      transitModelIndex.getPatternsForRoute(route)
     );
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot != null) {
@@ -551,17 +551,17 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public TripOnServiceDate getTripOnServiceDateById(FeedScopedId datedServiceJourneyId) {
+  public TripOnServiceDate getTripOnServiceDateById(FeedScopedId tripOnServiceDateId) {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot != null) {
       TripOnServiceDate tripOnServiceDate = currentSnapshot.getRealTimeAddedTripOnServiceDateById(
-        datedServiceJourneyId
+        tripOnServiceDateId
       );
       if (tripOnServiceDate != null) {
         return tripOnServiceDate;
       }
     }
-    return transitModelIndex.getTripOnServiceDateById().get(datedServiceJourneyId);
+    return transitModel.getTripOnServiceDateById(tripOnServiceDateId);
   }
 
   @Override
@@ -569,13 +569,11 @@ public class DefaultTransitService implements TransitEditorService {
     TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
     if (currentSnapshot != null) {
       return new CollectionsView<>(
-        transitModelIndex.getTripOnServiceDateForTripAndDay().values(),
+        transitModel.getAllTripOnServiceDates(),
         currentSnapshot.listRealTimeAddedTripOnServiceDate()
       );
     }
-    return Collections.unmodifiableCollection(
-      transitModelIndex.getTripOnServiceDateForTripAndDay().values()
-    );
+    return Collections.unmodifiableCollection(transitModel.getAllTripOnServiceDates());
   }
 
   @Override
@@ -591,7 +589,7 @@ public class DefaultTransitService implements TransitEditorService {
         return tripOnServiceDate;
       }
     }
-    return transitModelIndex.getTripOnServiceDateForTripAndDay().get(tripIdAndServiceDate);
+    return transitModelIndex.getTripOnServiceDateForTripAndDay(tripIdAndServiceDate);
   }
 
   /**
@@ -603,12 +601,7 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public List<TripOnServiceDate> getTripOnServiceDates(TripOnServiceDateRequest request) {
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
-    return transitModelIndex
-      .getTripOnServiceDateForTripAndDay()
-      .values()
-      .stream()
-      .filter(matcher::match)
-      .collect(Collectors.toList());
+    return getAllTripOnServiceDates().stream().filter(matcher::match).toList();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -322,7 +322,7 @@ public class DefaultTransitService implements TransitEditorService {
         currentSnapshot.listRealTimeAddedRoutes()
       );
     }
-    return Collections.unmodifiableCollection(transitModelIndex.getAllRoutes());
+    return transitModelIndex.getAllRoutes();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -13,6 +13,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -446,8 +447,8 @@ public class TransitModel implements Serializable {
     return tripOnServiceDates.get(tripOnServiceDateId);
   }
 
-  public Collection<TripOnServiceDate> getAllTripOnServiceDates() {
-    return tripOnServiceDates.values();
+  public Collection<TripOnServiceDate> getAllTripsOnServiceDates() {
+    return Collections.unmodifiableCollection(tripOnServiceDates.values());
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -406,9 +406,9 @@ public class TransitModel implements Serializable {
     return tripPatternForId.get(id);
   }
 
-  public void addTripOnServiceDate(FeedScopedId id, TripOnServiceDate tripOnServiceDate) {
+  public void addTripOnServiceDate(TripOnServiceDate tripOnServiceDate) {
     invalidateIndex();
-    tripOnServiceDates.put(id, tripOnServiceDate);
+    tripOnServiceDates.put(tripOnServiceDate.getId(), tripOnServiceDate);
   }
 
   /**
@@ -440,6 +440,10 @@ public class TransitModel implements Serializable {
    */
   public Collection<TripPattern> getAllTripPatterns() {
     return tripPatternForId.values();
+  }
+
+  public TripOnServiceDate getTripOnServiceDateById(FeedScopedId tripOnServiceDateId) {
+    return tripOnServiceDates.get(tripOnServiceDateId);
   }
 
   public Collection<TripOnServiceDate> getAllTripOnServiceDates() {

--- a/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
@@ -50,7 +50,6 @@ class TransitModelIndex {
   private final Multimap<StopLocation, TripPattern> patternsForStopId = ArrayListMultimap.create();
 
   private final Map<LocalDate, TIntSet> serviceCodesRunningForDate = new HashMap<>();
-  private final Map<FeedScopedId, TripOnServiceDate> tripOnServiceDateById = new HashMap<>();
   private final Map<TripIdAndServiceDate, TripOnServiceDate> tripOnServiceDateForTripAndDay = new HashMap<>();
 
   private final Multimap<GroupOfRoutes, Route> routesForGroupOfRoutes = ArrayListMultimap.create();
@@ -92,7 +91,6 @@ class TransitModelIndex {
     }
 
     for (TripOnServiceDate tripOnServiceDate : transitModel.getAllTripOnServiceDates()) {
-      tripOnServiceDateById.put(tripOnServiceDate.getId(), tripOnServiceDate);
       tripOnServiceDateForTripAndDay.put(
         new TripIdAndServiceDate(
           tripOnServiceDate.getTrip().getId(),
@@ -164,12 +162,8 @@ class TransitModelIndex {
     return tripForId;
   }
 
-  Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDateById() {
-    return tripOnServiceDateById;
-  }
-
-  Map<TripIdAndServiceDate, TripOnServiceDate> getTripOnServiceDateForTripAndDay() {
-    return tripOnServiceDateForTripAndDay;
+  TripOnServiceDate getTripOnServiceDateForTripAndDay(TripIdAndServiceDate tripIdAndServiceDate) {
+    return tripOnServiceDateForTripAndDay.get(tripIdAndServiceDate);
   }
 
   Collection<Route> getAllRoutes() {
@@ -180,8 +174,8 @@ class TransitModelIndex {
     return patternForTrip;
   }
 
-  Multimap<Route, TripPattern> getPatternsForRoute() {
-    return patternsForRoute;
+  Collection<TripPattern> getPatternsForRoute(Route route) {
+    return patternsForRoute.get(route);
   }
 
   Map<LocalDate, TIntSet> getServiceCodesRunningForDate() {

--- a/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
@@ -142,7 +142,8 @@ class TransitModelIndex {
   }
 
   Collection<Trip> getTripsForStop(StopLocation stop) {
-    return patternsForStop.get(stop)
+    return patternsForStop
+      .get(stop)
       .stream()
       .flatMap(TripPattern::scheduledTripsAsStream)
       .collect(Collectors.toList());
@@ -152,8 +153,12 @@ class TransitModelIndex {
     return operatorForId.get(operatorId);
   }
 
-  Map<FeedScopedId, Trip> getTripForId() {
-    return tripForId;
+  Collection<Trip> getAllTrips() {
+    return Collections.unmodifiableCollection(tripForId.values());
+  }
+
+  Trip getTripForId(FeedScopedId tripId) {
+    return tripForId.get(tripId);
   }
 
   TripOnServiceDate getTripOnServiceDateForTripAndDay(TripIdAndServiceDate tripIdAndServiceDate) {

--- a/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
@@ -166,7 +166,7 @@ class TransitModelIndex {
   }
 
   Collection<Route> getAllRoutes() {
-    return routeForId.values();
+    return Collections.unmodifiableCollection(routeForId.values());
   }
 
   TripPattern getPatternForTrip(Trip trip) {
@@ -174,7 +174,7 @@ class TransitModelIndex {
   }
 
   Collection<TripPattern> getPatternsForRoute(Route route) {
-    return patternsForRoute.get(route);
+    return Collections.unmodifiableCollection(patternsForRoute.get(route));
   }
 
   Map<LocalDate, TIntSet> getServiceCodesRunningForDate() {

--- a/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModelIndex.java
@@ -91,7 +91,7 @@ class TransitModelIndex {
       groupOfRoutesForId.put(groupOfRoutes.getId(), groupOfRoutes);
     }
 
-    for (TripOnServiceDate tripOnServiceDate : transitModel.getAllTripOnServiceDates()) {
+    for (TripOnServiceDate tripOnServiceDate : transitModel.getAllTripsOnServiceDates()) {
       tripOnServiceDateForTripAndDay.put(
         new TripIdAndServiceDate(
           tripOnServiceDate.getTrip().getId(),

--- a/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -87,7 +87,6 @@ class ScheduledTransitLegReferenceTest {
     transitModel.updateCalendarServiceData(true, calendarServiceData, DataImportIssueStore.NOOP);
 
     transitModel.addTripOnServiceDate(
-      TRIP_ON_SERVICE_DATE_ID,
       TripOnServiceDate
         .of(TRIP_ON_SERVICE_DATE_ID)
         .withTrip(trip)

--- a/src/test/java/org/opentripplanner/transit/service/TransitModelTest.java
+++ b/src/test/java/org/opentripplanner/transit/service/TransitModelTest.java
@@ -43,7 +43,7 @@ class TransitModelTest {
     // Then trip times should be same as in input data
     TransitModelIndex transitModelIndex = transitModel.getTransitModelIndex();
     Trip trip = transitModelIndex.getTripForId().get(SAMPLE_TRIP_ID);
-    Timetable timetable = transitModelIndex.getPatternForTrip().get(trip).getScheduledTimetable();
+    Timetable timetable = transitModelIndex.getPatternForTrip(trip).getScheduledTimetable();
     assertEquals(20 * 60, timetable.getTripTimes(trip).getDepartureTime(0));
 
     // Should throw on second bundle, with different agency time zone
@@ -102,7 +102,7 @@ class TransitModelTest {
 
     // Then trip times should be on hour less than in input data
     Trip trip = transitModelIndex.getTripForId().get(SAMPLE_TRIP_ID);
-    Timetable timetable = transitModelIndex.getPatternForTrip().get(trip).getScheduledTimetable();
+    Timetable timetable = transitModelIndex.getPatternForTrip(trip).getScheduledTimetable();
     assertEquals(20 * 60 - 60 * 60, timetable.getTripTimes(trip).getDepartureTime(0));
   }
 }

--- a/src/test/java/org/opentripplanner/transit/service/TransitModelTest.java
+++ b/src/test/java/org/opentripplanner/transit/service/TransitModelTest.java
@@ -42,7 +42,7 @@ class TransitModelTest {
 
     // Then trip times should be same as in input data
     TransitModelIndex transitModelIndex = transitModel.getTransitModelIndex();
-    Trip trip = transitModelIndex.getTripForId().get(SAMPLE_TRIP_ID);
+    Trip trip = transitModelIndex.getTripForId(SAMPLE_TRIP_ID);
     Timetable timetable = transitModelIndex.getPatternForTrip(trip).getScheduledTimetable();
     assertEquals(20 * 60, timetable.getTripTimes(trip).getDepartureTime(0));
 
@@ -101,7 +101,7 @@ class TransitModelTest {
     assertEquals("America/Chicago", transitModel.getTimeZone().getId());
 
     // Then trip times should be on hour less than in input data
-    Trip trip = transitModelIndex.getTripForId().get(SAMPLE_TRIP_ID);
+    Trip trip = transitModelIndex.getTripForId(SAMPLE_TRIP_ID);
     Timetable timetable = transitModelIndex.getPatternForTrip(trip).getScheduledTimetable();
     assertEquals(20 * 60 - 60 * 60, timetable.getTripTimes(trip).getDepartureTime(0));
   }

--- a/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
+++ b/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
@@ -65,7 +65,7 @@ public class RealtimeTestEnvironmentBuilder implements RealtimeTestConstants {
       .withServiceDate(SERVICE_DATE)
       .build();
 
-    transitModel.addTripOnServiceDate(tripOnServiceDate.getId(), tripOnServiceDate);
+    transitModel.addTripOnServiceDate(tripOnServiceDate);
 
     if (tripInput.route().getOperator() != null) {
       transitModel.getOperators().add(tripInput.route().getOperator());


### PR DESCRIPTION
### Summary

In this PR:
- Hide most of the maps in `TransitModelIndex`.
- Make collections returned by `TransitModelIndex` unmodifiable.
- Remove functionality from `TransitModelIndex` that already exists in `TransitModel`.

### Issue

See #6048 

### Unit tests

Some of the stuff in TransitModelIndex is untested. I didn't add any tests.

### Documentation

Didn't add any documentation.

### Bumping the serialization version id

I guess, since I'm changing the signature of the TransitModel?