### PR TITLE
Fix removal of old vehicle positions

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehiclePositionImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehiclePositionImpl.java
@@ -2,6 +2,8 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.time.OffsetDateTime;
+import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle.StopRelationship;
@@ -17,6 +19,14 @@ public class VehiclePositionImpl implements GraphQLDataFetchers.GraphQLVehiclePo
   @Override
   public DataFetcher<String> label() {
     return env -> getSource(env).label().orElse(null);
+  }
+
+  @Override
+  public DataFetcher<OffsetDateTime> lastUpdate() {
+    return env -> {
+      var zoneId = env.<GraphQLRequestContext>getContext().transitService().getTimeZone();
+      return getSource(env).time().map(time -> time.atZone(zoneId).toOffsetDateTime()).orElse(null);
+    };
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehiclePositionImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehiclePositionImpl.java
@@ -25,7 +25,7 @@ public class VehiclePositionImpl implements GraphQLDataFetchers.GraphQLVehiclePo
   public DataFetcher<OffsetDateTime> lastUpdate() {
     return env -> {
       var zoneId = env.<GraphQLRequestContext>getContext().transitService().getTimeZone();
-      return getSource(env).time().map(time -> time.atZone(zoneId).toOffsetDateTime()).orElse(null);
+      return getSource(env).time().map(time -> OffsetDateTime.ofInstant(time, zoneId)).orElse(null);
     };
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -1392,6 +1392,8 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<String> label();
 
+    public DataFetcher<java.time.OffsetDateTime> lastUpdate();
+
     public DataFetcher<Long> lastUpdated();
 
     public DataFetcher<Double> lat();

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
@@ -7,7 +7,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 
 public interface RealtimeVehicleRepository {
   /**
-   * Stores the relationship between of realtime vehicles with a pattern for a given feed id.
+   * Stores all realtime vehicles for a given {@code feedId} and associates each with a pattern.
    * If the pattern is a realtime-added one, then the original (scheduled) one is used as the key
    * for the map storing the information.
    * <p>

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.service.realtimevehicles;
 
+import com.google.common.collect.Multimap;
 import java.util.List;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -13,15 +14,8 @@ public interface RealtimeVehicleRepository {
    * This means that if there are two updaters providing vehicles for the same pattern they
    * overwrite each other.
    */
-  void setRealtimeVehicles(TripPattern pattern, List<RealtimeVehicle> updates);
+  void setRealtimeVehicles(String feedId, Multimap<TripPattern, RealtimeVehicle> updates);
 
-  /**
-   * Remove all vehicles for a given pattern.
-   * <p>
-   * This is useful to clear old vehicles for which there are no more updates and we assume that
-   * they have stopped their trip.
-   */
-  void clearRealtimeVehicles(TripPattern pattern);
   /**
    * Get the vehicles for a certain trip.
    */

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
@@ -7,12 +7,11 @@ import org.opentripplanner.transit.model.network.TripPattern;
 
 public interface RealtimeVehicleRepository {
   /**
-   * For the given pattern set all realtime vehicles.
+   * Stores the relationship between of realtime vehicles with a pattern for a given feed id.
+   * If the pattern is a realtime-added one, then the original (scheduled) one is used as the key
+   * for the map storing the information.
    * <p>
-   * The list is expected to be exhaustive: all existing vehicles will be overridden.
-   * <p>
-   * This means that if there are two updaters providing vehicles for the same pattern they
-   * overwrite each other.
+   * Before storing the new vehicles, it removes the previous updates for the given {@code feedId}.
    */
   void setRealtimeVehicles(String feedId, Multimap<TripPattern, RealtimeVehicle> updates);
 

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/RealtimeVehicleRepository.java
@@ -13,7 +13,7 @@ public interface RealtimeVehicleRepository {
    * <p>
    * Before storing the new vehicles, it removes the previous updates for the given {@code feedId}.
    */
-  void setRealtimeVehicles(String feedId, Multimap<TripPattern, RealtimeVehicle> updates);
+  void setRealtimeVehiclesForFeed(String feedId, Multimap<TripPattern, RealtimeVehicle> updates);
 
   /**
    * Get the vehicles for a certain trip.

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -37,7 +37,10 @@ public class DefaultRealtimeVehicleService
     this.transitService = transitService;
   }
 
-  public void setRealtimeVehicles(String feedId, Multimap<TripPattern, RealtimeVehicle> updates) {
+  public void setRealtimeVehiclesForFeed(
+    String feedId,
+    Multimap<TripPattern, RealtimeVehicle> updates
+  ) {
     Multimap<TripPattern, RealtimeVehicle> temp = ArrayListMultimap.create();
     temp.putAll(vehicles);
     // remove all previous updates for this specific feed id
@@ -58,7 +61,7 @@ public class DefaultRealtimeVehicleService
    * then the original (scheduled) one is used for the lookup instead, so you receive the correct
    * result no matter if you use the realtime or static information.
    *
-   * @see DefaultRealtimeVehicleService#setRealtimeVehicles(String, Multimap)
+   * @see DefaultRealtimeVehicleService#setRealtimeVehiclesForFeed(String, Multimap)
    */
   @Override
   public List<RealtimeVehicle> getRealtimeVehicles(TripPattern pattern) {

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -36,6 +36,7 @@ public class DefaultRealtimeVehicleService
    * Stores the relationship between a list of realtime vehicles with a pattern. If the pattern is
    * a realtime-added one, then the original (scheduled) one is used as the key for the map storing
    * the information.
+   * Before storing the new vehicles, removes the previous updates for the given {@code feedId}.
    */
   public void setRealtimeVehicles(String feedId, Multimap<TripPattern, RealtimeVehicle> updates) {
     Multimap<TripPattern, RealtimeVehicle> temp = ArrayListMultimap.create();

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -4,7 +4,9 @@ import static org.opentripplanner.transit.model.timetable.OccupancyStatus.NO_DAT
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,21 @@ public class DefaultRealtimeVehicleService
       pattern = pattern.getOriginalTripPattern();
     }
     vehicles.put(pattern, List.copyOf(updates));
+
+    vehicles
+      .values()
+      .stream()
+      .flatMap(Collection::stream)
+      .forEach(v -> {
+        var isOld = v
+          .time()
+          .stream()
+          .allMatch(t -> t.isBefore(Instant.now().minus(Duration.ofHours(1))));
+
+        if (isOld) {
+          System.out.println(v + "is old");
+        }
+      });
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.service.realtimevehicles.internal;
 
+import static org.opentripplanner.transit.model.timetable.OccupancyStatus.NO_DATA_AVAILABLE;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
@@ -14,7 +16,6 @@ import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.OccupancyStatus;
-import static org.opentripplanner.transit.model.timetable.OccupancyStatus.NO_DATA_AVAILABLE;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
 

--- a/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/application/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -23,7 +23,12 @@ import org.opentripplanner.transit.service.TransitService;
 public class DefaultRealtimeVehicleService
   implements RealtimeVehicleService, RealtimeVehicleRepository {
 
-  private ImmutableListMultimap<TripPattern, RealtimeVehicle> vehicles = ImmutableListMultimap.of();
+  /**
+   * This multimap is immutable and therefore thread-safe. It is updated using the copy-on-write
+   * pattern so data races are avoided. This is re-enforced with the variable being volatile.
+   */
+  private volatile ImmutableListMultimap<TripPattern, RealtimeVehicle> vehicles =
+    ImmutableListMultimap.of();
 
   private final TransitService transitService;
 
@@ -32,12 +37,6 @@ public class DefaultRealtimeVehicleService
     this.transitService = transitService;
   }
 
-  /**
-   * Stores the relationship between a list of realtime vehicles with a pattern. If the pattern is
-   * a realtime-added one, then the original (scheduled) one is used as the key for the map storing
-   * the information.
-   * Before storing the new vehicles, removes the previous updates for the given {@code feedId}.
-   */
   public void setRealtimeVehicles(String feedId, Multimap<TripPattern, RealtimeVehicle> updates) {
     Multimap<TripPattern, RealtimeVehicle> temp = ArrayListMultimap.create();
     temp.putAll(vehicles);

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Responsible for downloading GTFS-rt vehicle positions from a URL and loading into memory.
  */
-public class GtfsRealtimeHttpVehiclePositionSource {
+class GtfsRealtimeHttpVehiclePositionSource {
 
   private static final Logger LOG = LoggerFactory.getLogger(
     GtfsRealtimeHttpVehiclePositionSource.class

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/GtfsRealtimeHttpVehiclePositionSource.java
@@ -56,7 +56,7 @@ class GtfsRealtimeHttpVehiclePositionSource {
       .toString();
   }
 
-  public List<VehiclePosition> getPositions(InputStream is) throws IOException {
+  private List<VehiclePosition> getPositions(InputStream is) throws IOException {
     List<VehiclePosition> positions = null;
     List<GtfsRealtime.FeedEntity> feedEntityList;
     GtfsRealtime.FeedMessage feedMessage;

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
@@ -61,17 +61,15 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
     // Get update lists from update source
     List<VehiclePosition> updates = vehiclePositionSource.getPositions();
 
-    if (updates != null) {
-      // Handle updating trip positions via graph writer runnable
-      var runnable = new VehiclePositionUpdaterRunnable(
-        realtimeVehicleRepository,
-        vehiclePositionFeatures,
-        feedId,
-        fuzzyTripMatching,
-        updates
-      );
-      updateGraph(runnable);
-    }
+    // Handle updating trip positions via graph writer runnable
+    var runnable = new VehiclePositionUpdaterRunnable(
+      realtimeVehicleRepository,
+      vehiclePositionFeatures,
+      feedId,
+      fuzzyTripMatching,
+      updates
+    );
+    updateGraph(runnable);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
@@ -22,7 +22,7 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
   private static final Logger LOG = LoggerFactory.getLogger(PollingVehiclePositionUpdater.class);
 
   /**
-   * Update streamer
+   * Update source
    */
   private final GtfsRealtimeHttpVehiclePositionSource vehiclePositionSource;
   private final Set<VehiclePositionsUpdaterConfig.VehiclePositionFeature> vehiclePositionFeatures;
@@ -53,11 +53,11 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
   }
 
   /**
-   * Repeatedly makes blocking calls to an UpdateStreamer to retrieve new stop time updates, and
+   * Repeatedly makes blocking calls to a source to retrieve new stop time updates, and
    * applies those updates to the graph.
    */
   @Override
-  public void runPolling() throws InterruptedException, ExecutionException {
+  public void runPolling() {
     // Get update lists from update source
     List<VehiclePosition> updates = vehiclePositionSource.getPositions();
 

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
@@ -1,5 +1,13 @@
 package org.opentripplanner.updater.vehicle_position;
 
+import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.OCCUPANCY;
+import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.POSITION;
+import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.STOP_POSITION;
+import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.INVALID_INPUT_STRUCTURE;
+import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_SERVICE_ON_DATE;
+import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TRIP_NOT_FOUND;
+import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TRIP_NOT_FOUND_IN_PATTERN;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimaps;
@@ -25,9 +33,6 @@ import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle.StopStatus;
 import org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig;
-import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.OCCUPANCY;
-import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.POSITION;
-import static org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig.VehiclePositionFeature.STOP_POSITION;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.Result;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -37,10 +42,6 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.updater.spi.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateError;
-import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.INVALID_INPUT_STRUCTURE;
-import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_SERVICE_ON_DATE;
-import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TRIP_NOT_FOUND;
-import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TRIP_NOT_FOUND_IN_PATTERN;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.spi.UpdateSuccess;
 import org.opentripplanner.updater.trip.gtfs.GtfsRealtimeFuzzyTripMatcher;

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
@@ -114,7 +114,7 @@ class RealtimeVehiclePatternMatcher {
       );
 
     // passing the feed id leads to the previous updates being removed
-    repository.setRealtimeVehicles(feedId, vehicles);
+    repository.setRealtimeVehiclesForFeed(feedId, vehicles);
 
     if (!vehiclePositions.isEmpty() && vehicles.keySet().isEmpty()) {
       LOG.error(

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
@@ -99,10 +99,8 @@ class RealtimeVehiclePatternMatcher {
       .map(vehiclePosition -> toRealtimeVehicle(feedId, vehiclePosition))
       .toList();
 
-    // we take the list of vehicles and out of them create a Map<TripPattern, List<RealtimeVehicle>>
-    // that map makes it very easy to update the vehicles in the service
-    // it also enables the bookkeeping about which pattern previously had vehicles but no longer do
-    // these need to be removed from the service as we assume that the vehicle has stopped
+    // we take the list of vehicles and out of them create a MultiMap<TripPattern, RealtimeVehicle>
+    // that makes it very easy to update the vehicles in the service
     var vehicles = matchResults
       .stream()
       .filter(Result::isSuccess)
@@ -115,6 +113,7 @@ class RealtimeVehiclePatternMatcher {
         )
       );
 
+    // passing the feed id leads to the previous updates being removed
     repository.setRealtimeVehicles(feedId, vehicles);
 
     if (!vehiclePositions.isEmpty() && vehicles.keySet().isEmpty()) {

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * Responsible for converting vehicle positions in memory to exportable ones, and associating each
  * position with a pattern.
  */
-public class RealtimeVehiclePatternMatcher {
+class RealtimeVehiclePatternMatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(RealtimeVehiclePatternMatcher.class);
 

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionUpdaterRunnable.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/VehiclePositionUpdaterRunnable.java
@@ -9,7 +9,7 @@ import org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositi
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.RealTimeUpdateContext;
 
-public class VehiclePositionUpdaterRunnable implements GraphWriterRunnable {
+class VehiclePositionUpdaterRunnable implements GraphWriterRunnable {
 
   private final List<VehiclePosition> updates;
   private final RealtimeVehicleRepository realtimeVehicleRepository;

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2660,7 +2660,9 @@ type VehiclePosition {
   "Human-readable label of the vehicle, eg. a publicly visible number or a license plate"
   label: String
   "When the position of the vehicle was recorded in seconds since the UNIX epoch."
-  lastUpdated: Long
+  lastUpdated: Long @deprecated(reason: "Use `lastUpdate` instead.")
+  "When the position of the vehicle was recorded."
+  lastUpdate: OffsetDateTime
   "Latitude of the vehicle"
   lat: Float
   "Longitude of the vehicle"

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2659,10 +2659,10 @@ type VehiclePosition {
   heading: Float
   "Human-readable label of the vehicle, eg. a publicly visible number or a license plate"
   label: String
-  "When the position of the vehicle was recorded in seconds since the UNIX epoch."
-  lastUpdated: Long @deprecated(reason: "Use `lastUpdate` instead.")
   "When the position of the vehicle was recorded."
   lastUpdate: OffsetDateTime
+  "When the position of the vehicle was recorded in seconds since the UNIX epoch."
+  lastUpdated: Long @deprecated(reason : "Use `lastUpdate` instead.")
   "Latitude of the vehicle"
   lat: Float
   "Longitude of the vehicle"

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -400,13 +400,13 @@ class GraphQLIntegrationTest {
     var realtimeVehicleService = new DefaultRealtimeVehicleService(transitService);
     var occypancyVehicle = RealtimeVehicle.builder()
       .withTrip(trip)
-      .withTime(Instant.MAX)
+      .withTime(SERVICE_DATE.atStartOfDay(BERLIN).plusHours(16).toInstant())
       .withVehicleId(id("vehicle-1"))
       .withOccupancyStatus(FEW_SEATS_AVAILABLE)
       .build();
     var positionVehicle = RealtimeVehicle.builder()
       .withTrip(trip)
-      .withTime(Instant.MIN)
+      .withTime(SERVICE_DATE.atStartOfDay(BERLIN).plusHours(19).toInstant())
       .withVehicleId(id("vehicle-2"))
       .withLabel("vehicle2")
       .withCoordinates(new WgsCoordinate(60.0, 80.0))

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -415,7 +415,7 @@ class GraphQLIntegrationTest {
       .withStop(pattern.getStop(0))
       .withStopStatus(IN_TRANSIT_TO)
       .build();
-    realtimeVehicleService.setRealtimeVehicles(
+    realtimeVehicleService.setRealtimeVehiclesForFeed(
       pattern.getId().getFeedId(),
       new ImmutableListMultimap.Builder()
         .putAll(pattern, List.of(occypancyVehicle, positionVehicle))

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -17,6 +17,7 @@ import static org.opentripplanner.transit.model.basic.TransitMode.BUS;
 import static org.opentripplanner.transit.model.basic.TransitMode.FERRY;
 import static org.opentripplanner.transit.model.timetable.OccupancyStatus.FEW_SEATS_AVAILABLE;
 
+import com.google.common.collect.ImmutableListMultimap;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,7 +33,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
@@ -51,7 +51,6 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.RealTimeTripUpdate;
 import org.opentripplanner.model.TimetableSnapshot;
-import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareProduct;
@@ -416,7 +415,12 @@ class GraphQLIntegrationTest {
       .withStop(pattern.getStop(0))
       .withStopStatus(IN_TRANSIT_TO)
       .build();
-    realtimeVehicleService.setRealtimeVehicles(pattern, List.of(occypancyVehicle, positionVehicle));
+    realtimeVehicleService.setRealtimeVehicles(
+      pattern.getId().getFeedId(),
+      new ImmutableListMultimap.Builder()
+        .putAll(pattern, List.of(occypancyVehicle, positionVehicle))
+        .build()
+    );
 
     DefaultVehicleRentalService defaultVehicleRentalService = new DefaultVehicleRentalService();
     defaultVehicleRentalService.addVehicleRentalStation(VEHICLE_RENTAL_STATION);

--- a/application/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
@@ -54,17 +54,20 @@ class DefaultRealtimeVehicleServiceTest {
   @Test
   void clearFeed() {
     var service = service();
-    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of(PATTERN1, VEHICLE));
-    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of());
+    service.setRealtimeVehiclesForFeed(FEED_ID, ImmutableListMultimap.of(PATTERN1, VEHICLE));
+    service.setRealtimeVehiclesForFeed(FEED_ID, ImmutableListMultimap.of());
     assertThat(service.getRealtimeVehicles(PATTERN1)).isEmpty();
   }
 
   @Test
   void keepOtherFeeds() {
     var service = service();
-    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of(PATTERN1, VEHICLE));
-    service.setRealtimeVehicles(PATTERN2.getFeedId(), ImmutableListMultimap.of(PATTERN2, VEHICLE));
-    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of());
+    service.setRealtimeVehiclesForFeed(FEED_ID, ImmutableListMultimap.of(PATTERN1, VEHICLE));
+    service.setRealtimeVehiclesForFeed(
+      PATTERN2.getFeedId(),
+      ImmutableListMultimap.of(PATTERN2, VEHICLE)
+    );
+    service.setRealtimeVehiclesForFeed(FEED_ID, ImmutableListMultimap.of());
     assertEquals(List.of(VEHICLE), service.getRealtimeVehicles(PATTERN2));
   }
 
@@ -72,7 +75,7 @@ class DefaultRealtimeVehicleServiceTest {
   void originalPattern() {
     var service = service();
 
-    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of(PATTERN1, VEHICLE));
+    service.setRealtimeVehiclesForFeed(FEED_ID, ImmutableListMultimap.of(PATTERN1, VEHICLE));
     var updates = service.getRealtimeVehicles(PATTERN1);
     assertEquals(List.of(VEHICLE), updates);
   }
@@ -85,7 +88,7 @@ class DefaultRealtimeVehicleServiceTest {
       .withOriginalTripPattern(PATTERN1)
       .withCreatedByRealtimeUpdater(true)
       .build();
-    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of(realtimePattern, VEHICLE));
+    service.setRealtimeVehiclesForFeed(FEED_ID, ImmutableListMultimap.of(realtimePattern, VEHICLE));
     var updates = service.getRealtimeVehicles(PATTERN1);
     assertEquals(List.of(VEHICLE), updates);
   }

--- a/application/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
@@ -2,9 +2,11 @@ package org.opentripplanner.service.realtimevehicles.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.framework.geometry.WgsCoordinate.GREENWICH;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.tripPattern;
 
+import com.google.common.collect.ImmutableListMultimap;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -28,18 +30,22 @@ class DefaultRealtimeVehicleServiceTest {
     .withStopPattern(STOP_PATTERN)
     .build();
   private static final Instant TIME = Instant.ofEpochSecond(1000);
-  private static final List<RealtimeVehicle> VEHICLES = List.of(
-    RealtimeVehicle.builder().withTime(TIME).withCoordinates(GREENWICH).build()
-  );
+  private static final RealtimeVehicle VEHICLE = RealtimeVehicle.builder()
+    .withTime(TIME)
+    .withCoordinates(GREENWICH)
+    .build();
+
+  private static final String FEED_ID = ORIGINAL.getFeedId();
 
   @Test
   void originalPattern() {
     var service = new DefaultRealtimeVehicleService(
       new DefaultTransitService(new TimetableRepository())
     );
-    service.setRealtimeVehicles(ORIGINAL, VEHICLES);
+
+    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of(ORIGINAL, VEHICLE));
     var updates = service.getRealtimeVehicles(ORIGINAL);
-    assertEquals(VEHICLES, updates);
+    assertEquals(List.of(VEHICLE), updates);
   }
 
   @Test
@@ -52,8 +58,8 @@ class DefaultRealtimeVehicleServiceTest {
       .withOriginalTripPattern(ORIGINAL)
       .withCreatedByRealtimeUpdater(true)
       .build();
-    service.setRealtimeVehicles(realtimePattern, VEHICLES);
+    service.setRealtimeVehicles(FEED_ID, ImmutableListMultimap.of(realtimePattern, VEHICLE));
     var updates = service.getRealtimeVehicles(ORIGINAL);
-    assertEquals(VEHICLES, updates);
+    assertEquals(List.of(VEHICLE), updates);
   }
 }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/patterns.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/patterns.json
@@ -52,7 +52,7 @@
               }
             ],
             "occupancy": {
-              "occupancyStatus": "FEW_SEATS_AVAILABLE"
+              "occupancyStatus": "NO_DATA_AVAILABLE"
             }
           },
           {
@@ -165,7 +165,8 @@
             "stopRelationship": null,
             "speed": null,
             "heading": null,
-            "lastUpdated": 31556889864403199,
+            "lastUpdated": 1704121200,
+            "lastUpdate": "2024-01-01T16:00:00+01:00",
             "trip": {
               "gtfsId": "F:123"
             }
@@ -183,7 +184,8 @@
             },
             "speed": 10.2,
             "heading": 80.0,
-            "lastUpdated": -31557014167219200,
+            "lastUpdated": 1704132000,
+            "lastUpdate": "2024-01-01T19:00:00+01:00",
             "trip": {
               "gtfsId": "F:123"
             }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/patterns.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/patterns.graphql
@@ -36,6 +36,7 @@
       speed
       heading
       lastUpdated
+      lastUpdate
       trip {
         gtfsId
       }


### PR DESCRIPTION
### Summary

The real time vehicle service does not correctly remove the data from the previous download which this PR fixes.

It introduces copy-on-write semantics for the service rather than explicit removal by the calling code, reducing the number of places where mutable state is handled.

It also adds a new GraphQL property so that the last update is now expressed as an ISO date time rather than number of seconds since the epoch.

### Issue

n/a

### Unit tests

Added.

### Documentation

Javadoc

cc @whitneys-pm