### PR TITLE
Add a null-check to the ids argument in the stopPlaces Transmodel API endpoint.

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -457,20 +457,13 @@ public class TransmodelGraphQLSchema {
               .build()
           )
           .dataFetcher(env -> {
-            if (env.getArgument("ids") != null) {
-              var ids = mapIDsToDomainNullSafe(env.getArgument("ids"));
-              return ids
-                .stream()
-                .map(id -> StopPlaceType.fetchStopPlaceById(id, env))
-                .collect(Collectors.toList());
+            if (env.getArgument("ids") == null) {
+              throw new IllegalArgumentException("ids argument must be set to a non-null value.");
             }
-            TransitService transitService = GqlUtil.getTransitService(env);
-            return transitService
-              .listStations()
+            var ids = mapIDsToDomainNullSafe(env.getArgument("ids"));
+            return ids
               .stream()
-              .map(station ->
-                new MonoOrMultiModalStation(station, transitService.findMultiModalStation(station))
-              )
+              .map(id -> StopPlaceType.fetchStopPlaceById(id, env))
               .collect(Collectors.toList());
           })
           .build()

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -447,7 +447,7 @@ public class TransmodelGraphQLSchema {
       .field(
         GraphQLFieldDefinition.newFieldDefinition()
           .name("stopPlaces")
-          .description("Get all stopPlaces")
+          .description("Get stopPlaces by ids. The ids argument must be set to a non-null value.")
           .withDirective(TransmodelDirectives.TIMING_DATA)
           .type(new GraphQLNonNull(new GraphQLList(stopPlaceType)))
           .argument(

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -763,7 +763,7 @@ type QueryType {
   ): [PtSituationElement!]! @timingData
   "Get a single stopPlace based on its id)"
   stopPlace(id: String!): StopPlace @timingData
-  "Get all stopPlaces"
+  "Get stopPlaces by ids. The ids argument must be set to a non-null value."
   stopPlaces(ids: [String]): [StopPlace]! @timingData
   "Get all stop places within the specified bounding box"
   stopPlacesByBbox(


### PR DESCRIPTION
### Summary

This makes the stopPlaces API endpoint in the Transmodel API return an error if a null value is passed for the ids argument. This is in line with the behavior today, but today the error happens because the response is too large. Failing early is preferable.

### Issue

#6543

### Unit tests

Tested by running locally. There are no unit tests at this level.
