### PR TITLE
Return empty list if there is no siriUrls in situations/infoLinks

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/InfoLinkType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/InfoLinkType.java
@@ -20,7 +20,7 @@ public class InfoLinkType {
           .description("URI")
           .dataFetcher(environment -> {
             AlertUrl source = environment.getSource();
-            return source.uri;
+            return source.uri();
           })
           .build()
       )
@@ -32,7 +32,7 @@ public class InfoLinkType {
           .description("Label")
           .dataFetcher(environment -> {
             AlertUrl source = environment.getSource();
-            return source.label;
+            return source.label();
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
@@ -241,7 +241,7 @@ public class PtSituationElementType {
             if (!siriUrls.isEmpty()) {
               return siriUrls;
             }
-            return null;
+            return emptyList();
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/framework/i18n/I18NString.java
+++ b/application/src/main/java/org/opentripplanner/framework/i18n/I18NString.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.framework.i18n;
 
 import java.util.Locale;
+import javax.annotation.Nullable;
 
 /**
  * This interface is used when providing translations on server side. Sources: OSM tags with
@@ -9,9 +10,20 @@ import java.util.Locale;
  * @author mabu
  */
 public interface I18NString {
-  /** true if the given value is not {@code null} or has at least one none white-space character. */
-  public static boolean hasValue(I18NString value) {
-    return value != null && !value.toString().isBlank();
+  /**
+   * Return {@code true} if the given value is not {@code null} or has at least one none
+   * white-space character.
+   */
+  static boolean hasValue(@Nullable I18NString value) {
+    return !hasNoValue(value);
+  }
+
+  /**
+   * Return {@code true} if the given value has at least one none white-space character.
+   * Return {@code false} if the value is {@code null} or blank.
+   */
+  static boolean hasNoValue(@Nullable I18NString value) {
+    return value == null || value.toString().isBlank();
   }
 
   /**
@@ -26,8 +38,8 @@ public interface I18NString {
    */
   String toString(Locale locale);
 
-  static I18NString assertHasValue(I18NString value) {
-    if (value == null || value.toString().isBlank()) {
+  static I18NString assertHasValue(@Nullable I18NString value) {
+    if (hasNoValue(value)) {
       throw new IllegalArgumentException(
         "Value can not be null, empty or just whitespace: " +
         (value == null ? "null" : "'" + value + "'")

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertUrl.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertUrl.java
@@ -1,7 +1,10 @@
 package org.opentripplanner.routing.alertpatch;
 
-public class AlertUrl {
+import java.util.Objects;
+import javax.annotation.Nullable;
 
-  public String uri;
-  public String label;
+public record AlertUrl(String uri, @Nullable String label) {
+  public AlertUrl {
+    Objects.requireNonNull(uri);
+  }
 }

--- a/application/src/test/java/org/opentripplanner/framework/i18n/I18NStringTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/i18n/I18NStringTest.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.framework.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class I18NStringTest {
+
+  private final I18NString noValue = I18NString.of(" \t\n\r\f");
+  private final I18NString hasValue = I18NString.of("A value");
+
+  @Test
+  void hasValue() {
+    assertTrue(I18NString.hasValue(hasValue));
+    assertFalse(I18NString.hasValue(noValue));
+  }
+
+  @Test
+  void hasNoValue() {
+    assertFalse(I18NString.hasNoValue(hasValue));
+    assertTrue(I18NString.hasNoValue(noValue));
+  }
+
+  @Test
+  void assertHasValue() {
+    var ex = assertThrows(IllegalArgumentException.class, () -> I18NString.assertHasValue(noValue));
+    assertEquals("Value can not be null, empty or just whitespace: ' \t\n\r\f'", ex.getMessage());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/siri/SiriAlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/siri/SiriAlertsUpdateHandlerTest.java
@@ -198,8 +198,8 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     final List<AlertUrl> alertUrlList = transitAlert.siriUrls();
     AlertUrl alertUrl = alertUrlList.get(0);
-    assertEquals(infoLinkUri, alertUrl.uri);
-    assertEquals(infoLinkLabel, alertUrl.label);
+    assertEquals(infoLinkUri, alertUrl.uri());
+    assertEquals(infoLinkLabel, alertUrl.label());
   }
 
   @Test


### PR DESCRIPTION

### Summary

In the Transmodel API the `/stopPlace/quays[]/situations[]/infoLinks` is none-null, but the current code returns `null`if no infoLinks exist. This PR return an empty list instead. 

### Issue

There is no issue for this. This bug was reported by T. Sverdvik, Ruter yesterday in \\#shared-entur-ruter-utvikling at Entur.


### Unit tests

No test is added.

### Documentation

Not changed.

### Changelog

Probably to small of a fix to be notable.

### Bumping the serialization version id

Not needed.