### PR TITLE
Use locale param from plan queries for all translations in the GTFS API if accept-language header is not set

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BikeRentalStationImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/BikeRentalStationImpl.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
+import static org.opentripplanner.framework.graphql.GraphQLUtils.getLocale;
+
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -66,7 +68,7 @@ public class BikeRentalStationImpl implements GraphQLDataFetchers.GraphQLBikeRen
 
   @Override
   public DataFetcher<String> name() {
-    return environment -> getSource(environment).getName().toString(environment.getLocale());
+    return environment -> getSource(environment).getName().toString(getLocale(environment));
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RentalVehicleImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RentalVehicleImpl.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
+import static org.opentripplanner.framework.graphql.GraphQLUtils.getLocale;
+
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -40,7 +42,7 @@ public class RentalVehicleImpl implements GraphQLDataFetchers.GraphQLRentalVehic
 
   @Override
   public DataFetcher<String> name() {
-    return environment -> getSource(environment).getName().toString(environment.getLocale());
+    return environment -> getSource(environment).getName().toString(getLocale(environment));
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RoutingErrorImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RoutingErrorImpl.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
 import static org.opentripplanner.apis.gtfs.GraphQLUtils.toGraphQL;
+import static org.opentripplanner.framework.graphql.GraphQLUtils.getLocale;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -19,7 +20,7 @@ public class RoutingErrorImpl implements GraphQLDataFetchers.GraphQLRoutingError
   @Override
   public DataFetcher<String> description() {
     return environment ->
-      PlannerErrorMapper.mapMessage(getSource(environment)).message.get(environment.getLocale());
+      PlannerErrorMapper.mapMessage(getSource(environment)).message.get(getLocale(environment));
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehicleRentalStationImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/VehicleRentalStationImpl.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
+import static org.opentripplanner.framework.graphql.GraphQLUtils.getLocale;
+
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -59,7 +61,7 @@ public class VehicleRentalStationImpl implements GraphQLDataFetchers.GraphQLVehi
 
   @Override
   public DataFetcher<String> name() {
-    return environment -> getSource(environment).getName().toString(environment.getLocale());
+    return environment -> getSource(environment).getName().toString(getLocale(environment));
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/stepImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/stepImpl.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
+import static org.opentripplanner.framework.graphql.GraphQLUtils.getLocale;
+
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
@@ -81,7 +83,7 @@ public class stepImpl implements GraphQLDataFetchers.GraphQLStep {
   @Override
   public DataFetcher<String> streetName() {
     return environment ->
-      getSource(environment).getDirectionText().toString(environment.getLocale());
+      getSource(environment).getDirectionText().toString(getLocale(environment));
   }
 
   @Override


### PR DESCRIPTION
### Summary

Updates data fetchers to use the GraphQL utils for determining the locale for translations so that the `locale` param in plan queries is respected if no accept-language header is used.

### Issue

No issue

### Unit tests

Not sure if needed

### Documentation

No

### Changelog

From title
