### PR TITLE
Add @Deprecated to methods that are documented as deprecated [ci skip]

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/restapi/model/ApiLeg.java
+++ b/application/src/ext/java/org/opentripplanner/ext/restapi/model/ApiLeg.java
@@ -212,6 +212,7 @@ public class ApiLeg {
    *
    * @deprecated This is always null or false, the information is now stored per walk step
    */
+  @Deprecated
   public Boolean walkingBike;
 
   /**

--- a/application/src/main/java/org/opentripplanner/netex/index/api/ReadOnlyHierarchicalVersionMapById.java
+++ b/application/src/main/java/org/opentripplanner/netex/index/api/ReadOnlyHierarchicalVersionMapById.java
@@ -54,6 +54,7 @@ public interface ReadOnlyHierarchicalVersionMapById<V> {
    * of:
    * TODO TOP2 https://github.com/opentripplanner/OpenTripPlanner/issues/2781
    */
+  @Deprecated
   Collection<String> localKeys();
 
   /**

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/TransferPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/TransferPreferences.java
@@ -149,6 +149,7 @@ public final class TransferPreferences implements Serializable {
    * old functionality the same way, but we will try to map this parameter
    * so it does work similar as before.
    */
+  @Deprecated
   public int nonpreferredCost() {
     return nonpreferredCost.toSeconds();
   }


### PR DESCRIPTION
### Summary

Tiny PR that fixes some compiler warnings where methods are documented as deprecated but not annotated as such.

### Bumping the serialization version id

Nope