### PR TITLE
Install mkdocs with --break-system-packages

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -108,7 +108,7 @@ jobs:
         if: github.event_name == 'pull_request'
 
       - name: Install Python dependencies
-        run: pip install -r doc/user/requirements.txt
+        run: pip install --break-system-packages -r doc/user/requirements.txt
         
 
       - name: Build main documentation


### PR DESCRIPTION
### Summary

It appears that python and pip have become stricter and don't allow you to install into system directories anymore. However, since we are using a throwaway VM it's fine to do this anyway.