### PR TITLE
feature: Enable CAR transfers with ferries with NeTEx import

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -14,6 +14,7 @@ import org.opentripplanner.transit.model.basic.Accessibility;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.CarAccess;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.rutebanken.netex.model.DirectionTypeEnumeration;
@@ -130,6 +131,11 @@ class TripMapper {
       }
       builder.withMode(transitMode.mainMode());
       builder.withNetexSubmode(transitMode.subMode());
+      builder.withCarsAllowed(
+        transportModeMapper.mapCarsAllowed(serviceJourney.getTransportSubmode())
+      );
+    } else {
+      builder.withCarsAllowed(transportModeMapper.mapCarsAllowed(route.getNetexSubmode()));
     }
 
     builder.withDirection(DirectionMapper.map(resolveDirectionType(serviceJourney)));

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
@@ -5,6 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.opentripplanner.transit.model.network.CarAccess.ALLOWED;
+import static org.opentripplanner.transit.model.network.CarAccess.NOT_ALLOWED;
+import static org.rutebanken.netex.model.WaterSubmodeEnumeration.HIGH_SPEED_VEHICLE_SERVICE;
+import static org.rutebanken.netex.model.WaterSubmodeEnumeration.LOCAL_CAR_FERRY;
+import static org.rutebanken.netex.model.WaterSubmodeEnumeration.NATIONAL_CAR_FERRY;
+import static org.rutebanken.netex.model.WaterSubmodeEnumeration.POST_BOAT;
+import static org.rutebanken.netex.model.WaterSubmodeEnumeration.REGIONAL_CAR_FERRY;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -14,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.netex.mapping.TransportModeMapper.UnsupportedModeException;
+import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.rutebanken.netex.model.AirSubmodeEnumeration;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
@@ -126,10 +134,38 @@ class TransportModeMapperTest {
     assertThrows(UnsupportedModeException.class, () -> transportModeMapper.map(null, null));
   }
 
+  @Test
+  void carsAllowedBasedOnSubMode() {
+    assertEquals(ALLOWED, transportModeMapper.mapCarsAllowed(SubMode.of("nationalCarFerry")));
+    assertEquals(ALLOWED, transportModeMapper.mapCarsAllowed(SubMode.of("regionalCarFerry")));
+    assertEquals(ALLOWED, transportModeMapper.mapCarsAllowed(SubMode.of("localCarFerry")));
+    assertEquals(
+      ALLOWED,
+      transportModeMapper.mapCarsAllowed(SubMode.of("highSpeedVehicleService"))
+    );
+    assertEquals(NOT_ALLOWED, transportModeMapper.mapCarsAllowed(SubMode.UNKNOWN));
+    assertEquals(NOT_ALLOWED, transportModeMapper.mapCarsAllowed((SubMode) null));
+  }
+
+  @Test
+  void carsAllowedBasedOn() {
+    assertEquals(ALLOWED, transportModeMapper.mapCarsAllowed(tsm(NATIONAL_CAR_FERRY)));
+    assertEquals(ALLOWED, transportModeMapper.mapCarsAllowed(tsm(REGIONAL_CAR_FERRY)));
+    assertEquals(ALLOWED, transportModeMapper.mapCarsAllowed(tsm(LOCAL_CAR_FERRY)));
+    assertEquals(ALLOWED, transportModeMapper.mapCarsAllowed(tsm(HIGH_SPEED_VEHICLE_SERVICE)));
+    assertEquals(NOT_ALLOWED, transportModeMapper.mapCarsAllowed(tsm(POST_BOAT)));
+    assertEquals(NOT_ALLOWED, transportModeMapper.mapCarsAllowed(tsm(null)));
+    assertEquals(NOT_ALLOWED, transportModeMapper.mapCarsAllowed((TransportSubmodeStructure) null));
+  }
+
   private static List<Arguments> createSubModeTestCases() {
     return VALID_SUBMODE_STRUCTURES.entrySet()
       .stream()
       .map(entry -> Arguments.of(entry.getKey(), entry.getValue()))
       .toList();
+  }
+
+  private static TransportSubmodeStructure tsm(WaterSubmodeEnumeration waterSubMode) {
+    return new TransportSubmodeStructure().withWaterSubmode(waterSubMode);
   }
 }


### PR DESCRIPTION
### Summary

This PR will set the `Trip#carsAllowed` flag based on submodes in NeTEx. This will enable routing with CAR + FERRY. The submodes that enable the `carsAllowed` flag is: 

 - `NATIONAL_CAR_FERRY` (WATER)
 - `REGIONAL_CAR_FERRY` (WATER)
 - `LOCAL_CAR_FERRY` (WATER)
 - `HIGH_SPEED_VEHICLE_SERVICE` (WATER)

There are other modes witch also might take cars on board like the `CAR_TRANSPORT_RAIL_SERVICE`. 

At the moment we assume all stops used by a service with the submodes above is car accessible. This is not true in all cases. To account for this we need to know if a stop is car accessible, but this information does not exist in the Norwegian NeTEx data at the moment. 


### Issue

🟥  There is no issue for this.


### Unit tests

✅  I have added unit-tests for the NeTEx mapping.

### Documentation

Only JavaDoc is added.

### Changelog

✅  This should be included.

### Bumping the serialization version id

🟥  No changes to the serialized model.
