### PR TITLE
Fix initialisation logic of transit alert service

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -525,11 +525,12 @@ public class TimetableRepository implements Serializable {
   }
 
   /**
-   * Sets the updater manager for this repository.
+   * Sets the updater manager for this repository and makes sure the configured updaters
+   * are correctly applied to {@code transitAlertService}.
    * <p>
-   * Note: this also resets the {@code transitAlertService} so that the next call to
-   * {@link TimetableRepository#getTransitAlertService()} will then create a new instance
-   * of it.
+   * Note: before this method is called an empty {@code transitAlertService} is returned instead.
+   * <p>
+   * This logic is unfortunate and quite brittle. We would like to improve it in the future.
    */
   public void setUpdaterManager(GraphUpdaterManager updaterManager) {
     this.updaterManager = updaterManager;

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -387,11 +387,8 @@ public class TimetableRepository implements Serializable {
   }
 
   /**
-   * Returns the alert service. If {@link TimetableRepository#setUpdaterManager(GraphUpdaterManager)}
-   * has not been called, then this returns an empty instance.
-   * <p>
-   * After each call to {@link TimetableRepository#setUpdaterManager(GraphUpdaterManager)} the
-   * {@code transitAlertService} is re-instantiated.
+   * Returns the alert service. If no updaters are configured an empty instance is returned.
+   * See  {@link TimetableRepository#setUpdaterManager(GraphUpdaterManager)}.
    */
   public TransitAlertService getTransitAlertService() {
     if (transitAlertService == null) {

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -387,16 +387,14 @@ public class TimetableRepository implements Serializable {
   }
 
   /**
-   * Returns the alert service or null if the @{code updaterManager} is not set yet.
+   * Returns the alert service. If {@link TimetableRepository#setUpdaterManager(GraphUpdaterManager)}
+   * has not been called, then this returns an empty instance.
+   * <p>
+   * After each call to {@link TimetableRepository#setUpdaterManager(GraphUpdaterManager)} the
+   * {@code transitAlertService} is re-instantiated.
    */
-  @Nullable
   public TransitAlertService getTransitAlertService() {
-    // during initialization we must return null, otherwise we would permanently store an empty
-    // DelegatingTransitAlertServiceImpl
-    // this is wrong on many levels and should be refactored.
-    if (updaterManager == null) {
-      return null;
-    } else if (transitAlertService == null) {
+    if (transitAlertService == null) {
       transitAlertService = new DelegatingTransitAlertServiceImpl(this);
     }
     return transitAlertService;
@@ -529,8 +527,16 @@ public class TimetableRepository implements Serializable {
     flexTripsById.put(id, flexTrip);
   }
 
+  /**
+   * Sets the updater manager for this repository.
+   * <p>
+   * Note: this also resets the {@code transitAlertService} so that the next call to
+   * {@link TimetableRepository#getTransitAlertService()} will then create a new instance
+   * of it.
+   */
   public void setUpdaterManager(GraphUpdaterManager updaterManager) {
     this.updaterManager = updaterManager;
+    this.transitAlertService = null;
   }
 
   public void addAllTransfersByStops(Multimap<StopLocation, PathTransfer> transfersByStop) {


### PR DESCRIPTION
### Summary

In #6415 I introduced a bug which would cause API calls that involved alerts to crash with an NPE. This is because there is questionable initialization logic of `TransitAlertService` in `TimetableRepository`.

@t2gran has pointed out that there is probably a better fix that works in more case: you simply reset the `transitAlertService` after setting the `graphUpdaterManager`. 

This means that you always get a `TransitAlertService` even in cases where no real time updates at all were configured.

### Issue

None. However, I think we should remove this brittle initialisation logic and let Dagger manage the lifecycle of `UpdaterManager` and `TransitAlertService`.

### Unit tests

I opted to document the behaviour instead.

### Documentation

New Javadoc.