### PR TITLE
Remove the usage of UUID in TemporaryStreetLocation

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/index/StreetIndex.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
@@ -102,12 +101,7 @@ public class StreetIndex {
   ) {
     boolean wheelchairAccessible = false;
 
-    TemporaryStreetLocation location = new TemporaryStreetLocation(
-      label,
-      nearestPoint,
-      name,
-      endVertex
-    );
+    TemporaryStreetLocation location = new TemporaryStreetLocation(nearestPoint, name, endVertex);
 
     for (StreetEdge street : edges) {
       Vertex fromv = street.getFromVertex();
@@ -378,7 +372,6 @@ public class StreetIndex {
     }
 
     TemporaryStreetLocation temporaryStreetLocation = new TemporaryStreetLocation(
-      UUID.randomUUID().toString(),
       coordinate,
       name,
       endVertex

--- a/application/src/main/java/org/opentripplanner/street/model/vertex/TemporaryStreetLocation.java
+++ b/application/src/main/java/org/opentripplanner/street/model/vertex/TemporaryStreetLocation.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.vertex;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.edge.Edge;
@@ -7,15 +8,12 @@ import org.opentripplanner.street.model.edge.TemporaryEdge;
 
 public final class TemporaryStreetLocation extends StreetLocation implements TemporaryVertex {
 
+  private static final AtomicLong idCounter = new AtomicLong(0);
+
   private final boolean endVertex;
 
-  public TemporaryStreetLocation(
-    String id,
-    Coordinate nearestPoint,
-    I18NString name,
-    boolean endVertex
-  ) {
-    super(id, nearestPoint, name);
+  public TemporaryStreetLocation(Coordinate nearestPoint, I18NString name, boolean endVertex) {
+    super("TempVertex-" + idCounter.incrementAndGet(), nearestPoint, name);
     this.endVertex = endVertex;
   }
 

--- a/application/src/test/java/org/opentripplanner/astar/AStarTest.java
+++ b/application/src/test/java/org/opentripplanner/astar/AStarTest.java
@@ -164,7 +164,6 @@ public class AStarTest {
     request.withPreferences(pref -> pref.withWalk(w -> w.withSpeed(1.0)));
 
     TemporaryStreetLocation from = new TemporaryStreetLocation(
-      "near_shilshole_22nd",
       new Coordinate(-122.385050, 47.666620),
       new NonLocalizedString("near_shilshole_22nd"),
       false
@@ -172,7 +171,6 @@ public class AStarTest {
     TemporaryConcreteEdge.createTemporaryConcreteEdge(from, graph.getVertex("shilshole_22nd"));
 
     TemporaryStreetLocation to = new TemporaryStreetLocation(
-      "near_56th_20th",
       new Coordinate(-122.382347, 47.669518),
       new NonLocalizedString("near_56th_20th"),
       true
@@ -193,7 +191,7 @@ public class AStarTest {
 
     assertEquals(9, states.size());
 
-    assertEquals("near_shilshole_22nd", states.get(0).getVertex().getLabelString());
+    assertEquals("near_shilshole_22nd", states.get(0).getVertex().getDefaultName());
     assertEquals("shilshole_22nd", states.get(1).getVertex().getLabelString());
     assertEquals("ballard_22nd", states.get(2).getVertex().getLabelString());
     assertEquals("market_22nd", states.get(3).getVertex().getLabelString());
@@ -201,7 +199,7 @@ public class AStarTest {
     assertEquals("market_russell", states.get(5).getVertex().getLabelString());
     assertEquals("market_20th", states.get(6).getVertex().getLabelString());
     assertEquals("56th_20th", states.get(7).getVertex().getLabelString());
-    assertEquals("near_56th_20th", states.get(8).getVertex().getLabelString());
+    assertEquals("near_56th_20th", states.get(8).getVertex().getDefaultName());
   }
 
   @Test
@@ -212,7 +210,6 @@ public class AStarTest {
     request.setArriveBy(true);
 
     TemporaryStreetLocation from = new TemporaryStreetLocation(
-      "near_shilshole_22nd",
       new Coordinate(-122.385050, 47.666620),
       new NonLocalizedString("near_shilshole_22nd"),
       false
@@ -220,7 +217,6 @@ public class AStarTest {
     TemporaryConcreteEdge.createTemporaryConcreteEdge(from, graph.getVertex("shilshole_22nd"));
 
     TemporaryStreetLocation to = new TemporaryStreetLocation(
-      "near_56th_20th",
       new Coordinate(-122.382347, 47.669518),
       new NonLocalizedString("near_56th_20th"),
       true
@@ -241,7 +237,7 @@ public class AStarTest {
 
     assertEquals(9, states.size());
 
-    assertEquals("near_shilshole_22nd", states.get(0).getVertex().getLabelString());
+    assertEquals("near_shilshole_22nd", states.get(0).getVertex().getDefaultName());
     assertEquals("shilshole_22nd", states.get(1).getVertex().getLabelString());
     assertEquals("ballard_22nd", states.get(2).getVertex().getLabelString());
     assertEquals("market_22nd", states.get(3).getVertex().getLabelString());
@@ -249,7 +245,7 @@ public class AStarTest {
     assertEquals("market_russell", states.get(5).getVertex().getLabelString());
     assertEquals("market_20th", states.get(6).getVertex().getLabelString());
     assertEquals("56th_20th", states.get(7).getVertex().getLabelString());
-    assertEquals("near_56th_20th", states.get(8).getVertex().getLabelString());
+    assertEquals("near_56th_20th", states.get(8).getVertex().getDefaultName());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -360,7 +360,6 @@ public abstract class GraphRoutingTest {
       boolean endVertex
     ) {
       return new TemporaryStreetLocation(
-        name,
         new Coordinate(longitude, latitude),
         new NonLocalizedString(name),
         endVertex


### PR DESCRIPTION
### Summary

The other temporary vertex, TemporarySplitterVertex, is left as is. This is getting its id(label) from the splitter.


### Issue

🟥  No issue.



### Unit tests

🟥  No test, a few tests failed after the change - these are fixed.


### Documentation

🟥  No doc.


### Changelog

🟥  Not relevant.

### Bumping the serialization version id

🟥  Not needed.
