### PR TITLE
Update list of GTFS Fares v2 classes

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>4.3.0</version>
+            <version>5.0.0</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -28,7 +28,6 @@ import org.onebusaway.gtfs.model.ServiceCalendar;
 import org.onebusaway.gtfs.model.ServiceCalendarDate;
 import org.onebusaway.gtfs.model.ShapePoint;
 import org.onebusaway.gtfs.model.Stop;
-import org.onebusaway.gtfs.model.StopArea;
 import org.onebusaway.gtfs.model.StopAreaElement;
 import org.onebusaway.gtfs.model.Trip;
 import org.onebusaway.gtfs.serialization.GtfsReader;
@@ -68,7 +67,6 @@ public class GtfsModule implements GraphBuilderModule {
     FareTransferRule.class,
     RiderCategory.class,
     FareMedium.class,
-    StopArea.class,
     StopAreaElement.class,
     Area.class
   );

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.onebusaway.csv_entities.EntityHandler;
 import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
 import org.onebusaway.gtfs.model.Agency;
+import org.onebusaway.gtfs.model.Area;
 import org.onebusaway.gtfs.model.FareAttribute;
 import org.onebusaway.gtfs.model.FareLegRule;
 import org.onebusaway.gtfs.model.FareMedium;
@@ -28,6 +29,7 @@ import org.onebusaway.gtfs.model.ServiceCalendarDate;
 import org.onebusaway.gtfs.model.ShapePoint;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopArea;
+import org.onebusaway.gtfs.model.StopAreaElement;
 import org.onebusaway.gtfs.model.Trip;
 import org.onebusaway.gtfs.serialization.GtfsReader;
 import org.onebusaway.gtfs.services.GenericMutableDao;
@@ -66,7 +68,9 @@ public class GtfsModule implements GraphBuilderModule {
     FareTransferRule.class,
     RiderCategory.class,
     FareMedium.class,
-    StopArea.class
+    StopArea.class,
+    StopAreaElement.class,
+    Area.class
   );
 
   private static final Logger LOG = LoggerFactory.getLogger(GtfsModule.class);


### PR DESCRIPTION
### Summary

This updates the GTFS entities that are part of Fares V2. These are skipped unless you enable the `FaresV2` feature flag, because FaresV2 is still new and feeds frequently provide invalid data. Updating this list means that OTP will be ignoring more invalid FaresV2 data.

This PR also updates the OBA library to the latest version because previous ones had duplicate types for `StopArea` and `Area`, which are really the same thing.