### PR TITLE
Build preferences less often when using the reverse function

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/FlexAccessEgressAdapter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/FlexAccessEgressAdapter.java
@@ -5,6 +5,7 @@ import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.raptor.api.model.RaptorConstants;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 
 /**
  * This class is used to adapt the FlexAccessEgress into a time-dependent multi-leg DefaultAccessEgress.
@@ -15,12 +16,13 @@ public class FlexAccessEgressAdapter extends DefaultAccessEgress {
 
   public FlexAccessEgressAdapter(
     FlexAccessEgress flexAccessEgress,
-    AccessEgressType accessOrEgress
+    AccessEgressType accessOrEgress,
+    RoutingPreferences reversedPreferences
   ) {
     super(
       flexAccessEgress.stop().getIndex(),
       accessOrEgress.isEgress()
-        ? flexAccessEgress.lastState().reverse()
+        ? flexAccessEgress.lastState().reverse(reversedPreferences)
         : flexAccessEgress.lastState()
     );
     this.flexAccessEgress = flexAccessEgress;

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
@@ -9,6 +9,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessE
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.DefaultAccessEgress;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.FlexAccessEgressAdapter;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RoutingAccessEgress;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 
@@ -16,28 +17,33 @@ public class AccessEgressMapper {
 
   public static List<RoutingAccessEgress> mapNearbyStops(
     Collection<NearbyStop> accessStops,
-    AccessEgressType accessOrEgress
+    AccessEgressType accessOrEgress,
+    RoutingPreferences reversedPreferences
   ) {
     return accessStops
       .stream()
-      .map(nearbyStop -> mapNearbyStop(nearbyStop, accessOrEgress))
+      .map(nearbyStop -> mapNearbyStop(nearbyStop, accessOrEgress, reversedPreferences))
       .filter(Objects::nonNull)
       .collect(Collectors.toList());
   }
 
   public static Collection<RoutingAccessEgress> mapFlexAccessEgresses(
     Collection<FlexAccessEgress> flexAccessEgresses,
-    AccessEgressType accessOrEgress
+    AccessEgressType accessOrEgress,
+    RoutingPreferences reversedPreferences
   ) {
     return flexAccessEgresses
       .stream()
-      .map(flexAccessEgress -> new FlexAccessEgressAdapter(flexAccessEgress, accessOrEgress))
+      .map(flexAccessEgress ->
+        new FlexAccessEgressAdapter(flexAccessEgress, accessOrEgress, reversedPreferences)
+      )
       .collect(Collectors.toList());
   }
 
   private static RoutingAccessEgress mapNearbyStop(
     NearbyStop nearbyStop,
-    AccessEgressType accessOrEgress
+    AccessEgressType accessOrEgress,
+    RoutingPreferences reversedPreferences
   ) {
     if (!(nearbyStop.stop instanceof RegularStop)) {
       return null;
@@ -45,7 +51,7 @@ public class AccessEgressMapper {
 
     return new DefaultAccessEgress(
       nearbyStop.stop.getIndex(),
-      accessOrEgress.isEgress() ? nearbyStop.state.reverse() : nearbyStop.state
+      accessOrEgress.isEgress() ? nearbyStop.state.reverse(reversedPreferences) : nearbyStop.state
     );
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/RoutingPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/RoutingPreferences.java
@@ -61,6 +61,16 @@ public final class RoutingPreferences implements Serializable {
     return new Builder(this);
   }
 
+  /**
+   * The states of egress requests are reversed. When the states are reversed, these preferences
+   * need to be set. This was previously done separately for each reversed state.
+   */
+  public Builder copyOfWithReversedPreferences() {
+    return copyOf()
+      .withCar(c -> c.withRental(r -> r.withUseAvailabilityInformation(false)))
+      .withBike(b -> b.withRental(r -> r.withUseAvailabilityInformation(false)));
+  }
+
   public TransitPreferences transit() {
     return transit;
   }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
@@ -56,6 +56,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultCostCalculator;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.TestStateBuilder;
@@ -199,7 +200,8 @@ public class RaptorPathToItineraryMapperTest {
     );
     RaptorAccessEgress access = new FlexAccessEgressAdapter(
       flexAccessEgress,
-      AccessEgressType.ACCESS
+      AccessEgressType.ACCESS,
+      new RoutingPreferences()
     );
     Transfer transfer = new Transfer(S2.getIndex(), 0, EnumSet.of(StreetMode.WALK));
     RaptorTransfer raptorTransfer = new DefaultRaptorTransfer(S1.getIndex(), 0, 0, transfer);


### PR DESCRIPTION
### Summary

I noticed that the `CarPreferences` builder method `private CarPreferences(Builder builder)` was run ~31000 times when making a car transit request. The preferences were getting changed by the reverse function in the `State` class related to egress routing. After some dicussion on Gitter, I decided to look into whether this was necessary. This is the solution I came up with. Now the `CarPreferences` are built ~100 times per request.

Notes:
- This solution assumes that while states are being processed, the `RoutingPreferences` do not change.
- Performance checks should be run on this to check whether this is necessary at all.
- Should the `private Collection<? extends RoutingAccessEgress> fetchAccessEgresses(AccessEgressType type)` method in `TransitRouter` be split up for access and egress because there is separate functionality and lots of checks throughout checking which type is used?

### Issue

Related to https://github.com/opentripplanner/OpenTripPlanner/issues/5875 but does not specifically affect cars
