### PR TITLE
Fixes issue where empty ids list was causing errors.

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -458,8 +458,8 @@ public class TransmodelGraphQLSchema {
               .build()
           )
           .dataFetcher(env -> {
-            var ids = mapIDsToDomainNullSafe(env.getArgument("ids"));
-            if (!ids.isEmpty()) {
+            if (env.getArgument("ids") != null) {
+              var ids = mapIDsToDomainNullSafe(env.getArgument("ids"));
               return ids
                 .stream()
                 .map(id -> StopPlaceType.fetchStopPlaceById(id, env))


### PR DESCRIPTION
### Summary

This fixes an error introduced in https://github.com/opentripplanner/OpenTripPlanner/pull/6423 where an empty ID list was treated like a "list all" instead of a "list none" in the stopPlaces API.

Note that this change just reverts to the previous functioning version of the API. It does not improve on the previous state, for instance how `arg=null` is handled (it could be handled as an unset arg or the empty value for the arg), nor does implement any kind of paging for when all results are requested (which is what causes the error today). These are noted and will be handled in future improvements.

Erroring API call: https://api.dev.entur.io/graphql-explorer/journey-planner-v3?query=query%20stopPlaces%28%24ids%3A%5BString%21%5D%24lines%3A%5BID%5D%24startTime%3ADateTime%29%7BstopPlaces%28ids%3A%24ids%29%7Bid%20name%20latitude%20longitude%20estimatedCalls%28startTime%3A%24startTime%20timeRange%3A72000%20numberOfDepartures%3A50%20numberOfDeparturesPerLineAndDestinationDisplay%3A5%20arrivalDeparture%3Adepartures%20includeCancelledTrips%3Atrue%20whiteListed%3A%7Blines%3A%24lines%7D%29%7B...estimatedCallFields%7D%7D%7Dfragment%20estimatedCallFields%20on%20EstimatedCall%7Bquay%7Bid%20publicCode%7Ddate%20aimedDepartureTime%20expectedDepartureTime%20destinationDisplay%7BfrontText%20via%7Dnotices%7Btext%7Dsituations%7BsituationNumber%20reportType%7DserviceJourney%7Bid%20journeyPattern%7Bid%20line%7Bid%20name%20publicCode%7D%7DtransportMode%20transportSubmode%7Drealtime%20cancellation%20predictionInaccurate%20occupancyStatus%7D&variables=%7B%22ids%22%3A%5B%5D%2C%22lines%22%3A%5B%5D%2C%22startTime%22%3A%222025-02-19T10%3A32%3A00.000Z%22%7D

### Issue
Close #6482 

### Unit tests

Validated that this works locally as expected, no tests at this layer of the codebase.

### Bumping the serialization version id

No serialized types change so no bump necessary.