### PR TITLE
Extract mapper for Transmodel `bookWhen`, new values for `relativeDirection`

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/BookingInfoMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/BookingInfoMapper.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
+import org.opentripplanner.transit.model.timetable.booking.BookingTime;
+
+/**
+ * Maps the {@link BookingInfo} to enum value (as a string) returned by the API.
+ */
+public class BookingInfoMapper {
+
+  public static String mapToBookWhen(BookingInfo bookingInfo) {
+    if (bookingInfo.getMinimumBookingNotice().isPresent()) {
+      return null;
+    }
+    BookingTime latestBookingTime = bookingInfo.getLatestBookingTime();
+    BookingTime earliestBookingTime = bookingInfo.getEarliestBookingTime();
+
+    // Try to deduce the original enum from stored values
+    if (earliestBookingTime == null) {
+      if (latestBookingTime == null) {
+        return "timeOfTravelOnly";
+      } else if (latestBookingTime.getDaysPrior() == 1) {
+        return "untilPreviousDay";
+      } else if (latestBookingTime.getDaysPrior() == 0) {
+        return "advanceAndDayOfTravel";
+      } else {
+        return "other";
+      }
+    } else if (
+      earliestBookingTime.getDaysPrior() == 0 &&
+      (latestBookingTime == null || latestBookingTime.getDaysPrior() == 0)
+    ) {
+      return "dayOfTravelOnly";
+    } else {
+      return "other";
+    }
+  }
+}

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RelativeDirectionMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RelativeDirectionMapper.java
@@ -22,12 +22,12 @@ public class RelativeDirectionMapper {
         CIRCLE_COUNTERCLOCKWISE,
         ELEVATOR,
         UTURN_LEFT,
-        UTURN_RIGHT -> relativeDirection;
-      // for these the Transmodel API doesn't have a mapping. should it?
-      case ENTER_STATION,
+        UTURN_RIGHT,
+        ENTER_STATION,
         EXIT_STATION,
-        ENTER_OR_EXIT_STATION,
-        FOLLOW_SIGNS -> RelativeDirection.CONTINUE;
+        FOLLOW_SIGNS -> relativeDirection;
+      // this type should never be exposed by an API
+      case ENTER_OR_EXIT_STATION -> RelativeDirection.CONTINUE;
     };
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -289,6 +289,9 @@ public class EnumTypes {
     .value("elevator", RelativeDirection.ELEVATOR)
     .value("uturnLeft", RelativeDirection.UTURN_LEFT)
     .value("uturnRight", RelativeDirection.UTURN_RIGHT)
+    .value("enterStation", RelativeDirection.ENTER_STATION)
+    .value("exitStation", RelativeDirection.EXIT_STATION)
+    .value("followSigns", RelativeDirection.FOLLOW_SIGNS)
     .build();
 
   public static final GraphQLEnumType REPORT_TYPE = GraphQLEnumType

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1719,6 +1719,9 @@ enum RelativeDirection {
   continue
   depart
   elevator
+  enterStation
+  exitStation
+  followSigns
   hardLeft
   hardRight
   left

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/BookingInfoMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/BookingInfoMapperTest.java
@@ -1,0 +1,83 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.apis.transmodel.mapping.BookingInfoMapper.mapToBookWhen;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
+import org.opentripplanner.transit.model.timetable.booking.BookingTime;
+
+class BookingInfoMapperTest {
+
+  private static final Duration TEN_MINUTES = Duration.ofMinutes(10);
+  private static final BookingTime BOOKING_TIME_ZERO_DAYS_PRIOR = new BookingTime(
+    LocalTime.of(10, 0),
+    0
+  );
+
+  @Test
+  void bookingNotice() {
+    assertNull(mapToBookWhen(BookingInfo.of().withMinimumBookingNotice(TEN_MINUTES).build()));
+  }
+
+  @Test
+  void timeOfTravelOnly() {
+    assertEquals("timeOfTravelOnly", mapToBookWhen(BookingInfo.of().build()));
+  }
+
+  @Test
+  void untilPreviousDay() {
+    var info = daysPrior(1);
+    assertEquals("untilPreviousDay", mapToBookWhen(info));
+  }
+
+  @Test
+  void advanceAndDayOfTravel() {
+    var info = daysPrior(0);
+    assertEquals("advanceAndDayOfTravel", mapToBookWhen(info));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = { 2, 3, 4, 14, 28 })
+  void other(int days) {
+    var info = daysPrior(days);
+    assertEquals("other", mapToBookWhen(info));
+  }
+
+  @Test
+  void dayOfTravelOnly() {
+    var info = BookingInfo.of().withEarliestBookingTime(BOOKING_TIME_ZERO_DAYS_PRIOR).build();
+    assertEquals("dayOfTravelOnly", mapToBookWhen(info));
+  }
+
+  @Test
+  void latestBookingTime() {
+    var info = BookingInfo
+      .of()
+      .withEarliestBookingTime(BOOKING_TIME_ZERO_DAYS_PRIOR)
+      .withLatestBookingTime(BOOKING_TIME_ZERO_DAYS_PRIOR)
+      .build();
+    assertEquals("dayOfTravelOnly", mapToBookWhen(info));
+  }
+
+  @Test
+  void earliestBookingTimeZero() {
+    var info = BookingInfo
+      .of()
+      .withEarliestBookingTime(new BookingTime(LocalTime.of(10, 0), 10))
+      .build();
+    assertEquals("other", mapToBookWhen(info));
+  }
+
+  private static BookingInfo daysPrior(int daysPrior) {
+    return BookingInfo
+      .of()
+      .withLatestBookingTime(new BookingTime(LocalTime.of(10, 0), daysPrior))
+      .build();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/model/EnumTypesTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/model/EnumTypesTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.transmodel.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -93,7 +94,7 @@ class EnumTypesTest {
       Locale.ENGLISH
     );
     assertInstanceOf(String.class, value);
-    assertNotNull(value);
+    assertFalse(((String) value).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### `bookWhen`

@t2gran had to fix a bug I introduced in #6385 which I feel a bit bad about. In order for this to not repeat itself I extracted a mapper for the field in question and added lots and lots of tests.

The line coverage in the mapper is 100% and the branch coverage 93%.

### New enum values for Transmodel's relativeDirection

In #6343 we introduced a new internal enum value for RelativeDirection. We don't want to expose the type ever in the API so I introduced mapper to get rid of it. In that process I noticed that there are unmapped enum values in the Transmodel API, which I also mapped away.

@t2gran has requested that instead we add the enum values to the API which I did.

There was already a test for the enum serialisation which also tests the new values.

### Issue

Relates to #6384 

### Unit tests

Added.

### Documentation

Javadoc.