### PR TITLE
Fix duplicated dirty timetables

### DIFF
--- a/application/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/application/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -13,11 +13,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
@@ -83,10 +81,14 @@ public class TimetableSnapshot {
 
   /**
    * During the construction phase of the TimetableSnapshot, before it is considered immutable and
-   * used in routing, this Set holds all timetables that have been modified and are waiting to be
-   * indexed. This field will be set to null when the TimetableSnapshot becomes read-only.
+   * used in routing, this Map holds all timetables that have been modified and are waiting to be
+   * indexed.
+   * A real-time timetable overrides the scheduled timetable of a TripPattern for only a single
+   * service date. There can be only one overriding timetable per TripPattern and per service date.
+   * This is enforced by indexing the map with a pair (TripPattern, service date).
+   * This field will be set to null when the TimetableSnapshot becomes read-only.
    */
-  private final Set<Timetable> dirtyTimetables = new HashSet<>();
+  private final Map<TripPatternAndServiceDate, Timetable> dirtyTimetables = new HashMap<>();
 
   /**
    * For each TripPattern (sequence of stops on a particular Route) for which we have received a
@@ -383,7 +385,7 @@ public class TimetableSnapshot {
     );
 
     if (transitLayerUpdater != null) {
-      transitLayerUpdater.update(dirtyTimetables, timetables);
+      transitLayerUpdater.update(dirtyTimetables.values(), timetables);
     }
 
     this.dirtyTimetables.clear();
@@ -600,7 +602,12 @@ public class TimetableSnapshot {
     }
     sortedTimetables.add(updated);
     timetables.put(pattern, ImmutableSortedSet.copyOfSorted(sortedTimetables));
-    dirtyTimetables.add(updated);
+
+    // if the timetable was already modified by a previous real-time update in the same snapshot
+    // and for the same service date,
+    // then the previously updated timetable is superseded by the new one
+    dirtyTimetables.put(new TripPatternAndServiceDate(pattern, updated.getServiceDate()), updated);
+
     dirty = true;
   }
 
@@ -617,4 +624,9 @@ public class TimetableSnapshot {
       return t1.getServiceDate().compareTo(t2.getServiceDate());
     }
   }
+
+  /**
+   * A pair made of a TripPattern and one of the service dates it is running on.
+   */
+  private record TripPatternAndServiceDate(TripPattern tripPattern, LocalDate serviceDate) {}
 }

--- a/application/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/application/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -86,7 +86,7 @@ public class TimetableSnapshot {
    * A real-time timetable overrides the scheduled timetable of a TripPattern for only a single
    * service date. There can be only one overriding timetable per TripPattern and per service date.
    * This is enforced by indexing the map with a pair (TripPattern, service date).
-   * This field will be set to null when the TimetableSnapshot becomes read-only.
+   * This map is cleared when the TimetableSnapshot becomes read-only.
    */
   private final Map<TripPatternAndServiceDate, Timetable> dirtyTimetables = new HashMap<>();
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
@@ -60,7 +60,7 @@ public class TransitLayerUpdater {
   }
 
   public void update(
-    Set<Timetable> updatedTimetables,
+    Collection<Timetable> updatedTimetables,
     Map<TripPattern, SortedSet<Timetable>> timetables
   ) {
     if (!transitService.hasRealtimeTransitLayer()) {

--- a/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.model;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -20,19 +21,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner._support.time.ZoneIds;
-import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerUpdater;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.Result;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
-import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
@@ -296,18 +296,23 @@ public class TimetableSnapshotTest {
     snapshot.update(realTimeTripUpdate);
     assertTrue(snapshot.isDirty());
 
+    AtomicBoolean updateIsCalled = new AtomicBoolean();
+
     TransitLayerUpdater transitLayer = new TransitLayerUpdater(null) {
       @Override
       public void update(
         Collection<Timetable> updatedTimetables,
         Map<TripPattern, SortedSet<Timetable>> timetables
       ) {
-        assertEquals(1, updatedTimetables.size());
-        assertEquals(1, timetables.size());
+        updateIsCalled.set(true);
+        assertThat(updatedTimetables).hasSize(1);
+        assertThat(timetables).hasSize(1);
       }
     };
 
     snapshot.commit(transitLayer, true);
+
+    assertTrue(updateIsCalled.get());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
@@ -14,18 +14,28 @@ import com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelations
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.SortedSet;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner._support.time.ZoneIds;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerUpdater;
+import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.Result;
 import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.BackwardsDelayPropagationType;
@@ -33,6 +43,7 @@ import org.opentripplanner.updater.trip.BackwardsDelayPropagationType;
 public class TimetableSnapshotTest {
 
   private static final ZoneId timeZone = ZoneIds.GMT;
+  public static final LocalDate SERVICE_DATE = LocalDate.of(2024, 1, 1);
   private static Map<FeedScopedId, TripPattern> patternIndex;
   static String feedId;
 
@@ -259,6 +270,44 @@ public class TimetableSnapshotTest {
 
     assertNull(resolver.commit());
     assertFalse(resolver.isDirty());
+  }
+
+  @Test
+  void testUniqueDirtyTimetablesAfterMultipleUpdates() {
+    TimetableSnapshot snapshot = new TimetableSnapshot();
+    TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
+    Trip trip = pattern.scheduledTripsAsStream().findFirst().orElseThrow();
+
+    TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
+      trip,
+      List.of(new StopTime()),
+      new Deduplicator()
+    );
+    RealTimeTripUpdate realTimeTripUpdate = new RealTimeTripUpdate(
+      pattern,
+      updatedTriptimes,
+      SERVICE_DATE,
+      TripOnServiceDate.of(trip.getId()).withTrip(trip).withServiceDate(SERVICE_DATE).build(),
+      true,
+      true
+    );
+
+    snapshot.update(realTimeTripUpdate);
+    snapshot.update(realTimeTripUpdate);
+    assertTrue(snapshot.isDirty());
+
+    TransitLayerUpdater transitLayer = new TransitLayerUpdater(null) {
+      @Override
+      public void update(
+        Collection<Timetable> updatedTimetables,
+        Map<TripPattern, SortedSet<Timetable>> timetables
+      ) {
+        assertEquals(1, updatedTimetables.size());
+        assertEquals(1, timetables.size());
+      }
+    };
+
+    snapshot.commit(transitLayer, true);
   }
 
   @Test


### PR DESCRIPTION
### Summary

As detailed in #6135, a memory leak has been identified in the `TransitLayer`.
This bug was introduced in #6017.

The set of dirty timetables in `TimetableSnapshot` (that is: the set of timetables currently being modified and to be added to the next snapshot) should contain only one modified timetable per trip pattern and per service date.
Prior to #6017, if a timetable was modified several times when building the next snapshot, the same `Timetable` instance would be reused and updated, thus guaranteeing uniqueness.
In #6017, `Timetable` is immutable and the previous Timetable instance cannot be modified : it must be swapped with a new `Timetable` instance that integrates the latest changes.
However the code fails to remove the previously modified timetable before adding the new one and the `Set` that holds the dirty timetables does not enforce uniqueness (`Timetable` does not have an id and does not implement equals()). 

A simple fix would be to keep the existing data structure (`Set`) and explicitly remove the old instance before adding the new one.
Here a more reliable fix is proposed, where uniqueness is enforced by storing the dirty timetables in a map indexed by (`TripPattern`,  service date).



### Issue

Closes #6135

### Unit tests

Added unit test.

### Documentation

No

