### PR TITLE
Relax rejection of GTFS flex trips that also contain continuous stopping

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexStopTimesForTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexStopTimesForTest.java
@@ -1,12 +1,12 @@
 package org.opentripplanner.ext.flex;
 
-import static org.opentripplanner.model.StopTime.MISSING_VALUE;
-
 import org.opentripplanner._support.geometry.Polygons;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.utils.time.TimeUtils;
 
 public class FlexStopTimesForTest {
@@ -18,6 +18,8 @@ public class FlexStopTimesForTest {
     .build();
   private static final RegularStop REGULAR_STOP = TEST_MODEL.stop("stop").build();
 
+  private static final Trip TRIP = TimetableRepositoryForTest.trip("flex").build();
+
   public static StopTime area(String startTime, String endTime) {
     return area(AREA_STOP, endTime, startTime);
   }
@@ -27,26 +29,42 @@ public class FlexStopTimesForTest {
     stopTime.setStop(areaStop);
     stopTime.setFlexWindowStart(TimeUtils.time(startTime));
     stopTime.setFlexWindowEnd(TimeUtils.time(endTime));
+    stopTime.setTrip(TRIP);
     return stopTime;
   }
 
-  public static StopTime regularArrival(String arrivalTime) {
-    return regularStopTime(TimeUtils.time(arrivalTime), MISSING_VALUE);
+  public static StopTime regularStop(String arrivalTime, String departureTime) {
+    return regularStop(TimeUtils.time(arrivalTime), TimeUtils.time(departureTime));
   }
 
-  public static StopTime regularStopTime(String arrivalTime, String departureTime) {
-    return regularStopTime(TimeUtils.time(arrivalTime), TimeUtils.time(departureTime));
+  public static StopTime regularStop(String time) {
+    return regularStop(TimeUtils.time(time), TimeUtils.time(time));
   }
 
-  public static StopTime regularStopTime(int arrivalTime, int departureTime) {
+  public static StopTime regularStopWithContinuousStopping(String time) {
+    var st = regularStop(TimeUtils.time(time), TimeUtils.time(time));
+    st.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
+    st.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
+    return st;
+  }
+
+  public static StopTime regularStop(int arrivalTime, int departureTime) {
     var stopTime = new StopTime();
     stopTime.setStop(REGULAR_STOP);
     stopTime.setArrivalTime(arrivalTime);
     stopTime.setDepartureTime(departureTime);
+    stopTime.setTrip(TRIP);
     return stopTime;
   }
 
-  public static StopTime regularDeparture(String departureTime) {
-    return regularStopTime(MISSING_VALUE, TimeUtils.time(departureTime));
+  /**
+   * Returns an invalid combination of a flex area and continuous stopping.
+   */
+  public static StopTime areaWithContinuousStopping(String time) {
+    var st = area(time, time);
+    st.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
+    st.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
+    return st;
   }
+
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexStopTimesForTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexStopTimesForTest.java
@@ -33,6 +33,34 @@ public class FlexStopTimesForTest {
     return stopTime;
   }
 
+  /**
+   * Returns an invalid combination of a flex area and continuous stopping.
+   */
+  public static StopTime areaWithContinuousStopping(String time) {
+    var st = area(time, time);
+    st.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
+    st.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
+    return st;
+  }
+
+  /**
+   * Returns an invalid combination of a flex area and continuous pick up.
+   */
+  public static StopTime areaWithContinuousPickup(String time) {
+    var st = area(time, time);
+    st.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
+    return st;
+  }
+
+  /**
+   * Returns an invalid combination of a flex area and continuous drop off.
+   */
+  public static StopTime areaWithContinuousDropOff(String time) {
+    var st = area(time, time);
+    st.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
+    return st;
+  }
+
   public static StopTime regularStop(String arrivalTime, String departureTime) {
     return regularStop(TimeUtils.time(arrivalTime), TimeUtils.time(departureTime));
   }
@@ -48,6 +76,18 @@ public class FlexStopTimesForTest {
     return st;
   }
 
+  public static StopTime regularStopWithContinuousPickup(String time) {
+    var st = regularStop(TimeUtils.time(time), TimeUtils.time(time));
+    st.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
+    return st;
+  }
+
+  public static StopTime regularStopWithContinuousDropOff(String time) {
+    var st = regularStop(TimeUtils.time(time), TimeUtils.time(time));
+    st.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
+    return st;
+  }
+
   public static StopTime regularStop(int arrivalTime, int departureTime) {
     var stopTime = new StopTime();
     stopTime.setStop(REGULAR_STOP);
@@ -57,14 +97,6 @@ public class FlexStopTimesForTest {
     return stopTime;
   }
 
-  /**
-   * Returns an invalid combination of a flex area and continuous stopping.
-   */
-  public static StopTime areaWithContinuousStopping(String time) {
-    var st = area(time, time);
-    st.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
-    st.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
-    return st;
-  }
+
 
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/ScheduledFlexPathCalculatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/ScheduledFlexPathCalculatorTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.flex.flexpathcalculator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.ext.flex.FlexStopTimesForTest.area;
+import static org.opentripplanner.ext.flex.FlexStopTimesForTest.regularStop;
 import static org.opentripplanner.street.model._data.StreetModelForTest.V1;
 import static org.opentripplanner.street.model._data.StreetModelForTest.V2;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
@@ -10,7 +11,6 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.geometry.LineStrings;
-import org.opentripplanner.ext.flex.FlexStopTimesForTest;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
 
 class ScheduledFlexPathCalculatorTest {
@@ -19,9 +19,9 @@ class ScheduledFlexPathCalculatorTest {
     .of(id("123"))
     .withStopTimes(
       List.of(
-        FlexStopTimesForTest.regularStop("10:00", "10:01"),
+        regularStop("10:00", "10:01"),
         area("10:10", "10:20"),
-        FlexStopTimesForTest.regularStop("10:25", "10:26"),
+        regularStop("10:25", "10:26"),
         area("10:40", "10:50")
       )
     )

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/ScheduledFlexPathCalculatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/ScheduledFlexPathCalculatorTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.ext.flex.flexpathcalculator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.ext.flex.FlexStopTimesForTest.area;
-import static org.opentripplanner.ext.flex.FlexStopTimesForTest.regularStopTime;
 import static org.opentripplanner.street.model._data.StreetModelForTest.V1;
 import static org.opentripplanner.street.model._data.StreetModelForTest.V2;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
@@ -11,6 +10,7 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.geometry.LineStrings;
+import org.opentripplanner.ext.flex.FlexStopTimesForTest;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
 
 class ScheduledFlexPathCalculatorTest {
@@ -19,9 +19,9 @@ class ScheduledFlexPathCalculatorTest {
     .of(id("123"))
     .withStopTimes(
       List.of(
-        regularStopTime("10:00", "10:01"),
+        FlexStopTimesForTest.regularStop("10:00", "10:01"),
         area("10:10", "10:20"),
-        regularStopTime("10:25", "10:26"),
+        FlexStopTimesForTest.regularStop("10:25", "10:26"),
         area("10:40", "10:50")
       )
     )

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
@@ -51,7 +51,8 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
  * contains both flex zones but also scheduled stops. Inside the zone, passengers can get on or off
  * anywhere, so there it works more like a taxi.
  * <p>
- * Read about the details at: https://www.cobbcounty.org/transportation/cobblinc/routes-and-schedules/flex
+ * This service is not being offered anymore, but we keep the test because others of the same
+ * type still exist.
  */
 class ScheduledDeviatedTripIntegrationTest {
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
@@ -1,0 +1,251 @@
+package org.opentripplanner.ext.flex.trip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.TestOtpModel;
+import org.opentripplanner.TestServerContext;
+import org.opentripplanner._support.time.ZoneIds;
+import org.opentripplanner.ext.fares.DecorateWithFare;
+import org.opentripplanner.ext.flex.FlexIntegrationTestData;
+import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.ext.flex.FlexRouter;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.geometry.EncodedPolyline;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.filter.AllowAllTransitFilter;
+import org.opentripplanner.routing.framework.DebugTimingAggregator;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.model.vertex.StreetLocation;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.grouppriority.TransitGroupPriorityService;
+import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.utils.time.ServiceDateUtils;
+
+/**
+ * This tests that the feed for the Cobb County Flex service is processed correctly. This service
+ * contains both flex zones but also scheduled stops. Inside the zone, passengers can get on or off
+ * anywhere, so there it works more like a taxi.
+ * <p>
+ * Read about the details at: https://www.cobbcounty.org/transportation/cobblinc/routes-and-schedules/flex
+ */
+class ScheduledDeviatedTripIntegrationTest {
+
+  static Graph graph;
+  static TimetableRepository timetableRepository;
+
+  float delta = 0.01f;
+
+  @Test
+  void parseCobbCountyAsScheduledDeviatedTrip() {
+    var flexTrips = timetableRepository.getAllFlexTrips();
+    assertFalse(flexTrips.isEmpty());
+    assertEquals(72, flexTrips.size());
+
+    assertEquals(
+      Set.of(ScheduledDeviatedTrip.class),
+      flexTrips.stream().map(FlexTrip::getClass).collect(Collectors.toSet())
+    );
+
+    var trip = getFlexTrip();
+    var stop = trip
+      .getStops()
+      .stream()
+      .filter(s -> s.getId().getId().equals("cujv"))
+      .findFirst()
+      .orElseThrow();
+    assertEquals(33.85465, stop.getLat(), delta);
+    assertEquals(-84.60039, stop.getLon(), delta);
+
+    var flexZone = trip
+      .getStops()
+      .stream()
+      .filter(s -> s.getId().getId().equals("zone_3"))
+      .findFirst()
+      .orElseThrow();
+    assertEquals(33.825846635310214, flexZone.getLat(), delta);
+    assertEquals(-84.63430143459385, flexZone.getLon(), delta);
+  }
+
+  @Test
+  void calculateDirectFare() {
+    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
+    var trip = getFlexTrip();
+
+    var from = getNearbyStop(trip, "from-stop");
+    var to = getNearbyStop(trip, "to-stop");
+
+    var router = new FlexRouter(
+      graph,
+      new DefaultTransitService(timetableRepository),
+      FlexParameters.defaultValues(),
+      OffsetDateTime.parse("2021-11-12T10:15:24-05:00").toInstant(),
+      null,
+      1,
+      1,
+      List.of(from),
+      List.of(to)
+    );
+
+    var filter = new DecorateWithFare(graph.getFareService());
+
+    var itineraries = router
+      .createFlexOnlyItineraries(false)
+      .stream()
+      .peek(filter::decorate)
+      .toList();
+
+    var itinerary = itineraries.getFirst();
+
+    assertFalse(itinerary.getFares().getLegProducts().isEmpty());
+
+    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
+  }
+
+  /**
+   * Trips which consist of flex and fixed-schedule stops should work in transit mode.
+   * <p>
+   * The flex stops will show up as intermediate stops (without a departure/arrival time) but you
+   * cannot board or alight.
+   */
+  @Test
+  void flexTripInTransitMode() {
+    var feedId = timetableRepository.getFeedIds().iterator().next();
+
+    var serverContext = TestServerContext.createServerContext(graph, timetableRepository);
+
+    // from zone 3 to zone 2
+    var from = GenericLocation.fromStopId("Transfer Point for Route 30", feedId, "cujv");
+    var to = GenericLocation.fromStopId(
+      "Zone 1 - PUBLIX Super Market,Zone 1 Collection Point",
+      feedId,
+      "yz85"
+    );
+
+    var itineraries = getItineraries(from, to, serverContext);
+
+    assertEquals(2, itineraries.size());
+
+    var itin = itineraries.get(0);
+    var leg = itin.getLegs().get(0);
+
+    assertEquals("cujv", leg.getFrom().stop.getId().getId());
+    assertEquals("yz85", leg.getTo().stop.getId().getId());
+
+    var intermediateStops = leg.getIntermediateStops();
+    assertEquals(1, intermediateStops.size());
+    assertEquals("zone_1", intermediateStops.get(0).place.stop.getId().getId());
+
+    EncodedPolyline legGeometry = EncodedPolyline.encode(leg.getLegGeometry());
+    assertThatPolylinesAreEqual(
+      legGeometry.points(),
+      "kfsmEjojcOa@eBRKfBfHR|ALjBBhVArMG|OCrEGx@OhAKj@a@tAe@hA]l@MPgAnAgw@nr@cDxCm@t@c@t@c@x@_@~@]pAyAdIoAhG}@lE{AzHWhAtt@t~Aj@tAb@~AXdBHn@FlBC`CKnA_@nC{CjOa@dCOlAEz@E|BRtUCbCQ~CWjD??qBvXBl@kBvWOzAc@dDOx@sHv]aIG?q@@c@ZaB\\mA"
+    );
+  }
+
+  /**
+   * We add flex trips, that can potentially not have a departure and arrival time, to the trip.
+   * <p>
+   * Normally these trip times are interpolated/repaired during the graph build but for flex this is
+   * exactly what we don't want. Here we check that the interpolation process is skipped.
+   *
+   * @see ValidateAndInterpolateStopTimesForEachTrip#interpolateStopTimes(List)
+   */
+  @Test
+  void shouldNotInterpolateFlexTimes() {
+    var feedId = timetableRepository.getFeedIds().iterator().next();
+    var pattern = timetableRepository.getTripPatternForId(new FeedScopedId(feedId, "090z:0:01"));
+
+    assertEquals(3, pattern.numberOfStops());
+
+    var tripTimes = pattern.getScheduledTimetable().getTripTimes(0);
+    var arrivalTime = tripTimes.getArrivalTime(1);
+
+    assertEquals(StopTime.MISSING_VALUE, arrivalTime);
+  }
+
+  @BeforeAll
+  static void setup() {
+    TestOtpModel model = FlexIntegrationTestData.cobbFlexGtfs();
+    graph = model.graph();
+    timetableRepository = model.timetableRepository();
+  }
+
+  private static List<Itinerary> getItineraries(
+    GenericLocation from,
+    GenericLocation to,
+    OtpServerRequestContext serverContext
+  ) {
+    var zoneId = ZoneIds.NEW_YORK;
+    RouteRequest request = new RouteRequest();
+    request.journey().transit().setFilters(List.of(AllowAllTransitFilter.of()));
+    var dateTime = LocalDateTime.of(2021, Month.DECEMBER, 16, 12, 0).atZone(zoneId);
+    request.setDateTime(dateTime.toInstant());
+    request.setFrom(from);
+    request.setTo(to);
+
+    var transitStartOfTime = ServiceDateUtils.asStartOfService(request.dateTime(), zoneId);
+    var additionalSearchDays = AdditionalSearchDays.defaults(dateTime);
+    var result = TransitRouter.route(
+      request,
+      serverContext,
+      TransitGroupPriorityService.empty(),
+      transitStartOfTime,
+      additionalSearchDays,
+      new DebugTimingAggregator()
+    );
+
+    return result.getItineraries();
+  }
+
+  private static NearbyStop getNearbyStop(FlexTrip<?, ?> trip, String id) {
+    // getStops() returns a set of stops and the order doesn't correspond to the stop times
+    // of the trip
+    var stopLocation = trip
+      .getStops()
+      .stream()
+      .filter(s -> s instanceof AreaStop)
+      .findFirst()
+      .orElseThrow();
+
+    return new NearbyStop(
+      stopLocation,
+      0,
+      List.of(),
+      new State(
+        new StreetLocation(id, new Coordinate(0, 0), I18NString.of(id)),
+        StreetSearchRequest.of().build()
+      )
+    );
+  }
+
+  private static FlexTrip<?, ?> getFlexTrip() {
+    var feedId = timetableRepository.getFeedIds().iterator().next();
+    var tripId = new FeedScopedId(feedId, "a326c618-d42c-4bd1-9624-c314fbf8ecd8");
+    return timetableRepository.getFlexTrip(tripId);
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
@@ -1,255 +1,62 @@
 package org.opentripplanner.ext.flex.trip;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.flex.FlexStopTimesForTest.area;
+import static org.opentripplanner.ext.flex.FlexStopTimesForTest.areaWithContinuousStopping;
+import static org.opentripplanner.ext.flex.FlexStopTimesForTest.regularStop;
+import static org.opentripplanner.ext.flex.FlexStopTimesForTest.regularStopWithContinuousStopping;
 
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
-import org.opentripplanner.TestOtpModel;
-import org.opentripplanner.TestServerContext;
-import org.opentripplanner._support.time.ZoneIds;
-import org.opentripplanner.ext.fares.DecorateWithFare;
-import org.opentripplanner.ext.flex.FlexIntegrationTestData;
-import org.opentripplanner.ext.flex.FlexParameters;
-import org.opentripplanner.ext.flex.FlexRouter;
-import org.opentripplanner.framework.application.OTPFeature;
-import org.opentripplanner.framework.geometry.EncodedPolyline;
-import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
-import org.opentripplanner.model.GenericLocation;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.model.StopTime;
-import org.opentripplanner.model.plan.Itinerary;
-import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
-import org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter;
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.request.filter.AllowAllTransitFilter;
-import org.opentripplanner.routing.framework.DebugTimingAggregator;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graphfinder.NearbyStop;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
-import org.opentripplanner.street.model.vertex.StreetLocation;
-import org.opentripplanner.street.search.request.StreetSearchRequest;
-import org.opentripplanner.street.search.state.State;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.network.grouppriority.TransitGroupPriorityService;
-import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
-import org.opentripplanner.utils.time.ServiceDateUtils;
 
-/**
- * This tests that the feed for the Cobb County Flex service is processed correctly. This service
- * contains both flex zones but also scheduled stops. Inside the zone, passengers can get on or off
- * anywhere, so there it works more like a taxi.
- * <p>
- * Read about the details at: https://www.cobbcounty.org/transportation/cobblinc/routes-and-schedules/flex
- */
 class ScheduledDeviatedTripTest {
 
-  static Graph graph;
-  static TimetableRepository timetableRepository;
-
-  float delta = 0.01f;
-
-  @Test
-  void parseCobbCountyAsScheduledDeviatedTrip() {
-    var flexTrips = timetableRepository.getAllFlexTrips();
-    assertFalse(flexTrips.isEmpty());
-    assertEquals(72, flexTrips.size());
-
-    assertEquals(
-      Set.of(ScheduledDeviatedTrip.class),
-      flexTrips.stream().map(FlexTrip::getClass).collect(Collectors.toSet())
-    );
-
-    var trip = getFlexTrip();
-    var stop = trip
-      .getStops()
-      .stream()
-      .filter(s -> s.getId().getId().equals("cujv"))
-      .findFirst()
-      .orElseThrow();
-    assertEquals(33.85465, stop.getLat(), delta);
-    assertEquals(-84.60039, stop.getLon(), delta);
-
-    var flexZone = trip
-      .getStops()
-      .stream()
-      .filter(s -> s.getId().getId().equals("zone_3"))
-      .findFirst()
-      .orElseThrow();
-    assertEquals(33.825846635310214, flexZone.getLat(), delta);
-    assertEquals(-84.63430143459385, flexZone.getLon(), delta);
-  }
-
-  @Test
-  void calculateDirectFare() {
-    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
-    var trip = getFlexTrip();
-
-    var from = getNearbyStop(trip, "from-stop");
-    var to = getNearbyStop(trip, "to-stop");
-
-    var router = new FlexRouter(
-      graph,
-      new DefaultTransitService(timetableRepository),
-      FlexParameters.defaultValues(),
-      OffsetDateTime.parse("2021-11-12T10:15:24-05:00").toInstant(),
-      null,
-      1,
-      1,
-      List.of(from),
-      List.of(to)
-    );
-
-    var filter = new DecorateWithFare(graph.getFareService());
-
-    var itineraries = router
-      .createFlexOnlyItineraries(false)
-      .stream()
-      .peek(filter::decorate)
-      .toList();
-
-    var itinerary = itineraries.getFirst();
-
-    assertFalse(itinerary.getFares().getLegProducts().isEmpty());
-
-    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
-  }
-
-  /**
-   * Trips which consist of flex and fixed-schedule stops should work in transit mode.
-   * <p>
-   * The flex stops will show up as intermediate stops (without a departure/arrival time) but you
-   * cannot board or alight.
-   */
-  @Test
-  void flexTripInTransitMode() {
-    var feedId = timetableRepository.getFeedIds().iterator().next();
-
-    var serverContext = TestServerContext.createServerContext(graph, timetableRepository);
-
-    // from zone 3 to zone 2
-    var from = GenericLocation.fromStopId("Transfer Point for Route 30", feedId, "cujv");
-    var to = GenericLocation.fromStopId(
-      "Zone 1 - PUBLIX Super Market,Zone 1 Collection Point",
-      feedId,
-      "yz85"
-    );
-
-    var itineraries = getItineraries(from, to, serverContext);
-
-    assertEquals(2, itineraries.size());
-
-    var itin = itineraries.get(0);
-    var leg = itin.getLegs().get(0);
-
-    assertEquals("cujv", leg.getFrom().stop.getId().getId());
-    assertEquals("yz85", leg.getTo().stop.getId().getId());
-
-    var intermediateStops = leg.getIntermediateStops();
-    assertEquals(1, intermediateStops.size());
-    assertEquals("zone_1", intermediateStops.get(0).place.stop.getId().getId());
-
-    EncodedPolyline legGeometry = EncodedPolyline.encode(leg.getLegGeometry());
-    assertThatPolylinesAreEqual(
-      legGeometry.points(),
-      "kfsmEjojcOa@eBRKfBfHR|ALjBBhVArMG|OCrEGx@OhAKj@a@tAe@hA]l@MPgAnAgw@nr@cDxCm@t@c@t@c@x@_@~@]pAyAdIoAhG}@lE{AzHWhAtt@t~Aj@tAb@~AXdBHn@FlBC`CKnA_@nC{CjOa@dCOlAEz@E|BRtUCbCQ~CWjD??qBvXBl@kBvWOzAc@dDOx@sHv]aIG?q@@c@ZaB\\mA"
-    );
-  }
-
-  /**
-   * We add flex trips, that can potentially not have a departure and arrival time, to the trip.
-   * <p>
-   * Normally these trip times are interpolated/repaired during the graph build but for flex this is
-   * exactly what we don't want. Here we check that the interpolation process is skipped.
-   *
-   * @see ValidateAndInterpolateStopTimesForEachTrip#interpolateStopTimes(List)
-   */
-  @Test
-  void shouldNotInterpolateFlexTimes() {
-    var feedId = timetableRepository.getFeedIds().iterator().next();
-    var pattern = timetableRepository.getTripPatternForId(new FeedScopedId(feedId, "090z:0:01"));
-
-    assertEquals(3, pattern.numberOfStops());
-
-    var tripTimes = pattern.getScheduledTimetable().getTripTimes(0);
-    var arrivalTime = tripTimes.getArrivalTime(1);
-
-    assertEquals(StopTime.MISSING_VALUE, arrivalTime);
-  }
-
-  @BeforeAll
-  static void setup() {
-    TestOtpModel model = FlexIntegrationTestData.cobbFlexGtfs();
-    graph = model.graph();
-    timetableRepository = model.timetableRepository();
-  }
-
-  private static List<Itinerary> getItineraries(
-    GenericLocation from,
-    GenericLocation to,
-    OtpServerRequestContext serverContext
-  ) {
-    var zoneId = ZoneIds.NEW_YORK;
-    RouteRequest request = new RouteRequest();
-    request.journey().transit().setFilters(List.of(AllowAllTransitFilter.of()));
-    var dateTime = LocalDateTime.of(2021, Month.DECEMBER, 16, 12, 0).atZone(zoneId);
-    request.setDateTime(dateTime.toInstant());
-    request.setFrom(from);
-    request.setTo(to);
-
-    var transitStartOfTime = ServiceDateUtils.asStartOfService(request.dateTime(), zoneId);
-    var additionalSearchDays = AdditionalSearchDays.defaults(dateTime);
-    var result = TransitRouter.route(
-      request,
-      serverContext,
-      TransitGroupPriorityService.empty(),
-      transitStartOfTime,
-      additionalSearchDays,
-      new DebugTimingAggregator()
-    );
-
-    return result.getItineraries();
-  }
-
-  private static NearbyStop getNearbyStop(FlexTrip<?, ?> trip) {
-    return getNearbyStop(trip, "nearby-stop");
-  }
-
-  private static NearbyStop getNearbyStop(FlexTrip<?, ?> trip, String id) {
-    // getStops() returns a set of stops and the order doesn't correspond to the stop times
-    // of the trip
-    var stopLocation = trip
-      .getStops()
-      .stream()
-      .filter(s -> s instanceof AreaStop)
-      .findFirst()
-      .orElseThrow();
-
-    return new NearbyStop(
-      stopLocation,
-      0,
-      List.of(),
-      new State(
-        new StreetLocation(id, new Coordinate(0, 0), I18NString.of(id)),
-        StreetSearchRequest.of().build()
+  private static List<List<StopTime>> isScheduledDeviatedTripCases() {
+    return List.of(
+      List.of(
+        regularStop("10:10"),
+        area("10:20", "10:30"),
+        regularStop("10:40"),
+        area("10:50", "11:00")
+      ),
+      List.of(
+        regularStopWithContinuousStopping("10:10"),
+        area("10:20", "10:30"),
+        regularStopWithContinuousStopping("10:40"),
+        area("10:50", "11:00")
       )
     );
   }
 
-  private static FlexTrip<?, ?> getFlexTrip() {
-    var feedId = timetableRepository.getFeedIds().iterator().next();
-    var tripId = new FeedScopedId(feedId, "a326c618-d42c-4bd1-9624-c314fbf8ecd8");
-    return timetableRepository.getFlexTrip(tripId);
+  @ParameterizedTest
+  @MethodSource("isScheduledDeviatedTripCases")
+  void isScheduledDeviatedTrip(List<StopTime> stopTimes) {
+    assertTrue(ScheduledDeviatedTrip.isScheduledFlexTrip(stopTimes));
   }
+
+  private static List<List<StopTime>> isNotScheduledDeviatedTripCases() {
+    return List.of(
+      List.of(
+        areaWithContinuousStopping("10:10"),
+        area("10:20", "10:30"),
+        areaWithContinuousStopping("10:40"),
+        area("10:50", "11:00")
+      ),
+      List.of(
+        regularStop("10:10"),
+        regularStop("10:20")
+      )
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("isNotScheduledDeviatedTripCases")
+  void isNotScheduledDeviatedTrip(List<StopTime> stopTimes) {
+    assertFalse(ScheduledDeviatedTrip.isScheduledFlexTrip(stopTimes));
+  }
+
+
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
@@ -34,16 +34,16 @@ class ScheduledDeviatedTripTest {
   @ParameterizedTest
   @MethodSource("isScheduledDeviatedTripCases")
   void isScheduledDeviatedTrip(List<StopTime> stopTimes) {
-    assertTrue(ScheduledDeviatedTrip.isScheduledFlexTrip(stopTimes));
+    assertTrue(ScheduledDeviatedTrip.isScheduledDeviatedFlexTrip(stopTimes));
   }
 
   private static List<List<StopTime>> isNotScheduledDeviatedTripCases() {
     return List.of(
       List.of(
         areaWithContinuousStopping("10:10"),
-        area("10:20", "10:30"),
+        regularStop("10:20", "10:30"),
         areaWithContinuousStopping("10:40"),
-        area("10:50", "11:00")
+        regularStop("10:50", "11:00")
       ),
       List.of(
         regularStop("10:10"),
@@ -55,7 +55,7 @@ class ScheduledDeviatedTripTest {
   @ParameterizedTest
   @MethodSource("isNotScheduledDeviatedTripCases")
   void isNotScheduledDeviatedTrip(List<StopTime> stopTimes) {
-    assertFalse(ScheduledDeviatedTrip.isScheduledFlexTrip(stopTimes));
+    assertFalse(ScheduledDeviatedTrip.isScheduledDeviatedFlexTrip(stopTimes));
   }
 
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
@@ -50,6 +50,10 @@ class UnscheduledTripTest {
     private static final StopTime CONTINUOUS_PICKUP_STOP = new StopTime();
     private static final StopTime CONTINUOUS_DROP_OFF_STOP = new StopTime();
 
+    // disallowed by the GTFS spec
+    private static final StopTime FLEX_AND_CONTINUOUS_PICKUP_STOP = new StopTime();
+    private static final StopTime FLEX_AND_CONTINUOUS_DROP_OFF_STOP = new StopTime();
+
     static {
       var trip = TimetableRepositoryForTest.trip("flex").build();
       SCHEDULED_STOP.setArrivalTime(30);
@@ -63,16 +67,29 @@ class UnscheduledTripTest {
       UNSCHEDULED_STOP.setTrip(trip);
 
       CONTINUOUS_PICKUP_STOP.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
-      CONTINUOUS_PICKUP_STOP.setFlexWindowStart(30);
-      CONTINUOUS_PICKUP_STOP.setFlexWindowEnd(300);
-      CONTINUOUS_PICKUP_STOP.setStop(AREA_STOP);
+      CONTINUOUS_PICKUP_STOP.setArrivalTime(100);
+      CONTINUOUS_PICKUP_STOP.setDepartureTime(100);
+      CONTINUOUS_PICKUP_STOP.setStop(REGULAR_STOP);
       CONTINUOUS_PICKUP_STOP.setTrip(trip);
 
       CONTINUOUS_DROP_OFF_STOP.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
-      CONTINUOUS_DROP_OFF_STOP.setFlexWindowStart(100);
-      CONTINUOUS_DROP_OFF_STOP.setFlexWindowEnd(200);
-      CONTINUOUS_DROP_OFF_STOP.setStop(AREA_STOP);
+      CONTINUOUS_DROP_OFF_STOP.setArrivalTime(100);
+      CONTINUOUS_DROP_OFF_STOP.setDepartureTime(100);
+      CONTINUOUS_DROP_OFF_STOP.setStop(REGULAR_STOP);
       CONTINUOUS_DROP_OFF_STOP.setTrip(trip);
+
+
+      FLEX_AND_CONTINUOUS_PICKUP_STOP.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
+      FLEX_AND_CONTINUOUS_PICKUP_STOP.setFlexWindowStart(30);
+      FLEX_AND_CONTINUOUS_PICKUP_STOP.setFlexWindowEnd(300);
+      FLEX_AND_CONTINUOUS_PICKUP_STOP.setStop(AREA_STOP);
+      FLEX_AND_CONTINUOUS_PICKUP_STOP.setTrip(trip);
+
+      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
+      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setFlexWindowStart(100);
+      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setFlexWindowEnd(200);
+      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setStop(AREA_STOP);
+      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setTrip(trip);
     }
 
     static List<List<StopTime>> notUnscheduled() {
@@ -82,9 +99,9 @@ class UnscheduledTripTest {
         List.of(SCHEDULED_STOP, SCHEDULED_STOP),
         List.of(SCHEDULED_STOP, SCHEDULED_STOP, SCHEDULED_STOP),
         List.of(UNSCHEDULED_STOP, SCHEDULED_STOP, UNSCHEDULED_STOP),
-        List.of(UNSCHEDULED_STOP, CONTINUOUS_PICKUP_STOP),
-        List.of(UNSCHEDULED_STOP, CONTINUOUS_DROP_OFF_STOP),
-        List.of(CONTINUOUS_PICKUP_STOP, CONTINUOUS_DROP_OFF_STOP)
+        List.of(UNSCHEDULED_STOP, FLEX_AND_CONTINUOUS_PICKUP_STOP),
+        List.of(UNSCHEDULED_STOP, FLEX_AND_CONTINUOUS_DROP_OFF_STOP),
+        List.of(FLEX_AND_CONTINUOUS_PICKUP_STOP, FLEX_AND_CONTINUOUS_DROP_OFF_STOP)
       );
     }
 
@@ -101,7 +118,11 @@ class UnscheduledTripTest {
         List.of(SCHEDULED_STOP, UNSCHEDULED_STOP),
         List.of(UNSCHEDULED_STOP, UNSCHEDULED_STOP),
         List.of(UNSCHEDULED_STOP, UNSCHEDULED_STOP, UNSCHEDULED_STOP),
-        Collections.nCopies(10, UNSCHEDULED_STOP)
+        Collections.nCopies(10, UNSCHEDULED_STOP),
+        List.of(UNSCHEDULED_STOP, CONTINUOUS_PICKUP_STOP),
+        List.of(CONTINUOUS_PICKUP_STOP, UNSCHEDULED_STOP),
+        List.of(UNSCHEDULED_STOP, CONTINUOUS_DROP_OFF_STOP),
+        List.of(CONTINUOUS_DROP_OFF_STOP, UNSCHEDULED_STOP)
       );
     }
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
@@ -45,52 +45,14 @@ class UnscheduledTripTest {
   @Nested
   class IsUnscheduledTrip {
 
-    private static final StopTime SCHEDULED_STOP = new StopTime();
-    private static final StopTime UNSCHEDULED_STOP = new StopTime();
-    private static final StopTime CONTINUOUS_PICKUP_STOP = new StopTime();
-    private static final StopTime CONTINUOUS_DROP_OFF_STOP = new StopTime();
+    private static final StopTime SCHEDULED_STOP = FlexStopTimesForTest.regularStop("10:00");
+    private static final StopTime UNSCHEDULED_STOP = FlexStopTimesForTest.area("10:10", "10:20");
+    private static final StopTime CONTINUOUS_PICKUP_STOP = FlexStopTimesForTest.regularStopWithContinuousPickup("10:30");
+    private static final StopTime CONTINUOUS_DROP_OFF_STOP = FlexStopTimesForTest.regularStopWithContinuousDropOff("10:40");
 
     // disallowed by the GTFS spec
-    private static final StopTime FLEX_AND_CONTINUOUS_PICKUP_STOP = new StopTime();
-    private static final StopTime FLEX_AND_CONTINUOUS_DROP_OFF_STOP = new StopTime();
-
-    static {
-      var trip = TimetableRepositoryForTest.trip("flex").build();
-      SCHEDULED_STOP.setArrivalTime(30);
-      SCHEDULED_STOP.setDepartureTime(60);
-      SCHEDULED_STOP.setStop(AREA_STOP);
-      SCHEDULED_STOP.setTrip(trip);
-
-      UNSCHEDULED_STOP.setFlexWindowStart(30);
-      UNSCHEDULED_STOP.setFlexWindowEnd(300);
-      UNSCHEDULED_STOP.setStop(AREA_STOP);
-      UNSCHEDULED_STOP.setTrip(trip);
-
-      CONTINUOUS_PICKUP_STOP.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
-      CONTINUOUS_PICKUP_STOP.setArrivalTime(100);
-      CONTINUOUS_PICKUP_STOP.setDepartureTime(100);
-      CONTINUOUS_PICKUP_STOP.setStop(REGULAR_STOP);
-      CONTINUOUS_PICKUP_STOP.setTrip(trip);
-
-      CONTINUOUS_DROP_OFF_STOP.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
-      CONTINUOUS_DROP_OFF_STOP.setArrivalTime(100);
-      CONTINUOUS_DROP_OFF_STOP.setDepartureTime(100);
-      CONTINUOUS_DROP_OFF_STOP.setStop(REGULAR_STOP);
-      CONTINUOUS_DROP_OFF_STOP.setTrip(trip);
-
-
-      FLEX_AND_CONTINUOUS_PICKUP_STOP.setFlexContinuousPickup(PickDrop.COORDINATE_WITH_DRIVER);
-      FLEX_AND_CONTINUOUS_PICKUP_STOP.setFlexWindowStart(30);
-      FLEX_AND_CONTINUOUS_PICKUP_STOP.setFlexWindowEnd(300);
-      FLEX_AND_CONTINUOUS_PICKUP_STOP.setStop(AREA_STOP);
-      FLEX_AND_CONTINUOUS_PICKUP_STOP.setTrip(trip);
-
-      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setFlexContinuousDropOff(PickDrop.COORDINATE_WITH_DRIVER);
-      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setFlexWindowStart(100);
-      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setFlexWindowEnd(200);
-      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setStop(AREA_STOP);
-      FLEX_AND_CONTINUOUS_DROP_OFF_STOP.setTrip(trip);
-    }
+    private static final StopTime FLEX_AND_CONTINUOUS_PICKUP_STOP = FlexStopTimesForTest.areaWithContinuousPickup("10:50");
+    private static final StopTime FLEX_AND_CONTINUOUS_DROP_OFF_STOP = FlexStopTimesForTest.areaWithContinuousDropOff("11:00");
 
     static List<List<StopTime>> notUnscheduled() {
       return List.of(

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.ext.flex.FlexStopTimesForTest;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -48,16 +48,16 @@ public class FlexTripsMapper {
         result.add(
           ScheduledDeviatedTrip.of(trip.getId()).withTrip(trip).withStopTimes(stopTimes).build()
         );
-      } else if (hasContinuousStops(stopTimes) && FlexTrip.containsFlexStops(stopTimes)) {
+      } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlex)) {
         store.add(
-          "ContinuousFlexTrip",
-          "Trip %s contains both flex stops and continuous pick up/drop off. This is an invalid combination: https://github.com/MobilityData/gtfs-flex/issues/70",
+          "ContinuousFlexStopTime",
+          "Trip %s contains a stop time which combines flex with continuous pick up/drop off. This is an invalid combination: https://github.com/MobilityData/gtfs-flex/issues/70",
           trip.getId()
         );
         // result.add(new ContinuousPickupDropOffTrip(trip, stopTimes));
       }
 
-      //Keep lambda! A method-ref would causes incorrect class and line number to be logged
+      //Keep lambda! A method-ref would cause incorrect class and line number to be logged
       //noinspection Convert2MethodRef
       progress.step(m -> LOG.info(m));
     }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -44,11 +44,11 @@ public class FlexTripsMapper {
             .withTimePenalty(timePenalty)
             .build()
         );
-      } else if (ScheduledDeviatedTrip.isScheduledFlexTrip(stopTimes)) {
+      } else if (ScheduledDeviatedTrip.isScheduledDeviatedFlexTrip(stopTimes)) {
         result.add(
           ScheduledDeviatedTrip.of(trip.getId()).withTrip(trip).withStopTimes(stopTimes).build()
         );
-      } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlex)) {
+      } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlexWindow)) {
         store.add(
           "ContinuousFlexStopTime",
           "Trip %s contains a stop time which combines flex with continuous pick up/drop off. This is an invalid combination: https://github.com/MobilityData/gtfs-flex/issues/70",

--- a/application/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -34,7 +34,7 @@ public class ScheduledDeviatedTrip
   ScheduledDeviatedTrip(ScheduledDeviatedTripBuilder builder) {
     super(builder);
     List<StopTime> stopTimes = builder.stopTimes();
-    if (!isScheduledFlexTrip(stopTimes)) {
+    if (!isScheduledDeviatedFlexTrip(stopTimes)) {
       throw new IllegalArgumentException("Incompatible stopTimes for scheduled flex trip");
     }
 
@@ -54,10 +54,10 @@ public class ScheduledDeviatedTrip
     return new ScheduledDeviatedTripBuilder(id);
   }
 
-  public static boolean isScheduledFlexTrip(List<StopTime> stopTimes) {
+  public static boolean isScheduledDeviatedFlexTrip(List<StopTime> stopTimes) {
     Predicate<StopTime> notFixedStop = Predicate.not(st -> st.getStop() instanceof RegularStop);
     return (
-      stopTimes.stream().anyMatch(notFixedStop) && stopTimes.stream().noneMatch(StopTime::combinesContinuousStoppingWithFlex)
+      stopTimes.stream().anyMatch(notFixedStop) && stopTimes.stream().noneMatch(StopTime::combinesContinuousStoppingWithFlexWindow)
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.flex.trip;
 
-import static org.opentripplanner.model.PickDrop.NONE;
 import static org.opentripplanner.model.StopTime.MISSING_VALUE;
 
 import java.io.Serializable;
@@ -56,11 +55,9 @@ public class ScheduledDeviatedTrip
   }
 
   public static boolean isScheduledFlexTrip(List<StopTime> stopTimes) {
-    Predicate<StopTime> notStopType = Predicate.not(st -> st.getStop() instanceof RegularStop);
-    Predicate<StopTime> notContinuousStop = stopTime ->
-      stopTime.getFlexContinuousDropOff() == NONE && stopTime.getFlexContinuousPickup() == NONE;
+    Predicate<StopTime> notFixedStop = Predicate.not(st -> st.getStop() instanceof RegularStop);
     return (
-      stopTimes.stream().anyMatch(notStopType) && stopTimes.stream().allMatch(notContinuousStop)
+      stopTimes.stream().anyMatch(notFixedStop) && stopTimes.stream().noneMatch(StopTime::combinesContinuousStoppingWithFlex)
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.flex.trip;
 
-import static org.opentripplanner.model.PickDrop.NONE;
 import static org.opentripplanner.model.StopTime.MISSING_VALUE;
 
 import java.util.Arrays;
@@ -8,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.TimePenaltyCalculator;
@@ -81,11 +79,9 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
    *  - One or more stop times with a flexible time window but no fixed stop in between them
    */
   public static boolean isUnscheduledTrip(List<StopTime> stopTimes) {
-    Predicate<StopTime> hasContinuousStops = stopTime ->
-      stopTime.getFlexContinuousDropOff() != NONE || stopTime.getFlexContinuousPickup() != NONE;
     if (stopTimes.isEmpty()) {
       return false;
-    } else if (stopTimes.stream().anyMatch(hasContinuousStops)) {
+    } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlex)) {
       return false;
     } else if (N_STOPS.contains(stopTimes.size())) {
       return stopTimes.stream().anyMatch(StopTime::hasFlexWindow);

--- a/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -81,7 +81,7 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
   public static boolean isUnscheduledTrip(List<StopTime> stopTimes) {
     if (stopTimes.isEmpty()) {
       return false;
-    } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlex)) {
+    } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlexWindow)) {
       return false;
     } else if (N_STOPS.contains(stopTimes.size())) {
       return stopTimes.stream().anyMatch(StopTime::hasFlexWindow);

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -312,7 +312,7 @@ public final class StopTime implements Comparable<StopTime> {
    * Checks if this stop time combines flex windows with continuous stopping, which is against the
    * GTFS spec.
    */
-  public boolean combinesContinuousStoppingWithFlex() {
+  public boolean combinesContinuousStoppingWithFlexWindow() {
     return hasContinuousStopping() && hasFlexWindow();
   }
 

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -1,6 +1,8 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
+import static org.opentripplanner.model.PickDrop.NONE;
+
 import java.util.List;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -304,5 +306,17 @@ public final class StopTime implements Comparable<StopTime> {
    */
   public boolean hasFlexWindow() {
     return flexWindowStart != MISSING_VALUE || flexWindowEnd != MISSING_VALUE;
+  }
+
+  /**
+   * Checks if this stop time combines flex windows with continuous stopping, which is against the
+   * GTFS spec.
+   */
+  public boolean combinesContinuousStoppingWithFlex() {
+    return hasContinuousStopping() && hasFlexWindow();
+  }
+
+  public boolean hasContinuousStopping() {
+    return this.flexContinuousPickup != NONE || flexContinuousDropOff != NONE;
   }
 }

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -7,6 +7,16 @@ import { ItineraryGraphiQLLineLink } from './ItineraryGraphiQLLineLink.tsx';
 import { ItineraryGraphiQLQuayLink } from './ItineraryGraphiQLQuayLink.tsx';
 import { ItineraryGraphiQLAuthorityLink } from './ItineraryGraphiQLAuthorityLink.tsx';
 
+/**
+ * Some GTFS trips don't have a short name (public code) so we use the long name in this case.
+ */
+function legName(leg: Leg): string {
+  if (leg.line?.publicCode) {
+    return leg.line.publicCode + ' ' + leg.toEstimatedCall?.destinationDisplay?.frontText;
+  } else {
+    return leg.line?.name || 'unknown';
+  }
+}
 export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean }) {
   return (
     <div className="itinerary-leg-details">
@@ -20,10 +30,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
         <b>{leg.mode}</b>{' '}
         {leg.line && (
           <>
-            <ItineraryGraphiQLLineLink
-              legId={leg.line?.id}
-              legName={leg.line.publicCode + ' ' + leg.toEstimatedCall?.destinationDisplay?.frontText}
-            />
+            <ItineraryGraphiQLLineLink legId={leg.line?.id} legName={legName(leg)} />
             , <ItineraryGraphiQLAuthorityLink legId={leg.authority?.id} legName={leg.authority?.name} />
           </>
         )}{' '}


### PR DESCRIPTION
### Summary

This brings OTP in line with the GTFS spec by allowing flex and continuous stopping in the same trip as long as it's not mixed in the very same stop time.

There is also a small improvement to the debug UI where routes without a publicCode/shortName use the long name as the fallback.

### Issue

Closes #6230

### Unit tests

The majority of the code is test refactoring. Lots of tests for this behavior added.

### Documentation

n/a

### Bumping the serialization version id

I'm changing static method on a file that is being serialised so I'm bumping just in case.