### PR TITLE
Split the shaded jar out of application

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -8,7 +8,7 @@
         <artifactId>otp-root</artifactId>
         <version>2.7.0-SNAPSHOT</version>
     </parent>
-    <artifactId>otp</artifactId>
+    <artifactId>application</artifactId>
     <name>OpenTripPlanner - Application</name>
 
     <dependencies>
@@ -20,12 +20,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>otp-utils</artifactId>
+            <artifactId>utils</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>otp-raptor</artifactId>
+            <artifactId>raptor</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -452,81 +452,6 @@
                                 <source>src/test/java</source>
                                 <source>src/ext-test/java</source>
                             </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--
-             There used to be a dependency-plugin:copy-dependencies plugin entry here, but the
-             shade-plugin will explode the dependencies even if they aren't manually copied in.
-            -->
-            <plugin>
-                <!-- We want to create a standalone jar that can be run on the command
-                  line. Java does not really allow this - you cannot place jars inside of jars.
-                  You must either provide all the dependency jars to the user (usually lib/
-                  under the directory containing the runnable jar) or explode all the jars
-                  and repackage them into a single jar. The problem is that while class files
-                  are nicely organized into the package namespace and should not collide, the
-                  META-INF directories of the jars will collide. Maven's standard assembly
-                  plugin does not account for this and will just clobber metadata. This then
-                  causes runtime errors, particularly with Spring. Instead, we use the shade
-                  plugin which has transformers that will for example append files of the same
-                  name rather than overwrite them in the combined JAR. NB: Don't use a version
-                  of the shade plugin older than 1.3.2, as it fixed MSHADE-76 (files not merged
-                  properly if some input files are missing a terminating newline) -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <filters>
-                                <filter>
-                                    <!-- exclude signatures from merged JAR to avoid invalid signature messages -->
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <!-- The shaded JAR will not be the main artifact for the project, it will be attached
-                              for deployment in the way source and docs are. -->
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>shaded</shadedClassifierName>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <!-- MinimizeJar removes unused classes, (classes not imported explicitly by name).
-                              We have eliminated most Jersey auto-scanning, but there is still some need for include
-                              filters to force-include classes that are dynamically loaded by name/auto-scanned. -->
-                            <!-- This roughly halves the size of the OTP JAR, bringing it down to around 20 MB.
-                              <minimizeJar>true</minimizeJar>
-                              <filters> <filter> <artifact>com.sun.jersey:*</artifact> <includes> <include>**</include>
-                              </includes> </filter> <filter> <artifact>org.opentripplanner:*</artifact>
-                              <includes> <include>**</include> </includes> </filter> </filters> -->
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <manifestEntries>
-                                        <Main-Class>org.opentripplanner.standalone.OTPMain</Main-Class>
-                                        <!-- The ImageIO lines allow some image reader plugins to work
-                                             https://stackoverflow.com/questions/7051603/jai-vendorname-null#18495658 -->
-                                        <Specification-Title>Java Advanced Imaging Image I/O
-                                            Tools
-                                        </Specification-Title>
-                                        <Specification-Version>1.1</Specification-Version>
-                                        <Specification-Vendor>Sun Microsystems, Inc.</Specification-Vendor>
-                                        <Implementation-Title>com.sun.media.imageio</Implementation-Title>
-                                        <Implementation-Version>1.1</Implementation-Version>
-                                        <Implementation-Vendor>Sun Microsystems, Inc.</Implementation-Vendor>
-                                        <Extension-Name>com.sun.media.imageio</Extension-Name>
-                                    </manifestEntries>
-                                </transformer>
-                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,10 @@
     </distributionManagement>
 
     <modules>
-        <module>application</module>
-        <module>gtfs-realtime-protobuf</module>
         <module>utils</module>
         <module>raptor</module>
+        <module>gtfs-realtime-protobuf</module>
+        <module>application</module>
         <module>shaded-jar</module>
     </modules>
 
@@ -132,7 +132,6 @@
                             <OTP-Serialization-Version-Id>${otp.serialization.version.id}</OTP-Serialization-Version-Id>
                         </manifestEntries>
                     </archive>
-                    <skipIfEmpty>true</skipIfEmpty>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,17 @@
         <module>shaded-jar</module>
     </modules>
 
+
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.6.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <module>gtfs-realtime-protobuf</module>
         <module>utils</module>
         <module>raptor</module>
+        <module>shaded-jar</module>
     </modules>
 
     <build>
@@ -131,6 +132,7 @@
                             <OTP-Serialization-Version-Id>${otp.serialization.version.id}</OTP-Serialization-Version-Id>
                         </manifestEntries>
                     </archive>
+                    <skipIfEmpty>true</skipIfEmpty>
                 </configuration>
                 <executions>
                     <execution>
@@ -143,6 +145,7 @@
                         <configuration>
                             <classesDirectory>${basedir}/doc/javadoc</classesDirectory>
                             <classifier>javadoc</classifier>
+                            <skipIfEmpty>true</skipIfEmpty>
                         </configuration>
                     </execution>
                 </executions>

--- a/raptor/pom.xml
+++ b/raptor/pom.xml
@@ -9,7 +9,7 @@
         <version>2.7.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>otp-raptor</artifactId>
+    <artifactId>raptor</artifactId>
     <name>OpenTripPlanner - Raptor</name>
 
     <dependencies>

--- a/raptor/pom.xml
+++ b/raptor/pom.xml
@@ -17,7 +17,7 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>otp-utils</artifactId>
+            <artifactId>utils</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/shaded-jar/pom.xml
+++ b/shaded-jar/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.opentripplanner</groupId>
+        <artifactId>otp-root</artifactId>
+        <version>2.7.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>shaded-jar</artifactId>
+    <packaging>pom</packaging>
+    <name>OpenTripPlanner - Shaded Jar</name>
+
+    <properties>
+        <maven.source>skip</maven.source>
+    </properties>
+
+    <dependencies>
+        <!-- project dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>application</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- finalName>otp-${project.version}-shaded</finalName -->
+        <plugins>
+            <!--
+             There used to be a dependency-plugin:copy-dependencies plugin entry here, but the
+             shade-plugin will explode the dependencies even if they aren't manually copied in.
+            -->
+            <plugin>
+                <!-- We want to create a standalone jar that can be run on the command
+                  line. Java does not really allow this - you cannot place jars inside of jars.
+                  You must either provide all the dependency jars to the user (usually lib/
+                  under the directory containing the runnable jar) or explode all the jars
+                  and repackage them into a single jar. The problem is that while class files
+                  are nicely organized into the package namespace and should not collide, the
+                  META-INF directories of the jars will collide. Maven's standard assembly
+                  plugin does not account for this and will just clobber metadata. This then
+                  causes runtime errors, particularly with Spring. Instead, we use the shade
+                  plugin which has transformers that will for example append files of the same
+                  name rather than overwrite them in the combined JAR. NB: Don't use a version
+                  of the shade plugin older than 1.3.2, as it fixed MSHADE-76 (files not merged
+                  properly if some input files are missing a terminating newline) -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <!--
+                    We need to set the final name for two reasons:
+                      - We want the artifact to have another name than the maven module.
+                        It should be "otp" not "shaded-jar"
+                      - For some odd reason the maven-shade-plugin uses the ${project.packaging}
+                        as the fila extension. So, without it, the file name is
+                        "otp-SNAPSHOT-shaded.pom". Changing the packaging of the project is not
+                        what we want either.
+                    -->
+                    <outputFile>${build.directory}/otp-${project.version}-shaded.jar</outputFile>
+                    <filters>
+                        <filter>
+                            <!-- exclude signatures from merged JAR to avoid invalid signature messages -->
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <!-- The shaded JAR will not be the main artifact for the project, it will be attached
+                      for deployment in the way source and docs are. -->
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <!-- shadedClassifierName>shaded</shadedClassifierName -->
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <!-- MinimizeJar removes unused classes, (classes not imported explicitly by name).
+                      We have eliminated most Jersey auto-scanning, but there is still some need for include
+                      filters to force-include classes that are dynamically loaded by name/auto-scanned. -->
+                    <!-- This roughly halves the size of the OTP JAR, bringing it down to around 20 MB.
+                      <minimizeJar>true</minimizeJar>
+                      <filters> <filter> <artifact>com.sun.jersey:*</artifact> <includes> <include>**</include>
+                      </includes> </filter> <filter> <artifact>org.opentripplanner:*</artifact>
+                      <includes> <include>**</include> </includes> </filter> </filters> -->
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>org.opentripplanner.standalone.OTPMain</Main-Class>
+                                <!-- The ImageIO lines allow some image reader plugins to work
+                                     https://stackoverflow.com/questions/7051603/jai-vendorname-null#18495658 -->
+                                <Specification-Title>Java Advanced Imaging Image I/O
+                                    Tools
+                                </Specification-Title>
+                                <Specification-Version>1.1</Specification-Version>
+                                <Specification-Vendor>Sun Microsystems, Inc.</Specification-Vendor>
+                                <Implementation-Title>com.sun.media.imageio</Implementation-Title>
+                                <Implementation-Version>1.1</Implementation-Version>
+                                <Implementation-Vendor>Sun Microsystems, Inc.
+                                </Implementation-Vendor>
+                                <Extension-Name>com.sun.media.imageio</Extension-Name>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>shaded-jar</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/shaded-jar/pom.xml
+++ b/shaded-jar/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <maven.source>skip</maven.source>
+        <skipShadeJar>false</skipShadeJar>
     </properties>
 
     <dependencies>
@@ -48,7 +49,6 @@
                   properly if some input files are missing a terminating newline) -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
                 <configuration>
                     <!--
                     We need to set the final name for two reasons:
@@ -71,6 +71,7 @@
                             </excludes>
                         </filter>
                     </filters>
+                    <skip>${skipShadeJar}</skip>
                     <!-- The shaded JAR will not be the main artifact for the project, it will be attached
                       for deployment in the way source and docs are. -->
                     <shadedArtifactAttached>true</shadedArtifactAttached>
@@ -107,28 +108,13 @@
                         </transformer>
                     </transformers>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>build-shaded-jar</id>
+                        <goals><goal>shade</goal></goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>shaded-jar</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>shade</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/shaded-jar/pom.xml
+++ b/shaded-jar/pom.xml
@@ -59,7 +59,7 @@
                         "otp-SNAPSHOT-shaded.pom". Changing the packaging of the project is not
                         what we want either.
                     -->
-                    <outputFile>${build.directory}/otp-${project.version}-shaded.jar</outputFile>
+                    <outputFile>${project.build.directory}/otp-${project.version}-shaded.jar</outputFile>
                     <filters>
                         <filter>
                             <!-- exclude signatures from merged JAR to avoid invalid signature messages -->

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -9,7 +9,7 @@
         <version>2.7.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>otp-utils</artifactId>
+    <artifactId>utils</artifactId>
     <name>OpenTripPlanner - Utils</name>
 
     <dependencies>


### PR DESCRIPTION
### Summary

Creating the `otp-2.7.0-SNAPSHOT-shaded.jar` takes a bit of time (12.5s) on my machine. Most developers never uses this, at least during regular development. So, I think this should go into a separate maven module and I will enable developers to skip it using `-DskipShadeJar`.


### Issue
No issue exist.

### Unit tests
🟥  This is changing the build configuration only.

### Documentation
✅  I added some comments to the Maven `pom.xml` files to explain "non standard" config.

### Changelog

🟥  Skip

### Bumping the serialization version id

🟥  Not needed.