### PR TITLE
Document policy for doing breaking changes the the APIs.

### DIFF
--- a/doc/dev/decisionrecords/APIGraphQLDesign.md
+++ b/doc/dev/decisionrecords/APIGraphQLDesign.md
@@ -40,6 +40,6 @@ We allow breaking API changes in these cases:
   it. We will revert a removal if the request to keep it comes after the feature is removed. 
   Example:
 
-> Use featurer xyz instead. 
-> Note! This feature is subject for removal from september 2027! If you want this to stay, pleace
+> Use feature xyz instead. 
+> Note! This feature is subject for removal in September 2027! If you want this to stay, please
 >       notify the OTP community.

--- a/doc/dev/decisionrecords/APIGraphQLDesign.md
+++ b/doc/dev/decisionrecords/APIGraphQLDesign.md
@@ -31,10 +31,15 @@ new features, consider what is best; To follow the existing style or follow the 
 Our APIs need to be backwards compatible as they are used by hundreds of clients
 (web-pages/apps/services). Correcting mistakes may not be possible or may take a long time.
 
-We allow API breaking changes in these cases:
+We allow breaking API changes in these cases:
 
 - During incremental development of a new feature (multiple PRs). The new part of the API should be
   documented as _"WorkInProgress - Why/When is it ready"_. A new API should not stay "open" for a
   long time.
 - Deprecated features can be removed after 2 years (4 minor releases) unless a user wants to keep 
-  it. We will revert a removal if the request to keep it comes after the feature is removed.
+  it. We will revert a removal if the request to keep it comes after the feature is removed. 
+  Example:
+
+> Use featurer xyz instead. 
+> Note! This feature is subject for removal from september 2027! If you want this to stay, pleace
+>       notify the OTP community.

--- a/doc/dev/decisionrecords/APIGraphQLDesign.md
+++ b/doc/dev/decisionrecords/APIGraphQLDesign.md
@@ -13,11 +13,11 @@ stops, trips and routes. Very often OTP has a _finite_ list of entities in memor
 
 ## Refetching
 
-We often use `type(id)` format queries for fetching or refetching entities or value objects of type by id. Additionally,
-the GTFS GraphQL API has a node interface and query for refetching objects which follow the
-[GraphQL Global Object Identification Specification](https://relay.dev/graphql/objectidentification.htm). We should not use the
-node interface or query for non-entities (such as Itineraries and Legs) which do not always have an ID and/or which IDs are not
-trivial to reconstruct.
+We often use `type(id)` format queries for fetching or refetching entities or value objects of type
+by id. Additionally, the GTFS GraphQL API has a node interface and query for refetching objects 
+which follow the [GraphQL Global Object Identification Specification](https://relay.dev/graphql/objectidentification.htm). 
+We should not use the node interface or query for non-entities (such as Itineraries and Legs) which
+do not always have an ID and/or which IDs are not trivial to reconstruct.
 
 
 ## Consistency
@@ -28,6 +28,13 @@ new features, consider what is best; To follow the existing style or follow the 
 
 ### Context and Problem Statement
 
-Our APIs need to be backwards compatible as they are used by hundreds of clients (web-pages/apps/services)
-Correcting mistakes may not be possible or may take a long time. 
+Our APIs need to be backwards compatible as they are used by hundreds of clients
+(web-pages/apps/services). Correcting mistakes may not be possible or may take a long time.
 
+We allow API breaking changes in these cases:
+
+- During incremental development of a new feature (multiple PRs). The new part of the API should be
+  documented as _"WorkInProgress - Why/When is it ready"_. A new API should not stay "open" for a
+  long time.
+- Deprecated features can be removed after 2 years (4 minor releases) unless a user wants to keep 
+  it. We will revert a removal if the request to keep it comes after the feature is removed.


### PR DESCRIPTION
### Summary

This adds a policy for doing breaking-changes to the API. This is just a suggestion, we will discuss the details in
a developer meeting 

Ref: #6540

### Issue

No.

### Unit tests

Doc only

### Documentation

Yes.

### Changelog

No

### Bumping the serialization version id

No