### PR TITLE
When using ScheduledTransitLeg's copy builder, also copy alerts

### DIFF
--- a/application/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -98,6 +98,7 @@ public class ScheduledTransitLeg implements TransitLeg {
       getDistanceFromCoordinates(
         List.of(transitLegCoordinates.getFirst(), transitLegCoordinates.getLast())
       );
+    this.transitAlerts.addAll(builder.alerts());
   }
 
   public ZoneId getZoneId() {

--- a/application/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilder.java
@@ -3,7 +3,10 @@ package org.opentripplanner.model.plan;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
+import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -23,6 +26,7 @@ public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>>
   private ConstrainedTransfer transferToNextLeg;
   private int generalizedCost;
   private Float accessibilityScore;
+  private Set<TransitAlert> alerts = new HashSet<>();
 
   public ScheduledTransitLegBuilder() {}
 
@@ -40,6 +44,7 @@ public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>>
     generalizedCost = original.getGeneralizedCost();
     accessibilityScore = original.accessibilityScore();
     zoneId = original.getZoneId();
+    alerts = original.getTransitAlerts();
   }
 
   public B withTripTimes(TripTimes tripTimes) {
@@ -157,6 +162,10 @@ public class ScheduledTransitLegBuilder<B extends ScheduledTransitLegBuilder<B>>
 
   public Float accessibilityScore() {
     return accessibilityScore;
+  }
+
+  public Set<TransitAlert> alerts() {
+    return alerts;
   }
 
   public ScheduledTransitLeg build() {

--- a/application/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilderTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.model.plan;
 
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 

--- a/application/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/ScheduledTransitLegBuilderTest.java
@@ -1,14 +1,24 @@
 package org.opentripplanner.model.plan;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 
 import java.time.LocalDate;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.time.ZoneIds;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 
 class ScheduledTransitLegBuilderTest {
+
+  private static final TransitAlert ALERT = TransitAlert
+    .of(id("alert"))
+    .withDescriptionText(I18NString.of("alert"))
+    .build();
 
   @Test
   void transferZoneId() {
@@ -27,5 +37,25 @@ class ScheduledTransitLegBuilderTest {
     var withScore = newLeg.withAccessibilityScore(4f).build();
 
     assertEquals(ZoneIds.BERLIN, withScore.getZoneId());
+  }
+
+  @Test
+  void alerts() {
+    var pattern = TimetableRepositoryForTest.of().pattern(TransitMode.BUS).build();
+    var leg = new ScheduledTransitLegBuilder<>()
+      .withZoneId(ZoneIds.BERLIN)
+      .withServiceDate(LocalDate.of(2023, 11, 15))
+      .withTripPattern(pattern)
+      .withBoardStopIndexInPattern(0)
+      .withAlightStopIndexInPattern(1)
+      .build();
+
+    leg.addAlert(ALERT);
+
+    var newLeg = new ScheduledTransitLegBuilder<>(leg);
+
+    var withScore = newLeg.withAccessibilityScore(4f).build();
+
+    assertEquals(Set.of(ALERT), withScore.getTransitAlerts());
   }
 }


### PR DESCRIPTION
### Summary

This fixes a bug where transit alerts where not copied when using the leg to get a new builder.

This PR only fixes the bug but I will work on making the `ScheduledTransitLeg` completely immutable so this doesn't happen again (we have the same problem with the fares).

### Unit tests

Added.