### PR TITLE
Fix typo in access mode documentation

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/ModeInputType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/ModeInputType.java
@@ -21,7 +21,7 @@ class ModeInputType {
         .name("accessMode")
         .description(
           "The mode used to get from the origin to the access stops in the transit " +
-          "network the transit network (first-mile). If the element is not present or null," +
+          "network (first-mile). If the element is not present or null," +
           "only transit that can be immediately boarded from the origin will be used."
         )
         .type(EnumTypes.STREET_MODE)

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -2104,7 +2104,7 @@ input Location {
 
 "Input format for specifying which modes will be allowed for this search. If this element is not present, it will default to accessMode/egressMode/directMode of foot and all transport modes will be allowed."
 input Modes {
-  "The mode used to get from the origin to the access stops in the transit network the transit network (first-mile). If the element is not present or null,only transit that can be immediately boarded from the origin will be used."
+  "The mode used to get from the origin to the access stops in the transit network (first-mile). If the element is not present or null,only transit that can be immediately boarded from the origin will be used."
   accessMode: StreetMode
   "The mode used to get from the origin to the destination directly, without using the transit network. If the element is not present or null,direct travel without using transit will be disallowed."
   directMode: StreetMode


### PR DESCRIPTION

### Summary
This PR fixes a typo in the Transmodel GraphQL API documentation.

### Issue
No
### Unit tests
No

### Documentation
Updated

### Changelog

Skipped