### PR TITLE
Fix test failure when building OTP in a path with special characters

### DIFF
--- a/application/src/test/java/org/opentripplanner/test/support/ResourceLoader.java
+++ b/application/src/test/java/org/opentripplanner/test/support/ResourceLoader.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
@@ -46,7 +47,12 @@ public class ResourceLoader {
    */
   public File file(String path) {
     URL resource = url(path);
-    var file = new File(resource.getFile());
+    File file;
+    try {
+      file = new File(new URI(resource.toString()));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
     assertTrue(
       file.exists(),
       "File '%s' not found on file system.".formatted(file.getAbsolutePath())

--- a/application/src/test/java/org/opentripplanner/test/support/ResourceLoader.java
+++ b/application/src/test/java/org/opentripplanner/test/support/ResourceLoader.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;


### PR DESCRIPTION
### Summary

This pull request fixes test failures when building OpenTripPlanner in a folder containing URL-encodable characters (such as space, Chinese characters, etc.).

Please refer to https://stackoverflow.com/a/13470643 for details.

### Issue

fixes #6337

### Unit tests

Updated

### Documentation

None

### Changelog

Not needed

### Bumping the serialization version id

Not needed