### PR TITLE
Allow SIRI's StopPointRef to refer to a NeTEx scheduled stop point

### DIFF
--- a/application/src/main/java/org/opentripplanner/model/OtpTransitService.java
+++ b/application/src/main/java/org/opentripplanner/model/OtpTransitService.java
@@ -3,6 +3,7 @@ package org.opentripplanner.model;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.transit.model.basic.Notice;
@@ -15,6 +16,7 @@ import org.opentripplanner.transit.model.site.BoardingArea;
 import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.Pathway;
 import org.opentripplanner.transit.model.site.PathwayNode;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.SiteRepository;
 
@@ -77,4 +79,9 @@ public interface OtpTransitService {
    * transit services if they are outside the configured 'transitServiceStart' and 'transitServiceEnd'
    */
   boolean hasActiveTransit();
+
+  /**
+   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   */
+  Map<FeedScopedId, RegularStop> stopsByScheduledStopPoint();
 }

--- a/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -280,6 +280,13 @@ public class OtpTransitServiceBuilder {
     return vehicleParkings;
   }
 
+  /**
+   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   */
+  public Map<FeedScopedId, RegularStop> stopsByScheduledStopPoints() {
+    return stopsByScheduledStopPoints;
+  }
+
   public OtpTransitService build() {
     return new OtpTransitServiceImpl(this);
   }
@@ -317,10 +324,6 @@ public class OtpTransitServiceBuilder {
     }
     removeEntitiesWithInvalidReferences();
     LOG.info("Limiting transit service days to time period complete.");
-  }
-
-  public Map<FeedScopedId, RegularStop> getStopsByScheduledStopPoints() {
-    return stopsByScheduledStopPoints;
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -122,6 +122,8 @@ public class OtpTransitServiceBuilder {
 
   private final List<VehicleParking> vehicleParkings = new ArrayList<>();
 
+  private final Map<FeedScopedId, RegularStop> stopsByScheduledStopPoints = new HashMap<>();
+
   private final DataImportIssueStore issueStore;
 
   public OtpTransitServiceBuilder(SiteRepository siteRepository, DataImportIssueStore issueStore) {
@@ -317,6 +319,10 @@ public class OtpTransitServiceBuilder {
     LOG.info("Limiting transit service days to time period complete.");
   }
 
+  public Map<FeedScopedId, RegularStop> getStopsByScheduledStopPoints() {
+    return stopsByScheduledStopPoints;
+  }
+
   /**
    * Find all serviceIds in both CalendarServices and CalendarServiceDates.
    */
@@ -449,7 +455,7 @@ public class OtpTransitServiceBuilder {
   }
 
   /**
-   * Return {@code true} if the the point is a trip-transfer-point and the trip reference is
+   * Return {@code true} if the point is a trip-transfer-point and the trip reference is
    * missing.
    */
   private boolean transferPointTripReferenceDoesNotExist(TransferPoint point) {

--- a/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -327,6 +327,13 @@ public class OtpTransitServiceBuilder {
   }
 
   /**
+   * Add a mapping from a scheduled stop point to the regular stop.
+   */
+  public void addStopByScheduledStopPoint(FeedScopedId sspid, RegularStop stop) {
+    stopsByScheduledStopPoints.put(sspid, stop);
+  }
+
+  /**
    * Find all serviceIds in both CalendarServices and CalendarServiceDates.
    */
   Set<FeedScopedId> findAllServiceIds() {

--- a/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -93,7 +93,8 @@ class OtpTransitServiceImpl implements OtpTransitService {
     this.tripPatterns = immutableList(builder.getTripPatterns().values());
     this.trips = immutableList(builder.getTripsById().values());
     this.flexTrips = immutableList(builder.getFlexTripsById().values());
-    this.stopsByScheduledStopPoint = Collections.unmodifiableMap(builder.stopsByScheduledStopPoints());
+    this.stopsByScheduledStopPoint =
+      Collections.unmodifiableMap(builder.stopsByScheduledStopPoints());
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -25,6 +25,7 @@ import org.opentripplanner.transit.model.site.BoardingArea;
 import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.Pathway;
 import org.opentripplanner.transit.model.site.PathwayNode;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.SiteRepository;
 
@@ -70,6 +71,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
   private final Collection<Trip> trips;
 
   private final Collection<FlexTrip<?, ?>> flexTrips;
+  private final Map<FeedScopedId, RegularStop> stopsByScheduledStopPoint;
 
   /**
    * Create a read only version of the {@link OtpTransitService}.
@@ -91,6 +93,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
     this.tripPatterns = immutableList(builder.getTripPatterns().values());
     this.trips = immutableList(builder.getTripsById().values());
     this.flexTrips = immutableList(builder.getFlexTripsById().values());
+    this.stopsByScheduledStopPoint = Collections.unmodifiableMap(builder.stopsByScheduledStopPoints());
   }
 
   @Override
@@ -184,6 +187,14 @@ class OtpTransitServiceImpl implements OtpTransitService {
   @Override
   public boolean hasActiveTransit() {
     return serviceIds.size() > 0;
+  }
+
+  /**
+   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   */
+  @Override
+  public Map<FeedScopedId, RegularStop> stopsByScheduledStopPoint() {
+    return stopsByScheduledStopPoint;
   }
 
   /*  Private Methods */

--- a/application/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/application/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -96,6 +96,7 @@ public class NetexModule implements GraphBuilderModule {
         //           - have operators and notice assignments.
         timetableRepository.addOperators(otpService.getAllOperators());
         timetableRepository.addNoticeAssignments(otpService.getNoticeAssignments());
+        timetableRepository.addScheduledStopPointMapping(otpService.stopsByScheduledStopPoint());
 
         AddTransitEntitiesToGraph.addToGraph(
           otpService,

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/NetexDocumentParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/NetexDocumentParser.java
@@ -69,24 +69,24 @@ public class NetexDocumentParser {
   }
 
   private void parseCommonFrame(Common_VersionFrameStructure value) {
-    if (value instanceof ResourceFrame) {
-      parse((ResourceFrame) value, new ResourceFrameParser());
-    } else if (value instanceof ServiceCalendarFrame) {
-      parse((ServiceCalendarFrame) value, new ServiceCalendarFrameParser());
-    } else if (value instanceof TimetableFrame) {
-      parse((TimetableFrame) value, new TimeTableFrameParser());
-    } else if (value instanceof ServiceFrame) {
-      parse((ServiceFrame) value, new ServiceFrameParser(netexIndex.flexibleStopPlaceById));
-    } else if (value instanceof SiteFrame) {
-      parse((SiteFrame) value, new SiteFrameParser(ignoredFeatures));
-    } else if (!ignoredFeatures.contains(FARE_FRAME) && value instanceof FareFrame) {
-      parse((FareFrame) value, new FareFrameParser());
-    } else if (value instanceof CompositeFrame) {
+    if (value instanceof ResourceFrame frame) {
+      parse(frame, new ResourceFrameParser());
+    } else if (value instanceof ServiceCalendarFrame frame) {
+      parse(frame, new ServiceCalendarFrameParser());
+    } else if (value instanceof TimetableFrame frame) {
+      parse(frame, new TimeTableFrameParser());
+    } else if (value instanceof ServiceFrame frame) {
+      parse(frame, new ServiceFrameParser(netexIndex.flexibleStopPlaceById));
+    } else if (value instanceof SiteFrame frame) {
+      parse(frame, new SiteFrameParser(ignoredFeatures));
+    } else if (!ignoredFeatures.contains(FARE_FRAME) && value instanceof FareFrame fareFrame) {
+      parse(fareFrame, new FareFrameParser());
+    } else if (value instanceof CompositeFrame frame) {
       // We recursively parse composite frames and content until there
       // is no more nested frames - this is accepting documents which
       // are not withing the specification, but we leave this for the
       // document schema validation - not a OTP responsibility
-      parseCompositeFrame((CompositeFrame) value);
+      parseCompositeFrame(frame);
     } else if (value instanceof GeneralFrame || value instanceof InfrastructureFrame) {
       NetexParser.informOnElementIntentionallySkipped(LOG, value);
     } else {

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -142,7 +142,6 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
 
     for (JAXBElement<?> stopAssignment : stopAssignments.getStopAssignment()) {
       if (stopAssignment.getValue() instanceof PassengerStopAssignment assignment) {
-
         if (assignment.getQuayRef() == null) {
           PASSENGER_STOP_ASSIGNMENT_LOGGER.info(
             "PassengerStopAssignment with empty quay ref is dropped. Assigment: {}",

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.logging.MaxCountLogger;
 import org.opentripplanner.netex.index.NetexEntityIndex;
@@ -136,12 +137,11 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
     index.networkIdByGroupOfLineId.addAll(networkIdByGroupOfLineId);
   }
 
-  private void parseStopAssignments(StopAssignmentsInFrame_RelStructure stopAssignments) {
+  private void parseStopAssignments(@Nullable StopAssignmentsInFrame_RelStructure stopAssignments) {
     if (stopAssignments == null) return;
 
     for (JAXBElement<?> stopAssignment : stopAssignments.getStopAssignment()) {
-      if (stopAssignment.getValue() instanceof PassengerStopAssignment) {
-        var assignment = (PassengerStopAssignment) stopAssignment.getValue();
+      if (stopAssignment.getValue() instanceof PassengerStopAssignment assignment) {
 
         if (assignment.getQuayRef() == null) {
           PASSENGER_STOP_ASSIGNMENT_LOGGER.info(
@@ -153,9 +153,8 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
           String stopPointRef = assignment.getScheduledStopPointRef().getValue().getRef();
           quayIdByStopPointRef.put(stopPointRef, quayRef);
         }
-      } else if (stopAssignment.getValue() instanceof FlexibleStopAssignment) {
+      } else if (stopAssignment.getValue() instanceof FlexibleStopAssignment assignment) {
         if (OTPFeature.FlexRouting.isOn()) {
-          FlexibleStopAssignment assignment = (FlexibleStopAssignment) stopAssignment.getValue();
           String flexibleStopPlaceRef = assignment.getFlexibleStopPlaceRef().getRef();
 
           // TODO OTP2 - This check belongs to the mapping or as a separate validation
@@ -176,7 +175,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
     }
   }
 
-  private void parseRoutes(RoutesInFrame_RelStructure routes) {
+  private void parseRoutes(@Nullable RoutesInFrame_RelStructure routes) {
     if (routes == null) return;
 
     for (JAXBElement<?> element : routes.getRoute_()) {

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -537,7 +537,7 @@ public class NetexMapper {
         var sspid = idFactory.createId(id);
         var stopId = idFactory.createId(currentNetexIndex.getQuayIdByStopPointRef().lookup(id));
         var stop = Objects.requireNonNull(transitBuilder.getStops().get(stopId));
-        transitBuilder.stopsByScheduledStopPoints().put(sspid, stop);
+        transitBuilder.addStopByScheduledStopPoint(sspid, stop);
       });
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -536,7 +536,8 @@ public class NetexMapper {
       var sspid = idFactory.createId(id);
       var stopId = idFactory.createId(currentNetexIndex.getQuayIdByStopPointRef().lookup(id));
       var stop = Objects.requireNonNull(transitBuilder.getStops().get(stopId));
-      transitBuilder.getStopsByScheduledStopPoints().put(sspid, stop);
+      System.out.printf("%s -> %s%n", sspid, stopId);
+      transitBuilder.stopsByScheduledStopPoints().put(sspid, stop);
     });
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -208,8 +208,6 @@ public class NetexMapper {
     addEntriesToGroupMapperForPostProcessingLater();
   }
 
-
-
   /* PRIVATE METHODS */
 
   private void setupGroupMapping() {
@@ -532,13 +530,15 @@ public class NetexMapper {
   }
 
   private void mapScheduledStopPointsToQuays() {
-    currentNetexIndex.getQuayIdByStopPointRef().localKeys().forEach(id -> {
-      var sspid = idFactory.createId(id);
-      var stopId = idFactory.createId(currentNetexIndex.getQuayIdByStopPointRef().lookup(id));
-      var stop = Objects.requireNonNull(transitBuilder.getStops().get(stopId));
-      System.out.printf("%s -> %s%n", sspid, stopId);
-      transitBuilder.stopsByScheduledStopPoints().put(sspid, stop);
-    });
+    currentNetexIndex
+      .getQuayIdByStopPointRef()
+      .localKeys()
+      .forEach(id -> {
+        var sspid = idFactory.createId(id);
+        var stopId = idFactory.createId(currentNetexIndex.getQuayIdByStopPointRef().lookup(id));
+        var stop = Objects.requireNonNull(transitBuilder.getStops().get(stopId));
+        transitBuilder.stopsByScheduledStopPoints().put(sspid, stop);
+      });
   }
 
   private void mapVehicleParkings() {

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -202,10 +202,13 @@ public class NetexMapper {
     mapTripPatterns(serviceIds);
     mapNoticeAssignments();
 
+    mapScheduledStopPointsToQuays();
     mapVehicleParkings();
 
     addEntriesToGroupMapperForPostProcessingLater();
   }
+
+
 
   /* PRIVATE METHODS */
 
@@ -526,6 +529,15 @@ public class NetexMapper {
         currentNetexIndex.getServiceJourneyInterchangeById().localValues()
       );
     }
+  }
+
+  private void mapScheduledStopPointsToQuays() {
+    currentNetexIndex.getQuayIdByStopPointRef().localKeys().forEach(id -> {
+      var sspid = idFactory.createId(id);
+      var stopId = idFactory.createId(currentNetexIndex.getQuayIdByStopPointRef().lookup(id));
+      var stop = Objects.requireNonNull(transitBuilder.getStops().get(stopId));
+      transitBuilder.getStopsByScheduledStopPoints().put(sspid, stop);
+    });
   }
 
   private void mapVehicleParkings() {

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -603,6 +603,11 @@ public class DefaultTransitService implements TransitEditorService {
     return this.timetableRepositoryIndex.containsTrip(id);
   }
 
+  @Override
+  public Optional<RegularStop> findStopByScheduledStopPoint(FeedScopedId scheduledStopPoint) {
+    return timetableRepository.findStopByScheduledStopPoint(scheduledStopPoint);
+  }
+
   /**
    * Returns a list of Trips that match the filtering defined in the request.
    *

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -455,9 +455,26 @@ public class TimetableRepository implements Serializable {
     tripPatternForId.put(id, tripPattern);
   }
 
-  public void addScheduledStopPointMapping(FeedScopedId scheduledStopPointRef, FeedScopedId stopId) {
-    var stop = Objects.requireNonNull(siteRepository.getRegularStop(stopId));
-    stopsByScheduledStopPointRefs.put(scheduledStopPointRef, stop);
+  public void addScheduledStopPointMapping(Map<FeedScopedId, RegularStop> mapping) {
+    stopsByScheduledStopPointRefs.putAll(mapping);
+  }
+
+  /**
+   * Return the stop that is associated with the NeTEx concept of a scheduled stop point.
+   * <p>
+   * The scheduled stop point which is a "location-independent" stop that schedule systems provide
+   * which in turn can be later be resolved to an actual stop.
+   * <p>
+   * This way two schedule systems can use their own IDs for scheduled stop points but the stop (the
+   * actual physical infrastructure) is the same.
+   * <p>
+   * SIRI feeds are encouraged to refer to scheduled stop points in an EstimatedCall's stopPointRef
+   * but the specs are unclear and the reality on the ground very mixed.
+   *
+   * @link <a href="https://public.3.basecamp.com/p/TcEEP5WrNZJPBxrJU9GAjint">NeTEx Basecamp discussion</a>
+   */
+  public Optional<RegularStop> findStopByScheduledStopPoint(FeedScopedId scheduledStopPoint) {
+    return Optional.ofNullable(stopsByScheduledStopPointRefs.get(scheduledStopPoint));
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -150,6 +150,8 @@ public class TimetableRepository implements Serializable {
 
   private transient TransitAlertService transitAlertService;
 
+  private final Map<FeedScopedId, RegularStop> stopsByScheduledStopPointRefs = new HashMap<>();
+
   @Inject
   public TimetableRepository(SiteRepository siteRepository, Deduplicator deduplicator) {
     this.siteRepository = Objects.requireNonNull(siteRepository);
@@ -451,6 +453,11 @@ public class TimetableRepository implements Serializable {
   public void addTripPattern(FeedScopedId id, TripPattern tripPattern) {
     invalidateIndex();
     tripPatternForId.put(id, tripPattern);
+  }
+
+  public void addScheduledStopPointMapping(FeedScopedId scheduledStopPointRef, FeedScopedId stopId) {
+    var stop = Objects.requireNonNull(siteRepository.getRegularStop(stopId));
+    stopsByScheduledStopPointRefs.put(scheduledStopPointRef, stop);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -328,6 +328,11 @@ public interface TransitService {
   boolean containsTrip(FeedScopedId id);
 
   /**
+   * @see TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   */
+  Optional<RegularStop> findStopByScheduledStopPoint(FeedScopedId scheduledStopPoint);
+
+  /**
    * Returns a list of {@link RegularStop}s that lay within a bounding box and match the other criteria
    * in the request object.
    */

--- a/application/src/main/java/org/opentripplanner/updater/siri/EntityResolver.java
+++ b/application/src/main/java/org/opentripplanner/updater/siri/EntityResolver.java
@@ -190,7 +190,9 @@ public class EntityResolver {
    */
   public RegularStop resolveQuay(String stopPointRef) {
     var id = resolveId(stopPointRef);
-    return transitService.findStopByScheduledStopPoint(id).orElseGet(() -> transitService.getRegularStop(id));
+    return transitService
+      .findStopByScheduledStopPoint(id)
+      .orElseGet(() -> transitService.getRegularStop(id));
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/updater/siri/EntityResolver.java
+++ b/application/src/main/java/org/opentripplanner/updater/siri/EntityResolver.java
@@ -105,6 +105,7 @@ public class EntityResolver {
     );
   }
 
+  @Nullable
   public TripOnServiceDate resolveTripOnServiceDate(
     String serviceJourneyId,
     @Nullable LocalDate serviceDate
@@ -157,6 +158,7 @@ public class EntityResolver {
    * departure from the first stop, only the Date-part is actually used, and is defined to
    * represent the actual serviceDate. The time and zone part is ignored.
    */
+  @Nullable
   public LocalDate resolveServiceDate(@Nullable ZonedDateTime originAimedDepartureTime) {
     if (originAimedDepartureTime == null) {
       return null;
@@ -172,6 +174,7 @@ public class EntityResolver {
    * Resolve a {@link Trip} by resolving a service journey id from FramedVehicleJourneyRef ->
    * DatedVehicleJourneyRef.
    */
+  @Nullable
   public Trip resolveTrip(@Nullable FramedVehicleJourneyRefStructure journey) {
     if (journey != null) {
       return resolveTrip(journey.getDatedVehicleJourneyRef());

--- a/application/src/main/java/org/opentripplanner/updater/siri/EntityResolver.java
+++ b/application/src/main/java/org/opentripplanner/updater/siri/EntityResolver.java
@@ -107,7 +107,7 @@ public class EntityResolver {
 
   public TripOnServiceDate resolveTripOnServiceDate(
     String serviceJourneyId,
-    LocalDate serviceDate
+    @Nullable LocalDate serviceDate
   ) {
     if (serviceDate == null) {
       return null;
@@ -157,11 +157,11 @@ public class EntityResolver {
    * departure from the first stop, only the Date-part is actually used, and is defined to
    * represent the actual serviceDate. The time and zone part is ignored.
    */
-  public LocalDate resolveServiceDate(ZonedDateTime originAimedDepartureTime) {
+  public LocalDate resolveServiceDate(@Nullable ZonedDateTime originAimedDepartureTime) {
     if (originAimedDepartureTime == null) {
       return null;
     }
-    // This grab the local-date from timestamp passed into OTP ignoring the time and zone
+    // This grabs the local-date from timestamp passed into OTP ignoring the time and zone
     // information. An alternative is to use the transit model zone:
     // 'originAimedDepartureTime.withZoneSameInstant(transitService.getTimeZone())'
 
@@ -172,7 +172,7 @@ public class EntityResolver {
    * Resolve a {@link Trip} by resolving a service journey id from FramedVehicleJourneyRef ->
    * DatedVehicleJourneyRef.
    */
-  public Trip resolveTrip(FramedVehicleJourneyRefStructure journey) {
+  public Trip resolveTrip(@Nullable FramedVehicleJourneyRefStructure journey) {
     if (journey != null) {
       return resolveTrip(journey.getDatedVehicleJourneyRef());
     }
@@ -184,10 +184,13 @@ public class EntityResolver {
   }
 
   /**
-   * Resolve a {@link RegularStop} from a quay id.
+   * Resolve a {@link RegularStop} from a scheduled stop point or quay id.
+   *
+   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
    */
-  public RegularStop resolveQuay(String quayRef) {
-    return transitService.getRegularStop(resolveId(quayRef));
+  public RegularStop resolveQuay(String stopPointRef) {
+    var id = resolveId(stopPointRef);
+    return transitService.findStopByScheduledStopPoint(id).orElseGet(() -> transitService.getRegularStop(id));
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/transit/service/TimetableRepositoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/TimetableRepositoryTest.java
@@ -3,7 +3,9 @@ package org.opentripplanner.transit.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.framework.application.OtpFileNames.BUILD_CONFIG_FILENAME;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner._support.time.ZoneIds;
@@ -12,8 +14,10 @@ import org.opentripplanner.graph_builder.module.TimeZoneAdjusterModule;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 class TimetableRepositoryTest {
@@ -106,5 +110,14 @@ class TimetableRepositoryTest {
     Trip trip = timetableRepositoryIndex.getTripForId(SAMPLE_TRIP_ID);
     Timetable timetable = timetableRepositoryIndex.getPatternForTrip(trip).getScheduledTimetable();
     assertEquals(20 * 60 - 60 * 60, timetable.getTripTimes(trip).getDepartureTime(0));
+  }
+
+  @Test
+  void scheduledStopPoints() {
+    var repo = new TimetableRepository();
+    var sspId = id("ssp-1");
+    var stop = TimetableRepositoryForTest.of().stop("stop-1").build();
+    repo.addScheduledStopPointMapping(Map.of(sspId, stop));
+    assertEquals(stop, repo.findStopByScheduledStopPoint(sspId).get());
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/siri/EntityResolverTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/siri/EntityResolverTest.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.updater.siri;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.SiteRepository;
+import org.opentripplanner.transit.service.TimetableRepository;
+
+class EntityResolverTest {
+
+  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final RegularStop STOP_1 = TEST_MODEL.stop("stop-1").build();
+  private static final RegularStop STOP_2 = TEST_MODEL.stop("stop-2").build();
+  private static final SiteRepository SITE_REPOSITORY = TEST_MODEL
+    .siteRepositoryBuilder()
+    .withRegularStops(List.of(STOP_1, STOP_2))
+    .build();
+  private static final String FEED_ID = STOP_1.getId().getFeedId();
+  private static final FeedScopedId SSP_ID = new FeedScopedId(FEED_ID, "ssp-1");
+
+  @Test
+  void resolveScheduledStopPointId() {
+    var timetableRepository = new TimetableRepository();
+    timetableRepository.addScheduledStopPointMapping(Map.of(SSP_ID, STOP_1));
+    var transitService = new DefaultTransitService(timetableRepository);
+    var resolver = new EntityResolver(transitService, FEED_ID);
+    var stop = resolver.resolveQuay(SSP_ID.getId());
+    assertEquals(STOP_1, stop);
+  }
+
+  @Test
+  void resolveQuayId() {
+    var timetableRepository = new TimetableRepository(SITE_REPOSITORY, new Deduplicator());
+    var transitService = new DefaultTransitService(timetableRepository);
+    var resolver = new EntityResolver(transitService, FEED_ID);
+    var stop = resolver.resolveQuay(STOP_1.getId().getId());
+    assertEquals(STOP_1, stop);
+  }
+
+  @Test
+  void scheduledStopPointTakesPrecedence() {
+    var timetableRepository = new TimetableRepository(SITE_REPOSITORY, new Deduplicator());
+    var transitService = new DefaultTransitService(timetableRepository);
+    timetableRepository.addScheduledStopPointMapping(Map.of(SSP_ID, STOP_2));
+    var resolver = new EntityResolver(transitService, FEED_ID);
+    assertEquals(STOP_2, resolver.resolveQuay(SSP_ID.getId()));
+    assertEquals(STOP_1, resolver.resolveQuay(STOP_1.getId().getId()));
+  }
+}


### PR DESCRIPTION
### Summary

Even though the various documents on SIRI and NeTEx are quite unclear, even contradictory what exactly an EstimatedCall's `StopPointRef` should refer to, all the experts agree that a scheduled stop point is a valid target (as an alternative to the quay).

We discussed this at length at https://public.3.basecamp.com/p/TcEEP5WrNZJPBxrJU9GAjint

For this reason, this adds support for SIRI to refer to scheduled stop point.

### Issue
 
Closes #6340

### Unit tests

I added some for the EntityResolver and the TimetableRepository.

### Documentation

I didn't want to duplicate the documentation for this in several places so I opted to document it in the innermost layer (TimetableRepository) and link to it in other places.

### Bumping the serialization version id

:heavy_check_mark: 

cc @rcavaliere