### PR TITLE
Improve wording of GTFS-RT failure messages

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -88,7 +88,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
 
       lastTimestamp = feedTimestamp;
     } catch (Exception e) {
-      LOG.error("Error reading gtfs-realtime feed from " + url, e);
+      LOG.error("Failed to process GTFS-RT Alerts feed from {}", url, e);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/GtfsRealtimeTripUpdateSource.java
@@ -73,7 +73,7 @@ public class GtfsRealtimeTripUpdateSource {
         if (feedEntity.hasTripUpdate()) updates.add(feedEntity.getTripUpdate());
       }
     } catch (Exception e) {
-      LOG.error("Failed to parse GTFS-RT feed from {}", url, e);
+      LOG.error("Failed to process GTFS-RT TripUpdates feed from {}", url, e);
     }
     return updates;
   }


### PR DESCRIPTION
### Summary

@derhuerst has reported that the current log message about a failed GTFS-RT update is not very precise as it led him to believe there is a parsing issue when in fact his server returned a 404.