### PR TITLE
Allow GTFS fuzzy trip matching even when trip descriptor has an id

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -599,6 +599,18 @@ public class DefaultTransitService implements TransitEditorService {
     return getAllTripOnServiceDates().stream().filter(matcher::match).toList();
   }
 
+  @Override
+  public boolean containsTrip(FeedScopedId id) {
+    TimetableSnapshot currentSnapshot = lazyGetTimeTableSnapShot();
+    if (currentSnapshot != null) {
+      Trip trip = currentSnapshot.getRealTimeAddedTrip(id);
+      if (trip != null) {
+        return true;
+      }
+    }
+    return this.timetableRepositoryIndex.containsTrip(id);
+  }
+
   /**
    * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
    * this when doing the issue #3030.

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -167,7 +167,6 @@ public class TimetableRepository implements Serializable {
   public void index() {
     if (index == null) {
       LOG.info("Index timetable repository...");
-      // the transit model indexing updates the site repository index (flex stops added to the stop index)
       this.index = new TimetableRepositoryIndex(this);
       LOG.info("Index timetable repository complete.");
     }

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -166,10 +166,10 @@ public class TimetableRepository implements Serializable {
    */
   public void index() {
     if (index == null) {
-      LOG.info("Index transit model...");
+      LOG.info("Index timetable repository...");
       // the transit model indexing updates the site repository index (flex stops added to the stop index)
       this.index = new TimetableRepositoryIndex(this);
-      LOG.info("Index transit model complete.");
+      LOG.info("Index timetable repository complete.");
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepositoryIndex.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepositoryIndex.java
@@ -161,6 +161,16 @@ class TimetableRepositoryIndex {
     return tripForId.get(tripId);
   }
 
+  /**
+   * Checks if the specified trip is contained within the index.
+   *
+   * @param tripId the identifier of the trip to check
+   * @return true if the trip exists in the index map, false otherwise
+   */
+  boolean containsTrip(FeedScopedId tripId) {
+    return tripForId.containsKey(tripId);
+  }
+
   TripOnServiceDate getTripOnServiceDateForTripAndDay(TripIdAndServiceDate tripIdAndServiceDate) {
     return tripOnServiceDateForTripAndDay.get(tripIdAndServiceDate);
   }

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepositoryIndex.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepositoryIndex.java
@@ -164,7 +164,7 @@ class TimetableRepositoryIndex {
   /**
    * Checks if the specified trip is contained within the index.
    *
-   * @param tripId the identifier of the trip to check
+   * @param tripId the {@link FeedScopedId} of the trip to check
    * @return true if the trip exists in the index map, false otherwise
    */
   boolean containsTrip(FeedScopedId tripId) {

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepositoryIndex.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepositoryIndex.java
@@ -59,7 +59,7 @@ class TimetableRepositoryIndex {
   private FlexIndex flexIndex = null;
 
   TimetableRepositoryIndex(TimetableRepository timetableRepository) {
-    LOG.info("Transit model index init...");
+    LOG.info("Timetable repository index init...");
 
     for (Agency agency : timetableRepository.getAgencies()) {
       this.agencyForId.put(agency.getId(), agency);
@@ -113,7 +113,7 @@ class TimetableRepositoryIndex {
       }
     }
 
-    LOG.info("Transit Model index init complete.");
+    LOG.info("Timetable repository index init complete.");
   }
 
   Agency getAgencyForId(FeedScopedId id) {

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -324,7 +324,7 @@ public interface TransitService {
   /**
    * Checks if a trip with the given ID exists in the model.
    *
-   * @param id the ID of the trip to check
+   * @param id the {@link FeedScopedId} of the trip to check
    * @return true if the trip exists, false otherwise
    */
   boolean containsTrip(FeedScopedId id);

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -320,4 +320,12 @@ public interface TransitService {
    * @return - A list of TripOnServiceDates
    */
   List<TripOnServiceDate> getTripOnServiceDates(TripOnServiceDateRequest request);
+
+  /**
+   * Checks if a trip with the given ID exists in the model.
+   *
+   * @param id the ID of the trip to check
+   * @return true if the trip exists, false otherwise
+   */
+  boolean containsTrip(FeedScopedId id);
 }

--- a/application/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
@@ -36,8 +36,7 @@ public class GtfsRealtimeFuzzyTripMatcher {
 
   public TripDescriptor match(String feedId, TripDescriptor trip) {
     if (
-      trip.hasTripId() &&
-      transitService.getTripForId(new FeedScopedId(feedId, trip.getTripId())) != null
+      trip.hasTripId() && transitService.containsTrip(new FeedScopedId(feedId, trip.getTripId()))
     ) {
       // trip_id already exists
       return trip;

--- a/application/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
@@ -35,7 +35,10 @@ public class GtfsRealtimeFuzzyTripMatcher {
   }
 
   public TripDescriptor match(String feedId, TripDescriptor trip) {
-    if (trip.hasTripId()) {
+    if (
+      trip.hasTripId() &&
+      transitService.getTripForId(new FeedScopedId(feedId, trip.getTripId())) != null
+    ) {
       // trip_id already exists
       return trip;
     }

--- a/application/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.gtfs.mapping.TransitModeMapper;
@@ -153,7 +154,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param updates                       GTFS-RT TripUpdate's that should be applied atomically
    */
   public UpdateResult applyTripUpdates(
-    GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
+    @Nullable GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
     BackwardsDelayPropagationType backwardsDelayPropagationType,
     UpdateIncrementality updateIncrementality,
     List<TripUpdate> updates,

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -166,7 +166,7 @@ class GraphQLIntegrationTest {
       .trip("123")
       .withHeadsign(I18NString.of("Trip Headsign"))
       .build();
-    var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, T11_00);
+    var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, "11:00");
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, DEDUPLICATOR);
     final TripPattern pattern = TEST_MODEL
       .pattern(BUS)

--- a/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
@@ -17,7 +17,7 @@ class TripTimeOnDateTest implements PlanTestConstants {
     var testModel = TimetableRepositoryForTest.of();
     var pattern = testModel.pattern(TransitMode.BUS).build();
     var trip = TimetableRepositoryForTest.trip("123").build();
-    var stopTimes = testModel.stopTimesEvery5Minutes(3, trip, T11_00);
+    var stopTimes = testModel.stopTimesEvery5Minutes(3, trip, "11:00");
 
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
 

--- a/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -56,7 +55,7 @@ class ScheduledTransitLegReferenceTest {
     Trip trip = TimetableRepositoryForTest.trip("1").build();
     var tripTimes = TripTimesFactory.tripTimes(
       trip,
-      TEST_MODEL.stopTimesEvery5Minutes(5, trip, PlanTestConstants.T11_00),
+      TEST_MODEL.stopTimesEvery5Minutes(5, trip, "11:00"),
       new Deduplicator()
     );
     tripTimes.setServiceCode(SERVICE_CODE);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapperTest.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.Timetable;
-import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -38,7 +37,7 @@ public class TripPatternForDateMapperTest {
     var trip = TimetableRepositoryForTest.trip("1").build();
     var tripTimes = TripTimesFactory.tripTimes(
       trip,
-      TEST_MODEL.stopTimesEvery5Minutes(5, trip, PlanTestConstants.T11_00),
+      TEST_MODEL.stopTimesEvery5Minutes(5, trip, "11:00"),
       new Deduplicator()
     );
     tripTimes.setServiceCode(SERVICE_CODE);

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
@@ -228,18 +228,12 @@ public class TimetableRepositoryForTest {
    * <p>
    * The first stop has stop sequence 10, the following one has 20 and so on.
    */
-  public List<StopTime> stopTimesEvery5Minutes(int count, Trip trip, int startTime) {
+  public List<StopTime> stopTimesEvery5Minutes(int count, Trip trip, String time) {
+    var startTime = TimeUtils.time(time);
     return IntStream
       .range(0, count)
       .mapToObj(seq -> stopTime(trip, (seq + 1) * 10, startTime + (seq * 60 * 5)))
       .toList();
-  }
-
-  /**
-   * @see TimetableRepositoryForTest#stopTimesEvery5Minutes(int, Trip, int)
-   */
-  public List<StopTime> stopTimesEvery5Minutes(int count, Trip trip, String startTime) {
-    return stopTimesEvery5Minutes(count, trip, TimeUtils.time(startTime));
   }
 
   public StopPattern stopPattern(int numberOfStops) {

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
@@ -40,6 +40,7 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripBuilder;
 import org.opentripplanner.transit.service.SiteRepository;
 import org.opentripplanner.transit.service.SiteRepositoryBuilder;
+import org.opentripplanner.utils.time.TimeUtils;
 
 /**
  * Test utility class to help construct valid transit model objects.
@@ -232,6 +233,13 @@ public class TimetableRepositoryForTest {
       .range(0, count)
       .mapToObj(seq -> stopTime(trip, (seq + 1) * 10, startTime + (seq * 60 * 5)))
       .toList();
+  }
+
+  /**
+   * @see TimetableRepositoryForTest#stopTimesEvery5Minutes(int, Trip, int)
+   */
+  public List<StopTime> stopTimesEvery5Minutes(int count, Trip trip, String startTime) {
+    return stopTimesEvery5Minutes(count, trip, TimeUtils.time(startTime));
   }
 
   public StopPattern stopPattern(int numberOfStops) {

--- a/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.opentripplanner.transit.model.basic.TransitMode.BUS;
 import static org.opentripplanner.transit.model.basic.TransitMode.FERRY;
 import static org.opentripplanner.transit.model.basic.TransitMode.RAIL;
@@ -16,6 +17,7 @@ import org.opentripplanner.model.RealTimeTripUpdate;
 import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -120,5 +122,10 @@ class DefaultTransitServiceTest {
   void getPatternForStopsWithRealTime() {
     Collection<TripPattern> patternsForStop = service.getPatternsForStop(STOP_B, true);
     assertEquals(Set.of(FERRY_PATTERN, RAIL_PATTERN, REAL_TIME_PATTERN), patternsForStop);
+  }
+
+  @Test
+  void containsTrip() {
+    assertFalse(service.containsTrip(new FeedScopedId("x", "x")));
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
@@ -94,6 +94,27 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
     assertEquals(TRIP_ID, matcher.match(FEED_ID, trip1).getTripId());
   }
 
+  @Test
+  void incorrectRoute() {
+    var matcher = matcher();
+    TripDescriptor trip1 = matchingTripUpdate().setRouteId("does-not-exists").build();
+    assertFalse(matcher.match(FEED_ID, trip1).hasTripId());
+  }
+
+  @Test
+  void incorrectDateFormat() {
+    var matcher = matcher();
+    TripDescriptor trip1 = matchingTripUpdate().setStartDate("ZZZ").build();
+    assertFalse(matcher.match(FEED_ID, trip1).hasTripId());
+  }
+
+  @Test
+  void incorrectDirection() {
+    var matcher = matcher();
+    TripDescriptor trip1 = matchingTripUpdate().setDirectionId(1).build();
+    assertFalse(matcher.match(FEED_ID, trip1).hasTripId());
+  }
+
   public static List<Function<TripDescriptor.Builder, TripDescriptor.Builder>> incompleteDataCases() {
     return List.of(
       TripDescriptor.Builder::clearDirectionId,

--- a/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
@@ -2,47 +2,96 @@ package org.opentripplanner.updater;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.GtfsTest;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.model.calendar.CalendarServiceData;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.SiteRepository;
+import org.opentripplanner.transit.service.SiteRepositoryBuilder;
+import org.opentripplanner.transit.service.TimetableRepository;
 
-public class GtfsRealtimeFuzzyTripMatcherTest extends GtfsTest {
+public class GtfsRealtimeFuzzyTripMatcherTest {
+
+  private static final String ROUTE_ID = "r1";
+  private static final String FEED_ID = TimetableRepositoryForTest.FEED_ID;
+  private static final LocalDate SERVICE_DATE = LocalDate.of(2024, 11, 13);
+  private static final String GTFS_SERVICE_DATE = SERVICE_DATE.toString().replaceAll("-", "");
+  private static final int SERVICE_CODE = 555;
+  private static final SiteRepositoryBuilder siteRepositoryBuilder = SiteRepository.of();
+  private static final TimetableRepositoryForTest TEST_MODEL = new TimetableRepositoryForTest(
+    siteRepositoryBuilder
+  );
+  private static final RegularStop STOP_1 = TEST_MODEL.stop("s1").build();
+  private static final RegularStop STOP_2 = TEST_MODEL.stop("s2").build();
+  private static final TimetableRepository TT_REPO = new TimetableRepository(
+    siteRepositoryBuilder.build(),
+    new Deduplicator()
+  );
+  private static final Route ROUTE = TimetableRepositoryForTest.route(id(ROUTE_ID)).build();
+  private static final Trip TRIP = TimetableRepositoryForTest.trip("t1").build();
+
+  private static final FeedScopedId SERVICE_ID = TimetableRepositoryForTest.id("sid1");
+  private static final String START_TIME = "07:30:00";
+  private static final RealTimeTripTimes TRIP_TIMES = TripTimesFactory.tripTimes(
+    TRIP,
+    TEST_MODEL.stopTimesEvery5Minutes(5, TRIP, START_TIME),
+    new Deduplicator()
+  );
+  private static final TripPattern TRIP_PATTERN = TimetableRepositoryForTest
+    .tripPattern("tp1", ROUTE)
+    .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_1, STOP_2))
+    .withScheduledTimeTableBuilder(builder -> builder.addTripTimes(TRIP_TIMES))
+    .build();
+
+  @BeforeAll
+  static void setup() {
+    TRIP_TIMES.setServiceCode(SERVICE_CODE);
+    CalendarServiceData calendarServiceData = new CalendarServiceData();
+    calendarServiceData.putServiceDatesForServiceId(SERVICE_ID, List.of(SERVICE_DATE));
+    TT_REPO.addTripPattern(TRIP_PATTERN.getId(), TRIP_PATTERN);
+    TT_REPO.getServiceCodes().put(SERVICE_ID, SERVICE_CODE);
+    TT_REPO.updateCalendarServiceData(true, calendarServiceData, DataImportIssueStore.NOOP);
+    TT_REPO.index();
+  }
 
   @Test
-  public void testMatch() {
-    String feedId = timetableRepository.getFeedIds().iterator().next();
-
-    GtfsRealtimeFuzzyTripMatcher matcher = new GtfsRealtimeFuzzyTripMatcher(
-      new DefaultTransitService(timetableRepository)
-    );
+  public void simpleMatch() {
+    var matcher = matcher();
     TripDescriptor trip1 = TripDescriptor
       .newBuilder()
-      .setRouteId("1")
+      .setRouteId(ROUTE_ID)
+      .setDirectionId(2)
+      .setStartTime(START_TIME)
+      .setStartDate(GTFS_SERVICE_DATE)
+      .build();
+    assertEquals(TRIP.getId().getId(), matcher.match(FEED_ID, trip1).getTripId());
+  }
+
+  @Test
+  void noMatch() {
+    // Test matching with "real time", when schedule uses time grater than 24:00
+    var trip1 = TripDescriptor
+      .newBuilder()
+      .setRouteId("4")
       .setDirectionId(0)
-      .setStartTime("06:47:00")
+      .setStartTime("12:00:00")
       .setStartDate("20090915")
       .build();
-    assertEquals("10W1020", matcher.match(feedId, trip1).getTripId());
-    trip1 =
-      TripDescriptor
-        .newBuilder()
-        .setRouteId("4")
-        .setDirectionId(0)
-        .setStartTime("00:02:00")
-        .setStartDate("20090915")
-        .build();
-    assertEquals("40W1890", matcher.match(feedId, trip1).getTripId());
-    // Test matching with "real time", when schedule uses time grater than 24:00
-    trip1 =
-      TripDescriptor
-        .newBuilder()
-        .setRouteId("4")
-        .setDirectionId(0)
-        .setStartTime("12:00:00")
-        .setStartDate("20090915")
-        .build();
     // No departure at this time
     assertFalse(trip1.hasTripId());
     trip1 =
@@ -56,8 +105,7 @@ public class GtfsRealtimeFuzzyTripMatcherTest extends GtfsTest {
     assertFalse(trip1.hasTripId());
   }
 
-  @Override
-  public String getFeedName() {
-    return "portland/portland.gtfs.zip";
+  private static GtfsRealtimeFuzzyTripMatcher matcher() {
+    return new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(TT_REPO));
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
@@ -72,13 +72,14 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
   @Test
   public void simpleMatch() {
     var matcher = matcher();
-    TripDescriptor trip1 = TripDescriptor
-      .newBuilder()
-      .setRouteId(ROUTE_ID)
-      .setDirectionId(2)
-      .setStartTime(START_TIME)
-      .setStartDate(GTFS_SERVICE_DATE)
-      .build();
+    TripDescriptor trip1 = matchingTripUpdate().build();
+    assertEquals(TRIP.getId().getId(), matcher.match(FEED_ID, trip1).getTripId());
+  }
+
+  @Test
+  public void nonExistingTripId() {
+    var matcher = matcher();
+    TripDescriptor trip1 = matchingTripUpdate().setTripId("does-not-exist-in-timetable").build();
     assertEquals(TRIP.getId().getId(), matcher.match(FEED_ID, trip1).getTripId());
   }
 
@@ -107,5 +108,14 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
 
   private static GtfsRealtimeFuzzyTripMatcher matcher() {
     return new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(TT_REPO));
+  }
+
+  private static TripDescriptor.Builder matchingTripUpdate() {
+    return TripDescriptor
+      .newBuilder()
+      .setRouteId(ROUTE_ID)
+      .setDirectionId(2)
+      .setStartTime(START_TIME)
+      .setStartDate(GTFS_SERVICE_DATE);
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
@@ -78,49 +78,49 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
   @Test
   void noTripId() {
     var matcher = matcher();
-    TripDescriptor trip1 = matchingTripUpdate().build();
-    assertEquals(TRIP.getId().getId(), matcher.match(FEED_ID, trip1).getTripId());
+    TripDescriptor trip = matchingTripUpdate().build();
+    assertEquals(TRIP_ID, matcher.match(FEED_ID, trip).getTripId());
   }
 
   @Test
   void tripIdSetButNotInSchedule() {
     var matcher = matcher();
-    TripDescriptor trip1 = matchingTripUpdate().setTripId("does-not-exist-in-schedule").build();
-    assertEquals(TRIP_ID, matcher.match(FEED_ID, trip1).getTripId());
+    TripDescriptor trip = matchingTripUpdate().setTripId("does-not-exist-in-schedule").build();
+    assertEquals(TRIP_ID, matcher.match(FEED_ID, trip).getTripId());
   }
 
   @Test
   void tripIdExistsInSchedule() {
     var matcher = matcher();
-    TripDescriptor trip1 = matchingTripUpdate().setTripId(TRIP_ID).build();
-    assertEquals(TRIP_ID, matcher.match(FEED_ID, trip1).getTripId());
+    TripDescriptor trip = matchingTripUpdate().setTripId(TRIP_ID).build();
+    assertEquals(TRIP_ID, matcher.match(FEED_ID, trip).getTripId());
   }
 
   @Test
   void incorrectRoute() {
     var matcher = matcher();
-    TripDescriptor trip1 = matchingTripUpdate().setRouteId("does-not-exists").build();
-    assertFalse(matcher.match(FEED_ID, trip1).hasTripId());
+    TripDescriptor trip = matchingTripUpdate().setRouteId("does-not-exists").build();
+    assertFalse(matcher.match(FEED_ID, trip).hasTripId());
   }
 
   @Test
   void incorrectDateFormat() {
     var matcher = matcher();
-    TripDescriptor trip1 = matchingTripUpdate().setStartDate("ZZZ").build();
-    assertFalse(matcher.match(FEED_ID, trip1).hasTripId());
+    TripDescriptor trip = matchingTripUpdate().setStartDate("ZZZ").build();
+    assertFalse(matcher.match(FEED_ID, trip).hasTripId());
   }
 
   @Test
   void incorrectDirection() {
     var matcher = matcher();
-    TripDescriptor trip1 = matchingTripUpdate().setDirectionId(1).build();
-    assertFalse(matcher.match(FEED_ID, trip1).hasTripId());
+    TripDescriptor trip = matchingTripUpdate().setDirectionId(1).build();
+    assertFalse(matcher.match(FEED_ID, trip).hasTripId());
   }
 
   @Test
   void noMatch() {
-    // Test matching with "real time", when schedule uses time grater than 24:00
-    var trip1 = TripDescriptor
+    // Test matching with "real time", when schedule uses time greater than 24:00
+    var trip = TripDescriptor
       .newBuilder()
       .setRouteId("4")
       .setDirectionId(0)
@@ -128,8 +128,8 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
       .setStartDate("20090915")
       .build();
     // No departure at this time
-    assertFalse(trip1.hasTripId());
-    trip1 =
+    assertFalse(trip.hasTripId());
+    trip =
       TripDescriptor
         .newBuilder()
         .setRouteId("1")
@@ -137,7 +137,7 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
         .setStartDate("20090915")
         .build();
     // Missing direction id
-    assertFalse(trip1.hasTripId());
+    assertFalse(trip.hasTripId());
   }
 
   @Nested

--- a/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
@@ -46,7 +46,8 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
     new Deduplicator()
   );
   private static final Route ROUTE = TimetableRepositoryForTest.route(id(ROUTE_ID)).build();
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("t1").build();
+  private static final String TRIP_ID = "t1";
+  private static final Trip TRIP = TimetableRepositoryForTest.trip(TRIP_ID).build();
 
   private static final FeedScopedId SERVICE_ID = TimetableRepositoryForTest.id("sid1");
   private static final String START_TIME = "07:30:00";
@@ -73,24 +74,32 @@ public class GtfsRealtimeFuzzyTripMatcherTest {
   }
 
   @Test
-  void simpleMatch() {
+  void noTripId() {
     var matcher = matcher();
     TripDescriptor trip1 = matchingTripUpdate().build();
     assertEquals(TRIP.getId().getId(), matcher.match(FEED_ID, trip1).getTripId());
   }
 
   @Test
-  void nonExistingTripId() {
+  void tripIdSetButNotInSchedule() {
     var matcher = matcher();
-    TripDescriptor trip1 = matchingTripUpdate().setTripId("does-not-exist-in-timetable").build();
-    assertEquals(TRIP.getId().getId(), matcher.match(FEED_ID, trip1).getTripId());
+    TripDescriptor trip1 = matchingTripUpdate().setTripId("does-not-exist-in-schedule").build();
+    assertEquals(TRIP_ID, matcher.match(FEED_ID, trip1).getTripId());
+  }
+
+  @Test
+  void tripIdExistsInSchedule() {
+    var matcher = matcher();
+    TripDescriptor trip1 = matchingTripUpdate().setTripId(TRIP_ID).build();
+    assertEquals(TRIP_ID, matcher.match(FEED_ID, trip1).getTripId());
   }
 
   public static List<Function<TripDescriptor.Builder, TripDescriptor.Builder>> incompleteDataCases() {
     return List.of(
       TripDescriptor.Builder::clearDirectionId,
       TripDescriptor.Builder::clearRouteId,
-      TripDescriptor.Builder::clearStartTime
+      TripDescriptor.Builder::clearStartTime,
+      TripDescriptor.Builder::clearStartDate
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_position/RealtimeVehicleMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_position/RealtimeVehicleMatcherTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.updater.vehicle_position;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.model.plan.PlanTestConstants.T11_00;
 import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.OCCUPANCY;
 import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.POSITION;
 import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.STOP_POSITION;
@@ -92,7 +91,7 @@ public class RealtimeVehicleMatcherTest {
     var trip1 = TimetableRepositoryForTest.trip(tripId).build();
     var trip2 = TimetableRepositoryForTest.trip(secondTripId).build();
 
-    var stopTimes = testModel.stopTimesEvery5Minutes(3, trip1, T11_00);
+    var stopTimes = testModel.stopTimesEvery5Minutes(3, trip1, "11:00");
     var pattern = tripPattern(trip1, stopTimes);
 
     // Map positions to trips in feed


### PR DESCRIPTION
### Summary

It allows the fuzzy trip matching of GTFS-RT trips even when they have a trip id as these often don't match the timetable data.

### Issue

#6226

### Unit tests

The test was rewritten which was the main task here. It used to build a full graph with OSM and GTFS and this was replaced with a much faster setup. Execution time drops from 13s to 30ms.