### PR TITLE
Use default max stop count for mode from routing defaults in transfer requests

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/dataoverlay/api/DataOverlayParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/dataoverlay/api/DataOverlayParameters.java
@@ -35,7 +35,7 @@ public class DataOverlayParameters implements Serializable {
   private final Map<Parameter, Double> values;
 
   public DataOverlayParameters(Map<Parameter, Double> values) {
-    // Make a defencive copy to protect the map entries, this make this class immutable
+    // Make a defensive copy to protect the map entries, this makes the class immutable
     // and thread safe
     this.values = Map.copyOf(values);
   }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -266,9 +266,7 @@ public class TransitRouter {
       .accessEgress();
 
     Duration durationLimit = accessEgressPreferences.maxDuration().valueOf(mode);
-    int stopCountLimit = accessEgressPreferences
-      .maxStopCountForMode()
-      .getOrDefault(mode, accessEgressPreferences.defaultMaxStopCount());
+    int stopCountLimit = accessEgressPreferences.maxStopCountLimit().limitForMode(mode);
 
     var nearbyStops = AccessEgressRouter.findAccessEgresses(
       accessRequest,

--- a/application/src/main/java/org/opentripplanner/routing/api/request/framework/DurationForEnum.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/framework/DurationForEnum.java
@@ -152,7 +152,7 @@ public class DurationForEnum<E extends Enum<E>> implements Serializable {
 
     /**
      * Build a copy of the current values, excluding the defaultValue from the map. This
-     * ensures equality and make a defencive copy of the builder values. Hence, the builder
+     * ensures equality and makes a defensive copy of the builder values. Hence, the builder
      * can be used to generate new values if desired.
      * */
     Map<E, Duration> copyValueForEnum() {
@@ -185,7 +185,7 @@ public class DurationForEnum<E extends Enum<E>> implements Serializable {
     public DurationForEnum<E> build() {
       var it = new DurationForEnum<>(this);
 
-      // Return original if not change, subscriber is not notified
+      // Return the original if there are no changes, the subscriber is not notified.
       if (original != null && original.equals(it)) {
         return original;
       }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
@@ -122,7 +122,7 @@ public final class AccessEgressPreferences implements Serializable {
       Map<StreetMode, Integer> maxStopCountForMode
     ) {
       return withMaxStopCount(b ->
-        b.withDefaultLimit(defaultMaxStopCount).withValues(maxStopCountForMode)
+        b.withDefaultLimit(defaultMaxStopCount).withLimitsForModes(maxStopCountForMode)
       );
     }
 

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferences.java
@@ -4,7 +4,6 @@ import static java.time.Duration.ofMinutes;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -28,21 +27,18 @@ public final class AccessEgressPreferences implements Serializable {
 
   private final TimeAndCostPenaltyForEnum<StreetMode> penalty;
   private final DurationForEnum<StreetMode> maxDuration;
-  private final int defaultMaxStopCount;
-  private final Map<StreetMode, Integer> maxStopCountForMode;
+  private final MaxStopCountLimit maxStopCountLimit;
 
   private AccessEgressPreferences() {
     this.maxDuration = durationForStreetModeOf(ofMinutes(45));
     this.penalty = DEFAULT_TIME_AND_COST;
-    this.defaultMaxStopCount = 500;
-    this.maxStopCountForMode = Map.of();
+    this.maxStopCountLimit = new MaxStopCountLimit();
   }
 
   private AccessEgressPreferences(Builder builder) {
     this.maxDuration = builder.maxDuration;
     this.penalty = builder.penalty;
-    this.defaultMaxStopCount = builder.defaultMaxStopCount;
-    this.maxStopCountForMode = Collections.unmodifiableMap(builder.maxStopCountForMode);
+    this.maxStopCountLimit = builder.maxStopCountLimit;
   }
 
   public static Builder of() {
@@ -61,12 +57,8 @@ public final class AccessEgressPreferences implements Serializable {
     return maxDuration;
   }
 
-  public int defaultMaxStopCount() {
-    return defaultMaxStopCount;
-  }
-
-  public Map<StreetMode, Integer> maxStopCountForMode() {
-    return maxStopCountForMode;
+  public MaxStopCountLimit maxStopCountLimit() {
+    return maxStopCountLimit;
   }
 
   @Override
@@ -77,14 +69,13 @@ public final class AccessEgressPreferences implements Serializable {
     return (
       penalty.equals(that.penalty) &&
       maxDuration.equals(that.maxDuration) &&
-      defaultMaxStopCount == that.defaultMaxStopCount &&
-      maxStopCountForMode.equals(that.maxStopCountForMode)
+      maxStopCountLimit.equals(that.maxStopCountLimit)
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(penalty, maxDuration, defaultMaxStopCount, maxStopCountForMode);
+    return Objects.hash(penalty, maxDuration, maxStopCountLimit);
   }
 
   @Override
@@ -93,8 +84,7 @@ public final class AccessEgressPreferences implements Serializable {
       .of(AccessEgressPreferences.class)
       .addObj("penalty", penalty, DEFAULT.penalty)
       .addObj("maxDuration", maxDuration, DEFAULT.maxDuration)
-      .addObj("defaultMaxStopCount", defaultMaxStopCount, DEFAULT.defaultMaxStopCount)
-      .addObj("maxStopCountForMode", maxStopCountForMode, DEFAULT.maxStopCountForMode)
+      .addObj("maxStopCount", maxStopCountLimit, DEFAULT.maxStopCountLimit)
       .toString();
   }
 
@@ -103,15 +93,13 @@ public final class AccessEgressPreferences implements Serializable {
     private final AccessEgressPreferences original;
     private TimeAndCostPenaltyForEnum<StreetMode> penalty;
     private DurationForEnum<StreetMode> maxDuration;
-    private Map<StreetMode, Integer> maxStopCountForMode;
-    private int defaultMaxStopCount;
+    private MaxStopCountLimit maxStopCountLimit;
 
     public Builder(AccessEgressPreferences original) {
       this.original = original;
       this.maxDuration = original.maxDuration;
       this.penalty = original.penalty;
-      this.defaultMaxStopCount = original.defaultMaxStopCount;
-      this.maxStopCountForMode = original.maxStopCountForMode;
+      this.maxStopCountLimit = original.maxStopCountLimit;
     }
 
     public Builder withMaxDuration(Consumer<DurationForEnum.Builder<StreetMode>> body) {
@@ -124,13 +112,18 @@ public final class AccessEgressPreferences implements Serializable {
       return withMaxDuration(b -> b.withDefault(defaultValue).withValues(values));
     }
 
+    public Builder withMaxStopCount(Consumer<MaxStopCountLimit.Builder> body) {
+      this.maxStopCountLimit = this.maxStopCountLimit.copyOf().apply(body).build();
+      return this;
+    }
+
     public Builder withMaxStopCount(
       int defaultMaxStopCount,
       Map<StreetMode, Integer> maxStopCountForMode
     ) {
-      this.defaultMaxStopCount = defaultMaxStopCount;
-      this.maxStopCountForMode = maxStopCountForMode;
-      return this;
+      return withMaxStopCount(b ->
+        b.withDefaultLimit(defaultMaxStopCount).withValues(maxStopCountForMode)
+      );
     }
 
     public Builder withPenalty(Consumer<TimeAndCostPenaltyForEnum.Builder<StreetMode>> body) {

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
@@ -29,7 +29,7 @@ public class MaxStopCountLimit {
 
   MaxStopCountLimit(Builder builder) {
     this.defaultLimit = IntUtils.requireNotNegative(builder.defaultLimit());
-    this.limitForMode = builder.copyValueForEnum();
+    this.limitForMode = builder.copyCustomLimits();
   }
 
   public static Builder of() {
@@ -117,8 +117,8 @@ public class MaxStopCountLimit {
       return this;
     }
 
-    public Builder withValues(Map<StreetMode, Integer> values) {
-      for (Map.Entry<StreetMode, Integer> e : values.entrySet()) {
+    public Builder withLimitsForModes(Map<StreetMode, Integer> limitsForModes) {
+      for (Map.Entry<StreetMode, Integer> e : limitsForModes.entrySet()) {
         with(e.getKey(), e.getValue());
       }
       return this;
@@ -129,7 +129,7 @@ public class MaxStopCountLimit {
      * ensures equality and makes a defensive copy of the builder values. Hence, the builder
      * can be used to generate new values if desired.
      * */
-    Map<StreetMode, Integer> copyValueForEnum() {
+    Map<StreetMode, Integer> copyCustomLimits() {
       if (limitForMode == null) {
         // The limitForMode is protected and should never be mutated, so we can reuse it
         return original.limitForMode();

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
@@ -14,7 +14,7 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
  */
 public class MaxStopCountLimit {
 
-  public static final int DEFAULT_LIMIT = 500;
+  private static final int DEFAULT_LIMIT = 500;
   private static final Map<StreetMode, Integer> DEFAULT_FOR_MODE = Map.of();
 
   private final int defaultLimit;
@@ -41,6 +41,10 @@ public class MaxStopCountLimit {
     return limitForMode.getOrDefault(mode, defaultLimit);
   }
 
+  public int defaultLimit() {
+    return defaultLimit;
+  }
+
   @Override
   public String toString() {
     return ToStringBuilder
@@ -65,10 +69,6 @@ public class MaxStopCountLimit {
     return Objects.hash(defaultLimit, limitForMode);
   }
 
-  private int defaultLimit() {
-    return defaultLimit;
-  }
-
   private Map<StreetMode, Integer> limitForMode() {
     return limitForMode;
   }
@@ -90,10 +90,6 @@ public class MaxStopCountLimit {
 
     int defaultLimit() {
       return defaultLimit;
-    }
-
-    Map<StreetMode, Integer> limitForMode() {
-      return limitForMode;
     }
 
     public Builder withDefaultLimit(int defaultLimit) {

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
@@ -1,0 +1,161 @@
+package org.opentripplanner.routing.api.request.preference;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.utils.lang.IntUtils;
+import org.opentripplanner.utils.tostring.ToStringBuilder;
+
+/**
+ * This class is used for storing default and mode specific stop count limits for access and egress
+ * routing.
+ */
+public class MaxStopCountLimit {
+
+  public static final int DEFAULT_LIMIT = 500;
+  private static final Map<StreetMode, Integer> DEFAULT_FOR_MODE = Map.of();
+
+  private final int defaultLimit;
+  private final Map<StreetMode, Integer> limitForMode;
+
+  public MaxStopCountLimit() {
+    this.defaultLimit = DEFAULT_LIMIT;
+    this.limitForMode = DEFAULT_FOR_MODE;
+  }
+
+  MaxStopCountLimit(Builder builder) {
+    this.defaultLimit = IntUtils.requireNotNegative(builder.defaultLimit());
+    this.limitForMode = builder.copyValueForEnum();
+  }
+
+  public Builder copyOf() {
+    return new Builder(this);
+  }
+
+  /**
+   * Get the max stop count limit for mode. If no custom value is defined, default is used.
+   */
+  public int limitForMode(StreetMode mode) {
+    return limitForMode.getOrDefault(mode, defaultLimit);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(MaxStopCountLimit.class)
+      .addNum("defaultLimit", defaultLimit, DEFAULT_LIMIT)
+      .addObj("limitForMode", limitForMode, DEFAULT_FOR_MODE)
+      .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    var that = (MaxStopCountLimit) o;
+
+    return (defaultLimit == that.defaultLimit && limitForMode.equals(that.limitForMode));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(defaultLimit, limitForMode);
+  }
+
+  private int defaultLimit() {
+    return defaultLimit;
+  }
+
+  private Map<StreetMode, Integer> limitForMode() {
+    return limitForMode;
+  }
+
+  private boolean hasCustomLimit(StreetMode mode) {
+    return limitForMode.containsKey(mode);
+  }
+
+  public static class Builder {
+
+    private final MaxStopCountLimit original;
+    private int defaultLimit;
+    private Map<StreetMode, Integer> limitForMode = null;
+
+    Builder(MaxStopCountLimit original) {
+      this.original = original;
+      this.defaultLimit = original.defaultLimit();
+    }
+
+    int defaultLimit() {
+      return defaultLimit;
+    }
+
+    Map<StreetMode, Integer> limitForMode() {
+      return limitForMode;
+    }
+
+    public Builder withDefaultLimit(int defaultLimit) {
+      this.defaultLimit = defaultLimit;
+      return this;
+    }
+
+    public Builder with(StreetMode mode, Integer limit) {
+      // Lazy initialize the valueForEnum map
+      if (limitForMode == null) {
+        limitForMode = new EnumMap<>(StreetMode.class);
+        for (StreetMode it : StreetMode.values()) {
+          if (original.hasCustomLimit(it)) {
+            limitForMode.put(it, original.limitForMode(it));
+          }
+        }
+      }
+      limitForMode.put(mode, limit);
+      return this;
+    }
+
+    public Builder withValues(Map<StreetMode, Integer> values) {
+      for (Map.Entry<StreetMode, Integer> e : values.entrySet()) {
+        with(e.getKey(), e.getValue());
+      }
+      return this;
+    }
+
+    /**
+     * Build a copy of the current values, excluding the defaultLimit from the map. This
+     * ensures equality and make a defencive copy of the builder values. Hence, the builder
+     * can be used to generate new values if desired.
+     * */
+    Map<StreetMode, Integer> copyValueForEnum() {
+      if (limitForMode == null) {
+        // The limitForMode is protected and should never be mutated, so we can reuse it
+        return original.limitForMode();
+      }
+
+      var copy = new EnumMap<StreetMode, Integer>(StreetMode.class);
+      for (Map.Entry<StreetMode, Integer> it : limitForMode.entrySet()) {
+        if (defaultLimit != it.getValue()) {
+          copy.put(it.getKey(), it.getValue());
+        }
+      }
+      return copy;
+    }
+
+    public Builder apply(Consumer<Builder> body) {
+      body.accept(this);
+      return this;
+    }
+
+    public MaxStopCountLimit build() {
+      var it = new MaxStopCountLimit(this);
+
+      // Return original if not change, subscriber is not notified
+      if (original != null && original.equals(it)) {
+        return original;
+      }
+
+      return it;
+    }
+  }
+}

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
@@ -126,7 +126,7 @@ public class MaxStopCountLimit {
 
     /**
      * Build a copy of the current values, excluding the defaultLimit from the map. This
-     * ensures equality and make a defencive copy of the builder values. Hence, the builder
+     * ensures equality and makes a defensive copy of the builder values. Hence, the builder
      * can be used to generate new values if desired.
      * */
     Map<StreetMode, Integer> copyValueForEnum() {
@@ -152,7 +152,7 @@ public class MaxStopCountLimit {
     public MaxStopCountLimit build() {
       var it = new MaxStopCountLimit(this);
 
-      // Return original if not change, subscriber is not notified
+      // Return the original if there are no changes, the subscriber is not notified.
       if (original != null && original.equals(it)) {
         return original;
       }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
@@ -15,21 +15,21 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 public class MaxStopCountLimit {
 
   private static final int DEFAULT_LIMIT = 500;
-  private static final Map<StreetMode, Integer> DEFAULT_FOR_MODE = Map.of();
+  private static final Map<StreetMode, Integer> DEFAULT_FOR_MODES = Map.of();
 
   public static final MaxStopCountLimit DEFAULT = new MaxStopCountLimit();
 
   private final int defaultLimit;
-  private final Map<StreetMode, Integer> limitForMode;
+  private final Map<StreetMode, Integer> limitsForModes;
 
   public MaxStopCountLimit() {
     this.defaultLimit = DEFAULT_LIMIT;
-    this.limitForMode = DEFAULT_FOR_MODE;
+    this.limitsForModes = DEFAULT_FOR_MODES;
   }
 
   MaxStopCountLimit(Builder builder) {
     this.defaultLimit = IntUtils.requireNotNegative(builder.defaultLimit());
-    this.limitForMode = builder.copyCustomLimits();
+    this.limitsForModes = builder.copyCustomLimits();
   }
 
   public static Builder of() {
@@ -44,7 +44,7 @@ public class MaxStopCountLimit {
    * Get the max stop count limit for mode. If no custom value is defined, default is used.
    */
   public int limitForMode(StreetMode mode) {
-    return limitForMode.getOrDefault(mode, defaultLimit);
+    return limitsForModes.getOrDefault(mode, defaultLimit);
   }
 
   public int defaultLimit() {
@@ -56,7 +56,7 @@ public class MaxStopCountLimit {
     return ToStringBuilder
       .of(MaxStopCountLimit.class)
       .addNum("defaultLimit", defaultLimit, DEFAULT_LIMIT)
-      .addObj("limitForMode", limitForMode, DEFAULT_FOR_MODE)
+      .addObj("limitsForModes", limitsForModes, DEFAULT_FOR_MODES)
       .toString();
   }
 
@@ -67,27 +67,27 @@ public class MaxStopCountLimit {
 
     var that = (MaxStopCountLimit) o;
 
-    return (defaultLimit == that.defaultLimit && limitForMode.equals(that.limitForMode));
+    return (defaultLimit == that.defaultLimit && limitsForModes.equals(that.limitsForModes));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(defaultLimit, limitForMode);
+    return Objects.hash(defaultLimit, limitsForModes);
   }
 
-  private Map<StreetMode, Integer> limitForMode() {
-    return limitForMode;
+  private Map<StreetMode, Integer> limitsForModes() {
+    return limitsForModes;
   }
 
   private boolean hasCustomLimit(StreetMode mode) {
-    return limitForMode.containsKey(mode);
+    return limitsForModes.containsKey(mode);
   }
 
   public static class Builder {
 
     private final MaxStopCountLimit original;
     private int defaultLimit;
-    private Map<StreetMode, Integer> limitForMode = null;
+    private Map<StreetMode, Integer> limitsForModes = null;
 
     Builder(MaxStopCountLimit original) {
       this.original = original;
@@ -105,15 +105,15 @@ public class MaxStopCountLimit {
 
     public Builder with(StreetMode mode, Integer limit) {
       // Lazy initialize the valueForEnum map
-      if (limitForMode == null) {
-        limitForMode = new EnumMap<>(StreetMode.class);
+      if (limitsForModes == null) {
+        limitsForModes = new EnumMap<>(StreetMode.class);
         for (StreetMode it : StreetMode.values()) {
           if (original.hasCustomLimit(it)) {
-            limitForMode.put(it, original.limitForMode(it));
+            limitsForModes.put(it, original.limitForMode(it));
           }
         }
       }
-      limitForMode.put(mode, limit);
+      limitsForModes.put(mode, limit);
       return this;
     }
 
@@ -130,13 +130,13 @@ public class MaxStopCountLimit {
      * can be used to generate new values if desired.
      * */
     Map<StreetMode, Integer> copyCustomLimits() {
-      if (limitForMode == null) {
+      if (limitsForModes == null) {
         // The limitForMode is protected and should never be mutated, so we can reuse it
-        return original.limitForMode();
+        return original.limitsForModes();
       }
 
       var copy = new EnumMap<StreetMode, Integer>(StreetMode.class);
-      for (Map.Entry<StreetMode, Integer> it : limitForMode.entrySet()) {
+      for (Map.Entry<StreetMode, Integer> it : limitsForModes.entrySet()) {
         if (defaultLimit != it.getValue()) {
           copy.put(it.getKey(), it.getValue());
         }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimit.java
@@ -17,6 +17,8 @@ public class MaxStopCountLimit {
   private static final int DEFAULT_LIMIT = 500;
   private static final Map<StreetMode, Integer> DEFAULT_FOR_MODE = Map.of();
 
+  public static final MaxStopCountLimit DEFAULT = new MaxStopCountLimit();
+
   private final int defaultLimit;
   private final Map<StreetMode, Integer> limitForMode;
 
@@ -28,6 +30,10 @@ public class MaxStopCountLimit {
   MaxStopCountLimit(Builder builder) {
     this.defaultLimit = IntUtils.requireNotNegative(builder.defaultLimit());
     this.limitForMode = builder.copyValueForEnum();
+  }
+
+  public static Builder of() {
+    return DEFAULT.copyOf();
   }
 
   public Builder copyOf() {

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -27,6 +27,7 @@ import org.opentripplanner.routing.api.request.preference.AccessEgressPreference
 import org.opentripplanner.routing.api.request.preference.BikePreferences;
 import org.opentripplanner.routing.api.request.preference.CarPreferences;
 import org.opentripplanner.routing.api.request.preference.EscalatorPreferences;
+import org.opentripplanner.routing.api.request.preference.MaxStopCountLimit;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.api.request.preference.ScooterPreferences;
 import org.opentripplanner.routing.api.request.preference.StreetPreferences;
@@ -544,7 +545,7 @@ does not exist.
               Safety limit to prevent access to and egress from too many stops.
               """
               )
-              .asInt(dftAccessEgress.defaultMaxStopCount()),
+              .asInt(MaxStopCountLimit.DEFAULT_LIMIT),
             cae
               .of("maxStopCountForMode")
               .since(V2_7)

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -545,7 +545,7 @@ does not exist.
               Safety limit to prevent access to and egress from too many stops.
               """
               )
-              .asInt(MaxStopCountLimit.DEFAULT_LIMIT),
+              .asInt(dftAccessEgress.maxStopCountLimit().defaultLimit()),
             cae
               .of("maxStopCountForMode")
               .since(V2_7)

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferencesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferencesTest.java
@@ -71,7 +71,7 @@ public class AccessEgressPreferencesTest {
       "CAR_HAILING: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
       "FLEXIBLE: (timePenalty: 10m + 1.30 t, costFactor: 1.30)}, " +
       "maxDuration: DurationForStreetMode{default:5m}, " +
-      "maxStopCount: MaxStopCountLimit{defaultLimit: 245, limitForMode: {CAR=0}}" +
+      "maxStopCount: MaxStopCountLimit{defaultLimit: 245, limitsForModes: {CAR=0}}" +
       "}",
       subject.toString()
     );

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferencesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/AccessEgressPreferencesTest.java
@@ -1,0 +1,79 @@
+package org.opentripplanner.routing.api.request.preference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.opentripplanner.routing.api.request.preference.ImmutablePreferencesAsserts.assertEqualsAndHashCode;
+
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.framework.TimeAndCostPenalty;
+import org.opentripplanner.routing.api.request.framework.TimePenalty;
+
+public class AccessEgressPreferencesTest {
+
+  private static final Duration MAX_ACCESS_EGRESS = Duration.ofMinutes(5);
+  private static final int MAX_DEFAULT_STOP_COUNT = 245;
+  private static final int MAX_CAR_STOP_COUNT = 0;
+  private static final TimeAndCostPenalty CAR_TO_PARK_PENALTY = TimeAndCostPenalty.of(
+    TimePenalty.of("2m + 1.5t"),
+    3.5
+  );
+
+  private final AccessEgressPreferences subject = AccessEgressPreferences
+    .of()
+    .withPenalty(Map.of(StreetMode.CAR_TO_PARK, CAR_TO_PARK_PENALTY))
+    .withMaxDuration(MAX_ACCESS_EGRESS, Map.of())
+    .withMaxStopCount(MAX_DEFAULT_STOP_COUNT, Map.of(StreetMode.CAR, MAX_CAR_STOP_COUNT))
+    .build();
+
+  @Test
+  void accessEgressPenalty() {
+    assertEquals(TimeAndCostPenalty.ZERO, subject.penalty().valueOf(StreetMode.WALK));
+    assertEquals(CAR_TO_PARK_PENALTY, subject.penalty().valueOf(StreetMode.CAR_TO_PARK));
+  }
+
+  @Test
+  void maxAccessEgressDuration() {
+    assertEquals(MAX_ACCESS_EGRESS, subject.maxDuration().defaultValue());
+  }
+
+  @Test
+  void testOfAndCopyOf() {
+    // Return same object if no value is set
+    assertSame(AccessEgressPreferences.DEFAULT, AccessEgressPreferences.of().build());
+    assertSame(subject, subject.copyOf().build());
+  }
+
+  @Test
+  void testEqualsAndHashCode() {
+    // Create a copy, make a change and set it back again to force creating a new object
+    var other = subject.copyOf().withMaxStopCount(20, Map.of()).build();
+    var copy = other
+      .copyOf()
+      .withMaxStopCount(MAX_DEFAULT_STOP_COUNT, Map.of(StreetMode.CAR, MAX_CAR_STOP_COUNT))
+      .build();
+    assertEqualsAndHashCode(subject, other, copy);
+  }
+
+  @Test
+  void testToString() {
+    assertEquals("StreetPreferences{}", StreetPreferences.DEFAULT.toString());
+    assertEquals(
+      "AccessEgressPreferences{" +
+      "penalty: TimeAndCostPenaltyForEnum{" +
+      "CAR_TO_PARK: " +
+      CAR_TO_PARK_PENALTY +
+      ", " +
+      "CAR_PICKUP: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
+      "CAR_RENTAL: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
+      "CAR_HAILING: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
+      "FLEXIBLE: (timePenalty: 10m + 1.30 t, costFactor: 1.30)}, " +
+      "maxDuration: DurationForStreetMode{default:5m}, " +
+      "maxStopCount: MaxStopCountLimit{defaultLimit: 245, limitForMode: {CAR=0}}" +
+      "}",
+      subject.toString()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimitTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimitTest.java
@@ -16,7 +16,7 @@ public class MaxStopCountLimitTest {
   private final MaxStopCountLimit subject = MaxStopCountLimit
     .of()
     .withDefaultLimit(MAX_DEFAULT_STOP_COUNT)
-    .withValues(Map.of(StreetMode.CAR, MAX_CAR_STOP_COUNT))
+    .withLimitsForModes(Map.of(StreetMode.CAR, MAX_CAR_STOP_COUNT))
     .build();
 
   @Test

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimitTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimitTest.java
@@ -45,7 +45,7 @@ public class MaxStopCountLimitTest {
   void testToString() {
     assertEquals("StreetPreferences{}", StreetPreferences.DEFAULT.toString());
     assertEquals(
-      "MaxStopCountLimit{" + "defaultLimit: 245, " + "limitForMode: {CAR=0}" + "}",
+      "MaxStopCountLimit{" + "defaultLimit: 245, " + "limitsForModes: {CAR=0}" + "}",
       subject.toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimitTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/MaxStopCountLimitTest.java
@@ -1,0 +1,52 @@
+package org.opentripplanner.routing.api.request.preference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.opentripplanner.routing.api.request.preference.ImmutablePreferencesAsserts.assertEqualsAndHashCode;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.api.request.StreetMode;
+
+public class MaxStopCountLimitTest {
+
+  private static final int MAX_DEFAULT_STOP_COUNT = 245;
+  private static final int MAX_CAR_STOP_COUNT = 0;
+
+  private final MaxStopCountLimit subject = MaxStopCountLimit
+    .of()
+    .withDefaultLimit(MAX_DEFAULT_STOP_COUNT)
+    .withValues(Map.of(StreetMode.CAR, MAX_CAR_STOP_COUNT))
+    .build();
+
+  @Test
+  void maxAccessEgressStopCountLimit() {
+    assertEquals(MAX_DEFAULT_STOP_COUNT, subject.defaultLimit());
+    assertEquals(MAX_DEFAULT_STOP_COUNT, subject.limitForMode(StreetMode.BIKE));
+    assertEquals(MAX_CAR_STOP_COUNT, subject.limitForMode(StreetMode.CAR));
+  }
+
+  @Test
+  void testOfAndCopyOf() {
+    // Return same object if no value is set
+    assertSame(MaxStopCountLimit.DEFAULT, MaxStopCountLimit.of().build());
+    assertSame(subject, subject.copyOf().build());
+  }
+
+  @Test
+  void testEqualsAndHashCode() {
+    // Create a copy, make a change and set it back again to force creating a new object
+    var other = subject.copyOf().withDefaultLimit(20).build();
+    var copy = other.copyOf().withDefaultLimit(MAX_DEFAULT_STOP_COUNT).build();
+    assertEqualsAndHashCode(subject, other, copy);
+  }
+
+  @Test
+  void testToString() {
+    assertEquals("StreetPreferences{}", StreetPreferences.DEFAULT.toString());
+    assertEquals(
+      "MaxStopCountLimit{" + "defaultLimit: 245, " + "limitForMode: {CAR=0}" + "}",
+      subject.toString()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/StreetPreferencesTest.java
@@ -7,9 +7,6 @@ import static org.opentripplanner.routing.api.request.preference.ImmutablePrefer
 import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.routing.api.request.StreetMode;
-import org.opentripplanner.routing.api.request.framework.TimeAndCostPenalty;
-import org.opentripplanner.routing.api.request.framework.TimePenalty;
 import org.opentripplanner.street.search.intersection_model.DrivingDirection;
 import org.opentripplanner.street.search.intersection_model.IntersectionTraversalModel;
 
@@ -18,17 +15,11 @@ class StreetPreferencesTest {
   private static final double TURN_RELUCTANCE = 2.0;
   private static final Duration MAX_ACCESS_EGRESS = Duration.ofMinutes(5);
   private static final Duration MAX_DIRECT = Duration.ofMinutes(10);
-  private static final int MAX_DEFAULT_STOP_COUNT = 245;
-  private static final int MAX_CAR_STOP_COUNT = 0;
   private static final Duration ROUTING_TIMEOUT = Duration.ofSeconds(3);
   private static final DrivingDirection DRIVING_DIRECTION = DrivingDirection.LEFT;
   private static final int ELEVATOR_BOARD_TIME = (int) Duration.ofMinutes(2).toSeconds();
   private static final IntersectionTraversalModel INTERSECTION_TRAVERSAL_MODEL =
     IntersectionTraversalModel.CONSTANT;
-  private static final TimeAndCostPenalty CAR_TO_PARK_PENALTY = TimeAndCostPenalty.of(
-    TimePenalty.of("2m + 1.5t"),
-    3.5
-  );
 
   private final StreetPreferences subject = StreetPreferences
     .of()
@@ -36,11 +27,7 @@ class StreetPreferencesTest {
     .withTurnReluctance(TURN_RELUCTANCE)
     .withElevator(it -> it.withBoardTime(ELEVATOR_BOARD_TIME))
     .withIntersectionTraversalModel(INTERSECTION_TRAVERSAL_MODEL)
-    .withAccessEgress(it -> it.withPenalty(Map.of(StreetMode.CAR_TO_PARK, CAR_TO_PARK_PENALTY)))
     .withAccessEgress(it -> it.withMaxDuration(MAX_ACCESS_EGRESS, Map.of()))
-    .withAccessEgress(it ->
-      it.withMaxStopCount(MAX_DEFAULT_STOP_COUNT, Map.of(StreetMode.CAR, MAX_CAR_STOP_COUNT))
-    )
     .withMaxDirectDuration(MAX_DIRECT, Map.of())
     .withRoutingTimeout(ROUTING_TIMEOUT)
     .build();
@@ -53,36 +40,6 @@ class StreetPreferencesTest {
   @Test
   void intersectionTraversalModel() {
     assertEquals(INTERSECTION_TRAVERSAL_MODEL, subject.intersectionTraversalModel());
-  }
-
-  @Test
-  void accessEgressPenalty() {
-    assertEquals(
-      TimeAndCostPenalty.ZERO,
-      subject.accessEgress().penalty().valueOf(StreetMode.WALK)
-    );
-    assertEquals(
-      CAR_TO_PARK_PENALTY,
-      subject.accessEgress().penalty().valueOf(StreetMode.CAR_TO_PARK)
-    );
-  }
-
-  @Test
-  void maxAccessEgressDuration() {
-    assertEquals(MAX_ACCESS_EGRESS, subject.accessEgress().maxDuration().defaultValue());
-  }
-
-  @Test
-  void maxAccessEgressStopCountLimit() {
-    assertEquals(MAX_DEFAULT_STOP_COUNT, subject.accessEgress().maxStopCountLimit().defaultLimit());
-    assertEquals(
-      MAX_DEFAULT_STOP_COUNT,
-      subject.accessEgress().maxStopCountLimit().limitForMode(StreetMode.BIKE)
-    );
-    assertEquals(
-      MAX_CAR_STOP_COUNT,
-      subject.accessEgress().maxStopCountLimit().limitForMode(StreetMode.CAR)
-    );
   }
 
   @Test
@@ -130,16 +87,9 @@ class StreetPreferencesTest {
       "routingTimeout: 3s, " +
       "elevator: ElevatorPreferences{boardTime: 2m}, " +
       "intersectionTraversalModel: CONSTANT, " +
-      "accessEgress: AccessEgressPreferences{penalty: TimeAndCostPenaltyForEnum{" +
-      "CAR_TO_PARK: " +
-      CAR_TO_PARK_PENALTY +
-      ", " +
-      "CAR_PICKUP: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
-      "CAR_RENTAL: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
-      "CAR_HAILING: (timePenalty: 20m + 2.0 t, costFactor: 1.50), " +
-      "FLEXIBLE: (timePenalty: 10m + 1.30 t, costFactor: 1.30)}, " +
-      "maxDuration: DurationForStreetMode{default:5m}, " +
-      "maxStopCount: MaxStopCountLimit{defaultLimit: 245, limitForMode: {CAR=0}}}, " +
+      "accessEgress: AccessEgressPreferences{" +
+      "maxDuration: DurationForStreetMode{default:5m}" +
+      "}, " +
       "maxDirectDuration: DurationForStreetMode{default:10m}" +
       "}",
       subject.toString()


### PR DESCRIPTION
### Summary

Refactor max stop count limit so that the map is merged with any new definition of max stop counts. This also fixes an issue with default max stop count limit for mode being overridden by an empty map when using transfer cache requests.

This replaces https://github.com/opentripplanner/OpenTripPlanner/pull/6488

### Issue

No issue

### Unit tests

Updated

### Documentation

Not needed

### Changelog

From title
