### PR TITLE
Use locale param if one is defined over accept-language header in GTFS APIs

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/graphql/GraphQLUtils.java
+++ b/application/src/main/java/org/opentripplanner/framework/graphql/GraphQLUtils.java
@@ -7,8 +7,30 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 
+/**
+ * This class should always be used when translating fields or handling locales in GraphQL queries.
+ */
 public class GraphQLUtils {
 
+  /**
+   * If input is {@code null}, return null. Otherwise, input is translated using a locale from this
+   * prioritized list:
+   * <ol>
+   *   <li>
+   *   {@code language} parameter of a queried field.
+   *   </li>
+   *   <li>
+   *   Locale from the DataFetchingEnvironment's local context (for journey planning queries this is {@code locale} parameter).
+   *   </li>
+   *   <li>
+   *   DataFetchingEnvironment's locale which comes from the accept-language header.
+   *   </li>
+   *   <li>
+   *   Default locale.
+   *   </li>
+   * </ol>
+   */
+  @Nullable
   public static String getTranslation(
     @Nullable I18NString input,
     DataFetchingEnvironment environment
@@ -19,6 +41,23 @@ public class GraphQLUtils {
     return input.toString(getLocale(environment));
   }
 
+  /**
+   * Returns locale from this prioritized list:
+   * <ol>
+   *   <li>
+   *   {@code language} parameter of a queried field.
+   *   </li>
+   *   <li>
+   *   Locale from the DataFetchingEnvironment's local context (for journey planning queries this is {@code locale} parameter).
+   *   </li>
+   *   <li>
+   *   DataFetchingEnvironment's locale which comes from the accept-language header.
+   *   </li>
+   *   <li>
+   *   Default locale.
+   *   </li>
+   * </ol>
+   */
   public static Locale getLocale(DataFetchingEnvironment environment) {
     var localeString = environment.getArgument("language");
     if (localeString != null) {
@@ -28,6 +67,23 @@ public class GraphQLUtils {
     return getLocaleFromEnvironment(environment);
   }
 
+  /**
+   * Returns locale from this prioritized list:
+   * <ol>
+   *   <li>
+   *   {@code localeString}.
+   *   </li>
+   *   <li>
+   *   Locale from the DataFetchingEnvironment's local context (for journey planning queries this is {@code locale} parameter).
+   *   </li>
+   *   <li>
+   *   DataFetchingEnvironment's locale which comes from the accept-language header.
+   *   </li>
+   *   <li>
+   *   Default locale.
+   *   </li>
+   * </ol>
+   */
   public static Locale getLocale(
     DataFetchingEnvironment environment,
     @Nullable String localeString
@@ -39,6 +95,23 @@ public class GraphQLUtils {
     return getLocaleFromEnvironment(environment);
   }
 
+  /**
+   * Returns locale from this prioritized list:
+   * <ol>
+   *   <li>
+   *   {@code locale}.
+   *   </li>
+   *   <li>
+   *   Locale from the DataFetchingEnvironment's local context (for journey planning queries this is {@code locale} parameter).
+   *   </li>
+   *   <li>
+   *   DataFetchingEnvironment's locale which comes from the accept-language header.
+   *   </li>
+   *   <li>
+   *   Default locale.
+   *   </li>
+   * </ol>
+   */
   public static Locale getLocale(DataFetchingEnvironment environment, @Nullable Locale locale) {
     if (locale != null) {
       return locale;
@@ -47,15 +120,33 @@ public class GraphQLUtils {
     return getLocaleFromEnvironment(environment);
   }
 
+  /**
+   * Returns locale from this prioritized list:
+   * <ol>
+   *   <li>
+   *   Locale from the DataFetchingEnvironment's local context (for journey planning queries this is {@code locale} parameter).
+   *   </li>
+   *   <li>
+   *   DataFetchingEnvironment's locale which comes from the accept-language header.
+   *   </li>
+   *   <li>
+   *   Default locale.
+   *   </li>
+   * </ol>
+   */
   public static Locale getLocaleFromEnvironment(DataFetchingEnvironment environment) {
     // This can come from the accept-language header
     var envLocale = environment.getLocale();
     // This can come from a locale param
-    var localContextLocale = getDefaultLocale(environment);
+    var localContextLocale = getLocalContextLocale(environment);
     return localContextLocale.orElse(envLocale);
   }
 
-  private static Optional<Locale> getDefaultLocale(DataFetchingEnvironment environment) {
+  /**
+   * Returns locale from the DataFetchingEnvironment's local context (for journey planning queries
+   * this is {@code locale} parameter) or empty if none exist.
+   */
+  private static Optional<Locale> getLocalContextLocale(DataFetchingEnvironment environment) {
     Map<String, ?> localContext = environment.getLocalContext();
     if (localContext == null) {
       return Optional.empty();

--- a/application/src/main/java/org/opentripplanner/framework/graphql/GraphQLUtils.java
+++ b/application/src/main/java/org/opentripplanner/framework/graphql/GraphQLUtils.java
@@ -4,11 +4,15 @@ import graphql.schema.DataFetchingEnvironment;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 
 public class GraphQLUtils {
 
-  public static String getTranslation(I18NString input, DataFetchingEnvironment environment) {
+  public static String getTranslation(
+    @Nullable I18NString input,
+    DataFetchingEnvironment environment
+  ) {
     if (input == null) {
       return null;
     }
@@ -24,7 +28,10 @@ public class GraphQLUtils {
     return getLocaleFromEnvironment(environment);
   }
 
-  public static Locale getLocale(DataFetchingEnvironment environment, String localeString) {
+  public static Locale getLocale(
+    DataFetchingEnvironment environment,
+    @Nullable String localeString
+  ) {
     if (localeString != null) {
       return Locale.forLanguageTag(localeString);
     }
@@ -32,7 +39,7 @@ public class GraphQLUtils {
     return getLocaleFromEnvironment(environment);
   }
 
-  public static Locale getLocale(DataFetchingEnvironment environment, Locale locale) {
+  public static Locale getLocale(DataFetchingEnvironment environment, @Nullable Locale locale) {
     if (locale != null) {
       return locale;
     }
@@ -42,18 +49,10 @@ public class GraphQLUtils {
 
   public static Locale getLocaleFromEnvironment(DataFetchingEnvironment environment) {
     // This can come from the accept-language header
-    var userLocale = environment.getLocale();
-    var defaultLocale = getDefaultLocale(environment);
-
-    if (userLocale == null) {
-      return defaultLocale.orElse(Locale.forLanguageTag("*"));
-    }
-
-    if (defaultLocale.isPresent() && acceptAnyLocale(userLocale)) {
-      return defaultLocale.get();
-    }
-
-    return userLocale;
+    var envLocale = environment.getLocale();
+    // This can come from a locale param
+    var localContextLocale = getDefaultLocale(environment);
+    return localContextLocale.orElse(envLocale);
   }
 
   private static Optional<Locale> getDefaultLocale(DataFetchingEnvironment environment) {
@@ -62,9 +61,5 @@ public class GraphQLUtils {
       return Optional.empty();
     }
     return Optional.ofNullable((Locale) localContext.get("locale"));
-  }
-
-  private static boolean acceptAnyLocale(Locale locale) {
-    return locale.getLanguage().equals("*");
   }
 }

--- a/application/src/test/java/org/opentripplanner/framework/graphql/GraphQLUtilsTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/graphql/GraphQLUtilsTest.java
@@ -79,8 +79,7 @@ class GraphQLUtilsTest {
   void testGetLocaleWithEnvLocale() {
     var frenchLocale = Locale.FRENCH;
     var env = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(executionContext)
-      .localContext(Map.of("locale", Locale.GERMAN))
-      .locale(frenchLocale)
+      .locale(Locale.FRENCH)
       .build();
 
     var locale = GraphQLUtils.getLocale(env);
@@ -90,10 +89,11 @@ class GraphQLUtilsTest {
 
   @Test
   void testGetLocaleWithLocalContextLocale() {
-    // Should use locale from local context if env locale is not defined
+    // Should use locale from local context even if env locale is defined
 
     var frenchLocale = Locale.FRENCH;
     var envWithNoLocale = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(executionContext)
+      .locale(Locale.GERMAN)
       .localContext(Map.of("locale", Locale.FRENCH))
       .build();
 


### PR DESCRIPTION
### Summary

Previously if both accept-language header and locale param were defined, env would be used. This changes the prioritization so that the locale param is used.

### Issue

No issue

### Unit tests

Update tests

### Documentation

Not needed

### Changelog

From title
