### PR TITLE
Convert `RealTimeTestConstants` to class

### DIFF
--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
@@ -1,11 +1,8 @@
 package org.opentripplanner.updater.trip;
 
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
-
 import java.time.LocalDate;
 import java.time.ZoneId;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
-import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.SiteRepository;
@@ -17,8 +14,6 @@ public final class RealtimeTestConstants {
   public final String STOP_A1_ID = "A1";
   public final String STOP_B1_ID = "B1";
   public final String STOP_C1_ID = "C1";
-  public final String OPERATOR_1_ID = "TestOperator1";
-  public final Operator OPERATOR1 = Operator.of(id(OPERATOR_1_ID)).withName(OPERATOR_1_ID).build();
 
   public final ZoneId TIME_ZONE = ZoneId.of(TimetableRepositoryForTest.TIME_ZONE_ID);
   public final Station STATION_A = testModel.station("A").build();

--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
@@ -5,8 +5,6 @@ import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest
 import java.time.LocalDate;
 import java.time.ZoneId;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -16,15 +14,11 @@ public final class RealtimeTestConstants {
 
   private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
   public final LocalDate SERVICE_DATE = LocalDate.of(2024, 5, 8);
-  public final FeedScopedId SERVICE_ID = TimetableRepositoryForTest.id("CAL_1");
   public final String STOP_A1_ID = "A1";
   public final String STOP_B1_ID = "B1";
   public final String STOP_C1_ID = "C1";
-  public final String TRIP_1_ID = "TestTrip1";
-  public final String TRIP_2_ID = "TestTrip2";
   public final String OPERATOR_1_ID = "TestOperator1";
   public final Operator OPERATOR1 = Operator.of(id(OPERATOR_1_ID)).withName(OPERATOR_1_ID).build();
-  public final String ROUTE_1_ID = "TestRoute1";
 
   public final ZoneId TIME_ZONE = ZoneId.of(TimetableRepositoryForTest.TIME_ZONE_ID);
   public final Station STATION_A = testModel.station("A").build();
@@ -53,6 +47,4 @@ public final class RealtimeTestConstants {
     .withRegularStop(STOP_C1)
     .withRegularStop(STOP_D1)
     .build();
-
-  public final Route ROUTE_1 = TimetableRepositoryForTest.route(ROUTE_1_ID).build();
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
@@ -12,30 +12,41 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.SiteRepository;
 
-public interface RealtimeTestConstants {
-  LocalDate SERVICE_DATE = LocalDate.of(2024, 5, 8);
-  FeedScopedId SERVICE_ID = TimetableRepositoryForTest.id("CAL_1");
-  String STOP_A1_ID = "A1";
-  String STOP_B1_ID = "B1";
-  String STOP_C1_ID = "C1";
-  String TRIP_1_ID = "TestTrip1";
-  String TRIP_2_ID = "TestTrip2";
-  String OPERATOR_1_ID = "TestOperator1";
-  Operator OPERATOR1 = Operator.of(id(OPERATOR_1_ID)).withName(OPERATOR_1_ID).build();
-  String ROUTE_1_ID = "TestRoute1";
+public final class RealtimeTestConstants {
 
-  TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
-  ZoneId TIME_ZONE = ZoneId.of(TimetableRepositoryForTest.TIME_ZONE_ID);
-  Station STATION_A = TEST_MODEL.station("A").build();
-  Station STATION_B = TEST_MODEL.station("B").build();
-  Station STATION_C = TEST_MODEL.station("C").build();
-  Station STATION_D = TEST_MODEL.station("D").build();
-  RegularStop STOP_A1 = TEST_MODEL.stop(STOP_A1_ID).withParentStation(STATION_A).build();
-  RegularStop STOP_B1 = TEST_MODEL.stop(STOP_B1_ID).withParentStation(STATION_B).build();
-  RegularStop STOP_B2 = TEST_MODEL.stop("B2").withParentStation(STATION_B).build();
-  RegularStop STOP_C1 = TEST_MODEL.stop(STOP_C1_ID).withParentStation(STATION_C).build();
-  RegularStop STOP_D1 = TEST_MODEL.stop("D1").withParentStation(STATION_D).build();
-  SiteRepository SITE_REPOSITORY = TEST_MODEL.siteRepositoryBuilder()
+  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  public final LocalDate SERVICE_DATE = LocalDate.of(2024, 5, 8);
+  public final FeedScopedId SERVICE_ID = TimetableRepositoryForTest.id("CAL_1");
+  public final String STOP_A1_ID = "A1";
+  public final String STOP_B1_ID = "B1";
+  public final String STOP_C1_ID = "C1";
+  public final String TRIP_1_ID = "TestTrip1";
+  public final String TRIP_2_ID = "TestTrip2";
+  public final String OPERATOR_1_ID = "TestOperator1";
+  public final Operator OPERATOR1 = Operator.of(id(OPERATOR_1_ID)).withName(OPERATOR_1_ID).build();
+  public final String ROUTE_1_ID = "TestRoute1";
+
+  public final ZoneId TIME_ZONE = ZoneId.of(TimetableRepositoryForTest.TIME_ZONE_ID);
+  public final Station STATION_A = testModel.station("A").build();
+  public final Station STATION_B = testModel.station("B").build();
+  public final Station STATION_C = testModel.station("C").build();
+  public final Station STATION_D = testModel.station("D").build();
+  public final RegularStop STOP_A1 = testModel
+    .stop(STOP_A1_ID)
+    .withParentStation(STATION_A)
+    .build();
+  public final RegularStop STOP_B1 = testModel
+    .stop(STOP_B1_ID)
+    .withParentStation(STATION_B)
+    .build();
+  public final RegularStop STOP_B2 = testModel.stop("B2").withParentStation(STATION_B).build();
+  public final RegularStop STOP_C1 = testModel
+    .stop(STOP_C1_ID)
+    .withParentStation(STATION_C)
+    .build();
+  public final RegularStop STOP_D1 = testModel.stop("D1").withParentStation(STATION_D).build();
+  public final SiteRepository SITE_REPOSITORY = testModel
+    .siteRepositoryBuilder()
     .withRegularStop(STOP_A1)
     .withRegularStop(STOP_B1)
     .withRegularStop(STOP_B2)
@@ -43,5 +54,5 @@ public interface RealtimeTestConstants {
     .withRegularStop(STOP_D1)
     .build();
 
-  Route ROUTE_1 = TimetableRepositoryForTest.route(ROUTE_1_ID).build();
+  public final Route ROUTE_1 = TimetableRepositoryForTest.route(ROUTE_1_ID).build();
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironment.java
@@ -30,7 +30,10 @@ import uk.org.siri.siri21.EstimatedTimetableDeliveryStructure;
 /**
  * This class exists so that you can share the data building logic for GTFS and Siri tests.
  */
-public final class RealtimeTestEnvironment implements RealtimeTestConstants {
+public final class RealtimeTestEnvironment {
+
+  public final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
 
   public final TimetableRepository timetableRepository;
   public final TimetableSnapshotManager snapshotManager;
@@ -49,13 +52,13 @@ public final class RealtimeTestEnvironment implements RealtimeTestConstants {
     this.snapshotManager = new TimetableSnapshotManager(
       null,
       TimetableSnapshotParameters.PUBLISH_IMMEDIATELY,
-      () -> SERVICE_DATE
+      () -> CONSTANTS.SERVICE_DATE
     );
     siriAdapter = new SiriRealTimeTripUpdateAdapter(timetableRepository, snapshotManager);
     gtfsAdapter = new GtfsRealTimeTripUpdateAdapter(timetableRepository, snapshotManager, () ->
-      SERVICE_DATE
+      CONSTANTS.SERVICE_DATE
     );
-    dateTimeHelper = new DateTimeHelper(TIME_ZONE, SERVICE_DATE);
+    dateTimeHelper = new DateTimeHelper(CONSTANTS.TIME_ZONE, CONSTANTS.SERVICE_DATE);
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
@@ -2,6 +2,8 @@ package org.opentripplanner.updater.trip;
 
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
@@ -11,15 +13,23 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
+import org.opentripplanner.transit.service.SiteRepository;
 import org.opentripplanner.transit.service.TimetableRepository;
 
-public class RealtimeTestEnvironmentBuilder implements RealtimeTestConstants {
+public class RealtimeTestEnvironmentBuilder {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final FeedScopedId SERVICE_ID = CONSTANTS.SERVICE_ID;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
+  private static final SiteRepository SITE_REPOSITORY = CONSTANTS.SITE_REPOSITORY;
+  private static final ZoneId TIME_ZONE = CONSTANTS.TIME_ZONE;
 
   private final TimetableRepository timetableRepository = new TimetableRepository(
     SITE_REPOSITORY,

--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.IntStream;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -26,7 +25,7 @@ import org.opentripplanner.transit.service.TimetableRepository;
 public class RealtimeTestEnvironmentBuilder {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final FeedScopedId SERVICE_ID = CONSTANTS.SERVICE_ID;
+  private static final FeedScopedId SERVICE_ID = TimetableRepositoryForTest.id("CAL_1");
   private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
   private static final SiteRepository SITE_REPOSITORY = CONSTANTS.SITE_REPOSITORY;
   private static final ZoneId TIME_ZONE = CONSTANTS.TIME_ZONE;

--- a/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.utils.time.TimeUtils;
 
@@ -32,7 +33,11 @@ public record TripInput(String id, Route route, List<StopCall> stops) {
     private final String id;
     private final List<StopCall> stops = new ArrayList<>();
     // can be made configurable if needed
-    private Route route = TimetableRepositoryForTest.route("route-1").build();
+    private Route route = TimetableRepositoryForTest.route("route-1")
+      .withOperator(
+        Operator.of(TimetableRepositoryForTest.id("operator-1")).withName("Operator 1").build()
+      )
+      .build();
 
     TripInputBuilder(String id) {
       this.id = id;

--- a/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
@@ -15,12 +15,12 @@ public record TripInput(String id, Route route, List<StopCall> stops) {
     return new TripInputBuilder(id);
   }
 
-  public static class TripInputBuilder implements RealtimeTestConstants {
+  public static class TripInputBuilder {
 
     private final String id;
     private final List<StopCall> stops = new ArrayList<>();
     // can be made configurable if needed
-    private Route route = ROUTE_1;
+    private Route route = new RealtimeTestConstants().ROUTE_1;
 
     TripInputBuilder(String id) {
       this.id = id;

--- a/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
@@ -2,6 +2,7 @@ package org.opentripplanner.updater.trip;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.utils.time.TimeUtils;
@@ -15,12 +16,23 @@ public record TripInput(String id, Route route, List<StopCall> stops) {
     return new TripInputBuilder(id);
   }
 
+  /**
+   * The ID of the route without the feed ID prefix.
+   */
+  public String routeId() {
+    return route.getId().getId();
+  }
+
+  public String operatorId() {
+    return route.getOperator().getId().getId();
+  }
+
   public static class TripInputBuilder {
 
     private final String id;
     private final List<StopCall> stops = new ArrayList<>();
     // can be made configurable if needed
-    private Route route = new RealtimeTestConstants().ROUTE_1;
+    private Route route = TimetableRepositoryForTest.route("route-1").build();
 
     TripInputBuilder(String id) {
       this.id = id;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
@@ -12,12 +12,15 @@ import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import de.mfdz.MfdzRealtimeExtensions.StopTimePropertiesExtension.DropOffPickupType;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
@@ -26,7 +29,15 @@ import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
 
-class AddedTest implements RealtimeTestConstants {
+class AddedTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
+  private static final ZoneId TIME_ZONE = CONSTANTS.TIME_ZONE;
+  private static final String STOP_A1_ID = CONSTANTS.STOP_A1_ID;
+  private static final String STOP_B1_ID = CONSTANTS.STOP_B1_ID;
+  private static final String STOP_C1_ID = CONSTANTS.STOP_C1_ID;
 
   final String ADDED_TRIP_ID = "added_trip";
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
@@ -6,13 +6,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
 
-public class CanceledTripTest implements RealtimeTestConstants {
+public class CanceledTripTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
+  private static final ZoneId TIME_ZONE = CONSTANTS.TIME_ZONE;
 
   @Test
   void listCanceledTrips() {

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 public class CanceledTripTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
@@ -30,7 +30,7 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 public class CancellationDeletionTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final String STOP_A1_ID = CONSTANTS.STOP_A1_ID;
   private static final String STOP_B1_ID = CONSTANTS.STOP_B1_ID;
   private static final String STOP_C1_ID = CONSTANTS.STOP_C1_ID;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
@@ -10,10 +10,13 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSucce
 import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL;
 
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
@@ -24,7 +27,17 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
  * Cancellations and deletions should end up in the internal data model and make trips unavailable
  * for routing.
  */
-public class CancellationDeletionTest implements RealtimeTestConstants {
+public class CancellationDeletionTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String STOP_A1_ID = CONSTANTS.STOP_A1_ID;
+  private static final String STOP_B1_ID = CONSTANTS.STOP_B1_ID;
+  private static final String STOP_C1_ID = CONSTANTS.STOP_C1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
+  private static final ZoneId TIME_ZONE = CONSTANTS.TIME_ZONE;
 
   static List<Arguments> cases() {
     return List.of(

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
@@ -27,8 +27,8 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 class DelayedTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
-  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
+  private static final String TRIP_2_ID = "TestTrip2";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
@@ -10,8 +10,11 @@ import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.trip;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
@@ -21,7 +24,16 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 /**
  * Delays should be applied to the first trip but should leave the second trip untouched.
  */
-class DelayedTest implements RealtimeTestConstants {
+class DelayedTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
+  private static final ZoneId TIME_ZONE = CONSTANTS.TIME_ZONE;
 
   private static final int DELAY = 1;
   private static final int STOP_SEQUENCE = 1;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
@@ -11,7 +11,10 @@ import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.TripTimesStringBuilder;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
@@ -22,7 +25,15 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 /**
  * A mixture of delayed and skipped stops should result in both delayed and cancelled stops.
  */
-class SkippedTest implements RealtimeTestConstants {
+class SkippedTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
+  private static final ZoneId TIME_ZONE = CONSTANTS.TIME_ZONE;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_2_ID)
     .addStop(STOP_A1, "0:01:00", "0:01:01")

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
@@ -28,7 +28,7 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 class SkippedTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final String TRIP_2_ID = "TestTrip2";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
@@ -22,7 +22,7 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 class InvalidInputTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
@@ -18,7 +19,13 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
  * A trip with start date that is outside the service period shouldn't throw an exception and is
  * ignored instead.
  */
-class InvalidInputTest implements RealtimeTestConstants {
+class InvalidInputTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
 
   public static List<LocalDate> cases() {
     return List.of(SERVICE_DATE.minusYears(10), SERVICE_DATE.plusYears(10));
@@ -33,7 +40,7 @@ class InvalidInputTest implements RealtimeTestConstants {
       .build();
     var env = RealtimeTestEnvironment.of().addTrip(tripInput).build();
 
-    var update = new TripUpdateBuilder(TRIP_1_ID, date, SCHEDULED, TIME_ZONE)
+    var update = new TripUpdateBuilder(TRIP_1_ID, date, SCHEDULED, CONSTANTS.TIME_ZONE)
       .addDelayedStopTime(2, 60, 80)
       .build();
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
@@ -19,8 +19,8 @@ import uk.org.siri.siri21.EstimatedVehicleJourney;
 class SiriFuzzyTripMatcherTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
-  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
+  private static final String TRIP_2_ID = "TestTrip2";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
@@ -5,20 +5,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.MULTIPLE_FUZZY_TRIP_MATCHES;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_FUZZY_TRIP_MATCH;
-import static org.opentripplanner.updater.trip.RealtimeTestConstants.STOP_A1;
-import static org.opentripplanner.updater.trip.RealtimeTestConstants.STOP_B1;
-import static org.opentripplanner.updater.trip.RealtimeTestConstants.TRIP_1_ID;
-import static org.opentripplanner.updater.trip.RealtimeTestConstants.TRIP_2_ID;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.framework.Result;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import uk.org.siri.siri21.EstimatedVehicleJourney;
 
 class SiriFuzzyTripMatcherTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
 
   @Test
   void match() {

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
@@ -2,8 +2,6 @@ package org.opentripplanner.updater.trip.siri.moduletests.cancellation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
@@ -15,14 +13,13 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class CancellationTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_B2 = CONSTANTS.STOP_B2;
 
   private static final String ADDED_TRIP_ID = "newJourney";
   private static final String OPERATOR_1_ID = CONSTANTS.OPERATOR_1_ID;
-  private static final String ROUTE_1_ID = CONSTANTS.ROUTE_1_ID;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")
@@ -96,11 +93,12 @@ class CancellationTest {
   @Test
   void testChangeQuayAndCancelAddedTrip() {
     var env = RealtimeTestEnvironment.of().addTrip(TRIP_INPUT).build();
+
     var creation = new SiriEtBuilder(env.getDateTimeHelper())
       .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
       .withIsExtraJourney(true)
       .withOperatorRef(OPERATOR_1_ID)
-      .withLineRef(ROUTE_1_ID)
+      .withLineRef(TRIP_INPUT.routeId())
       .withEstimatedCalls(builder ->
         builder
           .call(STOP_A1)

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
@@ -12,14 +12,12 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class CancellationTest {
 
-  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
   private static final String TRIP_1_ID = "TestTrip1";
+  private static final String ADDED_TRIP_ID = "newJourney";
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_B2 = CONSTANTS.STOP_B2;
-
-  private static final String ADDED_TRIP_ID = "newJourney";
-  private static final String OPERATOR_1_ID = CONSTANTS.OPERATOR_1_ID;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")
@@ -97,7 +95,7 @@ class CancellationTest {
     var creation = new SiriEtBuilder(env.getDateTimeHelper())
       .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
       .withIsExtraJourney(true)
-      .withOperatorRef(OPERATOR_1_ID)
+      .withOperatorRef(TRIP_INPUT.operatorId())
       .withLineRef(TRIP_INPUT.routeId())
       .withEstimatedCalls(builder ->
         builder

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
@@ -2,21 +2,32 @@ package org.opentripplanner.updater.trip.siri.moduletests.cancellation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class CancellationTest implements RealtimeTestConstants {
+class CancellationTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_B2 = CONSTANTS.STOP_B2;
+
+  private static final String ADDED_TRIP_ID = "newJourney";
+  private static final String OPERATOR_1_ID = CONSTANTS.OPERATOR_1_ID;
+  private static final String ROUTE_1_ID = CONSTANTS.ROUTE_1_ID;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")
     .addStop(STOP_B1, "0:00:20", "0:00:21")
     .build();
-
-  private static final String ADDED_TRIP_ID = "newJourney";
 
   @Test
   void testCancelTrip() {

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
@@ -12,7 +12,7 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class CancelledStopTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final String TRIP_2_ID = "TestTrip2";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
@@ -3,12 +3,19 @@ package org.opentripplanner.updater.trip.siri.moduletests.cancellation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class CancelledStopTest implements RealtimeTestConstants {
+class CancelledStopTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_2_ID)
     .addStop(STOP_A1, "0:01:00", "0:01:01")

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
@@ -15,13 +15,12 @@ import uk.org.siri.siri21.EstimatedTimetableDeliveryStructure;
 
 class ExtraCallTest {
 
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
   private static final RegularStop STOP_D1 = CONSTANTS.STOP_D1;
-  private static final String ROUTE_1_ID = CONSTANTS.ROUTE_1_ID;
 
   private static final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")
@@ -158,7 +157,7 @@ class ExtraCallTest {
   ) {
     return new SiriEtBuilder(env.getDateTimeHelper())
       .withDatedVehicleJourneyRef(TRIP_1_ID)
-      .withLineRef(ROUTE_1_ID)
+      .withLineRef(TRIP_1_INPUT.routeId())
       .withRecordedCalls(builder -> builder.call(STOP_A1).departAimedActual("00:00:11", "00:00:15"))
       .withEstimatedCalls(builder ->
         builder

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailu
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
@@ -12,7 +13,15 @@ import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 import uk.org.siri.siri21.EstimatedTimetableDeliveryStructure;
 
-class ExtraCallTest implements RealtimeTestConstants {
+class ExtraCallTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
+  private static final RegularStop STOP_D1 = CONSTANTS.STOP_D1;
+  private static final String ROUTE_1_ID = CONSTANTS.ROUTE_1_ID;
 
   private static final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -5,9 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.organization.Operator;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
@@ -18,7 +22,20 @@ import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class ExtraJourneyTest implements RealtimeTestConstants {
+class ExtraJourneyTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
+  private static final RegularStop STOP_D1 = CONSTANTS.STOP_D1;
+
+  private static final Route ROUTE_1 = CONSTANTS.ROUTE_1;
+  private static final Operator OPERATOR1 = CONSTANTS.OPERATOR1;
+  private static final String ROUTE_1_ID = CONSTANTS.ROUTE_1_ID;
+  private static final String OPERATOR_1_ID = CONSTANTS.OPERATOR_1_ID;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
 
   private static final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
     .withRoute(ROUTE_1.copy().withOperator(OPERATOR1).build())

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -7,7 +7,7 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailu
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.ext.fares.model.FareAttribute;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Operator;
@@ -25,15 +25,14 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class ExtraJourneyTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
   private static final RegularStop STOP_D1 = CONSTANTS.STOP_D1;
 
-  private static final Route ROUTE_1 = CONSTANTS.ROUTE_1;
+  private static final Route ROUTE_1 = TimetableRepositoryForTest.route("route-2").build();
   private static final Operator OPERATOR1 = CONSTANTS.OPERATOR1;
-  private static final String ROUTE_1_ID = CONSTANTS.ROUTE_1_ID;
   private static final String OPERATOR_1_ID = CONSTANTS.OPERATOR_1_ID;
   private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
 
@@ -137,7 +136,7 @@ class ExtraJourneyTest {
       .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
       .withIsExtraJourney(true)
       .withOperatorRef(OPERATOR_1_ID)
-      .withLineRef(ROUTE_1_ID)
+      .withLineRef(TRIP_1_INPUT.routeId())
       .withEstimatedCalls(builder ->
         builder
           .call(STOP_A1)
@@ -162,7 +161,7 @@ class ExtraJourneyTest {
       // replace trip1
       .withVehicleJourneyRef(TRIP_1_ID)
       .withOperatorRef(OPERATOR_1_ID)
-      .withLineRef(ROUTE_1_ID)
+      .withLineRef(TRIP_1_INPUT.routeId())
       .withRecordedCalls(builder -> builder.call(STOP_A1).departAimedActual("00:01", "00:02"))
       .withEstimatedCalls(builder -> builder.call(STOP_C1).arriveAimedExpected("00:03", "00:04"))
       .buildEstimatedTimetableDeliveries();
@@ -194,7 +193,7 @@ class ExtraJourneyTest {
       .withIsExtraJourney(true)
       .withVehicleJourneyRef(TRIP_1_ID)
       .withOperatorRef(OPERATOR_1_ID)
-      .withLineRef(ROUTE_1_ID)
+      .withLineRef(TRIP_1_INPUT.routeId())
       .withEstimatedCalls(builder ->
         builder
           .call(STOP_A1)
@@ -215,7 +214,7 @@ class ExtraJourneyTest {
       .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
       .withIsExtraJourney(true)
       .withOperatorRef(OPERATOR_1_ID)
-      .withLineRef(ROUTE_1_ID)
+      .withLineRef(TRIP_1_INPUT.routeId())
       .withRecordedCalls(builder -> builder.call(STOP_C1).departAimedActual("00:01", "00:02"))
       .withEstimatedCalls(builder -> builder.call(STOP_D1).arriveAimedExpected("00:03", "00:04"));
   }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -32,12 +32,11 @@ class ExtraJourneyTest {
   private static final RegularStop STOP_D1 = CONSTANTS.STOP_D1;
 
   private static final Route ROUTE_1 = TimetableRepositoryForTest.route("route-2").build();
-  private static final Operator OPERATOR1 = CONSTANTS.OPERATOR1;
-  private static final String OPERATOR_1_ID = CONSTANTS.OPERATOR_1_ID;
+  private static final Operator OPERATOR_2 = Operator.of(id("o2")).withName("o").build();
   private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
 
   private static final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
-    .withRoute(ROUTE_1.copy().withOperator(OPERATOR1).build())
+    .withRoute(ROUTE_1.copy().withOperator(OPERATOR_2).build())
     .addStop(STOP_A1, "0:00:10", "0:00:11")
     .addStop(STOP_B1, "0:00:20", "0:00:21")
     .build();
@@ -135,7 +134,7 @@ class ExtraJourneyTest {
     var createExtraJourney = new SiriEtBuilder(env.getDateTimeHelper())
       .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
       .withIsExtraJourney(true)
-      .withOperatorRef(OPERATOR_1_ID)
+      .withOperatorRef(TRIP_1_INPUT.operatorId())
       .withLineRef(TRIP_1_INPUT.routeId())
       .withEstimatedCalls(builder ->
         builder
@@ -160,7 +159,7 @@ class ExtraJourneyTest {
       .withIsExtraJourney(true)
       // replace trip1
       .withVehicleJourneyRef(TRIP_1_ID)
-      .withOperatorRef(OPERATOR_1_ID)
+      .withOperatorRef(TRIP_1_INPUT.operatorId())
       .withLineRef(TRIP_1_INPUT.routeId())
       .withRecordedCalls(builder -> builder.call(STOP_A1).departAimedActual("00:01", "00:02"))
       .withEstimatedCalls(builder -> builder.call(STOP_C1).arriveAimedExpected("00:03", "00:04"))
@@ -192,7 +191,7 @@ class ExtraJourneyTest {
       .withDatedVehicleJourneyRef(ADDED_TRIP_ID)
       .withIsExtraJourney(true)
       .withVehicleJourneyRef(TRIP_1_ID)
-      .withOperatorRef(OPERATOR_1_ID)
+      .withOperatorRef(TRIP_1_INPUT.operatorId())
       .withLineRef(TRIP_1_INPUT.routeId())
       .withEstimatedCalls(builder ->
         builder
@@ -213,7 +212,7 @@ class ExtraJourneyTest {
     return new SiriEtBuilder(env.getDateTimeHelper())
       .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
       .withIsExtraJourney(true)
-      .withOperatorRef(OPERATOR_1_ID)
+      .withOperatorRef(TRIP_1_INPUT.operatorId())
       .withLineRef(TRIP_1_INPUT.routeId())
       .withRecordedCalls(builder -> builder.call(STOP_C1).departAimedActual("00:01", "00:02"))
       .withEstimatedCalls(builder -> builder.call(STOP_D1).arriveAimedExpected("00:03", "00:04"));

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
@@ -6,8 +6,6 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailu
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
@@ -18,7 +16,7 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class FuzzyTripMatchingTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
@@ -4,14 +4,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.organization.Operator;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class FuzzyTripMatchingTest implements RealtimeTestConstants {
+class FuzzyTripMatchingTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
@@ -6,13 +6,9 @@ import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TOO_FE
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TOO_MANY_STOPS;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.UNKNOWN_STOP;
 
-import java.time.LocalDate;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.apis.gtfs.datafetchers.QueryTypeImpl;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
-import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
@@ -23,7 +19,7 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class InvalidCallsTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final Station STATION_A = CONSTANTS.STATION_A;
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
@@ -6,20 +6,36 @@ import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TOO_FE
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.TOO_MANY_STOPS;
 import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.UNKNOWN_STOP;
 
+import java.time.LocalDate;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.gtfs.datafetchers.QueryTypeImpl;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.organization.Operator;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class InvalidCallsTest implements RealtimeTestConstants {
+class InvalidCallsTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final Station STATION_A = CONSTANTS.STATION_A;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
+  private static final RegularStop STOP_D1 = CONSTANTS.STOP_D1;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")
     .addStop(STOP_B1, "0:00:20", "0:00:21")
     .addStop(STOP_C1, "0:00:40", "0:00:41")
     .build();
+  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
 
   @Test
   void testTooFewCalls() {

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
@@ -12,7 +12,7 @@ import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class InvalidStopPointRefTest implements RealtimeTestConstants {
+class InvalidStopPointRefTest {
 
   private static Stream<Arguments> cases() {
     return Stream.of("", " ", "   ", "\n", "null", "\t", null).flatMap(id ->

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
@@ -3,13 +3,21 @@ package org.opentripplanner.updater.trip.siri.moduletests.rejection;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class NegativeTimesTest implements RealtimeTestConstants {
+class NegativeTimesTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;
 
   private static final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
@@ -13,8 +13,8 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class NegativeTimesTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
-  private static final String TRIP_2_ID = CONSTANTS.TRIP_2_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
+  private static final String TRIP_2_ID = "TestTrip2";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_C1 = CONSTANTS.STOP_C1;

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
@@ -13,7 +13,7 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class NotMonitoredTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
@@ -3,13 +3,19 @@ package org.opentripplanner.updater.trip.siri.moduletests.rejection;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class NotMonitoredTest implements RealtimeTestConstants {
+class NotMonitoredTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
 
   private static final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
@@ -12,7 +12,7 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class QuayChangeTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final RegularStop STOP_B2 = CONSTANTS.STOP_B2;

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
@@ -3,12 +3,19 @@ package org.opentripplanner.updater.trip.siri.moduletests.update;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class QuayChangeTest implements RealtimeTestConstants {
+class QuayChangeTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final RegularStop STOP_B2 = CONSTANTS.STOP_B2;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
@@ -15,7 +15,7 @@ import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 class UpdatedTimesTest {
 
   private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
-  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final String TRIP_1_ID = "TestTrip1";
   private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
   private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
   private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
@@ -3,14 +3,22 @@ package org.opentripplanner.updater.trip.siri.moduletests.update;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
-class UpdatedTimesTest implements RealtimeTestConstants {
+class UpdatedTimesTest {
+
+  private static final RealtimeTestConstants CONSTANTS = new RealtimeTestConstants();
+  private static final String TRIP_1_ID = CONSTANTS.TRIP_1_ID;
+  private static final RegularStop STOP_A1 = CONSTANTS.STOP_A1;
+  private static final RegularStop STOP_B1 = CONSTANTS.STOP_B1;
+  private static final LocalDate SERVICE_DATE = CONSTANTS.SERVICE_DATE;
 
   private static final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .addStop(STOP_A1, "0:00:10", "0:00:11")


### PR DESCRIPTION
### Summary

@t2gran has requested in a previous PR that the interface `RealTimeTestConstants` be turned into a class.

This PRs implements it.

### Further work

Potentially more of these fields can be moved into the `RealTimeTestEnvironment` but I would have to do more analysis to find a good design.
