### PR TITLE
Improve performance of speculative rental vehicle use in reverse search

### DIFF
--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -979,6 +979,16 @@ public class StreetEdge
     return (int) (SphericalDistanceLibrary.length(geometry) * 1000);
   }
 
+  /**
+   * Helper method for {@link #splitStatesAfterHavingExitedNoDropOffZoneWhenReverseSearching}.
+   * Create a single new state, exiting a no-drop-off zone, in reverse, and continuing
+   * on a rental vehicle in the named network, or an unknown network if network is null,
+   * unless the named network is not accepted by the {@link RoutingPreferences} given.
+   * @param s0 The parent state (i.e. the following state, as we are in reverse)
+   * @param network Network name, or null if unknown
+   * @param preferences Active {@link RoutingPreferences}
+   * @return Newly generated {@link State}, or null if the state would have been forbidden.
+   */
   private State makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(
     State s0,
     String network,

--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1036,7 +1036,9 @@ public class StreetEdge
       .rentalRestrictions()
       .noDropOffNetworks()
       .stream()
-      .map(network -> makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, network, preferences))
+      .map(network ->
+        makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, network, preferences)
+      )
       .filter(Objects::nonNull)
       .toList();
     var statesStream = states.stream();
@@ -1046,7 +1048,9 @@ public class StreetEdge
       // you have to check in the rental edge if this has search has been started in a no-drop off zone
       statesStream =
         Stream.concat(
-          Stream.of(makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, null, preferences)),
+          Stream.of(
+            makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, null, preferences)
+          ),
           statesStream
         );
     }

--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -977,7 +977,10 @@ public class StreetEdge
     return (int) (SphericalDistanceLibrary.length(geometry) * 1000);
   }
 
-  private State makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(State s0, String network) {
+  private State makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(
+    State s0,
+    String network
+  ) {
     var preferences = s0.getRequest().preferences();
     var edit = doTraverse(s0, TraverseMode.WALK, false);
     if (edit != null) {
@@ -1008,14 +1011,23 @@ public class StreetEdge
    * zone applies to where we pick up a vehicle with a specific network.
    */
   private State[] splitStatesAfterHavingExitedNoDropOffZoneWhenReverseSearching(State s0) {
-    var states = tov.rentalRestrictions().noDropOffNetworks().stream().map(network -> makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, network)).filter(Objects::nonNull).toList();
+    var states = tov
+      .rentalRestrictions()
+      .noDropOffNetworks()
+      .stream()
+      .map(network -> makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, network))
+      .filter(Objects::nonNull)
+      .toList();
     var statesStream = states.stream();
 
     if (!states.isEmpty()) {
       // null is a special rental network that speculatively assumes that you can take any vehicle
       // you have to check in the rental edge if this has search has been started in a no-drop off zone
-      statesStream = Stream.concat(Stream.of(makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, null)),
-        statesStream);
+      statesStream =
+        Stream.concat(
+          Stream.of(makeStateAfterHavingExitedNoDropOffZoneWhenReverseSearching(s0, null)),
+          statesStream
+        );
     }
 
     // Also include a state which continues walking, because the vehicle rental states are

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -13,6 +13,8 @@ import static org.opentripplanner.street.search.TraverseMode.WALK;
 import static org.opentripplanner.street.search.state.VehicleRentalState.HAVE_RENTED;
 import static org.opentripplanner.street.search.state.VehicleRentalState.RENTING_FLOATING;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -213,14 +215,7 @@ class StreetEdgeGeofencingTest {
     public void pickupFloatingVehicleWhenLeavingAZone() {
       var req = defaultArriveByRequest();
 
-      // this is the state that starts inside a restricted zone (no drop off, no traversal or outside business area)
-      // and is walking towards finding a rental vehicle
-      var haveRentedState = State
-        .getInitialStates(Set.of(V2), req)
-        .stream()
-        .filter(s -> s.getVehicleRentalState() == HAVE_RENTED)
-        .findAny()
-        .get();
+      var haveRentedState = makeHaveRentedState(V2, req);
 
       var edge = streetEdge(V1, V2);
       V2.addRentalRestriction(NO_TRAVERSAL);
@@ -244,14 +239,7 @@ class StreetEdgeGeofencingTest {
       V2.addRentalRestriction(NO_DROP_OFF_TIER);
       V2.addRentalRestriction(noDropOffRestriction(NETWORK_BIRD));
 
-      // this is the state that starts inside a no drop off
-      // and is walking towards finding a rental vehicle
-      var haveRentedState = State
-        .getInitialStates(Set.of(V2), req)
-        .stream()
-        .filter(s -> s.getVehicleRentalState() == HAVE_RENTED)
-        .findAny()
-        .get();
+      var haveRentedState = makeHaveRentedState(V2, req);
 
       var edge = streetEdge(V1, V2);
 
@@ -294,11 +282,150 @@ class StreetEdgeGeofencingTest {
        */
     }
 
+    @Test
+    public void pickupFloatingVehiclesWhenStartedInNoDropOffZoneAllNetworksAllowedByDefault() {
+      var states = runTraverse(Collections.emptySet(), Collections.emptySet());
+
+      // Walking, unknown, Tier, Bird. (Order of last two not guaranteed)
+      assertEquals(4, states.length);
+      final State walkState = states[0];
+      assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
+      assertEquals(WALK, walkState.currentMode());
+
+      final State unknownNetworkState = states[1];
+      assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
+      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertNull(unknownNetworkState.getVehicleRentalNetwork());
+
+      final State tierState = Arrays.stream(states).filter(s -> NETWORK_TIER.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
+      assertEquals(BICYCLE, tierState.currentMode());
+
+      final State birdState = Arrays.stream(states).filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
+      assertEquals(BICYCLE, birdState.currentMode());
+    }
+
+    @Test
+    public void pickupFloatingVehiclesWhenStartedInNoDropOffZoneAllNetworksAllowed() {
+      var states = runTraverse(Set.of(NETWORK_TIER, NETWORK_BIRD), Collections.emptySet());
+
+      // Walking, unknown, Tier, Bird. (Order of last two not guaranteed)
+      assertEquals(4, states.length);
+      final State walkState = states[0];
+      assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
+      assertEquals(WALK, walkState.currentMode());
+
+      final State unknownNetworkState = states[1];
+      assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
+      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertNull(unknownNetworkState.getVehicleRentalNetwork());
+
+      final State tierState = Arrays.stream(states).filter(s -> NETWORK_TIER.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
+      assertEquals(BICYCLE, tierState.currentMode());
+
+      final State birdState = Arrays.stream(states).filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
+      assertEquals(BICYCLE, birdState.currentMode());
+    }
+
+    @Test
+    public void pickupFloatingVehiclesWhenStartedInNoDropOffZoneSomeNetworksAllowed() {
+      var states = runTraverse(Set.of(NETWORK_TIER), Collections.emptySet());
+
+      // Walking, unknown, Tier.
+      assertEquals(3, states.length);
+      final State walkState = states[0];
+      assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
+      assertEquals(WALK, walkState.currentMode());
+
+      final State unknownNetworkState = states[1];
+      assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
+      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertNull(unknownNetworkState.getVehicleRentalNetwork());
+
+      final State tierState = states[2];
+      assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
+      assertEquals(BICYCLE, tierState.currentMode());
+      assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
+    }
+
+    @Test
+    public void pickupFloatingVehiclesWhenStartedInNoDropOffZoneAllNetworksBanned() {
+      var states = runTraverse(Collections.emptySet(), Set.of(NETWORK_TIER, NETWORK_BIRD));
+
+      // Should only have a walking state. The unknown network state should only be
+      // generated if there are known network states.
+      assertEquals(1, states.length);
+      final State walkState = states[0];
+      assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
+      assertEquals(WALK, walkState.currentMode());
+    }
+
+    @Test
+    public void pickupFloatingVehiclesWhenStartedInNoDropOffZoneSomeNetworksBanned() {
+      var states = runTraverse(Collections.emptySet(), Set.of(NETWORK_BIRD));
+
+      // Walking state, unknown network state, known network state for Tier (which wasn't banned)
+      assertEquals(3, states.length);
+
+      final State walkState = states[0];
+      assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
+      assertEquals(WALK, walkState.currentMode());
+
+      final State unknownNetworkState = states[1];
+      assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
+      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertNull(unknownNetworkState.getVehicleRentalNetwork());
+
+      final State tierState = states[2];
+      assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
+      assertEquals(BICYCLE, tierState.currentMode());
+      assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
+    }
+
+    private State[] runTraverse(Set<String> allowedNetworks, Set<String> bannedNetworks) {
+      var req = makeArriveByRequest(allowedNetworks, bannedNetworks);
+
+      V2.addRentalRestriction(NO_DROP_OFF_TIER);
+      V2.addRentalRestriction(noDropOffRestriction(NETWORK_BIRD));
+
+      var haveRentedState = makeHaveRentedState(V2, req);
+
+      var edge = streetEdge(V1, V2);
+
+      return edge.traverse(haveRentedState);
+    }
+
+    private static State makeHaveRentedState(Vertex vertex, StreetSearchRequest req) {
+      // this is the state that starts inside a restricted zone
+      // (no drop off, no traversal or outside business area)
+      // and is walking towards finding a rental vehicle
+      return State
+        .getInitialStates(Set.of(vertex), req)
+        .stream()
+        .filter(s -> s.getVehicleRentalState() == HAVE_RENTED)
+        .findAny()
+        .get();
+    }
+
     private static StreetSearchRequest defaultArriveByRequest() {
       return StreetSearchRequest
         .of()
         .withPreferences(p ->
           p.withBike(b -> b.withRental(r -> r.withAllowedNetworks(Set.of(NETWORK_TIER))))
+        )
+        .withMode(StreetMode.SCOOTER_RENTAL)
+        .withArriveBy(true)
+        .build();
+    }
+
+    private static StreetSearchRequest makeArriveByRequest(Set<String> allowedNetworks, Set<String> bannedNetworks) {
+      return StreetSearchRequest
+        .of()
+        .withPreferences(p ->
+          p.withBike(b -> b.withRental(r -> r.withAllowedNetworks(allowedNetworks).withBannedNetworks(bannedNetworks)))
         )
         .withMode(StreetMode.SCOOTER_RENTAL)
         .withArriveBy(true)

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -297,11 +297,19 @@ class StreetEdgeGeofencingTest {
       assertEquals(BICYCLE, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
-      final State tierState = Arrays.stream(states).filter(s -> NETWORK_TIER.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      final State tierState = Arrays
+        .stream(states)
+        .filter(s -> NETWORK_TIER.equals(s.getVehicleRentalNetwork()))
+        .findFirst()
+        .get();
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
       assertEquals(BICYCLE, tierState.currentMode());
 
-      final State birdState = Arrays.stream(states).filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      final State birdState = Arrays
+        .stream(states)
+        .filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork()))
+        .findFirst()
+        .get();
       assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
       assertEquals(BICYCLE, birdState.currentMode());
     }
@@ -321,11 +329,19 @@ class StreetEdgeGeofencingTest {
       assertEquals(BICYCLE, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
-      final State tierState = Arrays.stream(states).filter(s -> NETWORK_TIER.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      final State tierState = Arrays
+        .stream(states)
+        .filter(s -> NETWORK_TIER.equals(s.getVehicleRentalNetwork()))
+        .findFirst()
+        .get();
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
       assertEquals(BICYCLE, tierState.currentMode());
 
-      final State birdState = Arrays.stream(states).filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork())).findFirst().get();
+      final State birdState = Arrays
+        .stream(states)
+        .filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork()))
+        .findFirst()
+        .get();
       assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
       assertEquals(BICYCLE, birdState.currentMode());
     }
@@ -421,11 +437,18 @@ class StreetEdgeGeofencingTest {
         .build();
     }
 
-    private static StreetSearchRequest makeArriveByRequest(Set<String> allowedNetworks, Set<String> bannedNetworks) {
+    private static StreetSearchRequest makeArriveByRequest(
+      Set<String> allowedNetworks,
+      Set<String> bannedNetworks
+    ) {
       return StreetSearchRequest
         .of()
         .withPreferences(p ->
-          p.withBike(b -> b.withRental(r -> r.withAllowedNetworks(allowedNetworks).withBannedNetworks(bannedNetworks)))
+          p.withBike(b ->
+            b.withRental(r ->
+              r.withAllowedNetworks(allowedNetworks).withBannedNetworks(bannedNetworks)
+            )
+          )
         )
         .withMode(StreetMode.SCOOTER_RENTAL)
         .withArriveBy(true)

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -261,7 +261,7 @@ class StreetEdgeGeofencingTest {
 
       // we return 3 states: one for the speculative renting of a vehicle, but with the information
       // of which networks' no-drop-off zones it started in
-      assertEquals(4, states.length);
+      assertEquals(3, states.length);
 
       // first the fallback walk state
       final State walkState = states[0];
@@ -286,16 +286,22 @@ class StreetEdgeGeofencingTest {
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
       assertEquals(Set.of(), tierState.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
 
+      /*
+      * These rental networks are not allowed in the request so they are no longer returned
       final State birdState = states[3];
       assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
       assertEquals(BICYCLE, birdState.currentMode());
       assertEquals(NETWORK_BIRD, birdState.getVehicleRentalNetwork());
       assertEquals(Set.of(), birdState.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
+       */
     }
 
     private static StreetSearchRequest defaultArriveByRequest() {
       return StreetSearchRequest
         .of()
+        .withPreferences(p ->
+          p.withBike(b -> b.withRental(r -> r.withAllowedNetworks(Set.of(NETWORK_TIER))))
+        )
         .withMode(StreetMode.SCOOTER_RENTAL)
         .withArriveBy(true)
         .build();

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -255,7 +255,7 @@ class StreetEdgeGeofencingTest {
       assertEquals(WALK, walkState.currentMode());
 
       // then the speculative renting case for unknown rental network
-      final State speculativeRenting = states[1];
+      final State speculativeRenting = states[2];
       assertEquals(RENTING_FLOATING, speculativeRenting.getVehicleRentalState());
       assertEquals(BICYCLE, speculativeRenting.currentMode());
       // null means that the vehicle has been rented speculatively and the rest of the backwards search
@@ -267,19 +267,11 @@ class StreetEdgeGeofencingTest {
       );
 
       // then the speculative renting cases for specific rental networks
-      final State tierState = states[2];
+      final State tierState = states[1];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
       assertEquals(BICYCLE, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
       assertEquals(Set.of(), tierState.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
-      /*
-      * These rental networks are not allowed in the request so they are no longer returned
-      final State birdState = states[3];
-      assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
-      assertEquals(BICYCLE, birdState.currentMode());
-      assertEquals(NETWORK_BIRD, birdState.getVehicleRentalNetwork());
-      assertEquals(Set.of(), birdState.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
-       */
     }
 
     @Test
@@ -292,7 +284,7 @@ class StreetEdgeGeofencingTest {
       assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
       assertEquals(WALK, walkState.currentMode());
 
-      final State unknownNetworkState = states[1];
+      final State unknownNetworkState = states[3];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
       assertEquals(BICYCLE, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
@@ -324,7 +316,7 @@ class StreetEdgeGeofencingTest {
       assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
       assertEquals(WALK, walkState.currentMode());
 
-      final State unknownNetworkState = states[1];
+      final State unknownNetworkState = states[3];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
       assertEquals(BICYCLE, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
@@ -356,12 +348,12 @@ class StreetEdgeGeofencingTest {
       assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
       assertEquals(WALK, walkState.currentMode());
 
-      final State unknownNetworkState = states[1];
+      final State unknownNetworkState = states[2];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
       assertEquals(BICYCLE, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
-      final State tierState = states[2];
+      final State tierState = states[1];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
       assertEquals(BICYCLE, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
@@ -390,12 +382,12 @@ class StreetEdgeGeofencingTest {
       assertEquals(HAVE_RENTED, walkState.getVehicleRentalState());
       assertEquals(WALK, walkState.currentMode());
 
-      final State unknownNetworkState = states[1];
+      final State unknownNetworkState = states[2];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
       assertEquals(BICYCLE, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
-      final State tierState = states[2];
+      final State tierState = states[1];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
       assertEquals(BICYCLE, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -284,7 +284,6 @@ class StreetEdgeGeofencingTest {
       assertEquals(BICYCLE, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
       assertEquals(Set.of(), tierState.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
-
       /*
       * These rental networks are not allowed in the request so they are no longer returned
       final State birdState = states[3];


### PR DESCRIPTION
### Summary

Do not speculate use of rental networks which are not allowed by the request. They just cause extra states,
which in the end will not reach targets anyway.

### Issue

The speculative fanout of extra rental network states can be massive in pathological cases, and serious
in accidental difficult cases.

### Unit tests

The existing test StreetEdgeGeofencingTest did not find as many new states as it used to, and this
shows exactly what the fix is about. The expectation of the result was changed accordingly.

I can get better code coverage if this is not rejected outright.

### Documentation

No documentation change, no high-level visible behavior state except execution speed.

### Changelog

Could consider skip changelog.

### Bumping the serialization version id

No.