### PR TITLE
Don't use bicycle as street routing mode when car or scooter rental is requested

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/StreetModeToRentalTraverseModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/StreetModeToRentalTraverseModeMapper.java
@@ -1,0 +1,27 @@
+package org.opentripplanner.routing.algorithm.mapping;
+
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.street.search.TraverseMode;
+
+public class StreetModeToRentalTraverseModeMapper {
+
+  /**
+   * Maps street mode to rental traverse mode (i.e. CAR_RENTAL -> CAR).
+   */
+  public static TraverseMode map(StreetMode mode) {
+    return switch (mode) {
+      case BIKE_RENTAL -> TraverseMode.BICYCLE;
+      case SCOOTER_RENTAL -> TraverseMode.SCOOTER;
+      case CAR_RENTAL -> TraverseMode.CAR;
+      case NOT_SET,
+        WALK,
+        BIKE,
+        BIKE_TO_PARK,
+        CAR,
+        CAR_TO_PARK,
+        CAR_PICKUP,
+        CAR_HAILING,
+        FLEXIBLE -> throw new IllegalArgumentException("%s is not a rental mode.".formatted(mode));
+    };
+  }
+}

--- a/application/src/main/java/org/opentripplanner/street/search/state/StateData.java
+++ b/application/src/main/java/org/opentripplanner/street/search/state/StateData.java
@@ -8,6 +8,7 @@ import static org.opentripplanner.street.search.state.VehicleRentalState.RENTING
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.opentripplanner.routing.algorithm.mapping.StreetModeToRentalTraverseModeMapper;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.street.search.TraverseMode;
@@ -157,17 +158,18 @@ public class StateData implements Cloneable {
     //   - BEFORE_RENTING
     else if (requestMode.includesRenting()) {
       if (arriveBy) {
+        var vehicleMode = StreetModeToRentalTraverseModeMapper.map(requestMode);
         if (allowArrivingInRentedVehicleAtDestination) {
           var keptVehicleStateData = proto.clone();
           keptVehicleStateData.vehicleRentalState = RENTING_FROM_STATION;
-          keptVehicleStateData.currentMode = TraverseMode.BICYCLE;
+          keptVehicleStateData.currentMode = vehicleMode;
           keptVehicleStateData.mayKeepRentedVehicleAtDestination = true;
           res.add(keptVehicleStateData);
         }
         var floatingRentalStateData = proto.clone();
         floatingRentalStateData.vehicleRentalState = RENTING_FLOATING;
         floatingRentalStateData.rentalVehicleFormFactor = toFormFactor(requestMode);
-        floatingRentalStateData.currentMode = TraverseMode.BICYCLE;
+        floatingRentalStateData.currentMode = vehicleMode;
         res.add(floatingRentalStateData);
         var stationReturnedStateData = proto.clone();
         stationReturnedStateData.vehicleRentalState = HAVE_RENTED;

--- a/application/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/application/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -2,6 +2,7 @@ package org.opentripplanner.street.search.state;
 
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.opentripplanner.routing.algorithm.mapping.StreetModeToRentalTraverseModeMapper;
 import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -324,7 +325,7 @@ public class StateEditor {
       child.stateData.vehicleRentalState = VehicleRentalState.RENTING_FLOATING;
       child.stateData.currentMode = formFactor != null
         ? formFactor.traverseMode
-        : TraverseMode.BICYCLE;
+        : StreetModeToRentalTraverseModeMapper.map(child.getRequest().mode());
       child.stateData.vehicleRentalNetwork = network;
       child.stateData.rentalVehicleFormFactor = formFactor;
     } else {

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
 import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdge;
-import static org.opentripplanner.street.search.TraverseMode.BICYCLE;
 import static org.opentripplanner.street.search.TraverseMode.SCOOTER;
 import static org.opentripplanner.street.search.TraverseMode.WALK;
 import static org.opentripplanner.street.search.state.VehicleRentalState.HAVE_RENTED;
@@ -224,7 +223,7 @@ class StreetEdgeGeofencingTest {
       // we want to pick up a vehicle
       final State rentalState = states[1];
       assertEquals(RENTING_FLOATING, rentalState.getVehicleRentalState());
-      assertEquals(BICYCLE, rentalState.currentMode());
+      assertEquals(SCOOTER, rentalState.currentMode());
 
       // but also keep on walking in case we don't find an edge where to leave the vehicle
       var walkingState = states[0];
@@ -257,7 +256,7 @@ class StreetEdgeGeofencingTest {
       // then the speculative renting case for unknown rental network
       final State speculativeRenting = states[2];
       assertEquals(RENTING_FLOATING, speculativeRenting.getVehicleRentalState());
-      assertEquals(BICYCLE, speculativeRenting.currentMode());
+      assertEquals(SCOOTER, speculativeRenting.currentMode());
       // null means that the vehicle has been rented speculatively and the rest of the backwards search
       // needs to check if we really find a vehicle to pick up
       assertNull(speculativeRenting.getVehicleRentalNetwork());
@@ -269,7 +268,7 @@ class StreetEdgeGeofencingTest {
       // then the speculative renting cases for specific rental networks
       final State tierState = states[1];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
-      assertEquals(BICYCLE, tierState.currentMode());
+      assertEquals(SCOOTER, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
       assertEquals(Set.of(), tierState.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
     }
@@ -286,7 +285,7 @@ class StreetEdgeGeofencingTest {
 
       final State unknownNetworkState = states[3];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
-      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertEquals(SCOOTER, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
       final State tierState = Arrays.stream(states)
@@ -294,14 +293,14 @@ class StreetEdgeGeofencingTest {
         .findFirst()
         .get();
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
-      assertEquals(BICYCLE, tierState.currentMode());
+      assertEquals(SCOOTER, tierState.currentMode());
 
       final State birdState = Arrays.stream(states)
         .filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork()))
         .findFirst()
         .get();
       assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
-      assertEquals(BICYCLE, birdState.currentMode());
+      assertEquals(SCOOTER, birdState.currentMode());
     }
 
     @Test
@@ -316,7 +315,7 @@ class StreetEdgeGeofencingTest {
 
       final State unknownNetworkState = states[3];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
-      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertEquals(SCOOTER, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
       final State tierState = Arrays.stream(states)
@@ -324,14 +323,14 @@ class StreetEdgeGeofencingTest {
         .findFirst()
         .get();
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
-      assertEquals(BICYCLE, tierState.currentMode());
+      assertEquals(SCOOTER, tierState.currentMode());
 
       final State birdState = Arrays.stream(states)
         .filter(s -> NETWORK_BIRD.equals(s.getVehicleRentalNetwork()))
         .findFirst()
         .get();
       assertEquals(RENTING_FLOATING, birdState.getVehicleRentalState());
-      assertEquals(BICYCLE, birdState.currentMode());
+      assertEquals(SCOOTER, birdState.currentMode());
     }
 
     @Test
@@ -346,12 +345,12 @@ class StreetEdgeGeofencingTest {
 
       final State unknownNetworkState = states[2];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
-      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertEquals(SCOOTER, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
       final State tierState = states[1];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
-      assertEquals(BICYCLE, tierState.currentMode());
+      assertEquals(SCOOTER, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
     }
 
@@ -380,12 +379,12 @@ class StreetEdgeGeofencingTest {
 
       final State unknownNetworkState = states[2];
       assertEquals(RENTING_FLOATING, unknownNetworkState.getVehicleRentalState());
-      assertEquals(BICYCLE, unknownNetworkState.currentMode());
+      assertEquals(SCOOTER, unknownNetworkState.currentMode());
       assertNull(unknownNetworkState.getVehicleRentalNetwork());
 
       final State tierState = states[1];
       assertEquals(RENTING_FLOATING, tierState.getVehicleRentalState());
-      assertEquals(BICYCLE, tierState.currentMode());
+      assertEquals(SCOOTER, tierState.currentMode());
       assertEquals(NETWORK_TIER, tierState.getVehicleRentalNetwork());
     }
 
@@ -416,7 +415,7 @@ class StreetEdgeGeofencingTest {
     private static StreetSearchRequest defaultArriveByRequest() {
       return StreetSearchRequest.of()
         .withPreferences(p ->
-          p.withBike(b -> b.withRental(r -> r.withAllowedNetworks(Set.of(NETWORK_TIER))))
+          p.withScooter(b -> b.withRental(r -> r.withAllowedNetworks(Set.of(NETWORK_TIER))))
         )
         .withMode(StreetMode.SCOOTER_RENTAL)
         .withArriveBy(true)
@@ -429,7 +428,7 @@ class StreetEdgeGeofencingTest {
     ) {
       return StreetSearchRequest.of()
         .withPreferences(p ->
-          p.withBike(b ->
+          p.withScooter(b ->
             b.withRental(r ->
               r.withAllowedNetworks(allowedNetworks).withBannedNetworks(bannedNetworks)
             )

--- a/application/src/test/java/org/opentripplanner/street/search/state/StateTest.java
+++ b/application/src/test/java/org/opentripplanner/street/search/state/StateTest.java
@@ -16,6 +16,7 @@ import static org.opentripplanner.routing.api.request.StreetMode.SCOOTER_RENTAL;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
 import static org.opentripplanner.street.search.TraverseMode.BICYCLE;
 import static org.opentripplanner.street.search.TraverseMode.CAR;
+import static org.opentripplanner.street.search.TraverseMode.SCOOTER;
 import static org.opentripplanner.street.search.TraverseMode.WALK;
 import static org.opentripplanner.street.search.state.TestStateBuilder.ofCarRental;
 import static org.opentripplanner.street.search.state.TestStateBuilder.ofDriving;
@@ -51,12 +52,11 @@ class StateTest {
   static Stream<Arguments> testCases() {
     return Stream.of(
       of(SCOOTER_RENTAL, false, Set.of(BEFORE_RENTING), Set.of(WALK)),
-      //FIXME: it's strange that the arriveBy rental searches all start on a bicycle
-      of(SCOOTER_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
+      of(SCOOTER_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, SCOOTER)),
       of(BIKE_RENTAL, false, Set.of(BEFORE_RENTING), Set.of(WALK)),
       of(BIKE_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
       of(CAR_RENTAL, false, Set.of(BEFORE_RENTING), Set.of(WALK)),
-      of(CAR_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, BICYCLE)),
+      of(CAR_RENTAL, true, Set.of(HAVE_RENTED, RENTING_FLOATING), Set.of(WALK, CAR)),
       of(StreetMode.CAR, false, NULL_RENTAL_STATES, Set.of(CAR)),
       of(BIKE, false, NULL_RENTAL_STATES, Set.of(BICYCLE)),
       of(StreetMode.WALK, false, NULL_RENTAL_STATES, Set.of(TraverseMode.WALK)),


### PR DESCRIPTION
### Summary

This fixes an issue where rental routing sometimes used BICYCLE mode even if the search was done with SCOOTER or CAR mode. This caused the routing to follow bicycle routing rules and to use bicycle preferences instead of the relevant street preferences.

### Issue

Related to #6572

### Unit tests

Updated tests

### Documentation

Not needed

### Changelog

From title
