### PR TITLE
Fix null issue in SiriAzureETUpdaterParameters

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdaterParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdaterParameters.java
@@ -40,7 +40,7 @@ public class SiriAzureETUpdaterParameters
         return new ConnectionStringProperties(getServiceBusUrl()).getEndpoint().toString();
       } catch (IllegalArgumentException ignore) {}
     }
-    return "unkown";
+    return "unknown";
   }
 
   @Override

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdaterParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdaterParameters.java
@@ -29,12 +29,18 @@ public class SiriAzureETUpdaterParameters
 
   @Override
   public String url() {
-    var url = getServiceBusUrl();
-    try {
-      return new ConnectionStringProperties(url).getEndpoint().toString();
-    } catch (IllegalArgumentException e) {
-      return url;
+    // This url is only used for metrics
+    if (getFullyQualifiedNamespace() != null) {
+      return getFullyQualifiedNamespace();
     }
+    // fallback to service bus url
+    if (getServiceBusUrl() != null) {
+      try {
+        // Don't include the preshared key
+        return new ConnectionStringProperties(getServiceBusUrl()).getEndpoint().toString();
+      } catch (IllegalArgumentException ignore) {}
+    }
+    return "unkown";
   }
 
   @Override


### PR DESCRIPTION
### Summary

The serviceBusUrl in the siri azure parameters is optional, but there is a NPE when it's unset.
Pure sandbox code.

### Bumping the serialization version id

Nope