### PR TITLE
Make `motorroad=yes` car-only

### DIFF
--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/FinlandMapper.java
@@ -84,9 +84,6 @@ class FinlandMapper extends OsmTagMapper {
     // Don't recommend walking in trunk road tunnels
     props.setProperties("highway=trunk;tunnel=yes", withModes(CAR).bicycleSafety(7.47));
 
-    // Do not walk on "moottoriliikennetie"
-    props.setProperties("motorroad=yes", withModes(CAR).bicycleSafety(7.47));
-
     // Remove informal and private roads
     props.setProperties("highway=*;informal=yes", withModes(NONE));
     props.setProperties("highway=service;access=private", withModes(NONE));

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
@@ -103,7 +103,8 @@ public class OsmTagMapper {
     props.setProperties("highway=trunk", withModes(CAR).bicycleSafety(7.47));
     props.setProperties("highway=motorway", withModes(CAR).bicycleSafety(8));
 
-    // Do not walk on "moottoriliikennetie"/"Kraftfahrstrasse"
+    // Do not walk on "moottoriliikennetie"/"Kraftfahrstrasse"/"Limited access road"
+    // https://en.wikipedia.org/wiki/Limited-access_road
     props.setProperties(new ExactMatchSpecifier("motorroad=yes"), withModes(CAR));
 
     /* cycleway=lane */

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
@@ -14,7 +14,6 @@ import org.opentripplanner.osm.model.OsmWithTags;
 import org.opentripplanner.osm.wayproperty.WayProperties;
 import org.opentripplanner.osm.wayproperty.WayPropertySet;
 import org.opentripplanner.osm.wayproperty.specifier.BestMatchSpecifier;
-import org.opentripplanner.osm.wayproperty.specifier.Condition;
 import org.opentripplanner.osm.wayproperty.specifier.ExactMatchSpecifier;
 import org.opentripplanner.osm.wayproperty.specifier.LogicalOrSpecifier;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
@@ -103,6 +102,9 @@ public class OsmTagMapper {
 
     props.setProperties("highway=trunk", withModes(CAR).bicycleSafety(7.47));
     props.setProperties("highway=motorway", withModes(CAR).bicycleSafety(8));
+
+    // Do not walk on "moottoriliikennetie"/"Kraftfahrstrasse"
+    props.setProperties(new ExactMatchSpecifier("motorroad=yes"), withModes(CAR));
 
     /* cycleway=lane */
     props.setProperties(

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
@@ -244,7 +244,7 @@ class FinlandMapperTest {
     osmTagMapper.populateProperties(wps);
     var way = WayTestData.carTunnel();
     assertEquals(ALL, wps.getDataForWay(way).getPermission());
-    way.addTag("motorroad","yes");
+    way.addTag("motorroad", "yes");
     assertEquals(CAR, wps.getDataForWay(way).getPermission());
   }
 }

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/FinlandMapperTest.java
@@ -2,6 +2,8 @@ package org.opentripplanner.osm.tagmapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
+import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
 import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
@@ -12,15 +14,16 @@ import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.osm.model.OsmWithTags;
 import org.opentripplanner.osm.wayproperty.WayProperties;
 import org.opentripplanner.osm.wayproperty.WayPropertySet;
+import org.opentripplanner.osm.wayproperty.specifier.WayTestData;
 
-public class FinlandMapperTest {
+class FinlandMapperTest {
 
   private WayPropertySet wps;
   private OsmTagMapper mapper;
   static float epsilon = 0.01f;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.wps = new WayPropertySet();
     this.mapper = new FinlandMapper();
     this.mapper.populateProperties(this.wps);
@@ -30,7 +33,7 @@ public class FinlandMapperTest {
    * Test that bike and walk safety factors are calculated accurately
    */
   @Test
-  public void testSafety() {
+  void testSafety() {
     OsmWithTags primaryWay = new OsmWithTags();
     primaryWay.addTag("highway", "primary");
     primaryWay.addTag("oneway", "no");
@@ -141,7 +144,7 @@ public class FinlandMapperTest {
   }
 
   @Test
-  public void testSafetyWithMixins() {
+  void testSafetyWithMixins() {
     OsmWithTags wayWithMixins = new OsmWithTags();
     // highway=service has no custom bicycle or walk safety
     wayWithMixins.addTag("highway", "unclassified");
@@ -179,7 +182,7 @@ public class FinlandMapperTest {
   }
 
   @Test
-  public void testTagMapping() {
+  void testTagMapping() {
     OsmWithTags way;
     WayProperties wayData;
 
@@ -206,7 +209,7 @@ public class FinlandMapperTest {
    * Test that biking is not allowed in footway areas and transit platforms
    */
   @Test
-  public void testArea() {
+  void testArea() {
     OsmWithTags way;
     WayProperties wayData;
 
@@ -227,10 +230,21 @@ public class FinlandMapperTest {
   }
 
   @Test
-  public void serviceNoThroughTraffic() {
+  void serviceNoThroughTraffic() {
     var way = new OsmWay();
     way.addTag("highway", "residential");
     way.addTag("service", "driveway");
     assertTrue(mapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(way));
+  }
+
+  @Test
+  void motorroad() {
+    OsmTagMapper osmTagMapper = new FinlandMapper();
+    WayPropertySet wps = new WayPropertySet();
+    osmTagMapper.populateProperties(wps);
+    var way = WayTestData.carTunnel();
+    assertEquals(ALL, wps.getDataForWay(way).getPermission());
+    way.addTag("motorroad","yes");
+    assertEquals(CAR, wps.getDataForWay(way).getPermission());
   }
 }

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
 import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.osm.model.OsmWithTags;
 import org.opentripplanner.osm.wayproperty.WayPropertySet;
 import org.opentripplanner.osm.wayproperty.specifier.WayTestData;
@@ -168,16 +171,26 @@ class OsmTagMapperTest {
     assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
   }
 
-  @Test
-  void motorroad() {
+  public static List<OsmWithTags> roadCases() {
+    return List.of(
+      WayTestData.carTunnel(),
+      WayTestData.southwestMayoStreet(),
+      WayTestData.southeastLaBonitaWay(),
+      WayTestData.fiveLanes(),
+      WayTestData.highwayTertiary()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("roadCases")
+  void motorroad(OsmWithTags way) {
     OsmTagMapper osmTagMapper = new OsmTagMapper();
     WayPropertySet wps = new WayPropertySet();
     osmTagMapper.populateProperties(wps);
 
-    var way = WayTestData.carTunnel();
     assertEquals(ALL, wps.getDataForWay(way).getPermission());
 
-    way.addTag("motorroad","yes");
+    way.addTag("motorroad", "yes");
     assertEquals(CAR, wps.getDataForWay(way).getPermission());
   }
 

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -3,15 +3,18 @@ package org.opentripplanner.osm.tagmapping;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
 import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.osm.model.OsmWithTags;
+import org.opentripplanner.osm.wayproperty.WayPropertySet;
+import org.opentripplanner.osm.wayproperty.specifier.WayTestData;
 
-public class OsmTagMapperTest {
+class OsmTagMapperTest {
 
   @Test
-  public void isMotorThroughTrafficExplicitlyDisallowed() {
+  void isMotorThroughTrafficExplicitlyDisallowed() {
     OsmWithTags o = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -34,7 +37,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void isBicycleThroughTrafficExplicitlyDisallowed() {
+  void isBicycleThroughTrafficExplicitlyDisallowed() {
     OsmTagMapper osmTagMapper = new OsmTagMapper();
     assertTrue(
       osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(way("bicycle", "destination"))
@@ -45,14 +48,14 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void isWalkThroughTrafficExplicitlyDisallowed() {
+  void isWalkThroughTrafficExplicitlyDisallowed() {
     OsmTagMapper osmTagMapper = new OsmTagMapper();
     assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(way("foot", "destination")));
     assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(way("access", "destination")));
   }
 
   @Test
-  public void testAccessNo() {
+  void testAccessNo() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -64,7 +67,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testAccessPrivate() {
+  void testAccessPrivate() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -76,7 +79,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testFootModifier() {
+  void testFootModifier() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -89,7 +92,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testVehicleDenied() {
+  void testVehicleDenied() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -101,7 +104,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testVehicleDeniedMotorVehiclePermissive() {
+  void testVehicleDeniedMotorVehiclePermissive() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -114,7 +117,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testVehicleDeniedBicyclePermissive() {
+  void testVehicleDeniedBicyclePermissive() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -127,7 +130,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testMotorcycleModifier() {
+  void testMotorcycleModifier() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -140,7 +143,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testBicycleModifier() {
+  void testBicycleModifier() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -153,7 +156,7 @@ public class OsmTagMapperTest {
   }
 
   @Test
-  public void testBicyclePermissive() {
+  void testBicyclePermissive() {
     OsmWithTags tags = new OsmWithTags();
     OsmTagMapper osmTagMapper = new OsmTagMapper();
 
@@ -163,6 +166,19 @@ public class OsmTagMapperTest {
     assertTrue(osmTagMapper.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
     assertFalse(osmTagMapper.isBicycleThroughTrafficExplicitlyDisallowed(tags));
     assertTrue(osmTagMapper.isWalkThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  void motorroad() {
+    OsmTagMapper osmTagMapper = new OsmTagMapper();
+    WayPropertySet wps = new WayPropertySet();
+    osmTagMapper.populateProperties(wps);
+
+    var way = WayTestData.carTunnel();
+    assertEquals(ALL, wps.getDataForWay(way).getPermission());
+
+    way.addTag("motorroad","yes");
+    assertEquals(CAR, wps.getDataForWay(way).getPermission());
   }
 
   public OsmWithTags way(String key, String value) {

--- a/doc/user/osm/Finland.md
+++ b/doc/user/osm/Finland.md
@@ -41,7 +41,6 @@ Lower safety values make an OSM way more desirable and higher values less desira
 | `highway=trunk_link`                                                            | `ALL`                    | 2.06                          |             |
 | `highway=trunk`                                                                 | `ALL`                    | 7.47                          |             |
 | `highway=trunk; tunnel=yes`                                                     | `CAR`                    | 7.47                          |             |
-| `motorroad=yes`                                                                 | `CAR`                    | 7.47                          |             |
 | `present(highway); informal=yes`                                                | `NONE`                   |                               |             |
 | `highway=service; access=private`                                               | `NONE`                   |                               |             |
 | `highway=trail`                                                                 | `NONE`                   |                               |             |
@@ -105,6 +104,7 @@ Lower safety values make an OSM way more desirable and higher values less desira
 | `highway=motorway_link`                                                         | `CAR`                    | 2.06                          |             |
 | `highway=trunk`                                                                 | `CAR`                    | 7.47                          |             |
 | `highway=motorway`                                                              | `CAR`                    | 8.0                           |             |
+| `motorroad=yes`                                                                 | `CAR`                    |                               |             |
 | `present(highway); cycleway=lane`                                               | `PEDESTRIAN_AND_BICYCLE` | 0.87                          |             |
 | `highway=service; cycleway=lane`                                                | `ALL`                    | 0.77                          |             |
 | `highway=residential; cycleway=lane`                                            | `ALL`                    | 0.77                          |             |

--- a/doc/user/osm/Germany.md
+++ b/doc/user/osm/Germany.md
@@ -70,6 +70,7 @@ Lower safety values make an OSM way more desirable and higher values less desira
 | `highway=motorway_link`                                 | `CAR`                    | 2.06                          |             |
 | `highway=trunk`                                         | `CAR`                    | 7.47                          |             |
 | `highway=motorway`                                      | `CAR`                    | 8.0                           |             |
+| `motorroad=yes`                                         | `CAR`                    |                               |             |
 | `present(highway); cycleway=lane`                       | `PEDESTRIAN_AND_BICYCLE` | 0.87                          |             |
 | `highway=service; cycleway=lane`                        | `ALL`                    | 0.77                          |             |
 | `highway=residential; cycleway=lane`                    | `ALL`                    | 0.77                          |             |

--- a/doc/user/osm/OsmTag.md
+++ b/doc/user/osm/OsmTag.md
@@ -61,6 +61,7 @@ Lower safety values make an OSM way more desirable and higher values less desira
 | `highway=motorway_link`                                 | `CAR`                    | 2.06                          |             |
 | `highway=trunk`                                         | `CAR`                    | 7.47                          |             |
 | `highway=motorway`                                      | `CAR`                    | 8.0                           |             |
+| `motorroad=yes`                                         | `CAR`                    |                               |             |
 | `present(highway); cycleway=lane`                       | `PEDESTRIAN_AND_BICYCLE` | 0.87                          |             |
 | `highway=service; cycleway=lane`                        | `ALL`                    | 0.77                          |             |
 | `highway=residential; cycleway=lane`                    | `ALL`                    | 0.77                          |             |

--- a/doc/user/osm/UK.md
+++ b/doc/user/osm/UK.md
@@ -77,6 +77,7 @@ Lower safety values make an OSM way more desirable and higher values less desira
 | `highway=motorway_link`                                 | `CAR`                    | 2.06                          |             |
 | `highway=trunk`                                         | `CAR`                    | 7.47                          |             |
 | `highway=motorway`                                      | `CAR`                    | 8.0                           |             |
+| `motorroad=yes`                                         | `CAR`                    |                               |             |
 | `present(highway); cycleway=lane`                       | `PEDESTRIAN_AND_BICYCLE` | 0.87                          |             |
 | `highway=service; cycleway=lane`                        | `ALL`                    | 0.77                          |             |
 | `highway=residential; cycleway=lane`                    | `ALL`                    | 0.77                          |             |


### PR DESCRIPTION
### Summary

Make OSM ways tagged with `motorroad=yes` car-only.

#### Before

![Screenshot From 2024-11-28 11-12-43](https://github.com/user-attachments/assets/b2a2a229-308f-4654-bfa9-805955fdf03d)

#### After

![Screenshot From 2024-11-28 11-07-44](https://github.com/user-attachments/assets/554ba12c-cc34-4761-9a6b-86eb9d6c7ba6)


### Issue

Closes #6287 

### Unit tests

Added.

### Documentation

Autogenerated.