### PR TITLE
Detect JSON array in addition to JSON objects when including a file in the config.

### DIFF
--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/file/IncludeFileDirective.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/file/IncludeFileDirective.java
@@ -99,7 +99,7 @@ public class IncludeFileDirective {
       // ignore the optional quotes matched by the directive pattern
       var json = fileText.trim();
       if (
-        json.startsWith("{") && json.endsWith("}") || json.startsWith("[") && json.endsWith("]")
+        (json.startsWith("{") && json.endsWith("}")) || (json.startsWith("[") && json.endsWith("]"))
       ) {
         text = text.replace(entry.getKey(), fileText);
       } else {

--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/file/IncludeFileDirective.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/file/IncludeFileDirective.java
@@ -95,10 +95,12 @@ public class IncludeFileDirective {
       String directive = entry.getKey();
       String fileText = loadFile(entry.getValue(), directive, source);
 
-      // If the insert text is a legal JSON object "[white-space]{ ... }[white-space]", then
+      // If the insert text is a legal JSON object or array, then
       // ignore the optional quotes matched by the directive pattern
       var json = fileText.trim();
-      if (json.startsWith("{") && json.endsWith("}")) {
+      if (
+        json.startsWith("{") && json.endsWith("}") || json.startsWith("[") && json.endsWith("]")
+      ) {
         text = text.replace(entry.getKey(), fileText);
       } else {
         // Add back quotes if matched part of directive pattern

--- a/application/src/test/java/org/opentripplanner/standalone/config/framework/file/IncludeFileDirectiveTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/config/framework/file/IncludeFileDirectiveTest.java
@@ -46,6 +46,17 @@ public class IncludeFileDirectiveTest {
   }
 
   @Test
+  void includeFileWithQuotesAndJsonArrayInput() throws IOException {
+    savePartialFile(json("\t [\n  'foo', 'bar' \n  ]\n"));
+    String result = IncludeFileDirective.includeFileDirective(
+      CONFIG_DIR,
+      json("{ 'key' : '${includeFile:" + PART_FILE_NAME + "}'}"),
+      PART_FILE_NAME
+    );
+    assertEquals(json("{ 'key' : \t [\n  'foo', 'bar' \n  ]\n}"), result);
+  }
+
+  @Test
   void includeFileWithQuotesWithNoJsonInput() throws IOException {
     savePartialFile("value");
     String result = IncludeFileDirective.includeFileDirective(

--- a/doc/templates/Configuration.md
+++ b/doc/templates/Configuration.md
@@ -141,7 +141,8 @@ directory. Relative paths are not supported.
 
 To allow both files (the configuration file and the injected file) to be valid JSON files, a special
 case is supported. If the include file directive is quoted, then the quotes are removed, if the 
-text inserted is valid JSON (starts with `{` and ends with `}`). 
+text inserted is valid JSON object (starts with `{` and ends with `}`) or valid JSON array
+(starts with `[` and ends with `]`). 
 
 Variable substitution is performed on configuration file after the include file directive; Hence
 variable substitution is also performed on the text in the injected file.

--- a/doc/user/Configuration.md
+++ b/doc/user/Configuration.md
@@ -168,7 +168,8 @@ directory. Relative paths are not supported.
 
 To allow both files (the configuration file and the injected file) to be valid JSON files, a special
 case is supported. If the include file directive is quoted, then the quotes are removed, if the 
-text inserted is valid JSON (starts with `{` and ends with `}`). 
+text inserted is valid JSON object (starts with `{` and ends with `}`) or valid JSON array
+(starts with `[` and ends with `]`). 
 
 Variable substitution is performed on configuration file after the include file directive; Hence
 variable substitution is also performed on the text in the injected file.


### PR DESCRIPTION
### Summary

This detects `[]` in addition to `{}` when including JSON in config files.

### Issue
Fixes #6305

### Unit tests

Added for JSON array in addition for JSON object

### Documentation

Updated

### Changelog

### Bumping the serialization version id

Not needed