### PR TITLE
Reduce geocode cluster radius

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/geocoder/StopClusterMapper.java
@@ -121,7 +121,7 @@ class StopClusterMapper {
       .stream()
       .collect(
         Collectors.groupingBy(sl ->
-          new DeduplicationKey(sl.getName(), sl.getCoordinate().roundToApproximate100m())
+          new DeduplicationKey(sl.getName(), sl.getCoordinate().roundToApproximate10m())
         )
       )
       .values()


### PR DESCRIPTION
### Summary

This is a sandbox-only PR for the geocoder cluster feature: it reduces the radius for which clusters are formed.

### Changelog

No.

### Bumping the serialization version id

No.