### PR TITLE
Set transit-group-priority for requests without via points

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
@@ -199,11 +199,17 @@ public class RaptorRequestMapper<T extends RaptorTripSchedule> {
   }
 
   private boolean hasPassThroughOnly() {
-    return request.getViaLocations().stream().allMatch(ViaLocation::isPassThroughLocation);
+    return (
+      request.isViaSearch() &&
+      request.getViaLocations().stream().allMatch(ViaLocation::isPassThroughLocation)
+    );
   }
 
   private boolean hasViaLocationsOnly() {
-    return request.getViaLocations().stream().noneMatch(ViaLocation::isPassThroughLocation);
+    return (
+      request.isViaSearch() &&
+      request.getViaLocations().stream().noneMatch(ViaLocation::isPassThroughLocation)
+    );
   }
 
   private boolean hasViaLocationsAndPassThroughLocations() {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -88,6 +89,37 @@ class RaptorRequestMapperTest {
       "[(Via A, stops: " + STOP_A.getIndex() + ")]",
       result.multiCriteria().passThroughPoints().toString()
     );
+  }
+
+  @Test
+  void testTransitGroupPriority() {
+    var req = new RouteRequest();
+
+    // Set relax transit-group-priority
+    req.withPreferences(p ->
+      p.withTransit(t -> t.withRelaxTransitGroupPriority(CostLinearFunction.of("30m + 1.2t")))
+    );
+
+    var result = map(req);
+
+    assertFalse(result.multiCriteria().transitPriorityCalculator().isEmpty());
+  }
+
+  @Test
+  void testVisitViaAllowsTransitGroupPriority() {
+    var req = new RouteRequest();
+
+    // Set visit-via and relax transit-group-priority
+    req.setViaLocations(
+      List.of(new VisitViaLocation("Via A", null, List.of(STOP_A.getId()), List.of()))
+    );
+    req.withPreferences(p ->
+      p.withTransit(t -> t.withRelaxTransitGroupPriority(CostLinearFunction.of("30m + 1.2t")))
+    );
+
+    var result = map(req);
+
+    assertFalse(result.multiCriteria().transitPriorityCalculator().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### Summary

Currently `transitGroupPriority` is turned off for non-via requests, due to `hasPassThroughOnly()` being `true` for a request without any via locations:
```
 request.getViaLocations().stream().allMatch(ViaLocation::isPassThroughLocation)
```

This updates `hasPassThroughOnly()` and `hasViaLocationsOnly()` to also check that the request is actually a `isViaSearch()`.
 
### Unit tests

New tests are added to verify that `transitPriorityCalculator()` is set for non-via and visit-via searches.