### PR TITLE
Improve handling of null values in argument lists to the serviceJourneys graphQL method in the Transmodel API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -9,6 +9,7 @@ import static org.opentripplanner.apis.transmodel.model.EnumTypes.FILTER_PLACE_T
 import static org.opentripplanner.apis.transmodel.model.EnumTypes.MULTI_MODAL_MODE;
 import static org.opentripplanner.apis.transmodel.model.EnumTypes.TRANSPORT_MODE;
 import static org.opentripplanner.apis.transmodel.model.scalars.DateTimeScalarFactory.createMillisecondsSinceEpochAsDateTimeStringScalar;
+import static org.opentripplanner.apis.transmodel.support.GqlUtil.mapArgCollectionNullSafe;
 import static org.opentripplanner.model.projectinfo.OtpProjectInfo.projectInfo;
 
 import graphql.Scalars;
@@ -1310,11 +1311,11 @@ public class TransmodelGraphQLSchema {
             );
             var privateCodes = FilterValues.ofEmptyIsEverything(
               "privateCodes",
-              environment.<List<String>>getArgument("privateCodes")
+              mapArgCollectionNullSafe(environment.<List<String>>getArgument("privateCodes"))
             );
             var activeServiceDates = FilterValues.ofEmptyIsEverything(
               "activeDates",
-              environment.<List<LocalDate>>getArgument("activeDates")
+              mapArgCollectionNullSafe(environment.<List<LocalDate>>getArgument("activeDates"))
             );
 
             TripRequest tripRequest = TripRequest

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -9,7 +9,7 @@ import static org.opentripplanner.apis.transmodel.model.EnumTypes.FILTER_PLACE_T
 import static org.opentripplanner.apis.transmodel.model.EnumTypes.MULTI_MODAL_MODE;
 import static org.opentripplanner.apis.transmodel.model.EnumTypes.TRANSPORT_MODE;
 import static org.opentripplanner.apis.transmodel.model.scalars.DateTimeScalarFactory.createMillisecondsSinceEpochAsDateTimeStringScalar;
-import static org.opentripplanner.apis.transmodel.support.GqlUtil.mapArgCollectionNullSafe;
+import static org.opentripplanner.apis.transmodel.support.GqlUtil.toListNullSafe;
 import static org.opentripplanner.model.projectinfo.OtpProjectInfo.projectInfo;
 
 import graphql.Scalars;
@@ -1311,11 +1311,11 @@ public class TransmodelGraphQLSchema {
             );
             var privateCodes = FilterValues.ofEmptyIsEverything(
               "privateCodes",
-              mapArgCollectionNullSafe(environment.<List<String>>getArgument("privateCodes"))
+              toListNullSafe(environment.<List<String>>getArgument("privateCodes"))
             );
             var activeServiceDates = FilterValues.ofEmptyIsEverything(
               "activeDates",
-              mapArgCollectionNullSafe(environment.<List<LocalDate>>getArgument("activeDates"))
+              toListNullSafe(environment.<List<LocalDate>>getArgument("activeDates"))
             );
 
             TripRequest tripRequest = TripRequest

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
@@ -6,8 +6,11 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import javax.annotation.Nullable;
 import org.opentripplanner.apis.transmodel.TransmodelRequestContext;
 import org.opentripplanner.apis.transmodel.mapping.TransitIdMapper;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
@@ -18,7 +21,7 @@ import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Provide some of the commonly used "chain" of methods. Like all ids should be created the same
- * wayThis
+ * way.
  */
 public class GqlUtil {
 
@@ -95,5 +98,17 @@ public class GqlUtil {
     return lang != null
       ? GraphQLUtils.getLocale(environment, lang)
       : GraphQLUtils.getLocale(environment);
+  }
+
+  /**
+   * Null-safe handling of a collection of arguments of type T.
+   * Returns an empty collection if the collection is null.
+   * If the collection contains null elements, they are ignored.
+   */
+  public static <T> List<T> mapArgCollectionNullSafe(@Nullable Collection<T> args) {
+    if (args == null) {
+      return List.of();
+    }
+    return args.stream().filter(Objects::nonNull).toList();
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
@@ -101,11 +101,10 @@ public class GqlUtil {
   }
 
   /**
-   * Null-safe handling of a collection of arguments of type T.
-   * Returns an empty collection if the collection is null.
-   * If the collection contains null elements, they are ignored.
+   * Null-safe handling of a collection of type T. Returns an empty list if the collection is null.
+   * Null elements are filtered out.
    */
-  public static <T> List<T> mapArgCollectionNullSafe(@Nullable Collection<T> args) {
+  public static <T> List<T> toListNullSafe(@Nullable Collection<T> args) {
     if (args == null) {
       return List.of();
     }


### PR DESCRIPTION
### Summary

This ignores null members in lists of arguments. Today this fails with NullPointerExceptions deeper in the stack, which is difficult for users to interpret.

Tested with local runs.

Current error message:

`Exception while fetching data (/serviceJourneys) : Cannot invoke \"Object.equals(Object)\" because \"this.value\" is null`

New behavior is to just ignore the null in an argument set to: [null].

To recreate current error: https://api.entur.io/graphql-explorer/journey-planner-v3?query=query%20GetDepartureStops%28%24authorities%3A%5BString%5D%24privateCodes%3A%5BString%5D%24dateYesterday%3ADate%24date%3ADate%29%7BserviceJourneys%28authorities%3A%24authorities%20privateCodes%3A%24privateCodes%20activeDates%3A%5B%24dateYesterday%24date%5D%29%7Bid%20stopsYesterday%3AestimatedCalls%28date%3A%24dateYesterday%29%7Bquay%7Bname%7Ddate%20aimedDepartureTime%20expectedDepartureTime%20expectedArrivalTime%20forAlighting%7DstopsToday%3AestimatedCalls%28date%3A%24date%29%7Bquay%7Bname%7Ddate%20aimedDepartureTime%20expectedDepartureTime%20expectedArrivalTime%20forAlighting%7D%7D%7D&variables=%7B%0A%20%20%22authorities%22%3A%20%5B%0A%20%20%20%20%22VYG%3AAuthority%3AVYT%22%2C%0A%20%20%20%20%22VYG%3AAuthority%3AVY%22%2C%0A%20%20%20%20%22GJB%3AAuthority%3AGJB%22%2C%0A%20%20%20%20%22NSB%3AAuthority%3ANSB%22%2C%0A%20%20%20%20%22SJN%3AAuthority%3ASJN%22%2C%0A%20%20%20%20%22GOA%3AAuthority%3AGOA%22%2C%0A%20%20%20%20%22FLT%3AAuthority%3AFLT%22%0A%20%20%5D%2C%0A%20%20%22privateCodes%22%3A%20%5Bnull%5D%2C%0A%20%20%22dateYesterday%22%3A%20%222025-01-04%22%2C%0A%20%20%22date%22%3A%20%222025-01-05%22%0A%7D
