### PR TITLE
Add validation to the serviceJourney Transmodel API endpoint

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -1185,7 +1185,7 @@ public class TransmodelGraphQLSchema {
         GraphQLFieldDefinition.newFieldDefinition()
           .name("serviceJourneys")
           .description(
-            "Get all _service journeys_. At least one of the filter arguments must be non-null."
+            "Get _service journeys_. At least one of the filter arguments must be non-null."
           )
           .withDirective(TransmodelDirectives.TIMING_DATA)
           .type(new GraphQLNonNull(new GraphQLList(serviceJourneyType)))

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -1184,7 +1184,9 @@ public class TransmodelGraphQLSchema {
       .field(
         GraphQLFieldDefinition.newFieldDefinition()
           .name("serviceJourneys")
-          .description("Get all _service journeys_")
+          .description(
+            "Get all _service journeys_. At least one of the filter arguments must be non-null."
+          )
           .withDirective(TransmodelDirectives.TIMING_DATA)
           .type(new GraphQLNonNull(new GraphQLList(serviceJourneyType)))
           .argument(
@@ -1221,7 +1223,9 @@ public class TransmodelGraphQLSchema {
                 key -> environment.getArgument(key) != null
               )
             ) {
-              throw new IllegalArgumentException("At least one argument must be non-null");
+              throw new IllegalArgumentException(
+                "At least one of these filter arguments must be non-null: lines, privateCodes, authorities, activeDates"
+              );
             }
             var tripRequest = TripRequest.of()
               .withIncludeAgencies(mapIDsToDomain(environment.getArgument("authorities")))

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -1217,12 +1217,7 @@ public class TransmodelGraphQLSchema {
           )
           .dataFetcher(environment -> {
             if (
-              Stream.of(
-                "lines",
-                "privateCodes",
-                "authorities",
-                "activeDates"
-              ).noneMatch(
+              Stream.of("lines", "privateCodes", "authorities", "activeDates").noneMatch(
                 key -> environment.getArgument(key) != null
               )
             ) {
@@ -1231,7 +1226,9 @@ public class TransmodelGraphQLSchema {
             var tripRequest = TripRequest.of()
               .withIncludeAgencies(mapIDsToDomain(environment.getArgument("authorities")))
               .withIncludeRoutes(mapIDsToDomain(environment.getArgument("lines")))
-              .withIncludeNetexInternalPlanningCodes(GqlUtil.toList(environment.getArgument("privateCodes")))
+              .withIncludeNetexInternalPlanningCodes(
+                GqlUtil.toStringList(environment.getArgument("privateCodes"))
+              )
               .withIncludeServiceDates(GqlUtil.toList(environment.getArgument("activeDates")))
               .build();
 

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
@@ -108,4 +108,15 @@ public class GqlUtil {
     }
     return args.stream().filter(Objects::nonNull).toList();
   }
+
+  /**
+   * Null-safe handling of a collection of strings. Returns null if the incoming collection is null.
+   * Null and empty elements are filtered out.
+   */
+  public static List<String> toStringList(@Nullable Collection<String> args) {
+    if (args == null) {
+      return null;
+    }
+    return args.stream().filter(Objects::nonNull).filter(s -> !s.isEmpty()).toList();
+  }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
@@ -113,7 +113,7 @@ public class GqlUtil {
    * Null-safe handling of a collection of strings. Returns null if the incoming collection is null.
    * Null and empty elements are filtered out.
    */
-  public static List<String> toStringList(@Nullable Collection<String> args) {
+  public static @Nullable List<String> toStringList(@Nullable Collection<String> args) {
     if (args == null) {
       return null;
     }

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -739,7 +739,7 @@ type QueryType {
   serverInfo: ServerInfo! @timingData
   "Get a single service journey based on its id"
   serviceJourney(id: String!): ServiceJourney @timingData
-  "Get all _service journeys_"
+  "Get all _service journeys_. At least one of the filter arguments must be non-null."
   serviceJourneys(
     "Set of _operating days_ to fetch _service journeys_ for."
     activeDates: [Date],


### PR DESCRIPTION
### Summary

This change adds validation to the serviceJourney endpoint in the Transmodel API by requiring that at least one of the argument lists be non-null. It also aligns the meaning of passing an empty list and an empty string as values of the arguments. More details in the issue linked below. This change does not require that there always be at least one active date set, therefore this change does not close the issue.

### Issue

#6545

### Unit tests

No unit tests in this part of the code. Ran locally to verify that things are working.
