### PR TITLE
Add unit tests for parsing one-day NeTEx operating periods

### DIFF
--- a/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
@@ -182,6 +182,33 @@ class DayTypeAssignmentMapperTest {
   }
 
   @Test
+  void mapDayTypesToLocalDatesWithOneDayPeriod() {
+    // GIVEN
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+
+    {
+      // From 2020-11-01 to 2020-11-01 inclusive
+      dayTypes.add(createDayType(DAY_TYPE_1, EVERYDAY));
+      periods.add(createOperatingPeriod(OP_1, D2020_11_01, D2020_11_01));
+      assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+    }
+
+    // WHEN - create calendar
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      EMPTY_OPERATING_DAYS,
+      periods,
+      null
+    );
+
+    // THEN - verify
+    assertEquals("[2020-11-01]", toStr(result, DAY_TYPE_1));
+  }
+
+  @Test
   void mapDayTypesToLocalDatesWithOperatingDays() {
     // GIVEN
     var dayTypes = new HierarchicalMapById<DayType>();
@@ -207,6 +234,35 @@ class DayTypeAssignmentMapperTest {
 
     // THEN - verify
     assertEquals("[2020-11-01, 2020-11-02, 2020-11-03]", toStr(result, DAY_TYPE_1));
+  }
+
+  @Test
+  void mapDayTypesToLocalDatesWithOneDayOperatingPeriodWithOperatingDays() {
+    // GIVEN
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+    var operatingDays = new HierarchicalMapById<OperatingDay>();
+
+    // From 2020-11-01 to 2020-11-01 inclusive
+    operatingDays.add(createOperatingDay(OPERATING_DAY_1, D2020_11_01));
+    operatingDays.add(createOperatingDay(OPERATING_DAY_2, D2020_11_01));
+    periods.add(createOperatingPeriodWithOperatingDays(OP_1, OPERATING_DAY_1, OPERATING_DAY_2));
+    dayTypes.add(createDayType(DAY_TYPE_1, EVERYDAY));
+
+    assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+
+    // WHEN - create calendar
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      operatingDays,
+      periods,
+      null
+    );
+
+    // THEN - verify
+    assertEquals("[2020-11-01]", toStr(result, DAY_TYPE_1));
   }
 
   @Test


### PR DESCRIPTION
### Summary

This PR adds unit tests for parsing a NeTEx operating period whose From and To dates are identical.
OTP maps this as a period containing exactly one operating day.
This is true both for periods specified with `<FromDate>` and `<ToDate>` and periods specified with `<FromDateRef>` and `<ToDateRef>`

The Nordic NeTEx profile specifies that the end date of an operating period should be considered inclusive
https://enturas.atlassian.net/wiki/spaces/PUBLIC/pages/728727624/framework#OperatingPeriod

When the operating period is specified with `<FromDate>` and `<ToDate>`, the time component of the DateTime is ignored. 



### Issue

No

### Unit tests

Added unit tests

### Documentation

No

