### PR TITLE
always include a walk/vehicleRentalState=null state in initial states

### DIFF
--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
@@ -33,7 +33,7 @@ public class VehicleRentalEdge extends Edge {
 
   @Override
   public State[] traverse(State s0) {
-    if (!s0.getRequest().mode().includesRenting()) {
+    if (!s0.getRequest().mode().includesRenting() || s0.getVehicleRentalState() == null) {
       return State.empty();
     }
 

--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -330,7 +330,9 @@ public class StreetEdge
     final StateEditor editor;
 
     final boolean arriveByRental =
-      s0.getRequest().mode().includesRenting() && s0.getRequest().arriveBy();
+      s0.getRequest().mode().includesRenting() &&
+      s0.getRequest().arriveBy() &&
+      s0.getVehicleRentalState() != null;
     if (arriveByRental && tov.rentalTraversalBanned(s0)) {
       return State.empty();
     } else if (arriveByRental && hasStartedWalkingInNoDropOffZoneAndIsExitingIt(s0)) {

--- a/application/src/main/java/org/opentripplanner/street/search/state/StateData.java
+++ b/application/src/main/java/org/opentripplanner/street/search/state/StateData.java
@@ -172,6 +172,7 @@ public class StateData implements Cloneable {
         stationReturnedStateData.vehicleRentalState = HAVE_RENTED;
         stationReturnedStateData.currentMode = TraverseMode.WALK;
         res.add(stationReturnedStateData);
+        res.add(proto.clone());
       } else {
         var beforeRentalStateData = proto.clone();
         beforeRentalStateData.vehicleRentalState = BEFORE_RENTING;

--- a/application/src/test/java/org/opentripplanner/street/integration/BikeRentalTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BikeRentalTest.java
@@ -168,10 +168,10 @@ public class BikeRentalTest extends GraphRoutingTest {
         "null - BEFORE_RENTING - E1 (1,656.14, 828)"
       ),
       List.of(
-        "WALK - HAVE_RENTED - AB street (76.19, 38)",
-        "WALK - HAVE_RENTED - BC street (1,579.95, 790)",
-        "WALK - HAVE_RENTED - CD street (1,655.14, 828)",
-        "null - HAVE_RENTED - E1 (1,656.14, 828)"
+        "WALK - null - AB street (76.19, 38)",
+        "WALK - null - BC street (1,579.95, 790)",
+        "WALK - null - CD street (1,655.14, 828)",
+        "null - null - E1 (1,656.14, 828)"
       )
     );
   }
@@ -450,7 +450,7 @@ public class BikeRentalTest extends GraphRoutingTest {
     );
 
     assertEquals(
-      List.of("WALK - HAVE_RENTED - BC street (1,503.76, 752)"),
+      List.of("WALK - null - BC street (1,503.76, 752)"),
       runStreetSearchAndCreateDescriptor(fromVertex, toVertex, true, setter),
       "arriveBy"
     );

--- a/application/src/test/java/org/opentripplanner/street/search/state/StateTest.java
+++ b/application/src/test/java/org/opentripplanner/street/search/state/StateTest.java
@@ -48,15 +48,24 @@ class StateTest {
     NULL_RENTAL_STATES.add(null);
   }
 
+  static Set<VehicleRentalState> setOfWithNull(VehicleRentalState... states) {
+    var set = new HashSet<VehicleRentalState>();
+    set.add(null);
+    for (var state : states) {
+      set.add(state);
+    }
+    return set;
+  }
+
   static Stream<Arguments> testCases() {
     return Stream.of(
       of(SCOOTER_RENTAL, false, Set.of(BEFORE_RENTING), Set.of(WALK)),
       //FIXME: it's strange that the arriveBy rental searches all start on a bicycle
-      of(SCOOTER_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
+      of(SCOOTER_RENTAL, true, setOfWithNull(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
       of(BIKE_RENTAL, false, Set.of(BEFORE_RENTING), Set.of(WALK)),
-      of(BIKE_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
+      of(BIKE_RENTAL, true, setOfWithNull(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
       of(CAR_RENTAL, false, Set.of(BEFORE_RENTING), Set.of(WALK)),
-      of(CAR_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
+      of(CAR_RENTAL, true, setOfWithNull(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
       of(StreetMode.CAR, false, NULL_RENTAL_STATES, Set.of(CAR)),
       of(BIKE, false, NULL_RENTAL_STATES, Set.of(BICYCLE)),
       of(StreetMode.WALK, false, NULL_RENTAL_STATES, Set.of(TraverseMode.WALK)),


### PR DESCRIPTION
### Summary

Alternative fix for #6054 .

Generate an initial state with currentMode = WALK, vehicleRentalState = null in addition to the others, when requestMode.includesRenting() and arriveBy = true.

I think this solution changes some general assumptions in what states are possible, and should perhaps be discarded purely on that basis. Earlier, I think it was the case that if requestMode.includesRenting(), vehicleRentalState is never null, it's always either BEFORE_RENTING, HAVE_RENTED, RENTING_FROM_STATION, or RENTING_FLOATING, and the expectation was that it is allowed for BEFORE_RENTING or HAVE_RENTED to reach the goal without ever actually have been renting anything, and it's still a success. Now, it can be null, and it is possible that for correctness every state.getRequest().mode().includesRenting() should be state.getRequest().mode().includesRenting() && state.getVehicleRentalState() != null instead. I only changed the one at the beginning of StreetEdge.traverse, and it seems to work, but it feels incomplete.

### Issue

Closes #6054 

### Unit tests

Because of the above mentioned expectation on the link between includesRenting and vehicleRentalState, some unit test changes were forced.

### Documentation

None.

### Changelog

Yes, fixes a real bug.

### Bumping the serialization version id

No.