### PR TITLE
Add ci workflow for validating schema changes

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -9,6 +9,10 @@ jobs:
   validate-gtfs:
     if: github.repository_owner == 'opentripplanner'
     name: Validate GraphQL schema changes
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     runs-on: ubuntu-latest
  
     steps:

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -4,15 +4,16 @@ on:
   pull_request:
     branches:
       - dev-2.x
- 
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
 jobs:
   validate-gtfs:
     if: github.repository_owner == 'opentripplanner'
     name: Validate GraphQL schema changes
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
     runs-on: ubuntu-latest
  
     steps:

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,0 +1,34 @@
+name: Validate schema changes
+ 
+on:
+  pull_request:
+    branches:
+      - dev-2.x
+ 
+jobs:
+  validate-gtfs:
+    if: github.repository_owner == 'opentripplanner'
+    name: Validate GraphQL schema changes
+    runs-on: ubuntu-latest
+ 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+ 
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate GTFS GraphQL schema changes
+          schema: 'dev-2.x:application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls'
+          annotations: false
+          fail-on-breaking: true
+          rules: |
+            ignoreDescriptionChanges
+      
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Transmodel GraphQL schema changes
+          schema: 'dev-2.x:application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql'
+          annotations: false
+          fail-on-breaking: true
+          rules: |
+            ignoreDescriptionChanges


### PR DESCRIPTION
### Summary

Adds CI workflow that uses [schema inspector](https://the-guild.dev/graphql/inspector/docs/products/action) to validate that there are no breaking schema changes and to list changes.

### Issue

This was shortly discussed in a dev meeting this week.

### Unit tests

No

### Documentation

No

### Changelog

Skipped
