### PR TITLE
Portland test graph: calculate transfers between stops

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -207,7 +207,7 @@ public class GraphBuilder implements Runnable {
     graphBuilderModules.add(module);
   }
 
-  private void addModuleOptional(GraphBuilderModule module) {
+  private void addModuleOptional(@Nullable GraphBuilderModule module) {
     if (module != null) {
       graphBuilderModules.add(module);
     }

--- a/application/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/application/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -4,6 +4,7 @@ import com.csvreader.CsvReader;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -15,6 +16,8 @@ import org.opentripplanner.ext.fares.impl.DefaultFareServiceFactory;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.graph_builder.ConfiguredDataSource;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
+import org.opentripplanner.graph_builder.module.DirectTransferGenerator;
 import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.graph_builder.module.TestStreetLinkerModule;
 import org.opentripplanner.graph_builder.module.ned.ElevationModule;
@@ -27,6 +30,7 @@ import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
 import org.opentripplanner.netex.NetexBundle;
 import org.opentripplanner.netex.configure.NetexConfigure;
 import org.opentripplanner.osm.OsmProvider;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.linking.LinkingDirection;
@@ -167,7 +171,15 @@ public class ConstantsForTests {
 
       addPortlandVehicleRentals(graph);
 
-      timetableRepository.index();
+      new DirectTransferGenerator(
+        graph,
+        timetableRepository,
+        new DefaultDataImportIssueStore(),
+        Duration.ofMinutes(30),
+        List.of(new RouteRequest())
+      )
+        .buildGraph();
+
       graph.index(timetableRepository.getSiteRepository());
 
       return new TestOtpModel(graph, timetableRepository);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -230,6 +230,549 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedBicycle" : false,
+      "duration" : 2020,
+      "elevationGained" : 0.0,
+      "elevationLost" : 0.0,
+      "endTime" : "2009-11-17T18:35:19.000+00:00",
+      "fare" : {
+        "details" : { },
+        "fare" : { },
+        "legProducts" : [
+          {
+            "legIndices" : [
+              1
+            ],
+            "products" : [
+              {
+                "amount" : {
+                  "cents" : 200,
+                  "currency" : {
+                    "currency" : "USD",
+                    "currencyCode" : "USD",
+                    "defaultFractionDigits" : 2,
+                    "symbol" : "$"
+                  }
+                },
+                "id" : "prt:8",
+                "name" : "regular"
+              }
+            ]
+          },
+          {
+            "legIndices" : [
+              3
+            ],
+            "products" : [
+              {
+                "amount" : {
+                  "cents" : 200,
+                  "currency" : {
+                    "currency" : "USD",
+                    "currencyCode" : "USD",
+                    "defaultFractionDigits" : 2,
+                    "symbol" : "$"
+                  }
+                },
+                "id" : "prt:8",
+                "name" : "regular"
+              }
+            ]
+          }
+        ]
+      },
+      "generalizedCost" : 4023,
+      "legs" : [
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 1022.47,
+          "endTime" : "2009-11-17T18:14:50.000+00:00",
+          "from" : {
+            "departure" : "2009-11-17T18:01:39.000+00:00",
+            "lat" : 45.51726,
+            "lon" : -122.64847,
+            "name" : "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType" : "NORMAL"
+          },
+          "generalizedCost" : 1543,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 37,
+            "points" : "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?R?R?|@?dBAP?PAxD?nD?X?jE?bA?t@?N?Z?ZAX?^@bBAt@?zC?N?J?NQ?O?sA@?W"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:01:39.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "WEST",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 956.36,
+              "elevation" : "",
+              "lat" : 45.517186,
+              "lon" : -122.6484704,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Southeast Morrison Street",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "NORTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 66.13,
+              "elevation" : "",
+              "lat" : 45.5172325,
+              "lon" : -122.6607432,
+              "relativeDirection" : "RIGHT",
+              "stayOn" : false,
+              "streetName" : "Southeast Grand Avenue",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:14:50.000+00:00",
+            "departure" : "2009-11-17T18:14:50.000+00:00",
+            "lat" : 45.517828,
+            "lon" : -122.660632,
+            "name" : "SE Grand & Alder",
+            "stopCode" : "11485",
+            "stopId" : "prt:11485",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        },
+        {
+          "agencyId" : "prt:prt",
+          "agencyName" : "TriMet",
+          "agencyTimeZoneOffset" : -28800000,
+          "agencyUrl" : "http://trimet.org",
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 1580.92,
+          "endTime" : "2009-11-17T18:18:49.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:14:50.000+00:00",
+            "departure" : "2009-11-17T18:14:50.000+00:00",
+            "lat" : 45.517828,
+            "lon" : -122.660632,
+            "name" : "SE Grand & Alder",
+            "stopCode" : "11485",
+            "stopId" : "prt:11485",
+            "stopIndex" : 11,
+            "stopSequence" : 12,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 839,
+          "headsign" : "Jantzen Beach",
+          "interlineWithPreviousLeg" : false,
+          "intermediateStops" : [
+            {
+              "arrival" : "2009-11-17T18:15:25.000+00:00",
+              "departure" : "2009-11-17T18:15:25.000+00:00",
+              "lat" : 45.519986,
+              "lon" : -122.660636,
+              "name" : "SE Grand & Oak",
+              "stopCode" : "2174",
+              "stopId" : "prt:2174",
+              "stopIndex" : 12,
+              "stopSequence" : 13,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:16:10.000+00:00",
+              "departure" : "2009-11-17T18:16:10.000+00:00",
+              "lat" : 45.522782,
+              "lon" : -122.660589,
+              "name" : "SE Grand & E Burnside",
+              "stopCode" : "2167",
+              "stopId" : "prt:2167",
+              "stopIndex" : 13,
+              "stopSequence" : 14,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:16:39.000+00:00",
+              "departure" : "2009-11-17T18:16:39.000+00:00",
+              "lat" : 45.524582,
+              "lon" : -122.660578,
+              "name" : "NE Grand & Davis",
+              "stopCode" : "8829",
+              "stopId" : "prt:8829",
+              "stopIndex" : 14,
+              "stopSequence" : 15,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:17:26.000+00:00",
+              "departure" : "2009-11-17T18:17:26.000+00:00",
+              "lat" : 45.527519,
+              "lon" : -122.66056,
+              "name" : "NE Grand & Hoyt",
+              "stopCode" : "2169",
+              "stopId" : "prt:2169",
+              "stopIndex" : 15,
+              "stopSequence" : 16,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:18:00.000+00:00",
+              "departure" : "2009-11-17T18:18:00.000+00:00",
+              "lat" : 45.529602,
+              "lon" : -122.660529,
+              "name" : "NE Grand & Pacific",
+              "stopCode" : "2175",
+              "stopId" : "prt:2175",
+              "stopIndex" : 16,
+              "stopSequence" : 17,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            }
+          ],
+          "legGeometry" : {
+            "length" : 35,
+            "points" : "meytGtdtkVC?OAQ?}B?mC?{BA??Q?oCAmC?mC?qBA??]?mC?mCAm@???aB?{AC[?kDAsCBq@A??uA?iCAgC?w@???yA?sCCoCAiB@"
+          },
+          "mode" : "BUS",
+          "pathway" : false,
+          "realTime" : false,
+          "route" : "Martin Luther King Jr Blvd",
+          "routeId" : "prt:6",
+          "routeLongName" : "Martin Luther King Jr Blvd",
+          "routeShortName" : "6",
+          "routeType" : 3,
+          "serviceDate" : "2009-11-17",
+          "startTime" : "2009-11-17T18:14:50.000+00:00",
+          "steps" : [ ],
+          "to" : {
+            "arrival" : "2009-11-17T18:18:49.000+00:00",
+            "departure" : "2009-11-17T18:18:49.000+00:00",
+            "lat" : 45.532047,
+            "lon" : -122.660537,
+            "name" : "NE Grand & Wasco",
+            "stopCode" : "10953",
+            "stopId" : "prt:10953",
+            "stopIndex" : 17,
+            "stopSequence" : 18,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : true,
+          "tripBlockId" : "604",
+          "tripId" : "prt:60W1210"
+        },
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 51.83,
+          "endTime" : "2009-11-17T18:19:32.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:18:49.000+00:00",
+            "departure" : "2009-11-17T18:18:49.000+00:00",
+            "lat" : 45.532047,
+            "lon" : -122.660537,
+            "name" : "NE Grand & Wasco",
+            "stopCode" : "10953",
+            "stopId" : "prt:10953",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 80,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 10,
+            "points" : "g~{tGjctkV?B`@?\\?R?@?@?BC???I"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:18:49.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "SOUTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 51.83,
+              "elevation" : "",
+              "lat" : 45.532047,
+              "lon" : -122.6605564,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Northeast Grand Avenue",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:19:32.000+00:00",
+            "departure" : "2009-11-17T18:22:05.000+00:00",
+            "lat" : 45.531586,
+            "lon" : -122.660482,
+            "name" : "NE Multnomah & Grand",
+            "stopCode" : "4043",
+            "stopId" : "prt:4043",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        },
+        {
+          "agencyId" : "prt:prt",
+          "agencyName" : "TriMet",
+          "agencyTimeZoneOffset" : -28800000,
+          "agencyUrl" : "http://trimet.org",
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 3448.6,
+          "endTime" : "2009-11-17T18:34:55.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:19:32.000+00:00",
+            "departure" : "2009-11-17T18:22:05.000+00:00",
+            "lat" : 45.531586,
+            "lon" : -122.660482,
+            "name" : "NE Multnomah & Grand",
+            "stopCode" : "4043",
+            "stopId" : "prt:4043",
+            "stopIndex" : 82,
+            "stopSequence" : 83,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "generalizedCost" : 1523,
+          "headsign" : "Montgomery Park",
+          "interlineWithPreviousLeg" : false,
+          "intermediateStops" : [
+            {
+              "arrival" : "2009-11-17T18:23:09.000+00:00",
+              "departure" : "2009-11-17T18:23:09.000+00:00",
+              "lat" : 45.531159,
+              "lon" : -122.66293,
+              "name" : "NE Multnomah & 3rd",
+              "stopCode" : "11492",
+              "stopId" : "prt:11492",
+              "stopIndex" : 83,
+              "stopSequence" : 84,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:25:00.000+00:00",
+              "departure" : "2009-11-17T18:25:00.000+00:00",
+              "lat" : 45.530005,
+              "lon" : -122.666476,
+              "name" : "Rose Quarter Transit Center",
+              "stopCode" : "2592",
+              "stopId" : "prt:2592",
+              "stopIndex" : 84,
+              "stopSequence" : 85,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:28:20.000+00:00",
+              "departure" : "2009-11-17T18:28:20.000+00:00",
+              "lat" : 45.526655,
+              "lon" : -122.676462,
+              "name" : "NW Glisan & 6th",
+              "stopCode" : "10803",
+              "stopId" : "prt:10803",
+              "stopIndex" : 85,
+              "stopSequence" : 86,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:29:15.000+00:00",
+              "departure" : "2009-11-17T18:29:15.000+00:00",
+              "lat" : 45.528799,
+              "lon" : -122.677238,
+              "name" : "NW Station Way & Union Station",
+              "stopCode" : "12801",
+              "stopId" : "prt:12801",
+              "stopIndex" : 86,
+              "stopSequence" : 87,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:31:00.000+00:00",
+              "departure" : "2009-11-17T18:31:00.000+00:00",
+              "lat" : 45.531582,
+              "lon" : -122.681193,
+              "name" : "NW Northrup & 10th",
+              "stopCode" : "12802",
+              "stopId" : "prt:12802",
+              "stopIndex" : 87,
+              "stopSequence" : 88,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:31:33.000+00:00",
+              "departure" : "2009-11-17T18:31:33.000+00:00",
+              "lat" : 45.531534,
+              "lon" : -122.683319,
+              "name" : "NW 12th & Northrup",
+              "stopCode" : "12796",
+              "stopId" : "prt:12796",
+              "stopIndex" : 88,
+              "stopSequence" : 89,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:32:04.000+00:00",
+              "departure" : "2009-11-17T18:32:04.000+00:00",
+              "lat" : 45.531503,
+              "lon" : -122.685357,
+              "name" : "NW Northrup & 14th",
+              "stopCode" : "10775",
+              "stopId" : "prt:10775",
+              "stopIndex" : 89,
+              "stopSequence" : 90,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:33:07.000+00:00",
+              "departure" : "2009-11-17T18:33:07.000+00:00",
+              "lat" : 45.531434,
+              "lon" : -122.689417,
+              "name" : "NW Northrup & 18th",
+              "stopCode" : "10776",
+              "stopId" : "prt:10776",
+              "stopIndex" : 90,
+              "stopSequence" : 91,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:34:24.000+00:00",
+              "departure" : "2009-11-17T18:34:24.000+00:00",
+              "lat" : 45.531346,
+              "lon" : -122.694455,
+              "name" : "NW Northrup & 21st",
+              "stopCode" : "10777",
+              "stopId" : "prt:10777",
+              "stopIndex" : 91,
+              "stopSequence" : 92,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            }
+          ],
+          "legGeometry" : {
+            "length" : 101,
+            "points" : "}z{tG~btkV?^?nE?V@Z?PH\\Nb@`@~@Rf@??`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
+          },
+          "mode" : "BUS",
+          "pathway" : false,
+          "realTime" : false,
+          "route" : "Broadway/Halsey",
+          "routeId" : "prt:77",
+          "routeLongName" : "Broadway/Halsey",
+          "routeShortName" : "77",
+          "routeType" : 3,
+          "serviceDate" : "2009-11-17",
+          "startTime" : "2009-11-17T18:22:05.000+00:00",
+          "steps" : [ ],
+          "to" : {
+            "arrival" : "2009-11-17T18:34:55.000+00:00",
+            "departure" : "2009-11-17T18:34:55.000+00:00",
+            "lat" : 45.531308,
+            "lon" : -122.696445,
+            "name" : "NW Northrup & 22nd",
+            "stopCode" : "10778",
+            "stopId" : "prt:10778",
+            "stopIndex" : 92,
+            "stopSequence" : 93,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : true,
+          "tripBlockId" : "7736",
+          "tripId" : "prt:771W1160"
+        },
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 18.81,
+          "endTime" : "2009-11-17T18:35:19.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:34:55.000+00:00",
+            "departure" : "2009-11-17T18:34:55.000+00:00",
+            "lat" : 45.531308,
+            "lon" : -122.696445,
+            "name" : "NW Northrup & 22nd",
+            "stopCode" : "10778",
+            "stopId" : "prt:10778",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 37,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 7,
+            "points" : "sy{tGxc{kV???LABF?B??J"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:34:55.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "WEST",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 18.81,
+              "elevation" : "",
+              "lat" : 45.5313019,
+              "lon" : -122.6964448,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Northwest Northrup Street",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:35:19.000+00:00",
+            "lat" : 45.53122,
+            "lon" : -122.69659,
+            "name" : "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType" : "NORMAL"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        }
+      ],
+      "startTime" : "2009-11-17T18:01:39.000+00:00",
+      "tooSloped" : false,
+      "transfers" : 1,
+      "transitTime" : 1009,
+      "waitingTime" : 153,
+      "walkDistance" : 1093.11,
+      "walkLimitExceeded" : false,
+      "walkTime" : 858
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle" : false,
       "duration" : 2261,
       "elevationGained" : 0.0,
       "elevationLost" : 0.0,
@@ -1211,6 +1754,549 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedBicycle" : false,
+      "duration" : 2020,
+      "elevationGained" : 0.0,
+      "elevationLost" : 0.0,
+      "endTime" : "2009-11-17T18:51:19.000+00:00",
+      "fare" : {
+        "details" : { },
+        "fare" : { },
+        "legProducts" : [
+          {
+            "legIndices" : [
+              1
+            ],
+            "products" : [
+              {
+                "amount" : {
+                  "cents" : 200,
+                  "currency" : {
+                    "currency" : "USD",
+                    "currencyCode" : "USD",
+                    "defaultFractionDigits" : 2,
+                    "symbol" : "$"
+                  }
+                },
+                "id" : "prt:8",
+                "name" : "regular"
+              }
+            ]
+          },
+          {
+            "legIndices" : [
+              3
+            ],
+            "products" : [
+              {
+                "amount" : {
+                  "cents" : 200,
+                  "currency" : {
+                    "currency" : "USD",
+                    "currencyCode" : "USD",
+                    "defaultFractionDigits" : 2,
+                    "symbol" : "$"
+                  }
+                },
+                "id" : "prt:8",
+                "name" : "regular"
+              }
+            ]
+          }
+        ]
+      },
+      "generalizedCost" : 4023,
+      "legs" : [
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 1022.47,
+          "endTime" : "2009-11-17T18:30:50.000+00:00",
+          "from" : {
+            "departure" : "2009-11-17T18:17:39.000+00:00",
+            "lat" : 45.51726,
+            "lon" : -122.64847,
+            "name" : "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType" : "NORMAL"
+          },
+          "generalizedCost" : 1543,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 37,
+            "points" : "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?R?R?|@?dBAP?PAxD?nD?X?jE?bA?t@?N?Z?ZAX?^@bBAt@?zC?N?J?NQ?O?sA@?W"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:17:39.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "WEST",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 956.36,
+              "elevation" : "",
+              "lat" : 45.517186,
+              "lon" : -122.6484704,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Southeast Morrison Street",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "NORTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 66.13,
+              "elevation" : "",
+              "lat" : 45.5172325,
+              "lon" : -122.6607432,
+              "relativeDirection" : "RIGHT",
+              "stayOn" : false,
+              "streetName" : "Southeast Grand Avenue",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:30:50.000+00:00",
+            "departure" : "2009-11-17T18:30:50.000+00:00",
+            "lat" : 45.517828,
+            "lon" : -122.660632,
+            "name" : "SE Grand & Alder",
+            "stopCode" : "11485",
+            "stopId" : "prt:11485",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        },
+        {
+          "agencyId" : "prt:prt",
+          "agencyName" : "TriMet",
+          "agencyTimeZoneOffset" : -28800000,
+          "agencyUrl" : "http://trimet.org",
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 1580.92,
+          "endTime" : "2009-11-17T18:34:53.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:30:50.000+00:00",
+            "departure" : "2009-11-17T18:30:50.000+00:00",
+            "lat" : 45.517828,
+            "lon" : -122.660632,
+            "name" : "SE Grand & Alder",
+            "stopCode" : "11485",
+            "stopId" : "prt:11485",
+            "stopIndex" : 11,
+            "stopSequence" : 12,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 843,
+          "headsign" : "Jantzen Beach",
+          "interlineWithPreviousLeg" : false,
+          "intermediateStops" : [
+            {
+              "arrival" : "2009-11-17T18:31:25.000+00:00",
+              "departure" : "2009-11-17T18:31:25.000+00:00",
+              "lat" : 45.519986,
+              "lon" : -122.660636,
+              "name" : "SE Grand & Oak",
+              "stopCode" : "2174",
+              "stopId" : "prt:2174",
+              "stopIndex" : 12,
+              "stopSequence" : 13,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:32:10.000+00:00",
+              "departure" : "2009-11-17T18:32:10.000+00:00",
+              "lat" : 45.522782,
+              "lon" : -122.660589,
+              "name" : "SE Grand & E Burnside",
+              "stopCode" : "2167",
+              "stopId" : "prt:2167",
+              "stopIndex" : 13,
+              "stopSequence" : 14,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:32:39.000+00:00",
+              "departure" : "2009-11-17T18:32:39.000+00:00",
+              "lat" : 45.524582,
+              "lon" : -122.660578,
+              "name" : "NE Grand & Davis",
+              "stopCode" : "8829",
+              "stopId" : "prt:8829",
+              "stopIndex" : 14,
+              "stopSequence" : 15,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:33:26.000+00:00",
+              "departure" : "2009-11-17T18:33:26.000+00:00",
+              "lat" : 45.527519,
+              "lon" : -122.66056,
+              "name" : "NE Grand & Hoyt",
+              "stopCode" : "2169",
+              "stopId" : "prt:2169",
+              "stopIndex" : 15,
+              "stopSequence" : 16,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:34:00.000+00:00",
+              "departure" : "2009-11-17T18:34:00.000+00:00",
+              "lat" : 45.529602,
+              "lon" : -122.660529,
+              "name" : "NE Grand & Pacific",
+              "stopCode" : "2175",
+              "stopId" : "prt:2175",
+              "stopIndex" : 16,
+              "stopSequence" : 17,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            }
+          ],
+          "legGeometry" : {
+            "length" : 35,
+            "points" : "meytGtdtkVC?OAQ?}B?mC?{BA??Q?oCAmC?mC?qBA??]?mC?mCAm@???aB?{AC[?kDAsCBq@A??uA?iCAgC?w@???yA?sCCoCAiB@"
+          },
+          "mode" : "BUS",
+          "pathway" : false,
+          "realTime" : false,
+          "route" : "Martin Luther King Jr Blvd",
+          "routeId" : "prt:6",
+          "routeLongName" : "Martin Luther King Jr Blvd",
+          "routeShortName" : "6",
+          "routeType" : 3,
+          "serviceDate" : "2009-11-17",
+          "startTime" : "2009-11-17T18:30:50.000+00:00",
+          "steps" : [ ],
+          "to" : {
+            "arrival" : "2009-11-17T18:34:53.000+00:00",
+            "departure" : "2009-11-17T18:34:53.000+00:00",
+            "lat" : 45.532047,
+            "lon" : -122.660537,
+            "name" : "NE Grand & Wasco",
+            "stopCode" : "10953",
+            "stopId" : "prt:10953",
+            "stopIndex" : 17,
+            "stopSequence" : 18,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : true,
+          "tripBlockId" : "605",
+          "tripId" : "prt:60W1220"
+        },
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 51.83,
+          "endTime" : "2009-11-17T18:35:36.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:34:53.000+00:00",
+            "departure" : "2009-11-17T18:34:53.000+00:00",
+            "lat" : 45.532047,
+            "lon" : -122.660537,
+            "name" : "NE Grand & Wasco",
+            "stopCode" : "10953",
+            "stopId" : "prt:10953",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 80,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 10,
+            "points" : "g~{tGjctkV?B`@?\\?R?@?@?BC???I"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:34:53.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "SOUTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 51.83,
+              "elevation" : "",
+              "lat" : 45.532047,
+              "lon" : -122.6605564,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Northeast Grand Avenue",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:35:36.000+00:00",
+            "departure" : "2009-11-17T18:38:05.000+00:00",
+            "lat" : 45.531586,
+            "lon" : -122.660482,
+            "name" : "NE Multnomah & Grand",
+            "stopCode" : "4043",
+            "stopId" : "prt:4043",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        },
+        {
+          "agencyId" : "prt:prt",
+          "agencyName" : "TriMet",
+          "agencyTimeZoneOffset" : -28800000,
+          "agencyUrl" : "http://trimet.org",
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 3448.6,
+          "endTime" : "2009-11-17T18:50:55.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:35:36.000+00:00",
+            "departure" : "2009-11-17T18:38:05.000+00:00",
+            "lat" : 45.531586,
+            "lon" : -122.660482,
+            "name" : "NE Multnomah & Grand",
+            "stopCode" : "4043",
+            "stopId" : "prt:4043",
+            "stopIndex" : 82,
+            "stopSequence" : 83,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "generalizedCost" : 1519,
+          "headsign" : "Montgomery Park",
+          "interlineWithPreviousLeg" : false,
+          "intermediateStops" : [
+            {
+              "arrival" : "2009-11-17T18:39:09.000+00:00",
+              "departure" : "2009-11-17T18:39:09.000+00:00",
+              "lat" : 45.531159,
+              "lon" : -122.66293,
+              "name" : "NE Multnomah & 3rd",
+              "stopCode" : "11492",
+              "stopId" : "prt:11492",
+              "stopIndex" : 83,
+              "stopSequence" : 84,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:41:00.000+00:00",
+              "departure" : "2009-11-17T18:41:00.000+00:00",
+              "lat" : 45.530005,
+              "lon" : -122.666476,
+              "name" : "Rose Quarter Transit Center",
+              "stopCode" : "2592",
+              "stopId" : "prt:2592",
+              "stopIndex" : 84,
+              "stopSequence" : 85,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:44:20.000+00:00",
+              "departure" : "2009-11-17T18:44:20.000+00:00",
+              "lat" : 45.526655,
+              "lon" : -122.676462,
+              "name" : "NW Glisan & 6th",
+              "stopCode" : "10803",
+              "stopId" : "prt:10803",
+              "stopIndex" : 85,
+              "stopSequence" : 86,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:45:15.000+00:00",
+              "departure" : "2009-11-17T18:45:15.000+00:00",
+              "lat" : 45.528799,
+              "lon" : -122.677238,
+              "name" : "NW Station Way & Union Station",
+              "stopCode" : "12801",
+              "stopId" : "prt:12801",
+              "stopIndex" : 86,
+              "stopSequence" : 87,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:47:00.000+00:00",
+              "departure" : "2009-11-17T18:47:00.000+00:00",
+              "lat" : 45.531582,
+              "lon" : -122.681193,
+              "name" : "NW Northrup & 10th",
+              "stopCode" : "12802",
+              "stopId" : "prt:12802",
+              "stopIndex" : 87,
+              "stopSequence" : 88,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:47:33.000+00:00",
+              "departure" : "2009-11-17T18:47:33.000+00:00",
+              "lat" : 45.531534,
+              "lon" : -122.683319,
+              "name" : "NW 12th & Northrup",
+              "stopCode" : "12796",
+              "stopId" : "prt:12796",
+              "stopIndex" : 88,
+              "stopSequence" : 89,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:48:04.000+00:00",
+              "departure" : "2009-11-17T18:48:04.000+00:00",
+              "lat" : 45.531503,
+              "lon" : -122.685357,
+              "name" : "NW Northrup & 14th",
+              "stopCode" : "10775",
+              "stopId" : "prt:10775",
+              "stopIndex" : 89,
+              "stopSequence" : 90,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:49:07.000+00:00",
+              "departure" : "2009-11-17T18:49:07.000+00:00",
+              "lat" : 45.531434,
+              "lon" : -122.689417,
+              "name" : "NW Northrup & 18th",
+              "stopCode" : "10776",
+              "stopId" : "prt:10776",
+              "stopIndex" : 90,
+              "stopSequence" : 91,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:50:24.000+00:00",
+              "departure" : "2009-11-17T18:50:24.000+00:00",
+              "lat" : 45.531346,
+              "lon" : -122.694455,
+              "name" : "NW Northrup & 21st",
+              "stopCode" : "10777",
+              "stopId" : "prt:10777",
+              "stopIndex" : 91,
+              "stopSequence" : 92,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            }
+          ],
+          "legGeometry" : {
+            "length" : 101,
+            "points" : "}z{tG~btkV?^?nE?V@Z?PH\\Nb@`@~@Rf@??`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
+          },
+          "mode" : "BUS",
+          "pathway" : false,
+          "realTime" : false,
+          "route" : "Broadway/Halsey",
+          "routeId" : "prt:77",
+          "routeLongName" : "Broadway/Halsey",
+          "routeShortName" : "77",
+          "routeType" : 3,
+          "serviceDate" : "2009-11-17",
+          "startTime" : "2009-11-17T18:38:05.000+00:00",
+          "steps" : [ ],
+          "to" : {
+            "arrival" : "2009-11-17T18:50:55.000+00:00",
+            "departure" : "2009-11-17T18:50:55.000+00:00",
+            "lat" : 45.531308,
+            "lon" : -122.696445,
+            "name" : "NW Northrup & 22nd",
+            "stopCode" : "10778",
+            "stopId" : "prt:10778",
+            "stopIndex" : 92,
+            "stopSequence" : 93,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : true,
+          "tripBlockId" : "7705",
+          "tripId" : "prt:771W1170"
+        },
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 18.81,
+          "endTime" : "2009-11-17T18:51:19.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:50:55.000+00:00",
+            "departure" : "2009-11-17T18:50:55.000+00:00",
+            "lat" : 45.531308,
+            "lon" : -122.696445,
+            "name" : "NW Northrup & 22nd",
+            "stopCode" : "10778",
+            "stopId" : "prt:10778",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 37,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 7,
+            "points" : "sy{tGxc{kV???LABF?B??J"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:50:55.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "WEST",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 18.81,
+              "elevation" : "",
+              "lat" : 45.5313019,
+              "lon" : -122.6964448,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Northwest Northrup Street",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:51:19.000+00:00",
+            "lat" : 45.53122,
+            "lon" : -122.69659,
+            "name" : "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType" : "NORMAL"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        }
+      ],
+      "startTime" : "2009-11-17T18:17:39.000+00:00",
+      "tooSloped" : false,
+      "transfers" : 1,
+      "transitTime" : 1013,
+      "waitingTime" : 149,
+      "walkDistance" : 1093.11,
+      "walkLimitExceeded" : false,
+      "walkTime" : 858
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle" : false,
       "duration" : 2275,
       "elevationGained" : 0.0,
       "elevationLost" : 0.0,
@@ -1666,1053 +2752,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "walkDistance" : 1919.43,
       "walkLimitExceeded" : false,
       "walkTime" : 1490
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle" : false,
-      "duration" : 1540,
-      "elevationGained" : 0.0,
-      "elevationLost" : 0.0,
-      "endTime" : "2009-11-17T18:55:32.000+00:00",
-      "fare" : {
-        "details" : { },
-        "fare" : { },
-        "legProducts" : [
-          {
-            "legIndices" : [
-              1
-            ],
-            "products" : [
-              {
-                "amount" : {
-                  "cents" : 200,
-                  "currency" : {
-                    "currency" : "USD",
-                    "currencyCode" : "USD",
-                    "defaultFractionDigits" : 2,
-                    "symbol" : "$"
-                  }
-                },
-                "id" : "prt:8",
-                "name" : "regular"
-              }
-            ]
-          }
-        ]
-      },
-      "generalizedCost" : 2385,
-      "legs" : [
-        {
-          "agencyTimeZoneOffset" : -28800000,
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 62.01,
-          "endTime" : "2009-11-17T18:30:40.000+00:00",
-          "from" : {
-            "departure" : "2009-11-17T18:29:52.000+00:00",
-            "lat" : 45.51726,
-            "lon" : -122.64847,
-            "name" : "SE Morrison St. & SE 17th Ave. (P1)",
-            "vertexType" : "NORMAL"
-          },
-          "generalizedCost" : 95,
-          "interlineWithPreviousLeg" : false,
-          "legGeometry" : {
-            "length" : 4,
-            "points" : "kaytG~wqkV?T?fCG?"
-          },
-          "mode" : "WALK",
-          "pathway" : false,
-          "realTime" : false,
-          "rentedBike" : false,
-          "route" : "",
-          "startTime" : "2009-11-17T18:29:52.000+00:00",
-          "steps" : [
-            {
-              "absoluteDirection" : "WEST",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 62.02,
-              "elevation" : "",
-              "lat" : 45.517186,
-              "lon" : -122.6484704,
-              "relativeDirection" : "DEPART",
-              "stayOn" : false,
-              "streetName" : "Southeast Morrison Street",
-              "walkingBike" : false
-            }
-          ],
-          "to" : {
-            "arrival" : "2009-11-17T18:30:40.000+00:00",
-            "departure" : "2009-11-17T18:30:40.000+00:00",
-            "lat" : 45.517226,
-            "lon" : -122.649266,
-            "name" : "SE Morrison & 16th",
-            "stopCode" : "4019",
-            "stopId" : "prt:4019",
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "transitLeg" : false,
-          "walkingBike" : false
-        },
-        {
-          "agencyId" : "prt:prt",
-          "agencyName" : "TriMet",
-          "agencyTimeZoneOffset" : -28800000,
-          "agencyUrl" : "http://trimet.org",
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 5218.86,
-          "endTime" : "2009-11-17T18:52:04.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T18:30:40.000+00:00",
-            "departure" : "2009-11-17T18:30:40.000+00:00",
-            "lat" : 45.517226,
-            "lon" : -122.649266,
-            "name" : "SE Morrison & 16th",
-            "stopCode" : "4019",
-            "stopId" : "prt:4019",
-            "stopIndex" : 50,
-            "stopSequence" : 51,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 1884,
-          "headsign" : "NW 27th & Thurman",
-          "interlineWithPreviousLeg" : false,
-          "intermediateStops" : [
-            {
-              "arrival" : "2009-11-17T18:31:15.000+00:00",
-              "departure" : "2009-11-17T18:31:15.000+00:00",
-              "lat" : 45.517253,
-              "lon" : -122.651354,
-              "name" : "SE Morrison & 14th",
-              "stopCode" : "4016",
-              "stopId" : "prt:4016",
-              "stopIndex" : 51,
-              "stopSequence" : 52,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:32:00.000+00:00",
-              "departure" : "2009-11-17T18:32:00.000+00:00",
-              "lat" : 45.517299,
-              "lon" : -122.654067,
-              "name" : "SE Morrison & 12th",
-              "stopCode" : "4014",
-              "stopId" : "prt:4014",
-              "stopIndex" : 52,
-              "stopSequence" : 53,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:32:38.000+00:00",
-              "departure" : "2009-11-17T18:32:38.000+00:00",
-              "lat" : 45.517292,
-              "lon" : -122.656563,
-              "name" : "SE Morrison & 9th",
-              "stopCode" : "4026",
-              "stopId" : "prt:4026",
-              "stopIndex" : 53,
-              "stopSequence" : 54,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:33:08.000+00:00",
-              "departure" : "2009-11-17T18:33:08.000+00:00",
-              "lat" : 45.517322,
-              "lon" : -122.65847,
-              "name" : "SE Morrison & 7th",
-              "stopCode" : "4025",
-              "stopId" : "prt:4025",
-              "stopIndex" : 54,
-              "stopSequence" : 55,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:33:39.000+00:00",
-              "departure" : "2009-11-17T18:33:39.000+00:00",
-              "lat" : 45.517298,
-              "lon" : -122.660523,
-              "name" : "SE Morrison & Grand",
-              "stopCode" : "4013",
-              "stopId" : "prt:4013",
-              "stopIndex" : 55,
-              "stopSequence" : 56,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:35:03.000+00:00",
-              "departure" : "2009-11-17T18:35:03.000+00:00",
-              "lat" : 45.517351,
-              "lon" : -122.66601,
-              "name" : "Morrison Bridge",
-              "stopCode" : "4029",
-              "stopId" : "prt:4029",
-              "stopIndex" : 56,
-              "stopSequence" : 57,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:37:27.000+00:00",
-              "departure" : "2009-11-17T18:37:27.000+00:00",
-              "lat" : 45.51959,
-              "lon" : -122.674599,
-              "name" : "SW Washington & 3rd",
-              "stopCode" : "6158",
-              "stopId" : "prt:6158",
-              "stopIndex" : 57,
-              "stopSequence" : 58,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:38:00.000+00:00",
-              "departure" : "2009-11-17T18:38:00.000+00:00",
-              "lat" : 45.520129,
-              "lon" : -122.676635,
-              "name" : "SW Washington & 5th",
-              "stopCode" : "6160",
-              "stopId" : "prt:6160",
-              "stopIndex" : 58,
-              "stopSequence" : 59,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:38:52.000+00:00",
-              "departure" : "2009-11-17T18:38:52.000+00:00",
-              "lat" : 45.520695,
-              "lon" : -122.678657,
-              "name" : "SW Washington & Broadway",
-              "stopCode" : "6137",
-              "stopId" : "prt:6137",
-              "stopIndex" : 59,
-              "stopSequence" : 60,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:39:34.000+00:00",
-              "departure" : "2009-11-17T18:39:34.000+00:00",
-              "lat" : 45.521124,
-              "lon" : -122.6803,
-              "name" : "SW Washington & 9th",
-              "stopCode" : "6169",
-              "stopId" : "prt:6169",
-              "stopIndex" : 60,
-              "stopSequence" : 61,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:40:47.000+00:00",
-              "departure" : "2009-11-17T18:40:47.000+00:00",
-              "lat" : 45.521094,
-              "lon" : -122.682819,
-              "name" : "SW 11th & Alder",
-              "stopCode" : "9600",
-              "stopId" : "prt:9600",
-              "stopIndex" : 61,
-              "stopSequence" : 62,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:41:36.000+00:00",
-              "departure" : "2009-11-17T18:41:36.000+00:00",
-              "lat" : 45.52055,
-              "lon" : -122.683933,
-              "name" : "SW Morrison & 12th",
-              "stopCode" : "9598",
-              "stopId" : "prt:9598",
-              "stopIndex" : 62,
-              "stopSequence" : 63,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:42:25.000+00:00",
-              "departure" : "2009-11-17T18:42:25.000+00:00",
-              "lat" : 45.521063,
-              "lon" : -122.685848,
-              "name" : "SW Morrison & 14th",
-              "stopCode" : "9708",
-              "stopId" : "prt:9708",
-              "stopIndex" : 63,
-              "stopSequence" : 64,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:43:18.000+00:00",
-              "departure" : "2009-11-17T18:43:18.000+00:00",
-              "lat" : 45.521641,
-              "lon" : -122.687932,
-              "name" : "SW Morrison & 16th",
-              "stopCode" : "9613",
-              "stopId" : "prt:9613",
-              "stopIndex" : 64,
-              "stopSequence" : 65,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:44:00.000+00:00",
-              "departure" : "2009-11-17T18:44:00.000+00:00",
-              "lat" : 45.52206,
-              "lon" : -122.689577,
-              "name" : "SW Morrison & 17th",
-              "stopCode" : "9599",
-              "stopId" : "prt:9599",
-              "stopIndex" : 65,
-              "stopSequence" : 66,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:45:03.000+00:00",
-              "departure" : "2009-11-17T18:45:03.000+00:00",
-              "lat" : 45.523097,
-              "lon" : -122.690083,
-              "name" : "W Burnside & NW 19th",
-              "stopCode" : "735",
-              "stopId" : "prt:735",
-              "stopIndex" : 66,
-              "stopSequence" : 67,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:45:46.000+00:00",
-              "departure" : "2009-11-17T18:45:46.000+00:00",
-              "lat" : 45.523176,
-              "lon" : -122.692139,
-              "name" : "W Burnside & NW 20th",
-              "stopCode" : "741",
-              "stopId" : "prt:741",
-              "stopIndex" : 67,
-              "stopSequence" : 68,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:46:07.000+00:00",
-              "departure" : "2009-11-17T18:46:07.000+00:00",
-              "lat" : 45.52322,
-              "lon" : -122.69313,
-              "name" : "W Burnside & NW 20th Pl",
-              "stopCode" : "742",
-              "stopId" : "prt:742",
-              "stopIndex" : 68,
-              "stopSequence" : 69,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:46:44.000+00:00",
-              "departure" : "2009-11-17T18:46:44.000+00:00",
-              "lat" : 45.523312,
-              "lon" : -122.694901,
-              "name" : "W Burnside & NW King",
-              "stopCode" : "747",
-              "stopId" : "prt:747",
-              "stopIndex" : 69,
-              "stopSequence" : 70,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:47:51.000+00:00",
-              "departure" : "2009-11-17T18:47:51.000+00:00",
-              "lat" : 45.523512,
-              "lon" : -122.698081,
-              "name" : "W Burnside & NW 23rd",
-              "stopCode" : "755",
-              "stopId" : "prt:755",
-              "stopIndex" : 70,
-              "stopSequence" : 71,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:48:53.000+00:00",
-              "departure" : "2009-11-17T18:48:53.000+00:00",
-              "lat" : 45.525416,
-              "lon" : -122.698381,
-              "name" : "NW 23rd & Flanders",
-              "stopCode" : "7157",
-              "stopId" : "prt:7157",
-              "stopIndex" : 71,
-              "stopSequence" : 72,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:49:56.000+00:00",
-              "departure" : "2009-11-17T18:49:56.000+00:00",
-              "lat" : 45.527543,
-              "lon" : -122.698473,
-              "name" : "NW 23rd & Irving",
-              "stopCode" : "7161",
-              "stopId" : "prt:7161",
-              "stopIndex" : 72,
-              "stopSequence" : 73,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:51:00.000+00:00",
-              "departure" : "2009-11-17T18:51:00.000+00:00",
-              "lat" : 45.529681,
-              "lon" : -122.698529,
-              "name" : "NW 23rd & Lovejoy",
-              "stopCode" : "7163",
-              "stopId" : "prt:7163",
-              "stopIndex" : 73,
-              "stopSequence" : 74,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            }
-          ],
-          "legGeometry" : {
-            "length" : 135,
-            "points" : "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB??S?oCDmCDmCBo@@"
-          },
-          "mode" : "BUS",
-          "pathway" : false,
-          "realTime" : false,
-          "route" : "Belmont/NW 23rd",
-          "routeId" : "prt:15",
-          "routeLongName" : "Belmont/NW 23rd",
-          "routeShortName" : "15",
-          "routeType" : 3,
-          "serviceDate" : "2009-11-17",
-          "startTime" : "2009-11-17T18:30:40.000+00:00",
-          "steps" : [ ],
-          "to" : {
-            "arrival" : "2009-11-17T18:52:04.000+00:00",
-            "departure" : "2009-11-17T18:52:04.000+00:00",
-            "lat" : 45.532159,
-            "lon" : -122.698634,
-            "name" : "NW 23rd & Overton",
-            "stopCode" : "8981",
-            "stopId" : "prt:8981",
-            "stopIndex" : 74,
-            "stopSequence" : 75,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "transitLeg" : true,
-          "tripBlockId" : "1541",
-          "tripId" : "prt:150W1410"
-        },
-        {
-          "agencyTimeZoneOffset" : -28800000,
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 266.21,
-          "endTime" : "2009-11-17T18:55:32.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T18:52:04.000+00:00",
-            "departure" : "2009-11-17T18:52:04.000+00:00",
-            "lat" : 45.532159,
-            "lon" : -122.698634,
-            "name" : "NW 23rd & Overton",
-            "stopCode" : "8981",
-            "stopId" : "prt:8981",
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 405,
-          "interlineWithPreviousLeg" : false,
-          "legGeometry" : {
-            "length" : 13,
-            "points" : "}~{tGnq{kV?LVAF?J?L?rBCLA?Q?EAyAEcH?G"
-          },
-          "mode" : "WALK",
-          "pathway" : false,
-          "realTime" : false,
-          "rentedBike" : false,
-          "route" : "",
-          "startTime" : "2009-11-17T18:52:04.000+00:00",
-          "steps" : [
-            {
-              "absoluteDirection" : "SOUTH",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 104.46,
-              "elevation" : "",
-              "lat" : 45.5321578,
-              "lon" : -122.6987026,
-              "relativeDirection" : "DEPART",
-              "stayOn" : false,
-              "streetName" : "Northwest 23rd Avenue",
-              "walkingBike" : false
-            },
-            {
-              "absoluteDirection" : "EAST",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 161.77,
-              "elevation" : "",
-              "lat" : 45.5312188,
-              "lon" : -122.6986675,
-              "relativeDirection" : "LEFT",
-              "stayOn" : false,
-              "streetName" : "Northwest Northrup Street",
-              "walkingBike" : false
-            }
-          ],
-          "to" : {
-            "arrival" : "2009-11-17T18:55:32.000+00:00",
-            "lat" : 45.53122,
-            "lon" : -122.69659,
-            "name" : "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType" : "NORMAL"
-          },
-          "transitLeg" : false,
-          "walkingBike" : false
-        }
-      ],
-      "startTime" : "2009-11-17T18:29:52.000+00:00",
-      "tooSloped" : false,
-      "transfers" : 0,
-      "transitTime" : 1284,
-      "waitingTime" : 0,
-      "walkDistance" : 328.22,
-      "walkLimitExceeded" : false,
-      "walkTime" : 256
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle" : false,
-      "duration" : 1849,
-      "elevationGained" : 0.0,
-      "elevationLost" : 0.0,
-      "endTime" : "2009-11-17T19:08:19.000+00:00",
-      "fare" : {
-        "details" : { },
-        "fare" : { },
-        "legProducts" : [
-          {
-            "legIndices" : [
-              1
-            ],
-            "products" : [
-              {
-                "amount" : {
-                  "cents" : 200,
-                  "currency" : {
-                    "currency" : "USD",
-                    "currencyCode" : "USD",
-                    "defaultFractionDigits" : 2,
-                    "symbol" : "$"
-                  }
-                },
-                "id" : "prt:8",
-                "name" : "regular"
-              }
-            ]
-          },
-          {
-            "legIndices" : [
-              2
-            ],
-            "products" : [
-              {
-                "amount" : {
-                  "cents" : 200,
-                  "currency" : {
-                    "currency" : "USD",
-                    "currencyCode" : "USD",
-                    "defaultFractionDigits" : 2,
-                    "symbol" : "$"
-                  }
-                },
-                "id" : "prt:8",
-                "name" : "regular"
-              }
-            ]
-          }
-        ]
-      },
-      "generalizedCost" : 3375,
-      "legs" : [
-        {
-          "agencyTimeZoneOffset" : -28800000,
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 419.62,
-          "endTime" : "2009-11-17T18:42:54.000+00:00",
-          "from" : {
-            "departure" : "2009-11-17T18:37:30.000+00:00",
-            "lat" : 45.51726,
-            "lon" : -122.64847,
-            "name" : "SE Morrison St. & SE 17th Ave. (P1)",
-            "vertexType" : "NORMAL"
-          },
-          "generalizedCost" : 636,
-          "interlineWithPreviousLeg" : false,
-          "legGeometry" : {
-            "length" : 14,
-            "points" : "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?RN?L??O"
-          },
-          "mode" : "WALK",
-          "pathway" : false,
-          "realTime" : false,
-          "rentedBike" : false,
-          "route" : "",
-          "startTime" : "2009-11-17T18:37:30.000+00:00",
-          "steps" : [
-            {
-              "absoluteDirection" : "WEST",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 403.66,
-              "elevation" : "",
-              "lat" : 45.517186,
-              "lon" : -122.6484704,
-              "relativeDirection" : "DEPART",
-              "stayOn" : false,
-              "streetName" : "Southeast Morrison Street",
-              "walkingBike" : false
-            },
-            {
-              "absoluteDirection" : "SOUTH",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 15.96,
-              "elevation" : "",
-              "lat" : 45.5172031,
-              "lon" : -122.6536511,
-              "relativeDirection" : "LEFT",
-              "stayOn" : false,
-              "streetName" : "Southeast 12th Avenue",
-              "walkingBike" : false
-            }
-          ],
-          "to" : {
-            "arrival" : "2009-11-17T18:42:54.000+00:00",
-            "departure" : "2009-11-17T18:42:54.000+00:00",
-            "lat" : 45.517059,
-            "lon" : -122.65358,
-            "name" : "SE 12th & Morrison",
-            "stopCode" : "6588",
-            "stopId" : "prt:6588",
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "transitLeg" : false,
-          "walkingBike" : false
-        },
-        {
-          "agencyId" : "prt:prt",
-          "agencyName" : "TriMet",
-          "agencyTimeZoneOffset" : -28800000,
-          "agencyUrl" : "http://trimet.org",
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 2035.62,
-          "endTime" : "2009-11-17T18:51:01.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T18:42:54.000+00:00",
-            "departure" : "2009-11-17T18:42:54.000+00:00",
-            "lat" : 45.517059,
-            "lon" : -122.65358,
-            "name" : "SE 12th & Morrison",
-            "stopCode" : "6588",
-            "stopId" : "prt:6588",
-            "stopIndex" : 31,
-            "stopSequence" : 32,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 1087,
-          "headsign" : "Rose Qtr TC",
-          "interlineWithPreviousLeg" : false,
-          "intermediateStops" : [
-            {
-              "arrival" : "2009-11-17T18:44:00.000+00:00",
-              "departure" : "2009-11-17T18:44:00.000+00:00",
-              "lat" : 45.519229,
-              "lon" : -122.653546,
-              "name" : "SE 12th & Stark",
-              "stopCode" : "6594",
-              "stopId" : "prt:6594",
-              "stopIndex" : 32,
-              "stopSequence" : 33,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:44:44.000+00:00",
-              "departure" : "2009-11-17T18:44:44.000+00:00",
-              "lat" : 45.520674,
-              "lon" : -122.653544,
-              "name" : "SE 12th & Pine",
-              "stopCode" : "6589",
-              "stopId" : "prt:6589",
-              "stopIndex" : 33,
-              "stopSequence" : 34,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:46:00.000+00:00",
-              "departure" : "2009-11-17T18:46:00.000+00:00",
-              "lat" : 45.52318,
-              "lon" : -122.653507,
-              "name" : "NE 12th & Sandy",
-              "stopCode" : "6592",
-              "stopId" : "prt:6592",
-              "stopIndex" : 34,
-              "stopSequence" : 35,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:47:45.000+00:00",
-              "departure" : "2009-11-17T18:47:45.000+00:00",
-              "lat" : 45.527449,
-              "lon" : -122.653462,
-              "name" : "NE 12th & Irving",
-              "stopCode" : "6582",
-              "stopId" : "prt:6582",
-              "stopIndex" : 35,
-              "stopSequence" : 36,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T18:49:00.000+00:00",
-              "departure" : "2009-11-17T18:49:00.000+00:00",
-              "lat" : 45.529793,
-              "lon" : -122.654429,
-              "name" : "NE 11th & Holladay",
-              "stopCode" : "8513",
-              "stopId" : "prt:8513",
-              "stopIndex" : 36,
-              "stopSequence" : 37,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:49:39.000+00:00",
-              "departure" : "2009-11-17T18:49:39.000+00:00",
-              "lat" : 45.53135,
-              "lon" : -122.654497,
-              "name" : "NE 11th & Multnomah",
-              "stopCode" : "8938",
-              "stopId" : "prt:8938",
-              "stopIndex" : 37,
-              "stopSequence" : 38,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:50:15.000+00:00",
-              "departure" : "2009-11-17T18:50:15.000+00:00",
-              "lat" : 45.531573,
-              "lon" : -122.656408,
-              "name" : "NE Multnomah & 9th",
-              "stopCode" : "4056",
-              "stopId" : "prt:4056",
-              "stopIndex" : 38,
-              "stopSequence" : 39,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            }
-          ],
-          "legGeometry" : {
-            "length" : 49,
-            "points" : "s`ytGhxrkV[?mCAmC?wBA??W?mC?{BA??Q?oC?mC?kBAa@?w@???wA?mCAmC?oCA}C?sDC??aBAm@@k@AY?uABU@I@IBQFb@fC}@d@OFO@q@???Q?]?gGA??[??nJ???b@?vK?rA"
-          },
-          "mode" : "BUS",
-          "pathway" : false,
-          "realTime" : false,
-          "route" : "12th Ave",
-          "routeId" : "prt:70",
-          "routeLongName" : "12th Ave",
-          "routeShortName" : "70",
-          "routeType" : 3,
-          "serviceDate" : "2009-11-17",
-          "startTime" : "2009-11-17T18:42:54.000+00:00",
-          "steps" : [ ],
-          "to" : {
-            "arrival" : "2009-11-17T18:51:01.000+00:00",
-            "departure" : "2009-11-17T18:54:29.000+00:00",
-            "lat" : 45.531569,
-            "lon" : -122.659045,
-            "name" : "NE Multnomah & 7th",
-            "stopCode" : "4054",
-            "stopId" : "prt:4054",
-            "stopIndex" : 39,
-            "stopSequence" : 40,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "0"
-          },
-          "transitLeg" : true,
-          "tripBlockId" : "7002",
-          "tripId" : "prt:700W1170"
-        },
-        {
-          "agencyId" : "prt:prt",
-          "agencyName" : "TriMet",
-          "agencyTimeZoneOffset" : -28800000,
-          "agencyUrl" : "http://trimet.org",
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 3560.24,
-          "endTime" : "2009-11-17T19:07:55.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T18:51:01.000+00:00",
-            "departure" : "2009-11-17T18:54:29.000+00:00",
-            "lat" : 45.531569,
-            "lon" : -122.659045,
-            "name" : "NE Multnomah & 7th",
-            "stopCode" : "4054",
-            "stopId" : "prt:4054",
-            "stopIndex" : 81,
-            "stopSequence" : 82,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "0"
-          },
-          "generalizedCost" : 1614,
-          "headsign" : "Montgomery Park",
-          "interlineWithPreviousLeg" : false,
-          "intermediateStops" : [
-            {
-              "arrival" : "2009-11-17T18:55:05.000+00:00",
-              "departure" : "2009-11-17T18:55:05.000+00:00",
-              "lat" : 45.531586,
-              "lon" : -122.660482,
-              "name" : "NE Multnomah & Grand",
-              "stopCode" : "4043",
-              "stopId" : "prt:4043",
-              "stopIndex" : 82,
-              "stopSequence" : 83,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:56:09.000+00:00",
-              "departure" : "2009-11-17T18:56:09.000+00:00",
-              "lat" : 45.531159,
-              "lon" : -122.66293,
-              "name" : "NE Multnomah & 3rd",
-              "stopCode" : "11492",
-              "stopId" : "prt:11492",
-              "stopIndex" : 83,
-              "stopSequence" : 84,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T18:58:00.000+00:00",
-              "departure" : "2009-11-17T18:58:00.000+00:00",
-              "lat" : 45.530005,
-              "lon" : -122.666476,
-              "name" : "Rose Quarter Transit Center",
-              "stopCode" : "2592",
-              "stopId" : "prt:2592",
-              "stopIndex" : 84,
-              "stopSequence" : 85,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:01:20.000+00:00",
-              "departure" : "2009-11-17T19:01:20.000+00:00",
-              "lat" : 45.526655,
-              "lon" : -122.676462,
-              "name" : "NW Glisan & 6th",
-              "stopCode" : "10803",
-              "stopId" : "prt:10803",
-              "stopIndex" : 85,
-              "stopSequence" : 86,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:02:15.000+00:00",
-              "departure" : "2009-11-17T19:02:15.000+00:00",
-              "lat" : 45.528799,
-              "lon" : -122.677238,
-              "name" : "NW Station Way & Union Station",
-              "stopCode" : "12801",
-              "stopId" : "prt:12801",
-              "stopIndex" : 86,
-              "stopSequence" : 87,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:04:00.000+00:00",
-              "departure" : "2009-11-17T19:04:00.000+00:00",
-              "lat" : 45.531582,
-              "lon" : -122.681193,
-              "name" : "NW Northrup & 10th",
-              "stopCode" : "12802",
-              "stopId" : "prt:12802",
-              "stopIndex" : 87,
-              "stopSequence" : 88,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:04:33.000+00:00",
-              "departure" : "2009-11-17T19:04:33.000+00:00",
-              "lat" : 45.531534,
-              "lon" : -122.683319,
-              "name" : "NW 12th & Northrup",
-              "stopCode" : "12796",
-              "stopId" : "prt:12796",
-              "stopIndex" : 88,
-              "stopSequence" : 89,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:05:04.000+00:00",
-              "departure" : "2009-11-17T19:05:04.000+00:00",
-              "lat" : 45.531503,
-              "lon" : -122.685357,
-              "name" : "NW Northrup & 14th",
-              "stopCode" : "10775",
-              "stopId" : "prt:10775",
-              "stopIndex" : 89,
-              "stopSequence" : 90,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:06:07.000+00:00",
-              "departure" : "2009-11-17T19:06:07.000+00:00",
-              "lat" : 45.531434,
-              "lon" : -122.689417,
-              "name" : "NW Northrup & 18th",
-              "stopCode" : "10776",
-              "stopId" : "prt:10776",
-              "stopIndex" : 90,
-              "stopSequence" : 91,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:07:24.000+00:00",
-              "departure" : "2009-11-17T19:07:24.000+00:00",
-              "lat" : 45.531346,
-              "lon" : -122.694455,
-              "name" : "NW Northrup & 21st",
-              "stopCode" : "10777",
-              "stopId" : "prt:10777",
-              "stopIndex" : 91,
-              "stopSequence" : 92,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            }
-          ],
-          "legGeometry" : {
-            "length" : 104,
-            "points" : "yz{tG`zskV?tBCfD???^?nE?V@Z?PH\\Nb@`@~@Rf@??`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
-          },
-          "mode" : "BUS",
-          "pathway" : false,
-          "realTime" : false,
-          "route" : "Broadway/Halsey",
-          "routeId" : "prt:77",
-          "routeLongName" : "Broadway/Halsey",
-          "routeShortName" : "77",
-          "routeType" : 3,
-          "serviceDate" : "2009-11-17",
-          "startTime" : "2009-11-17T18:54:29.000+00:00",
-          "steps" : [ ],
-          "to" : {
-            "arrival" : "2009-11-17T19:07:55.000+00:00",
-            "departure" : "2009-11-17T19:07:55.000+00:00",
-            "lat" : 45.531308,
-            "lon" : -122.696445,
-            "name" : "NW Northrup & 22nd",
-            "stopCode" : "10778",
-            "stopId" : "prt:10778",
-            "stopIndex" : 92,
-            "stopSequence" : 93,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "transitLeg" : true,
-          "tripBlockId" : "7702",
-          "tripId" : "prt:771W1180"
-        },
-        {
-          "agencyTimeZoneOffset" : -28800000,
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 18.81,
-          "endTime" : "2009-11-17T19:08:19.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T19:07:55.000+00:00",
-            "departure" : "2009-11-17T19:07:55.000+00:00",
-            "lat" : 45.531308,
-            "lon" : -122.696445,
-            "name" : "NW Northrup & 22nd",
-            "stopCode" : "10778",
-            "stopId" : "prt:10778",
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 37,
-          "interlineWithPreviousLeg" : false,
-          "legGeometry" : {
-            "length" : 7,
-            "points" : "sy{tGxc{kV???LABF?B??J"
-          },
-          "mode" : "WALK",
-          "pathway" : false,
-          "realTime" : false,
-          "rentedBike" : false,
-          "route" : "",
-          "startTime" : "2009-11-17T19:07:55.000+00:00",
-          "steps" : [
-            {
-              "absoluteDirection" : "WEST",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 18.81,
-              "elevation" : "",
-              "lat" : 45.5313019,
-              "lon" : -122.6964448,
-              "relativeDirection" : "DEPART",
-              "stayOn" : false,
-              "streetName" : "Northwest Northrup Street",
-              "walkingBike" : false
-            }
-          ],
-          "to" : {
-            "arrival" : "2009-11-17T19:08:19.000+00:00",
-            "lat" : 45.53122,
-            "lon" : -122.69659,
-            "name" : "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType" : "NORMAL"
-          },
-          "transitLeg" : false,
-          "walkingBike" : false
-        }
-      ],
-      "startTime" : "2009-11-17T18:37:30.000+00:00",
-      "tooSloped" : false,
-      "transfers" : 1,
-      "transitTime" : 1293,
-      "waitingTime" : 208,
-      "walkDistance" : 438.43,
-      "walkLimitExceeded" : false,
-      "walkTime" : 348
     }
   ]
 ]
@@ -3836,6 +3875,642 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedBicycle" : false,
+      "duration" : 2260,
+      "elevationGained" : 0.0,
+      "elevationLost" : 0.0,
+      "endTime" : "2009-11-17T19:07:27.000+00:00",
+      "fare" : {
+        "details" : { },
+        "fare" : { },
+        "legProducts" : [
+          {
+            "legIndices" : [
+              1
+            ],
+            "products" : [
+              {
+                "amount" : {
+                  "cents" : 200,
+                  "currency" : {
+                    "currency" : "USD",
+                    "currencyCode" : "USD",
+                    "defaultFractionDigits" : 2,
+                    "symbol" : "$"
+                  }
+                },
+                "id" : "prt:8",
+                "name" : "regular"
+              }
+            ]
+          },
+          {
+            "legIndices" : [
+              3
+            ],
+            "products" : [
+              {
+                "amount" : {
+                  "cents" : 200,
+                  "currency" : {
+                    "currency" : "USD",
+                    "currencyCode" : "USD",
+                    "defaultFractionDigits" : 2,
+                    "symbol" : "$"
+                  }
+                },
+                "id" : "prt:8",
+                "name" : "regular"
+              }
+            ]
+          }
+        ]
+      },
+      "generalizedCost" : 4058,
+      "legs" : [
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 87.02,
+          "endTime" : "2009-11-17T18:31:00.000+00:00",
+          "from" : {
+            "departure" : "2009-11-17T18:29:47.000+00:00",
+            "lat" : 45.52337,
+            "lon" : -122.653725,
+            "name" : "NE 12th & Couch",
+            "stopCode" : "6577",
+            "stopId" : "prt:6577",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 137,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 9,
+            "points" : "ahztGxxrkV@Sb@?`@@?a@?k@GGKY@A"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:29:47.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "SOUTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 39.06,
+              "elevation" : "",
+              "lat" : 45.5233684,
+              "lon" : -122.6536225,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Northeast 12th Avenue",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "EAST",
+              "area" : false,
+              "bogusName" : true,
+              "distance" : 47.96,
+              "elevation" : "",
+              "lat" : 45.5230172,
+              "lon" : -122.6536338,
+              "relativeDirection" : "LEFT",
+              "stayOn" : false,
+              "streetName" : "path",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:31:00.000+00:00",
+            "departure" : "2009-11-17T18:31:00.000+00:00",
+            "lat" : 45.523103,
+            "lon" : -122.653064,
+            "name" : "NE Sandy & 12th",
+            "stopCode" : "5055",
+            "stopId" : "prt:5055",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        },
+        {
+          "agencyId" : "prt:prt",
+          "agencyName" : "TriMet",
+          "agencyTimeZoneOffset" : -28800000,
+          "agencyUrl" : "http://trimet.org",
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 1883.59,
+          "endTime" : "2009-11-17T18:38:19.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:31:00.000+00:00",
+            "departure" : "2009-11-17T18:31:00.000+00:00",
+            "lat" : 45.523103,
+            "lon" : -122.653064,
+            "name" : "NE Sandy & 12th",
+            "stopCode" : "5055",
+            "stopId" : "prt:5055",
+            "stopIndex" : 84,
+            "stopSequence" : 85,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 1039,
+          "headsign" : "Sherwood via Portland city center",
+          "interlineWithPreviousLeg" : false,
+          "intermediateStops" : [
+            {
+              "arrival" : "2009-11-17T18:31:47.000+00:00",
+              "departure" : "2009-11-17T18:31:47.000+00:00",
+              "lat" : 45.523024,
+              "lon" : -122.656526,
+              "name" : "E Burnside & NE 9th",
+              "stopCode" : "819",
+              "stopId" : "prt:819",
+              "stopIndex" : 85,
+              "stopSequence" : 86,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:32:24.000+00:00",
+              "departure" : "2009-11-17T18:32:24.000+00:00",
+              "lat" : 45.523012,
+              "lon" : -122.659365,
+              "name" : "E Burnside & NE 6th",
+              "stopCode" : "805",
+              "stopId" : "prt:805",
+              "stopIndex" : 86,
+              "stopSequence" : 87,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:32:52.000+00:00",
+              "departure" : "2009-11-17T18:32:52.000+00:00",
+              "lat" : 45.523015,
+              "lon" : -122.661534,
+              "name" : "E Burnside & NE M L King",
+              "stopCode" : "705",
+              "stopId" : "prt:705",
+              "stopIndex" : 87,
+              "stopSequence" : 88,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:35:00.000+00:00",
+              "departure" : "2009-11-17T18:35:00.000+00:00",
+              "lat" : 45.523249,
+              "lon" : -122.671269,
+              "name" : "W Burnside & Burnside Bridge",
+              "stopCode" : "689",
+              "stopId" : "prt:689",
+              "stopIndex" : 88,
+              "stopSequence" : 89,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            }
+          ],
+          "legGeometry" : {
+            "length" : 43,
+            "points" : "weztGdtrkV?BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE\\CPBt@ZvAl@d@R"
+          },
+          "mode" : "BUS",
+          "pathway" : false,
+          "realTime" : false,
+          "route" : "Barbur/Sandy Blvd",
+          "routeId" : "prt:12",
+          "routeLongName" : "Barbur/Sandy Blvd",
+          "routeShortName" : "12",
+          "routeType" : 3,
+          "serviceDate" : "2009-11-17",
+          "startTime" : "2009-11-17T18:31:00.000+00:00",
+          "steps" : [ ],
+          "to" : {
+            "arrival" : "2009-11-17T18:38:19.000+00:00",
+            "departure" : "2009-11-17T18:38:19.000+00:00",
+            "lat" : 45.521958,
+            "lon" : -122.675956,
+            "name" : "SW 5th & Pine",
+            "stopCode" : "7631",
+            "stopId" : "prt:7631",
+            "stopIndex" : 89,
+            "stopSequence" : 90,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "transitLeg" : true,
+          "tripBlockId" : "1235",
+          "tripId" : "prt:120W1270"
+        },
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 534.33,
+          "endTime" : "2009-11-17T18:45:25.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:38:19.000+00:00",
+            "departure" : "2009-11-17T18:38:19.000+00:00",
+            "lat" : 45.521958,
+            "lon" : -122.675956,
+            "name" : "SW 5th & Pine",
+            "stopCode" : "7631",
+            "stopId" : "prt:7631",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "generalizedCost" : 820,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 24,
+            "points" : "e_ztGvcwkVADlAl@NFi@|CAFCJCJCNi@|CCRGXm@lDdCfA]hBo@rDCPADL@H@F@JB@@@K"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T18:38:19.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "SOUTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 47.2,
+              "elevation" : "",
+              "lat" : 45.5219669,
+              "lon" : -122.6759883,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Southwest 5th Avenue",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "SOUTH",
+              "area" : false,
+              "bogusName" : true,
+              "distance" : 9.01,
+              "elevation" : "",
+              "lat" : 45.5215719,
+              "lon" : -122.67621,
+              "relativeDirection" : "CONTINUE",
+              "stayOn" : false,
+              "streetName" : "path",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "WEST",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 243.52,
+              "elevation" : "",
+              "lat" : 45.5214961,
+              "lon" : -122.676251,
+              "relativeDirection" : "RIGHT",
+              "stayOn" : false,
+              "streetName" : "Southwest Oak Street",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "SOUTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 79.59,
+              "elevation" : "",
+              "lat" : 45.5222784,
+              "lon" : -122.6791704,
+              "relativeDirection" : "LEFT",
+              "stayOn" : false,
+              "streetName" : "Southwest Park Avenue",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "WEST",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 129.53,
+              "elevation" : "",
+              "lat" : 45.5216085,
+              "lon" : -122.6795303,
+              "relativeDirection" : "RIGHT",
+              "stayOn" : false,
+              "streetName" : "Southwest Stark Street",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "SOUTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 25.48,
+              "elevation" : "",
+              "lat" : 45.5220244,
+              "lon" : -122.6810834,
+              "relativeDirection" : "LEFT",
+              "stayOn" : false,
+              "streetName" : "Southwest 10th Avenue",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T18:45:25.000+00:00",
+            "departure" : "2009-11-17T18:48:09.000+00:00",
+            "lat" : 45.521786,
+            "lon" : -122.68109,
+            "name" : "SW 10th & Stark",
+            "stopCode" : "10769",
+            "stopId" : "prt:10769",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        },
+        {
+          "agencyId" : "prt:prt",
+          "agencyName" : "TriMet",
+          "agencyTimeZoneOffset" : -28800000,
+          "agencyUrl" : "http://trimet.org",
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 2493.24,
+          "endTime" : "2009-11-17T19:05:00.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T18:45:25.000+00:00",
+            "departure" : "2009-11-17T18:48:09.000+00:00",
+            "lat" : 45.521786,
+            "lon" : -122.68109,
+            "name" : "SW 10th & Stark",
+            "stopCode" : "10769",
+            "stopId" : "prt:10769",
+            "stopIndex" : 12,
+            "stopSequence" : 13,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "0"
+          },
+          "generalizedCost" : 1775,
+          "headsign" : "NW 23rd Ave",
+          "interlineWithPreviousLeg" : false,
+          "intermediateStops" : [
+            {
+              "arrival" : "2009-11-17T18:49:35.000+00:00",
+              "departure" : "2009-11-17T18:49:35.000+00:00",
+              "lat" : 45.523593,
+              "lon" : -122.681083,
+              "name" : "NW 10th & Couch",
+              "stopCode" : "10770",
+              "stopId" : "prt:10770",
+              "stopIndex" : 13,
+              "stopSequence" : 14,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:50:41.000+00:00",
+              "departure" : "2009-11-17T18:50:41.000+00:00",
+              "lat" : 45.525011,
+              "lon" : -122.681113,
+              "name" : "NW 10th & Everett",
+              "stopCode" : "10771",
+              "stopId" : "prt:10771",
+              "stopIndex" : 14,
+              "stopSequence" : 15,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:51:49.000+00:00",
+              "departure" : "2009-11-17T18:51:49.000+00:00",
+              "lat" : 45.526446,
+              "lon" : -122.68118,
+              "name" : "NW 10th & Glisan",
+              "stopCode" : "10772",
+              "stopId" : "prt:10772",
+              "stopIndex" : 15,
+              "stopSequence" : 16,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "0"
+            },
+            {
+              "arrival" : "2009-11-17T18:53:30.000+00:00",
+              "departure" : "2009-11-17T18:53:30.000+00:00",
+              "lat" : 45.528572,
+              "lon" : -122.68125,
+              "name" : "NW 10th & Johnson",
+              "stopCode" : "10773",
+              "stopId" : "prt:10773",
+              "stopIndex" : 16,
+              "stopSequence" : 17,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:55:11.000+00:00",
+              "departure" : "2009-11-17T18:55:11.000+00:00",
+              "lat" : 45.530707,
+              "lon" : -122.68132,
+              "name" : "NW 10th & Marshall",
+              "stopCode" : "10774",
+              "stopId" : "prt:10774",
+              "stopIndex" : 17,
+              "stopSequence" : 18,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:56:52.000+00:00",
+              "departure" : "2009-11-17T18:56:52.000+00:00",
+              "lat" : 45.531534,
+              "lon" : -122.683319,
+              "name" : "NW 12th & Northrup",
+              "stopCode" : "12796",
+              "stopId" : "prt:12796",
+              "stopIndex" : 18,
+              "stopSequence" : 19,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T18:58:00.000+00:00",
+              "departure" : "2009-11-17T19:00:00.000+00:00",
+              "lat" : 45.531503,
+              "lon" : -122.685357,
+              "name" : "NW Northrup & 14th",
+              "stopCode" : "10775",
+              "stopId" : "prt:10775",
+              "stopIndex" : 19,
+              "stopSequence" : 20,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T19:01:26.000+00:00",
+              "departure" : "2009-11-17T19:01:26.000+00:00",
+              "lat" : 45.531434,
+              "lon" : -122.689417,
+              "name" : "NW Northrup & 18th",
+              "stopCode" : "10776",
+              "stopId" : "prt:10776",
+              "stopIndex" : 20,
+              "stopSequence" : 21,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T19:03:13.000+00:00",
+              "departure" : "2009-11-17T19:03:13.000+00:00",
+              "lat" : 45.531346,
+              "lon" : -122.694455,
+              "name" : "NW Northrup & 21st",
+              "stopCode" : "10777",
+              "stopId" : "prt:10777",
+              "stopIndex" : 21,
+              "stopSequence" : 22,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            },
+            {
+              "arrival" : "2009-11-17T19:03:55.000+00:00",
+              "departure" : "2009-11-17T19:03:55.000+00:00",
+              "lat" : 45.531308,
+              "lon" : -122.696445,
+              "name" : "NW Northrup & 22nd",
+              "stopCode" : "10778",
+              "stopId" : "prt:10778",
+              "stopIndex" : 22,
+              "stopSequence" : 23,
+              "vertexType" : "TRANSIT",
+              "zoneId" : "1"
+            }
+          ],
+          "legGeometry" : {
+            "length" : 55,
+            "points" : "e~ytGbdxkV[OQ@{CFa@B{B@??S@mC@Q@eB@??U@mCB{BD??S?mCBmCFyBB??U?kCBsCDsBD??W?kCBBlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKvBE"
+          },
+          "mode" : "TRAM",
+          "pathway" : false,
+          "realTime" : false,
+          "route" : "Portland Streetcar",
+          "routeId" : "prt:193",
+          "routeLongName" : "Portland Streetcar",
+          "routeType" : 0,
+          "serviceDate" : "2009-11-17",
+          "startTime" : "2009-11-17T18:48:09.000+00:00",
+          "steps" : [ ],
+          "to" : {
+            "arrival" : "2009-11-17T19:05:00.000+00:00",
+            "departure" : "2009-11-17T19:05:00.000+00:00",
+            "lat" : 45.530612,
+            "lon" : -122.698688,
+            "name" : "NW 23rd & Marshall",
+            "stopCode" : "8989",
+            "stopId" : "prt:8989",
+            "stopIndex" : 23,
+            "stopSequence" : 24,
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "transitLeg" : true,
+          "tripBlockId" : "9380",
+          "tripId" : "prt:1930W1240"
+        },
+        {
+          "agencyTimeZoneOffset" : -28800000,
+          "arrivalDelay" : 0,
+          "departureDelay" : 0,
+          "distance" : 187.24,
+          "endTime" : "2009-11-17T19:07:27.000+00:00",
+          "from" : {
+            "arrival" : "2009-11-17T19:05:00.000+00:00",
+            "departure" : "2009-11-17T19:05:00.000+00:00",
+            "lat" : 45.530612,
+            "lon" : -122.698688,
+            "name" : "NW 23rd & Marshall",
+            "stopCode" : "8989",
+            "stopId" : "prt:8989",
+            "vertexType" : "TRANSIT",
+            "zoneId" : "1"
+          },
+          "generalizedCost" : 286,
+          "interlineWithPreviousLeg" : false,
+          "legGeometry" : {
+            "length" : 7,
+            "points" : "iu{tGxq{kV?DK?GBwADK?DpH"
+          },
+          "mode" : "WALK",
+          "pathway" : false,
+          "realTime" : false,
+          "rentedBike" : false,
+          "route" : "",
+          "startTime" : "2009-11-17T19:05:00.000+00:00",
+          "steps" : [
+            {
+              "absoluteDirection" : "NORTH",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 60.76,
+              "elevation" : "",
+              "lat" : 45.5306118,
+              "lon" : -122.6987102,
+              "relativeDirection" : "DEPART",
+              "stayOn" : false,
+              "streetName" : "Northwest 23rd Avenue",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "NORTH",
+              "area" : false,
+              "bogusName" : true,
+              "distance" : 7.29,
+              "elevation" : "",
+              "lat" : 45.531153,
+              "lon" : -122.6987606,
+              "relativeDirection" : "CONTINUE",
+              "stayOn" : false,
+              "streetName" : "path",
+              "walkingBike" : false
+            },
+            {
+              "absoluteDirection" : "WEST",
+              "area" : false,
+              "bogusName" : false,
+              "distance" : 119.18,
+              "elevation" : "",
+              "lat" : 45.5312184,
+              "lon" : -122.698768,
+              "relativeDirection" : "LEFT",
+              "stayOn" : false,
+              "streetName" : "Northwest Northrup Street",
+              "walkingBike" : false
+            }
+          ],
+          "to" : {
+            "arrival" : "2009-11-17T19:07:27.000+00:00",
+            "lat" : 45.531,
+            "lon" : -122.70029,
+            "name" : "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType" : "NORMAL"
+          },
+          "transitLeg" : false,
+          "walkingBike" : false
+        }
+      ],
+      "startTime" : "2009-11-17T18:29:47.000+00:00",
+      "tooSloped" : false,
+      "transfers" : 1,
+      "transitTime" : 1450,
+      "waitingTime" : 164,
+      "walkDistance" : 808.59,
+      "walkLimitExceeded" : false,
+      "walkTime" : 646
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle" : false,
       "duration" : 1553,
       "elevationGained" : 0.0,
       "elevationLost" : 0.0,
@@ -4795,533 +5470,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "walkDistance" : 252.2,
       "walkLimitExceeded" : false,
       "walkTime" : 197
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle" : false,
-      "duration" : 1578,
-      "elevationGained" : 0.0,
-      "elevationLost" : 0.0,
-      "endTime" : "2009-11-17T19:25:05.000+00:00",
-      "fare" : {
-        "details" : { },
-        "fare" : { },
-        "legProducts" : [
-          {
-            "legIndices" : [
-              1
-            ],
-            "products" : [
-              {
-                "amount" : {
-                  "cents" : 200,
-                  "currency" : {
-                    "currency" : "USD",
-                    "currencyCode" : "USD",
-                    "defaultFractionDigits" : 2,
-                    "symbol" : "$"
-                  }
-                },
-                "id" : "prt:8",
-                "name" : "regular"
-              }
-            ]
-          },
-          {
-            "legIndices" : [
-              2
-            ],
-            "products" : [
-              {
-                "amount" : {
-                  "cents" : 200,
-                  "currency" : {
-                    "currency" : "USD",
-                    "currencyCode" : "USD",
-                    "defaultFractionDigits" : 2,
-                    "symbol" : "$"
-                  }
-                },
-                "id" : "prt:8",
-                "name" : "regular"
-              }
-            ]
-          }
-        ]
-      },
-      "generalizedCost" : 3015,
-      "legs" : [
-        {
-          "agencyTimeZoneOffset" : -28800000,
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 87.02,
-          "endTime" : "2009-11-17T19:00:00.000+00:00",
-          "from" : {
-            "departure" : "2009-11-17T18:58:47.000+00:00",
-            "lat" : 45.52337,
-            "lon" : -122.653725,
-            "name" : "NE 12th & Couch",
-            "stopCode" : "6577",
-            "stopId" : "prt:6577",
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 137,
-          "interlineWithPreviousLeg" : false,
-          "legGeometry" : {
-            "length" : 9,
-            "points" : "ahztGxxrkV@Sb@?`@@?a@?k@GGKY@A"
-          },
-          "mode" : "WALK",
-          "pathway" : false,
-          "realTime" : false,
-          "rentedBike" : false,
-          "route" : "",
-          "startTime" : "2009-11-17T18:58:47.000+00:00",
-          "steps" : [
-            {
-              "absoluteDirection" : "SOUTH",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 39.06,
-              "elevation" : "",
-              "lat" : 45.5233684,
-              "lon" : -122.6536225,
-              "relativeDirection" : "DEPART",
-              "stayOn" : false,
-              "streetName" : "Northeast 12th Avenue",
-              "walkingBike" : false
-            },
-            {
-              "absoluteDirection" : "EAST",
-              "area" : false,
-              "bogusName" : true,
-              "distance" : 47.96,
-              "elevation" : "",
-              "lat" : 45.5230172,
-              "lon" : -122.6536338,
-              "relativeDirection" : "LEFT",
-              "stayOn" : false,
-              "streetName" : "path",
-              "walkingBike" : false
-            }
-          ],
-          "to" : {
-            "arrival" : "2009-11-17T19:00:00.000+00:00",
-            "departure" : "2009-11-17T19:00:00.000+00:00",
-            "lat" : 45.523103,
-            "lon" : -122.653064,
-            "name" : "NE Sandy & 12th",
-            "stopCode" : "5055",
-            "stopId" : "prt:5055",
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "transitLeg" : false,
-          "walkingBike" : false
-        },
-        {
-          "agencyId" : "prt:prt",
-          "agencyName" : "TriMet",
-          "agencyTimeZoneOffset" : -28800000,
-          "agencyUrl" : "http://trimet.org",
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 3520.32,
-          "endTime" : "2009-11-17T19:12:44.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T19:00:00.000+00:00",
-            "departure" : "2009-11-17T19:00:00.000+00:00",
-            "lat" : 45.523103,
-            "lon" : -122.653064,
-            "name" : "NE Sandy & 12th",
-            "stopCode" : "5055",
-            "stopId" : "prt:5055",
-            "stopIndex" : 94,
-            "stopSequence" : 95,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 1364,
-          "headsign" : "23rd Ave to Tichner",
-          "interlineWithPreviousLeg" : false,
-          "intermediateStops" : [
-            {
-              "arrival" : "2009-11-17T19:00:47.000+00:00",
-              "departure" : "2009-11-17T19:00:47.000+00:00",
-              "lat" : 45.523024,
-              "lon" : -122.656526,
-              "name" : "E Burnside & NE 9th",
-              "stopCode" : "819",
-              "stopId" : "prt:819",
-              "stopIndex" : 95,
-              "stopSequence" : 96,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:01:24.000+00:00",
-              "departure" : "2009-11-17T19:01:24.000+00:00",
-              "lat" : 45.523012,
-              "lon" : -122.659365,
-              "name" : "E Burnside & NE 6th",
-              "stopCode" : "805",
-              "stopId" : "prt:805",
-              "stopIndex" : 96,
-              "stopSequence" : 97,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:01:52.000+00:00",
-              "departure" : "2009-11-17T19:01:52.000+00:00",
-              "lat" : 45.523015,
-              "lon" : -122.661534,
-              "name" : "E Burnside & NE M L King",
-              "stopCode" : "705",
-              "stopId" : "prt:705",
-              "stopIndex" : 97,
-              "stopSequence" : 98,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:04:00.000+00:00",
-              "departure" : "2009-11-17T19:04:00.000+00:00",
-              "lat" : 45.523249,
-              "lon" : -122.671269,
-              "name" : "W Burnside & Burnside Bridge",
-              "stopCode" : "689",
-              "stopId" : "prt:689",
-              "stopIndex" : 98,
-              "stopSequence" : 99,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:05:00.000+00:00",
-              "departure" : "2009-11-17T19:05:00.000+00:00",
-              "lat" : 45.523169,
-              "lon" : -122.675893,
-              "name" : "W Burnside & NW 5th",
-              "stopCode" : "782",
-              "stopId" : "prt:782",
-              "stopIndex" : 99,
-              "stopSequence" : 100,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:06:17.000+00:00",
-              "departure" : "2009-11-17T19:06:17.000+00:00",
-              "lat" : 45.523115,
-              "lon" : -122.678939,
-              "name" : "W Burnside & NW Park",
-              "stopCode" : "716",
-              "stopId" : "prt:716",
-              "stopIndex" : 100,
-              "stopSequence" : 101,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:07:25.000+00:00",
-              "departure" : "2009-11-17T19:07:25.000+00:00",
-              "lat" : 45.523048,
-              "lon" : -122.681606,
-              "name" : "W Burnside & NW 10th",
-              "stopCode" : "10791",
-              "stopId" : "prt:10791",
-              "stopIndex" : 101,
-              "stopSequence" : 102,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:08:14.000+00:00",
-              "departure" : "2009-11-17T19:08:14.000+00:00",
-              "lat" : 45.523,
-              "lon" : -122.683535,
-              "name" : "W Burnside & NW 12th",
-              "stopCode" : "11032",
-              "stopId" : "prt:11032",
-              "stopIndex" : 102,
-              "stopSequence" : 103,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "0"
-            },
-            {
-              "arrival" : "2009-11-17T19:10:09.000+00:00",
-              "departure" : "2009-11-17T19:10:09.000+00:00",
-              "lat" : 45.522985,
-              "lon" : -122.688091,
-              "name" : "W Burnside & NW 17th",
-              "stopCode" : "10809",
-              "stopId" : "prt:10809",
-              "stopIndex" : 103,
-              "stopSequence" : 104,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:11:00.000+00:00",
-              "departure" : "2009-11-17T19:11:00.000+00:00",
-              "lat" : 45.523097,
-              "lon" : -122.690083,
-              "name" : "W Burnside & NW 19th",
-              "stopCode" : "735",
-              "stopId" : "prt:735",
-              "stopIndex" : 104,
-              "stopSequence" : 105,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:11:27.000+00:00",
-              "departure" : "2009-11-17T19:11:27.000+00:00",
-              "lat" : 45.523176,
-              "lon" : -122.692139,
-              "name" : "W Burnside & NW 20th",
-              "stopCode" : "741",
-              "stopId" : "prt:741",
-              "stopIndex" : 105,
-              "stopSequence" : 106,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:11:40.000+00:00",
-              "departure" : "2009-11-17T19:11:40.000+00:00",
-              "lat" : 45.52322,
-              "lon" : -122.69313,
-              "name" : "W Burnside & NW 20th Pl",
-              "stopCode" : "742",
-              "stopId" : "prt:742",
-              "stopIndex" : 106,
-              "stopSequence" : 107,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:12:03.000+00:00",
-              "departure" : "2009-11-17T19:12:03.000+00:00",
-              "lat" : 45.523312,
-              "lon" : -122.694901,
-              "name" : "W Burnside & NW King",
-              "stopCode" : "747",
-              "stopId" : "prt:747",
-              "stopIndex" : 107,
-              "stopSequence" : 108,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            }
-          ],
-          "legGeometry" : {
-            "length" : 90,
-            "points" : "weztGdtrkV?BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC"
-          },
-          "mode" : "BUS",
-          "pathway" : false,
-          "realTime" : false,
-          "route" : "Burnside/Stark",
-          "routeId" : "prt:20",
-          "routeLongName" : "Burnside/Stark",
-          "routeShortName" : "20",
-          "routeType" : 3,
-          "serviceDate" : "2009-11-17",
-          "startTime" : "2009-11-17T19:00:00.000+00:00",
-          "steps" : [ ],
-          "to" : {
-            "arrival" : "2009-11-17T19:12:44.000+00:00",
-            "departure" : "2009-11-17T19:17:51.000+00:00",
-            "lat" : 45.523512,
-            "lon" : -122.698081,
-            "name" : "W Burnside & NW 23rd",
-            "stopCode" : "755",
-            "stopId" : "prt:755",
-            "stopIndex" : 108,
-            "stopSequence" : 109,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "transitLeg" : true,
-          "tripBlockId" : "2038",
-          "tripId" : "prt:200W1230"
-        },
-        {
-          "agencyId" : "prt:prt",
-          "agencyName" : "TriMet",
-          "agencyTimeZoneOffset" : -28800000,
-          "agencyUrl" : "http://trimet.org",
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 981.85,
-          "endTime" : "2009-11-17T19:22:04.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T19:12:44.000+00:00",
-            "departure" : "2009-11-17T19:17:51.000+00:00",
-            "lat" : 45.523512,
-            "lon" : -122.698081,
-            "name" : "W Burnside & NW 23rd",
-            "stopCode" : "755",
-            "stopId" : "prt:755",
-            "stopIndex" : 70,
-            "stopSequence" : 71,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 1160,
-          "headsign" : "27th & Thurman",
-          "interlineWithPreviousLeg" : false,
-          "intermediateStops" : [
-            {
-              "arrival" : "2009-11-17T19:18:53.000+00:00",
-              "departure" : "2009-11-17T19:18:53.000+00:00",
-              "lat" : 45.525416,
-              "lon" : -122.698381,
-              "name" : "NW 23rd & Flanders",
-              "stopCode" : "7157",
-              "stopId" : "prt:7157",
-              "stopIndex" : 71,
-              "stopSequence" : 72,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:19:56.000+00:00",
-              "departure" : "2009-11-17T19:19:56.000+00:00",
-              "lat" : 45.527543,
-              "lon" : -122.698473,
-              "name" : "NW 23rd & Irving",
-              "stopCode" : "7161",
-              "stopId" : "prt:7161",
-              "stopIndex" : 72,
-              "stopSequence" : 73,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            },
-            {
-              "arrival" : "2009-11-17T19:21:00.000+00:00",
-              "departure" : "2009-11-17T19:21:00.000+00:00",
-              "lat" : 45.529681,
-              "lon" : -122.698529,
-              "name" : "NW 23rd & Lovejoy",
-              "stopCode" : "7163",
-              "stopId" : "prt:7163",
-              "stopIndex" : 73,
-              "stopSequence" : 74,
-              "vertexType" : "TRANSIT",
-              "zoneId" : "1"
-            }
-          ],
-          "legGeometry" : {
-            "length" : 22,
-            "points" : "khztGbn{kVAPkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB??S?oCDmCDmCBo@@"
-          },
-          "mode" : "BUS",
-          "pathway" : false,
-          "realTime" : false,
-          "route" : "Belmont/NW 23rd",
-          "routeId" : "prt:15",
-          "routeLongName" : "Belmont/NW 23rd",
-          "routeShortName" : "15",
-          "routeType" : 3,
-          "serviceDate" : "2009-11-17",
-          "startTime" : "2009-11-17T19:17:51.000+00:00",
-          "steps" : [ ],
-          "to" : {
-            "arrival" : "2009-11-17T19:22:04.000+00:00",
-            "departure" : "2009-11-17T19:22:04.000+00:00",
-            "lat" : 45.532159,
-            "lon" : -122.698634,
-            "name" : "NW 23rd & Overton",
-            "stopCode" : "8981",
-            "stopId" : "prt:8981",
-            "stopIndex" : 74,
-            "stopSequence" : 75,
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "transitLeg" : true,
-          "tripBlockId" : "1550",
-          "tripId" : "prt:150W1430"
-        },
-        {
-          "agencyTimeZoneOffset" : -28800000,
-          "arrivalDelay" : 0,
-          "departureDelay" : 0,
-          "distance" : 231.46,
-          "endTime" : "2009-11-17T19:25:05.000+00:00",
-          "from" : {
-            "arrival" : "2009-11-17T19:22:04.000+00:00",
-            "departure" : "2009-11-17T19:22:04.000+00:00",
-            "lat" : 45.532159,
-            "lon" : -122.698634,
-            "name" : "NW 23rd & Overton",
-            "stopCode" : "8981",
-            "stopId" : "prt:8981",
-            "vertexType" : "TRANSIT",
-            "zoneId" : "1"
-          },
-          "generalizedCost" : 353,
-          "interlineWithPreviousLeg" : false,
-          "legGeometry" : {
-            "length" : 10,
-            "points" : "}~{tGnq{kV?LVAF?J?L?rBCLA?RDpH"
-          },
-          "mode" : "WALK",
-          "pathway" : false,
-          "realTime" : false,
-          "rentedBike" : false,
-          "route" : "",
-          "startTime" : "2009-11-17T19:22:04.000+00:00",
-          "steps" : [
-            {
-              "absoluteDirection" : "SOUTH",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 104.46,
-              "elevation" : "",
-              "lat" : 45.5321578,
-              "lon" : -122.6987026,
-              "relativeDirection" : "DEPART",
-              "stayOn" : false,
-              "streetName" : "Northwest 23rd Avenue",
-              "walkingBike" : false
-            },
-            {
-              "absoluteDirection" : "WEST",
-              "area" : false,
-              "bogusName" : false,
-              "distance" : 127.01,
-              "elevation" : "",
-              "lat" : 45.5312188,
-              "lon" : -122.6986675,
-              "relativeDirection" : "RIGHT",
-              "stayOn" : false,
-              "streetName" : "Northwest Northrup Street",
-              "walkingBike" : false
-            }
-          ],
-          "to" : {
-            "arrival" : "2009-11-17T19:25:05.000+00:00",
-            "lat" : 45.531,
-            "lon" : -122.70029,
-            "name" : "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType" : "NORMAL"
-          },
-          "transitLeg" : false,
-          "walkingBike" : false
-        }
-      ],
-      "startTime" : "2009-11-17T18:58:47.000+00:00",
-      "tooSloped" : false,
-      "transfers" : 1,
-      "transitTime" : 1017,
-      "waitingTime" : 307,
-      "walkDistance" : 318.48,
-      "walkLimitExceeded" : false,
-      "walkTime" : 254
     }
   ]
 ]

--- a/application/src/test/resources/speedtest/travelSearch-expected-results-bd.csv
+++ b/application/src/test/resources/speedtest/travelSearch-expected-results-bd.csv
@@ -1,3 +1,3 @@
 tcId,nTransfers,duration,cost,walkDistance,startTime,endTime,agencies,modes,routes,stops,details
-1,0,43m25s,-1,0,12:00:00,12:43:25,,,,,Unknown transit 0tx 43m25s
-2,0,43m25s,-1,0,12:00:00,12:43:25,,,,,Unknown transit 0tx 43m25s
+1,0,42m16s,-1,0,12:00:00,12:42:16,,,,,Unknown transit 0tx 42m16s
+2,0,42m16s,-1,0,12:00:00,12:42:16,,,,,Unknown transit 0tx 42m16s

--- a/application/src/test/resources/speedtest/travelSearch-expected-results-btr.csv
+++ b/application/src/test/resources/speedtest/travelSearch-expected-results-btr.csv
@@ -1,5 +1,3 @@
 tcId,nTransfers,duration,cost,walkDistance,startTime,endTime,agencies,modes,routes,stops,details
-1,0,1h11m14s,-1,0,12:48:46,14:00:00,,,,,Unknown transit 0tx 1h11m14s
-1,1,1h9m14s,-1,0,12:50:46,14:00:00,,,,,Unknown transit 1tx 1h9m14s
-2,0,1h11m14s,-1,0,12:48:46,14:00:00,,,,,Unknown transit 0tx 1h11m14s
-2,1,1h9m14s,-1,0,12:50:46,14:00:00,,,,,Unknown transit 1tx 1h9m14s
+1,0,1h9m14s,-1,0,12:50:46,14:00:00,,,,,Unknown transit 0tx 1h9m14s
+2,0,1h9m14s,-1,0,12:50:46,14:00:00,,,,,Unknown transit 0tx 1h9m14s


### PR DESCRIPTION
### Summary

The Portland graph used for snapshot test was missing generated transfers between stops: this updates the graph building process to use `DirectTransferGenerator`.