### PR TITLE
Replacing protobuf-format in SIRI-Updater with standard xml

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -138,13 +138,6 @@
             <version>${siri-java-model.version}</version>
         </dependency>
 
-        <!-- XML <-> protobuf-mapper for SIRI-->
-        <dependency>
-            <groupId>org.entur</groupId>
-            <artifactId>siri-protobuf-mapper</artifactId>
-            <version>1.0.3</version>
-        </dependency>
-
         <dependency>
             <groupId>org.mobilitydata</groupId>
             <artifactId>gbfs-java-model</artifactId>


### PR DESCRIPTION
### Summary

Replaces the usage of proprietary protobuf-format for SIRI ET-data with standard XML.

### Issue

The protobuf-solution was very sensitive to changes, and upgrading protobuf-java (e.g. as in #6342) caused OTP to no longer being able to process SIRI ET-data.
