### PR TITLE
Add 'maxStopCountForMode' to the router config

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
@@ -4,6 +4,7 @@ import static java.time.Duration.ofMinutes;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -27,18 +28,21 @@ public final class AccessEgressPreferences implements Serializable {
 
   private final TimeAndCostPenaltyForEnum<StreetMode> penalty;
   private final DurationForEnum<StreetMode> maxDuration;
-  private final int maxStopCount;
+  private final int defaultMaxStopCount;
+  private final Map<StreetMode, Integer> maxStopCountForMode;
 
   private AccessEgressPreferences() {
     this.maxDuration = durationForStreetModeOf(ofMinutes(45));
     this.penalty = DEFAULT_TIME_AND_COST;
-    this.maxStopCount = 500;
+    this.defaultMaxStopCount = 500;
+    this.maxStopCountForMode = Map.of();
   }
 
   private AccessEgressPreferences(Builder builder) {
     this.maxDuration = builder.maxDuration;
     this.penalty = builder.penalty;
-    this.maxStopCount = builder.maxStopCount;
+    this.defaultMaxStopCount = builder.defaultMaxStopCount;
+    this.maxStopCountForMode = Collections.unmodifiableMap(builder.maxStopCountForMode);
   }
 
   public static Builder of() {
@@ -57,8 +61,12 @@ public final class AccessEgressPreferences implements Serializable {
     return maxDuration;
   }
 
-  public int maxStopCount() {
-    return maxStopCount;
+  public int defaultMaxStopCount() {
+    return defaultMaxStopCount;
+  }
+
+  public Map<StreetMode, Integer> maxStopCountForMode() {
+    return maxStopCountForMode;
   }
 
   @Override
@@ -69,13 +77,14 @@ public final class AccessEgressPreferences implements Serializable {
     return (
       penalty.equals(that.penalty) &&
       maxDuration.equals(that.maxDuration) &&
-      maxStopCount == that.maxStopCount
+      defaultMaxStopCount == that.defaultMaxStopCount &&
+      maxStopCountForMode.equals(that.maxStopCountForMode)
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(penalty, maxDuration, maxStopCount);
+    return Objects.hash(penalty, maxDuration, defaultMaxStopCount, maxStopCountForMode);
   }
 
   @Override
@@ -84,7 +93,8 @@ public final class AccessEgressPreferences implements Serializable {
       .of(AccessEgressPreferences.class)
       .addObj("penalty", penalty, DEFAULT.penalty)
       .addObj("maxDuration", maxDuration, DEFAULT.maxDuration)
-      .addObj("maxStopCount", maxStopCount, DEFAULT.maxStopCount)
+      .addObj("defaultMaxStopCount", defaultMaxStopCount, DEFAULT.defaultMaxStopCount)
+      .addObj("maxStopCountForMode", maxStopCountForMode, DEFAULT.maxStopCountForMode)
       .toString();
   }
 
@@ -93,13 +103,15 @@ public final class AccessEgressPreferences implements Serializable {
     private final AccessEgressPreferences original;
     private TimeAndCostPenaltyForEnum<StreetMode> penalty;
     private DurationForEnum<StreetMode> maxDuration;
-    private int maxStopCount;
+    private Map<StreetMode, Integer> maxStopCountForMode;
+    private int defaultMaxStopCount;
 
     public Builder(AccessEgressPreferences original) {
       this.original = original;
       this.maxDuration = original.maxDuration;
       this.penalty = original.penalty;
-      this.maxStopCount = original.maxStopCount;
+      this.defaultMaxStopCount = original.defaultMaxStopCount;
+      this.maxStopCountForMode = original.maxStopCountForMode;
     }
 
     public Builder withMaxDuration(Consumer<DurationForEnum.Builder<StreetMode>> body) {
@@ -112,8 +124,12 @@ public final class AccessEgressPreferences implements Serializable {
       return withMaxDuration(b -> b.withDefault(defaultValue).withValues(values));
     }
 
-    public Builder withMaxStopCount(int maxCount) {
-      this.maxStopCount = maxCount;
+    public Builder withMaxStopCount(
+      int defaultMaxStopCount,
+      Map<StreetMode, Integer> maxStopCountForMode
+    ) {
+      this.defaultMaxStopCount = defaultMaxStopCount;
+      this.maxStopCountForMode = maxStopCountForMode;
       return this;
     }
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -542,7 +542,20 @@ does not exist.
               Safety limit to prevent access to and egress from too many stops.
               """
               )
-              .asInt(dftAccessEgress.maxStopCount())
+              .asInt(dftAccessEgress.defaultMaxStopCount()),
+            cae
+              .of("maxStopCountForMode")
+              .since(V2_7)
+              .summary(
+                "Maximal number of stops collected in access/egress routing for the given mode"
+              )
+              .description(
+                """
+              Safety limit to prevent access to and egress from too many stops.
+              Mode-specific version of `maxStopCount`.
+              """
+              )
+              .asEnumMap(StreetMode.class, Integer.class)
           );
       })
       .withMaxDirectDuration(

--- a/application/src/test/resources/standalone/config/router-config.json
+++ b/application/src/test/resources/standalone/config/router-config.json
@@ -99,6 +99,9 @@
         "BIKE_RENTAL": "20m"
       },
       "maxStopCount": 500,
+      "maxStopCountForMode": {
+        "CAR": 0
+      },
       "penalty": {
         "FLEXIBLE": {
           "timePenalty": "2m + 1.1t",

--- a/doc/user/RouteRequest.md
+++ b/doc/user/RouteRequest.md
@@ -1263,6 +1263,9 @@ include stairs as a last result.
         "BIKE_RENTAL" : "20m"
       },
       "maxStopCount" : 500,
+      "maxStopCountForMode" : {
+        "CAR" : 0
+      },
       "penalty" : {
         "FLEXIBLE" : {
           "timePenalty" : "2m + 1.1t",

--- a/doc/user/RouteRequest.md
+++ b/doc/user/RouteRequest.md
@@ -46,6 +46,7 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 |    [maxDuration](#rd_accessEgress_maxDuration)                                                               |       `duration`       | This is the maximum duration for access/egress for street searches.                                                                                      | *Optional* | `"PT45M"`        |  2.1  |
 |    [maxStopCount](#rd_accessEgress_maxStopCount)                                                             |        `integer`       | Maximal number of stops collected in access/egress routing                                                                                               | *Optional* | `500`            |  2.4  |
 |    [maxDurationForMode](#rd_accessEgress_maxDurationForMode)                                                 | `enum map of duration` | Limit access/egress per street mode.                                                                                                                     | *Optional* |                  |  2.1  |
+|    [maxStopCountForMode](#rd_accessEgress_maxStopCountForMode)                                               |  `enum map of integer` | Maximal number of stops collected in access/egress routing for the given mode                                                                            | *Optional* |                  |  2.7  |
 |    [penalty](#rd_accessEgress_penalty)                                                                       |  `enum map of object`  | Penalty for access/egress by street mode.                                                                                                                | *Optional* |                  |  2.4  |
 |       FLEXIBLE                                                                                               |        `object`        | NA                                                                                                                                                       | *Optional* |                  |  2.4  |
 |          costFactor                                                                                          |        `double`        | A factor multiplied with the time-penalty to get the cost-penalty.                                                                                       | *Optional* | `0.0`            |  2.4  |
@@ -429,6 +430,18 @@ Limit access/egress per street mode.
 
 Override the settings in `maxDuration` for specific street modes. This is
 done because some street modes searches are much more resource intensive than others.
+
+
+<h3 id="rd_accessEgress_maxStopCountForMode">maxStopCountForMode</h3>
+
+**Since version:** `2.7` ∙ **Type:** `enum map of integer` ∙ **Cardinality:** `Optional`   
+**Path:** /routingDefaults/accessEgress   
+**Enum keys:** `not-set` | `walk` | `bike` | `bike-to-park` | `bike-rental` | `scooter-rental` | `car` | `car-to-park` | `car-pickup` | `car-rental` | `car-hailing` | `flexible`
+
+Maximal number of stops collected in access/egress routing for the given mode
+
+Safety limit to prevent access to and egress from too many stops.
+Mode-specific version of `maxStopCount`.
 
 
 <h3 id="rd_accessEgress_penalty">penalty</h3>

--- a/doc/user/RouterConfiguration.md
+++ b/doc/user/RouterConfiguration.md
@@ -551,6 +551,9 @@ Used to group requests when monitoring OTP.
         "BIKE_RENTAL" : "20m"
       },
       "maxStopCount" : 500,
+      "maxStopCountForMode" : {
+        "CAR" : 0
+      },
       "penalty" : {
         "FLEXIBLE" : {
           "timePenalty" : "2m + 1.1t",


### PR DESCRIPTION
### Summary

This PR adds a mode-specific version of the `maxStopCount` parameter (`maxStopCountForMode`) to the router config. This can be useful for setting higher limits for modes that can travel larger distances such as cars. Setting the parameter to a higher value has the downside of requiring more computation.

### Issue

This is a follow-up PR related to issue https://github.com/opentripplanner/OpenTripPlanner/issues/5875

### Unit tests

No unit tests created, manual testing has been performed

### Documentation

Changes to `RouteRequest.md`
