### PR TITLE
 Boarding location linking accepts very short links instead of throwing an exception

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -656,6 +656,9 @@ public class VertexLinker {
           )
           .findFirst();
         if (!nearest.isPresent()) {
+          /* This can happen when all (probably the single one) visibility points are very close
+	       to the linked vertex. Such situatin can arise in boarding location linking which skips
+	       the snapping logic of normal linking and calls addPermanentAreaVertex directly */
           nearest = areaGroup.visibilityVertices().stream().findFirst();
         }
         if (nearest.isPresent()) {

--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -654,9 +654,13 @@ public class VertexLinker {
           .filter(v -> distSquared(v, newVertex) >= DUPLICATE_NODE_EPSILON_DEGREES_SQUARED)
           .sorted((v1, v2) -> Double.compare(distSquared(v1, newVertex), distSquared(v2, newVertex))
           )
-          .findFirst()
-          .get();
-        return addVisibilityEdges(newVertex, nearest, areaGroup, scope, tempEdges, true);
+          .findFirst();
+        if (!nearest.isPresent()) {
+          nearest = areaGroup.visibilityVertices().stream().findFirst();
+        }
+        if (nearest.isPresent()) {
+          return addVisibilityEdges(newVertex, nearest.get(), areaGroup, scope, tempEdges, true);
+        }
       }
       return false;
     } else if (scope == Scope.PERMANENT) {

--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -656,9 +656,9 @@ public class VertexLinker {
           )
           .findFirst();
         if (!nearest.isPresent()) {
-          /* This can happen when all (probably the single one) visibility points are very close
-	       to the linked vertex. Such situatin can arise in boarding location linking which skips
-	       the snapping logic of normal linking and calls addPermanentAreaVertex directly */
+          // This can happen when all (probably the single one) visibility points are very close
+          // to the linked vertex. Such situation can arise in boarding location linking which skips
+          // the snapping logic of normal linking and calls addPermanentAreaVertex directly
           nearest = areaGroup.visibilityVertices().stream().findFirst();
         }
         if (nearest.isPresent()) {

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
@@ -214,6 +214,43 @@ public class LinkStopToPlatformTest {
   }
 
   /**
+   * Link an interior vertex which is very close to a visibility vertex by
+   * calling directly addPermanentAreaVertex used in boarding location linking
+   * A connecting edge pair is created despite of the small distance
+   */
+  @Test
+  void testAddPermanentAreaVertex() {
+    Coordinate[] platform = {
+      new Coordinate(10, 60.002),
+      new Coordinate(10.004, 60.002),
+      new Coordinate(10.004, 60),
+      new Coordinate(10, 60),
+    };
+    // add one entrance to bottom left corner
+    int[] visibilityPoints = { 3 };
+
+    // No stops
+    Coordinate[] stops = {};
+
+    Graph graph = prepareTest(platform, visibilityPoints, stops);
+
+    // dig up the AreaGroup
+    AreaGroup ag = null;
+    var edge = graph.getEdges().stream().findFirst().get();
+    if (edge instanceof AreaEdge ae) {
+      ag = ae.getArea();
+    }
+    assertNotNull(ag);
+
+    var vertexFactory = new VertexFactory(graph);
+    var v = vertexFactory.intersection("boardingLocation", 10.00000001, 60.00000001);
+    graph.getLinker().addPermanentAreaVertex(v, ag);
+
+    // vertex links to the single visibility point with 2 edges
+    assertEquals(10, graph.getEdges().size());
+  }
+
+  /**
    * Link a stop which is inside an area and very close to its edge.
    * Linking snaps directly to the edge without short connecting edges
    */

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
@@ -28,6 +28,7 @@ import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.LabelledIntersectionVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.model.vertex.VertexFactory;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
 import org.opentripplanner.test.support.GeoJsonIo;
@@ -46,14 +47,15 @@ public class LinkStopToPlatformTest {
     var deduplicator = new Deduplicator();
     var siteRepository = new SiteRepository();
     Graph graph = new Graph(deduplicator);
+    var vertexFactory = new VertexFactory(graph);
+
     var timetableRepository = new TimetableRepository(siteRepository, deduplicator);
     ArrayList<IntersectionVertex> vertices = new ArrayList<>();
     Coordinate[] closedGeom = new Coordinate[platform.length + 1];
 
     for (int i = 0; i < platform.length; i++) {
       Coordinate c = platform[i];
-      var vertex = new LabelledIntersectionVertex(String.valueOf(i), c.x, c.y, false, false);
-      graph.addVertex(vertex);
+      var vertex = vertexFactory.intersection(String.valueOf(i), c.x, c.y);
       vertices.add(vertex);
       closedGeom[i] = c;
     }
@@ -109,8 +111,7 @@ public class LinkStopToPlatformTest {
     graph.index(timetableRepository.getSiteRepository());
 
     for (RegularStop s : transitStops) {
-      var v = TransitStopVertex.of().withStop(s).build();
-      graph.addVertex(v);
+      vertexFactory.transitStop(TransitStopVertex.of().withStop(s));
     }
 
     return graph;


### PR DESCRIPTION
### Summary

VertexLinker no longer assumes that a non-overlapping area visibility vertex is found.

### Issue

Closes #6596 

### Unit tests

Unit test to verify the regression fix added.

