### PR TITLE
Avoid NullPointerException in GTFS GraphQL API

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/restapi/mapping/BookingInfoMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/restapi/mapping/BookingInfoMapper.java
@@ -27,8 +27,8 @@ public class BookingInfoMapper {
       BookingMethodMapper.mapBookingMethods(info.bookingMethods()),
       BookingTimeMapper.mapBookingTime(info.getEarliestBookingTime()),
       BookingTimeMapper.mapBookingTime(info.getLatestBookingTime()),
-      info.getMinimumBookingNotice(),
-      info.getMaximumBookingNotice(),
+      info.getMinimumBookingNotice().orElse(null),
+      info.getMaximumBookingNotice().orElse(null),
       info.getMessage(),
       isPickup ? info.getPickupMessage() : null,
       !isPickup ? info.getDropOffMessage() : null

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImpl.java
@@ -2,6 +2,7 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.time.Duration;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
@@ -31,7 +32,7 @@ public class BookingInfoImpl implements GraphQLDataFetchers.GraphQLBookingInfo {
 
   @Override
   public DataFetcher<Long> maximumBookingNoticeSeconds() {
-    return environment -> getSource(environment).getMaximumBookingNotice().toSeconds();
+    return environment -> getSource(environment).getMaximumBookingNotice().map(Duration::toSeconds).orElse(null);
   }
 
   @Override
@@ -41,7 +42,7 @@ public class BookingInfoImpl implements GraphQLDataFetchers.GraphQLBookingInfo {
 
   @Override
   public DataFetcher<Long> minimumBookingNoticeSeconds() {
-    return environment -> getSource(environment).getMinimumBookingNotice().toSeconds();
+    return environment -> getSource(environment).getMinimumBookingNotice().map(Duration::toSeconds).orElse(null);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImpl.java
@@ -32,7 +32,8 @@ public class BookingInfoImpl implements GraphQLDataFetchers.GraphQLBookingInfo {
 
   @Override
   public DataFetcher<Long> maximumBookingNoticeSeconds() {
-    return environment -> getSource(environment).getMaximumBookingNotice().map(Duration::toSeconds).orElse(null);
+    return environment ->
+      getSource(environment).getMaximumBookingNotice().map(Duration::toSeconds).orElse(null);
   }
 
   @Override
@@ -42,7 +43,8 @@ public class BookingInfoImpl implements GraphQLDataFetchers.GraphQLBookingInfo {
 
   @Override
   public DataFetcher<Long> minimumBookingNoticeSeconds() {
-    return environment -> getSource(environment).getMinimumBookingNotice().map(Duration::toSeconds).orElse(null);
+    return environment ->
+      getSource(environment).getMinimumBookingNotice().map(Duration::toSeconds).orElse(null);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/booking/BookingInfo.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/booking/BookingInfo.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.model.timetable.booking;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.EnumSet;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -99,14 +100,12 @@ public class BookingInfo implements Serializable {
     return latestBookingTime;
   }
 
-  @Nullable
-  public Duration getMinimumBookingNotice() {
-    return minimumBookingNotice;
+  public Optional<Duration> getMinimumBookingNotice() {
+    return Optional.ofNullable(minimumBookingNotice);
   }
 
-  @Nullable
-  public Duration getMaximumBookingNotice() {
-    return maximumBookingNotice;
+  public Optional<Duration> getMaximumBookingNotice() {
+    return Optional.ofNullable(maximumBookingNotice);
   }
 
   @Nullable

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/booking/RoutingBookingInfo.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/booking/RoutingBookingInfo.java
@@ -151,17 +151,17 @@ public final class RoutingBookingInfo {
         return this;
       }
       withLatestBookingTime(bookingInfo.getLatestBookingTime());
-      withMinimumBookingNotice(bookingInfo.getMinimumBookingNotice());
+      withMinimumBookingNotice(bookingInfo.getMinimumBookingNotice().orElse(null));
       return this;
     }
 
-    public Builder withLatestBookingTime(BookingTime latestBookingTime) {
+    public Builder withLatestBookingTime(@Nullable BookingTime latestBookingTime) {
       this.latestBookingTime =
         latestBookingTime == null ? NOT_SET : latestBookingTime.relativeTimeSeconds();
       return this;
     }
 
-    public Builder withMinimumBookingNotice(Duration minimumBookingNotice) {
+    public Builder withMinimumBookingNotice(@Nullable Duration minimumBookingNotice) {
       this.minimumBookingNotice =
         minimumBookingNotice == null ? NOT_SET : (int) minimumBookingNotice.toSeconds();
       return this;

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
@@ -1,0 +1,43 @@
+package org.opentripplanner.apis.gtfs.datafetchers;
+
+import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import graphql.ExecutionInput;
+import graphql.execution.ExecutionId;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
+
+class BookingInfoImplTest {
+
+    @Test
+    void map() throws Exception {
+
+      ExecutionInput executionInput = ExecutionInput
+        .newExecutionInput()
+        .query("")
+        .operationName("plan")
+        .locale(Locale.ENGLISH)
+        .build();
+
+      var executionContext = newExecutionContextBuilder()
+        .executionInput(executionInput)
+        .executionId(ExecutionId.from(this.getClass().getName()))
+        .build();
+      var env = DataFetchingEnvironmentImpl
+        .newDataFetchingEnvironment(executionContext)
+        .arguments(Map.of())
+        .source(BookingInfo.of().withMinimumBookingNotice(Duration.ofMinutes(10)).build())
+        .build();
+      var impl = new BookingInfoImpl();
+      var seconds = impl.minimumBookingNoticeSeconds().get(env);
+      assertEquals(600, seconds);
+    }
+  
+  
+
+}

--- a/application/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
@@ -193,6 +193,6 @@ class BookingInfoMapperTest {
 
     BookingInfo bookingInfo = subject.map(stopPoint, null, null);
 
-    assertEquals(THIRTY_MINUTES, bookingInfo.getMinimumBookingNotice());
+    assertEquals(THIRTY_MINUTES, bookingInfo.getMinimumBookingNotice().get());
   }
 }

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/booking/BookingInfoTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/booking/BookingInfoTest.java
@@ -58,7 +58,7 @@ class BookingInfoTest {
       .build();
 
     assertNull(subject.getLatestBookingTime());
-    assertEquals(minimumBookingNotice, subject.getMinimumBookingNotice());
+    assertEquals(minimumBookingNotice, subject.getMinimumBookingNotice().get());
 
     assertEquals(
       "BookingInfo{bookingMethods: [CALL_DRIVER], minimumBookingNotice: 45m}",


### PR DESCRIPTION
### Summary

It fixes a NPE in `BookingInfoImpl` when `minimumBookingNotice` is null.

### Issue

Closes #6273

### Unit tests

Added. The reason that I didn't add a new file to `GraphQLIntegrationTest` is that only flex legs can currently have a booking info, which would require me to add a flex leg and update all assertion files.