### PR TITLE
Split schema validation actions workflow into two jobs

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -6,19 +6,18 @@ on:
       - dev-2.x
  
 jobs:
-  validate-gtfs:
+  validate-gtfs-schema:
     if: github.repository_owner == 'opentripplanner'
-    name: Validate GraphQL schema changes
+    name: Validate GTFS GraphQL schema changes
     runs-on: ubuntu-latest
- 
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: 'Fetch dev.2.x for diffing'
         run: |
           git fetch origin dev-2.x --depth 1
-
 
       - uses: actions/setup-node@v4
         with:
@@ -27,10 +26,31 @@ jobs:
       - name: Install GraphQL Inspector
         run: |
           npm i --global @graphql-inspector/ci graphql @graphql-inspector/diff-command @graphql-inspector/graphql-loader @graphql-inspector/git-loader
-      
+
       - name: Validate GTFS GraphQL schema changes
         run: |
           graphql-inspector diff 'git:origin/dev-2.x:application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls' 'application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls'
+
+  validate-transmodel-schema:
+    if: github.repository_owner == 'opentripplanner'
+    name: Validate Transmodel GraphQL schema changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: 'Fetch dev.2.x for diffing'
+        run: |
+          git fetch origin dev-2.x --depth 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install GraphQL Inspector
+        run: |
+          npm i --global @graphql-inspector/ci graphql @graphql-inspector/diff-command @graphql-inspector/graphql-loader @graphql-inspector/git-loader
 
       - name: Validate Transmodel GraphQL schema changes
         run: |


### PR DESCRIPTION
### Summary

Splits schema validation actions workflow into two jobs so we always see the validation results from both validation runs.

### Issue

No issue

### Unit tests

None

### Documentation

None

### Changelog

Skipped
