### PR TITLE
Deprecate vertexType in GTFS API

### DIFF
--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1036,7 +1036,7 @@ type Place {
   Type of vertex. (Normal, Bike sharing station, Bike P+R, Transit stop) Mostly
   used for better localization of bike sharing and P+R station names
   """
-  vertexType: VertexType
+  vertexType: VertexType @deprecated(reason : "Unmaintained. Use `stop`, `vehicleParking` or `vehicleRentalStation` to tell which type it is.")
 }
 
 type Plan {

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1036,7 +1036,7 @@ type Place {
   Type of vertex. (Normal, Bike sharing station, Bike P+R, Transit stop) Mostly
   used for better localization of bike sharing and P+R station names
   """
-  vertexType: VertexType @deprecated(reason : "Unmaintained. Use `stop`, `vehicleParking` or `vehicleRentalStation` to tell which type it is.")
+  vertexType: VertexType @deprecated(reason : "Unmaintained. Use `stop`, `rentalVehicle`, `vehicleParking` or `vehicleRentalStation` to tell which type it is.")
 }
 
 type Plan {


### PR DESCRIPTION
### Summary

The field `vertexType` in the GTFS API hasn't been maintained for years and is of questionable value. It also uses oddly specific street routing language.

For this reason I would like to deprecatate it.