### PR TITLE
Cleanup DefaultServerRequestContext

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -424,6 +424,19 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.dagger</groupId>
+                            <artifactId>dagger-compiler</artifactId>
+                            <version>${google.dagger.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.6.0</version>

--- a/application/src/main/java/org/opentripplanner/inspector/raster/TileRendererManager.java
+++ b/application/src/main/java/org/opentripplanner/inspector/raster/TileRendererManager.java
@@ -39,7 +39,7 @@ public class TileRendererManager {
     renderers.put("traversal", new EdgeVertexTileRenderer(new TraversalPermissionsEdgeRenderer()));
     renderers.put(
       "wheelchair",
-      new EdgeVertexTileRenderer(new WheelchairEdgeRenderer(routingPreferences))
+      new EdgeVertexTileRenderer(new WheelchairEdgeRenderer(routingPreferences.wheelchair()))
     );
     renderers.put("elevation", new EdgeVertexTileRenderer(new ElevationEdgeRenderer(graph)));
     renderers.put("pathways", new EdgeVertexTileRenderer(new PathwayEdgeRenderer()));

--- a/application/src/main/java/org/opentripplanner/inspector/raster/WheelchairEdgeRenderer.java
+++ b/application/src/main/java/org/opentripplanner/inspector/raster/WheelchairEdgeRenderer.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.opentripplanner.inspector.raster.EdgeVertexTileRenderer.EdgeVertexRenderer;
 import org.opentripplanner.inspector.raster.EdgeVertexTileRenderer.EdgeVisualAttributes;
 import org.opentripplanner.inspector.raster.EdgeVertexTileRenderer.VertexVisualAttributes;
-import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
+import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.ElevatorHopEdge;
 import org.opentripplanner.street.model.edge.StreetEdge;
@@ -25,9 +25,8 @@ public class WheelchairEdgeRenderer implements EdgeVertexRenderer {
   private static final Color NO_WHEELCHAIR_INFORMATION_COLOR = Color.ORANGE;
   private final ScalarColorPalette slopePalette;
 
-  public WheelchairEdgeRenderer(RoutingPreferences routingPreferences) {
-    this.slopePalette =
-      new DefaultScalarColorPalette(0.0, routingPreferences.wheelchair().maxSlope(), 1.0);
+  public WheelchairEdgeRenderer(WheelchairPreferences wheelchairPreferences) {
+    this.slopePalette = new DefaultScalarColorPalette(0.0, wheelchairPreferences.maxSlope(), 1.0);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationModule.java
@@ -12,6 +12,7 @@ import org.opentripplanner.ext.interactivelauncher.api.LauncherRequestDecorator;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.sorlandsbanen.SorlandsbanenNorwayService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
+import org.opentripplanner.inspector.raster.TileRendererManager;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.graph.Graph;
@@ -52,27 +53,35 @@ public class ConstructApplicationModule {
   ) {
     var defaultRequest = launcherRequestDecorator.intercept(routerConfig.routingRequestDefaults());
 
-    return DefaultServerRequestContext.create(
-      routerConfig.transitTuningConfig(),
-      defaultRequest,
-      raptorConfig,
+    var transitRoutingConfig = routerConfig.transitTuningConfig();
+    var vectorTileConfig = routerConfig.vectorTileConfig();
+    var flexParameters = routerConfig.flexParameters();
+
+    // TODO: Inject this, can this use the routerConfig routingRequest ?
+    var tileRendererManager = new TileRendererManager(graph, defaultRequest.preferences());
+
+    return new DefaultServerRequestContext(
+      debugUiConfig,
+      flexParameters,
       graph,
-      transitService,
       Metrics.globalRegistry,
-      routerConfig.vectorTileConfig(),
-      worldEnvelopeService,
+      raptorConfig,
       realtimeVehicleService,
-      vehicleRentalService,
-      vehicleParkingService,
-      emissionsService,
-      sorlandsbanenService,
-      routerConfig.flexParameters(),
       rideHailingServices,
-      stopConsolidationService,
+      defaultRequest,
       streetLimitationParametersService,
-      traverseVisitor,
+      transitRoutingConfig,
+      transitService,
+      vectorTileConfig,
+      vehicleParkingService,
+      vehicleRentalService,
+      worldEnvelopeService,
+      emissionsService,
       luceneIndex,
-      debugUiConfig
+      sorlandsbanenService,
+      stopConsolidationService,
+      tileRendererManager,
+      traverseVisitor
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -35,130 +35,98 @@ import org.opentripplanner.transit.service.TransitService;
 @HttpRequestScoped
 public class DefaultServerRequestContext implements OtpServerRequestContext {
 
-  private final List<RideHailingService> rideHailingServices;
+  // Keep sort order: Main services, optional services and writable/none final fields
+  //                  All 3 sections is sorted alphabetically.
+
+  private final DebugUiConfig debugUiConfig;
+  private final FlexParameters flexParameters;
   private final Graph graph;
-  private final TransitService transitService;
-  private final TransitRoutingConfig transitRoutingConfig;
-  private final RouteRequest routeRequestDefaults;
   private final MeterRegistry meterRegistry;
   private final RaptorConfig<TripSchedule> raptorConfig;
-  private final TileRendererManager tileRendererManager;
-  private final VectorTileConfig vectorTileConfig;
-  private final FlexParameters flexParameters;
-  private final TraverseVisitor traverseVisitor;
-  private final WorldEnvelopeService worldEnvelopeService;
   private final RealtimeVehicleService realtimeVehicleService;
-  private final VehicleRentalService vehicleRentalService;
+  private final List<RideHailingService> rideHailingServices;
+  private final RouteRequest routeRequestDefaults;
+  private final StreetLimitationParametersService streetLimitationParametersService;
+  private final TransitRoutingConfig transitRoutingConfig;
+  private final TransitService transitService;
+  private final VectorTileConfig vectorTileConfig;
   private final VehicleParkingService vehicleParkingService;
+  private final VehicleRentalService vehicleRentalService;
+  private final WorldEnvelopeService worldEnvelopeService;
+
+  /* Optional services */
+
+  @Nullable
   private final EmissionsService emissionsService;
+
+  @Nullable
+  private final LuceneIndex luceneIndex;
+
+  @Nullable
+  private final TileRendererManager tileRendererManager;
 
   @Nullable
   private final SorlandsbanenNorwayService sorlandsbanenService;
 
+  @Nullable
   private final StopConsolidationService stopConsolidationService;
-  private final StreetLimitationParametersService streetLimitationParametersService;
-  private final LuceneIndex luceneIndex;
-  private final DebugUiConfig debugUiConfig;
+
+  @Nullable
+  private final TraverseVisitor traverseVisitor;
+
+  /* Writable fields */
 
   private RouteRequest defaultRouteRequestWithTimeSet = null;
 
   /**
+   * Create a server context valid for one http request only!
    * Make sure all mutable components are copied/cloned before calling this constructor.
    */
-  private DefaultServerRequestContext(
+  public DefaultServerRequestContext(
+    // Keep the same order as in the field declaration
+    DebugUiConfig debugUiConfig,
+    FlexParameters flexParameters,
     Graph graph,
-    TransitService transitService,
-    TransitRoutingConfig transitRoutingConfig,
-    RouteRequest routeRequestDefaults,
     MeterRegistry meterRegistry,
     RaptorConfig<TripSchedule> raptorConfig,
-    TileRendererManager tileRendererManager,
-    VectorTileConfig vectorTileConfig,
-    WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleService realtimeVehicleService,
-    VehicleRentalService vehicleRentalService,
-    VehicleParkingService vehicleParkingService,
-    @Nullable EmissionsService emissionsService,
-    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
     List<RideHailingService> rideHailingServices,
-    @Nullable StopConsolidationService stopConsolidationService,
+    RouteRequest routeRequestDefaults,
     StreetLimitationParametersService streetLimitationParametersService,
-    FlexParameters flexParameters,
-    @Nullable TraverseVisitor traverseVisitor,
+    TransitRoutingConfig transitRoutingConfig,
+    TransitService transitService,
+    VectorTileConfig vectorTileConfig,
+    VehicleParkingService vehicleParkingService,
+    VehicleRentalService vehicleRentalService,
+    WorldEnvelopeService worldEnvelopeService,
+    @Nullable EmissionsService emissionsService,
     @Nullable LuceneIndex luceneIndex,
-    DebugUiConfig debugUiConfig
+    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
+    @Nullable StopConsolidationService stopConsolidationService,
+    @Nullable TileRendererManager tileRendererManager,
+    @Nullable TraverseVisitor traverseVisitor
   ) {
+    this.debugUiConfig = debugUiConfig;
+    this.flexParameters = flexParameters;
     this.graph = graph;
-    this.transitService = transitService;
-    this.transitRoutingConfig = transitRoutingConfig;
     this.meterRegistry = meterRegistry;
     this.raptorConfig = raptorConfig;
-    this.tileRendererManager = tileRendererManager;
-    this.vectorTileConfig = vectorTileConfig;
-    this.vehicleRentalService = vehicleRentalService;
-    this.vehicleParkingService = vehicleParkingService;
-    this.flexParameters = flexParameters;
-    this.traverseVisitor = traverseVisitor;
-    this.routeRequestDefaults = routeRequestDefaults;
-    this.worldEnvelopeService = worldEnvelopeService;
     this.realtimeVehicleService = realtimeVehicleService;
     this.rideHailingServices = rideHailingServices;
+    this.routeRequestDefaults = routeRequestDefaults;
+    this.streetLimitationParametersService = streetLimitationParametersService;
+    this.transitRoutingConfig = transitRoutingConfig;
+    this.transitService = transitService;
+    this.vectorTileConfig = vectorTileConfig;
+    this.vehicleParkingService = vehicleParkingService;
+    this.vehicleRentalService = vehicleRentalService;
+    this.worldEnvelopeService = worldEnvelopeService;
     this.emissionsService = emissionsService;
+    this.luceneIndex = luceneIndex;
     this.sorlandsbanenService = sorlandsbanenService;
     this.stopConsolidationService = stopConsolidationService;
-    this.streetLimitationParametersService = streetLimitationParametersService;
-    this.luceneIndex = luceneIndex;
-    this.debugUiConfig = debugUiConfig;
-  }
-
-  /**
-   * Create a server context valid for one http request only!
-   */
-  public static DefaultServerRequestContext create(
-    TransitRoutingConfig transitRoutingConfig,
-    RouteRequest routeRequestDefaults,
-    RaptorConfig<TripSchedule> raptorConfig,
-    Graph graph,
-    TransitService transitService,
-    MeterRegistry meterRegistry,
-    VectorTileConfig vectorTileConfig,
-    WorldEnvelopeService worldEnvelopeService,
-    RealtimeVehicleService realtimeVehicleService,
-    VehicleRentalService vehicleRentalService,
-    VehicleParkingService vehicleParkingService,
-    @Nullable EmissionsService emissionsService,
-    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
-    FlexParameters flexParameters,
-    List<RideHailingService> rideHailingServices,
-    @Nullable StopConsolidationService stopConsolidationService,
-    StreetLimitationParametersService streetLimitationParametersService,
-    @Nullable TraverseVisitor traverseVisitor,
-    @Nullable LuceneIndex luceneIndex,
-    DebugUiConfig debugUiConfig
-  ) {
-    return new DefaultServerRequestContext(
-      graph,
-      transitService,
-      transitRoutingConfig,
-      routeRequestDefaults,
-      meterRegistry,
-      raptorConfig,
-      new TileRendererManager(graph, routeRequestDefaults.preferences()),
-      vectorTileConfig,
-      worldEnvelopeService,
-      realtimeVehicleService,
-      vehicleRentalService,
-      vehicleParkingService,
-      emissionsService,
-      sorlandsbanenService,
-      rideHailingServices,
-      stopConsolidationService,
-      streetLimitationParametersService,
-      flexParameters,
-      traverseVisitor,
-      luceneIndex,
-      debugUiConfig
-    );
+    this.tileRendererManager = tileRendererManager;
+    this.traverseVisitor = traverseVisitor;
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -54,7 +54,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   private final VehicleRentalService vehicleRentalService;
   private final WorldEnvelopeService worldEnvelopeService;
 
-  /* Optional services */
+  /* Optional fields */
 
   @Nullable
   private final EmissionsService emissionsService;
@@ -74,7 +74,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   @Nullable
   private final TraverseVisitor traverseVisitor;
 
-  /* Writable fields */
+  /* Lazy initialized fields */
 
   private RouteRequest defaultRouteRequestWithTimeSet = null;
 
@@ -121,6 +121,8 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     this.vehicleParkingService = vehicleParkingService;
     this.vehicleRentalService = vehicleRentalService;
     this.worldEnvelopeService = worldEnvelopeService;
+
+    // Optional fields
     this.emissionsService = emissionsService;
     this.luceneIndex = luceneIndex;
     this.sorlandsbanenService = sorlandsbanenService;

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -245,6 +245,6 @@ public abstract class GtfsTest {
       alertsUpdateHandler.update(feedMessage, null);
     } catch (FileNotFoundException exception) {}
     serverContext =
-      TestServerContext.createServerContext(graph, timetableRepository, snapshotManager);
+      TestServerContext.createServerContext(graph, timetableRepository, snapshotManager, null);
   }
 }

--- a/application/src/test/java/org/opentripplanner/TestServerContext.java
+++ b/application/src/test/java/org/opentripplanner/TestServerContext.java
@@ -5,10 +5,13 @@ import static org.opentripplanner.standalone.configure.ConstructApplication.crea
 import io.micrometer.core.instrument.Metrics;
 import java.time.LocalDate;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.emissions.DefaultEmissionsService;
 import org.opentripplanner.ext.emissions.EmissionsDataModel;
 import org.opentripplanner.ext.emissions.EmissionsService;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleService;
@@ -39,59 +42,73 @@ public class TestServerContext {
 
   private TestServerContext() {}
 
+  /** Create a context for unit testing using default RoutingRequest.*/
   public static OtpServerRequestContext createServerContext(
     Graph graph,
     TimetableRepository timetableRepository
   ) {
-    timetableRepository.index();
-    createTransitLayerForRaptor(timetableRepository, RouterConfig.DEFAULT.transitTuningConfig());
-    return createServerContext(
-      graph,
-      timetableRepository,
-      new TimetableSnapshotManager(null, TimetableSnapshotSourceParameters.DEFAULT, LocalDate::now)
-    );
+    return createServerContext(graph, timetableRepository, null, null);
   }
 
-  /** Create a context for unit testing, using the default RouteRequest. */
+  /** Create a context for unit testing */
   public static OtpServerRequestContext createServerContext(
     Graph graph,
     TimetableRepository timetableRepository,
-    TimetableSnapshotManager snapshotManager
+    @Nullable TimetableSnapshotManager snapshotManager,
+    @Nullable RouteRequest request
   ) {
-    timetableRepository.index();
     var routerConfig = RouterConfig.DEFAULT;
-    //createTransitLayerForRaptor(timetableRepository, routerConfig.transitTuningConfig());
+
+    if (request == null) {
+      request = routerConfig.routingRequestDefaults();
+    }
+    if (snapshotManager == null) {
+      snapshotManager =
+        new TimetableSnapshotManager(
+          null,
+          TimetableSnapshotSourceParameters.DEFAULT,
+          LocalDate::now
+        );
+    }
+
+    timetableRepository.index();
+    createTransitLayerForRaptor(timetableRepository, routerConfig.transitTuningConfig());
+
     snapshotManager.purgeAndCommit();
+
     var transitService = new DefaultTransitService(
       timetableRepository,
       snapshotManager.getTimetableSnapshot()
     );
-    DefaultServerRequestContext context = DefaultServerRequestContext.create(
+
+    var raptorConfig = new RaptorConfig<TripSchedule>(
       routerConfig.transitTuningConfig(),
-      routerConfig.routingRequestDefaults(),
-      new RaptorConfig<>(
-        routerConfig.transitTuningConfig(),
-        RaptorEnvironmentFactory.create(routerConfig.transitTuningConfig().searchThreadPoolSize())
-      ),
+      RaptorEnvironmentFactory.create(routerConfig.transitTuningConfig().searchThreadPoolSize())
+    );
+
+    return new DefaultServerRequestContext(
+      DebugUiConfig.DEFAULT,
+      routerConfig.flexParameters(),
       graph,
-      transitService,
       Metrics.globalRegistry,
-      routerConfig.vectorTileConfig(),
-      createWorldEnvelopeService(),
+      raptorConfig,
       createRealtimeVehicleService(transitService),
-      createVehicleRentalService(),
+      List.of(),
+      request,
+      createStreetLimitationParametersService(),
+      routerConfig.transitTuningConfig(),
+      transitService,
+      routerConfig.vectorTileConfig(),
       createVehicleParkingService(),
+      createVehicleRentalService(),
+      createWorldEnvelopeService(),
       createEmissionsService(),
       null,
-      routerConfig.flexParameters(),
-      List.of(),
-      null,
-      createStreetLimitationParametersService(),
       null,
       null,
-      DebugUiConfig.DEFAULT
+      null,
+      null
     );
-    return context;
   }
 
   /** Static factory method to create a service for test purposes. */

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
@@ -12,7 +12,6 @@ import graphql.ExecutionInput;
 import graphql.execution.ExecutionId;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
-import io.micrometer.core.instrument.Metrics;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -27,10 +26,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentripplanner.TestServerContext;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.apis.transmodel.TransmodelRequestContext;
-import org.opentripplanner.ext.emissions.DefaultEmissionsService;
-import org.opentripplanner.ext.emissions.EmissionsDataModel;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.plan.Itinerary;
@@ -38,7 +36,6 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
-import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.StreetPreferences;
@@ -46,32 +43,18 @@ import org.opentripplanner.routing.api.request.preference.TimeSlopeSafetyTriangl
 import org.opentripplanner.routing.api.request.via.ViaLocation;
 import org.opentripplanner.routing.core.VehicleRoutingOptimizeType;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleService;
-import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
-import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingService;
-import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
-import org.opentripplanner.service.worldenvelope.internal.DefaultWorldEnvelopeRepository;
-import org.opentripplanner.service.worldenvelope.internal.DefaultWorldEnvelopeService;
-import org.opentripplanner.standalone.config.DebugUiConfig;
-import org.opentripplanner.standalone.config.RouterConfig;
-import org.opentripplanner.standalone.server.DefaultServerRequestContext;
-import org.opentripplanner.street.model.StreetLimitationParameters;
-import org.opentripplanner.street.service.DefaultStreetLimitationParametersService;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TimetableRepository;
 
 public class TripRequestMapperTest implements PlanTestConstants {
 
-  private static TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
-
+  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
   private static final Duration MAX_FLEXIBLE = Duration.ofMinutes(20);
-
   private static final Function<StopLocation, String> STOP_TO_ID = s -> s.getId().toString();
 
   private static final Route route1 = TimetableRepositoryForTest.route("route1").build();
@@ -82,7 +65,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
   private static final RegularStop stop3 = TEST_MODEL.stop("ST:stop3", 3, 1).build();
 
   private static final Graph graph = new Graph();
-  private static final DefaultTransitService transitService;
+  private static final TimetableRepository timetableRepository;
 
   private TransmodelRequestContext context;
 
@@ -99,7 +82,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
       .withRegularStop(stop3)
       .build();
 
-    var timetableRepository = new TimetableRepository(siteRepository, new Deduplicator());
+    timetableRepository = new TimetableRepository(siteRepository, new Deduplicator());
     timetableRepository.initTimeZone(ZoneIds.STOCKHOLM);
     var calendarServiceData = new CalendarServiceData();
     LocalDate serviceDate = itinerary.startTime().toLocalDate();
@@ -116,7 +99,6 @@ public class TripRequestMapperTest implements PlanTestConstants {
       DataImportIssueStore.NOOP
     );
     timetableRepository.index();
-    transitService = new DefaultTransitService(timetableRepository);
   }
 
   @BeforeEach
@@ -134,32 +116,18 @@ public class TripRequestMapperTest implements PlanTestConstants {
       )
     );
 
+    var otpServerRequestContext = TestServerContext.createServerContext(
+      graph,
+      timetableRepository,
+      null,
+      defaultRequest
+    );
+
     context =
       new TransmodelRequestContext(
-        DefaultServerRequestContext.create(
-          RouterConfig.DEFAULT.transitTuningConfig(),
-          defaultRequest,
-          RaptorConfig.defaultConfigForTest(),
-          graph,
-          transitService,
-          Metrics.globalRegistry,
-          RouterConfig.DEFAULT.vectorTileConfig(),
-          new DefaultWorldEnvelopeService(new DefaultWorldEnvelopeRepository()),
-          new DefaultRealtimeVehicleService(transitService),
-          new DefaultVehicleRentalService(),
-          new DefaultVehicleParkingService(new DefaultVehicleParkingRepository()),
-          new DefaultEmissionsService(new EmissionsDataModel()),
-          null,
-          RouterConfig.DEFAULT.flexParameters(),
-          List.of(),
-          null,
-          new DefaultStreetLimitationParametersService(new StreetLimitationParameters()),
-          null,
-          null,
-          DebugUiConfig.DEFAULT
-        ),
-        null,
-        transitService
+        otpServerRequestContext,
+        otpServerRequestContext.routingService(),
+        otpServerRequestContext.transitService()
       );
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,13 +129,6 @@
                 <configuration>
                     <!-- Target Java version -->
                     <release>21</release>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.dagger</groupId>
-                            <artifactId>dagger-compiler</artifactId>
-                            <version>${google.dagger.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Summary

Today I got a merge conflict when rebasing the via coordinates So I have refactored and cleaned up the `DefaultServerRequestContext`  to avoid these kind of problems in the futue. This also improve the readability.

A reminder - why do we keep things (fields, arguments and methods) sorted in code:
 - Reduce merge conflicts: Insert B, T, in (A, F, T) - If two PRs append then you have a merge conflict, if you insert in the right place there is no conflict.
 - Easier to avoid duplicates, reuse.
 - Easier to find/read, if you look for `transit` you can skip to this end.
 

### Issue

🟥  There is not issue for this, but this is in our coding standards.


### Unit tests

🟥  This is a "pure" refactoring, the code should work as before.

### Documentation

I added a few comments.

### Changelog

🟥  Not relevant


### Bumping the serialization version id

🟥  Not needed
