### PR TITLE
Remove default accessegress penalty for car modes that use transit

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
@@ -171,7 +171,9 @@ public final class AccessEgressPreferences implements Serializable {
     // Add penalty to all car variants with access and/or egress.
     var carPenalty = TimeAndCostPenalty.of(TimePenalty.of(ofMinutes(20), 2f), 1.5);
     for (var it : StreetMode.values()) {
-      if (it.includesDriving() && (it.accessAllowed() || it.egressAllowed())) {
+      if (
+        it.includesDriving() && (it.accessAllowed() || it.egressAllowed()) && !it.transferAllowed()
+      ) {
         penaltyBuilder.with(it, carPenalty);
       }
     }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
@@ -170,11 +170,11 @@ public final class AccessEgressPreferences implements Serializable {
 
     var carPenalty = TimeAndCostPenalty.of(TimePenalty.of(ofMinutes(20), 2f), 1.5);
     for (var it : StreetMode.values()) {
-      // Apply car-penalty to all car modes allowed in access/egress only. Exclude car modes(CAR) used
-      // in direct street routing and car modes used when you bring the car with you onto transit. This is
-      // a bit limited and will not work if we combine car access/egress modes like CAR_TO_PARK with CAR
-      // in the same search. This is currently not possible, but if we enable this in the future this logic must be
-      // looked at again.
+      // Apply car-penalty to all car modes used in access/egress. Car modes(CAR) used in direct street
+      // routing and car modes used when you bring the car with you onto transit should be excluded. The
+      // penalty should also be applied to modes used in access, egress AND direct (CAR_TO_PARK and
+      // CAR_RENTAL). This is not ideal, since we get an unfair comparison in the itinerary filters. We will
+      // live with this for now, but might revisit it later.
       if (
         it.includesDriving() && (it.accessAllowed() || it.egressAllowed()) && it != StreetMode.CAR
       ) {

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
@@ -168,11 +168,15 @@ public final class AccessEgressPreferences implements Serializable {
     var flexDefaultPenalty = TimeAndCostPenalty.of(TimePenalty.of(ofMinutes(10), 1.3f), 1.3);
     penaltyBuilder.with(StreetMode.FLEXIBLE, flexDefaultPenalty);
 
-    // Add penalty to all car variants with access and/or egress.
     var carPenalty = TimeAndCostPenalty.of(TimePenalty.of(ofMinutes(20), 2f), 1.5);
     for (var it : StreetMode.values()) {
+      // Apply car-penalty to all car modes allowed in access/egress only. Exclude car modes(CAR) used
+      // in direct street routing and car modes used when you bring the car with you onto transit. This is
+      // a bit limited and will not work if we combine car access/egress modes like CAR_TO_PARK with CAR
+      // in the same search. This is currently not possible, but if we enable this in the future this logic must be
+      // looked at again.
       if (
-        it.includesDriving() && (it.accessAllowed() || it.egressAllowed()) && !it.transferAllowed()
+        it.includesDriving() && (it.accessAllowed() || it.egressAllowed()) && it != StreetMode.CAR
       ) {
         penaltyBuilder.with(it, carPenalty);
       }

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -780,7 +780,7 @@ type QueryType {
   "Input type for executing a travel search for a trip between two locations. Returns trip patterns describing suggested alternatives for the trip."
   trip(
     "Time and cost penalty on access/egress modes."
-    accessEgressPenalty: [PenaltyForStreetMode!] = [{streetMode : car, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : car_park, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : car_pickup, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : car_rental, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : flexible, timePenalty : "10m + 1.30 t", costFactor : 1.3}],
+    accessEgressPenalty: [PenaltyForStreetMode!] = [{streetMode : car_park, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : car_pickup, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : car_rental, timePenalty : "20m + 2.0 t", costFactor : 1.5}, {streetMode : flexible, timePenalty : "10m + 1.30 t", costFactor : 1.3}],
     "The alightSlack is the minimum extra time after exiting a public transport vehicle. This is the default value used, if not overridden by the 'alightSlackList'."
     alightSlackDefault: Int = 0,
     "List of alightSlack for a given set of modes. Defaults: []"

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
@@ -113,7 +113,6 @@ class StreetPreferencesTest {
       "elevator: ElevatorPreferences{boardTime: 2m}, " +
       "intersectionTraversalModel: CONSTANT, " +
       "accessEgress: AccessEgressPreferences{penalty: TimeAndCostPenaltyForEnum{" +
-      "CAR: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
       "CAR_TO_PARK: " +
       CAR_TO_PARK_PENALTY +
       ", " +

--- a/doc/user/RouteRequest.md
+++ b/doc/user/RouteRequest.md
@@ -460,7 +460,6 @@ performance will be better.
 
 The default values are
 
-- `car` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)
 - `car-to-park` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)
 - `car-pickup` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)
 - `car-rental` = (timePenalty: 20m + 2.0 t, costFactor: 1.50)


### PR DESCRIPTION
### Summary

This PR removes the default accessegress penalty for car modes that use transit.

### Issue

This is a follow-up PR related to issue https://github.com/opentripplanner/OpenTripPlanner/issues/5875

### Documentation

Automatically generated changes.
