### PR TITLE
Add @Nullable annotations to Trip and Leg

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedTransitLeg.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/CombinedInterlinedTransitLeg.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.model.plan.Itinerary.UNKNOWN;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.framework.collection.ListUtils;
 import org.opentripplanner.model.fare.FareProductUse;
@@ -94,6 +95,7 @@ class CombinedInterlinedTransitLeg implements TransitLeg {
   }
 
   @Override
+  @Nullable
   public LineString getLegGeometry() {
     return null;
   }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
@@ -6,6 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.ext.flex.edgetype.FlexTripEdge;
 import org.opentripplanner.framework.i18n.I18NString;
@@ -65,6 +66,7 @@ public class FlexibleTransitLeg implements TransitLeg {
   }
 
   @Override
+  @Nullable
   public Operator getOperator() {
     return getTrip().getOperator();
   }

--- a/application/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -161,6 +161,7 @@ public interface Leg {
   /**
    * For transit legs, the route agency. For non-transit legs {@code null}.
    */
+  @Nullable
   default Agency getAgency() {
     return null;
   }
@@ -171,6 +172,7 @@ public interface Leg {
    *
    * @see Trip#getOperator()
    */
+  @Nullable
   default Operator getOperator() {
     return null;
   }
@@ -178,6 +180,7 @@ public interface Leg {
   /**
    * For transit legs, the route. For non-transit legs, null.
    */
+  @Nullable
   default Route getRoute() {
     return null;
   }
@@ -198,6 +201,7 @@ public interface Leg {
     return null;
   }
 
+  @Nullable
   default Accessibility getTripWheelchairAccessibility() {
     return null;
   }
@@ -245,6 +249,7 @@ public interface Leg {
     return false;
   }
 
+  @Nullable
   default RealTimeState getRealTimeState() {
     return null;
   }
@@ -261,6 +266,7 @@ public interface Leg {
   /**
    * Is this a frequency-based trip with non-strict departure times?
    */
+  @Nullable
   default Boolean getNonExactFrequency() {
     return null;
   }
@@ -270,6 +276,7 @@ public interface Leg {
    * non-strict frequency trips, but could become important for real-time trips, strict frequency
    * trips, and scheduled trips with empirical headways.
    */
+  @Nullable
   default Integer getHeadway() {
     return null;
   }
@@ -293,6 +300,7 @@ public interface Leg {
    * using the Hierarchical Vehicle Type (HVT) codes from the European TPEG standard Also see
    * http://groups.google.com/group/gtfs-changes/msg/ed917a69cf8c5bef
    */
+  @Nullable
   default Integer getRouteType() {
     return null;
   }
@@ -300,6 +308,7 @@ public interface Leg {
   /**
    * For transit legs, the headsign of the bus or train being used. For non-transit legs, null.
    */
+  @Nullable
   default I18NString getHeadsign() {
     return null;
   }
@@ -312,6 +321,7 @@ public interface Leg {
    * for a given trip may happen at service date March 25th and service time 25:00, which in local
    * time would be Mach 26th 01:00.
    */
+  @Nullable
   default LocalDate getServiceDate() {
     return null;
   }
@@ -319,6 +329,7 @@ public interface Leg {
   /**
    * For transit leg, the route's branding URL (if one exists). For non-transit legs, null.
    */
+  @Nullable
   default String getRouteBrandingUrl() {
     return null;
   }
@@ -337,6 +348,7 @@ public interface Leg {
    * For transit legs, intermediate stops between the Place where the leg originates and the Place
    * where the leg ends. For non-transit legs, {@code null}.
    */
+  @Nullable
   default List<StopArrival> getIntermediateStops() {
     return null;
   }
@@ -344,6 +356,7 @@ public interface Leg {
   /**
    * The leg's geometry.
    */
+  @Nullable
   LineString getLegGeometry();
 
   /**
@@ -352,6 +365,7 @@ public interface Leg {
    * The elevation profile as a comma-separated list of x,y values. x is the distance from the start
    * of the leg, y is the elevation at this distance.
    */
+  @Nullable
   default ElevationProfile getElevationProfile() {
     return null;
   }
@@ -364,49 +378,59 @@ public interface Leg {
   }
 
   default Set<StreetNote> getStreetNotes() {
-    return null;
+    return Set.of();
   }
 
   default Set<TransitAlert> getTransitAlerts() {
     return Set.of();
   }
 
+  @Nullable
   default PickDrop getBoardRule() {
     return null;
   }
 
+  @Nullable
   default PickDrop getAlightRule() {
     return null;
   }
 
+  @Nullable
   default BookingInfo getDropOffBookingInfo() {
     return null;
   }
 
+  @Nullable
   default BookingInfo getPickupBookingInfo() {
     return null;
   }
 
+  @Nullable
   default ConstrainedTransfer getTransferFromPrevLeg() {
     return null;
   }
 
+  @Nullable
   default ConstrainedTransfer getTransferToNextLeg() {
     return null;
   }
 
+  @Nullable
   default Integer getBoardStopPosInPattern() {
     return null;
   }
 
+  @Nullable
   default Integer getAlightStopPosInPattern() {
     return null;
   }
 
+  @Nullable
   default Integer getBoardingGtfsStopSequence() {
     return null;
   }
 
+  @Nullable
   default Integer getAlightGtfsStopSequence() {
     return null;
   }
@@ -414,6 +438,7 @@ public interface Leg {
   /**
    * Is this leg walking with a bike?
    */
+  @Nullable
   default Boolean getWalkingBike() {
     return null;
   }
@@ -435,10 +460,12 @@ public interface Leg {
     return null;
   }
 
+  @Nullable
   default Boolean getRentedVehicle() {
     return null;
   }
 
+  @Nullable
   default String getVehicleRentalNetwork() {
     return null;
   }
@@ -453,6 +480,7 @@ public interface Leg {
    */
   int getGeneralizedCost();
 
+  @Nullable
   default LegReference getLegReference() {
     return null;
   }

--- a/application/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -96,10 +96,7 @@ public class ScheduledTransitLeg implements TransitLeg {
     setDistanceMeters(getDistanceFromCoordinates(transitLegCoordinates));
     this.directDistanceMeters =
       getDistanceFromCoordinates(
-        List.of(
-          transitLegCoordinates.get(0),
-          transitLegCoordinates.get(transitLegCoordinates.size() - 1)
-        )
+        List.of(transitLegCoordinates.getFirst(), transitLegCoordinates.getLast())
       );
   }
 
@@ -139,22 +136,23 @@ public class ScheduledTransitLeg implements TransitLeg {
 
   @Override
   public Agency getAgency() {
-    return getTrip().getRoute().getAgency();
+    return trip().getRoute().getAgency();
   }
 
   @Override
+  @Nullable
   public Operator getOperator() {
-    return getTrip().getOperator();
+    return trip().getOperator();
   }
 
   @Override
   public Route getRoute() {
-    return getTrip().getRoute();
+    return trip().getRoute();
   }
 
   @Override
   public Trip getTrip() {
-    return tripTimes.getTrip();
+    return trip();
   }
 
   @Override
@@ -182,7 +180,7 @@ public class ScheduledTransitLeg implements TransitLeg {
 
   @Override
   public TransitMode getMode() {
-    return getTrip().getMode();
+    return trip().getMode();
   }
 
   @Override
@@ -247,7 +245,7 @@ public class ScheduledTransitLeg implements TransitLeg {
 
   @Override
   public Integer getRouteType() {
-    return getTrip().getRoute().getGtfsType();
+    return trip().getRoute().getGtfsType();
   }
 
   @Override
@@ -300,6 +298,7 @@ public class ScheduledTransitLeg implements TransitLeg {
   }
 
   @Override
+  @Nullable
   public PickDrop getBoardRule() {
     if (transferFromPrevLeg != null && transferFromPrevLeg.getTransferConstraint().isStaySeated()) {
       return null;
@@ -308,6 +307,7 @@ public class ScheduledTransitLeg implements TransitLeg {
   }
 
   @Override
+  @Nullable
   public PickDrop getAlightRule() {
     if (transferToNextLeg != null && transferToNextLeg.getTransferConstraint().isStaySeated()) {
       return null;
@@ -432,6 +432,13 @@ public class ScheduledTransitLeg implements TransitLeg {
       .addObj("transferFromPrevLeg", transferFromPrevLeg)
       .addObj("transferToNextLeg", transferToNextLeg)
       .toString();
+  }
+
+  /**
+   * Non-null getter for trip
+   */
+  private Trip trip() {
+    return tripTimes.getTrip();
   }
 
   private List<Coordinate> extractTransitLegCoordinates(

--- a/application/src/main/java/org/opentripplanner/model/plan/UnknownTransitPathLeg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/UnknownTransitPathLeg.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.model.plan.Itinerary.UNKNOWN;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
@@ -84,6 +85,7 @@ public class UnknownTransitPathLeg implements Leg {
   }
 
   @Override
+  @Nullable
   public LineString getLegGeometry() {
     return null;
   }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.netex.mapping;
 import jakarta.xml.bind.JAXBElement;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 import net.opengis.gml._3.LineStringType;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
@@ -116,6 +117,7 @@ class ServiceLinkMapper {
     return geometries;
   }
 
+  @Nullable
   private LineString mapServiceLink(
     ServiceLink serviceLink,
     StopPattern stopPattern,

--- a/application/src/main/java/org/opentripplanner/transit/model/network/Route.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/Route.java
@@ -156,6 +156,9 @@ public final class Route extends AbstractTransitEntity<Route, RouteBuilder> impl
     return gtfsSortOrder;
   }
 
+  /**
+   * Returns the NeTEx submode for the route. Will return UNKNOWN by default.
+   */
   public SubMode getNetexSubmode() {
     return netexSubmode;
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
@@ -34,23 +34,35 @@ import org.opentripplanner.transit.model.organization.Operator;
  */
 public final class Trip extends AbstractTransitEntity<Trip, TripBuilder> implements LogInfo {
 
-  private final Operator operator;
   private final Route route;
-  private final FeedScopedId serviceId;
-  private final String shortName;
   private final TransitMode mode;
-  private final SubMode netexSubmode;
-  private final I18NString headsign;
-  private final FeedScopedId shapeId;
-
   private final Direction direction;
   private final BikeAccess bikesAllowed;
   private final Accessibility wheelchairBoarding;
 
+  private final SubMode netexSubmode;
+  private final TripAlteration netexAlteration;
+
+  @Nullable
+  private final Operator operator;
+
+  @Nullable
+  private final FeedScopedId serviceId;
+
+  @Nullable
+  private final String shortName;
+
+  @Nullable
+  private final I18NString headsign;
+
+  @Nullable
+  private final FeedScopedId shapeId;
+
+  @Nullable
   private final String gtfsBlockId;
 
+  @Nullable
   private final String netexInternalPlanningCode;
-  private final TripAlteration netexAlteration;
 
   Trip(TripBuilder builder) {
     super(builder.getId());

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -7,7 +8,6 @@ import static org.opentripplanner.routing.api.request.StreetMode.NOT_SET;
 import static org.opentripplanner.routing.api.request.StreetMode.WALK;
 import static org.opentripplanner.updater.trip.BackwardsDelayPropagationType.REQUIRED_NO_DATA;
 
-import com.google.common.truth.Truth;
 import com.google.transit.realtime.GtfsRealtime.FeedEntity;
 import com.google.transit.realtime.GtfsRealtime.FeedMessage;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
@@ -179,7 +179,7 @@ public abstract class GtfsTest {
       assertEquals(1, leg.getStreetNotes().size());
       assertEquals(alert, leg.getStreetNotes().iterator().next().note.toString());
     } else {
-      Truth.assertThat(leg.getStreetNotes()).isEmpty();
+      assertThat(leg.getStreetNotes()).isEmpty();
     }
   }
 

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -7,6 +7,7 @@ import static org.opentripplanner.routing.api.request.StreetMode.NOT_SET;
 import static org.opentripplanner.routing.api.request.StreetMode.WALK;
 import static org.opentripplanner.updater.trip.BackwardsDelayPropagationType.REQUIRED_NO_DATA;
 
+import com.google.common.truth.Truth;
 import com.google.transit.realtime.GtfsRealtime.FeedEntity;
 import com.google.transit.realtime.GtfsRealtime.FeedMessage;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
@@ -178,7 +179,7 @@ public abstract class GtfsTest {
       assertEquals(1, leg.getStreetNotes().size());
       assertEquals(alert, leg.getStreetNotes().iterator().next().note.toString());
     } else {
-      assertNull(leg.getStreetNotes());
+      Truth.assertThat(leg.getStreetNotes()).isEmpty();
     }
   }
 


### PR DESCRIPTION
### Summary

Add `@Nullable` annotiation to stuff that can be null in `Trip` and `Leg`. Also reorder the fields in Trip to be more in order of importance.

### Issue

#6048 

### Unit tests

No tests

### Bumping the serialization version id

The fields in `Trip` are reordered, but this should not change serialization.
