### PR TITLE
Add main operation to startup/shutdown logging

### DIFF
--- a/application/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
+++ b/application/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
@@ -80,7 +80,7 @@ public class OtpProjectInfo implements Serializable {
    * dev-2.x}
    */
   public String getVersionString() {
-    String format = "version: %s, ser.ver.id: %s, commit: %s, branch: %s";
+    String format = "Version: %s, ser.ver.id: %s, commit: %s, branch: %s";
     return String.format(
       format,
       version.version,
@@ -91,8 +91,8 @@ public class OtpProjectInfo implements Serializable {
   }
 
   /**
-   * This method compare the maven project version, an return {@code true} if both are the same. Two
-   * different SNAPSHOT versions are considered the same - work in progress.
+   * This method compares the maven project version, and return {@code true} if both are the same.
+   * Two different SNAPSHOT versions are considered the same version - they are work in progress.
    */
   public boolean sameVersion(OtpProjectInfo other) {
     return this.version.sameVersion(other.version);
@@ -100,8 +100,8 @@ public class OtpProjectInfo implements Serializable {
 
   /**
    * The OTP Serialization version id is used to determine if OTP and a serialized blob(Graph.obj)
-   * of the otp internal model are compatible. This filed is writen into the Graph.obj file header
-   * and checked when loading the graph later.
+   * of the otp internal model are compatible. This field is written into the <em>Graph.obj</em>
+   * file header and checked when loading the graph later.
    */
   public String getOtpSerializationVersionId() {
     return graphFileHeaderInfo.otpSerializationVersionId();

--- a/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -52,7 +52,7 @@ public class OTPMain {
     try {
       Thread.currentThread().setName("main");
       CommandLineParameters params = parseAndValidateCmdLine(args);
-      OtpStartupInfo.logInfo();
+      OtpStartupInfo.logInfo(params.logInfo());
       startOTPServer(params);
     } catch (OtpAppException ae) {
       LOG.error(ae.getMessage(), ae);

--- a/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -52,7 +52,7 @@ public class OTPMain {
     try {
       Thread.currentThread().setName("main");
       CommandLineParameters params = parseAndValidateCmdLine(args);
-      OtpStartupInfo.logInfo(params.logInfo());
+      OtpStartupInfo.logInfo(params.logTaskInfo());
       startOTPServer(params);
     } catch (OtpAppException ae) {
       LOG.error(ae.getMessage(), ae);

--- a/application/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/application/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -34,13 +34,18 @@ public class OtpStartupInfo {
     );
   }
 
-  public static void logInfo() {
+  public static void logInfo(String runInfo) {
     // This is good when aggregating logs across multiple load balanced instances of OTP
     // Hint: a regexp filter like "^OTP (START|SHUTTING)" will list nodes going up/down
-    LOG.info("OTP STARTING UP ({}) using Java {}", projectInfo().getVersionString(), javaVersion());
+    LOG.info(
+      "OTP STARTING UP - {} - {} - Java {}",
+      runInfo,
+      projectInfo().getVersionString(),
+      javaVersion()
+    );
     ApplicationShutdownSupport.addShutdownHook(
       "server-shutdown-info",
-      () -> LOG.info("OTP SHUTTING DOWN ({})", projectInfo().getVersionString())
+      () -> LOG.info("OTP SHUTTING DOWN - {} - {}", runInfo, projectInfo().getVersionString())
     );
     LOG.info(NEW_LINE + "{}", info());
   }

--- a/application/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/application/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -34,18 +34,18 @@ public class OtpStartupInfo {
     );
   }
 
-  public static void logInfo(String runInfo) {
+  public static void logInfo(String cliTaskInfo) {
     // This is good when aggregating logs across multiple load balanced instances of OTP
     // Hint: a regexp filter like "^OTP (START|SHUTTING)" will list nodes going up/down
     LOG.info(
       "OTP STARTING UP - {} - {} - Java {}",
-      runInfo,
+      cliTaskInfo,
       projectInfo().getVersionString(),
       javaVersion()
     );
     ApplicationShutdownSupport.addShutdownHook(
       "server-shutdown-info",
-      () -> LOG.info("OTP SHUTTING DOWN - {} - {}", runInfo, projectInfo().getVersionString())
+      () -> LOG.info("OTP SHUTTING DOWN - {} - {}", cliTaskInfo, projectInfo().getVersionString())
     );
     LOG.info(NEW_LINE + "{}", info());
   }

--- a/application/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
@@ -201,7 +201,7 @@ public class CommandLineParameters {
     return load || (serve && doBuildTransit());
   }
 
-  public String logInfo() {
+  public String logTaskInfo() {
     var mainCommands = new ArrayList<String>();
     if (doBuildStreet() & doBuildTransit()) {
       mainCommands.add("Build Street & Transit Graph");

--- a/application/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
@@ -201,6 +201,21 @@ public class CommandLineParameters {
     return load || (serve && doBuildTransit());
   }
 
+  public String logInfo() {
+    var mainCommands = new ArrayList<String>();
+    if (doBuildStreet() & doBuildTransit()) {
+      mainCommands.add("BUILD STREET & TRANSIT GRAPH");
+    } else if (doBuildStreet()) {
+      mainCommands.add("BUILD STREET GRAPH");
+    } else if (doBuildTransit()) {
+      mainCommands.add("BUILD TRANSIT GRAPH");
+    }
+    if (doServe()) {
+      mainCommands.add("RUN PLANNER");
+    }
+    return String.join(", ", mainCommands);
+  }
+
   /**
    * @param port a port that we plan to bind to
    * @throws ParameterException if that port is not available

--- a/application/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
@@ -204,14 +204,14 @@ public class CommandLineParameters {
   public String logInfo() {
     var mainCommands = new ArrayList<String>();
     if (doBuildStreet() & doBuildTransit()) {
-      mainCommands.add("BUILD STREET & TRANSIT GRAPH");
+      mainCommands.add("Build Street & Transit Graph");
     } else if (doBuildStreet()) {
-      mainCommands.add("BUILD STREET GRAPH");
+      mainCommands.add("Build Street Graph");
     } else if (doBuildTransit()) {
-      mainCommands.add("BUILD TRANSIT GRAPH");
+      mainCommands.add("Build Transit Graph");
     }
     if (doServe()) {
-      mainCommands.add("RUN PLANNER");
+      mainCommands.add("Run Server");
     }
     return String.join(", ", mainCommands);
   }

--- a/application/src/test/java/org/opentripplanner/standalone/config/CommandLineParametersTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/config/CommandLineParametersTest.java
@@ -41,6 +41,8 @@ public class CommandLineParametersTest {
     assertFalse(subject.doLoadStreetGraph());
     assertFalse(subject.doSaveGraph());
     assertFalse(subject.doServe());
+    var ex = assertThrows(ParameterException.class, () -> subject.inferAndValidate());
+    assertEquals("Nothing to do. Use --help to see available options.", ex.getMessage());
   }
 
   @Test
@@ -50,6 +52,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doBuildTransit());
     assertFalse(subject.doSaveGraph());
     assertFalse(subject.doServe());
+    assertEquals("BUILD STREET & TRANSIT GRAPH", subject.logInfo());
 
     subject.save = true;
     subject.serve = false;
@@ -58,6 +61,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doSaveGraph());
     assertFalse(subject.doServe());
     subject.inferAndValidate();
+    assertEquals("BUILD STREET & TRANSIT GRAPH", subject.logInfo());
 
     subject.save = false;
     subject.serve = true;
@@ -66,6 +70,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doSaveGraph());
     assertTrue(subject.doServe());
     subject.inferAndValidate();
+    assertEquals("BUILD STREET & TRANSIT GRAPH, RUN PLANNER", subject.logInfo());
 
     subject.save = true;
     subject.serve = true;
@@ -74,6 +79,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doSaveGraph());
     assertTrue(subject.doServe());
     subject.inferAndValidate();
+    assertEquals("BUILD STREET & TRANSIT GRAPH, RUN PLANNER", subject.logInfo());
   }
 
   @Test
@@ -83,6 +89,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doBuildTransit());
     assertTrue(subject.doSaveStreetGraph());
     assertFalse(subject.doSaveGraph());
+    assertEquals("BUILD STREET GRAPH", subject.logInfo());
   }
 
   @Test
@@ -90,6 +97,7 @@ public class CommandLineParametersTest {
     subject.load = true;
     assertTrue(subject.doLoadGraph());
     assertTrue(subject.doServe());
+    assertEquals("RUN PLANNER", subject.logInfo());
   }
 
   @Test
@@ -99,6 +107,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doBuildStreet());
     assertFalse(subject.doSaveStreetGraph());
     assertFalse(subject.doSaveGraph());
+    assertEquals("BUILD TRANSIT GRAPH", subject.logInfo());
 
     subject.save = true;
     subject.serve = true;
@@ -119,6 +128,7 @@ public class CommandLineParametersTest {
 
     // Implicit given, but should be ok to set
     subject.serve = true;
+    assertEquals("RUN PLANNER", subject.logInfo());
 
     // No exception thrown
     subject.inferAndValidate();

--- a/application/src/test/java/org/opentripplanner/standalone/config/CommandLineParametersTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/config/CommandLineParametersTest.java
@@ -52,7 +52,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doBuildTransit());
     assertFalse(subject.doSaveGraph());
     assertFalse(subject.doServe());
-    assertEquals("BUILD STREET & TRANSIT GRAPH", subject.logInfo());
+    assertEquals("Build Street & Transit Graph", subject.logInfo());
 
     subject.save = true;
     subject.serve = false;
@@ -61,7 +61,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doSaveGraph());
     assertFalse(subject.doServe());
     subject.inferAndValidate();
-    assertEquals("BUILD STREET & TRANSIT GRAPH", subject.logInfo());
+    assertEquals("Build Street & Transit Graph", subject.logInfo());
 
     subject.save = false;
     subject.serve = true;
@@ -70,7 +70,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doSaveGraph());
     assertTrue(subject.doServe());
     subject.inferAndValidate();
-    assertEquals("BUILD STREET & TRANSIT GRAPH, RUN PLANNER", subject.logInfo());
+    assertEquals("Build Street & Transit Graph, Run Server", subject.logInfo());
 
     subject.save = true;
     subject.serve = true;
@@ -79,7 +79,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doSaveGraph());
     assertTrue(subject.doServe());
     subject.inferAndValidate();
-    assertEquals("BUILD STREET & TRANSIT GRAPH, RUN PLANNER", subject.logInfo());
+    assertEquals("Build Street & Transit Graph, Run Server", subject.logInfo());
   }
 
   @Test
@@ -89,7 +89,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doBuildTransit());
     assertTrue(subject.doSaveStreetGraph());
     assertFalse(subject.doSaveGraph());
-    assertEquals("BUILD STREET GRAPH", subject.logInfo());
+    assertEquals("Build Street Graph", subject.logInfo());
   }
 
   @Test
@@ -97,7 +97,7 @@ public class CommandLineParametersTest {
     subject.load = true;
     assertTrue(subject.doLoadGraph());
     assertTrue(subject.doServe());
-    assertEquals("RUN PLANNER", subject.logInfo());
+    assertEquals("Run Server", subject.logInfo());
   }
 
   @Test
@@ -107,7 +107,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doBuildStreet());
     assertFalse(subject.doSaveStreetGraph());
     assertFalse(subject.doSaveGraph());
-    assertEquals("BUILD TRANSIT GRAPH", subject.logInfo());
+    assertEquals("Build Transit Graph", subject.logInfo());
 
     subject.save = true;
     subject.serve = true;
@@ -128,7 +128,7 @@ public class CommandLineParametersTest {
 
     // Implicit given, but should be ok to set
     subject.serve = true;
-    assertEquals("RUN PLANNER", subject.logInfo());
+    assertEquals("Run Server", subject.logInfo());
 
     // No exception thrown
     subject.inferAndValidate();

--- a/application/src/test/java/org/opentripplanner/standalone/config/CommandLineParametersTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/config/CommandLineParametersTest.java
@@ -52,7 +52,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doBuildTransit());
     assertFalse(subject.doSaveGraph());
     assertFalse(subject.doServe());
-    assertEquals("Build Street & Transit Graph", subject.logInfo());
+    assertEquals("Build Street & Transit Graph", subject.logTaskInfo());
 
     subject.save = true;
     subject.serve = false;
@@ -61,7 +61,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doSaveGraph());
     assertFalse(subject.doServe());
     subject.inferAndValidate();
-    assertEquals("Build Street & Transit Graph", subject.logInfo());
+    assertEquals("Build Street & Transit Graph", subject.logTaskInfo());
 
     subject.save = false;
     subject.serve = true;
@@ -70,7 +70,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doSaveGraph());
     assertTrue(subject.doServe());
     subject.inferAndValidate();
-    assertEquals("Build Street & Transit Graph, Run Server", subject.logInfo());
+    assertEquals("Build Street & Transit Graph, Run Server", subject.logTaskInfo());
 
     subject.save = true;
     subject.serve = true;
@@ -79,7 +79,7 @@ public class CommandLineParametersTest {
     assertTrue(subject.doSaveGraph());
     assertTrue(subject.doServe());
     subject.inferAndValidate();
-    assertEquals("Build Street & Transit Graph, Run Server", subject.logInfo());
+    assertEquals("Build Street & Transit Graph, Run Server", subject.logTaskInfo());
   }
 
   @Test
@@ -89,7 +89,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doBuildTransit());
     assertTrue(subject.doSaveStreetGraph());
     assertFalse(subject.doSaveGraph());
-    assertEquals("Build Street Graph", subject.logInfo());
+    assertEquals("Build Street Graph", subject.logTaskInfo());
   }
 
   @Test
@@ -97,7 +97,7 @@ public class CommandLineParametersTest {
     subject.load = true;
     assertTrue(subject.doLoadGraph());
     assertTrue(subject.doServe());
-    assertEquals("Run Server", subject.logInfo());
+    assertEquals("Run Server", subject.logTaskInfo());
   }
 
   @Test
@@ -107,7 +107,7 @@ public class CommandLineParametersTest {
     assertFalse(subject.doBuildStreet());
     assertFalse(subject.doSaveStreetGraph());
     assertFalse(subject.doSaveGraph());
-    assertEquals("Build Transit Graph", subject.logInfo());
+    assertEquals("Build Transit Graph", subject.logTaskInfo());
 
     subject.save = true;
     subject.serve = true;
@@ -128,7 +128,7 @@ public class CommandLineParametersTest {
 
     // Implicit given, but should be ok to set
     subject.serve = true;
-    assertEquals("Run Server", subject.logInfo());
+    assertEquals("Run Server", subject.logTaskInfo());
 
     // No exception thrown
     subject.inferAndValidate();

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -144,7 +144,7 @@ public class SpeedTest {
 
   public static void main(String[] args) {
     try {
-      OtpStartupInfo.logInfo();
+      OtpStartupInfo.logInfo("Run SpeedTest");
       // Given the following setup
       SpeedTestCmdLineOpts opts = new SpeedTestCmdLineOpts(args);
       var config = SpeedTestConfig.config(opts.rootDir());

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -144,7 +144,7 @@ public class SpeedTest {
 
   public static void main(String[] args) {
     try {
-      OtpStartupInfo.logInfo("Run SpeedTest");
+      OtpStartupInfo.logInfo("Run Speed Test");
       // Given the following setup
       SpeedTestCmdLineOpts opts = new SpeedTestCmdLineOpts(args);
       var config = SpeedTestConfig.config(opts.rootDir());


### PR DESCRIPTION
### Summary

This small PR add the main operations OTP is instructed to do from the command line to the startup and shutdown log events. The new log event lok like this:


#### Startup excamples
```
14:21:36.700 INFO [main]  (OtpStartupInfo.java:40) OTP STARTING UP - Build Street Graph - version: 2.7.0-SNAPSHOT ...
14:29:19.308 INFO [main]  (OtpStartupInfo.java:40) OTP STARTING UP - Build Transit Graph - version: 2.7.0-SNAPSHOT ...
14:33:49.023 INFO [main]  (OtpStartupInfo.java:40) OTP STARTING UP - Build Street & Transit Graph - version: 2.7.0-SNAPSHOT ...
14:34:28.785 INFO [main]  (OtpStartupInfo.java:40) OTP STARTING UP - Run Planner - version: 2.7.0-SNAPSHOT ...
14:35:17.095 INFO [main]  (OtpStartupInfo.java:40) OTP STARTING UP - Build Street & Transit Graph, Run Planner - version: 2.7.0-SNAPSHOT ...
```


#### Shutdown examples
```
14:29:19.416 INFO [server-shutdown-info]  (OtpStartupInfo.java:48) OTP SHUTTING DOWN - Build Transit Graph - version: 2.7.0-SNAPSHOT ...
14:35:44.038 INFO [server-shutdown-info]  (OtpStartupInfo.java:48) OTP SHUTTING DOWN - Build Street & Transit Graph, Run Planner - version: 2.7.0-SNAPSHOT ...
```

The use-case we have for this is that we build both street-graph and transit-graph in the same cluster and the logs end up in the same aggregated logs. To find the right OTP brah builder I first have to look at the startup log message, then filter on this node and sjekkthe other events if it is building the street-graph or transit-graph. So, by adding the main operations OTP is about to perform I can skip the second step and find the right OTP instance just by looking at the OTP STARTING UP log events. 


### Unit tests
✅  Unit tests improved for CommandLineArgumants

### Documentation
🟥  No doc on this

### Changelog

🟥  This feature is too small

### Bumping the serialization version id

🟥  Not needed
