### PR TITLE
Fix rental searches when destination is in a no-drop-off zone

### DIFF
--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1006,6 +1006,10 @@ public class StreetEdge
       return null;
     });
 
+    // Also include a state which continues walking, because the vehicle rental states are
+    // speculation. It is possible that the rental states don't end up at the target at all
+    // due to mode limitations or not finding a place to pick up the rental vehicle, or that
+    // the rental possibility is simply more expensive than walking.
     StateEditor walking = doTraverse(s0, TraverseMode.WALK, false);
     if (walking != null) {
       var forkState = walking.makeState();

--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1005,7 +1005,10 @@ public class StreetEdge
       }
       return null;
     });
-    return State.ofStream(states);
+
+    StateEditor walking = doTraverse(s0, TraverseMode.WALK, false);
+    var forkState = walking.makeState();
+    return State.ofStream(Stream.concat(Stream.of(forkState), states));
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1007,8 +1007,11 @@ public class StreetEdge
     });
 
     StateEditor walking = doTraverse(s0, TraverseMode.WALK, false);
-    var forkState = walking.makeState();
-    return State.ofStream(Stream.concat(Stream.of(forkState), states));
+    if (walking != null) {
+      var forkState = walking.makeState();
+      states = Stream.concat(Stream.of(forkState), states);
+    }
+    return State.ofStream(states);
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -259,8 +259,8 @@ class StreetEdgeGeofencingTest {
 
       var states = edge.traverse(haveRentedState);
 
-      // we return 3 states: one for the speculative renting of a vehicle, but with the information
-      // of which networks' no-drop-off zones it started in
+      // we return 4 states: one for continuing walking, one for the speculative renting of
+      // a vehicle, but with the information of which networks' no-drop-off zones it started in
       assertEquals(4, states.length);
 
       // first the fallback walk state
@@ -268,7 +268,7 @@ class StreetEdgeGeofencingTest {
       assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
       assertEquals(WALK, walkState.currentMode());
 
-      // then the speculative renting case
+      // then the speculative renting case for unknown rental network
       final State speculativeRenting = states[1];
       assertEquals(RENTING_FLOATING, speculativeRenting.getVehicleRentalState());
       assertEquals(BICYCLE, speculativeRenting.currentMode());
@@ -280,6 +280,7 @@ class StreetEdgeGeofencingTest {
         speculativeRenting.stateData.noRentalDropOffZonesAtStartOfReverseSearch
       );
 
+      // then the speculative renting cases for specific rental networks
       final State tierState = states[2];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
       assertEquals(BICYCLE, tierState.currentMode());

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -301,56 +301,6 @@ class StreetEdgeGeofencingTest {
         .withArriveBy(true)
         .build();
     }
-
-    @Test
-    public void hslFailTst() {
-      StreetVertex V5 = intersectionVertex("V5", 1, 1);
-      StreetVertex V6 = intersectionVertex("V6", 2, 2);
-      V6.addRentalRestriction(NO_DROP_OFF_TIER);
-      Edge edge = streetEdge(V5, V6);
-      var req = hslArriveByRequest();
-      var haveRentedState = State
-        .getInitialStates(Set.of(V6), req)
-        .stream()
-        .filter(s -> s.getVehicleRentalState() == HAVE_RENTED)
-        .findAny()
-        .get();
-      var states = edge.traverse(haveRentedState);
-      assertEquals(3, states.length);
-      State stateUnknownNetwork = Arrays
-        .stream(states)
-        .filter(s -> s.getVehicleRentalState() == RENTING_FLOATING && s.unknownRentalNetwork())
-        .findAny()
-        .get();
-      State stateTierNetwork = Arrays
-        .stream(states)
-        .filter(s ->
-          s.getVehicleRentalState() == RENTING_FLOATING &&
-          s.getVehicleRentalNetwork() == NETWORK_TIER
-        )
-        .findAny()
-        .get();
-      State stateWalk = Arrays
-        .stream(states)
-        .filter(s -> s.getVehicleRentalState() == HAVE_RENTED)
-        .findAny()
-        .get();
-      assertNotNull(stateUnknownNetwork);
-      assertNotNull(stateTierNetwork);
-      assertNotNull(stateWalk);
-      assertEquals(stateWalk.currentMode(), WALK);
-    }
-
-    private static StreetSearchRequest hslArriveByRequest() {
-      return StreetSearchRequest
-        .of()
-        .withPreferences(p ->
-          p.withBike(b -> b.withRental(r -> r.withAllowedNetworks(Set.of(NETWORK_TIER))))
-        )
-        .withMode(StreetMode.BIKE_RENTAL)
-        .withArriveBy(true)
-        .build();
-    }
   }
 
   private static GeofencingZoneExtension noDropOffRestriction(String networkTier) {

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -13,12 +13,10 @@ import static org.opentripplanner.street.search.TraverseMode.WALK;
 import static org.opentripplanner.street.search.state.VehicleRentalState.HAVE_RENTED;
 import static org.opentripplanner.street.search.state.VehicleRentalState.RENTING_FLOATING;
 
-import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.api.request.StreetMode;
-import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.street.BusinessAreaBorder;
 import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -13,10 +13,12 @@ import static org.opentripplanner.street.search.TraverseMode.WALK;
 import static org.opentripplanner.street.search.state.VehicleRentalState.HAVE_RENTED;
 import static org.opentripplanner.street.search.state.VehicleRentalState.RENTING_FLOATING;
 
+import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.street.BusinessAreaBorder;
 import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;
@@ -259,10 +261,15 @@ class StreetEdgeGeofencingTest {
 
       // we return 3 states: one for the speculative renting of a vehicle, but with the information
       // of which networks' no-drop-off zones it started in
-      assertEquals(3, states.length);
+      assertEquals(4, states.length);
 
-      // first the speculative renting case
-      final State speculativeRenting = states[0];
+      // first the fallback walk state
+      final State walkState = states[0];
+      assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
+      assertEquals(WALK, walkState.currentMode());
+
+      // then the speculative renting case
+      final State speculativeRenting = states[1];
       assertEquals(RENTING_FLOATING, speculativeRenting.getVehicleRentalState());
       assertEquals(BICYCLE, speculativeRenting.currentMode());
       // null means that the vehicle has been rented speculatively and the rest of the backwards search
@@ -273,14 +280,13 @@ class StreetEdgeGeofencingTest {
         speculativeRenting.stateData.noRentalDropOffZonesAtStartOfReverseSearch
       );
 
-      // first the speculative renting case
-      final State tierState = states[1];
+      final State tierState = states[2];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
       assertEquals(BICYCLE, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
       assertEquals(Set.of(), tierState.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
 
-      final State birdState = states[2];
+      final State birdState = states[3];
       assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
       assertEquals(BICYCLE, birdState.currentMode());
       assertEquals(NETWORK_BIRD, birdState.getVehicleRentalNetwork());
@@ -291,6 +297,56 @@ class StreetEdgeGeofencingTest {
       return StreetSearchRequest
         .of()
         .withMode(StreetMode.SCOOTER_RENTAL)
+        .withArriveBy(true)
+        .build();
+    }
+
+    @Test
+    public void hslFailTst() {
+      StreetVertex V5 = intersectionVertex("V5", 1, 1);
+      StreetVertex V6 = intersectionVertex("V6", 2, 2);
+      V6.addRentalRestriction(NO_DROP_OFF_TIER);
+      Edge edge = streetEdge(V5, V6);
+      var req = hslArriveByRequest();
+      var haveRentedState = State
+        .getInitialStates(Set.of(V6), req)
+        .stream()
+        .filter(s -> s.getVehicleRentalState() == HAVE_RENTED)
+        .findAny()
+        .get();
+      var states = edge.traverse(haveRentedState);
+      assertEquals(3, states.length);
+      State stateUnknownNetwork = Arrays
+        .stream(states)
+        .filter(s -> s.getVehicleRentalState() == RENTING_FLOATING && s.unknownRentalNetwork())
+        .findAny()
+        .get();
+      State stateTierNetwork = Arrays
+        .stream(states)
+        .filter(s ->
+          s.getVehicleRentalState() == RENTING_FLOATING &&
+          s.getVehicleRentalNetwork() == NETWORK_TIER
+        )
+        .findAny()
+        .get();
+      State stateWalk = Arrays
+        .stream(states)
+        .filter(s -> s.getVehicleRentalState() == HAVE_RENTED)
+        .findAny()
+        .get();
+      assertNotNull(stateUnknownNetwork);
+      assertNotNull(stateTierNetwork);
+      assertNotNull(stateWalk);
+      assertEquals(stateWalk.currentMode(), WALK);
+    }
+
+    private static StreetSearchRequest hslArriveByRequest() {
+      return StreetSearchRequest
+        .of()
+        .withPreferences(p ->
+          p.withBike(b -> b.withRental(r -> r.withAllowedNetworks(Set.of(NETWORK_TIER))))
+        )
+        .withMode(StreetMode.BIKE_RENTAL)
         .withArriveBy(true)
         .build();
     }


### PR DESCRIPTION
### Summary

Fixes #6054 

It turns out that the egress search ended up on a rental bike at all possible stops so StreetNearbyStopFinder.findNearbyStops didn't find anything. Based on my reading and debug runs, it is caused by the branch in StreetEdge.splitStatesAfterHavingExitedNoDropOffZoneWhenReverseSearching not having a walk state as one of the option.

I further think, but did not include in this PR, that the networks generated here should be filtered by what networks are allowed in the request. Now it generates everything allowed by the vertex, ignoring the request. This is not a correctness issue but affects performance.

### Issue

Closes #6054 

Also closes #6244

### Unit tests

I added a short test which failed before but succeeds now.

Maybe there should be a larger scope test which replicates the situation as findNearestStops sees it?

### Documentation

No changes.

### Changelog

Changelog-worthy bug fix, maybe?

### Bumping the serialization version id

No need.