### PR TITLE
Add edge name for indoor area

### DIFF
--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
@@ -668,6 +668,8 @@ public class OsmTagMapper {
     props.createNames("highway=bridleway", "name.bridleway");
     props.createNames("highway=footway;bicycle=no", "name.pedestrian_path");
     props.createNames("highway=corridor", "name.corridor");
+    props.createNames("indoor=corridor", "name.corridor");
+    props.createNames("indoor=area", "name.indoor_area");
 
     // Platforms
     props.createNames("otp:route_ref=*", "name.otp_route_ref");
@@ -678,6 +680,7 @@ public class OsmTagMapper {
     props.createNames("railway=platform;highway=pedestrian", "name.platform");
     props.createNames("railway=platform;highway=path", "name.platform");
     props.createNames("railway=platform;highway=footway", "name.platform");
+    props.createNames("public_transport=platform", "name.platform");
     props.createNames("highway=platform", "name.platform");
     props.createNames("railway=platform", "name.platform");
     props.createNames("railway=platform;highway=footway;bicycle=no", "name.platform");

--- a/application/src/main/resources/WayProperties.properties
+++ b/application/src/main/resources/WayProperties.properties
@@ -9,6 +9,7 @@ name.pedestrian_area=open area
 name.path=path
 name.bridleway=bridleway
 name.corridor=corridor
+name.indoor_area=indoor area
 
 name.otp_route_ref=Route {otp:route_ref}
 name.platform_ref=Platform {ref}

--- a/application/src/main/resources/WayProperties_de.properties
+++ b/application/src/main/resources/WayProperties_de.properties
@@ -10,6 +10,7 @@ name.pedestrian_area=Fu\u00dfg\u00e4ngerzone
 name.path=Weg
 name.bridleway=Reitweg
 name.corridor=Korridor
+name.indoor_area=Innenbereich
 
 name.otp_route_ref=Route {otp:route_ref}
 name.platform_ref=Plattform {ref}

--- a/application/src/main/resources/WayProperties_fi.properties
+++ b/application/src/main/resources/WayProperties_fi.properties
@@ -9,7 +9,7 @@ name.pedestrian_area=aukio
 name.path=polku
 name.bridleway=ratsupolku
 name.corridor=käytävä
-name.indoor_area=sisätilat
+name.indoor_area=sisätila
 
 name.otp_route_ref=linja {otp:route_ref}
 name.platform_ref=laituri {ref}

--- a/application/src/main/resources/WayProperties_fi.properties
+++ b/application/src/main/resources/WayProperties_fi.properties
@@ -9,7 +9,7 @@ name.pedestrian_area=aukio
 name.path=polku
 name.bridleway=ratsupolku
 name.corridor=käytävä
-name.indoor_area=Innenbereich
+name.indoor_area=sisätilat
 
 name.otp_route_ref=linja {otp:route_ref}
 name.platform_ref=laituri {ref}

--- a/application/src/main/resources/WayProperties_fi.properties
+++ b/application/src/main/resources/WayProperties_fi.properties
@@ -9,6 +9,7 @@ name.pedestrian_area=aukio
 name.path=polku
 name.bridleway=ratsupolku
 name.corridor=käytävä
+name.indoor_area=Innenbereich
 
 name.otp_route_ref=linja {otp:route_ref}
 name.platform_ref=laituri {ref}

--- a/application/src/main/resources/WayProperties_fr.properties
+++ b/application/src/main/resources/WayProperties_fr.properties
@@ -10,6 +10,7 @@ name.pedestrian_area=plateau pi\u00e9tonnier
 name.path=chemin
 name.bridleway=sentier \u00e9questre
 name.corridor=couloir
+name.indoor_area=zone int\u00e9rieure
 
 name.otp_route_ref=Ligne {otp:route_ref}
 name.platform_ref=Plate-forme {ref}

--- a/application/src/main/resources/WayProperties_hu.properties
+++ b/application/src/main/resources/WayProperties_hu.properties
@@ -9,6 +9,7 @@ name.pedestrian_area=t\u00E9r
 name.path=path
 name.bridleway=nyomvonal
 name.corridor=folyoso
+name.indoor_area=belteri terulet
 
 name.otp_route_ref={otp:route_ref}
 name.platform_ref={ref}

--- a/application/src/main/resources/WayProperties_nl.properties
+++ b/application/src/main/resources/WayProperties_nl.properties
@@ -10,6 +10,7 @@ name.pedestrian_area=open ruimte
 name.path=pad
 name.bridleway=ruiterpad
 name.corridor=gang
+name.indoor_area=binnenruimte
 
 name.otp_route_ref=Lijn {otp:route_ref}
 name.platform_ref=Spoor {ref}

--- a/application/src/main/resources/WayProperties_no.properties
+++ b/application/src/main/resources/WayProperties_no.properties
@@ -9,6 +9,7 @@ name.pedestrian_area=plass
 name.path=sti
 name.bridleway=bridleway
 name.corridor=korridor
+name.indoor_area=innendors omrade
 
 name.otp_route_ref=Rute {otp:route_ref}
 name.platform_ref=Plattform {ref}

--- a/application/src/main/resources/WayProperties_sv.properties
+++ b/application/src/main/resources/WayProperties_sv.properties
@@ -9,6 +9,7 @@ name.pedestrian_area=torget
 name.path=stigen
 name.bridleway=ridvägem
 name.corridor=korridor
+name.indoor_area=inomhusomrade
 
 name.otp_route_ref=linje {otp:route_ref}
 name.platform_ref=plattform {ref}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcaveHoleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcaveHoleTest.java
@@ -29,7 +29,7 @@ import org.opentripplanner.transit.model.framework.Deduplicator;
  * <p>
  * Further reading: https://github.com/opentripplanner/OpenTripPlanner/pull/6486
  */
-public class ConcaveHoleTest {
+class ConcaveHoleTest {
 
   @Test
   void visibilityNodes() {

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -202,6 +202,15 @@ class OsmTagMapperTest {
     assertEquals("käytävä", wps.getCreativeNameForWay(way).toString(Locale.of("FI")));
   }
 
+  @Test
+  void indoorAreaName() {
+    var wps = wayProperySet();
+    var way = way("indoor", "area");
+    assertEquals("corridor", wps.getCreativeNameForWay(way).toString());
+    assertEquals("Korridor", wps.getCreativeNameForWay(way).toString(Locale.GERMANY));
+    assertEquals("käytävä", wps.getCreativeNameForWay(way).toString(Locale.of("FI")));
+  }
+
   public OsmEntity way(String key, String value) {
     var way = new OsmEntity();
     way.addTag(key, value);

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -210,7 +210,7 @@ class OsmTagMapperTest {
     var way = way("indoor", "area");
     assertEquals("indoor area", wps.getCreativeNameForWay(way).toString());
     assertEquals("Innenbereich", wps.getCreativeNameForWay(way).toString(Locale.GERMANY));
-    assertEquals("sisätilat", wps.getCreativeNameForWay(way).toString(FI));
+    assertEquals("sisätila", wps.getCreativeNameForWay(way).toString(FI));
   }
 
   public OsmEntity way(String key, String value) {

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/OsmTagMapperTest.java
@@ -17,6 +17,8 @@ import org.opentripplanner.osm.wayproperty.specifier.WayTestData;
 
 class OsmTagMapperTest {
 
+  private static final Locale FI = Locale.of("FI");
+
   @Test
   void isMotorThroughTrafficExplicitlyDisallowed() {
     OsmEntity o = new OsmEntity();
@@ -199,16 +201,16 @@ class OsmTagMapperTest {
     var way = way("highway", "corridor");
     assertEquals("corridor", wps.getCreativeNameForWay(way).toString());
     assertEquals("Korridor", wps.getCreativeNameForWay(way).toString(Locale.GERMANY));
-    assertEquals("käytävä", wps.getCreativeNameForWay(way).toString(Locale.of("FI")));
+    assertEquals("käytävä", wps.getCreativeNameForWay(way).toString(FI));
   }
 
   @Test
   void indoorAreaName() {
     var wps = wayProperySet();
     var way = way("indoor", "area");
-    assertEquals("corridor", wps.getCreativeNameForWay(way).toString());
-    assertEquals("Korridor", wps.getCreativeNameForWay(way).toString(Locale.GERMANY));
-    assertEquals("käytävä", wps.getCreativeNameForWay(way).toString(Locale.of("FI")));
+    assertEquals("indoor area", wps.getCreativeNameForWay(way).toString());
+    assertEquals("Innenbereich", wps.getCreativeNameForWay(way).toString(Locale.GERMANY));
+    assertEquals("sisätilat", wps.getCreativeNameForWay(way).toString(FI));
   }
 
   public OsmEntity way(String key, String value) {


### PR DESCRIPTION
### Summary

We recently allowed routing through areas tagged with `indoor=area` but we haven't assigned a namer to it, which this PR fixes.

### Unit tests

Added.

### Documentation

N/a

### Changelog
 
skip