### PR TITLE
Interpret GTFS extended route types 801-899 also as trolleybus service

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
@@ -30,11 +30,10 @@ public class TransitModeMapper {
       return TransitMode.RAIL;
     } else if (routeType >= 500 && routeType < 700) { //Metro Service and Underground Service
       return TransitMode.SUBWAY;
-    } else if (routeType >= 700 && routeType < 900) { //Bus Service and Trolleybus service
-      if (routeType == 800) {
-        return TransitMode.TROLLEYBUS;
-      }
+    } else if (routeType >= 700 && routeType < 800) { //Bus Service
       return TransitMode.BUS;
+    } else if (routeType >= 800 && routeType < 900) { //Trolleybus Service
+      return TransitMode.TROLLEYBUS;
     } else if (routeType >= 900 && routeType < 1000) { //Tram service
       return TransitMode.TRAM;
     } else if (routeType >= 1000 && routeType < 1100) { //Water Transport Service

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
@@ -16,7 +16,8 @@ public class TransitModeMapper {
     }
 
     /* TPEG Extension  https://groups.google.com/d/msg/gtfs-changes/keT5rTPS7Y0/71uMz2l6ke0J */
-    if (routeType >= 100 && routeType < 200) { // Railway Service
+    if (routeType >= 100 && routeType < 200) {
+      // Railway Service
       return TransitMode.RAIL;
     } else if (routeType >= 200 && routeType < 300) { //Coach Service
       return TransitMode.BUS;
@@ -28,23 +29,32 @@ public class TransitModeMapper {
         return TransitMode.MONORAIL;
       }
       return TransitMode.RAIL;
-    } else if (routeType >= 500 && routeType < 700) { //Metro Service and Underground Service
+    } else if (routeType >= 500 && routeType < 700) {
+      // Metro Service and Underground Service
       return TransitMode.SUBWAY;
-    } else if (routeType >= 700 && routeType < 800) { //Bus Service
+    } else if (routeType >= 700 && routeType < 800) {
+      // Bus Service
       return TransitMode.BUS;
-    } else if (routeType >= 800 && routeType < 900) { //Trolleybus Service
+    } else if (routeType >= 800 && routeType < 900) {
+      // Trolleybus Service
       return TransitMode.TROLLEYBUS;
-    } else if (routeType >= 900 && routeType < 1000) { //Tram service
+    } else if (routeType >= 900 && routeType < 1000) {
+      // Tram service
       return TransitMode.TRAM;
-    } else if (routeType >= 1000 && routeType < 1100) { //Water Transport Service
+    } else if (routeType >= 1000 && routeType < 1100) {
+      // Water Transport Service
       return TransitMode.FERRY;
-    } else if (routeType >= 1100 && routeType < 1200) { //Air Service
+    } else if (routeType >= 1100 && routeType < 1200) {
+      // Air Service
       return TransitMode.AIRPLANE;
-    } else if (routeType >= 1200 && routeType < 1300) { //Ferry Service
+    } else if (routeType >= 1200 && routeType < 1300) {
+      // Ferry Service
       return TransitMode.FERRY;
-    } else if (routeType >= 1300 && routeType < 1400) { //Telecabin Service
+    } else if (routeType >= 1300 && routeType < 1400) {
+      // Telecabin Service
       return TransitMode.GONDOLA;
-    } else if (routeType >= 1400 && routeType < 1500) { //Funicular Service
+    } else if (routeType >= 1400 && routeType < 1500) {
+      // Funicular Service
       return TransitMode.FUNICULAR;
     } else if (routeType >= 1551 && routeType < 1561) {
       // Carpooling, not defined anywhere, so we've chosen this number space
@@ -52,11 +62,13 @@ public class TransitModeMapper {
       // standardise
       return TransitMode.CARPOOL;
     } else if (routeType >= 1500 && routeType < 1599) {
-      //Taxi Service
+      // Taxi Service
       return TransitMode.TAXI;
-    } else if (routeType >= 1600 && routeType < 1700) { //Self drive
+    } else if (routeType >= 1600 && routeType < 1700) {
+      // Self drive
       return TransitMode.BUS;
-    } else if (routeType >= 1700 && routeType < 1800) { //Miscellaneous Service
+    } else if (routeType >= 1700 && routeType < 1800) {
+      // Miscellaneous Service
       return null;
     }
     /* Original GTFS route types. Should these be checked before TPEG types? */

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/TransitModeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/TransitModeMapperTest.java
@@ -1,7 +1,19 @@
 package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.transit.model.basic.TransitMode.*;
+import static org.opentripplanner.transit.model.basic.TransitMode.AIRPLANE;
+import static org.opentripplanner.transit.model.basic.TransitMode.BUS;
+import static org.opentripplanner.transit.model.basic.TransitMode.CABLE_CAR;
+import static org.opentripplanner.transit.model.basic.TransitMode.CARPOOL;
+import static org.opentripplanner.transit.model.basic.TransitMode.FERRY;
+import static org.opentripplanner.transit.model.basic.TransitMode.FUNICULAR;
+import static org.opentripplanner.transit.model.basic.TransitMode.GONDOLA;
+import static org.opentripplanner.transit.model.basic.TransitMode.MONORAIL;
+import static org.opentripplanner.transit.model.basic.TransitMode.RAIL;
+import static org.opentripplanner.transit.model.basic.TransitMode.SUBWAY;
+import static org.opentripplanner.transit.model.basic.TransitMode.TAXI;
+import static org.opentripplanner.transit.model.basic.TransitMode.TRAM;
+import static org.opentripplanner.transit.model.basic.TransitMode.TROLLEYBUS;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/TransitModeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/TransitModeMapperTest.java
@@ -1,8 +1,7 @@
 package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.transit.model.basic.TransitMode.CARPOOL;
-import static org.opentripplanner.transit.model.basic.TransitMode.TAXI;
+import static org.opentripplanner.transit.model.basic.TransitMode.*;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,6 +13,49 @@ class TransitModeMapperTest {
 
   static Stream<Arguments> testCases() {
     return Stream.of(
+      // base GTFS route types
+      // https://gtfs.org/documentation/schedule/reference/#routestxt
+      Arguments.of(0, TRAM),
+      Arguments.of(1, SUBWAY),
+      Arguments.of(2, RAIL),
+      Arguments.of(3, BUS),
+      Arguments.of(4, FERRY),
+      Arguments.of(5, CABLE_CAR),
+      Arguments.of(6, GONDOLA),
+      Arguments.of(7, FUNICULAR),
+      Arguments.of(11, TROLLEYBUS),
+      Arguments.of(12, MONORAIL),
+      // extended route types
+      // https://developers.google.com/transit/gtfs/reference/extended-route-types
+      // https://groups.google.com/g/gtfs-changes/c/keT5rTPS7Y0/m/71uMz2l6ke0J?pli=1
+      Arguments.of(100, RAIL),
+      Arguments.of(199, RAIL),
+      Arguments.of(400, RAIL),
+      Arguments.of(401, SUBWAY),
+      Arguments.of(402, SUBWAY),
+      Arguments.of(403, RAIL),
+      Arguments.of(404, RAIL),
+      Arguments.of(405, MONORAIL),
+      Arguments.of(500, SUBWAY),
+      Arguments.of(599, SUBWAY),
+      Arguments.of(600, SUBWAY),
+      Arguments.of(699, SUBWAY),
+      Arguments.of(700, BUS),
+      Arguments.of(799, BUS),
+      Arguments.of(800, TROLLEYBUS),
+      Arguments.of(899, TROLLEYBUS),
+      Arguments.of(900, TRAM),
+      Arguments.of(999, TRAM),
+      Arguments.of(1000, FERRY),
+      Arguments.of(1099, FERRY),
+      Arguments.of(1100, AIRPLANE),
+      Arguments.of(1199, AIRPLANE),
+      Arguments.of(1200, FERRY),
+      Arguments.of(1299, FERRY),
+      Arguments.of(1300, GONDOLA),
+      Arguments.of(1399, GONDOLA),
+      Arguments.of(1400, FUNICULAR),
+      Arguments.of(1499, FUNICULAR),
       Arguments.of(1500, TAXI),
       Arguments.of(1510, TAXI),
       Arguments.of(1551, CARPOOL),


### PR DESCRIPTION
### Summary

Fix GTFS extended route types for trolleybus (8xx).

This replaces #6086 for trolleybuses only, and add tests for existing modes (except 200-299).

### Issue
None yet

### Unit tests
added for more existing modes

### Documentation
None

