### PR TITLE
HSL prefers fares with zones identical to those required by the journey

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
@@ -90,7 +90,7 @@ public class HSLFareServiceTest implements PlanTestConstants {
 
     var AB_PRICE = euros(2.80f);
     var BC_PRICE = euros(2.80f);
-    var CD_PRICE = euros(3.20f);
+    var CD_PRICE = euros(2.80f);
     var ABC_PRICE = euros(4.10f);
     var BCD_PRICE = euros(4.10f);
     var ABCD_PRICE = euros(5.70f);

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
@@ -182,7 +182,10 @@ public class HSLFareService extends DefaultFareService {
             }
           }
           Money newFare = attribute.getPrice();
-          if (newFare.lessThan(bestFare)) {
+          if (
+            newFare.lessThan(bestFare) ||
+            (newFare.equals(bestFare) && ruleSet.getContains().equals(zones)) // prefer the closest ticket type
+          ) {
             bestAttribute = attribute;
             bestFare = newFare;
           }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/HSLFareService.java
@@ -184,7 +184,7 @@ public class HSLFareService extends DefaultFareService {
           Money newFare = attribute.getPrice();
           if (
             newFare.lessThan(bestFare) ||
-            (newFare.equals(bestFare) && ruleSet.getContains().equals(zones)) // prefer the closest ticket type
+            (newFare.equals(bestFare) && ruleSet.getContains().equals(zones))
           ) {
             bestAttribute = attribute;
             bestFare = newFare;


### PR DESCRIPTION
### Summary

When there are many suitable fare options (the same price), the HSL fare service should prefer a fare that has an identical set of zones to the required zones if such a fare exists. 

### Issue

When the journey happens only within a single zone, the service returns a two-zone fare when a single zone fare also exists. Currently single zone fares are never returned.

### Unit tests

Manually verified.
Fixed the unit test. (The unit test for zone D journey should originally have failed as the service gave it a CD fare in a real world case, however the CD fare in the test had an incorrect price, making it more expensive than a D fare.)

