### PR TITLE
Change GraphQL tooltip for searchWindowUsed to say minutes, instead of seconds

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/TripMetadataType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/TripMetadataType.java
@@ -26,7 +26,7 @@ public class TripMetadataType {
             "override the value if it is too small or too large. When paging OTP adjusts " +
             "it to the appropriate size, depending on the number of itineraries found in " +
             "the current search window. The scaling of the search window ensures faster " +
-            "paging and limits resource usage. The unit is seconds."
+            "paging and limits resource usage. The unit is minutes."
           )
           .type(new GraphQLNonNull(Scalars.GraphQLInt))
           .dataFetcher(e -> ((TripSearchMetadata) e.getSource()).searchWindowUsed.toMinutes())

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1382,7 +1382,7 @@ type TripSearchData {
   nextDateTime: DateTime @deprecated(reason : "Use pageCursor instead")
   "This is the suggested search time for the \"previous page\" or time-window. Insert it together with the 'searchWindowUsed' in the request to get a new set of trips preceding in the time-window BEFORE the current search."
   prevDateTime: DateTime @deprecated(reason : "Use pageCursor instead")
-  "This is the time window used by the raptor search. The input searchWindow is an optional parameter and is dynamically assigned if not set. OTP might override the value if it is too small or too large. When paging OTP adjusts it to the appropriate size, depending on the number of itineraries found in the current search window. The scaling of the search window ensures faster paging and limits resource usage. The unit is seconds."
+  "This is the time window used by the raptor search. The input searchWindow is an optional parameter and is dynamically assigned if not set. OTP might override the value if it is too small or too large. When paging OTP adjusts it to the appropriate size, depending on the number of itineraries found in the current search window. The scaling of the search window ensures faster paging and limits resource usage. The unit is minutes."
   searchWindowUsed: Int!
 }
 


### PR DESCRIPTION
### Summary

The GraphQL tooltip incorrectly states that the searchWindowUsed is in seconds, when it's actually minutes. This change fixes that.