### PR TITLE
Fixed Siri SX alerts handling with dedicated wrapper

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.siri.siri21.ServiceDelivery;
 
-public class SiriAzureSXUpdater implements TransitAlertProvider, SiriAzureMessageHandler {
+public class SiriAzureSXUpdater implements SiriAzureMessageHandler {
 
   private final Logger LOG = LoggerFactory.getLogger(getClass());
   private final SiriAlertsUpdateHandler updateHandler;
@@ -50,7 +50,6 @@ public class SiriAzureSXUpdater implements TransitAlertProvider, SiriAzureMessag
     }
   }
 
-  @Override
   public TransitAlertService getTransitAlertService() {
     return this.transitAlertService;
   }


### PR DESCRIPTION
### Summary

Fixed Siri SX alerts handling with dedicated wrapper

### Issue

Fix SIRI SX alerts with dedicated wrapper class

Fixes a bug where SIRI SX alerts weren't being processed because SiriAzureUpdater wasn't recognized as a TransitAlertProvider.

Created a specialized SxWrapper subclass that implements TransitAlertProvider and gets registered in the alert service registry. This ensures the TransitAlertServiceImpl inside SiriAzureSXUpdater is properly discovered without affecting the ET updater functionality.

### Unit tests

Verification was done using Skånetrafiken SX tests. They did not pass before the fix and passed after the fix.
Also ran the Skånetrafiken ET test to verify that they still worked.

