### PR TITLE
Hide transfer URLs from Maven CI logs, upload test data to codecov

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -62,6 +62,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+      - name: Upload test results to Codecov
+        # always upload test results, even when failed
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Deploy to Github Package Registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -52,7 +52,7 @@ jobs:
         # https://github.com/actions/runner-images/issues/1499
         # we set nodePath and npmPath to skip downloading the node binary, which frequently times out
         run: |
-          mvn $MAVEN_ARGS jacoco:prepare-agent test jacoco:report -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
+          mvn $MAVEN_ARGS jacoco:prepare-agent test jacoco:report-aggregate -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
           mvn $MAVEN_ARGS package -Dmaven.test.skip -P prettierSkip
 
       - name: Send coverage data to codecov.io

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -68,6 +68,7 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: "*TEST-*.xml"
 
       - name: Deploy to Github Package Registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -52,14 +52,13 @@ jobs:
         # https://github.com/actions/runner-images/issues/1499
         # we set nodePath and npmPath to skip downloading the node binary, which frequently times out
         run: |
-          mvn $MAVEN_ARGS jacoco:prepare-agent test jacoco:report-aggregate -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
+          mvn $MAVEN_ARGS jacoco:prepare-agent test jacoco:report -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
           mvn $MAVEN_ARGS package -Dmaven.test.skip -P prettierSkip
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner'
         uses: codecov/codecov-action@v4
         with:
-          files: target/site/jacoco-aggregate/jacoco.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -14,6 +14,12 @@ on:
       - master
       - dev-1.x
       - dev-2.x
+env:
+  # Since version 3.9.0 of Maven it will automatically understand this environment variable.
+  # However, as of 2024-11 the latest versions of Ubuntu and Debian were on 3.8.8 so it will take some
+  # time until we can remove the $MAVEN_ARGS below.
+  MAVEN_ARGS: "--batch-mode --no-transfer-log"
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest
@@ -61,7 +67,7 @@ jobs:
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierSkip -P deployGitHub
+        run: mvn $MAVEN_ARGS deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierSkip -P deployGitHub
 
   build-windows:
     timeout-minutes: 20
@@ -79,7 +85,7 @@ jobs:
       - name: Configure Windows Pagefile
         uses: al-cheb/configure-pagefile-action@v1.4
       - name: Run tests
-        run: mvn --batch-mode test -P prettierSkip
+        run: mvn $MAVEN_ARGS test -P prettierSkip
 
   docs:
     if: github.repository_owner == 'opentripplanner'
@@ -192,7 +198,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Compile Java code
-        run: mvn --batch-mode compile -DskipTests -P prettierSkip
+        run: mvn $MAVEN_ARGS compile -DskipTests -P prettierSkip
 
   container-image:
     if: github.repository_owner == 'opentripplanner' && github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
@@ -237,4 +243,4 @@ jobs:
           
           MAVEN_SKIP_ARGS="-P prettierSkip -Dmaven.test.skip=true -Dmaven.source.skip=true"
           
-          mvn --batch-mode $MAVEN_SKIP_ARGS package com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,$image_version
+          mvn $MAVEN_ARGS $MAVEN_SKIP_ARGS package com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,$image_version

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -59,7 +59,7 @@ jobs:
         if: github.repository_owner == 'opentripplanner'
         uses: codecov/codecov-action@v4
         with:
-          files: target/site/jacoco/jacoco.xml
+          files: target/site/jacoco-aggregate/jacoco.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -52,8 +52,8 @@ jobs:
         # https://github.com/actions/runner-images/issues/1499
         # we set nodePath and npmPath to skip downloading the node binary, which frequently times out
         run: |
-          mvn --batch-mode jacoco:prepare-agent test jacoco:report -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
-          mvn --batch-mode package -Dmaven.test.skip -P prettierSkip
+          mvn $MAVEN_ARGS jacoco:prepare-agent test jacoco:report -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
+          mvn $MAVEN_ARGS package -Dmaven.test.skip -P prettierSkip
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner'

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,7 +18,7 @@ env:
   # Since version 3.9.0 of Maven it will automatically understand this environment variable.
   # However, as of 2024-11 the latest versions of Ubuntu and Debian were on 3.8.8 so it will take some
   # time until we can remove the $MAVEN_ARGS below.
-  MAVEN_ARGS: "--batch-mode --no-transfer-progress"
+  MAVEN_ARGS: "--no-transfer-progress -Dstyle.color=always"
 
 jobs:
   build-linux:

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,7 +18,7 @@ env:
   # Since version 3.9.0 of Maven it will automatically understand this environment variable.
   # However, as of 2024-11 the latest versions of Ubuntu and Debian were on 3.8.8 so it will take some
   # time until we can remove the $MAVEN_ARGS below.
-  MAVEN_ARGS: "--batch-mode --no-transfer-log"
+  MAVEN_ARGS: "--batch-mode --no-transfer-progress"
 
 jobs:
   build-linux:

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
                         <printStderrOnError>true</printStderrOnError>
                         <printStderrOnFailure>true</printStderrOnFailure>
                         <printStderrOnSuccess>false</printStderrOnSuccess>
+                        <theme>UNICODE</theme>
                     </statelessTestsetInfoReporter>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,6 @@
                         --add-opens java.base/sun.invoke.util=ALL-UNNAMED
                         --add-opens java.xml/org.xml.sax.helpers=ALL-UNNAMED
                     </argLine>
-                    <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
-                    <disableXmlReport>true</disableXmlReport>
                     <reportFormat>plain</reportFormat>
                     <consoleOutputReporter>
                         <disable>true</disable>


### PR DESCRIPTION
### Summary

Whenever I need to look at a CI log, I have to scroll past a very long list of URLs that Maven has downloaded and I never had any use from these at all.

For this reason I'm proposing to completely hide these URLs from the CI log.

On top of this, the PR also enables colour output for the CI logs and adds some Unicode characters.

It looks like this:

![image](https://github.com/user-attachments/assets/cfde0b66-9459-4bc2-a8c2-bf085fb27a53)


### Coverage data aggregation

I also removed the hardcoded path to the coverage file and I hope that this will automatically lead to sub-module's coverage data being discovered.

### Test data uploads

Codecov has a new feature where they allow you to upload test data, which I want to try out. It's doesn't work out of the box with JUnit yet, but I'm working on it: https://github.com/codecov/feedback/issues/304#issuecomment-2454739120
