### PR TITLE
Fix regression error in passThroughPoints in the Transmodel API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/ViaLocationInputType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/ViaLocationInputType.java
@@ -5,6 +5,7 @@ import static graphql.Scalars.GraphQLString;
 
 import graphql.language.StringValue;
 import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import java.time.Duration;
@@ -84,7 +85,7 @@ public class ViaLocationInputType {
       b
         .name(FIELD_STOP_LOCATION_IDS)
         .description(DOC_STOP_LOCATION_IDS)
-        .type(gqlListOfNonNullStrings())
+        .type(requiredListOfNonNullStrings())
     )
     /*
       TODO: Add support for coordinates
@@ -101,7 +102,7 @@ public class ViaLocationInputType {
       b
         .name(FIELD_STOP_LOCATION_IDS)
         .description(DOC_STOP_LOCATION_IDS)
-        .type(gqlListOfNonNullStrings())
+        .type(requiredListOfNonNullStrings())
     )
     .build();
 
@@ -119,7 +120,7 @@ public class ViaLocationInputType {
     )
     .build();
 
-  private static GraphQLList gqlListOfNonNullStrings() {
-    return new GraphQLList(new GraphQLNonNull(GraphQLString));
+  private static GraphQLInputType requiredListOfNonNullStrings() {
+    return new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString)));
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/via/PassThroughViaLocation.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/via/PassThroughViaLocation.java
@@ -16,7 +16,8 @@ public class PassThroughViaLocation extends AbstractViaLocation {
     super(label, stopLocationIds);
     if (stopLocationIds.isEmpty()) {
       throw new IllegalArgumentException(
-        "A pass through via location must have at least one stop location. Label: " + label
+        "A pass through via location must have at least one stop location." +
+        (label == null ? "" : " Label: " + label)
       );
     }
   }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/via/VisitViaLocation.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/via/VisitViaLocation.java
@@ -41,7 +41,8 @@ public class VisitViaLocation extends AbstractViaLocation {
 
     if (stopLocationIds().isEmpty() && coordinates().isEmpty()) {
       throw new IllegalArgumentException(
-        "A via location must have at least one stop location or a coordinate. Label: " + label
+        "A via location must have at least one stop location or a coordinate." +
+        (label == null ? "" : " Label: " + label)
       );
     }
   }

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -2204,7 +2204,7 @@ input TripPassThroughViaLocationInput {
   stop place or a group of stop places. It is enough to visit ONE of the locations
   listed.
   """
-  stopLocationIds: [String!]
+  stopLocationIds: [String!]!
 }
 
 """
@@ -2239,7 +2239,7 @@ input TripVisitViaLocationInput {
   stop place or a group of stop places. It is enough to visit ONE of the locations
   listed.
   """
-  stopLocationIds: [String!]
+  stopLocationIds: [String!]!
 }
 
 "Input format for specifying a location through either a place reference (id), coordinates or both. If both place and coordinates are provided the place ref will be used if found, coordinates will only be used if place is not known. The location also contain information about the minimum and maximum time the user is willing to stay at the via location."


### PR DESCRIPTION
### Summary

The list of ids inside passThroughPoints is allowed to be empty or null. We cannot change this - that would be a breaking change. So, when the via search enforced this, the API was not backward compatible anymore. This commit reverts the behavior and just ignores the passThroughPoints if the list of ids is null or empty. This bug was
introduced in PR #6084.

This PR also changes the graphql schema for via search - the assumtion is that no one has put it in production jet. The list of stop ids are med required. This was initially optional, because we want to add coordinates. But, it should be relaxed when the coordinates are added, not now. At least one id or coordinate must be set anyway!

### Issue

🟥  There is not OTP issue for this.


### Unit tests

✅  Regression unit tests are added to via and passthrough in the TransmodelAPI for this.

### Documentation

🟥  This does not change any doc.

### Changelog

🟥  This is a regression fix to the via PR #6084 merged last week.


### Bumping the serialization version id

🟥  Should not be requiered.