### PR TITLE
Fix NPEs when processing FaresV2 feeds

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -310,7 +310,7 @@ public class GtfsModule implements GraphBuilderModule {
   private GtfsMutableRelationalDao loadBundle(GtfsBundle gtfsBundle) throws IOException {
     StoreImpl store = new StoreImpl(new GtfsRelationalDaoImpl());
     store.open();
-    LOG.info("reading {}", gtfsBundle.toString());
+    LOG.info("reading {}", gtfsBundle);
 
     GtfsFeedId gtfsFeedId = gtfsBundle.getFeedId();
 
@@ -388,9 +388,15 @@ public class GtfsModule implements GraphBuilderModule {
       fareProduct.getId().setAgencyId(reader.getDefaultAgencyId());
     }
     for (var transferRule : store.getAllEntitiesForType(FareTransferRule.class)) {
-      transferRule.getFareProductId().setAgencyId(reader.getDefaultAgencyId());
-      transferRule.getFromLegGroupId().setAgencyId(reader.getDefaultAgencyId());
-      transferRule.getToLegGroupId().setAgencyId(reader.getDefaultAgencyId());
+      if (transferRule.getFareProductId() != null) {
+        transferRule.getFareProductId().setAgencyId(reader.getDefaultAgencyId());
+      }
+      if (transferRule.getFromLegGroupId() != null) {
+        transferRule.getFromLegGroupId().setAgencyId(reader.getDefaultAgencyId());
+      }
+      if (transferRule.getToLegGroupId() != null) {
+        transferRule.getToLegGroupId().setAgencyId(reader.getDefaultAgencyId());
+      }
     }
     for (var transferRule : store.getAllEntitiesForType(FareLegRule.class)) {
       transferRule.getFareProductId().setAgencyId(reader.getDefaultAgencyId());

--- a/application/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
@@ -14,7 +14,6 @@ import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.impl.CalendarServiceImpl;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.StopTransferPriority;
 import org.opentripplanner.transit.service.SiteRepository;
@@ -69,24 +68,8 @@ public class GtfsContextBuilder {
     return transitBuilder;
   }
 
-  public GtfsContextBuilder withIssueStoreAndDeduplicator(Graph graph) {
-    return withIssueStoreAndDeduplicator(graph, DataImportIssueStore.NOOP);
-  }
-
-  public GtfsContextBuilder withIssueStoreAndDeduplicator(
-    Graph graph,
-    DataImportIssueStore issueStore
-  ) {
-    return withDataImportIssueStore(issueStore).withDeduplicator(graph.deduplicator);
-  }
-
   public GtfsContextBuilder withDataImportIssueStore(DataImportIssueStore issueStore) {
     this.issueStore = issueStore;
-    return this;
-  }
-
-  private GtfsContextBuilder withDeduplicator(Deduplicator deduplicator) {
-    this.deduplicator = deduplicator;
     return this;
   }
 

--- a/application/src/test/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.graph_builder.module;
+package org.opentripplanner.gtfs.graphbuilder;
 
 import static graphql.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,8 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.ConstantsForTests;
-import org.opentripplanner.gtfs.graphbuilder.GtfsBundle;
-import org.opentripplanner.gtfs.graphbuilder.GtfsModule;
+import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;


### PR DESCRIPTION
### Summary

GTFS Fares V2 allows you to leave out the field `fare_product_id`, `from_leg_group_id`, `to_leg_group_id`, however when you do so exceptions are thrown during graph building.

This PR fixes it.

cc @miles-grant-ibigroup 

### Issue

n/a

### Unit tests

I would like to add some but I would have to refactor `GtfsModule` quite a bit. Given that Thomas is working on the same classes I will defer that to another PR.

There is a tiny bit of clean up of the test code.

### Documentation

n/a