### PR TITLE
Make estimated calls non nullable in the TransModel API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/DatedServiceJourneyType.java
@@ -132,7 +132,7 @@ public class DatedServiceJourneyType {
       .field(
         GraphQLFieldDefinition.newFieldDefinition()
           .name("estimatedCalls")
-          .type(new GraphQLList(estimatedCallType))
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(estimatedCallType))))
           .withDirective(TransmodelDirectives.TIMING_DATA)
           .description(
             "Returns scheduled passingTimes for this dated service journey, " +
@@ -142,7 +142,7 @@ public class DatedServiceJourneyType {
             TripOnServiceDate tripOnServiceDate = tripOnServiceDate(environment);
             return GqlUtil.getTransitService(environment)
               .getTripTimeOnDates(tripOnServiceDate.getTrip(), tripOnServiceDate.getServiceDate())
-              .orElse(null);
+              .orElse(List.of());
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -221,7 +221,7 @@ public class ServiceJourneyType {
       .field(
         GraphQLFieldDefinition.newFieldDefinition()
           .name("estimatedCalls")
-          .type(new GraphQLList(estimatedCallType))
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(estimatedCallType))))
           .withDirective(TransmodelDirectives.TIMING_DATA)
           .description(
             "Returns scheduled passingTimes for this ServiceJourney for a given date, updated with real-time-updates (if available). " +
@@ -241,7 +241,7 @@ public class ServiceJourneyType {
               .orElse(LocalDate.now(GqlUtil.getTransitService(environment).getTimeZone()));
             return GqlUtil.getTransitService(environment)
               .getTripTimeOnDates(trip(environment), serviceDate)
-              .orElse(null);
+              .orElse(List.of());
           })
           .build()
       )

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -159,7 +159,7 @@ type Contact {
 "A planned journey on a specific day"
 type DatedServiceJourney {
   "Returns scheduled passingTimes for this dated service journey, updated with real-time-updates (if available). "
-  estimatedCalls: [EstimatedCall] @timingData
+  estimatedCalls: [EstimatedCall!]! @timingData
   id: ID!
   "JourneyPattern for the dated service journey."
   journeyPattern: JourneyPattern
@@ -1145,7 +1145,7 @@ type ServiceJourney {
   estimatedCalls(
     "Date to get estimated calls for. Defaults to today."
     date: Date
-  ): [EstimatedCall] @timingData
+  ): [EstimatedCall!]! @timingData
   id: ID!
   "JourneyPattern for the service journey, according to scheduled data. If the ServiceJourney is not included in the scheduled data, null is returned."
   journeyPattern: JourneyPattern


### PR DESCRIPTION
### Summary

As a consequence of #6245, the TransModel API can return `null` for the list of `estimatedCalls` of a given `ServiceJourney` or `DatedServiceJourney`, if the trip does not run on the given date. Before this change, the API would return an empty list `[]`.

This is not consistent with the rest of the API: On `quays` and `stopPlaces`, `estimatedCalls` are expected to be non-null. The same applies for `serviceJourneyEstimatedCalls` and `intermediateEstimatedCalls` in other parts of the API.

This PR:
- reverts to the original behavior where the API returns an empty list instead of null.
- aligns the behavior of `estimatedCalls` on `ServiceJourney` and `DatedServiceJourney` with the rest of the API, by making them explicitly non-nullable: `[EstimatedCall!]!`

**Note**: while making a nullable input type non-nullable is a breaking change, making a nullable output type non-nullable does not break compatibility for API clients.


### Issue

No.

### Unit tests

No. The change is made in the GraphQL layer where we have little support for unit testing.

### Documentation

No


