### PR TITLE
Fix `bookWhen` field is `null` in the Transmodel API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/BookingArrangementType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/BookingArrangementType.java
@@ -109,7 +109,7 @@ public class BookingArrangementType {
           .type(EnumTypes.PURCHASE_WHEN)
           .dataFetcher(environment -> {
             BookingInfo bookingInfo = bookingInfo(environment);
-            if (bookingInfo.getMinimumBookingNotice() != null) {
+            if (bookingInfo.getMinimumBookingNotice().isPresent()) {
               return null;
             }
             BookingTime latestBookingTime = bookingInfo.getLatestBookingTime();


### PR DESCRIPTION
### Summary

The `bookWhen` field in booking-info is not populated in the Transmodel API any more. This is a regression. The problem was introduced in f3121446ecffee3c539ce287b7f45f09a099c4b4.

### Issue

Closes #6384

### Unit tests

🟥  This is a critical fix - writing a unit test for this require refactoring. The implementation is imperative and the business rules is not encapsulated. So, I have not provided any test - that would introduce extra risk.

### Documentation

🟥  Not relevant

### Changelog

✅ Should be included


### Bumping the serialization version id

🟥  No changes to the serialized model
