### PR TITLE
Only run "Debug Client" workflow on `dev-2.x` branch

### DIFF
--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -2,6 +2,8 @@ name: Debug client
 
 on:
   push:
+    branches:
+      - dev-2.x
     paths:
       - 'client/**'
   pull_request:
@@ -45,7 +47,7 @@ jobs:
           npm run coverage
 
       - name: Deploy compiled assets to repo
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev-2.x'
+        if: github.event_name == 'push'
         env:
           REMOTE: debug-client
           LOCAL_BRANCH: local-assets

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'client/**'
   pull_request:
+    branches:
+      - dev-2.x
     paths:
       - 'client/**'
 


### PR DESCRIPTION
### Summary

This action is run today in entur downstream fork when someone changes a file under `/client/**`. The action is aborted, but it clutter up the list of run actions. I am not an expert on workflows, but I chaned it slightly so the trigger now filter on both path and branch for pushes. This also make the script a bit cleaner, since the branch filter does not need to be repeated in the run section.

> **Note!** If you use `dev-2.x` in the fork as a active branch the this PR will not prevent this workflow from running, as @optionsome mentions in a comment below. 


### Issue
🟥  There is no issue for this.

### Unit tests

🟥  This is CI config change, we do not have tests for this.


### Documentation
🟥  I have not changed/added doc.

### Changelog

🟥  Not relevant

### Bumping the serialization version id

🟥  There is no changes to the OTP code.