### PR TITLE
Use default value with `asEnumMap` function to fix transfer cache initialization for `maxStopCountForMode`

### DIFF
--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
@@ -272,13 +272,36 @@ public class ParameterBuilder {
    * @return a map of listed enum values as keys with value, or an empty map if not set.
    */
   public <T, E extends Enum<E>> Map<E, T> asEnumMap(Class<E> enumType, Class<T> elementJavaType) {
+    return asEnumMap(enumType, elementJavaType, Map.of());
+  }
+
+  /**
+   * Get a map of enum values listed in the config like this: (This example has Boolean values)
+   * <pre>
+   * key : {
+   *   A : true,  // turned on
+   *   B : false  // turned off
+   *   // Commented out to use default value
+   *   // C : true
+   * }
+   * </pre>
+   *
+   * @param <E>  The enum type
+   * @param <T>  The map value type.
+   * @return a map of listed enum values as keys with value, or the default value if not set.
+   */
+  public <T, E extends Enum<E>> Map<E, T> asEnumMap(
+    Class<E> enumType,
+    Class<T> elementJavaType,
+    Map<E, T> defaultValue
+  ) {
     var elementType = ConfigType.of(elementJavaType);
     info.withOptional().withEnumMap(enumType, elementType);
 
     var mapNode = buildObject();
 
     if (mapNode.isEmpty()) {
-      return Map.of();
+      return defaultValue;
     }
     EnumMap<E, T> result = new EnumMap<>(enumType);
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -557,7 +557,7 @@ does not exist.
               Mode-specific version of `maxStopCount`.
               """
               )
-              .asEnumMap(StreetMode.class, Integer.class)
+              .asEnumMap(StreetMode.class, Integer.class, dft.accessEgress().maxStopCountForMode())
           );
       })
       .withMaxDirectDuration(


### PR DESCRIPTION
### Summary

The transfer cache initialization required manually setting the `maxStopCountForMode` object in the `transferCacheRequests` even though it should have automatically been included from the `router-config.json` configuration. The reason for this was that there was no default value when mapping the `transferCacheRequests`.

### Issue

N/A

This fixes an issue related to PR https://github.com/opentripplanner/OpenTripPlanner/pull/6383

### Unit tests

N/A
