### PR TITLE
Fix NPE in RoutingWorker after #6535 was merged

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -222,7 +222,7 @@ public class RoutingWorker {
     //       would be nice to also support via as a feature in the direct-street
     //       search.
     if (request.isViaSearch()) {
-      return null;
+      return RoutingResult.empty();
     }
 
     debugTimingAggregator.startedDirectStreetRouter();


### PR DESCRIPTION
### Summary

We get a NullPointerException for via search after #6535 was merged. One return statement was missed when converting to use Result DTO in RoutingWorker.

### Issue

🟥  There is no issue.

### Unit tests

🟥  We do not have integration test on this - we probably should.

### Documentation

🟥  This is a regression, no feature changes.

### Changelog

🟥  The PR #6535 is in the same version as this.

### Bumping the serialization version id

🟥  Not needed, no changes to model.