### PR TITLE
Add highway=platform to IsBoardingLocation()

### DIFF
--- a/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
@@ -579,6 +579,7 @@ public class OsmEntity {
       isTag("railway", "halt") ||
       isTag("amenity", "bus_station") ||
       isTag("amenity", "ferry_terminal") ||
+      isTag("highway", "platform") ||
       isPlatform()
     );
   }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/BoardingLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/BoardingLocationTest.java
@@ -66,4 +66,28 @@ public class BoardingLocationTest {
     var platform = osmInfoRepository.findPlatform(edges.getFirst());
     assertTrue(platform.isEmpty());
   }
+
+  @Test
+  void testHighwayPlatform() {
+    var way = new OsmWay();
+    way.addTag("highway", "platform");
+    way.addTag("ref", "1");
+    var provider = TestOsmProvider.of().addWay(way).build();
+
+    var graph = new Graph(new Deduplicator());
+    var osmInfoRepository = new DefaultOsmInfoGraphBuildRepository();
+    var osmModule = OsmModule
+      .of(provider, graph, osmInfoRepository, new DefaultVehicleParkingRepository())
+      .withBoardingAreaRefTags(Set.of("ref"))
+      .build();
+
+    osmModule.buildGraph();
+    var edges = List.copyOf(graph.getEdges());
+    assertThat(edges).hasSize(2);
+
+    var platform = osmInfoRepository.findPlatform(edges.getFirst());
+
+    assertTrue(platform.isPresent());
+    assertEquals(Set.of("1"), platform.get().references());
+  }
 }

--- a/doc/user/BoardingLocations.md
+++ b/doc/user/BoardingLocations.md
@@ -20,6 +20,8 @@ You can add cross-references to a stop's id or code on all OSM entities (nodes, 
 have one of the following tag combinations:
 
 - `public_transport=platform`
+- `railway=platform`
+- `highway=platform`
 - `highway=bus_stop`
 - `railway=tram_stop`
 - `railway=station`


### PR DESCRIPTION
### Summary

Since https://github.com/opentripplanner/OpenTripPlanner/pull/6247 it has been possible to link transit data to the streetgraph for linear ways and not just nodes and areas. The list of tags in IsBoardingLocation() was not appropriate for this with regards to buses which use tag highway=platform for linear ways. This PR therefore adds highway=platform to the function.

### Issue

Closes #6433

### Unit tests

None

### Documentation

Docs were updated and now mention both highway=platform and railway=platform in addition to the previous list of tags.