### PR TITLE
Update `azure-identity` to fix build

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -369,7 +369,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.11.2</version>
+            <version>1.15.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Right now dev-2.x is broken because of what looks like a problem during generation of the maven-metadata file for a transitive dependency: https://github.com/netplex/json-smart-v2/issues/240

In order to continue our work, we decided to upgrade the library that is causing the issue (even though it's not the library's fault).