### PR TITLE
Show generalized cost in debug UI

### DIFF
--- a/client/src/components/ItineraryList/ItineraryDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryDetails.tsx
@@ -11,7 +11,7 @@ export function ItineraryDetails({ tripPattern }: { tripPattern: TripPattern }) 
         <ItineraryLegDetails key={leg.id ? leg.id : `noid_${i}`} leg={leg} isLast={i === tripPattern.legs.length - 1} />
       ))}
 
-      <div className="generalized-cost">Generalized cost: ${tripPattern.generalizedCost}</div>
+      <div className="generalized-cost">Generalized cost: ¢{tripPattern.generalizedCost}</div>
     </div>
   );
 }

--- a/client/src/components/ItineraryList/ItineraryDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryDetails.tsx
@@ -11,9 +11,7 @@ export function ItineraryDetails({ tripPattern }: { tripPattern: TripPattern }) 
         <ItineraryLegDetails key={leg.id ? leg.id : `noid_${i}`} leg={leg} isLast={i === tripPattern.legs.length - 1} />
       ))}
 
-      <div className="generalized-cost">
-        Generalized cost: ${tripPattern.generalizedCost}
-      </div>
+      <div className="generalized-cost">Generalized cost: ${tripPattern.generalizedCost}</div>
     </div>
   );
 }

--- a/client/src/components/ItineraryList/ItineraryDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryDetails.tsx
@@ -10,6 +10,10 @@ export function ItineraryDetails({ tripPattern }: { tripPattern: TripPattern }) 
       {tripPattern.legs.map((leg, i) => (
         <ItineraryLegDetails key={leg.id ? leg.id : `noid_${i}`} leg={leg} isLast={i === tripPattern.legs.length - 1} />
       ))}
+
+      <div className="generalized-cost">
+        Generalized cost: ${tripPattern.generalizedCost}
+      </div>
     </div>
   );
 }

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -21,7 +21,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
   return (
     <div className="itinerary-leg-details">
       <div className="times">
-        {formatDistance(leg.distance)}, {formatDuration(leg.duration)}
+        {formatDistance(leg.distance)}, {formatDuration(leg.duration)}, ${leg.generalizedCost}
       </div>
       <InterchangeInfo leg={leg} />
       <LegTime

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -22,7 +22,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
     <div className="itinerary-leg-details">
       <div className="times">
         {formatDistance(leg.distance)}, {formatDuration(leg.duration)},{' '}
-        <span title={'Generalized cost: $' + leg.generalizedCost}>${leg.generalizedCost}</span>
+        <span title={'Generalized cost: ¢' + leg.generalizedCost}>¢{leg.generalizedCost}</span>
       </div>
       <InterchangeInfo leg={leg} />
       <LegTime

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -21,7 +21,8 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
   return (
     <div className="itinerary-leg-details">
       <div className="times">
-        {formatDistance(leg.distance)}, {formatDuration(leg.duration)}, ${leg.generalizedCost}
+        {formatDistance(leg.distance)}, {formatDuration(leg.duration)},{' '}
+        <span title={'Generalized cost: $' + leg.generalizedCost}>${leg.generalizedCost}</span>
       </div>
       <InterchangeInfo leg={leg} />
       <LegTime

--- a/client/src/static/query/tripQuery.tsx
+++ b/client/src/static/query/tripQuery.tsx
@@ -35,6 +35,7 @@ export const query = graphql(`
         expectedStartTime
         duration
         distance
+        generalizedCost
         legs {
           id
           mode
@@ -45,6 +46,7 @@ export const query = graphql(`
           realtime
           distance
           duration
+          generalizedCost
           fromPlace {
             name
             quay {

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -113,6 +113,12 @@
   font-size: 11px;
 }
 
+.accordion-body .generalized-cost {
+  font-size: 11px;
+  text-align: end;
+  margin-right: 9px;
+}
+
 .itinerary-leg-details .mode {
   margin-top: 2px;
 }

--- a/client/src/util/formatDuration.ts
+++ b/client/src/util/formatDuration.ts
@@ -10,22 +10,16 @@ export function formatDuration(seconds: number) {
 
   let formatted = '';
 
-  if (hrs === 1) {
-    formatted = `${formatted}${hrs} hr `;
-  } else if (hrs > 1) {
-    formatted = `${formatted}${hrs} hrs `;
+  if (hrs > 0) {
+    formatted = `${formatted}${hrs}h `;
   }
 
-  if (mins === 1) {
-    formatted = `${formatted}${mins} min `;
-  } else if (mins > 1) {
-    formatted = `${formatted}${mins} mins `;
+  if (mins > 0) {
+    formatted = `${formatted}${mins}min `;
   }
 
-  if (secs === 1) {
-    formatted = `${formatted}${secs} sec `;
-  } else if (secs > 1) {
-    formatted = `${formatted}${secs} secs `;
+  if (secs > 1) {
+    formatted = `${formatted}${secs}s`;
   }
 
   return formatted;


### PR DESCRIPTION
### Summary

This adds the generalized cost for legs and itineraries to the debug UI. It looks like this:

![image](https://github.com/user-attachments/assets/5f36a4a8-21f9-447a-9ab2-059077f5b675)


In order to make some room, I formatted the leg duration a bit more compactly.