### PR TITLE
Switch GTFS flex `safe_duration_offset` back to seconds

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -84,7 +84,7 @@ class TripMapper {
     } else {
       var offset = rhs.getSafeDurationOffset() == null
         ? Duration.ZERO
-        : Duration.ofMinutes(rhs.getSafeDurationOffset().longValue());
+        : Duration.ofSeconds(rhs.getSafeDurationOffset().longValue());
       var factor = rhs.getSafeDurationFactor() == null
         ? 1d
         : rhs.getSafeDurationFactor().doubleValue();

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -150,8 +150,8 @@ public class TripMapperTest {
 
   private static Stream<Arguments> provideOffsetAndFactor() {
     return Stream.of(
-      Arguments.of(1.5d, 60d, 1.5d, Duration.ofHours(1)),
-      Arguments.of(null, 120d, 1d, Duration.ofHours(2)),
+      Arguments.of(1.5d, 60d, 1.5d, Duration.ofMinutes(1)),
+      Arguments.of(null, 120d, 1d, Duration.ofMinutes(2)),
       Arguments.of(1.5d, null, 1.5d, Duration.ZERO)
     );
   }


### PR DESCRIPTION
### Summary

There has been a bit of unfortunate back-and-forth when writing the spec draft for the GTFS flex duration extension. We agreed that we want to switch the field `safe_duration_offset` to mean seconds as other duration in the spec also us this unit.

### Issue

https://github.com/MobilityData/gtfs-flex/pull/79

### Unit tests

Updated.

### Documentation

No.