### PR TITLE
Deprecate old alert translations in the GTFS API and add language param to a few alert fields

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertImpl.java
@@ -23,6 +23,7 @@ import org.opentripplanner.apis.gtfs.model.RouteTypeModel;
 import org.opentripplanner.apis.gtfs.model.StopOnRouteModel;
 import org.opentripplanner.apis.gtfs.model.StopOnTripModel;
 import org.opentripplanner.apis.gtfs.model.UnknownModel;
+import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.TranslatedString;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
@@ -65,11 +66,11 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
   public DataFetcher<String> alertDescriptionText() {
     return environment -> {
       var alert = getSource(environment);
-      return alert
-        .descriptionText()
-        .or(alert::headerText)
-        .map(t -> t.toString(environment.getLocale()))
-        .orElse(FALLBACK_EMPTY_STRING);
+      var descriptionText = GraphQLUtils.getTranslation(
+        alert.descriptionText().or(alert::headerText).orElse(null),
+        environment
+      );
+      return descriptionText != null ? descriptionText : FALLBACK_EMPTY_STRING;
     };
   }
 
@@ -103,11 +104,11 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
   public DataFetcher<String> alertHeaderText() {
     return environment -> {
       var alert = getSource(environment);
-      return alert
-        .headerText()
-        .or(alert::descriptionText)
-        .map(h -> h.toString(environment.getLocale()))
-        .orElse(FALLBACK_EMPTY_STRING);
+      var headerText = GraphQLUtils.getTranslation(
+        alert.headerText().or(alert::descriptionText).orElse(null),
+        environment
+      );
+      return headerText != null ? headerText : FALLBACK_EMPTY_STRING;
     };
   }
 
@@ -125,7 +126,7 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
   @Override
   public DataFetcher<String> alertUrl() {
     return environment ->
-      getSource(environment).url().map(u -> u.toString(environment.getLocale())).orElse(null);
+      GraphQLUtils.getTranslation(getSource(environment).url().orElse(null), environment);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -75,6 +75,63 @@ public class GraphQLTypes {
     ROUTE_TYPES,
   }
 
+  public static class GraphQLAlertAlertDescriptionTextArgs {
+
+    private String language;
+
+    public GraphQLAlertAlertDescriptionTextArgs(Map<String, Object> args) {
+      if (args != null) {
+        this.language = (String) args.get("language");
+      }
+    }
+
+    public String getGraphQLLanguage() {
+      return this.language;
+    }
+
+    public void setGraphQLLanguage(String language) {
+      this.language = language;
+    }
+  }
+
+  public static class GraphQLAlertAlertHeaderTextArgs {
+
+    private String language;
+
+    public GraphQLAlertAlertHeaderTextArgs(Map<String, Object> args) {
+      if (args != null) {
+        this.language = (String) args.get("language");
+      }
+    }
+
+    public String getGraphQLLanguage() {
+      return this.language;
+    }
+
+    public void setGraphQLLanguage(String language) {
+      this.language = language;
+    }
+  }
+
+  public static class GraphQLAlertAlertUrlArgs {
+
+    private String language;
+
+    public GraphQLAlertAlertUrlArgs(Map<String, Object> args) {
+      if (args != null) {
+        this.language = (String) args.get("language");
+      }
+    }
+
+    public String getGraphQLLanguage() {
+      return this.language;
+    }
+
+    public void setGraphQLLanguage(String language) {
+      this.language = language;
+    }
+  }
+
   /** Cause of a alert */
   public enum GraphQLAlertCauseType {
     ACCIDENT,

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -117,23 +117,32 @@ type Alert implements Node {
   "Alert cause"
   alertCause: AlertCauseType
   "Long description of the alert"
-  alertDescriptionText: String!
+  alertDescriptionText(
+    "Returns description with the specified language, if found, otherwise returns the value with some default language."
+    language: String
+  ): String!
   "Long descriptions of the alert in all different available languages"
-  alertDescriptionTextTranslations: [TranslatedString!]!
+  alertDescriptionTextTranslations: [TranslatedString!]! @deprecated(reason : "Use `alertDescriptionText` instead. `accept-language` header can be used for translations or the `language` parameter on the `alertDescriptionText` field.")
   "Alert effect"
   alertEffect: AlertEffectType
   "hashcode from the original GTFS-RT alert"
   alertHash: Int
   "Header of the alert, if available"
-  alertHeaderText: String
+  alertHeaderText(
+    "Returns header with the specified language, if found, otherwise returns the value with some default language."
+    language: String
+  ): String
   "Header of the alert in all different available languages"
-  alertHeaderTextTranslations: [TranslatedString!]!
+  alertHeaderTextTranslations: [TranslatedString!]! @deprecated(reason : "Use `alertHeaderText` instead. `accept-language` header can be used for translations or the `language` parameter on the `alertHeaderText` field.")
   "Alert severity level"
   alertSeverityLevel: AlertSeverityLevelType
   "Url with more information"
-  alertUrl: String
+  alertUrl(
+    "Returns URL with the specified language, if found, otherwise returns the value with some default language."
+    language: String
+  ): String
   "Url with more information in all different available languages"
-  alertUrlTranslations: [TranslatedString!]!
+  alertUrlTranslations: [TranslatedString!]! @deprecated(reason : "Use `alertUrl` instead. `accept-language` header can be used for translations or the `language` parameter on the `alertUrl` field.")
   "Time when this alert is not in effect anymore. Format: Unix timestamp in seconds"
   effectiveEndDate: Long
   "Time when this alert comes into effect. Format: Unix timestamp in seconds"

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/alerts.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/alerts.json
@@ -1,63 +1,41 @@
 {
-  "data" : {
-    "alerts" : [
+  "data": {
+    "alerts": [
       {
-        "id" : "QWxlcnQ6RjpuZWl0aGVyLWhlYWRlci1ub3ItZGVzY3JpcHRpb24",
-        "alertHeaderText" : "",
-        "alertDescriptionText" : "",
-        "alertUrl" : null,
-        "alertDescriptionTextTranslations" : [ ],
-        "alertHeaderTextTranslations" : [ ]
+        "id": "QWxlcnQ6RjpuZWl0aGVyLWhlYWRlci1ub3ItZGVzY3JpcHRpb24",
+        "headerDefault": "",
+        "headerDe": "",
+        "descriptionDefault": "",
+        "descriptionDe": "",
+        "urlDefault": null,
+        "urlDe": null
       },
       {
-        "id" : "QWxlcnQ6Rjpuby1oZWFkZXI",
-        "alertHeaderText" : "Second string",
-        "alertDescriptionText" : "Second string",
-        "alertUrl" : null,
-        "alertDescriptionTextTranslations" : [
-          {
-            "language" : null,
-            "text" : "Second string"
-          },
-          {
-            "language" : "de",
-            "text" : "Zweite Zeichenabfolge"
-          },
-          {
-            "language" : "fi",
-            "text" : "Etkö ole varma, mitä tämä tarkoittaa"
-          }
-        ],
-        "alertHeaderTextTranslations" : [ ]
+        "id": "QWxlcnQ6Rjpuby1oZWFkZXI",
+        "headerDefault": "Second string",
+        "headerDe": "Zweite Zeichenabfolge",
+        "descriptionDefault": "Second string",
+        "descriptionDe": "Zweite Zeichenabfolge",
+        "urlDefault": null,
+        "urlDe": null
       },
       {
-        "id" : "QWxlcnQ6Rjphbi1hbGVydA",
-        "alertHeaderText" : "A header",
-        "alertDescriptionText" : "A description",
-        "alertUrl" : "https://example.com",
-        "alertDescriptionTextTranslations" : [ ],
-        "alertHeaderTextTranslations" : [ ]
+        "id": "QWxlcnQ6Rjphbi1hbGVydA",
+        "headerDefault": "A header",
+        "headerDe": "A header",
+        "descriptionDefault": "A description",
+        "descriptionDe": "A description",
+        "urlDefault": "https://example.com",
+        "urlDe": "https://example.com"
       },
       {
-        "id" : "QWxlcnQ6Rjpuby1kZXNjcmlwdGlvbg",
-        "alertHeaderText" : "First string",
-        "alertDescriptionText" : "First string",
-        "alertUrl" : null,
-        "alertDescriptionTextTranslations" : [ ],
-        "alertHeaderTextTranslations" : [
-          {
-            "text" : "First string",
-            "language" : null
-          },
-          {
-            "text" : "Erste Zeichenabfolge",
-            "language" : "de"
-          },
-          {
-            "text" : "Minulla ei ole aavistustakaan kuinka puhua suomea",
-            "language" : "fi"
-          }
-        ]
+        "id": "QWxlcnQ6Rjpuby1kZXNjcmlwdGlvbg",
+        "headerDefault": "First string",
+        "headerDe": "Erste Zeichenabfolge",
+        "descriptionDefault": "First string",
+        "descriptionDe": "Erste Zeichenabfolge",
+        "urlDefault": null,
+        "urlDe": null
       }
     ]
   }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/alerts.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/alerts.graphql
@@ -1,18 +1,11 @@
 {
   alerts {
     id
-    alertHeaderText
-    alertDescriptionText
-    alertUrl
-    # these translations are a bit questionable, the above fields are already translated into the
-    # language selected in the request
-    alertDescriptionTextTranslations {
-      language
-      text
-    }
-    alertHeaderTextTranslations {
-      text
-      language
-    }
+    headerDefault: alertHeaderText
+    headerDe: alertHeaderText(language: "de")
+    descriptionDefault: alertDescriptionText
+    descriptionDe: alertDescriptionText(language: "de")
+    urlDefault: alertUrl
+    urlDe: alertUrl(language: "de")
   }
 }


### PR DESCRIPTION
### Summary

This deprecates old alert translations fields from GTFS API and add language param to normal fields.

### Issue

Minor GraphQL API update, no issue

### Unit tests

Updated tests

### Documentation

Not needed

### Changelog

From title
