### PR TITLE
Add Git commit id in jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
                                  our dependencies specify a module name. -->
                             <Automatic-Module-Name>org.opentripplanner.otp</Automatic-Module-Name>
                             <OTP-Serialization-Version-Id>${otp.serialization.version.id}</OTP-Serialization-Version-Id>
+                            <SCM-Revision>${git.commit.id}</SCM-Revision>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
### Summary

Add the Git commit id in the application jar manifest (this ends up in the OTP shaded jar manifest as well)
This is useful when testing snapshot versions.
The new entry looks like:
`SCM-Revision: 42e77fa2883aecbec36185ebd22f1a70e1424b86`

### Issue

No
### Unit tests
No

### Documentation

No
