### PR TITLE
Minor cleanup of operator stuff in TransitModel

### DIFF
--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -90,7 +90,7 @@ public class NetexModule implements GraphBuilderModule {
         // TODO OTP2 - Move this into the AddTransitModelEntitiesToGraph
         //           - and make sure they also work with GTFS feeds - GTFS do no
         //           - have operators and notice assignments.
-        transitModel.getOperators().addAll(otpService.getAllOperators());
+        transitModel.addOperators(otpService.getAllOperators());
         transitModel.addNoticeAssignments(otpService.getNoticeAssignments());
 
         AddTransitModelEntitiesToGraph.addToGraph(

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -123,11 +123,6 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public Collection<Operator> getOperators() {
-    return this.transitModel.getOperators();
-  }
-
-  @Override
   public Collection<Notice> getNoticesByEntity(AbstractTransitEntity<?, ?> entity) {
     return this.transitModel.getNoticesByElement().get(entity);
   }

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -13,6 +13,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -349,7 +350,11 @@ public class TransitModel implements Serializable {
   }
 
   public Collection<Operator> getOperators() {
-    return operators;
+    return Collections.unmodifiableCollection(operators);
+  }
+
+  public void addOperators(Collection<Operator> operators) {
+    this.operators.addAll(operators);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -71,8 +71,6 @@ public interface TransitService {
 
   FeedInfo getFeedInfo(String feedId);
 
-  Collection<Operator> getOperators();
-
   Collection<Notice> getNoticesByEntity(AbstractTransitEntity<?, ?> entity);
 
   /**

--- a/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
+++ b/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
@@ -68,7 +68,7 @@ public class RealtimeTestEnvironmentBuilder implements RealtimeTestConstants {
     transitModel.addTripOnServiceDate(tripOnServiceDate.getId(), tripOnServiceDate);
 
     if (tripInput.route().getOperator() != null) {
-      transitModel.getOperators().add(tripInput.route().getOperator());
+      transitModel.addOperators(List.of(tripInput.route().getOperator()));
     }
 
     var stopTimes = IntStream


### PR DESCRIPTION
### Summary

- Add specific method for adding operators.
- Make operator list unmodifiable.
- Remove `TransitService.getOperators()` since we already have `TransitService.getAllOperators()`.

### Issue

#6048 

### Unit tests

No tests for this.

### Bumping the serialization version id

I'm changing the signature of TransitModel.