### PR TITLE
Add endpoint to download Transmodel GraphQL Schema

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
@@ -33,6 +33,15 @@ import org.slf4j.LoggerFactory;
 @Produces(MediaType.APPLICATION_JSON)
 public class TransmodelAPI {
 
+  // Note, the blank line at the end is intended
+  private static final String SCHEMA_DOC_HEADER =
+    """
+# THIS IS NOT INTENDED FOR PRODUCTION USE. We recommend using the GraphQL introspection instead.
+# This is intended for the OTP Debug UI and can also be used by humans to get the schema with the
+# OTP configured default-values injected.
+
+""";
+
   private static final Logger LOG = LoggerFactory.getLogger(TransmodelAPI.class);
 
   private static GraphQLSchema schema;
@@ -143,7 +152,8 @@ public class TransmodelAPI {
   @GET
   @Path("schema.graphql")
   public Response getGraphQLSchema() {
-    return Response.ok().encoding("UTF-8").entity(new SchemaPrinter().print(schema)).build();
+    var text = SCHEMA_DOC_HEADER + new SchemaPrinter().print(schema);
+    return Response.ok().encoding("UTF-8").entity(text).build();
   }
 
   private static Iterable<Tag> getTagsFromHeaders(HttpHeaders headers) {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
@@ -2,9 +2,11 @@ package org.opentripplanner.apis.transmodel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaPrinter;
 import io.micrometer.core.instrument.Tag;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -136,6 +138,12 @@ public class TransmodelAPI {
       maxNumberOfResultFields,
       getTagsFromHeaders(headers)
     );
+  }
+
+  @GET
+  @Path("schema.graphql")
+  public Response getGraphQLSchema() {
+    return Response.ok().encoding("UTF-8").entity(new SchemaPrinter().print(schema)).build();
   }
 
   private static Iterable<Tag> getTagsFromHeaders(HttpHeaders headers) {


### PR DESCRIPTION
### Summary

This PR add a read-only endpoint (HTTP GET) for fetching the Transmodel GraphQL Schema. The schema can be fetched today using the GraphQL introspection, but this is a bit technical and the result need to be translated into SDL (if needed). 

We will use this to generate the input controls for the trip search in the OTP Debug UI. It can also be used for "human introspection".

### Issue

🟥  No issue, but this is part of making a generic input control for the Debug UI.


### Unit tests

🟥  This is just one line of code with logic - only using library code. The schema is for

### Documentation

✅  The usage is documented with a comment included at the top of the schema file.
🟥  The endpoint is not documented outside the code - this should be sufficient since it is not intended
       for production/integration - only for the convenience of developers.

### Changelog

🟥  Not a production feature or relevant for Product Owners


### Bumping the serialization version id

🟥  Not needed