### PR TITLE
Convert booking notices to duration in GTFS GraphQL API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImpl.java
@@ -31,6 +31,11 @@ public class BookingInfoImpl implements GraphQLDataFetchers.GraphQLBookingInfo {
   }
 
   @Override
+  public DataFetcher<Duration> maximumBookingNotice() {
+    return env -> getSource(env).getMaximumBookingNotice().orElse(null);
+  }
+
+  @Override
   public DataFetcher<Long> maximumBookingNoticeSeconds() {
     return environment ->
       getSource(environment).getMaximumBookingNotice().map(Duration::toSeconds).orElse(null);
@@ -39,6 +44,11 @@ public class BookingInfoImpl implements GraphQLDataFetchers.GraphQLBookingInfo {
   @Override
   public DataFetcher<String> message() {
     return environment -> getSource(environment).getMessage();
+  }
+
+  @Override
+  public DataFetcher<Duration> minimumBookingNotice() {
+    return env -> getSource(env).getMinimumBookingNotice().orElse(null);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -221,9 +221,13 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<BookingTime> latestBookingTime();
 
+    public DataFetcher<java.time.Duration> maximumBookingNotice();
+
     public DataFetcher<Long> maximumBookingNoticeSeconds();
 
     public DataFetcher<String> message();
+
+    public DataFetcher<java.time.Duration> minimumBookingNotice();
 
     public DataFetcher<Long> minimumBookingNoticeSeconds();
 

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -279,12 +279,16 @@ type BookingInfo {
   earliestBookingTime: BookingTime
   "When is the latest time the service can be booked"
   latestBookingTime: BookingTime
+  "Maximum duration before travel to make the request."
+  maximumBookingNotice: Duration
   "Maximum number of seconds before travel to make the request"
-  maximumBookingNoticeSeconds: Long
+  maximumBookingNoticeSeconds: Long @deprecated(reason : "Use `maximumBookingNotice`")
   "A general message for those booking the service"
   message: String
+  "Minimum duration before travel to make the request"
+  minimumBookingNotice: Duration
   "Minimum number of seconds before travel to make the request"
-  minimumBookingNoticeSeconds: Long
+  minimumBookingNoticeSeconds: Long @deprecated(reason : "Use `minimumBookingNotice`")
   "A message specific to the pick up"
   pickupMessage: String
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
@@ -15,25 +15,38 @@ class BookingInfoImplTest {
 
   private static final BookingInfoImpl SUBJECT = new BookingInfoImpl();
   private static final Duration TEN_MINUTES = Duration.ofMinutes(10);
+  private static final BookingInfo WITH_NOTICE_DURATIONS = BookingInfo
+    .of()
+    .withMinimumBookingNotice(TEN_MINUTES)
+    .withMaximumBookingNotice(TEN_MINUTES)
+    .build();
 
   @Test
-  void emptyDurations() throws Exception {
+  void emptyNoticeSeconds() throws Exception {
     var env = dataFetchingEnvironment(BookingInfo.of().build());
     assertNull(SUBJECT.minimumBookingNoticeSeconds().get(env));
     assertNull(SUBJECT.maximumBookingNoticeSeconds().get(env));
   }
 
   @Test
-  void durations() throws Exception {
-    var env = dataFetchingEnvironment(
-      BookingInfo
-        .of()
-        .withMinimumBookingNotice(TEN_MINUTES)
-        .withMaximumBookingNotice(TEN_MINUTES)
-        .build()
-    );
+  void emptyNoticeDurations() throws Exception {
+    var env = dataFetchingEnvironment(BookingInfo.of().build());
+    assertNull(SUBJECT.minimumBookingNotice().get(env));
+    assertNull(SUBJECT.maximumBookingNotice().get(env));
+  }
+
+  @Test
+  void seconds() throws Exception {
+    var env = dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
     assertEquals(600, SUBJECT.minimumBookingNoticeSeconds().get(env));
     assertEquals(600, SUBJECT.maximumBookingNoticeSeconds().get(env));
+  }
+
+  @Test
+  void durations() throws Exception {
+    var env = dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
+    assertEquals(TEN_MINUTES, SUBJECT.minimumBookingNotice().get(env));
+    assertEquals(TEN_MINUTES, SUBJECT.maximumBookingNotice().get(env));
   }
 
   private DataFetchingEnvironment dataFetchingEnvironment(BookingInfo bookingInfo) {


### PR DESCRIPTION
### Summary

In a (previous PR)[https://github.com/opentripplanner/OpenTripPlanner/pull/6274] I noticed that the booking notices in BookingInfo use seconds for expressing durations, but we want to use ISO durations instead, which this PR does.

### Unit tests

Added.