### PR TITLE
Reduce Azure Service Bus autoDeleteOnIdle from 1 hour to 5 minutes

### DIFF
--- a/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/azure/SiriAzureUpdaterConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/azure/SiriAzureUpdaterConfig.java
@@ -43,7 +43,7 @@ public abstract class SiriAzureUpdaterConfig {
         .of("autoDeleteOnIdle")
         .since(V2_5)
         .summary("The time after which an inactive subscription is removed.")
-        .asDuration(Duration.ofHours(1))
+        .asDuration(Duration.ofMinutes(5))
     );
     parameters.setPrefetchCount(
       c

--- a/doc/user/sandbox/siri/SiriAzureUpdater.md
+++ b/doc/user/sandbox/siri/SiriAzureUpdater.md
@@ -26,7 +26,7 @@ To enable the SIRI updater you need to add it to the updaters section of the `ro
 |------------------------------------------------------------|:----------:|------------------------------------------------------------------|:----------:|---------------------|:-----:|
 | type = "siri-azure-et-updater"                             |   `enum`   | The type of the updater.                                         | *Required* |                     |  1.5  |
 | [authenticationType](#u__11__authenticationType)           |   `enum`   | Which authentication type to use                                 | *Optional* | `"sharedaccesskey"` |  2.5  |
-| autoDeleteOnIdle                                           | `duration` | The time after which an inactive subscription is removed.        | *Optional* | `"PT1H"`            |  2.5  |
+| autoDeleteOnIdle                                           | `duration` | The time after which an inactive subscription is removed.        | *Optional* | `"PT5M"`            |  2.5  |
 | [customMidnight](#u__11__customMidnight)                   |  `integer` | Time on which time breaks into new day.                          | *Optional* | `0`                 |  2.2  |
 | feedId                                                     |  `string`  | The ID of the feed to apply the updates to.                      | *Required* |                     |  2.2  |
 | [fullyQualifiedNamespace](#u__11__fullyQualifiedNamespace) |  `string`  | Service Bus fully qualified namespace used for authentication.   | *Optional* |                     |  2.5  |
@@ -114,7 +114,7 @@ Has to be present for authenticationMethod SharedAccessKey. This should be Prima
 |------------------------------------------------------------|:----------:|------------------------------------------------------------------|:----------:|---------------------|:-----:|
 | type = "siri-azure-sx-updater"                             |   `enum`   | The type of the updater.                                         | *Required* |                     |  1.5  |
 | [authenticationType](#u__10__authenticationType)           |   `enum`   | Which authentication type to use                                 | *Optional* | `"sharedaccesskey"` |  2.5  |
-| autoDeleteOnIdle                                           | `duration` | The time after which an inactive subscription is removed.        | *Optional* | `"PT1H"`            |  2.5  |
+| autoDeleteOnIdle                                           | `duration` | The time after which an inactive subscription is removed.        | *Optional* | `"PT5M"`            |  2.5  |
 | [customMidnight](#u__10__customMidnight)                   |  `integer` | Time on which time breaks into new day.                          | *Optional* | `0`                 |  2.2  |
 | feedId                                                     |  `string`  | The ID of the feed to apply the updates to.                      | *Required* |                     |  2.2  |
 | [fullyQualifiedNamespace](#u__10__fullyQualifiedNamespace) |  `string`  | Service Bus fully qualified namespace used for authentication.   | *Optional* |                     |  2.5  |


### PR DESCRIPTION
# Shorten Azure idle subscription cleanup to 5 minutes

## Summary
Reduce Azure Service Bus autoDeleteOnIdle from 1 hour to 5 minutes to improve resource cleanup after abnormal pod terminations.

## Issue
This change reduces the time after which an inactive Azure Service Bus subscription is automatically removed from 1 hour to 5 minutes. This improvement only affects the cleanup mechanism on the Azure Service Bus side and has no impact on normal pod operation.

Key points:
- Legitimate, active subscriptions will NOT be deleted during normal operation
- As long as the pod runs, it maintains an active connection to the subscription
- The autoDeleteOnIdle timer only starts when the subscription has no active connections
- The 5-minute limit serves as a "safety net" to clean up subscriptions when pods terminate abnormally

## Unit tests
The change was manually verified using the following methodology:
1. Used Azure CLI and kubectl to list all subscriptions on a topic
2. Identified the pod ↔ subscription relationship by examining pod hostnames
3. Deliberately terminated a pod and observed subscription behavior
4. Verified that after the fix, the subscription was removed within 5 minutes when the pod was truly shut down with no active connection remaining, compared to 1 hour before the fix

## Documentation
Updated the configuration documentation in `doc/user/sandbox/siri/SiriAzureUpdater.md` to reflect the new default value of 5 minutes instead of 1 hour for the `autoDeleteOnIdle` parameter.