### PR TITLE
Make stop layers clickable again in debug client

### DIFF
--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -62,6 +62,8 @@ class LayerControl implements IControl {
             }
           }
         });
+      // initialize clickable layers (initially stops)
+      this.updateInteractiveLayerIds(map);
     });
 
     return this.container;


### PR DESCRIPTION
### Summary

#6146 introduced a regression: on initial load of the debug client, stop layers (regular, area, group) are not clickable.

Luckily this is easily fixed.