### PR TITLE
feature: Add version 2.8 to OtpVersion

### DIFF
--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
@@ -12,7 +12,8 @@ public enum OtpVersion {
   V2_4("2.4"),
   V2_5("2.5"),
   V2_6("2.6"),
-  V2_7("2.7");
+  V2_7("2.7"),
+  V2_8("2.8");
 
   private final String text;
 


### PR DESCRIPTION
### Summary

Add OTP Version `v2.8` tag. This is used to tag new parameters in the cinfiguration.

### Issue

No issue.

### Unit tests

No test.

### Documentation

No Doc.

### Changelog

No relevant.

### Bumping the serialization version id

Not needed.