### PR TITLE
Add a null-check to the ids argument in the quays Transmodel API endpoint.

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -583,18 +583,25 @@ public class TransmodelGraphQLSchema {
           .argument(GraphQLArgument.newArgument().name("name").type(Scalars.GraphQLString).build())
           .dataFetcher(environment -> {
             if (environment.containsArgument("ids")) {
-              var ids = mapIDsToDomainNullSafe(environment.getArgument("ids"));
-
+              if (environment.getArgument("ids") == null) {
+                throw new IllegalArgumentException("ids argument must be set to a non-null value.");
+              }
               if (environment.getArgument("name") != null) {
                 throw new IllegalArgumentException("Unable to combine other filters with ids");
               }
+
+              var ids = mapIDsToDomainNullSafe(environment.getArgument("ids"));
 
               TransitService transitService = GqlUtil.getTransitService(environment);
               return ids.stream().map(transitService::getStopLocation).toList();
             }
 
+            if (environment.getArgument("name") == null) {
+              throw new IllegalArgumentException("At least one of ids or name must be set.");
+            }
+
             FindStopLocationsRequest request = FindStopLocationsRequest.of()
-              .withName(environment.getArgument("name"))
+              .withName(Objects.requireNonNull(environment.getArgument("name")))
               .build();
 
             return GqlUtil.getTransitService(environment).findStopLocations(request);

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -571,7 +571,7 @@ public class TransmodelGraphQLSchema {
       .field(
         GraphQLFieldDefinition.newFieldDefinition()
           .name("quays")
-          .description("Get all quays")
+          .description("Get quays. Either ids or name must be set.")
           .withDirective(TransmodelDirectives.TIMING_DATA)
           .type(new GraphQLNonNull(new GraphQLList(quayType)))
           .argument(

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -3,7 +3,6 @@ package org.opentripplanner.apis.transmodel;
 import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 import static org.opentripplanner.apis.transmodel.mapping.SeverityMapper.getTransmodelSeverity;
-import static org.opentripplanner.apis.transmodel.mapping.TransitIdMapper.mapIDToApi;
 import static org.opentripplanner.apis.transmodel.mapping.TransitIdMapper.mapIDToDomain;
 import static org.opentripplanner.apis.transmodel.mapping.TransitIdMapper.mapIDsToDomain;
 import static org.opentripplanner.apis.transmodel.mapping.TransitIdMapper.mapIDsToDomainNullSafe;

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -703,7 +703,7 @@ type QueryType {
   operators: [Operator]! @timingData
   "Get a single quay based on its id)"
   quay(id: String!): Quay @timingData
-  "Get all quays"
+  "Get quays. Either ids or name must be set."
   quays(ids: [String], name: String): [Quay]! @timingData
   "Get all quays within the specified bounding box"
   quaysByBbox(


### PR DESCRIPTION
### Summary

This makes the quays API endpoint in the Transmodel API return an error if a null value is passed for the ids argument. This is in line with the behavior today, but today the error happens because the response is too large. Failing early is preferable.

This change also throws an exception when no parameters are set, requiring that either name or ids is set.

### Issue

#6543

### Unit tests

Tested by running locally. There are no unit tests at this level.