### PR TITLE
Fix itinerary cost review

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/FaresFilterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/FaresFilterTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.FareProductUse;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
@@ -30,9 +30,9 @@ public class FaresFilterTest implements PlanTestConstants {
       .bus(ID, 52, 100, C)
       .build();
 
-    assertEquals(ItineraryFares.empty(), i1.fare());
+    assertEquals(ItineraryFare.empty(), i1.fare());
 
-    var fares = new ItineraryFares();
+    var fares = new ItineraryFare();
 
     var leg = i1.legs().get(1);
     var fp = new FareProduct(id("fp"), "fare product", Money.euros(10.00f), null, null, null);

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.FareProductUse;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.core.FareType;
@@ -47,7 +47,7 @@ class DefaultFareServiceTest implements PlanTestConstants {
     service.addFareRules(FareType.regular, List.of());
     var itin = newItinerary(A, T11_00).bus(1, T11_05, T11_12, B).build();
     var fare = service.calculateFares(itin);
-    assertEquals(ItineraryFares.empty(), fare);
+    assertEquals(ItineraryFare.empty(), fare);
   }
 
   @Test

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/FaresIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/FaresIntegrationTest.java
@@ -14,7 +14,7 @@ import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.TestServerContext;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.ItineraryFilterDebugProfile;
@@ -42,7 +42,7 @@ public class FaresIntegrationTest {
     var from = GenericLocation.fromStopId("Origin", feedId, "Millbrae Caltrain");
     var to = GenericLocation.fromStopId("Destination", feedId, "Mountain View Caltrain");
 
-    ItineraryFares fare = getFare(from, to, start, serverContext);
+    ItineraryFare fare = getFare(from, to, start, serverContext);
     var product = fare.getLegProducts().values().iterator().next().product();
     assertEquals(Money.usDollars(4.25f), product.price());
     assertEquals("OW_2", product.id().getId().toString());
@@ -73,7 +73,7 @@ public class FaresIntegrationTest {
       .atZone(ZoneId.of("America/Los_Angeles"))
       .toInstant();
 
-    ItineraryFares fare = getFare(from, to, startTime, serverContext);
+    ItineraryFare fare = getFare(from, to, startTime, serverContext);
     var fpu = List.copyOf(fare.getLegProducts().values());
     assertEquals(1, fpu.size());
 
@@ -108,7 +108,7 @@ public class FaresIntegrationTest {
     // assertEquals(cost.getFare(FareType.regular), new Money(new WrappedCurrency("USD"), 430));
   }
 
-  private static ItineraryFares getFare(
+  private static ItineraryFare getFare(
     GenericLocation from,
     GenericLocation to,
     Instant time,

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -38,7 +38,7 @@ import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.model.Cost;
 import org.opentripplanner.model.fare.FareProductUse;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
@@ -93,12 +93,7 @@ public class OrcaFareServiceTest {
     );
   }
 
-  private static void assertLegFareEquals(
-    int fare,
-    Leg leg,
-    ItineraryFares fares,
-    boolean hasXfer
-  ) {
+  private static void assertLegFareEquals(int fare, Leg leg, ItineraryFare fares, boolean hasXfer) {
     var legFareProducts = fares.getLegProducts().get(leg);
 
     var rideCost = legFareProducts

--- a/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
@@ -64,7 +64,10 @@ class RealtimeResolverTest {
       .build();
     transitService.getTransitAlertService().setAlerts(List.of(alert));
 
-    var itinerariesWithRealtime = RealtimeResolver.populateLegsWithRealtime(List.of(itinerary), transitService);
+    var itinerariesWithRealtime = RealtimeResolver.populateLegsWithRealtime(
+      List.of(itinerary),
+      transitService
+    );
 
     assertFalse(itinerariesWithRealtime.isEmpty());
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.realtimeresolver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
@@ -63,13 +64,11 @@ class RealtimeResolverTest {
       .build();
     transitService.getTransitAlertService().setAlerts(List.of(alert));
 
-    var itineraries = List.of(itinerary);
-    itineraries = RealtimeResolver.populateLegsWithRealtime(itineraries, transitService);
+    var itinerariesWithRealtime = RealtimeResolver.populateLegsWithRealtime(List.of(itinerary), transitService);
 
-    assertEquals(1, itineraries.size());
-    itinerary = itineraries.getFirst();
+    assertFalse(itinerariesWithRealtime.isEmpty());
 
-    var legs = itinerary.legs();
+    var legs = itinerariesWithRealtime.getFirst().legs();
     var leg1ArrivalDelay = legs
       .get(0)
       .asScheduledTransitLeg()
@@ -81,6 +80,7 @@ class RealtimeResolverTest {
     assertEquals(123, leg1ArrivalDelay);
     assertEquals(0, legs.get(0).getTransitAlerts().size());
     assertEquals(1, legs.get(1).getTransitAlerts().size());
+    assertEquals(1, itinerariesWithRealtime.size());
   }
 
   @Test

--- a/application/src/ext/java/org/opentripplanner/ext/fares/ItineraryFaresDecorator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/ItineraryFaresDecorator.java
@@ -2,7 +2,7 @@ package org.opentripplanner.ext.fares;
 
 import java.util.List;
 import org.opentripplanner.model.fare.FareProductUse;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.FareProductAware;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.TransitLeg;
@@ -13,20 +13,20 @@ import org.opentripplanner.utils.collection.ListUtils;
  */
 public final class ItineraryFaresDecorator {
 
-  private final ItineraryFares fare;
+  private final ItineraryFare fare;
   private final List<FareProductUse> itineraryFareUses;
 
-  public ItineraryFaresDecorator(ItineraryFares fare, List<FareProductUse> itineraryFareUses) {
+  public ItineraryFaresDecorator(ItineraryFare fare, List<FareProductUse> itineraryFareUses) {
     this.fare = fare;
     this.itineraryFareUses = itineraryFareUses;
   }
 
-  public static Itinerary decorateItineraryWithFare(Itinerary i, ItineraryFares fare) {
+  public static Itinerary decorateItineraryWithFare(Itinerary i, ItineraryFare fare) {
     var legDecorator = new ItineraryFaresDecorator(fare, createItineraryFareUses(i, fare));
     return i.copyOf().withFare(fare).transformTransitLegs(legDecorator::decorateTransitLeg).build();
   }
 
-  private static List<FareProductUse> createItineraryFareUses(Itinerary i, ItineraryFares fare) {
+  private static List<FareProductUse> createItineraryFareUses(Itinerary i, ItineraryFare fare) {
     return fare
       .getItineraryProducts()
       .stream()

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/AtlantaFareService.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.model.fare.FareProduct;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.transit.model.basic.Money;
@@ -378,7 +378,7 @@ public class AtlantaFareService extends DefaultFareService {
   }
 
   @Override
-  public ItineraryFares calculateFaresForType(
+  public ItineraryFare calculateFaresForType(
     Currency currency,
     FareType fareType,
     List<Leg> legs,
@@ -411,7 +411,7 @@ public class AtlantaFareService extends DefaultFareService {
       null,
       null
     );
-    var fare = ItineraryFares.empty();
+    var fare = ItineraryFare.empty();
     fare.addItineraryProducts(List.of(fareProduct));
     return fare;
   }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareService.java
@@ -21,7 +21,7 @@ import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.flex.FlexibleTransitLeg;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.FareProductUse;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
@@ -100,7 +100,7 @@ public class DefaultFareService implements FareService {
   }
 
   @Override
-  public ItineraryFares calculateFares(Itinerary itinerary) {
+  public ItineraryFare calculateFares(Itinerary itinerary) {
     var fareLegs = itinerary
       .legs()
       .stream()
@@ -116,7 +116,7 @@ public class DefaultFareService implements FareService {
     }
     var fareLegsByFeed = fareLegsByFeed(fareLegs);
 
-    ItineraryFares fare = ItineraryFares.empty();
+    ItineraryFare fare = ItineraryFare.empty();
     for (FareType fareType : fareRulesPerType.keySet()) {
       for (String feedId : fareLegsByFeed.keySet()) {
         var fareRules = fareRulesForFeed(fareType, feedId);
@@ -124,7 +124,7 @@ public class DefaultFareService implements FareService {
         // Get the currency from the first fareAttribute, assuming that all tickets use the same currency.
         if (fareRules != null && !fareRules.isEmpty()) {
           Currency currency = fareRules.iterator().next().getFareAttribute().getPrice().currency();
-          ItineraryFares computedFaresForType = calculateFaresForType(
+          ItineraryFare computedFaresForType = calculateFaresForType(
             currency,
             fareType,
             fareLegsByFeed.get(feedId),
@@ -173,7 +173,7 @@ public class DefaultFareService implements FareService {
    * If our only rule were A-B with a fare of 10, we would have no lowest fare, but we will still
    * have one fare detail with fare 10 for the route A-B. B-C will not just not be listed at all.
    */
-  protected ItineraryFares calculateFaresForType(
+  protected ItineraryFare calculateFaresForType(
     Currency currency,
     FareType fareType,
     List<Leg> legs,
@@ -231,7 +231,7 @@ public class DefaultFareService implements FareService {
       start = via + 1;
     }
 
-    var fare = ItineraryFares.empty();
+    var fare = ItineraryFare.empty();
     fare.addFareProductUses(fareProductUses);
     return fare;
   }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/GtfsFaresService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/GtfsFaresService.java
@@ -3,18 +3,15 @@ package org.opentripplanner.ext.fares.impl;
 import java.util.Collection;
 import java.util.Objects;
 import org.opentripplanner.ext.fares.model.LegProducts;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.fares.FareService;
 
 public record GtfsFaresService(DefaultFareService faresV1, GtfsFaresV2Service faresV2)
   implements FareService {
   @Override
-  public ItineraryFares calculateFares(Itinerary itinerary) {
-    var fare = Objects.requireNonNullElse(
-      faresV1.calculateFares(itinerary),
-      ItineraryFares.empty()
-    );
+  public ItineraryFare calculateFares(Itinerary itinerary) {
+    var fare = Objects.requireNonNullElse(faresV1.calculateFares(itinerary), ItineraryFare.empty());
     var products = faresV2.getProducts(itinerary);
     fare.addItineraryProducts(products.itineraryProducts());
     if (products.itineraryProducts().isEmpty()) {
@@ -25,7 +22,7 @@ public record GtfsFaresService(DefaultFareService faresV1, GtfsFaresV2Service fa
   /**
    * Add a complex set of fare products for a specific leg;
    */
-  private static void addLegProducts(Collection<LegProducts> legProducts, ItineraryFares fares) {
+  private static void addLegProducts(Collection<LegProducts> legProducts, ItineraryFare fares) {
     legProducts.forEach(lp -> {
       lp
         .products()

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/GtfsFaresV2Service.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/GtfsFaresV2Service.java
@@ -50,7 +50,7 @@ public final class GtfsFaresV2Service implements Serializable {
   }
 
   public ProductResult getProducts(Itinerary itinerary) {
-    var transitLegs = itinerary.findScheduledTransitLegs();
+    var transitLegs = itinerary.listScheduledTransitLegs();
 
     var allLegProducts = new HashSet<LegProducts>();
     for (int i = 0; i < transitLegs.size(); i++) {
@@ -104,7 +104,7 @@ public final class GtfsFaresV2Service implements Serializable {
   }
 
   private boolean coversItinerary(Itinerary i, LegProducts.ProductWithTransfer pwt) {
-    var transitLegs = i.findScheduledTransitLegs();
+    var transitLegs = i.listScheduledTransitLegs();
     var allLegsInProductFeed = transitLegs
       .stream()
       .allMatch(leg -> leg.getAgency().getId().getFeedId().equals(pwt.legRule().feedId()));
@@ -127,7 +127,7 @@ public final class GtfsFaresV2Service implements Serializable {
     LegProducts.ProductWithTransfer pwt
   ) {
     var feedIdsInItinerary = i
-      .findScheduledTransitLegs()
+      .listScheduledTransitLegs()
       .stream()
       .map(l -> l.getAgency().getId().getFeedId())
       .collect(Collectors.toSet());

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.model.fare.FareProduct;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.routing.core.FareType;
@@ -48,7 +48,7 @@ public class HighestFareInFreeTransferWindowFareService extends DefaultFareServi
    * additional free transfers from there.
    */
   @Override
-  protected ItineraryFares calculateFaresForType(
+  protected ItineraryFare calculateFaresForType(
     Currency currency,
     FareType fareType,
     List<Leg> legs,
@@ -94,7 +94,7 @@ public class HighestFareInFreeTransferWindowFareService extends DefaultFareServi
       null,
       null
     );
-    var fare = ItineraryFares.empty();
+    var fare = ItineraryFare.empty();
     if (cost.greaterThan(zero)) {
       fare.addItineraryProducts(List.of(fp));
     }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/NoopFareServiceFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/NoopFareServiceFactory.java
@@ -3,7 +3,7 @@ package org.opentripplanner.ext.fares.impl;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.ext.fares.model.FareRulesData;
 import org.opentripplanner.model.OtpTransitService;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.fares.FareServiceFactory;
@@ -37,7 +37,7 @@ public class NoopFareServiceFactory implements FareServiceFactory {
   private static class NoopFareService implements FareService {
 
     @Override
-    public ItineraryFares calculateFares(Itinerary path) {
+    public ItineraryFare calculateFares(Itinerary path) {
       return null;
     }
   }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -19,7 +19,7 @@ import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareProduct;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.fare.RiderCategory;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.core.FareType;
@@ -437,13 +437,13 @@ public class OrcaFareService extends DefaultFareService {
    * one.
    */
   @Override
-  public ItineraryFares calculateFaresForType(
+  public ItineraryFare calculateFaresForType(
     Currency currency,
     FareType fareType,
     List<Leg> legs,
     Collection<FareRuleSet> fareRules
   ) {
-    var fare = ItineraryFares.empty();
+    var fare = ItineraryFare.empty();
     Money cost = Money.ZERO_USD;
     var orcaFareDiscount = new TransferData();
     HashMap<String, TransferData> perAgencyTransferDiscount = new HashMap<>();
@@ -513,14 +513,14 @@ public class OrcaFareService extends DefaultFareService {
    * Adds a leg fare product to the given itinerary fares object
    *
    * @param leg              The leg to create a fareproduct for
-   * @param itineraryFares   The itinerary fares to store the fare product in
+   * @param itineraryFare   The itinerary fares to store the fare product in
    * @param fareType         Fare type (split into container and rider category)
    * @param totalFare        Total fare paid after transfer
    * @param transferDiscount Transfer discount applied
    */
   private static void addLegFareProduct(
     Leg leg,
-    ItineraryFares itineraryFares,
+    ItineraryFare itineraryFare,
     FareType fareType,
     Money totalFare,
     Money transferDiscount
@@ -536,7 +536,7 @@ public class OrcaFareService extends DefaultFareService {
     }
     var duration = Duration.ZERO;
     var fareProduct = new FareProduct(id, "rideCost", totalFare, duration, riderCategory, medium);
-    itineraryFares.addFareProduct(leg, fareProduct);
+    itineraryFare.addFareProduct(leg, fareProduct);
     // If a transfer was used, then also add a transfer fare product.
     if (transferDiscount.isPositive()) {
       var transferFareProduct = new FareProduct(
@@ -547,7 +547,7 @@ public class OrcaFareService extends DefaultFareService {
         riderCategory,
         medium
       );
-      itineraryFares.addFareProduct(leg, transferFareProduct);
+      itineraryFare.addFareProduct(leg, transferFareProduct);
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/model/fare/ItineraryFare.java
+++ b/application/src/main/java/org/opentripplanner/model/fare/ItineraryFare.java
@@ -17,7 +17,7 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
  * ItineraryFares is a set of fares for different legs, rider categories or fare media.
  */
 @Sandbox
-public class ItineraryFares {
+public class ItineraryFare {
 
   /**
    * The fare products that are valid for all legs of an itinerary, like a day pass.
@@ -33,8 +33,8 @@ public class ItineraryFares {
    */
   private final Multimap<Leg, FareProductUse> legProducts = LinkedHashMultimap.create();
 
-  public static ItineraryFares empty() {
-    return new ItineraryFares();
+  public static ItineraryFare empty() {
+    return new ItineraryFare();
   }
 
   /**
@@ -67,7 +67,7 @@ public class ItineraryFares {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    ItineraryFares fare1 = (ItineraryFares) o;
+    ItineraryFare fare1 = (ItineraryFare) o;
     return (
       Objects.equals(itineraryProducts, fare1.itineraryProducts) &&
       Objects.equals(legProducts, fare1.legProducts)
@@ -106,7 +106,7 @@ public class ItineraryFares {
   /**
    * Add the contents of another instance to this one.
    */
-  public void add(ItineraryFares fare) {
+  public void add(ItineraryFare fare) {
     itineraryProducts.addAll(fare.itineraryProducts);
     legProducts.putAll(fare.legProducts);
   }

--- a/application/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -14,7 +14,7 @@ import org.opentripplanner.ext.flex.FlexibleTransitLeg;
 import org.opentripplanner.framework.model.Cost;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.model.SystemNotice;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.raptor.api.model.RaptorConstants;
 import org.opentripplanner.raptor.api.path.PathStringBuilder;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -86,7 +86,7 @@ public class Itinerary implements ItinerarySortKey {
 
   private final Float accessibilityScore;
   private final Emissions emissionsPerPerson;
-  private final ItineraryFares fare;
+  private final ItineraryFare fare;
 
   Itinerary(ItineraryBuilder builder) {
     this.legs = List.copyOf(builder.legs);
@@ -591,7 +591,7 @@ public class Itinerary implements ItinerarySortKey {
   /**
    * The fare products of this itinerary.
    */
-  public ItineraryFares fare() {
+  public ItineraryFare fare() {
     return fare;
   }
 

--- a/application/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -443,9 +443,10 @@ public class Itinerary implements ItinerarySortKey {
    * by the algorithm. This is relevant for anyone who want to debug a search and tuning the
    * system. The unit should be equivalent to the cost of "one second of transit".
    * <p>
-   * -1 indicate that the cost is not set/computed.
+   * Zero(0) cost indicate that the cost is not set/computed.
    */
   public int generalizedCost() {
+    // TODO Return Cost type, not int
     return generalizedCost.toSeconds();
   }
 
@@ -560,7 +561,7 @@ public class Itinerary implements ItinerarySortKey {
     }
   }
 
-  public List<ScheduledTransitLeg> findScheduledTransitLegs() {
+  public List<ScheduledTransitLeg> listScheduledTransitLegs() {
     return legs()
       .stream()
       .filter(ScheduledTransitLeg.class::isInstance)

--- a/application/src/main/java/org/opentripplanner/model/plan/ItineraryBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/ItineraryBuilder.java
@@ -6,7 +6,7 @@ import java.util.function.Function;
 import org.opentripplanner.framework.model.Cost;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.model.SystemNotice;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 
 public class ItineraryBuilder {
 
@@ -39,7 +39,7 @@ public class ItineraryBuilder {
   /* SANDBOX EXPERIMENTAL PROPERTIES */
   Float accessibilityScore;
   Emissions emissionsPerPerson;
-  ItineraryFares fare = ItineraryFares.empty();
+  ItineraryFare fare = ItineraryFare.empty();
 
   ItineraryBuilder(List<Leg> legs, boolean searchWindowAware) {
     this.legs = legs;
@@ -190,11 +190,11 @@ public class ItineraryBuilder {
     return this;
   }
 
-  public ItineraryFares fare() {
+  public ItineraryFare fare() {
     return fare;
   }
 
-  public ItineraryBuilder withFare(ItineraryFares fare) {
+  public ItineraryBuilder withFare(ItineraryFare fare) {
     this.fare = fare;
     return this;
   }

--- a/application/src/main/java/org/opentripplanner/model/plan/ItineraryBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/ItineraryBuilder.java
@@ -148,6 +148,11 @@ public class ItineraryBuilder {
     return this;
   }
 
+  /**
+   * Decorate the existing legs with new information. This method takes a lambda to make sure
+   * the caller uses the right set of legs as abase for the decoration, and not just set a
+   * new set of legs - witch may lead to information loss.
+   */
   public ItineraryBuilder withLegs(Function<List<Leg>, List<Leg>> body) {
     this.legs = body.apply(legs);
     return this;

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingResult.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingResult.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.api.response.RoutingError;
 
@@ -21,32 +20,34 @@ class RoutingResult {
   private final Set<RoutingError> errors = new HashSet<>();
 
   RoutingResult(Collection<Itinerary> itineraries, Collection<RoutingError> errors) {
-    addAll(itineraries, errors);
+    addItineraries(itineraries);
+    addErrors(errors);
   }
 
   static RoutingResult empty() {
-    return new RoutingResult(null, null);
+    return new RoutingResult(List.of(), List.of());
   }
 
   static RoutingResult ok(List<Itinerary> itineraries) {
-    return new RoutingResult(itineraries, null);
+    return new RoutingResult(itineraries, List.of());
   }
 
   static RoutingResult failed(Collection<RoutingError> errors) {
-    return new RoutingResult(null, errors);
+    return new RoutingResult(List.of(), errors);
   }
 
   List<Itinerary> itineraries() {
-    return itineraries;
+    return List.copyOf(itineraries);
   }
 
   Set<RoutingError> errors() {
-    return errors;
+    return Set.copyOf(errors);
   }
 
   void merge(RoutingResult... others) {
     for (RoutingResult it : others) {
-      addAll(it.itineraries, it.errors);
+      addItineraries(it.itineraries);
+      addErrors(it.errors);
     }
   }
 
@@ -70,19 +71,12 @@ class RoutingResult {
   }
 
   void addErrors(Collection<RoutingError> errors) {
-    addToIfNotNull(this.errors, errors);
+    this.errors.addAll(errors);
   }
 
   /* private methods */
 
-  private void addAll(Collection<Itinerary> itineraries, Collection<RoutingError> errors) {
-    addToIfNotNull(this.itineraries, itineraries);
-    addToIfNotNull(this.errors, errors);
-  }
-
-  private static <T> void addToIfNotNull(Collection<T> target, @Nullable Collection<T> values) {
-    if (values != null) {
-      target.addAll(values);
-    }
+  private void addItineraries(Collection<Itinerary> itineraries) {
+    this.itineraries.addAll(itineraries);
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/fares/FareService.java
+++ b/application/src/main/java/org/opentripplanner/routing/fares/FareService.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.routing.fares;
 
 import java.io.Serializable;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 
 /**
@@ -12,5 +12,5 @@ public interface FareService extends Serializable {
   /**
    * @param itinerary the OTP2 Itinerary for which we want to compute a fare
    */
-  ItineraryFares calculateFares(Itinerary itinerary);
+  ItineraryFare calculateFares(Itinerary itinerary);
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -54,7 +54,7 @@ import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareProduct;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.fare.RiderCategory;
 import org.opentripplanner.model.plan.Emissions;
 import org.opentripplanner.model.plan.Itinerary;
@@ -379,7 +379,7 @@ class GraphQLIntegrationTest {
     legs.set(2, railLeg);
     i1 = i1.copyOf().withLegs(ignore -> legs).build();
 
-    var fares = new ItineraryFares();
+    var fares = new ItineraryFare();
 
     var dayPass = fareProduct("day-pass");
     fares.addItineraryProducts(List.of(dayPass));

--- a/application/src/test/java/org/opentripplanner/routing/core/ItineraryFareTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/core/ItineraryFareTest.java
@@ -18,11 +18,11 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.FareProductUse;
-import org.opentripplanner.model.fare.ItineraryFares;
+import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.transit.model.basic.Money;
 
-class ItineraryFaresTest {
+class ItineraryFareTest {
 
   @Test
   void legProduct() {
@@ -35,7 +35,7 @@ class ItineraryFaresTest {
     var busLeg = i1.transitLeg(1);
     var railLeg = i1.transitLeg(2);
 
-    var fares = new ItineraryFares();
+    var fares = new ItineraryFare();
 
     var busTicket = fareProduct("bus");
     var railTicketA = fareProduct("rail-a");
@@ -61,7 +61,7 @@ class ItineraryFaresTest {
 
   @Test
   void empty() {
-    assertTrue(ItineraryFares.empty().isEmpty());
+    assertTrue(ItineraryFare.empty().isEmpty());
   }
 
   private static FareProduct fareProduct(String id) {


### PR DESCRIPTION
### Summary

Small fixes suggest in the review of #6535.

Renaming [`ItineraryFares` to `ItineraryFares`](https://github.com/opentripplanner/OpenTripPlanner/pull/6539/commits/fa6efcbdd0958b3d67d8cc2f44f5743bbed74969) is debatable:
 - In old Java conventions plural is used for naming variables and classes witch are of collection type, not necesseraly extending the java collections, but something containing a collection of the singular form.
 - Note that `ItineraryFare` is related to the itinerary, it does contain a collection of fares for legs - but only one fare for the total Itinerary. 
 
 Alternative name: `ItineraryFareInfo`


### Issue

🟥  This is code cleanup

### Unit tests

🟥  No new functional changes

### Documentation

✅  JavaDoc is updated


### Changelog

🟥  This is code cleanup

### Bumping the serialization version id

🟥  No changes to serialized classes
