### PR TITLE
Add filter and transit service API for quays

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -124,6 +124,7 @@ import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.api.request.FindRegularStopsByBoundingBoxRequest;
 import org.opentripplanner.transit.api.request.FindRoutesRequest;
+import org.opentripplanner.transit.api.request.FindStopLocationsRequest;
 import org.opentripplanner.transit.api.request.TripRequest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -468,9 +469,10 @@ public class TransmodelGraphQLSchema {
               .build()
           )
           .dataFetcher(env -> {
-            if ((env.getArgument("ids") instanceof List)) {
-              return ((List<String>) env.getArgument("ids")).stream()
-                .map(TransitIdMapper::mapIDToDomain)
+            var ids = mapIDsToDomainNullSafe(env.getArgument("ids"));
+            if (!ids.isEmpty()) {
+              return ids
+                .stream()
                 .map(id -> StopPlaceType.fetchStopPlaceById(id, env))
                 .collect(Collectors.toList());
             }
@@ -603,32 +605,23 @@ public class TransmodelGraphQLSchema {
           )
           .argument(GraphQLArgument.newArgument().name("name").type(Scalars.GraphQLString).build())
           .dataFetcher(environment -> {
-            if ((environment.getArgument("ids") instanceof List)) {
-              if (
-                environment
-                  .getArguments()
-                  .entrySet()
-                  .stream()
-                  .filter(stringObjectEntry -> stringObjectEntry.getValue() != null)
-                  .count() !=
-                1
-              ) {
+            if (environment.containsArgument("ids")) {
+              var ids = mapIDsToDomainNullSafe(environment.getArgument("ids"));
+
+              if (environment.getArgument("name") != null) {
                 throw new IllegalArgumentException("Unable to combine other filters with ids");
               }
+
               TransitService transitService = GqlUtil.getTransitService(environment);
-              return ((List<String>) environment.getArgument("ids")).stream()
-                .map(id -> transitService.getStopLocation(mapIDToDomain(id)))
-                .collect(Collectors.toList());
+              return ids.stream().map(transitService::getStopLocation).collect(Collectors.toList());
             }
-            if (environment.getArgument("name") == null) {
-              return GqlUtil.getTransitService(environment).listStopLocations();
-            }
-            //                            else {
-            //                                return index.getLuceneIndex().query(environment.getArgument("name"), true, true, false)
-            //                                        .stream()
-            //                                        .map(result -> index.stopForId.get(mapper.fromIdString(result.id)));
-            //                            }
-            return emptyList();
+
+            FindStopLocationsRequest request = FindStopLocationsRequest
+              .of()
+              .withName(environment.getArgument("name"))
+              .build();
+
+            return GqlUtil.getTransitService(environment).findStopLocations(request);
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/transit/api/request/FindStopLocationsRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/FindStopLocationsRequest.java
@@ -1,0 +1,18 @@
+package org.opentripplanner.transit.api.request;
+
+public class FindStopLocationsRequest {
+
+  private String name;
+
+  protected FindStopLocationsRequest(String name) {
+    this.name = name;
+  }
+
+  public static FindStopLocationsRequestBuilder of() {
+    return new FindStopLocationsRequestBuilder();
+  }
+
+  public String name() {
+    return name;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/transit/api/request/FindStopLocationsRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/FindStopLocationsRequestBuilder.java
@@ -1,0 +1,17 @@
+package org.opentripplanner.transit.api.request;
+
+public class FindStopLocationsRequestBuilder {
+
+  private String name;
+
+  protected FindStopLocationsRequestBuilder() {}
+
+  public FindStopLocationsRequestBuilder withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public FindStopLocationsRequest build() {
+    return new FindStopLocationsRequest(name);
+  }
+}

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/StopLocationMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/StopLocationMatcherFactory.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.transit.model.filter.transit;
+
+import org.opentripplanner.transit.api.request.FindStopLocationsRequest;
+import org.opentripplanner.transit.model.filter.expr.EqualityMatcher;
+import org.opentripplanner.transit.model.filter.expr.ExpressionBuilder;
+import org.opentripplanner.transit.model.filter.expr.Matcher;
+import org.opentripplanner.transit.model.filter.expr.NullSafeWrapperMatcher;
+import org.opentripplanner.transit.model.site.StopLocation;
+
+public class StopLocationMatcherFactory {
+
+  public static Matcher<StopLocation> of(FindStopLocationsRequest request) {
+    ExpressionBuilder<StopLocation> expr = ExpressionBuilder.of();
+
+    if (request.name() != null) {
+      expr.matches(name(request.name()));
+    }
+
+    return expr.build();
+  }
+
+  static Matcher<StopLocation> name(String name) {
+    return new NullSafeWrapperMatcher<>(
+      "name",
+      StopLocation::getName,
+      new EqualityMatcher<>("name", name, s -> s.getName().toString())
+    );
+  }
+}

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -38,6 +38,7 @@ import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.routing.stoptimes.StopTimesHelper;
 import org.opentripplanner.transit.api.request.FindRegularStopsByBoundingBoxRequest;
 import org.opentripplanner.transit.api.request.FindRoutesRequest;
+import org.opentripplanner.transit.api.request.FindStopLocationsRequest;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.api.request.TripRequest;
 import org.opentripplanner.transit.model.basic.Notice;
@@ -45,6 +46,7 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
 import org.opentripplanner.transit.model.filter.transit.RegularStopMatcherFactory;
 import org.opentripplanner.transit.model.filter.transit.RouteMatcherFactory;
+import org.opentripplanner.transit.model.filter.transit.StopLocationMatcherFactory;
 import org.opentripplanner.transit.model.filter.transit.TripMatcherFactory;
 import org.opentripplanner.transit.model.filter.transit.TripOnServiceDateMatcherFactory;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
@@ -258,6 +260,12 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public StopLocation getStopLocation(FeedScopedId id) {
     return timetableRepository.getSiteRepository().getStopLocation(id);
+  }
+
+  @Override
+  public Collection<StopLocation> findStopLocations(FindStopLocationsRequest request) {
+    Matcher<StopLocation> matcher = StopLocationMatcherFactory.of(request);
+    return listStopLocations().stream().filter(matcher::match).toList();
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -26,6 +26,7 @@ import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.transit.api.request.FindRegularStopsByBoundingBoxRequest;
 import org.opentripplanner.transit.api.request.FindRoutesRequest;
+import org.opentripplanner.transit.api.request.FindStopLocationsRequest;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.api.request.TripRequest;
 import org.opentripplanner.transit.model.basic.Notice;
@@ -138,7 +139,7 @@ public interface TransitService {
 
   Collection<GroupStop> listGroupStops();
 
-  StopLocation getStopLocation(FeedScopedId parseId);
+  StopLocation getStopLocation(FeedScopedId id);
 
   /**
    * Return all stops associated with the given id. If a Station, a MultiModalStation, or a
@@ -345,4 +346,9 @@ public interface TransitService {
    * Returns a list of {@link Route}s that match the filtering defined in the request.
    */
   Collection<Route> findRoutes(FindRoutesRequest request);
+
+  /**
+   * Returns a list of {@link StopLocation}s that match the filtering defined in the request.
+   */
+  Collection<StopLocation> findStopLocations(FindStopLocationsRequest request);
 }

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/RouteMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/RouteMatcherFactoryTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.transit.model.filter.transit;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,7 +14,6 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.organization.Agency;
 
 class RouteMatcherFactoryTest {
 
@@ -23,7 +21,7 @@ class RouteMatcherFactoryTest {
   private Route route2;
 
   @BeforeEach
-  void setUp() {
+  void setup() {
     route1 =
       Route
         .of(new FeedScopedId("feedId", "routeId"))

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/StopLocationMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/StopLocationMatcherFactoryTest.java
@@ -1,0 +1,49 @@
+package org.opentripplanner.transit.model.filter.transit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.transit.api.request.FindStopLocationsRequest;
+import org.opentripplanner.transit.model.filter.expr.Matcher;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.StopLocation;
+
+public class StopLocationMatcherFactoryTest {
+
+  private static StopLocation stop1;
+  private static StopLocation stop2;
+
+  @BeforeEach
+  void setup() {
+    stop1 =
+      RegularStop
+        .of(new FeedScopedId("agency", "stopId"), new AtomicInteger()::getAndIncrement)
+        .withName(I18NString.of("name"))
+        .build();
+
+    stop2 =
+      RegularStop
+        .of(new FeedScopedId("otherAgency", "otherStopId"), new AtomicInteger()::getAndIncrement)
+        .withName(I18NString.of("otherName"))
+        .build();
+  }
+
+  @Test
+  public void testEmptyMatchesAll() {
+    FindStopLocationsRequest request = FindStopLocationsRequest.of().build();
+    Matcher<StopLocation> matcher = StopLocationMatcherFactory.of(request);
+    assertTrue(matcher.match(stop1));
+    assertTrue(matcher.match(stop2));
+  }
+
+  @Test
+  public void testName() {
+    Matcher<StopLocation> matcher = StopLocationMatcherFactory.name("name");
+    assertTrue(matcher.match(stop1));
+    assertFalse(matcher.match(stop2));
+  }
+}


### PR DESCRIPTION
# Summary

This change allows for a clean separation of concerns and lays the path for more efficient filtering logic down the line.

The name filtering in quays is currently not functional. This change adds it back.

# Issue

#5630

# Unit tests
Added unit tests for each matcher and the new factory. Also ensured that the API in local runs behaves as expected.

# Documentation
Added JavaDoc.