### PR TITLE
Update protobuf, OSM parser and Google cloud tools

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -312,9 +312,9 @@
         </dependency>
         <!-- OpenStreetMap protobuf (PBF) definitions and parser -->
         <dependency>
-            <groupId>org.openstreetmap.osmosis</groupId>
-            <artifactId>osmosis-osm-binary</artifactId>
-            <version>0.48.3</version>
+            <groupId>org.openstreetmap.pbf</groupId>
+            <artifactId>osmpbf</artifactId>
+            <version>1.6.0</version>
         </dependency>
         <!-- Command line parameter parsing -->
         <dependency>

--- a/application/src/main/java/org/opentripplanner/osm/OsmParser.java
+++ b/application/src/main/java/org/opentripplanner/osm/OsmParser.java
@@ -1,11 +1,11 @@
 package org.opentripplanner.osm;
 
+import crosby.binary.BinaryParser;
+import crosby.binary.Osmformat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.openstreetmap.osmosis.osmbinary.BinaryParser;
-import org.openstreetmap.osmosis.osmbinary.Osmformat;
 import org.opentripplanner.graph_builder.module.osm.OsmDatabase;
 import org.opentripplanner.osm.model.OsmMemberType;
 import org.opentripplanner.osm.model.OsmNode;

--- a/application/src/main/java/org/opentripplanner/osm/OsmProvider.java
+++ b/application/src/main/java/org/opentripplanner/osm/OsmProvider.java
@@ -1,11 +1,11 @@
 package org.opentripplanner.osm;
 
+import crosby.binary.file.BlockInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.ZoneId;
-import org.openstreetmap.osmosis.osmbinary.file.BlockInputStream;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.file.FileDataSource;

--- a/application/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/GtfsRealtimeAlertsUpdater.java
@@ -68,7 +68,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
       final FeedMessage feed = otpHttpClient.getAndMap(
         URI.create(url),
         this.headers.asMap(),
-        FeedMessage.PARSER::parseFrom
+        FeedMessage::parseFrom
       );
 
       long feedTimestamp = feed.getHeader().getTimestamp();

--- a/application/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/MqttGtfsRealtimeUpdater.java
@@ -138,7 +138,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
       UpdateIncrementality updateIncrementality = FULL_DATASET;
       try {
         // Decode message
-        GtfsRealtime.FeedMessage feedMessage = GtfsRealtime.FeedMessage.PARSER.parseFrom(
+        GtfsRealtime.FeedMessage feedMessage = GtfsRealtime.FeedMessage.parseFrom(
           message.getPayload()
         );
         List<GtfsRealtime.FeedEntity> feedEntityList = feedMessage.getEntityList();

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -221,7 +221,7 @@ public abstract class GtfsTest {
 
     try {
       InputStream inputStream = new FileInputStream(gtfsRealTime);
-      FeedMessage feedMessage = FeedMessage.PARSER.parseFrom(inputStream);
+      FeedMessage feedMessage = FeedMessage.parseFrom(inputStream);
       List<FeedEntity> feedEntityList = feedMessage.getEntityList();
       List<TripUpdate> updates = new ArrayList<>(feedEntityList.size());
       for (FeedEntity feedEntity : feedEntityList) {

--- a/gtfs-realtime-protobuf/pom.xml
+++ b/gtfs-realtime-protobuf/pom.xml
@@ -11,10 +11,15 @@
     <artifactId>gtfs-realtime-protobuf</artifactId>
     <name>OpenTripPlanner - GTFS Realtime (protobuf)</name>
 
+    <properties>
+        <protobuf.version>4.28.3</protobuf.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -46,7 +51,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.22.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
                 <!-- This make sure all google libraries are using compatible versions. -->
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.48.0</version>
+                <version>26.51.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
### Summary

It turned out that we never actually set the version of the protbuf java library and compiler and relied on it being set by the OSM and Google Cloud libraries.

Starting with version 26.51.0 of Google Cloud it introduced a new version of protobuf that was incompatible with the one used by the OSM library and the tests started failing.

For this reason I [updated the OSM library](https://github.com/openstreetmap/OSM-binary/pull/84) and used the newest version of protobuf. This means that we can now also update Google Cloud.

Since the new protbuf Java runtime has change a bit, some protobuf-related classes had to be adjusted.

### Unit tests

The unit tests that parse real OSM files prevented something bad from happening.

### Bumping the serialization version id

I don't think it's required since protbuf is only used for imports, but I can set the tags if requested.