### PR TITLE
Add availableUntil to rental vehicles in the GTFS GraphQL API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RentalVehicleImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RentalVehicleImpl.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.framework.graphql.GraphQLUtils.getLocale;
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.time.OffsetDateTime;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleFuel;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -22,6 +23,11 @@ public class RentalVehicleImpl implements GraphQLDataFetchers.GraphQLRentalVehic
   @Override
   public DataFetcher<RentalVehicleFuel> fuel() {
     return environment -> getSource(environment).getFuel();
+  }
+
+  @Override
+  public DataFetcher<OffsetDateTime> availableUntil() {
+    return environment -> getSource(environment).getAvailableUntil();
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -6,6 +6,7 @@ import graphql.relay.DefaultEdge;
 import graphql.relay.Edge;
 import graphql.schema.DataFetcher;
 import graphql.schema.TypeResolver;
+import java.time.OffsetDateTime;
 import java.util.Currency;
 import java.util.Map;
 import org.locationtech.jts.geom.Coordinate;
@@ -915,6 +916,8 @@ public class GraphQLDataFetchers {
   /** Rental vehicle represents a vehicle that belongs to a rental network. */
   public interface GraphQLRentalVehicle {
     public DataFetcher<Boolean> allowPickupNow();
+
+    public DataFetcher<OffsetDateTime> availableUntil();
 
     public DataFetcher<RentalVehicleFuel> fuel();
 

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalVehicle.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalVehicle.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.service.vehiclerental.model;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Set;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.RentalFormFactor;
@@ -25,6 +26,7 @@ public class VehicleRentalVehicle implements VehicleRentalPlace {
   public VehicleRentalStation station;
   public String pricingPlanId;
   public RentalVehicleFuel fuel;
+  public OffsetDateTime availableUntil;
 
   @Override
   public FeedScopedId getId() {
@@ -136,5 +138,9 @@ public class VehicleRentalVehicle implements VehicleRentalPlace {
 
   public RentalVehicleFuel getFuel() {
     return fuel;
+  }
+
+  public OffsetDateTime getAvailableUntil() {
+    return availableUntil;
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.vehicle_rental.datasources;
 import static java.util.Objects.requireNonNullElse;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -17,6 +18,7 @@ import org.opentripplanner.service.vehiclerental.model.VehicleRentalVehicle;
 import org.opentripplanner.transit.model.basic.Distance;
 import org.opentripplanner.transit.model.basic.Ratio;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.utils.lang.StringUtils;
 import org.opentripplanner.utils.logging.Throttle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,6 +87,10 @@ public class GbfsFreeVehicleStatusMapper {
         return null;
       }
       rentalVehicle.fuel = new RentalVehicleFuel(fuelRatio, rangeMeters);
+      String availableUntil = vehicle.getAvailableUntil();
+      if (StringUtils.hasValue(availableUntil)) {
+        rentalVehicle.availableUntil = OffsetDateTime.parse(availableUntil);
+      }
       rentalVehicle.pricingPlanId = vehicle.getPricingPlanId();
       GBFSRentalUris rentalUris = vehicle.getRentalUris();
       if (rentalUris != null) {

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1900,6 +1900,8 @@ type RealTimeEstimate {
 type RentalVehicle implements Node & PlaceInterface {
   "If true, vehicle is currently available for renting."
   allowPickupNow: Boolean
+  "The vehicle should be returned before this deadline."
+  availableUntil: OffsetDateTime
   "Fuel or battery status of the rental vehicle"
   fuel: RentalVehicleFuel
   "Global object ID provided by Relay. This value can be used to refetch this object using **node** query."

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestFreeFloatingRentalVehicleBuilder.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestFreeFloatingRentalVehicleBuilder.java
@@ -1,5 +1,10 @@
 package org.opentripplanner.service.vehiclerental.model;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.street.model.RentalFormFactor;
@@ -21,6 +26,10 @@ public class TestFreeFloatingRentalVehicleBuilder {
   private Double currentRangeMeters = DEFAULT_CURRENT_RANGE_METERS;
   private VehicleRentalSystem system = null;
   private String network = NETWORK_1;
+  private static final OffsetDateTime DEFAULT_AVAILABLE_UNTIL = OffsetDateTime.of(
+    LocalDateTime.of(LocalDate.of(2025, 1, 1), LocalTime.MIN),
+    ZoneOffset.UTC
+  );
 
   private RentalVehicleType vehicleType = RentalVehicleType.getDefaultType(NETWORK_1);
 
@@ -105,6 +114,7 @@ public class TestFreeFloatingRentalVehicleBuilder {
       currentFuelPercent,
       Distance.ofMetersBoxed(currentRangeMeters, ignore -> {}).orElse(null)
     );
+    vehicle.availableUntil = DEFAULT_AVAILABLE_UNTIL;
     return vehicle;
   }
 

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/rental-vehicle.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/rental-vehicle.json
@@ -19,7 +19,8 @@
       "fuel": {
         "percent": 0.5,
         "range": 5501
-      }
+      },
+      "availableUntil": "2025-01-01T00:00:00Z"
     }
   }
 }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/rental-vehicle.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/rental-vehicle.graphql
@@ -23,5 +23,6 @@
       percent
       range
     }
+    availableUntil
   }
 }


### PR DESCRIPTION
### Summary

This PR adds availability information to  the rental vehicle model and GraphQL API by using the `available_until` field of the vehicle_status.json in GBFS.

### Issue

https://github.com/opentripplanner/OpenTripPlanner/issues/6547

The PR handles the first two steps in this commend: https://github.com/opentripplanner/OpenTripPlanner/issues/6547#issuecomment-2752085568

This field can be used to better inform the user about the availability of the vehicle.
Also this field can later be used, to consider it the routing as described in the linked issue.

It does not consider the new more complex GBFS extension(vehicle_availability.json), linked in the issue, because the GBFS model does not exist in the library yet.

### Unit tests

- considers the `available_until` field in the GraphQLIntegrationTest
