### PR TITLE
Only add accessibility score to itinerary when it's walk-only or transit

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
@@ -77,4 +77,12 @@ class DecorateWithAccessibilityScoreTest implements PlanTestConstants {
     assertNull(itinerary.accessibilityScore());
     itinerary.legs().forEach(l -> assertNull(l.accessibilityScore()));
   }
+
+  @MethodSource("nonWalkingCases")
+  @ParameterizedTest
+  void itineraryLevelScore(Function<TestItineraryBuilder, TestItineraryBuilder> modifier) {
+    var itinerary = modifier.apply(newItinerary(A, 0)).walk(10, C).build();
+    itinerary = DECORATOR.decorate(itinerary);
+    assertNull(itinerary.accessibilityScore());
+  }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScoreTest.java
@@ -78,6 +78,10 @@ class DecorateWithAccessibilityScoreTest implements PlanTestConstants {
     itinerary.legs().forEach(l -> assertNull(l.accessibilityScore()));
   }
 
+  /**
+   * Only itinerary which are walk-only or have a transit leg should have an itinerary-level
+   * score.
+   */
   @MethodSource("nonWalkingCases")
   @ParameterizedTest
   void itineraryLevelScore(Function<TestItineraryBuilder, TestItineraryBuilder> modifier) {

--- a/application/src/ext/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScore.java
+++ b/application/src/ext/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScore.java
@@ -4,7 +4,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import org.opentripplanner.model.plan.Itinerary;
-import org.opentripplanner.model.plan.ItineraryBuilder;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.StreetLeg;
@@ -37,10 +36,11 @@ public class DecorateWithAccessibilityScore implements ItineraryDecorator {
 
   @Override
   public Itinerary decorate(Itinerary itinerary) {
-    return addAccessibilityScore(itinerary.copyOf()).build();
+    return addAccessibilityScore(itinerary);
   }
 
-  private ItineraryBuilder addAccessibilityScore(ItineraryBuilder builder) {
+  private Itinerary addAccessibilityScore(Itinerary i) {
+    var builder = i.copyOf();
     var legs = builder
       .legs()
       .stream()
@@ -54,7 +54,11 @@ public class DecorateWithAccessibilityScore implements ItineraryDecorator {
         }
       })
       .toList();
-    return builder.withLegs(ignore -> legs).withAccessibilityScore(compute(legs));
+    builder.withLegs(ignore -> legs);
+    if (i.isWalkOnly() || i.hasTransit()) {
+      builder.withAccessibilityScore(compute(legs));
+    }
+    return builder.build();
   }
 
   private static float compute(ScheduledTransitLeg leg) {


### PR DESCRIPTION
### Summary

@amy-corson-ibigroup has requested the following change to the accessibility score: only those itineraries which are walk-only or have a transit leg should receive an itinerary-level score.

### Unit tests

Added.

### Changelog

Skip

### Bumping the serialization version id

No