### PR TITLE
Rename State's `walkDistance` to `traversalDistance_m`

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
@@ -103,7 +103,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor<State, Edge> 
   @Override
   public void visitVertex(State state) {
     Vertex vertex = state.getVertex();
-    double distance = state.getWalkDistance();
+    double distance = state.getTraversalDistanceMeters();
     if (vertex instanceof TransitStopVertex transitVertex) {
       RegularStop stop = transitVertex.getStop();
       handleStop(stop, distance);
@@ -141,7 +141,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor<State, Edge> 
         }
       }
 
-      return current.getWalkDistance() > furthestDistance;
+      return current.getTraversalDistanceMeters() > furthestDistance;
     };
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/StopFinderTraverseVisitor.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/StopFinderTraverseVisitor.java
@@ -50,6 +50,6 @@ public class StopFinderTraverseVisitor implements TraverseVisitor<State, Edge> {
    * reached.
    */
   public SkipEdgeStrategy<State, Edge> getSkipEdgeStrategy() {
-    return (current, edge) -> current.getWalkDistance() > radiusMeters;
+    return (current, edge) -> current.getTraversalDistanceMeters() > radiusMeters;
   }
 }

--- a/application/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
@@ -37,7 +37,7 @@ public class EscalatorEdge extends Edge {
       }
       s1.incrementWeight(s0.getPreferences().walk().escalator().reluctance() * time);
       s1.incrementTimeInSeconds((long) time);
-      s1.incrementWalkDistance(getDistanceMeters());
+      s1.incrementTraversalDistanceMeters(getDistanceMeters());
       return s1.makeStateArray();
     } else return State.empty();
   }

--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1231,7 +1231,7 @@ public class StreetEdge
       }
 
       if (!traverseMode.isInCar()) {
-        s1.incrementWalkDistance(turnDuration / 100); // just a tie-breaker
+        s1.incrementTraversalDistanceMeters(turnDuration / 100); // just a tie-breaker
       }
 
       time_ms += (long) Math.ceil(1000.0 * turnDuration);
@@ -1239,7 +1239,7 @@ public class StreetEdge
     }
 
     if (!traverseMode.isInCar()) {
-      s1.incrementWalkDistance(getDistanceWithElevation());
+      s1.incrementTraversalDistanceMeters(getDistanceWithElevation());
     }
 
     if (costExtension != null) {

--- a/application/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/application/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -46,10 +46,8 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
   /* StateData contains data which is unlikely to change as often */
   public StateData stateData;
 
-  // how far have we walked
-  // TODO(flamholz): this is a very confusing name as it actually applies to all non-transit modes.
-  // we should DEFINITELY rename this variable and the associated methods.
-  public double walkDistance;
+  // how far have we traversed through the graph
+  public double traversalDistance_m;
 
   /* CONSTRUCTORS */
 
@@ -75,7 +73,7 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
       this.stateData.noRentalDropOffZonesAtStartOfReverseSearch =
         vertex.rentalRestrictions().noDropOffNetworks();
     }
-    this.walkDistance = 0;
+    this.traversalDistance_m = 0;
     this.time_ms = startTime.toEpochMilli();
   }
 
@@ -272,8 +270,11 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
     return stateData.rentalVehicleFormFactor;
   }
 
-  public double getWalkDistance() {
-    return walkDistance;
+  /**
+   * Return how far this state has traversed through the graph, in meters.
+   */
+  public double getTraversalDistanceMeters() {
+    return traversalDistance_m;
   }
 
   public Vertex getVertex() {
@@ -381,7 +382,7 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
 
       editor.incrementTimeInMilliseconds(orig.getAbsTimeDeltaMilliseconds());
       editor.incrementWeight(orig.getWeightDelta());
-      editor.incrementWalkDistance(orig.getWalkDistanceDelta());
+      editor.incrementTraversalDistanceMeters(orig.getWalkDistanceDeltaMeters());
 
       // propagate the modes through to the reversed edge
       editor.setBackMode(orig.getBackMode());
@@ -517,9 +518,9 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
     return Math.abs(getTimeDeltaMilliseconds());
   }
 
-  private double getWalkDistanceDelta() {
+  private double getWalkDistanceDeltaMeters() {
     if (backState != null) {
-      return Math.abs(this.walkDistance - backState.walkDistance);
+      return Math.abs(this.traversalDistance_m - backState.traversalDistance_m);
     } else {
       return 0.0;
     }

--- a/application/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/application/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -191,13 +191,16 @@ public class StateEditor {
     incrementTimeInMilliseconds(1000L * seconds);
   }
 
-  public void incrementWalkDistance(double length) {
+  /**
+   * Increment the distance traversed through the graph in meters.
+   */
+  public void incrementTraversalDistanceMeters(double length) {
     if (length < 0) {
-      LOG.warn("A state's walk distance is being incremented by a negative amount.");
+      LOG.warn("A state's traversal distance is being incremented by a negative amount.");
       defectiveTraversal = true;
       return;
     }
-    child.walkDistance += length;
+    child.traversalDistance_m += length;
   }
 
   /* Basic Setters */

--- a/application/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
+++ b/application/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
@@ -146,7 +146,7 @@ public abstract class DominanceFunctions implements Serializable, DominanceFunct
 
     @Override
     protected boolean betterOrEqual(State a, State b) {
-      return a.getWalkDistance() <= b.getWalkDistance();
+      return a.getTraversalDistanceMeters() <= b.getTraversalDistanceMeters();
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -1432,7 +1432,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
       stateListModel.addElement("weightdelta:" + st.getWeightDelta());
       stateListModel.addElement("rentingVehicle:" + st.isRentingVehicle());
       stateListModel.addElement("vehicleParked:" + st.isVehicleParked());
-      stateListModel.addElement("walkDistance:" + st.getTraversalDistanceMeters());
+      stateListModel.addElement("traversalDistance:" + st.getTraversalDistanceMeters());
       stateListModel.addElement("elapsedTime:" + st.getElapsedTimeSeconds());
       outputList.setModel(stateListModel);
 

--- a/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -1432,7 +1432,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
       stateListModel.addElement("weightdelta:" + st.getWeightDelta());
       stateListModel.addElement("rentingVehicle:" + st.isRentingVehicle());
       stateListModel.addElement("vehicleParked:" + st.isVehicleParked());
-      stateListModel.addElement("walkDistance:" + st.getWalkDistance());
+      stateListModel.addElement("walkDistance:" + st.getTraversalDistanceMeters());
       stateListModel.addElement("elapsedTime:" + st.getElapsedTimeSeconds());
       outputList.setModel(stateListModel);
 


### PR DESCRIPTION
### Summary

The State class' field `walkDistance` is not actually the walk distance but the traversal distance of all modes. For years there has been a comment stating this and I want to finally rename it to it's proper name, which is suggest to be `traversalDistance_m`, in line with the confirmed naming scheme for units.
