### PR TITLE
Add fallback name for corridors

### DIFF
--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
@@ -624,7 +624,7 @@ public class OsmTagMapper {
     props.setSlopeOverride(new BestMatchSpecifier("indoor=yes"), true);
   }
 
-  public void populateNotesAndNames(WayPropertySet props) {
+  static void populateNotesAndNames(WayPropertySet props) {
     /* and the notes */
     // TODO: The curly brackets in the string below mean that the CreativeNamer should substitute in OSM tag values.
     // However they are not taken into account when passed to the translation function.
@@ -667,6 +667,7 @@ public class OsmTagMapper {
     props.createNames("highway=footway", "name.pedestrian_path");
     props.createNames("highway=bridleway", "name.bridleway");
     props.createNames("highway=footway;bicycle=no", "name.pedestrian_path");
+    props.createNames("highway=corridor", "name.corridor");
 
     // Platforms
     props.createNames("otp:route_ref=*", "name.otp_route_ref");

--- a/application/src/main/resources/WayProperties.properties
+++ b/application/src/main/resources/WayProperties.properties
@@ -8,6 +8,7 @@ name.pedestrian_path=path
 name.pedestrian_area=open area
 name.path=path
 name.bridleway=bridleway
+name.corridor=corridor
 
 name.otp_route_ref=Route {otp:route_ref}
 name.platform_ref=Platform {ref}

--- a/application/src/main/resources/WayProperties_de.properties
+++ b/application/src/main/resources/WayProperties_de.properties
@@ -9,6 +9,7 @@ name.pedestrian_path=Fu\u00dfweg
 name.pedestrian_area=Fu\u00dfg\u00e4ngerzone
 name.path=Weg
 name.bridleway=Reitweg
+name.corridor=Korridor
 
 name.otp_route_ref=Route {otp:route_ref}
 name.platform_ref=Plattform {ref}

--- a/application/src/main/resources/WayProperties_fi.properties
+++ b/application/src/main/resources/WayProperties_fi.properties
@@ -8,6 +8,7 @@ name.pedestrian_path=polku
 name.pedestrian_area=aukio
 name.path=polku
 name.bridleway=ratsupolku
+name.corridor=käytävä
 
 name.otp_route_ref=linja {otp:route_ref}
 name.platform_ref=laituri {ref}

--- a/application/src/main/resources/WayProperties_fr.properties
+++ b/application/src/main/resources/WayProperties_fr.properties
@@ -9,6 +9,7 @@ name.pedestrian_path=chemin pi\u00e9tonnier
 name.pedestrian_area=plateau pi\u00e9tonnier
 name.path=chemin
 name.bridleway=sentier \u00e9questre
+name.corridor=couloir
 
 name.otp_route_ref=Ligne {otp:route_ref}
 name.platform_ref=Plate-forme {ref}

--- a/application/src/main/resources/WayProperties_hu.properties
+++ b/application/src/main/resources/WayProperties_hu.properties
@@ -8,6 +8,7 @@ name.pedestrian_path=gyalog\u00FAt
 name.pedestrian_area=t\u00E9r
 name.path=path
 name.bridleway=nyomvonal
+name.corridor=folyoso
 
 name.otp_route_ref={otp:route_ref}
 name.platform_ref={ref}

--- a/application/src/main/resources/WayProperties_nl.properties
+++ b/application/src/main/resources/WayProperties_nl.properties
@@ -9,6 +9,7 @@ name.pedestrian_path=voetpad
 name.pedestrian_area=open ruimte
 name.path=pad
 name.bridleway=ruiterpad
+name.corridor=gang
 
 name.otp_route_ref=Lijn {otp:route_ref}
 name.platform_ref=Spoor {ref}

--- a/application/src/main/resources/WayProperties_no.properties
+++ b/application/src/main/resources/WayProperties_no.properties
@@ -8,6 +8,7 @@ name.pedestrian_path=gangvei
 name.pedestrian_area=plass
 name.path=sti
 name.bridleway=bridleway
+name.corridor=korridor
 
 name.otp_route_ref=Rute {otp:route_ref}
 name.platform_ref=Plattform {ref}

--- a/application/src/main/resources/WayProperties_sv.properties
+++ b/application/src/main/resources/WayProperties_sv.properties
@@ -8,6 +8,7 @@ name.pedestrian_path=gångbanan
 name.pedestrian_area=torget
 name.path=stigen
 name.bridleway=ridvägem
+name.corridor=korridor
 
 name.otp_route_ref=linje {otp:route_ref}
 name.platform_ref=plattform {ref}

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -184,9 +184,7 @@ class OsmTagMapperTest {
   @ParameterizedTest
   @MethodSource("roadCases")
   void motorroad(OsmWithTags way) {
-    OsmTagMapper osmTagMapper = new OsmTagMapper();
-    WayPropertySet wps = new WayPropertySet();
-    osmTagMapper.populateProperties(wps);
+    final WayPropertySet wps = wayProperySet();
 
     assertEquals(ALL, wps.getDataForWay(way).getPermission());
 
@@ -194,9 +192,23 @@ class OsmTagMapperTest {
     assertEquals(CAR, wps.getDataForWay(way).getPermission());
   }
 
+  @Test
+  void corridorName() {
+    final WayPropertySet wps = wayProperySet();
+    var way = way("highway", "corridor");
+    assertEquals("corridor", wps.getCreativeNameForWay(way).toString());
+  }
+
   public OsmWithTags way(String key, String value) {
     var way = new OsmWithTags();
     way.addTag(key, value);
     return way;
+  }
+
+  private static WayPropertySet wayProperySet() {
+    OsmTagMapper osmTagMapper = new OsmTagMapper();
+    WayPropertySet wps = new WayPropertySet();
+    osmTagMapper.populateProperties(wps);
+    return wps;
   }
 }

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -7,6 +7,7 @@ import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
 import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
 
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -197,6 +198,8 @@ class OsmTagMapperTest {
     final WayPropertySet wps = wayProperySet();
     var way = way("highway", "corridor");
     assertEquals("corridor", wps.getCreativeNameForWay(way).toString());
+    assertEquals("Korridor", wps.getCreativeNameForWay(way).toString(Locale.GERMANY));
+    assertEquals("käytävä", wps.getCreativeNameForWay(way).toString(Locale.of("FI")));
   }
 
   public OsmWithTags way(String key, String value) {


### PR DESCRIPTION
### Summary

Many types of OSM ways have a fallback name like "path", "stairs" or "tunnel" but those tagged with `highway=corridor` do not. This PR adds it.

### Unit tests

Added.