### PR TITLE
Restore ability to click on stops in debug UI on first map load

### DIFF
--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -84,6 +84,7 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
       const mapInstance = mapRef.getMap();
       mapInstance.setLayoutProperty(layerId, 'visibility', isVisible ? 'visible' : 'none');
 
+      // After toggling, recalculate which interactive layers are visible.
       const selected = findSelectedDebugLayers(mapInstance);
       setInteractiveLayerIds(selected);
     },

--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import type { ControlPosition } from 'react-map-gl/maplibre';
-import type { MapRef } from 'react-map-gl/maplibre';
+import React, { useCallback, useEffect, useState } from 'react';
+import type { ControlPosition, MapRef } from 'react-map-gl/maplibre';
+import { findSelectedDebugLayers } from '../../util/map.ts';
 
 interface Layer {
   id: string;
@@ -84,16 +84,8 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
       const mapInstance = mapRef.getMap();
       mapInstance.setLayoutProperty(layerId, 'visibility', isVisible ? 'visible' : 'none');
 
-      // After toggling, recalculate which interactive layers are visible.
-      const style = mapInstance.getStyle();
-      if (!style || !style.layers) return;
-
-      const visibleInteractive = style.layers
-        .filter((l) => l.type !== 'raster' && !l.id.startsWith('jsx'))
-        .filter((l) => mapInstance.getLayoutProperty(l.id, 'visibility') !== 'none')
-        .map((l) => l.id);
-
-      setInteractiveLayerIds(visibleInteractive);
+      const selected = findSelectedDebugLayers(mapInstance);
+      setInteractiveLayerIds(selected);
     },
     [mapRef, setInteractiveLayerIds],
   );

--- a/client/src/components/MapView/MapView.tsx
+++ b/client/src/components/MapView/MapView.tsx
@@ -17,6 +17,7 @@ import { useState, useCallback, useRef } from 'react';
 import { ContextMenuPopup } from './ContextMenuPopup.tsx';
 import { GeometryPropertyPopup } from './GeometryPropertyPopup.tsx';
 import RightMenu from './RightMenu.tsx';
+import { findSelectedDebugLayers } from '../../util/map.ts';
 
 const styleUrl = import.meta.env.VITE_DEBUG_STYLE_URL;
 
@@ -63,7 +64,7 @@ export function MapView({
     // provided by the WorldEnvelopeService
     if (map.getZoom() < 2) {
       const source = map.getSource('stops') as VectorTileSource;
-      map.fitBounds(source.bounds, { maxDuration: 50, linear: true });
+      map.fitBounds(source.bounds, { animate: false });
     }
   };
 
@@ -75,6 +76,9 @@ export function MapView({
   function handleMapLoad(e: MapEvent) {
     // 1) Call your existing function
     panToWorldEnvelopeIfRequired(e);
+
+    const selected = findSelectedDebugLayers(e.target);
+    setInteractiveLayerIds(selected);
 
     // 2) Add the native MapLibre attribution control
     onLoad(e);

--- a/client/src/util/map.ts
+++ b/client/src/util/map.ts
@@ -4,7 +4,6 @@ import { MapInstance } from 'react-map-gl/maplibre';
  * Find currently selected (= visible) debug layers.
  */
 export const findSelectedDebugLayers = (mapInstance: MapInstance): string[] => {
-  // After toggling, recalculate which interactive layers are visible.
   const style = mapInstance.getStyle();
   if (!style || !style.layers) {
     return [];

--- a/client/src/util/map.ts
+++ b/client/src/util/map.ts
@@ -1,0 +1,17 @@
+import { MapInstance } from 'react-map-gl/maplibre';
+
+/**
+ * Find currently selected (= visible) debug layers.
+ */
+export const findSelectedDebugLayers = (mapInstance: MapInstance): string[] => {
+  // After toggling, recalculate which interactive layers are visible.
+  const style = mapInstance.getStyle();
+  if (!style || !style.layers) {
+    return [];
+  }
+
+  return style.layers
+    .filter((l) => l.type !== 'raster' && !l.id.startsWith('jsx'))
+    .filter((l) => mapInstance.getLayoutProperty(l.id, 'visibility') !== 'none')
+    .map((l) => l.id);
+};


### PR DESCRIPTION
### Summary

@t2gran asked in today's meeting if it was possible to click on stops in the debug view. This feature existed for a while but was inadvertently broken in #6370 as the stops are not clickable when you first load the map. They only become clickable after opening the right hand panel.

This PR restores it. It seems that I'm the Chief Restorer of Clickable Stops, since this is actually the second time I'm fixing this: https://github.com/opentripplanner/OpenTripPlanner/pull/6261

This also removes the animation from the map pan when loading the app.