### PR TITLE
Add explanation of underscore-separated units in variable names [ci skip]

### DIFF
--- a/doc/dev/decisionrecords/Codestyle.md
+++ b/doc/dev/decisionrecords/Codestyle.md
@@ -170,10 +170,6 @@ non-null if they are not marked as `@Nullable`. However, there are places where 
 annotation is missing even if it should have been used. Those can be updated to use the `@Nullable`
 annotation.
 
-### Units in Variable Identifiers
-
-Variables of numeric types may include units as an underscore-separated suffix to the variable name. For example: `length_mm` or `duration_msec`. The reason for this exception to standard camelCase naming is that case is significant in metric prefixes (e.g. `M` for mega- versus `m` for milli-). It also reinforces that these are units rather than part of the base variable name.
-
 ## JavaScript
 
 As of [#206](https://github.com/opentripplanner/OpenTripPlanner/issues/206), we follow

--- a/doc/dev/decisionrecords/Codestyle.md
+++ b/doc/dev/decisionrecords/Codestyle.md
@@ -170,6 +170,10 @@ non-null if they are not marked as `@Nullable`. However, there are places where 
 annotation is missing even if it should have been used. Those can be updated to use the `@Nullable`
 annotation.
 
+### Units in Variable Identifiers
+
+Variables of numeric types may include units as an underscore-separated suffix to the variable name. For example: `length_mm` or `duration_msec`. The reason for this exception to standard camelCase naming is that case is significant in metric prefixes (e.g. `M` for mega- versus `m` for milli-). It also reinforces that these are units rather than part of the base variable name.
+
 ## JavaScript
 
 As of [#206](https://github.com/opentripplanner/OpenTripPlanner/issues/206), we follow

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -62,6 +62,12 @@ them.
 | `setStop(Stop stop)`                        | Set a mutable Stop reference. Avoid if not part of natural lifecycle. Use `initStop(...)` if possible. |
 | `getStop() : Stop`                          | Old style accessor. Use the shorter form `stop() : Stop`.                                              |
 
+
+## Variables
+
+We follow the Java standard of using camelCase with a lower-case first letter for variable names. However, variables of numeric types may include units as an underscore-separated suffix. For example, `length_mm` or `duration_msec`. The reason is that case is significant in metric prefixes (e.g. `M` for mega- versus `m` for milli-). The underscore also reinforces that these are units rather than part of the base variable name.
+
+
 ## Service, Model and Repository
 
 ![MainModelOverview](../images/ServiceModelOverview.png)

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -1,9 +1,11 @@
 # Naming Conventions
 
 In general, we use American English. We use the GTFS terminology inside OTP as the transit
-domain-specific language. In cases where GTFS does not provide an alternative, we use NeTEx. The
-naming should follow the Java standard naming conventions. For example, a "real-time updater" class
-is named `RealTimeUpdater`. If in doubt, check the Oxford Dictionary (American).
+domain-specific language. In cases where GTFS does not provide an alternative, we use NeTEx.
+We follow the [Google Java Style Guide - Naming](https://google.github.io/styleguide/javaguide.html#s5-naming) conventions.
+The code formatting part of that style guide is not relevant, as OTP code is auto-formatted using Prettier.
+If in doubt, check the Oxford Dictionary (American).
+
 
 ## Packages
 
@@ -65,7 +67,7 @@ them.
 
 ## Variables
 
-We follow the standard of using camelCase with a lower-case first letter for variable names. However, variables of numeric types _may_ include units as an underscore-separated suffix. For example, `length_mm` or `duration_msec`. The reason is that case is significant in metric prefixes (e.g. `M` for mega- versus `m` for milli-). The underscore also reinforces that these are units rather than part of the base variable name. Use the full version in constants, `SLACK_IN_SECONDS`, not ~~`SLACK_S`~~.
+We follow the [standard of using camelCase](https://google.github.io/styleguide/javaguide.html#s5.2.5-non-constant-field-names) with a lower-case first letter for variable, parameter, and field names. However, variables of numeric types _may_ include units as an underscore-separated suffix. For example, `length_mm` or `duration_msec`. The reason is that case is significant in metric prefixes (e.g. `M` for mega- versus `m` for milli-). The underscore also reinforces that these are units rather than part of the base variable name. In constants, use the full word: `SLACK_IN_SECONDS`, not ~~`SLACK_S`~~.
 
 
 ## Service, Model and Repository

--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -65,7 +65,7 @@ them.
 
 ## Variables
 
-We follow the Java standard of using camelCase with a lower-case first letter for variable names. However, variables of numeric types may include units as an underscore-separated suffix. For example, `length_mm` or `duration_msec`. The reason is that case is significant in metric prefixes (e.g. `M` for mega- versus `m` for milli-). The underscore also reinforces that these are units rather than part of the base variable name.
+We follow the standard of using camelCase with a lower-case first letter for variable names. However, variables of numeric types _may_ include units as an underscore-separated suffix. For example, `length_mm` or `duration_msec`. The reason is that case is significant in metric prefixes (e.g. `M` for mega- versus `m` for milli-). The underscore also reinforces that these are units rather than part of the base variable name. Use the full version in constants, `SLACK_IN_SECONDS`, not ~~`SLACK_S`~~.
 
 
 ## Service, Model and Repository


### PR DESCRIPTION
As discussed in a recent meeting, this adds a short explanation of why some variables have underscore-separated units as part of their names, defying standard camelCase.

It seems a little strange to update an already existing decision record, but this is a very minor point and probably less likely to be seen if it were split out into a separate style document.