### PR TITLE
Add an example of a factory method in naming conventions

### DIFF
--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -44,6 +44,7 @@ Here is a list of common prefixes used and what to expect.
 | `listStops() : List/Stream<Stop>`                     | List ALL stops in context; return a Collection or Stream (List is preferred). |
 | `withStop(Stop stop) : Builder`                       | Set Stop in builder, replacing existing value; return `this` builder.         |
 | `initStop(Stop stop) : void`                          | Set property _once_; a second call throws an exception.                       |
+| `createStop(String name) : Stop`                      | Factory methods for creating objects should start with `create` prefix.       |
 | `addStop(Stop stop) : void/Builder`                   | Add a Stop to a collection of Stops.                                          |
 | `addStops(Collection<Stop> stops) : void/Builder`     | Add set of Stops to existing set.                                             |
 | `withBike(Consumer<BikePref.Builder> body) : Builder` | For nested builders, use lambdas.                                             |


### PR DESCRIPTION
### Summary

Adds example for naming a factory method in naming conventions.

### Issue

No issue

### Unit tests

No tests

### Documentation

Updated naming conventions

### Changelog

Skipped
