### PR TITLE
Fix stop index filtering on ServiceJourney Transmodel GraphQL API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
@@ -124,15 +124,19 @@ public class DatedServiceJourneyType {
             List<StopLocation> stops = tripPattern.getStops();
 
             if (first != null && last != null) {
-              throw new AssertException("Both first and last can't be defined simultaneously.");
-            } else if (first != null) {
-              if (first > stops.size()) {
-                return stops.subList(0, first);
-              }
-            } else if (last != null) {
-              if (last > stops.size()) {
-                return stops.subList(stops.size() - last, stops.size());
-              }
+              throw new AssertException(
+                "Both first and last can't be defined simultaneously."
+              );
+            }
+
+            if ((first != null && first < 0) || (last != null && last < 0)) {
+              throw new AssertException("first and last must be positive integers.");
+            }
+
+            if (first != null && first < stops.size()) {
+              return stops.subList(0, first);
+            } else if (last != null && last < stops.size()) {
+              return stops.subList(stops.size() - last, stops.size());
             }
             return stops;
           })

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
@@ -124,9 +124,7 @@ public class DatedServiceJourneyType {
             List<StopLocation> stops = tripPattern.getStops();
 
             if (first != null && last != null) {
-              throw new AssertException(
-                "Both first and last can't be defined simultaneously."
-              );
+              throw new AssertException("Both first and last can't be defined simultaneously.");
             }
 
             if ((first != null && first < 0) || (last != null && last < 0)) {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -218,14 +218,16 @@ public class ServiceJourneyType {
 
             if (first != null && last != null) {
               throw new AssertException("Both first and last can't be defined simultaneously.");
-            } else if (first != null) {
-              if (first > stops.size()) {
-                return stops.subList(0, first);
-              }
-            } else if (last != null) {
-              if (last > stops.size()) {
-                return stops.subList(stops.size() - last, stops.size());
-              }
+            }
+
+            if ((first != null && first < 0) || (last != null && last < 0)) {
+              throw new AssertException("first and last must be positive integers.");
+            }
+
+            if (first != null && first < stops.size()) {
+              return stops.subList(0, first);
+            } else if (last != null && last < stops.size()) {
+              return stops.subList(stops.size() - last, stops.size());
             }
             return stops;
           })

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -210,9 +210,7 @@ public class ServiceJourneyType {
             List<StopLocation> stops = tripPattern.getStops();
 
             if (first != null && last != null) {
-              throw new AssertException(
-                "Both first and last can't be defined simultaneously."
-              );
+              throw new AssertException("Both first and last can't be defined simultaneously.");
             }
 
             if ((first != null && first < 0) || (last != null && last < 0)) {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -210,13 +210,13 @@ public class ServiceJourneyType {
             List<StopLocation> stops = tripPattern.getStops();
 
             if (first != null && last != null) {
-              throw new IllegalArgumentException(
+              throw new AssertException(
                 "Both first and last can't be defined simultaneously."
               );
             }
 
             if ((first != null && first < 0) || (last != null && last < 0)) {
-              throw new IllegalArgumentException("first and last must be positive integers.");
+              throw new AssertException("first and last must be positive integers.");
             }
 
             if (first != null && first < stops.size()) {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -75,13 +75,6 @@ public class ServiceJourneyType {
           )
           .build()
       )
-      //                .field(GraphQLFieldDefinition.newFieldDefinition()
-      //                        .name("serviceAlteration")
-      //                        .type(serviceAlterationEnum)
-      //                        .description("Whether journey is as planned, a cancellation or an extra journey. Default is as planned")
-      //                        .dataFetcher(environment -> (((Trip) trip(environment)).getServiceAlteration()))
-      //                        .build())
-
       .field(
         GraphQLFieldDefinition
           .newFieldDefinition()
@@ -331,17 +324,6 @@ public class ServiceJourneyType {
           )
           .build()
       )
-      //                .field(GraphQLFieldDefinition.newFieldDefinition()
-      //                        .name("keyValues")
-      //                        .description("List of keyValue pairs for the service journey.")
-      //                        .type(new GraphQLList(keyValueType))
-      //                        .dataFetcher(environment -> ((Trip) trip(environment)).getKeyValues())
-      //                        .build())
-      //                .field(GraphQLFieldDefinition.newFieldDefinition()
-      //                        .name("flexibleServiceType")
-      //                        .description("Type of flexible service, or null if service is not flexible.")
-      //                        .type(flexibleServiceTypeEnum)
-      //                        .build())
       .field(
         GraphQLFieldDefinition
           .newFieldDefinition()

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -210,11 +210,13 @@ public class ServiceJourneyType {
             List<StopLocation> stops = tripPattern.getStops();
 
             if (first != null && last != null) {
-              throw new AssertException("Both first and last can't be defined simultaneously.");
+              throw new IllegalArgumentException(
+                "Both first and last can't be defined simultaneously."
+              );
             }
 
             if ((first != null && first < 0) || (last != null && last < 0)) {
-              throw new AssertException("first and last must be positive integers.");
+              throw new IllegalArgumentException("first and last must be positive integers.");
             }
 
             if (first != null && first < stops.size()) {


### PR DESCRIPTION
### Summary

This PR fixes a bug on the quay filter on the serviceJourney GraphQL type: https://github.com/opentripplanner/OpenTripPlanner/blob/46be411361388514c21453e0d6162528d4df8834/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java#L181-L232

The filter was not applied because the comparisons of first and last to the length of the list are reversed. This change flips the comparisons so that they are applied. Also removes some code that was commented out for some reason.

To reproduce the current bug with Entur's data, go to:
https://api.entur.io/graphql-explorer/journey-planner-v3?query=%7BserviceJourney%28id%3A%22KOL%3AServiceJourney%3A1006_240513063897572_2110%22%29%7Bid%20quays%28first%3A1%29%7Bname%7D%7D%7D&variables=

### Unit tests

No unit tests changed but I tested this locally.

### Documentation

The implementation now matches the existing documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opentripplanner/OpenTripPlanner/6251)
<!-- Reviewable:end -->
