### PR TITLE
Fix warnings in SiriAlertsUpdateHandlerTest

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/restapi/resources/IndexAPI.java
+++ b/application/src/ext/java/org/opentripplanner/ext/restapi/resources/IndexAPI.java
@@ -462,7 +462,7 @@ public class IndexAPI {
   public Collection<ApiAlert> getAlertsForTrip(@PathParam("tripId") String tripId) {
     var alertMapper = new AlertMapper(null); // TODO: Add locale
     var id = createId("tripId", tripId);
-    return alertMapper.mapToApi(transitService().getTransitAlertService().getTripAlerts(id, null));
+    return alertMapper.mapToApi(transitService().getTransitAlertService().getTripAlerts(id));
   }
 
   @GET

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
@@ -72,7 +72,7 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
               break;
             case TRIPS:
               getTrips(environment).forEach(trip ->
-                alerts.addAll(alertService.getTripAlerts(trip.getId(), null))
+                alerts.addAll(alertService.getTripAlerts(trip.getId()))
               );
               break;
             case STOPS_ON_PATTERN:

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
@@ -68,7 +68,7 @@ public class RouteImpl implements GraphQLDataFetchers.GraphQLRoute {
               break;
             case TRIPS:
               getTrips(environment).forEach(trip ->
-                alerts.addAll(alertService.getTripAlerts(trip.getId(), null))
+                alerts.addAll(alertService.getTripAlerts(trip.getId()))
               );
               break;
             case STOPS_ON_ROUTE:

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -93,7 +93,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
             if (types.contains(GraphQLTypes.GraphQLStopAlertType.TRIPS)) {
               pattern
                 .scheduledTripsAsStream()
-                .forEach(trip -> alerts.addAll(alertService.getTripAlerts(trip.getId(), null)));
+                .forEach(trip -> alerts.addAll(alertService.getTripAlerts(trip.getId())));
             }
           });
         }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
@@ -62,7 +62,7 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
         types.forEach(type -> {
           switch (type) {
             case TRIP:
-              alerts.addAll(alertService.getTripAlerts(getSource(environment).getId(), null));
+              alerts.addAll(alertService.getTripAlerts(getSource(environment).getId()));
               break;
             case AGENCY:
               alerts.addAll(alertService.getAgencyAlerts(getAgency(environment).getId()));
@@ -118,7 +118,7 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
         });
         return alerts.stream().distinct().collect(Collectors.toList());
       } else {
-        return alertService.getTripAlerts(getSource(environment).getId(), null);
+        return alertService.getTripAlerts(getSource(environment).getId());
       }
     };
   }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -284,7 +284,7 @@ public class ServiceJourneyType {
           .dataFetcher(environment ->
             GqlUtil.getTransitService(environment)
               .getTransitAlertService()
-              .getTripAlerts(trip(environment).getId(), null)
+              .getTripAlerts(trip(environment).getId())
           )
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.alertpatch;
 
 import java.time.LocalDate;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.Direction;
 
@@ -56,7 +57,7 @@ public sealed interface EntitySelector {
     }
   }
 
-  record Trip(FeedScopedId tripId, LocalDate serviceDate) implements EntitySelector {
+  record Trip(FeedScopedId tripId, @Nullable LocalDate serviceDate) implements EntitySelector {
     public Trip(FeedScopedId tripId) {
       this(tripId, null);
     }

--- a/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -96,6 +96,15 @@ public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
   }
 
   @Override
+  public Collection<TransitAlert> getTripAlerts(FeedScopedId trip) {
+    return transitAlertServices
+      .stream()
+      .map(transitAlertService -> transitAlertService.getTripAlerts(trip))
+      .flatMap(Collection::stream)
+      .collect(Collectors.toList());
+  }
+
+  @Override
   public Collection<TransitAlert> getTripAlerts(FeedScopedId trip, LocalDate serviceDate) {
     return transitAlertServices
       .stream()

--- a/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
+++ b/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
@@ -41,6 +41,11 @@ public interface TransitAlertService {
 
   Collection<TransitAlert> getRouteAlerts(FeedScopedId route);
 
+  /**
+   * Get Trip alerts for any date
+   */
+  Collection<TransitAlert> getTripAlerts(FeedScopedId trip);
+
   Collection<TransitAlert> getTripAlerts(FeedScopedId trip, LocalDate serviceDate);
 
   Collection<TransitAlert> getAgencyAlerts(FeedScopedId agency);

--- a/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.GtfsTest;
@@ -200,7 +201,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertFalse(transitAlert.siriUrls().isEmpty());
 
     final List<AlertUrl> alertUrlList = transitAlert.siriUrls();
-    AlertUrl alertUrl = alertUrlList.get(0);
+    AlertUrl alertUrl = alertUrlList.getFirst();
     assertEquals(infoLinkUri, alertUrl.uri());
     assertEquals(infoLinkLabel, alertUrl.label());
   }
@@ -276,7 +277,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       ZonedDateTime.parse("2014-01-01T00:00:00+01:00"),
       ZonedDateTime.parse("2014-01-01T23:59:59+01:00"),
-      createAffectsStop(null, stopId0.getId(), stopId1.getId())
+      createAffectsStop(List.of(), stopId0.getId(), stopId1.getId())
     );
 
     final String reportType = "incident";
@@ -361,7 +362,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       startTime,
       endTime,
-      createAffectsFramedVehicleJourney(tripId.getId(), "2014-01-01", null)
+      createAffectsFramedVehicleJourney(tripId.getId(), "2014-01-01")
     );
 
     alertsUpdateHandler.update(createServiceDelivery(ptSituation), realTimeUpdateContext);
@@ -411,7 +412,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       startTime,
       endTime,
-      createAffectsFramedVehicleJourney(tripId.getId(), null, null)
+      createAffectsFramedVehicleJourney(tripId.getId(), null)
     );
 
     alertsUpdateHandler.update(createServiceDelivery(ptSituation), realTimeUpdateContext);
@@ -427,8 +428,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     final TransitAlert datedTransitAlert = tripPatches.iterator().next();
 
     // Verify that NOT requesting specific date includes alert for all dates
-    serviceDate = null;
-    tripPatches = transitAlertService.getTripAlerts(tripId, serviceDate);
+    tripPatches = transitAlertService.getTripAlerts(tripId);
 
     assertNotNull(tripPatches);
     assertEquals(1, tripPatches.size());
@@ -471,7 +471,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       startTime,
       endTime,
-      createAffectsVehicleJourney(tripId.getId(), startTime, null)
+      createAffectsVehicleJourney(tripId.getId(), startTime)
     );
 
     alertsUpdateHandler.update(createServiceDelivery(ptSituation), realTimeUpdateContext);
@@ -555,7 +555,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       startTime,
       endTime,
-      createAffectsDatedVehicleJourney(tripId.getId(), null)
+      createAffectsDatedVehicleJourney(tripId.getId())
     );
 
     alertsUpdateHandler.update(createServiceDelivery(ptSituation), realTimeUpdateContext);
@@ -591,7 +591,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       startTime,
       endTime,
-      createAffectsLine(lineRef.getId(), null)
+      createAffectsLine(lineRef.getId())
     );
 
     final ServiceDelivery serviceDelivery = createServiceDelivery(ptSituation);
@@ -637,7 +637,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       startTime,
       endTime,
-      createAffectsLine(lineRef.getId(), null)
+      createAffectsLine(lineRef.getId())
     );
 
     alertsUpdateHandler.update(createServiceDelivery(ptSituation), realTimeUpdateContext);
@@ -657,7 +657,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       situationNumber,
       startTime,
       endTime,
-      createAffectsLine(lineRef.getId(), null)
+      createAffectsLine(lineRef.getId())
     );
 
     ptSituation.setProgress(WorkflowStatusEnumeration.CLOSED);
@@ -871,14 +871,14 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
   private PtSituationElement createPtSituationElement(
     String situationNumber,
-    ZonedDateTime startTime,
-    ZonedDateTime endTime,
+    @Nullable ZonedDateTime startTime,
+    @Nullable ZonedDateTime endTime,
     AffectsScopeStructure affects
   ) {
     PtSituationElement element = new PtSituationElement();
     element.setCreationTime(ZonedDateTime.now());
     element.setProgress(WorkflowStatusEnumeration.OPEN);
-    if ((startTime != null) | (endTime != null)) {
+    if ((startTime != null) || (endTime != null)) {
       HalfOpenTimestampOutputRangeStructure period = new HalfOpenTimestampOutputRangeStructure();
 
       if (startTime != null) {
@@ -916,9 +916,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       stopPointRef.setValue(stopId);
       AffectedStopPointStructure affectedStopPoint = new AffectedStopPointStructure();
       affectedStopPoint.setStopPointRef(stopPointRef);
-      if (stopConditions != null) {
-        affectedStopPoint.getStopConditions().addAll(stopConditions);
-      }
+      affectedStopPoint.getStopConditions().addAll(stopConditions);
       stopPoints.getAffectedStopPoints().add(affectedStopPoint);
     }
 
@@ -1025,7 +1023,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
   private AffectsScopeStructure createAffectsFramedVehicleJourney(
     String datedVehicleJourney,
-    String dataFrameValue,
+    @Nullable String dataFrameValue,
     String... stopIds
   ) {
     AffectsScopeStructure affects = new AffectsScopeStructure();
@@ -1042,7 +1040,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     }
     affectedVehicleJourney.setFramedVehicleJourneyRef(framedVehicleJourneyRef);
 
-    if (stopIds != null) {
+    if (stopIds.length > 0) {
       AffectedRouteStructure affectedRoute = new AffectedRouteStructure();
       AffectedRouteStructure.StopPoints stopPoints = createAffectedStopPoints(stopIds);
       affectedRoute.setStopPoints(stopPoints);
@@ -1082,7 +1080,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     affectedVehicleJourney.getVehicleJourneyReves().add(vehicleJourney);
     affectedVehicleJourney.setOriginAimedDepartureTime(originAimedDepartureTime);
 
-    if (stopIds != null) {
+    if (stopIds.length > 0) {
       AffectedRouteStructure affectedRoute = new AffectedRouteStructure();
       AffectedRouteStructure.StopPoints stopPoints = createAffectedStopPoints(stopIds);
       affectedRoute.setStopPoints(stopPoints);
@@ -1108,7 +1106,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     datedVehicleJourney.setValue(datedVehicleJourneyRef);
     affectedVehicleJourney.getDatedVehicleJourneyReves().add(datedVehicleJourney);
 
-    if (stopIds != null) {
+    if (stopIds.length > 0) {
       AffectedRouteStructure affectedRoute = new AffectedRouteStructure();
       AffectedRouteStructure.StopPoints stopPoints = createAffectedStopPoints(stopIds);
       affectedRoute.setStopPoints(stopPoints);
@@ -1133,7 +1131,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     TransitAlert transitAlert,
     FeedScopedId stopId,
     FeedScopedId routeOrTripId,
-    LocalDate serviceDate
+    @Nullable LocalDate serviceDate
   ) {
     boolean foundMatch = false;
     for (EntitySelector entity : transitAlert.entities()) {
@@ -1162,7 +1160,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     affectedLine.setLineRef(lineRef);
     affectedNetwork.getAffectedLines().add(affectedLine);
 
-    if (stopIds != null) {
+    if (stopIds.length > 0) {
       AffectedLineStructure.Routes routes = new AffectedLineStructure.Routes();
       AffectedRouteStructure affectedRoute = new AffectedRouteStructure();
 
@@ -1235,7 +1233,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     networks.getAffectedNetworks().add(affectedNetwork);
     affects.setNetworks(networks);
-    if (stopIds != null) {
+    if (stopIds.length > 0) {
       AffectsScopeStructure.StopPoints stopPoints = new AffectsScopeStructure.StopPoints();
       for (String stopId : stopIds) {
         AffectedStopPointStructure affectedStopPoint = new AffectedStopPointStructure();
@@ -1305,7 +1303,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     networks.getAffectedNetworks().add(affectedNetwork);
     affects.setNetworks(networks);
-    if (stopIds != null) {
+    if (stopIds.length > 0) {
       AffectsScopeStructure.StopPlaces stopPlaces = new AffectsScopeStructure.StopPlaces();
       for (String stopId : stopIds) {
         AffectedStopPlaceStructure affectedStopPlaceStructure = new AffectedStopPlaceStructure();


### PR DESCRIPTION
### Summary

This is a pure refactor. It doesn't change any functionality.

This fixes some warnings of the type:
```
non-varargs call of varargs method with inexact argument type for last parameter
```

Also a minor improvement: adding a method `TransitAlertService.getTripAlerts(FeedScopedId trip)` so you don't have to do `TransitAlertService.getTripAlerts(trip, null)`. 

### Unit tests
 
This is mostly a cleanup of some test code.

### Bumping the serialization version id

Nope