### PR TITLE
Remove legacy bike access mapping

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/BikeAccessMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/BikeAccessMapper.java
@@ -5,64 +5,23 @@ import org.onebusaway.gtfs.model.Trip;
 import org.opentripplanner.transit.model.network.BikeAccess;
 
 /**
- * Model bike access for GTFS trips.
- * <p>
- * The GTFS bike extensions is originally discussed at: https://groups.google.com/d/msg/gtfs-changes/QqaGOuNmG7o/xyqORy-T4y0J
- * <p>
- * It proposes "route_bikes_allowed" in routes.txt and "trip_bikes_allowed" in trips.txt with the
- * following semantics:
- * <p>
- * 2: bikes allowed<br> 1: no bikes allowed<br> 0: no information (same as field omitted)<br>
- * <p>
- * The values in trips.txt override the values in routes.txt.
- * <p>
- * An alternative proposal is discussed in: https://groups.google.com/d/msg/gtfs-changes/rEiSeKNc4cs/gTTnQ_yXtPgJ
- * <p>
- * Here, the field "bikes_allowed" is used in both routes.txt and trip.txt with the following
- * semantics:
- * <p>
- * 2: no bikes allowed<br> 1: bikes allowed<br> 0: no information (same as field omitted)<br>
- * <p>
- * Here, the 0,1,2 semantics have been changed to match the convention used in the
- * "wheelchair_accessible" field in trips.txt.
- * <p>
- * A number of feeds are still using the original proposal and a number of feeds have been updated
- * to use the new proposal. For now, we support both, using "bikes_allowed" if specified and then
- * "trip_bikes_allowed".
+ * Model bike access for GTFS trips by using the bikes_allowed fields from route and trip.
  */
 class BikeAccessMapper {
 
   public static BikeAccess mapForTrip(Trip rhs) {
-    //noinspection deprecation
-    return mapValues(rhs.getBikesAllowed(), rhs.getTripBikesAllowed());
+    return mapValues(rhs.getBikesAllowed());
   }
 
   public static BikeAccess mapForRoute(Route rhs) {
-    //noinspection deprecation
-    return mapValues(rhs.getBikesAllowed(), rhs.getRouteBikesAllowed());
+    return mapValues(rhs.getBikesAllowed());
   }
 
-  private static BikeAccess mapValues(int bikesAllowed, int legacyBikesAllowed) {
-    if (bikesAllowed != 0) {
-      switch (bikesAllowed) {
-        case 1:
-          return BikeAccess.ALLOWED;
-        case 2:
-          return BikeAccess.NOT_ALLOWED;
-        default:
-          return BikeAccess.UNKNOWN;
-      }
-    } else if (legacyBikesAllowed != 0) {
-      switch (legacyBikesAllowed) {
-        case 1:
-          return BikeAccess.NOT_ALLOWED;
-        case 2:
-          return BikeAccess.ALLOWED;
-        default:
-          return BikeAccess.UNKNOWN;
-      }
-    }
-
-    return BikeAccess.UNKNOWN;
+  private static BikeAccess mapValues(int bikesAllowed) {
+    return switch (bikesAllowed) {
+      case 1 -> BikeAccess.ALLOWED;
+      case 2 -> BikeAccess.NOT_ALLOWED;
+      default -> BikeAccess.UNKNOWN;
+    };
   }
 }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/BikeAccessMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/BikeAccessMapperTest.java
@@ -11,7 +11,6 @@ public class BikeAccessMapperTest {
 
   private static final int BIKES_ALLOWED = 1;
   private static final int BIKES_NOT_ALLOWED = 2;
-  private static final int TRIP_BIKES_NOT_ALLOWED = 1;
 
   @Test
   public void testTripProvidedValues() {

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/BikeAccessMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/BikeAccessMapperTest.java
@@ -11,10 +11,7 @@ public class BikeAccessMapperTest {
 
   private static final int BIKES_ALLOWED = 1;
   private static final int BIKES_NOT_ALLOWED = 2;
-  private static final int TRIP_BIKES_ALLOWED = 2;
   private static final int TRIP_BIKES_NOT_ALLOWED = 1;
-  private static final int ROUTE_BIKES_ALLOWED = 2;
-  private static final int ROUTE_BIKES_NOT_ALLOWED = 1;
 
   @Test
   public void testTripProvidedValues() {
@@ -29,24 +26,11 @@ public class BikeAccessMapperTest {
   }
 
   @Test
-  public void testLegacyTripProvidedValues() {
-    Trip trip = new Trip();
-    assertEquals(BikeAccess.UNKNOWN, BikeAccessMapper.mapForTrip(trip));
-
-    trip.setTripBikesAllowed(TRIP_BIKES_ALLOWED);
-    assertEquals(BikeAccess.ALLOWED, BikeAccessMapper.mapForTrip(trip));
-
-    trip.setTripBikesAllowed(TRIP_BIKES_NOT_ALLOWED);
-    assertEquals(BikeAccess.NOT_ALLOWED, BikeAccessMapper.mapForTrip(trip));
-  }
-
-  @Test
   public void testTripProvidedValuesPrecedence() {
     Trip trip = new Trip();
     assertEquals(BikeAccess.UNKNOWN, BikeAccessMapper.mapForTrip(trip));
 
     trip.setBikesAllowed(BIKES_ALLOWED);
-    trip.setTripBikesAllowed(TRIP_BIKES_NOT_ALLOWED);
     assertEquals(BikeAccess.ALLOWED, BikeAccessMapper.mapForTrip(trip));
   }
 
@@ -60,27 +44,5 @@ public class BikeAccessMapperTest {
 
     route.setBikesAllowed(BIKES_NOT_ALLOWED);
     assertEquals(BikeAccess.NOT_ALLOWED, BikeAccessMapper.mapForRoute(route));
-  }
-
-  @Test
-  public void testLegacyRouteProvidedValues() {
-    Route route = new Route();
-    assertEquals(BikeAccess.UNKNOWN, BikeAccessMapper.mapForRoute(route));
-
-    route.setRouteBikesAllowed(ROUTE_BIKES_ALLOWED);
-    assertEquals(BikeAccess.ALLOWED, BikeAccessMapper.mapForRoute(route));
-
-    route.setRouteBikesAllowed(ROUTE_BIKES_NOT_ALLOWED);
-    assertEquals(BikeAccess.NOT_ALLOWED, BikeAccessMapper.mapForRoute(route));
-  }
-
-  @Test
-  public void testRouteProvidedValuesPrecedence() {
-    Route route = new Route();
-    assertEquals(BikeAccess.UNKNOWN, BikeAccessMapper.mapForRoute(route));
-
-    route.setBikesAllowed(BIKES_ALLOWED);
-    route.setRouteBikesAllowed(ROUTE_BIKES_NOT_ALLOWED);
-    assertEquals(BikeAccess.ALLOWED, BikeAccessMapper.mapForRoute(route));
   }
 }

--- a/application/src/test/resources/gtfs/simple/routes.txt
+++ b/application/src/test/resources/gtfs/simple/routes.txt
@@ -1,13 +1,13 @@
-route_id,route_short_name,route_long_name,route_type,route_bikes_allowed
-1,1,1,3,2
-2,2,2,3,1
+route_id,route_short_name,route_long_name,route_type,bikes_allowed
+1,1,1,3,1
+2,2,2,3,2
 3,3,3,3,
 4,4,4,7,
 5,5,5,2,
 6,6,6,2,
 7,7,7,2,
 8,8,8,3,
-9,9,9,2,2
+9,9,9,2,1
 10,10,10,2,
 11,11,11,2,
 12,12,12,2,

--- a/application/src/test/resources/gtfs/simple/trips.txt
+++ b/application/src/test/resources/gtfs/simple/trips.txt
@@ -1,9 +1,9 @@
-route_id,service_id,trip_id,shape_id,block_id,wheelchair_accessible,trip_bikes_allowed,direction_id,trip_headsign
+route_id,service_id,trip_id,shape_id,block_id,wheelchair_accessible,bikes_allowed,direction_id,trip_headsign
 1,alldays,1.1,,,1,,,foo
 1,alldays,1.2,,,1,,,foo
 1,alldays,1.3,,,1,,,foo
-2,alldays,2.1,,,0,2,,foo
-2,alldays,2.2,,,0,2,,foo
+2,alldays,2.1,,,0,1,,foo
+2,alldays,2.2,,,0,1,,foo
 3,alldays,3.1,,,1,,,foo
 3,alldays,3.2,,,1,,,foo
 4,weekdays,4.1,4,,,,,foo
@@ -15,7 +15,7 @@ route_id,service_id,trip_id,shape_id,block_id,wheelchair_accessible,trip_bikes_a
 6,alldays,6.2,,block.2,,,,foo
 7,alldays,7.2,,block.2,,,,foo
 8,alldays,8.1,,block.2,,,,foo
-9,alldays,9.1,,,,1,,foo
+9,alldays,9.1,,,,2,,foo
 10,alldays,10.1,,,,,,foo
 10,alldays,10.2,,,,,,foo
 10,alldays,10.3,,,,,,foo


### PR DESCRIPTION
### Summary

This removes the parsing of legacy `bikes_allowed` information. The fields `trip_bikes_allowed` and `route_bikes_allowed` were discussed early in the GTFS spec process but have never made it into the specification.

It has been deprecated in onebusaway-gtfs for many years and removed in the latest version.

### Issue

None.

### Unit tests

Existing ones updated.