### PR TITLE
Handle duration tags for elevators in the same way as for escalators

### DIFF
--- a/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
@@ -318,6 +318,10 @@ public class OsmEntity {
     return Optional.empty();
   }
 
+  public Optional<Duration> getDuration(Consumer<String> errorHandler) {
+    return getTagValueAsDuration("duration", errorHandler);
+  }
+
   /**
    * Some tags are allowed to have values like 55, "true" or "false".
    * <p>

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmWay.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmWay.java
@@ -133,10 +133,6 @@ public class OsmWay extends OsmEntity {
     return (isTag("highway", "steps") && isOneOfTags("conveying", ESCALATOR_CONVEYING_TAGS));
   }
 
-  public Optional<Duration> getDuration(Consumer<String> errorHandler) {
-    return getTagValueAsDuration("duration", errorHandler);
-  }
-
   public boolean isForwardEscalator() {
     return isEscalator() && "forward".equals(this.getTag("conveying"));
   }

--- a/application/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
@@ -98,6 +98,10 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     return permission;
   }
 
+  public int getTravelTime() {
+    return travelTime;
+  }
+
   @Override
   public State[] traverse(State s0) {
     RoutingPreferences preferences = s0.getPreferences();

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/BoardingLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/BoardingLocationTest.java
@@ -16,7 +16,7 @@ import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepo
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 
-public class BoardingLocationTest {
+class BoardingLocationTest {
 
   /**
    * There is a one-way road which is also marked as a platform in Sky Campus which crashed OSM.

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/ElevatorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/ElevatorTest.java
@@ -1,0 +1,67 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.graph_builder.module.osm.moduletests._support.NodeBuilder.node;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.graph_builder.module.osm.OsmModule;
+import org.opentripplanner.graph_builder.module.osm.moduletests._support.TestOsmProvider;
+import org.opentripplanner.osm.model.OsmWay;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
+import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
+import org.opentripplanner.street.model.edge.ElevatorHopEdge;
+import org.opentripplanner.transit.model.framework.Deduplicator;
+
+class ElevatorTest {
+
+  @Test
+  void testDuration() {
+    var way = new OsmWay();
+    way.addTag("duration", "00:01:02");
+    way.addTag("highway", "elevator");
+    var provider = TestOsmProvider.of().addWay(way).build();
+    var graph = new Graph(new Deduplicator());
+    var osmModule = OsmModule.of(
+      provider,
+      graph,
+      new DefaultOsmInfoGraphBuildRepository(),
+      new DefaultVehicleParkingRepository()
+    ).build();
+    osmModule.buildGraph();
+    var edges = graph.getEdgesOfType(ElevatorHopEdge.class);
+    assertThat(edges).hasSize(2);
+    for (var edge : edges) {
+      assertEquals(62, edge.getTravelTime());
+    }
+  }
+
+  @Test
+  void testMultilevelNodeDuration() {
+    var node0 = node(0, new WgsCoordinate(0, 0));
+    var node1 = node(1, new WgsCoordinate(2, 0));
+    var node = node(2, new WgsCoordinate(1, 0));
+    node.addTag("duration", "00:01:02");
+    node.addTag("highway", "elevator");
+    node.addTag("level", "1;2");
+    var provider = TestOsmProvider.of()
+      .addWayFromNodes(way -> way.addTag("level", "1"), node0, node)
+      .addWayFromNodes(way -> way.addTag("level", "2"), node1, node)
+      .build();
+    var graph = new Graph(new Deduplicator());
+    var osmModule = OsmModule.of(
+      provider,
+      graph,
+      new DefaultOsmInfoGraphBuildRepository(),
+      new DefaultVehicleParkingRepository()
+    ).build();
+    osmModule.buildGraph();
+    var edges = graph.getEdgesOfType(ElevatorHopEdge.class);
+    assertThat(edges).hasSize(2);
+    for (var edge : edges) {
+      assertEquals(62, edge.getTravelTime());
+    }
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/TestOsmProvider.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/TestOsmProvider.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.graph_builder.module.osm.OsmDatabase;
 import org.opentripplanner.osm.OsmProvider;
@@ -127,6 +128,18 @@ public class TestOsmProvider implements OsmProvider {
       way.addTag("highway", "pedestrian");
       way.getNodeRefs().addAll(nodeIds);
 
+      this.ways.add(way);
+      return this;
+    }
+
+    public Builder addWayFromNodes(Consumer<OsmWay> wayConsumer, OsmNode... nodes) {
+      this.nodes.addAll(Arrays.stream(nodes).toList());
+      var nodeIds = Arrays.stream(nodes).map(OsmEntity::getId).toList();
+      var way = new OsmWay();
+      way.setId(counter.incrementAndGet());
+      way.addTag("highway", "pedestrian");
+      wayConsumer.accept(way);
+      way.getNodeRefs().addAll(nodeIds);
       this.ways.add(way);
       return this;
     }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/TestOsmProvider.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/_support/TestOsmProvider.java
@@ -120,32 +120,27 @@ public class TestOsmProvider implements OsmProvider {
     }
 
     public Builder addWayFromNodes(long id, List<OsmNode> nodes) {
-      this.nodes.addAll(nodes);
-      var nodeIds = nodes.stream().map(OsmEntity::getId).toList();
-
-      var way = new OsmWay();
-      way.setId(id);
-      way.addTag("highway", "pedestrian");
-      way.getNodeRefs().addAll(nodeIds);
-
-      this.ways.add(way);
-      return this;
+      return addWayFromNodes(way -> {}, id, nodes);
     }
 
     public Builder addWayFromNodes(Consumer<OsmWay> wayConsumer, OsmNode... nodes) {
-      this.nodes.addAll(Arrays.stream(nodes).toList());
-      var nodeIds = Arrays.stream(nodes).map(OsmEntity::getId).toList();
-      var way = new OsmWay();
-      way.setId(counter.incrementAndGet());
-      way.addTag("highway", "pedestrian");
-      wayConsumer.accept(way);
-      way.getNodeRefs().addAll(nodeIds);
-      this.ways.add(way);
-      return this;
+      return addWayFromNodes(wayConsumer, counter.incrementAndGet(), List.of(nodes));
     }
 
     public Builder addRelation(OsmRelation relation) {
       this.relations.add(relation);
+      return this;
+    }
+
+    private Builder addWayFromNodes(Consumer<OsmWay> wayConsumer, long id, List<OsmNode> nodes) {
+      this.nodes.addAll(nodes);
+      var nodeIds = nodes.stream().map(OsmEntity::getId).toList();
+      var way = new OsmWay();
+      way.setId(id);
+      way.addTag("highway", "pedestrian");
+      wayConsumer.accept(way);
+      way.getNodeRefs().addAll(nodeIds);
+      this.ways.add(way);
       return this;
     }
   }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/SimpleAreaTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/SimpleAreaTest.java
@@ -16,7 +16,7 @@ import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.test.support.GeoJsonIo;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 
-public class SimpleAreaTest {
+class SimpleAreaTest {
 
   @Test
   void walkableArea() {

--- a/application/src/test/java/org/opentripplanner/street/model/edge/ElevatorHopEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/ElevatorHopEdgeTest.java
@@ -1,10 +1,8 @@
 package org.opentripplanner.street.model.edge;
 
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.graph_builder.module.osm.moduletests._support.NodeBuilder.node;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
 
 import java.util.stream.Stream;
@@ -12,22 +10,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opentripplanner.framework.geometry.WgsCoordinate;
-import org.opentripplanner.graph_builder.module.osm.OsmModule;
-import org.opentripplanner.graph_builder.module.osm.moduletests._support.TestOsmProvider;
-import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.AccessibilityPreferences;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
-import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.transit.model.basic.Accessibility;
-import org.opentripplanner.transit.model.framework.Deduplicator;
 
 class ElevatorHopEdgeTest {
 
@@ -88,66 +78,6 @@ class ElevatorHopEdgeTest {
     assertEquals(expectedCost, wheelchairResult.weight);
   }
 
-  private State[] traverse(Accessibility wheelchair, StreetSearchRequest req) {
-    var edge = ElevatorHopEdge.createElevatorHopEdge(
-      from,
-      to,
-      StreetTraversalPermission.ALL,
-      wheelchair
-    );
-    var state = new State(from, req);
-
-    return edge.traverse(state);
-  }
-
-  @Test
-  void testDuration() {
-    var way = new OsmWay();
-    way.addTag("duration", "00:01:02");
-    way.addTag("highway", "elevator");
-    var provider = TestOsmProvider.of().addWay(way).build();
-    var graph = new Graph(new Deduplicator());
-    var osmModule = OsmModule.of(
-      provider,
-      graph,
-      new DefaultOsmInfoGraphBuildRepository(),
-      new DefaultVehicleParkingRepository()
-    ).build();
-    osmModule.buildGraph();
-    var edges = graph.getEdgesOfType(ElevatorHopEdge.class);
-    assertThat(edges).hasSize(2);
-    for (var edge : edges) {
-      assertThat(edge.getTravelTime()).isEqualTo(62);
-    }
-  }
-
-  @Test
-  void testMultilevelNodeDuration() {
-    var node0 = node(0, new WgsCoordinate(0, 0));
-    var node1 = node(1, new WgsCoordinate(2, 0));
-    var node = node(2, new WgsCoordinate(1, 0));
-    node.addTag("duration", "00:01:02");
-    node.addTag("highway", "elevator");
-    node.addTag("level", "1;2");
-    var provider = TestOsmProvider.of()
-      .addWayFromNodes(way -> way.addTag("level", "1"), node0, node)
-      .addWayFromNodes(way -> way.addTag("level", "2"), node1, node)
-      .build();
-    var graph = new Graph(new Deduplicator());
-    var osmModule = OsmModule.of(
-      provider,
-      graph,
-      new DefaultOsmInfoGraphBuildRepository(),
-      new DefaultVehicleParkingRepository()
-    ).build();
-    osmModule.buildGraph();
-    var edges = graph.getEdgesOfType(ElevatorHopEdge.class);
-    assertThat(edges).hasSize(2);
-    for (var edge : edges) {
-      assertThat(edge.getTravelTime()).isEqualTo(62);
-    }
-  }
-
   @Test
   void testTraversal() {
     var edge = ElevatorHopEdge.createElevatorHopEdge(
@@ -160,6 +90,18 @@ class ElevatorHopEdgeTest {
     );
     var req = StreetSearchRequest.of().withMode(StreetMode.WALK);
     var res = edge.traverse(new State(from, req.build()))[0];
-    assertThat(res.getTimeDeltaMilliseconds()).isEqualTo(62_000);
+    assertEquals(62_000, res.getTimeDeltaMilliseconds());
+  }
+
+  private State[] traverse(Accessibility wheelchair, StreetSearchRequest req) {
+    var edge = ElevatorHopEdge.createElevatorHopEdge(
+      from,
+      to,
+      StreetTraversalPermission.ALL,
+      wheelchair
+    );
+    var state = new State(from, req);
+
+    return edge.traverse(state);
   }
 }


### PR DESCRIPTION
### Summary

Elevators can now also have a hh:mm:ss format duration tag in OSM, and we recognize them.

### Issue

The way we handled elevator duration tags was against OSM data spec.

### Unit tests

The OsmProcessors are hard to test, and because of that are undertested. I added one here.

### Changelog

Yes.

### Bumping the serialization version id

Yes.