### PR TITLE
Make `slopeExceededReluctance` example more realistic [ci skip]

### DIFF
--- a/doc/user/Accessibility.md
+++ b/doc/user/Accessibility.md
@@ -44,7 +44,7 @@ If you want to allow trips and stops of unknown wheelchair-accessibility then ad
       },
       "inaccessibleStreetReluctance": 25,
       "maxSlope": 0.08333,
-      "slopeExceededReluctance": 50,
+      "slopeExceededReluctance": 1,
       "stairsReluctance": 25
     }
   },


### PR DESCRIPTION
### Summary

@vpaturet has correctly pointed out that the example configuration for the accessibility feature suggests an absurdly large value which we should change.

I'm not sure how it happened but 50 means that for every percent you go over the limit you will multiply the edge cost by 50 which might lead to integer overflows.

A value of 1 doubles the cost for every percent over the limit which is enough of a penalty, I feel.

### Issue

[Gitter chat](https://matrix.to/#/!oXNNoHKzbaSOlFzLEt:gitter.im/$tcGyq09eBy_3fYn387MEzIZRzKOdLMkxANEKfwbru1g?via=gitter.im&via=matrix.org&via=builtin.io)
