### PR TITLE
Remove deprecated `relaxTransitSearchGeneralizedCostAtDestination`

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/TripQuery.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/TripQuery.java
@@ -536,30 +536,6 @@ public class TripQuery {
       )
       .argument(
         GraphQLArgument.newArgument()
-          .name("relaxTransitSearchGeneralizedCostAtDestination")
-          .deprecate("This is replaced by 'relaxTransitGroupPriority'.")
-          .description(
-            """
-            Whether non-optimal transit paths at the destination should be returned. Let c be the
-            existing minimum pareto optimal generalized-cost to beat. Then a trip with cost c' is
-            accepted if the following is true:
-
-            `c' < Math.round(c * relaxTransitSearchGeneralizedCostAtDestination)`
-
-            The parameter is optional. If not set, a normal comparison is performed.
-
-            Values less than 1.0 is not allowed, and values greater than 2.0 are not
-            supported, due to performance reasons.
-            """
-          )
-          .type(Scalars.GraphQLFloat)
-          .defaultValueProgrammatic(
-            preferences.transit().raptor().relaxGeneralizedCostAtDestination().orElse(null)
-          )
-          .build()
-      )
-      .argument(
-        GraphQLArgument.newArgument()
           .name("itineraryFilters")
           .description(
             "Configure the itinerary-filter-chain. NOTE! THESE PARAMETERS ARE USED " +

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -863,19 +863,6 @@ type QueryType {
     """
     relaxTransitGroupPriority: RelaxCostInput = null,
     """
-    Whether non-optimal transit paths at the destination should be returned. Let c be the
-    existing minimum pareto optimal generalized-cost to beat. Then a trip with cost c' is
-    accepted if the following is true:
-    
-    `c' < Math.round(c * relaxTransitSearchGeneralizedCostAtDestination)`
-    
-    The parameter is optional. If not set, a normal comparison is performed.
-    
-    Values less than 1.0 is not allowed, and values greater than 2.0 are not
-    supported, due to performance reasons.
-    """
-    relaxTransitSearchGeneralizedCostAtDestination: Float = null @deprecated(reason : "This is replaced by 'relaxTransitGroupPriority'."),
-    """
     The length of the search-window in minutes. This parameter is optional.
     
     The search-window is defined as the duration between the earliest-departure-time(EDT) and


### PR DESCRIPTION
### Summary

This PR removes the `relaxTransitSearchGeneralizedCostAtDestination` input field in the trip plan request in the Transmodel API.

This feature was an experiment and should not have been used in production. It was deprecated in 2023-12-20. We take away the parameter from the API now, and then if noone complains, then we will remove the feature implementation
 including Raptor code in a few weeks time.

I have not removed the implementation of the configuration for this - we are waiting to see if this will cause any problems. But, I will remove all code for this feature before I continue with the via Raptor improvements. There is a bit of work and risk when removing this, so we prefer to do it in 2 steps.

### Issue

🟥  There is not issue for this.


### Unit tests

✅  The API schema test is updated.

### Documentation

✅  Doc on the feature is removed

### Changelog

🟥  This feature was hopefully only used at Entur - it never worked in a good way. We do not need this in the change log. 

### Bumping the serialization version id

🟥  Not needed