### PR TITLE
Clean up `doc/dev` documentation files

### DIFF
--- a/doc/dev/decisionrecords/Codestyle.md
+++ b/doc/dev/decisionrecords/Codestyle.md
@@ -10,9 +10,9 @@ run `prettier-maven-plugin`. A check is run in the CI build, which fails the bui
 merging a PR if the code style is incorrect.
 
 There are two ways to format the code before checking it in. You may run a normal build with
-Maven—it takes a bit of time, but reformat the entire codebase. Only code you have changed should be
-formatted, since the existing code is already formatted. The second way is to set up Prettier and
-run it manually or hick it into your IDE, so it runs every time a file is changed.
+Maven; it takes a bit of time, but it reformats the entire codebase. Only code you have changed
+should be formatted, since the existing code is already formatted. The second way is to set up
+Prettier and run it manually or hick it into your IDE, so it runs every time a file is changed.
 
 ### How to Run Prettier with Maven
 
@@ -47,10 +47,10 @@ The check is run by the CI server and will fail the build if the code is incorre
 
 You should use the Prettier Maven plugin to reformat the code or run Prettier with Node (faster).
 
-Prettier does _not_ format the doc and Markdown files—only Java code. So, for other files, you
+Prettier does _not_ format the doc and Markdown files, only Java code. So, for other files you
 should use the _project_ code style. It is automatically imported when you first open the project.
 But, if you have set a custom code style in your settings (as we used until OTP v2.1), then you need
-to  change to the _Project_ code style. Open the `Preferences` from the menu and select _Editor >
+to change to the _Project_ code style. Open the `Preferences` from the menu and select _Editor >
 Code Style_. Then select **Project** in the \_Scheme drop down.
 
 #### Run Prettier Maven Plugin as an External Tool in IntelliJ

--- a/doc/dev/decisionrecords/Codestyle.md
+++ b/doc/dev/decisionrecords/Codestyle.md
@@ -70,7 +70,7 @@ Working Directory: $ProjectFileDir$
 > **Tip!**  Add an unused key shortcut to execute the external tool. Then you can use the old 
 > shortcut to format other file types.
 
-#### Install File Watchers Plugin in IntelliJ
+#### Install File Watchers plugin in IntelliJ
 
 You can also configure IntelliJ to run Prettier every time IntelliJ saves a Java file. But if you
 are editing the file at the same time, you will get a warning that the file in memory and the file

--- a/doc/dev/decisionrecords/Codestyle.md
+++ b/doc/dev/decisionrecords/Codestyle.md
@@ -1,96 +1,96 @@
-# Codestyle
+# Code Style
 
 We use the following code conventions for [Java](#Java) and [JavaScript](#JavaScript).
 
 ## Java
 
 The OpenTripPlanner Java code style is revised in OTP v2.2. We use the
-[Prettier Java](https://github.com/jhipster/prettier-java) as is. Maven is setup to
+[Prettier Java](https://github.com/jhipster/prettier-java) as is. Maven is set up to
 run `prettier-maven-plugin`. A check is run in the CI build, which fails the build preventing
-merging a PR if the code-style is incorrect.
+merging a PR if the code style is incorrect.
 
-There is two ways to format the code before checkin it in. You may run a normal build with maven -
-it takes a bit of time, but reformat the entire codebase. Only code you have changed should be
-formatted, since the existing code is already formatted. The second way is to set up prettier and
+There are two ways to format the code before checking it in. You may run a normal build with
+Maven—it takes a bit of time, but reformat the entire codebase. Only code you have changed should be
+formatted, since the existing code is already formatted. The second way is to set up Prettier and
 run it manually or hick it into your IDE, so it runs every time a file is changed.
 
-### How to run Prettier with Maven
+### How to Run Prettier with Maven
 
-Prettier will automatically format all code in the Maven "validate" phase, which runs before the test, package, and install phases. So formatting will happen for example when you run:
+Prettier will automatically format all code in the Maven "validate" phase, which runs before the
+test, package, and install phases. So formatting will happen for example when you run:
 
-```
+```shell
 % mvn test
 ```
 
 You can manually run _only_ the formatting process with:
 
-```
+```shell
 % mvn prettier:write
-
 ```
 
-To skip the prettier formating use profile `prettierSkip`:
+To skip the Prettier formating, use the profile `prettierSkip`:
 
-```
+```shell
 % mvn test -P prettierSkip
 ```
 
-The check for formatting errors use profile `prettierCheck`:
+To check for formatting errors, use the profile `prettierCheck`:
 
-```
+```shell
 % mvn test -P prettierCheck
 ```
 
 The check is run by the CI server and will fail the build if the code is incorrectly formatted.
 
-### IntellJ and Code Style Formatting
+### IntelliJ and Code Style Formatting
 
-You should use the prettier Maven plugin to reformat the code or run prettier with Node(faster).
+You should use the Prettier Maven plugin to reformat the code or run Prettier with Node (faster).
 
-The prettier does NOT format the doc and markdown files, only Java code. So, for other files you should
-use the _project_ code-style. It is automatically imported when you first open the project. But, if
-you have set a custom code-style in your settings (as we used until OTP v2.1), then you need to
-change to the _Project_ Code Style. Open the `Preferences` from the menu and select _
-Editor > Code Style_. Then select **Project** in the \_Scheme drop down.
+Prettier does _not_ format the doc and Markdown files—only Java code. So, for other files, you
+should use the _project_ code style. It is automatically imported when you first open the project.
+But, if you have set a custom code style in your settings (as we used until OTP v2.1), then you need
+to  change to the _Project_ code style. Open the `Preferences` from the menu and select _Editor >
+Code Style_. Then select **Project** in the \_Scheme drop down.
 
 #### Run Prettier Maven Plugin as an external tool in IntelliJ
 
 You can run the Prettier Maven plugin as an external tool in IntelliJ. Set it up as an
-`External tool` and assign a key-shortcut to the tool execution.
+`External tool` and assign a keyboard shortcut to the tool execution.
 
 ![External Tool Dialog](../images/ExternalToolDialog.png)
 
-```
+```text
 Name:              Prettier Format Current File
 Program:           mvn
 Arguments:         prettier:write -Dprettier.inputGlobs=$FilePathRelativeToProjectRoot$
 Working Directory: $ProjectFileDir$
 ```
-> **Tip!**  Add a unused key shortcut to execute the external tool, then you can use the old 
-> short-cut to format other file types.
 
-
+> **Tip!**  Add an unused key shortcut to execute the external tool. Then you can use the old 
+> shortcut to format other file types.
 
 #### Install File Watchers Plugin in IntelliJ
 
-You can also configure IntelliJ to run the prettier every time IntelliJ save a Java file. But,
-if you are editing the file at the same time you will get a warning that the file in memory and the
-file on disk both changed - and asked to select one of them.
+You can also configure IntelliJ to run Prettier every time IntelliJ saves a Java file. But if you
+are editing the file at the same time, you will get a warning that the file in memory and the file
+on disk both changed, and asked to select one of them.
 
-1. In the menyopen _Prefernces..._ and select _Plugins_.
-2. Search for "File Watchers" in Marketplace
-3. Run _Install_
+1. In the menu, open _Preferences..._ and select _Plugins_.
+2. Search for "File Watchers" in the Marketplace.
+3. Run _Install_.
 
-##### Configure File Watcher
+##### Configure File Watchers
 
-You can run Prettier on every file save in Intellij using the File Watcher plugin. There is several
-ways to set it up. Below is hwo to configure it using Maven to run the formatter. The Maven way work
-without any installation of other components, but might be a bit slow. So, you might want to install
-[prettier-java](https://github.com/jhipster/prettier-java/) in your shell and run it instead.
+You can run Prettier upon every file save in IntelliJ using the File Watchers plugin. There are
+several ways to set it up. Below is how to configure it using Maven to run the formatter. The Maven
+way works without any installation of other components but might be a bit slow. So you might want to
+install [prettier-java](https://github.com/jhipster/prettier-java/) in your shell and run it
+instead.
 
-```
+```text
 Name:              Format files with Prettier
-File type:         Java
+File Type:         Java
 Scope:             Project Files
 Program:           mvn
 Arguments:         prettier:write -Dprettier.inputGlobs=$FilePathRelativeToProjectRoot$
@@ -99,43 +99,44 @@ Working Directory: $ProjectFileDir$
 
 ### Other IDEs
 
-We do not have support for other IDEs at the moment. If you use another editor and make one please
+We do not have support for other IDEs at the moment. If you use another editor and make one, please
 feel free to share it.
 
 ### Sorting Class Members
 
-Some of the classes in OTP have a lot of fields and methods. Keeping members sorted reduce the merge
+Some of the classes in OTP have a lot of fields and methods. Keeping members sorted reduces merge
 conflicts. Adding fields and methods to the end of the list will cause merge conflicts more often
-than inserting methods and fields in an ordered list. Fields and methods can be sorted in "feature"
-sections or alphabetically, but stick to it and respect it when adding new methods and fields.
+than will inserting methods and fields in an ordered list. Fields and methods can be sorted in
+"feature" sections or alphabetically, but stick to it and respect it when adding new methods and
+fields.
 
 The provided formatter will group class members in this order:
 
-1. Getter and Setter methods are kept together
-2. Overridden methods are kept together
-3. Dependent methods are sorted in a breadth-first order.
+1. Getter and setter methods are kept together.
+2. Overridden methods are kept together.
+3. Dependent methods are sorted in breadth-first order.
 4. Members are sorted like this:
-    1. `static` `final` fields (constants)
+    1. `static final` fields (constants)
     2. `static` fields (avoid)
-    3. instance fields
-    4. static initializer
-    5. class initializer
-    6. constructor
+    3. Instance fields
+    4. Static initializers
+    5. Class initializers
+    6. Constructors
     7. `static` factory methods
     8. `public` methods
-    9. getter and setters
-    8. `private`/package methods
-    10. `private` enums (avoid `public`)
-    11. interfaces
-    12. `private static` classes (avoid `public`)
-    13. instance classes (avoid)
+    9. Getter and setters
+    10. `private`/package methods
+    11. `private` enums (avoid `public`)
+    12. Interfaces
+    13. `private static` classes (avoid `public`)
+    14. Instance classes (avoid)
 
-### JavaDoc Guidlines
+### Javadoc Guidelines
 
 As a matter of [policy](http://github.com/opentripplanner/OpenTripPlanner/issues/93), all new
 methods, classes, and fields should include comments explaining what they are for and any other
 pertinent information. For Java code, the comments should follow industry standards. It is best to
-provide comments that not only explain *what* you did but also *why you did it* while providing some
+provide comments that explain not only *what* you did but also *why you did it* while providing some
 context. Please avoid including trivial Javadoc or the empty Javadoc stubs added by IDEs, such as
 `@param` annotations with no description.
 
@@ -144,41 +145,28 @@ context. Please avoid including trivial Javadoc or the empty Javadoc stubs added
     - Contract of the method
         - Input domain for which the logic is designed
         - Range of outputs produced from valid inputs
-        - Is behavior undefined or will fail when conditions are not met
-        - Are null values allowed as inputs
-        - Will null values occur as outputs (what do they mean)
+        - Is behavior undefined or will the method fail when conditions are not met?
+        - Are null values allowed as inputs?
+        - Will null values occur as outputs (and what do they mean)?
     - Invariants that hold if the preconditions are met
     - Concurrency
-        - Is method thread-safe
+        - Is the method thread-safe?
         - Usage constraints for multi-threaded use
 - On classes:
     - Initialization and teardown process
-    - Can instance be reused for multiple operations, or should it be discarded
-    - Is it immutable or should anything be treated as immutable
-    - Is it a utility class of static methods that should not be instantiated
-
-### Annotations
-
-- On methods:
-    - Method should be marked as `@Nullable` if they can return null values
-    - Method parameters should be marked as `@Nullable` if they can take null values.
-- On fields:
-    - Fields should be marked as `@Nullable` if they are nullable.
-
-Use of `@Nonnull` annotation is not allowed. It should be assumed methods/parameters/fields
-are non-null if they are not marked as `@Nullable`. However, there are places where the
-`@Nullable` annotation is missing even if it should have been used. Those can be updated
-to use the `@Nullable` annotation.
+    - Can an instance be reused for multiple operations, or should it be discarded?
+    - Is it immutable, or should anything be treated as immutable?
+    - Is it a utility class of static methods that should not be instantiated?
 
 ## JavaScript
 
-As of #206, we
-follow [Crockford's JavaScript code conventions](http://javascript.crockford.com/code.html). Further
+As of [#206](https://github.com/opentripplanner/OpenTripPlanner/issues/206), we follow
+[Crockford's JavaScript code conventions](http://javascript.crockford.com/code.html). Further
 guidelines include:
 
 * All .js source files should contain one class only
-* Capitalize the class name, as well as the source file name (a la Java)
-* Include the namespace definition in each and every file: `otp.namespace("otp.configure");`
+* Capitalize the class name, as well as the source file name (a la Java).
+* Include the namespace definition in each and every file: `otp.namespace("otp.configure");`.
 * Include a class comment. For example,
 
 ```javascript
@@ -187,8 +175,8 @@ guidelines include:
  *
  * Purpose is to allow a generic configuration object to be read via AJAX/JSON, and inserted into an
  * Ext Store
- * The implementation is TriMet route map specific...but replacing ConfigureStore object (or member
- * variables) with another implementation, will give this widget flexibility for other uses beyond
+ * The implementation is TriMet route map-specific...but replacing ConfigureStore object (or member
+ * variables) with another implementation will give this widget flexibility for other uses beyond
  * the iMap.
  *
  * @class

--- a/doc/dev/decisionrecords/Codestyle.md
+++ b/doc/dev/decisionrecords/Codestyle.md
@@ -158,6 +158,19 @@ context. Please avoid including trivial Javadoc or the empty Javadoc stubs added
     - Is it immutable, or should anything be treated as immutable?
     - Is it a utility class of static methods that should not be instantiated?
 
+### Annotations
+
+- On methods:
+    - Method should be marked as `@Nullable` if they can return null values.
+    - Method parameters should be marked as `@Nullable` if they can take null values.
+- On fields:
+    - Fields should be marked as `@Nullable` if they are nullable.
+
+Use of `@NonNull` annotation is not allowed. It should be assumed methods/parameters/fields are
+non-null if they are not marked as `@Nullable`. However, there are places where the `@Nullable`
+annotation is missing even if it should have been used. Those can be updated to use the `@Nullable`
+annotation.
+
 ## JavaScript
 
 As of [#206](https://github.com/opentripplanner/OpenTripPlanner/issues/206), we follow

--- a/doc/dev/decisionrecords/Codestyle.md
+++ b/doc/dev/decisionrecords/Codestyle.md
@@ -53,7 +53,7 @@ But, if you have set a custom code style in your settings (as we used until OTP 
 to  change to the _Project_ code style. Open the `Preferences` from the menu and select _Editor >
 Code Style_. Then select **Project** in the \_Scheme drop down.
 
-#### Run Prettier Maven Plugin as an external tool in IntelliJ
+#### Run Prettier Maven Plugin as an External Tool in IntelliJ
 
 You can run the Prettier Maven plugin as an external tool in IntelliJ. Set it up as an
 `External tool` and assign a keyboard shortcut to the tool execution.
@@ -70,7 +70,7 @@ Working Directory: $ProjectFileDir$
 > **Tip!**  Add an unused key shortcut to execute the external tool. Then you can use the old 
 > shortcut to format other file types.
 
-#### Install File Watchers plugin in IntelliJ
+#### Install File Watchers Plugin in IntelliJ
 
 You can also configure IntelliJ to run Prettier every time IntelliJ saves a Java file. But if you
 are editing the file at the same time, you will get a warning that the file in memory and the file
@@ -106,9 +106,8 @@ feel free to share it.
 
 Some of the classes in OTP have a lot of fields and methods. Keeping members sorted reduces merge
 conflicts. Adding fields and methods to the end of the list will cause merge conflicts more often
-than will inserting methods and fields in an ordered list. Fields and methods can be sorted in
-"feature" sections or alphabetically, but stick to it and respect it when adding new methods and
-fields.
+than inserting methods and fields in an ordered list. Fields and methods can be sorted in "feature"
+sections or alphabetically, but stick to it and respect it when adding new methods and fields.
 
 The provided formatter will group class members in this order:
 
@@ -166,7 +165,7 @@ context. Please avoid including trivial Javadoc or the empty Javadoc stubs added
 - On fields:
     - Fields should be marked as `@Nullable` if they are nullable.
 
-Use of `@NonNull` annotation is not allowed. It should be assumed methods/parameters/fields are
+Use of `@Nonnull` annotation is not allowed. It should be assumed methods/parameters/fields are
 non-null if they are not marked as `@Nullable`. However, there are places where the `@Nullable`
 annotation is missing even if it should have been used. Those can be updated to use the `@Nullable`
 annotation.

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -2,7 +2,7 @@
 
 In general, we use American English. We use the GTFS terminology inside OTP as the transit
 domain-specific language. In cases where GTFS does not provide an alternative, we use NeTEx. The
-naming  should follow the Java standard naming conventions. For example, a "real-time updater" class
+naming should follow the Java standard naming conventions. For example, a "real-time updater" class
 is named `RealTimeUpdater`. If in doubt, check the Oxford Dictionary (American).
 
 ## Packages

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -63,7 +63,7 @@ them.
 
 Naming convention for builders with and without a context.
 
-#### Graph Build and Tests Run Without a Context
+#### Graph builds and tests run without a context
 
 ```java
 // Create a new Stop

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -1,74 +1,71 @@
 # Naming Conventions
 
-In general, we use American English. We use the GTFS terminology inside OTP as the transit domain
-specific language. In cases where GTFS does not provide an alternative we use NeTEx. The naming
-should follow the Java standard naming conventions. For example a "real-time updater" class
-is named `RealTimeUpdater`. If in doubt check the Oxford Dictionary(American).
-
+In general, we use American English. We use the GTFS terminology inside OTP as the transit
+domain-specific language. In cases where GTFS does not provide an alternative, we use NeTEx. The
+naming  should follow the Java standard naming conventions. For example, a "real-time updater" class
+is named `RealTimeUpdater`. If in doubt, check the Oxford Dictionary (American).
 
 ## Packages
 
 Try to arrange code by domain functionality, not technology. The main structure of a package should
 be `org.opentripplanner.<domain>.<component>.<sub-component>`.
 
-| Package                         | Description                                                                                                                                                                                              |
-| ------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `o.o.<domain>`                  | At the top level we should divide OTP into "domain"s like `apis`, `framework`, `transit`, `street`, `astar`, `raptor`, `feeds`, `updaters`, and `application`.                                           |
-| `component` and `sub-component` | A group of packages/classes which naturally belong together, think aggregate as in Domain Driven Design.                                                                                                 |
-| `component.api`                 | Used for components to define the programing interface for the component. If present, (see Raptor) all outside dependencies to the component should be through the `api`.                                |
-| `component.model`               | Used to create a model of a Entites, ValueObjects, ++. If exposed outside the component you should include an entry point like `xyz.model.XyzModel` and/or a Service (in api or component root package). |
-| `component.service`             | Implementation of the service like `DefaultTransitService`, may also contain use-case specific code. Note, the Service interface goes into the component root or `api`, not in the service package.      |
-| `component.configure`           | Component creation/orchestration. Put Dependency Injection code here, like the Dagger Module.                                                                                                            |
-| `support`                       | Sometimes domain logic get complicated, then extracting/isolating it helps. `support` is used internally in a component, not outside.                                                                    |
-| `framework`                     | (Abstract) building blocks internal to a domain/parent package. In some cases accessed outside the component, e.g. `OptAppException`, `TransitEntity`.                                                   |
-| `mapping`                       | Map between two domains/components.                                                                                                                                                                      |
-| `util`                          | General "util" functionality, often characterized by `static` methods. Dependencies to other OTP packages is NOT allowed, only 3rd party utils libs.                                                     |
-| `o.o.apis`                      | OTP external endpoints. Note! Many apis are in the Sandbox where they are in the `o.o.ext` package.                                                                                                      |
+| Package                         | Description                                                                                                                                                                                                 |
+| ------------------------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `o.o.<domain>`                  | At the top level, we should divide OTP into "domains" like `apis`, `framework`, `transit`, `street`, `astar`, `raptor`, `feeds`, `updaters`, and `application`.                                             |
+| `component` and `sub-component` | A group of packages/classes that naturally belong together; think aggregate as in Domain-Driven Design.                                                                                                     |
+| `component.api`                 | Used for components to define the programing interface for the component. If present, (see Raptor) all outside dependencies to the component should be through the `api`.                                   |
+| `component.model`               | Used to create a model of Entities, ValueObjects, etc. If exposed outside the component, you should include an entry point like `xyz.model.XyzModel` and/or a Service (in `api` or component root package). |
+| `component.service`             | Implementation of a service like `DefaultTransitService`; may also contain use case-specific code. Note: The Service interface goes into the component root or `api`, not in the service package.           |
+| `component.configure`           | Component creation/orchestration. Put dependency injection code here, like the Dagger module.                                                                                                               |
+| `support`                       | Sometimes domain logic gets complicated; then extracting/isolating it helps. `support` is used internally in a component, not outside.                                                                      |
+| `framework`                     | (Abstract) building blocks internal to a domain/parent package. In some cases accessed outside the component; e.g., `OptAppException`, `TransitEntity`.                                                     |
+| `mapping`                       | Map between two domains/components.                                                                                                                                                                         |
+| `util`                          | General "util" functionality, often characterized by `static` methods. Dependencies to other OTP packages are NOT allowed; only third-party utils libraries.                                                |
+| `o.o.apis`                      | OTP external endpoints. Note! Many APIs are in the Sandbox where they are in the `o.o.ext` package.                                                                                                         |
 
-> **Note!** The above is the goal, the current package structure needs cleanup.
+> **Note!** The above is the goal. The current package structure needs cleanup.
 
-> **Note!** Util methods depending on an OTP type/component should go into that type/component, not in the
-utils class. E.g. static factory methods. Warning the "pure" utilities right now are placed into
-sub-packages of `o.o.util`, the root package needs cleanup.
-
+> **Note!** Util methods depending on an OTP type/component should go into that type/component, not
+> in the utils class; e.g., static factory methods. Warning: The "pure" utilities right now are
+> placed into subpackages of `o.o.util`. The root package needs cleanup.
 
 ## Methods
 
-Here are a list of common prefixes used, and what to expect.
+Here is a list of common prefixes used and what to expect.
 
-| Good method prefixes                                  | Description                                                                 |
-|-------------------------------------------------------|-----------------------------------------------------------------------------|
-| `stop() : Stop`                                       | Field accessor, equivalent to `getStop` as in the Java Bean standard        |
-| `getStop(ID id) : Stop`                               | Get Stop by ID, throws exception if not found                               |
-| `getStops(Collection<ID> id) : List/Collection<Stop>` | Get ALL Stops by set of IDs, throws exception if not found                  |
-| `findStop(Criteria criteria) : Optional<Stop>`        | Find one or zero stops, return `Optional`                                   |
-| `findStops(Criteria criteria) : List/Stream<Stop>`    | Find 0, 1 or many stops, return a collection or stream(List is preferred)   |
-| `listStops() : List/Stream<Stop>`                     | List ALL stops in context, return a collection or stream(List is preferred) |
-| `withStop(Stop stop) : Builder`                       | Set stop in builder, replacing existing value and return `this` builder     |
-| `initStop(Stop stop) : void`                          | Set property ONCE, a second call throws an exception                        |
-| `addStop(Stop stop) : void/Builder`                   | Add a stop to a collection of stops.                                        |
-| `addStops(Collection<Stop> stops) : void/Builder`     | Add set of stops to existing set.                                           |
-| `withBike(Consumer<BikePref.Builder> body) : Builder` | For nested builders use lambdas.                                            |
+| Good method prefixes                                  | Description                                                                   |
+|-------------------------------------------------------|-------------------------------------------------------------------------------|
+| `stop() : Stop`                                       | Field accessor, equivalent to `getStop` as in the Java Bean standard.         |
+| `getStop(ID id) : Stop`                               | Get Stop by ID; throws exception if not found.                                |
+| `getStops(Collection<ID> id) : List/Collection<Stop>` | Get _all_ Stops by set of IDs; throws exception if not found.                 |
+| `findStop(Criteria criteria) : Optional<Stop>`        | Find one or zero stops; return `Optional`.                                    |
+| `findStops(Criteria criteria) : List/Stream<Stop>`    | Find 0, 1, or many stops; return a Collection or Stream (List is preferred).  |
+| `listStops() : List/Stream<Stop>`                     | List ALL stops in context; return a Collection or Stream (List is preferred). |
+| `withStop(Stop stop) : Builder`                       | Set Stop in builder, replacing existing value; return `this` builder.         |
+| `initStop(Stop stop) : void`                          | Set property _once_; a second call throws an exception.                       |
+| `addStop(Stop stop) : void/Builder`                   | Add a Stop to a collection of Stops.                                          |
+| `addStops(Collection<Stop> stops) : void/Builder`     | Add set of Stops to existing set.                                             |
+| `withBike(Consumer<BikePref.Builder> body) : Builder` | For nested builders, use lambdas.                                             |
 
-These prefixes are also "allowed", but not preferred - they have some kind of negative "force" to them.
+These prefixes are also "allowed" but not preferred; they have some kind of negative "force" to
+them.
 
-| Ok method prefixes, but ...                 | Description                                                                                           |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `withStops(Collection<Stop> stops) : this`) | Replace all stops in builder with new set, consider using `addStops(...)` instead                     |
-| `setStop(Stop stop)`                        | Set a mutable stop reference. Avoid if not part of natural lifecycle. Use `initStop(...)` if possible |
-| `getStop() : Stop`                          | Old style accessor, use the shorter form `stop() : Stop`                                              |
+| Okay method prefixes, but ...               | Description                                                                                            |
+|---------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `withStops(Collection<Stop> stops) : this`) | Replace all Stops in builder with new set. Consider using `addStops(...)` instead.                     |
+| `setStop(Stop stop)`                        | Set a mutable Stop reference. Avoid if not part of natural lifecycle. Use `initStop(...)` if possible. |
+| `getStop() : Stop`                          | Old style accessor. Use the shorter form `stop() : Stop`.                                              |
 
-## Service, Model and Repository
+## Service, Model, and Repository
 
 ![MainModelOverview](../images/ServiceModelOverview.png)
 
-
-
 Naming convention for builders with and without a context.
 
-#### Graph Build and tests run without a context
+#### Graph Build and Tests Run Without a Context
 
-```Java
+```java
 // Create a new Stop
 trip = Trip.of(id).withName("The Express").build();
 

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -63,7 +63,7 @@ them.
 
 Naming convention for builders with and without a context.
 
-#### Graph builds and tests run without a context
+#### Graph Builds and Tests Run Without a Context
 
 ```java
 // Create a new Stop

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -57,7 +57,7 @@ them.
 | `setStop(Stop stop)`                        | Set a mutable Stop reference. Avoid if not part of natural lifecycle. Use `initStop(...)` if possible. |
 | `getStop() : Stop`                          | Old style accessor. Use the shorter form `stop() : Stop`.                                              |
 
-## Service, Model, and Repository
+## Service, Model and Repository
 
 ![MainModelOverview](../images/ServiceModelOverview.png)
 

--- a/doc/dev/decisionrecords/RecordsPOJOsBuilders.md
+++ b/doc/dev/decisionrecords/RecordsPOJOsBuilders.md
@@ -1,8 +1,8 @@
 ## Records, POJOs and Builders
 
-We prefer immutable typesafe types over flexibility and "short" class definitions. This makes
-the code more robust and less error-prone. References to other entities might need to be mutable,
-if so try to init them once, and throw an exception if set again. Example:
+We prefer immutable typesafe types over flexibility and "short" class definitions. This makes the
+code more robust and less error-prone. References to other entities might need to be mutable; if so,
+try to init them once and throw an exception if set again. Example:
 
 ```java
 Builder initStop(Stop stop) {
@@ -10,37 +10,46 @@ Builder initStop(Stop stop) {
 }
 ```
 
-
 ### Records
 
-You may use records, but avoid using records if you cannot encapsulate them properly. Generally, records are considered appropriate and useful for throw-away compound types private to an implementation, such as hash table keys or compound values in a temporary list or set. On the other hand, records are generally not appropriate in the domain model where we insist on full encapsulation, which records cannot readily provide. Be especially
-aware of array fields (which can not be protected) and collections (remember to make a defensive copy). Consider overriding `toString`. But if you need to override `equals` and `hashCode`, then it is probably not worth using a record. The implicit `equals()` and `hashCode()` implementations for records behave as if they call `equals` and `hashCode` on each field of the record, so their behavior will depend heavily on the types of these fields.
+You may use records, but avoid using records if you cannot encapsulate them properly. Generally,
+records are considered appropriate and useful for throwaway compound types private to an
+implementation, such as hash table keys or compound values in a temporary list or set. On the other
+hand, records are generally not appropriate in the domain model where we insist on full
+encapsulation, which records cannot readily provide. Be especially aware of array fields (which
+cannot be protected) and collections (remember to make a defensive copy). Consider overriding
+`toString`. But if you need to override `equals` and `hashCode`, then it is probably not worth using
+a record. The implicit `equals` and `hashCode` implementations for records behave as if they call
+`equals` and `hashCode` on each field of the record, so their behavior will depend heavily on the
+types of these fields.
 
 ### Builders
 
 OTP used a simple builder pattern in many places, especially when creating immutable types.
 
 #### Builder conventions
-- Use factory methods to create builder, either `of()` or `copyOf()`. The _copyOf_ uses an existing
-  instance as its base. The `of()` creates a builder with all default values set. All constructors
-  should be private (or package local) to enforce the use of the factory methods.
-- If the class has more than 5 fields, then avoid using an inner class builder, instead create a 
+
+- Use factory methods to create builder—either `of` or `copyOf`. The `copyOf` uses an existing
+  instance as its base. The `of` creates a builder with all default values set. All constructors
+  should be private (or package-local) to enforce use of the factory methods.
+- If the class has more than 5 fields, then avoid using an inner class builder. Instead, create a 
   builder in the same package.
 - Make all fields in the main class final to enforce immutability.
 - Consider using utility methods for parameter checking, like `Objects#requireNonNull` and
-  `ObjectUtils.ifNotNull`.
-- Validate all fields in the main type constructor(i.e. not in the builder), especially null checks.
-  Prefer default values over null-checks. All business logic using the type can rely on its validity.
+  `ObjectUtils#ifNotNull`.
+- Validate all fields in the main type constructor (i.e., not in the builder), especially null
+  checks. Prefer default values over null checks. All business logic using the type can rely on its
+  validity.
 - You may keep the original instance in the builder to avoid creating a new object if nothing
-  changed. This prevents polluting the heap for long-lived objects and make comparison very fast.
-- There is no need to provide all get accessors in the Builder if not needed.
+  changed. This prevents polluting the heap for long-lived objects and makes comparison very fast.
+- There is no need to provide all get accessors in the builder if not needed.
 - Unit-test builders and verify all fields are copied over.
-- For nested builders see the field `nested` in the example.
+- For nested builders, see the field `nested` in the example.
 
 <details>
-    <summary><b>Builder example</b></summary>
+  <summary><b>Builder example</b></summary>
 
-```Java
+```java
 /**
  * THIS CLASS IS IMMUTABLE AND THREAD-SAFE
  */

--- a/doc/dev/decisionrecords/RecordsPOJOsBuilders.md
+++ b/doc/dev/decisionrecords/RecordsPOJOsBuilders.md
@@ -27,7 +27,7 @@ types of these fields.
 
 OTP used a simple builder pattern in many places, especially when creating immutable types.
 
-#### Builder conventions
+#### Builder Conventions
 
 - Use factory methods to create builder—either `of` or `copyOf`. The `copyOf` uses an existing
   instance as its base. The `of` creates a builder with all default values set. All constructors
@@ -47,7 +47,7 @@ OTP used a simple builder pattern in many places, especially when creating immut
 - For nested builders, see the field `nested` in the example.
 
 <details>
-  <summary><b>Builder example</b></summary>
+  <summary><b>Builder Example</b></summary>
 
 ```java
 /**

--- a/doc/dev/decisionrecords/UseDecisionRecords.md
+++ b/doc/dev/decisionrecords/UseDecisionRecords.md
@@ -1,37 +1,36 @@
 # Decision Records
 
-An OTP Decision Record is a justified software design choice that addresses a significant 
-functional or non-functional requirement. [Architectural Decision Records](https://adr.github.io/) is a similar 
-concept, but we have widened the scope to include any relevant decision about OTP development.
-
+An OTP Decision Record is a justified software design choice that addresses a significant
+functional or non-functional requirement. [Architectural Decision Records](https://adr.github.io/)
+is a similar concept,  but we have widened the scope to include any relevant decision about OTP
+development.
 
 ## Process
 
 Decisions we make in the developer meetings are recorded in the [Developer Decision Records](/DEVELOPMENT_DECISION_RECORDS.md)
-list. If the decision is small and uncontroversial, but yet important and can be expressed in 
+list. If the decision is small and uncontroversial, yet is important and can be expressed in
 maximum 2 sentences, we will list it here without any more documentation. If the decision requires
-a bit more discussion and explanations, then we will create a PR with a document for it.
+a bit more discussion and explanation, then we will create a PR with a document for it.
 
-Use the **[template](/doc/dev/decisionrecords/_TEMPLATE.md) as a starting point for documenting
-the decision.
-
+Use the [template](/doc/dev/decisionrecords/_TEMPLATE.md) as a starting point for documenting the
+decision.
 
 ### How to discuss and document a Decision Record
 
-- Create a new pull-request and describe the decision record by adding a document to the 
+- Create a new pull request and describe the decision record by adding a document to the 
   `/doc/dev/decisionrecords` folder. Use the [template](/doc/dev/decisionrecords/_TEMPLATE.md).
-  template.
-- Present the decision record in a developer meeting. Make sure to update the main description
-  based on the feedback/discussion and decisions in the developer meeting.
-- The final approval is done in the developer meeting, at least 3 developers representing 3
+- Present the decision record in a developer meeting. Make sure to update the main description based
+  on the feedback/discussion and decisions in the developer meeting.
+- The final approval is done in the developer meeting. At least 3 developers representing 3
   different organisations should approve it. No vote against the proposal. If the developers
   are not able to agree, the PLC can decide.
 - References to Development Decision Records in reviews can be done by linking or just typing. 
-  For example `Use-Dependency-Injection` or [Use-Dependency-Injection](../../../DEVELOPMENT_DECISION_RECORDS.md#use-dependency-injection)
+  For example, `Use-Dependency-Injection` or [Use-Dependency-Injection](../../../DEVELOPMENT_DECISION_RECORDS.md#use-dependency-injection).
 
 ### Checklist
+
 - [ ] Give it a meaningful title that quickly lets the reader understand what it is all about.
 - [ ] Get it approved in a developer meeting with 3 votes in favor (3 organisations).
-- [ ] Add the name and description to the list in the [Development Decision Records](../../../DEVELOPMENT_DECISION_RECORDS.md) list.
-      Maximum two sentences should be used. Try to keep it as short as possible.
+- [ ] Add the name and description to the list in the [Development Decision Records](../../../DEVELOPMENT_DECISION_RECORDS.md)
+      list. Maximum two sentences should be used. Try to keep it as short as possible.
 - [ ] Remember to link to the PR.

--- a/doc/dev/decisionrecords/UseDecisionRecords.md
+++ b/doc/dev/decisionrecords/UseDecisionRecords.md
@@ -2,7 +2,7 @@
 
 An OTP Decision Record is a justified software design choice that addresses a significant
 functional or non-functional requirement. [Architectural Decision Records](https://adr.github.io/)
-is a similar concept,  but we have widened the scope to include any relevant decision about OTP
+is a similar concept, but we have widened the scope to include any relevant decision about OTP
 development.
 
 ## Process

--- a/doc/dev/decisionrecords/UseDecisionRecords.md
+++ b/doc/dev/decisionrecords/UseDecisionRecords.md
@@ -15,7 +15,7 @@ a bit more discussion and explanation, then we will create a PR with a document 
 Use the [template](/doc/dev/decisionrecords/_TEMPLATE.md) as a starting point for documenting the
 decision.
 
-### How to discuss and document a Decision Record
+### How to Discuss and Document a Decision Record
 
 - Create a new pull request and describe the decision record by adding a document to the 
   `/doc/dev/decisionrecords` folder. Use the [template](/doc/dev/decisionrecords/_TEMPLATE.md).

--- a/doc/dev/decisionrecords/_TEMPLATE.md
+++ b/doc/dev/decisionrecords/_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 {DESCRIPTION}
 <!-- 
-  One or two sentences which go into the [DECISION_RECORDS](/DEVELOPMENT_DECISION_RECORDS.md) document
-  later. 
+  One or two sentences which go into the [DECISION_RECORDS](/DEVELOPMENT_DECISION_RECORDS.md) 
+  document later. 
 -->
 
 Original pull-request: {#NNNN}
@@ -12,13 +12,13 @@ Original pull-request: {#NNNN}
 ### Context and Problem Statement
 
 <!-- 
-   Describe the context and problem statement, e.g., in free form using two to three
-   sentences. You may want to articulate the issue in the form of a question.
+  Describe the context and problem statement, e.g., in free form using two to three sentences. You
+  may want to articulate the issue in the form of a question.
 -->
 
 ### Other options
 
- - 
+- 
 
 ### Decision & Consequences
 
@@ -26,8 +26,8 @@ Original pull-request: {#NNNN}
 
 #### Positive Consequences
 
- - 
+- 
 
 #### Negative Consequences
 
- - 
+- 

--- a/doc/dev/decisionrecords/_TEMPLATE.md
+++ b/doc/dev/decisionrecords/_TEMPLATE.md
@@ -6,7 +6,7 @@
   document later. 
 -->
 
-Original pull-request: {#NNNN}
+Original pull request: {#NNNN}
 
 
 ### Context and Problem Statement
@@ -20,7 +20,7 @@ Original pull-request: {#NNNN}
 
 - 
 
-### Decision & Consequences
+### Decision and Consequences
 
 <!-- Describes the effects of the change. What becomes easier? What will be more difficult? -->
 

--- a/doc/dev/onboarding-checklist.md
+++ b/doc/dev/onboarding-checklist.md
@@ -1,4 +1,5 @@
 # Onboarding Checklist
+
 * What is OTP?
   * [Website](https://www.opentripplanner.org/)
   * History


### PR DESCRIPTION
### Summary

Cleans up miscellaneous typos, grammatical errors, style inconsistencies, etc. in documentation. This will improve readability for those accessing and referencing the docs, especially for new contributors.

There doesn't appear to be a formatter-enforced line length, so this PR uses 80 characters as that seems to be the loose consensus across other Markdown files in this directory. For stylistic choices like list indents or Oxford commas, this PR makes no decision and preserves existing usage. In general, this PR always favors consistency with existing choices over any standardization of style.

For now, I've touched only the `doc/dev` Markdown files. I can clean up the Markdown files for other docs as well in the future.