### PR TITLE
Apply stricter motor vehicle nothrough traffic rules in Finland

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/SafetyValueNormalizer.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/SafetyValueNormalizer.java
@@ -86,8 +86,8 @@ class SafetyValueNormalizer {
     boolean motorVehicleNoThrough = tagMapperForWay.isMotorVehicleThroughTrafficExplicitlyDisallowed(
       way
     );
-    boolean bicycleNoThrough = tagMapperForWay.isBicycleNoThroughTrafficExplicitlyDisallowed(way);
-    boolean walkNoThrough = tagMapperForWay.isWalkNoThroughTrafficExplicitlyDisallowed(way);
+    boolean bicycleNoThrough = tagMapperForWay.isBicycleThroughTrafficExplicitlyDisallowed(way);
+    boolean walkNoThrough = tagMapperForWay.isWalkThroughTrafficExplicitlyDisallowed(way);
 
     if (street != null) {
       double bicycleSafety = wayData.bicycleSafety().forward();

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.osm.tagmapping;
 
-import java.util.Set;
-
 import static org.opentripplanner.osm.wayproperty.MixinPropertiesBuilder.ofWalkSafety;
 import static org.opentripplanner.osm.wayproperty.WayPropertiesBuilder.withModes;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
@@ -10,6 +8,7 @@ import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
 
+import java.util.Set;
 import org.opentripplanner.framework.functional.FunctionUtils.TriFunction;
 import org.opentripplanner.osm.model.OsmWithTags;
 import org.opentripplanner.osm.wayproperty.WayPropertySet;
@@ -27,6 +26,7 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
  * @see OsmTagMapper
  */
 class FinlandMapper extends OsmTagMapper {
+
   private static final Set<String> NOTHROUGH_DRIVING_TAGS = Set.of(
     "parking_aisle",
     "driveway",

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.osm.tagmapping;
 
+import java.util.Set;
+
 import static org.opentripplanner.osm.wayproperty.MixinPropertiesBuilder.ofWalkSafety;
 import static org.opentripplanner.osm.wayproperty.WayPropertiesBuilder.withModes;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
@@ -25,6 +27,13 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
  * @see OsmTagMapper
  */
 class FinlandMapper extends OsmTagMapper {
+  private static final Set<String> NOTHROUGH_DRIVING_TAGS = Set.of(
+    "parking_aisle",
+    "driveway",
+    "alley",
+    "emergency_access",
+    "drive-through"
+  );
 
   @Override
   public void populateProperties(WayPropertySet props) {
@@ -218,5 +227,13 @@ class FinlandMapper extends OsmTagMapper {
   public boolean isWalkNoThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
     String foot = way.getTag("foot");
     return isGeneralNoThroughTraffic(way) || doesTagValueDisallowThroughTraffic(foot);
+  }
+
+  @Override
+  public boolean isMotorVehicleThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
+    if (super.isMotorVehicleThroughTrafficExplicitlyDisallowed(way)) {
+      return true;
+    }
+    return way.isOneOfTags("service", NOTHROUGH_DRIVING_TAGS);
   }
 }

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
@@ -215,7 +215,7 @@ class FinlandMapper extends OsmTagMapper {
   }
 
   @Override
-  public boolean isBicycleNoThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
+  public boolean isBicycleThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
     String bicycle = way.getTag("bicycle");
     return (
       isVehicleThroughTrafficExplicitlyDisallowed(way) ||
@@ -224,7 +224,7 @@ class FinlandMapper extends OsmTagMapper {
   }
 
   @Override
-  public boolean isWalkNoThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
+  public boolean isWalkThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
     String foot = way.getTag("foot");
     return isGeneralNoThroughTraffic(way) || doesTagValueDisallowThroughTraffic(foot);
   }

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
@@ -768,7 +768,7 @@ public class OsmTagMapper {
   /**
    * Returns true if through traffic for bicycle is not allowed.
    */
-  public boolean isBicycleNoThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
+  public boolean isBicycleThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
     String bicycle = way.getTag("bicycle");
     if (bicycle != null) {
       return doesTagValueDisallowThroughTraffic(bicycle);
@@ -780,7 +780,7 @@ public class OsmTagMapper {
   /**
    * Returns true if through traffic for walk is not allowed.
    */
-  public boolean isWalkNoThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
+  public boolean isWalkThroughTrafficExplicitlyDisallowed(OsmWithTags way) {
     String foot = way.getTag("foot");
     if (foot != null) {
       return doesTagValueDisallowThroughTraffic(foot);

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/ConstantSpeedMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/ConstantSpeedMapperTest.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.osm.tagmapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.osm.model.OsmWithTags;
+
+public class ConstantSpeedMapperTest {
+
+  @Test
+  public void constantSpeedCarRouting() {
+    OsmTagMapper osmTagMapper = new ConstantSpeedFinlandMapper(20f);
+
+    var slowWay = new OsmWithTags();
+    slowWay.addTag("highway", "residential");
+    assertEquals(20f, osmTagMapper.getCarSpeedForWay(slowWay, true));
+
+    var fastWay = new OsmWithTags();
+    fastWay.addTag("highway", "motorway");
+    fastWay.addTag("maxspeed", "120 kmph");
+    assertEquals(20f, osmTagMapper.getCarSpeedForWay(fastWay, true));
+  }
+}

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
@@ -1,10 +1,12 @@
 package org.opentripplanner.osm.tagmapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.osm.model.OsmWithTags;
@@ -13,12 +15,15 @@ import org.opentripplanner.osm.wayproperty.WayPropertySet;
 
 public class FinlandMapperTest {
 
-  static WayPropertySet wps = new WayPropertySet();
+  private WayPropertySet wps;
+  private OsmTagMapper mapper;
   static float epsilon = 0.01f;
 
-  static {
-    var source = new FinlandMapper();
-    source.populateProperties(wps);
+  @BeforeEach
+  public void setup() {
+    this.wps = new WayPropertySet();
+    this.mapper = new FinlandMapper();
+    this.mapper.populateProperties(this.wps);
   }
 
   /**
@@ -219,5 +224,27 @@ public class FinlandMapperTest {
     way.addTag("bicycle", "yes");
     wayData = wps.getDataForWay(way);
     assertEquals(wayData.getPermission(), PEDESTRIAN_AND_BICYCLE);
+  }
+
+  @Test
+  public void constantSpeedCarRouting() {
+    OsmTagMapper osmTagMapper = new ConstantSpeedFinlandMapper(20f);
+
+    var slowWay = new OsmWithTags();
+    slowWay.addTag("highway", "residential");
+    assertEquals(20f, osmTagMapper.getCarSpeedForWay(slowWay, true));
+
+    var fastWay = new OsmWithTags();
+    fastWay.addTag("highway", "motorway");
+    fastWay.addTag("maxspeed", "120 kmph");
+    assertEquals(20f, osmTagMapper.getCarSpeedForWay(fastWay, true));
+  }
+
+  @Test
+  public void serviceNoThroughTraffic() {
+    var way = new OsmWay();
+    way.addTag("highway", "residential");
+    way.addTag("service", "driveway");
+    assertTrue(mapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(way));
   }
 }

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
@@ -227,20 +227,6 @@ public class FinlandMapperTest {
   }
 
   @Test
-  public void constantSpeedCarRouting() {
-    OsmTagMapper osmTagMapper = new ConstantSpeedFinlandMapper(20f);
-
-    var slowWay = new OsmWithTags();
-    slowWay.addTag("highway", "residential");
-    assertEquals(20f, osmTagMapper.getCarSpeedForWay(slowWay, true));
-
-    var fastWay = new OsmWithTags();
-    fastWay.addTag("highway", "motorway");
-    fastWay.addTag("maxspeed", "120 kmph");
-    assertEquals(20f, osmTagMapper.getCarSpeedForWay(fastWay, true));
-  }
-
-  @Test
   public void serviceNoThroughTraffic() {
     var way = new OsmWay();
     way.addTag("highway", "residential");

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -34,20 +34,6 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void constantSpeedCarRouting() {
-    OsmTagMapper osmTagMapper = new ConstantSpeedFinlandMapper(20f);
-
-    var slowWay = new OsmWithTags();
-    slowWay.addTag("highway", "residential");
-    assertEquals(20f, osmTagMapper.getCarSpeedForWay(slowWay, true));
-
-    var fastWay = new OsmWithTags();
-    fastWay.addTag("highway", "motorway");
-    fastWay.addTag("maxspeed", "120 kmph");
-    assertEquals(20f, osmTagMapper.getCarSpeedForWay(fastWay, true));
-  }
-
-  @Test
   public void isBicycleNoThroughTrafficExplicitlyDisallowed() {
     OsmTagMapper osmTagMapper = new OsmTagMapper();
     assertTrue(

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -34,23 +34,21 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void isBicycleNoThroughTrafficExplicitlyDisallowed() {
+  public void isBicycleThroughTrafficExplicitlyDisallowed() {
     OsmTagMapper osmTagMapper = new OsmTagMapper();
     assertTrue(
-      osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(way("bicycle", "destination"))
+      osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(way("bicycle", "destination"))
     );
     assertTrue(
-      osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(way("access", "destination"))
+      osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(way("access", "destination"))
     );
   }
 
   @Test
-  public void isWalkNoThroughTrafficExplicitlyDisallowed() {
+  public void isWalkThroughTrafficExplicitlyDisallowed() {
     OsmTagMapper osmTagMapper = new OsmTagMapper();
-    assertTrue(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(way("foot", "destination")));
-    assertTrue(
-      osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(way("access", "destination"))
-    );
+    assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(way("foot", "destination")));
+    assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(way("access", "destination")));
   }
 
   @Test
@@ -61,8 +59,8 @@ public class OsmTagMapperTest {
     tags.addTag("access", "no");
 
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -73,8 +71,8 @@ public class OsmTagMapperTest {
     tags.addTag("access", "private");
 
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -86,8 +84,8 @@ public class OsmTagMapperTest {
     tags.addTag("foot", "yes");
 
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -98,8 +96,8 @@ public class OsmTagMapperTest {
     tags.addTag("vehicle", "destination");
 
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -111,8 +109,8 @@ public class OsmTagMapperTest {
     tags.addTag("motor_vehicle", "designated");
 
     assertFalse(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -124,8 +122,8 @@ public class OsmTagMapperTest {
     tags.addTag("bicycle", "designated");
 
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -137,8 +135,8 @@ public class OsmTagMapperTest {
     tags.addTag("motor_vehicle", "yes");
 
     assertFalse(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -150,8 +148,8 @@ public class OsmTagMapperTest {
     tags.addTag("bicycle", "yes");
 
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   @Test
@@ -163,8 +161,8 @@ public class OsmTagMapperTest {
     tags.addTag("bicycle", "permissive");
 
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(osmTagMapper.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(osmTagMapper.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
   public OsmWithTags way(String key, String value) {


### PR DESCRIPTION
### Summary

According to OSM guide lines, ways tagged as service=parking_aisle,driveway,alley,emergency_access,drive-through are not intended for pass through traffic. It seems that at least in Finland, such ways often lack explicit access restriction tagging (e.g. access=private).

This PR extends the pass through traffic restrictions of Finland tag mapping for car routing to include such service ways. We may consider if the same logic should be applied in the default tag mapper class. 

Two pass through methods are now renamed. Double negation in the names made those hard to understand.

### Unit tests

A test for a service way added.

### Documentation

Self-documenting code.
 