### PR TITLE
Fix race in execution of tests

### DIFF
--- a/application/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -232,7 +232,7 @@ public class Itinerary implements ItinerarySortKey {
   }
 
   public boolean isFlaggedForDeletion() {
-    return !getSystemNotices().isEmpty();
+    return !systemNotices.isEmpty();
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
@@ -305,12 +305,12 @@ class ItineraryListFilterChainTest implements PlanTestConstants {
   @Nested
   class FlexSearchWindow {
 
-    private static final Itinerary FLEX = newItinerary(A, T11_00)
+    private final Itinerary flex = newItinerary(A, T11_00)
       .flex(T11_00, T11_30, B)
       .withIsSearchWindowAware(false)
       .build();
-    private static final Instant EARLIEST_DEPARTURE = FLEX.startTime().plusMinutes(10).toInstant();
-    private static final Duration SEARCH_WINDOW = Duration.ofHours(7);
+    private final Instant earliestDeparture = flex.startTime().plusMinutes(10).toInstant();
+    private final Duration searchWindow = Duration.ofHours(7);
 
     /**
      * When the filtering of direct flex by the transit search window is deactivated, the direct
@@ -320,18 +320,18 @@ class ItineraryListFilterChainTest implements PlanTestConstants {
     void keepDirectFlexWhenFilteringByEarliestDepartureIsDisabled() {
       ItineraryListFilterChain chain = createBuilder(true, false, 10)
         .withFilterDirectFlexBySearchWindow(false)
-        .withSearchWindow(EARLIEST_DEPARTURE, SEARCH_WINDOW)
+        .withSearchWindow(earliestDeparture, searchWindow)
         .build();
-      assertEquals(toStr(List.of(FLEX)), toStr(chain.filter(List.of(FLEX))));
+      assertEquals(toStr(List.of(flex)), toStr(chain.filter(List.of(flex))));
     }
 
     @Test
     void removeDirectFlexWhenFilteringByEarliestDepartureIsEnabled() {
       ItineraryListFilterChain chain = createBuilder(true, false, 10)
         .withFilterDirectFlexBySearchWindow(true)
-        .withSearchWindow(EARLIEST_DEPARTURE, SEARCH_WINDOW)
+        .withSearchWindow(earliestDeparture, searchWindow)
         .build();
-      assertEquals(toStr(List.of()), toStr(chain.filter(List.of(FLEX))));
+      assertEquals(toStr(List.of()), toStr(chain.filter(List.of(flex))));
     }
   }
 


### PR DESCRIPTION
### Summary

Make the test itinerary instance non-static as it's modified in some tests.
Specifically, an itinerary can be flagged for deletion in one test, which affects the assertions in the next test.

Without this, tests may fail if they are executed in a certain order. This may be because LC_COLLATE is not set in the environment.

### Similar code

Searching for this idiom in the tree:
```
private static final Itinerary INSTANCE = newItinerary( ... );
```
...reveals other usages, although that presently they do not cause build problems. But in the worst case, it could be that a test passes because a previously executed test provides the wanted state.

### Bonus observation

`Itinerary.isFlaggedForDeletion()` calls `getSystemNotices()` which in turn makes a copy of the `systemNotices` collection. This seems wasteful and just generates GC churn.
