### PR TITLE
Update suggested machine type for Google Cloud [ci skip]

### DIFF
--- a/doc/user/System-Requirements.md
+++ b/doc/user/System-Requirements.md
@@ -22,5 +22,5 @@ For Azure, the Digitransit project did benchmarking of the available virtual mac
 
 ### Google Cloud
 
-Entur uses a scalable fleet of instances of type `c2d-standard-8`.
+Entur uses a scalable fleet of instances of type `c4-standard-8`.
   


### PR DESCRIPTION
### Summary

The suggested machine types for Google Cloud is outdated, Entur uses now a more recent version.

### Issue

No

### Unit tests

No
### Documentation

Updated documentation

### Changelog

Skip changelog

