### PR TITLE
Create TripOnServiceDate for added GTFS trips

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/GtfsRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/GtfsRealTimeTripUpdateAdapter.java
@@ -55,6 +55,7 @@ import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TimetableRepository;
@@ -887,6 +888,14 @@ public class GtfsRealTimeTripUpdateAdapter {
           .ifPresent(newTripTimes::updateWheelchairAccessibility);
       }
     }
+
+    // create a TripOnServiceDate for added trips
+    TripOnServiceDate tripOnServiceDate = null;
+    if (realTimeState == RealTimeState.ADDED) {
+      tripOnServiceDate =
+        TripOnServiceDate.of(trip.getId()).withTrip(trip).withServiceDate(serviceDate).build();
+    }
+
     trace(
       trip.getId(),
       serviceDate,
@@ -896,14 +905,14 @@ public class GtfsRealTimeTripUpdateAdapter {
       pattern.firstStop().getName(),
       pattern.lastStop().getName()
     );
+
     // Add new trip times to the buffer
-    // TODO add support for TripOnServiceDate for GTFS-RT
     return snapshotManager.updateBuffer(
       new RealTimeTripUpdate(
         pattern,
         newTripTimes,
         serviceDate,
-        null,
+        tripOnServiceDate,
         realTimeState == RealTimeState.ADDED,
         isAddedRoute
       )

--- a/application/src/test/java/org/opentripplanner/updater/trip/moduletests/addition/AddedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/moduletests/addition/AddedTest.java
@@ -131,6 +131,9 @@ class AddedTest implements RealtimeTestConstants {
     Trip trip = transitService.getTrip(TimetableRepositoryForTest.id(ADDED_TRIP_ID));
     assertNotNull(trip);
     assertNotNull(transitService.findPattern(trip));
+    assertNotNull(
+      transitService.getTripOnServiceDate(TimetableRepositoryForTest.id(ADDED_TRIP_ID))
+    );
 
     var stopA = env.timetableRepository.getSiteRepository().getRegularStop(STOP_A1.getId());
     // Get the trip pattern of the added trip which goes through stopA


### PR DESCRIPTION
### Summary

The SIRI-ET updater creates `TripOnServiceDates` when adding extra journeys.
 This PR ensures that the GTFS-RT updater does the same for added trip.

### Issue

No

### Unit tests

Updated unit tests.


### Documentation

No

