### PR TITLE
do not discard turn restrictions where the turn description and angle do not match, just add an issue

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/TurnRestrictionUnifier.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/TurnRestrictionUnifier.java
@@ -40,6 +40,8 @@ class TurnRestrictionUnifier {
             if (angleDiff < 0) {
               angleDiff += 360;
             }
+            // If the angle seems off for the stated restriction direction, add an issue
+            // to the issue store, but do not ignore the restriction.
             switch (restrictionTag.direction) {
               case LEFT -> {
                 if (angleDiff >= 160) {
@@ -49,7 +51,6 @@ class TurnRestrictionUnifier {
                       "Left turn restriction is not on edges which turn left"
                     )
                   );
-                  continue; // not a left turn
                 }
               }
               case RIGHT -> {
@@ -60,7 +61,6 @@ class TurnRestrictionUnifier {
                       "Right turn restriction is not on edges which turn right"
                     )
                   );
-                  continue; // not a right turn
                 }
               }
               case U -> {
@@ -71,7 +71,6 @@ class TurnRestrictionUnifier {
                       "U-turn restriction is not on U-turn"
                     )
                   );
-                  continue; // not a U turn
                 }
               }
               case STRAIGHT -> {
@@ -82,7 +81,6 @@ class TurnRestrictionUnifier {
                       "Straight turn restriction is not on edges which go straight"
                     )
                   );
-                  continue; // not straight
                 }
               }
             }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
@@ -1,19 +1,23 @@
 package org.opentripplanner.graph_builder.module.osm.moduletests;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.graph_builder.module.osm.moduletests._support.NodeBuilder.node;
 
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
+import org.opentripplanner.graph_builder.issues.TurnRestrictionBad;
 import org.opentripplanner.graph_builder.module.osm.OsmModule;
 import org.opentripplanner.graph_builder.module.osm.moduletests._support.RelationBuilder;
 import org.opentripplanner.graph_builder.module.osm.moduletests._support.TestOsmProvider;
+import org.opentripplanner.osm.model.OsmNode;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
-import org.opentripplanner.test.support.GeoJsonIo;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 
 /**
@@ -25,39 +29,64 @@ import org.opentripplanner.transit.model.framework.Deduplicator;
  */
 class TurnRestrictionsTest {
 
-  @Test
-  void noStraightOn() {
-    var node0 = node(0, new WgsCoordinate(0, 0));
-    var node1 = node(1, new WgsCoordinate(0, -1));
-    var node2 = node(2, new WgsCoordinate(1, 0));
+  static Stream<Arguments> testTurnRestrictionsSource() {
+    var node05 = node(0, new WgsCoordinate(0, 5));
+    var node05b = node(1, new WgsCoordinate(0, 5.1));
+    var node15 = node(2, new WgsCoordinate(1, 5));
+    var node16 = node(3, new WgsCoordinate(1, 6));
+    var node24 = node(4, new WgsCoordinate(2, 4));
+    var node25 = node(5, new WgsCoordinate(2, 5));
+    var node26 = node(6, new WgsCoordinate(2, 6));
+    return Stream.of(
+      Arguments.of("no_straight_on", false, node05, node15, node25),
+      Arguments.of("no_left_turn", false, node05, node15, node24),
+      Arguments.of("no_right_turn", false, node05, node15, node26),
+      Arguments.of("no_u_turn", false, node05, node15, node05b),
+      Arguments.of("no_straight_on", true, node05, node15, node24),
+      Arguments.of("no_left_turn", true, node05, node15, node26),
+      Arguments.of("no_right_turn", true, node05, node15, node24),
+      Arguments.of("no_u_turn", true, node05, node15, node16)
+    );
+  }
 
+  @ParameterizedTest
+  @MethodSource("testTurnRestrictionsSource")
+  void testTurnRestrictions(
+    String restrictionType,
+    boolean shouldWarn,
+    OsmNode node0,
+    OsmNode node1,
+    OsmNode node2
+  ) {
     long way1Id = 100;
     long way2Id = 101;
 
-    var turnRestriction = RelationBuilder.ofTurnRestriction("no_straight_on")
+    var turnRestriction = RelationBuilder.ofTurnRestriction(restrictionType)
       .withWayMember(way1Id, "from")
       .withWayMember(way2Id, "to")
-      .withNodeMember(node0.getId(), "via")
+      .withNodeMember(node1.getId(), "via")
       .build();
 
     var provider = TestOsmProvider.of()
       .addWayFromNodes(way1Id, List.of(node0, node1))
-      .addWayFromNodes(way2Id, List.of(node0, node2))
+      .addWayFromNodes(way2Id, List.of(node1, node2))
       .addRelation(turnRestriction)
       .build();
 
     var graph = new Graph(new Deduplicator());
+
+    var issueStore = new DefaultDataImportIssueStore();
 
     var osmModule = OsmModule.of(
       provider,
       graph,
       new DefaultOsmInfoGraphBuildRepository(),
       new DefaultVehicleParkingRepository()
-    ).build();
+    )
+      .withIssueStore(issueStore)
+      .build();
 
     osmModule.buildGraph();
-
-    System.out.println(GeoJsonIo.toUrl(graph));
 
     var edgesWithTurnRestrictions = graph
       .getStreetEdges()
@@ -65,5 +94,8 @@ class TurnRestrictionsTest {
       .filter(e -> !e.getTurnRestrictions().isEmpty())
       .toList();
     assertThat(edgesWithTurnRestrictions).hasSize(1);
+    assertThat(
+      issueStore.listIssues().stream().filter(i -> i instanceof TurnRestrictionBad).toList()
+    ).hasSize(shouldWarn ? 1 : 0);
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
@@ -1,0 +1,69 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.graph_builder.module.osm.moduletests._support.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.graph_builder.module.osm.OsmModule;
+import org.opentripplanner.graph_builder.module.osm.moduletests._support.RelationBuilder;
+import org.opentripplanner.graph_builder.module.osm.moduletests._support.TestOsmProvider;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
+import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
+import org.opentripplanner.test.support.GeoJsonIo;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+
+/**
+ * Checks that turn restrictions are processed even if they don't strictly adhere to their
+ * stated type, for example that a "no straight on" restriction is added to two edges even if
+ * - geometrically speaking - you are not going straight.
+ * <p>
+ * https://github.com/opentripplanner/OpenTripPlanner/issues/6536
+ */
+class TurnRestrictionsTest {
+
+  @Test
+  void noStraightOn() {
+    var node0 = node(0, new WgsCoordinate(0, 0));
+    var node1 = node(1, new WgsCoordinate(0, -1));
+    var node2 = node(2, new WgsCoordinate(1, 0));
+
+    long way1Id = 100;
+    long way2Id = 101;
+
+    var turnRestriction = RelationBuilder.ofTurnRestriction("no_straight_on")
+      .withWayMember(way1Id, "from")
+      .withWayMember(way2Id, "to")
+      .withNodeMember(node0.getId(), "via")
+      .build();
+
+    var provider = TestOsmProvider.of()
+      .addWayFromNodes(way1Id, List.of(node0, node1))
+      .addWayFromNodes(way2Id, List.of(node0, node2))
+      .addRelation(turnRestriction)
+      .build();
+
+    var graph = new Graph(new Deduplicator());
+
+    var osmModule = OsmModule.of(
+      provider,
+      graph,
+      new DefaultOsmInfoGraphBuildRepository(),
+      new DefaultVehicleParkingRepository()
+    ).build();
+
+    osmModule.buildGraph();
+
+    System.out.println(GeoJsonIo.toUrl(graph));
+
+    var edgesWithTurnRestrictions = graph
+      .getStreetEdges()
+      .stream()
+      .filter(e -> !e.getTurnRestrictions().isEmpty())
+      .toList();
+    assertThat(edgesWithTurnRestrictions).hasSize(1);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/RelationBuilder.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/RelationBuilder.java
@@ -15,16 +15,31 @@ public class RelationBuilder {
     return builder;
   }
 
+  public static RelationBuilder ofTurnRestriction(String restrictionType) {
+    var builder = new RelationBuilder();
+    builder.relation.addTag("type", "restriction");
+    builder.relation.addTag("restriction", restrictionType);
+    return builder;
+  }
+
   public RelationBuilder withWayMember(long id, String role) {
-    var member = new OsmRelationMember();
-    member.setRole(role);
-    member.setType(OsmMemberType.WAY);
-    member.setRef(id);
-    relation.addMember(member);
-    return this;
+    return withMember(id, role, OsmMemberType.WAY);
+  }
+
+  public RelationBuilder withNodeMember(long id, String role) {
+    return withMember(id, role, OsmMemberType.NODE);
   }
 
   public OsmRelation build() {
     return relation;
+  }
+
+  private RelationBuilder withMember(long id, String role, OsmMemberType osmMemberType) {
+    var member = new OsmRelationMember();
+    member.setRole(role);
+    member.setType(osmMemberType);
+    member.setRef(id);
+    relation.addMember(member);
+    return this;
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/TestOsmProvider.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/TestOsmProvider.java
@@ -115,12 +115,15 @@ public class TestOsmProvider implements OsmProvider {
     }
 
     public Builder addWayFromNodes(OsmNode... nodes) {
-      var wayNodes = Arrays.stream(nodes).toList();
-      this.nodes.addAll(wayNodes);
-      var nodeIds = wayNodes.stream().map(OsmEntity::getId).toList();
+      return addWayFromNodes(counter.incrementAndGet(), Arrays.stream(nodes).toList());
+    }
+
+    public Builder addWayFromNodes(long id, List<OsmNode> nodes) {
+      this.nodes.addAll(nodes);
+      var nodeIds = nodes.stream().map(OsmEntity::getId).toList();
 
       var way = new OsmWay();
-      way.setId(counter.incrementAndGet());
+      way.setId(id);
       way.addTag("highway", "pedestrian");
       way.getNodeRefs().addAll(nodeIds);
 


### PR DESCRIPTION

### Summary

Throwing out restrictions based on a heuristic was wrong. We still continue adding issues to the issue store for them.

The code in question is really old, and no one really remembered why it is written this way. Maybe OSM data used to be worse, these days this check seems counterproductive.

### Issue

Fixes #6536 

### Unit tests

None existed in the first place.

### Documentation

I left a comment explaining the logic.

### Changelog

No.

### Bumping the serialization version id

No.