### PR TITLE
Add CT Fares for Mar 1 fare changes + flex support

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.COMM_TRANS_AGENCY_ID;
+import static org.opentripplanner.ext.fares.impl.OrcaFareService.COMM_TRANS_FLEX_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.KC_METRO_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.KITSAP_TRANSIT_AGENCY_ID;
 import static org.opentripplanner.ext.fares.impl.OrcaFareService.PIERCE_COUNTY_TRANSIT_AGENCY_ID;
@@ -133,11 +134,11 @@ public class OrcaFareServiceTest {
   void calculateFareForSingleAgency() {
     List<Leg> rides = List.of(getLeg(COMM_TRANS_AGENCY_ID, "400", 0));
     calculateFare(rides, regular, DEFAULT_TEST_RIDE_PRICE);
-    calculateFare(rides, FareType.senior, TWO_DOLLARS);
+    calculateFare(rides, FareType.senior, usDollars(1.25f));
     calculateFare(rides, FareType.youth, ZERO_USD);
-    calculateFare(rides, FareType.electronicSpecial, TWO_DOLLARS);
+    calculateFare(rides, FareType.electronicSpecial, usDollars(1.25f));
     calculateFare(rides, FareType.electronicRegular, DEFAULT_TEST_RIDE_PRICE);
-    calculateFare(rides, FareType.electronicSenior, TWO_DOLLARS);
+    calculateFare(rides, FareType.electronicSenior, usDollars(1.25f));
     calculateFare(rides, FareType.electronicYouth, ZERO_USD);
   }
 
@@ -170,11 +171,16 @@ public class OrcaFareServiceTest {
    */
   @Test
   void calculateFareByLeg() {
-    List<Leg> rides = List.of(getLeg(KITSAP_TRANSIT_AGENCY_ID, 0), getLeg(COMM_TRANS_AGENCY_ID, 2));
+    List<Leg> rides = List.of(
+      getLeg(KITSAP_TRANSIT_AGENCY_ID, 0),
+      getLeg(COMM_TRANS_AGENCY_ID, 2),
+      getLeg(COMM_TRANS_FLEX_AGENCY_ID, 3)
+    );
     var fares = orcaFareService.calculateFaresForType(USD, FareType.electronicRegular, rides, null);
 
     assertLegFareEquals(349, rides.get(0), fares, false);
     assertLegFareEquals(0, rides.get(1), fares, true);
+    assertLegFareEquals(0, rides.get(2), fares, true);
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.transit.model.basic.Money.usDollars;
 
 import com.google.common.collect.Lists;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Currency;
@@ -370,7 +371,7 @@ public class OrcaFareService extends DefaultFareService {
         if (
           leg
             .getStartTime()
-            .isBefore(ZonedDateTime.of(2025, 3, 1, 0, 0, 0, 0, leg.getStartTime().getZone()))
+            .isBefore(LocalDate.of(2025, 3, 1).atStartOfDay(leg.getStartTime().getZone()))
         ) {
           yield optionalUSD(1.25f);
         } else {


### PR DESCRIPTION
### Summary

Two changes for fares:
- Adds support for Community Transit's flex service (which is a different agency ID) to the fare module
- Adjusts the reduced fares after Mar 1 2025 to $1. The code that checks the date can be removed after Mar 1. 

### Unit tests

I'm not writing a test for the date since it's temporary and would require a reconfiguration of the test utilities to support specifying a date. I have modified a test to check the flex fare works.