### PR TITLE
Disable protocol upgrades for the HTTP client by default.

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
+++ b/application/src/main/java/org/opentripplanner/framework/io/OtpHttpClient.java
@@ -378,6 +378,7 @@ public class OtpHttpClient {
       .custom()
       .setResponseTimeout(Timeout.of(timeout))
       .setConnectionRequestTimeout(Timeout.of(timeout))
+      .setProtocolUpgradeEnabled(false)
       .build();
   }
 

--- a/application/src/main/java/org/opentripplanner/framework/io/OtpHttpClientFactory.java
+++ b/application/src/main/java/org/opentripplanner/framework/io/OtpHttpClientFactory.java
@@ -132,6 +132,7 @@ public class OtpHttpClientFactory implements AutoCloseable {
       .custom()
       .setResponseTimeout(Timeout.of(timeout))
       .setConnectionRequestTimeout(Timeout.of(timeout))
+      .setProtocolUpgradeEnabled(false)
       .build();
   }
 }


### PR DESCRIPTION
### Summary

This avoids problems where a connection could be blocked by an intermediate proxy that disallows protocol upgrades. 

### Issue

In OTP PR #6079 the Apache HTTP client was upgraded 5.4. They in turn enabled protocol upgrades by default in [HTTPCLIENT-751](https://issues.apache.org/jira/browse/HTTPCLIENT-751). This means that the client/server will try upgrading a plain HTTP connection to a TLS one (among other upgrades).

Unfortunately this causes problems in our deployment as we run an Envoy proxy server on top of our instances (specifically our SIRI updaters can't connect to the history service). Envoy currently doesn't support protocol upgrades by default and will answer the request with 403.

For the curious, Envoy have issues open on the subject: Envoy [\#36305](https://github.com/envoyproxy/envoy/issues/36305), Envoy [\#36469](https://github.com/envoyproxy/envoy/issues/36469)

There is also a slightly heated Apache HTTP client bug ticket [HTTPCLIENT-2344](https://issues.apache.org/jira/browse/HTTPCLIENT-2344) - which is closed as 'invalid', and which indicates that the current behavior wont change.

This subject was discussed and agreed in a dev meeting that it's better to disable protocol upgrades by default for all clients.
If wanted, it could be enabled on an individual case by adding a configuration API on the OTP HTTP client.

### Testing

Tested in a runtime environment.
