### PR TITLE
Rename FilterValues implementations, make them package-private

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/filter/FilterMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/filter/FilterMapperTest.java
@@ -74,7 +74,7 @@ class FilterMapperTest {
     assertEquals(expected, actual);
 
     assertEquals(
-      "TripRequest{includeAgencies: FilterValuesNullIsEverything{name: 'includeAgencies', values: [F:a1]}, includeRoutes: FilterValuesNullIsEverything{name: 'includeRoutes', values: [F:r1]}, excludeAgencies: FilterValuesEmptyIsEverything{name: 'excludedAgencies', values: [F:a1]}, excludeRoutes: FilterValuesEmptyIsEverything{name: 'excludedRoutes', values: [F:r1]}, includeNetexInternalPlanningCodes: FilterValuesNullIsEverything{name: 'includeNetexInternalPlanningCodes'}, includeServiceDates: FilterValuesNullIsEverything{name: 'includeServiceDates'}}",
+      "TripRequest{includeAgencies: NullIsEverythingFilter{name: 'includeAgencies', values: [F:a1]}, includeRoutes: NullIsEverythingFilter{name: 'includeRoutes', values: [F:r1]}, excludeAgencies: EmptyIsEverythingFilter{name: 'excludedAgencies', values: [F:a1]}, excludeRoutes: EmptyIsEverythingFilter{name: 'excludedRoutes', values: [F:r1]}, includeNetexInternalPlanningCodes: NullIsEverythingFilter{name: 'includeNetexInternalPlanningCodes'}, includeServiceDates: NullIsEverythingFilter{name: 'includeServiceDates'}}",
       actual.toString()
     );
   }

--- a/application/src/main/java/org/opentripplanner/transit/api/model/EmptyIsEverythingFilter.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/model/EmptyIsEverythingFilter.java
@@ -3,12 +3,12 @@ package org.opentripplanner.transit.api.model;
 import java.util.Collection;
 
 /**
- * {@link FilterValuesEmptyIsEverything} is a subclass of {@link FilterValues} that includes
+ * {@link EmptyIsEverythingFilter} is a subclass of {@link FilterValues} that includes
  * everything if the values are null or empty.
  */
-public class FilterValuesEmptyIsEverything<E> extends FilterValues<E> {
+class EmptyIsEverythingFilter<E> extends FilterValues<E> {
 
-  FilterValuesEmptyIsEverything(String name, Collection<E> values) {
+  EmptyIsEverythingFilter(String name, Collection<E> values) {
     super(name, values);
   }
 
@@ -19,6 +19,6 @@ public class FilterValuesEmptyIsEverything<E> extends FilterValues<E> {
 
   @Override
   public boolean equals(Object obj) {
-    return obj instanceof FilterValuesEmptyIsEverything<?> && super.equals(obj);
+    return obj instanceof EmptyIsEverythingFilter<?> && super.equals(obj);
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/api/model/FilterValues.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/model/FilterValues.java
@@ -41,7 +41,7 @@ public abstract class FilterValues<E> {
     String name,
     @Nullable Collection<E> values
   ) {
-    return new FilterValuesEmptyIsEverything<>(name, values);
+    return new EmptyIsEverythingFilter<>(name, values);
   }
 
   /**
@@ -56,7 +56,7 @@ public abstract class FilterValues<E> {
     String name,
     @Nullable Collection<E> values
   ) {
-    return new FilterValuesNullIsEverything<>(name, values);
+    return new NullIsEverythingFilter<>(name, values);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/api/model/NullIsEverythingFilter.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/model/NullIsEverythingFilter.java
@@ -3,12 +3,12 @@ package org.opentripplanner.transit.api.model;
 import java.util.Collection;
 
 /**
- * {@link FilterValuesNullIsEverything} is a subclass of {@link FilterValues} that
+ * {@link NullIsEverythingFilter} is a subclass of {@link FilterValues} that
  * includes everything only if the values collection is null.
  */
-public class FilterValuesNullIsEverything<E> extends FilterValues<E> {
+class NullIsEverythingFilter<E> extends FilterValues<E> {
 
-  FilterValuesNullIsEverything(String name, Collection<E> values) {
+  NullIsEverythingFilter(String name, Collection<E> values) {
     super(name, values);
   }
 

--- a/application/src/main/java/org/opentripplanner/transit/api/model/RequiredFilterValues.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/model/RequiredFilterValues.java
@@ -1,14 +1,15 @@
 package org.opentripplanner.transit.api.model;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 
 /**
  * {@link RequiredFilterValues} is a subclass of {@link FilterValues} that requires at least one
  * value to be included.
  */
-public class RequiredFilterValues<E> extends FilterValues<E> {
+class RequiredFilterValues<E> extends FilterValues<E> {
 
-  RequiredFilterValues(String name, Collection<E> values) {
+  RequiredFilterValues(String name, @Nullable Collection<E> values) {
     super(name, values);
     if (values == null || values.isEmpty()) {
       throw new IllegalArgumentException("Filter %s values must not be empty.".formatted(name));

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.transit.api.request;
 
 import java.time.LocalDate;
 import org.opentripplanner.transit.api.model.FilterValues;
-import org.opentripplanner.transit.api.model.RequiredFilterValues;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
@@ -24,7 +23,7 @@ public class TripOnServiceDateRequest {
   private final FilterValues<TripAlteration> alterations;
 
   TripOnServiceDateRequest(
-    RequiredFilterValues<LocalDate> serviceDates,
+    FilterValues<LocalDate> serviceDates,
     FilterValues<FeedScopedId> agencies,
     FilterValues<FeedScopedId> routes,
     FilterValues<FeedScopedId> serviceJourneys,
@@ -41,7 +40,7 @@ public class TripOnServiceDateRequest {
     this.alterations = alterations;
   }
 
-  public static TripOnServiceDateRequestBuilder of(RequiredFilterValues<LocalDate> serviceDates) {
+  public static TripOnServiceDateRequestBuilder of(FilterValues<LocalDate> serviceDates) {
     return new TripOnServiceDateRequestBuilder(serviceDates);
   }
 

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
@@ -3,7 +3,6 @@ package org.opentripplanner.transit.api.request;
 import java.time.LocalDate;
 import java.util.List;
 import org.opentripplanner.transit.api.model.FilterValues;
-import org.opentripplanner.transit.api.model.RequiredFilterValues;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
 
@@ -30,9 +29,9 @@ public class TripOnServiceDateRequestBuilder {
     "alterations",
     List.of()
   );
-  private final RequiredFilterValues<LocalDate> serviceDates;
+  private final FilterValues<LocalDate> serviceDates;
 
-  TripOnServiceDateRequestBuilder(RequiredFilterValues<LocalDate> serviceDates) {
+  TripOnServiceDateRequestBuilder(FilterValues<LocalDate> serviceDates) {
     this.serviceDates = serviceDates;
   }
 

--- a/application/src/test/java/org/opentripplanner/transit/api/model/EmptyIsEverythingFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/api/model/EmptyIsEverythingFilterTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class FilterValuesEmptyIsEverythingTest {
+public class EmptyIsEverythingFilterTest {
 
   @Test
   void testEmptyIncludeEverything() {


### PR DESCRIPTION
### Summary

In #6421 @t2gran has requested that the implementations of `FilterValues` be renamed and they be made package private. I changed it in this PR.