### PR TITLE
Disable OptimizeTransfers for via search temporarily.

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -157,7 +157,13 @@ public class TransitRouter {
 
     Collection<RaptorPath<TripSchedule>> paths = transitResponse.paths();
 
-    if (OTPFeature.OptimizeTransfers.isOn() && !transitResponse.containsUnknownPaths()) {
+    // TODO VIA Temporarily turn OptimizeTransfers OFF for VIA search until the service support via
+    //          Remove '&& !request.isViaSearch()'
+    if (
+      OTPFeature.OptimizeTransfers.isOn() &&
+      !transitResponse.containsUnknownPaths() &&
+      !request.isViaSearch()
+    ) {
       var service = TransferOptimizationServiceConfigurator.createOptimizeTransferService(
         raptorTransitData::getStopByIndex,
         requestTransitDataProvider.stopNameResolver(),


### PR DESCRIPTION
### Summary

This PR disable OptimizeTransfers for via search. The OptimizeTransfers does not work with via search as is. It is not implemented yet. 

The plan is to support the via in TransferOptimization soon, but until then merging this PR into your code will make the via work.


### Issue

There is no issue for this - this is a known limitation due to the fact that we have not implemented support for the feature. 

### Unit tests

🟥  Not relevant


### Documentation

A comment is added to the code to explain why the TransferOptimization is temporarily turned off.

### Changelog

🟥  Not relevant


### Bumping the serialization version id

🟥  Not needed
