### PR TITLE
Improve visibility of map lines in debug UI

### DIFF
--- a/client/src/components/MapView/LegLines.tsx
+++ b/client/src/components/MapView/LegLines.tsx
@@ -28,8 +28,19 @@ export function LegLines({ tripPattern }: { tripPattern?: TripPattern }) {
                   'line-cap': 'round',
                 }}
                 paint={{
-                  'line-color': getColorForLeg(leg),
+                  'line-color': '#000',
                   'line-width': 5,
+                }}
+              />
+              <Layer
+                type="line"
+                layout={{
+                  'line-join': 'round',
+                  'line-cap': 'round',
+                }}
+                paint={{
+                  'line-color': getColorForLeg(leg),
+                  'line-width': 4,
                 }}
               />
             </Source>

--- a/client/src/util/getColorForLeg.ts
+++ b/client/src/util/getColorForLeg.ts
@@ -8,7 +8,7 @@ const getColorForMode = function (mode: Mode) {
   if (mode === Mode.Rail) return '#86BF8B';
   if (mode === Mode.Coach) return '#25642A';
   if (mode === Mode.Metro) return '#D9B250';
-  if (mode === Mode.Bus) return '#25642A';
+  if (mode === Mode.Bus) return '#fe0000';
   if (mode === Mode.Tram) return '#D9B250';
   if (mode === Mode.Trolleybus) return '#25642A';
   if (mode === Mode.Water) return '#81304C';


### PR DESCRIPTION
### Summary

@t2gran has complained that the fallback colours for transit legs in the debug UI can be hard to see. For this reason I added an outline to those lines.

### Before

![Screenshot From 2024-11-20 15-10-10](https://github.com/user-attachments/assets/3c32b121-1da5-4f94-8ef5-eb3c2592d5a7)

### After

![Screenshot From 2024-11-20 15-10-18](https://github.com/user-attachments/assets/51d6e52e-dea8-4653-9363-9bf7744c0e04)