### PR TITLE
Fix transfer for rental modes in deprecated `plan` query

### DIFF
--- a/application/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
+++ b/application/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
@@ -83,6 +83,7 @@ public class QualifiedModeSet implements Serializable {
         case BICYCLE -> {
           if (requestMode.qualifiers.contains(Qualifier.RENT)) {
             mBuilder.withAllStreetModes(StreetMode.BIKE_RENTAL);
+            mBuilder.withTransferMode(StreetMode.WALK);
           } else if (requestMode.qualifiers.contains(Qualifier.PARK)) {
             mBuilder.withAccessMode(StreetMode.BIKE_TO_PARK);
             mBuilder.withEgressMode(StreetMode.WALK);
@@ -104,6 +105,7 @@ public class QualifiedModeSet implements Serializable {
         case CAR -> {
           if (requestMode.qualifiers.contains(Qualifier.RENT)) {
             mBuilder.withAllStreetModes(StreetMode.CAR_RENTAL);
+            mBuilder.withTransferMode(StreetMode.WALK);
           } else if (requestMode.qualifiers.contains(Qualifier.PARK)) {
             mBuilder.withAccessMode(StreetMode.CAR_TO_PARK);
             mBuilder.withTransferMode(StreetMode.WALK);


### PR DESCRIPTION
### Summary

This fixes the transfer mode setting for the deprecated `plan` query. This is very similar to #6597 but for bike and car rental.

My suspicion is that this behaviour changed during @VillePihlava's refactoring of the transfers so we have to adapt this API.

### Issue

https://github.com/public-transport/transitous/issues/1092

### Unit tests

Unit tests added.

cc @hbruch 