### PR TITLE
Fix negative cost in filter

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCost.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCost.java
@@ -26,6 +26,9 @@ public class RemoveOtherThanSameLegsMaxGeneralizedCost implements RemoveItinerar
   private final double maxCostOtherLegsFactor;
 
   public RemoveOtherThanSameLegsMaxGeneralizedCost(double maxCostOtherLegsFactor) {
+    if (maxCostOtherLegsFactor < 1.0) {
+      throw new IllegalArgumentException("maxCostOtherLegsFactor must be >= 1.0");
+    }
     this.maxCostOtherLegsFactor = maxCostOtherLegsFactor;
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCost.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCost.java
@@ -17,6 +17,22 @@ import org.opentripplanner.transit.model.timetable.Trip;
  * itineraries have a much higher cost for the other legs. This is similar to {@link
  * org.opentripplanner.routing.algorithm.filterchain.filters.transit.TransitGeneralizedCostFilter},
  * but is used together with {@link GroupByFilter} to filter within the groups.
+ *
+ * <h3>Example</h3>
+ *
+ * Lets give 5% slack: f=1.05
+ *
+ * <pre>
+ * Itin A:  | ### cost of legs common trips - $42 ### | ########## other legs - $41 ########## |    (Total: $83)
+ * Itin B:  | ######## cost of legs common trips - $52 ######## | ### other legs - $27 ### |        (Total: $79)
+ * </pre>
+ *
+ * <ul>
+ * <li>Min cost common legs: a=$42</li>
+ * <li>Min cost all itineraries: b=$79</li>
+ * <li>maxLimit = a + (b - a) * f = 42 + 37 * 1.05 = 81</li>
+ * <li><b>Result:</b> Keep itinerary A, and drop B ($83 > limit $81)</li>
+ * </ul>
  */
 public class RemoveOtherThanSameLegsMaxGeneralizedCost implements RemoveItineraryFlagger {
 

--- a/application/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -303,7 +303,13 @@ public class TestItineraryBuilder implements PlanTestConstants {
   /**
    * Add a rail/train leg to the itinerary
    */
-  public TestItineraryBuilder rail(int tripId, int startTime, int endTime, Place to) {
+  public TestItineraryBuilder rail(
+    int tripId,
+    int startTime,
+    int endTime,
+    Place to,
+    @Nullable Integer cost
+  ) {
     return transit(
       RAIL_ROUTE,
       Integer.toString(tripId),
@@ -314,8 +320,13 @@ public class TestItineraryBuilder implements PlanTestConstants {
       to,
       null,
       null,
-      null
+      null,
+      cost
     );
+  }
+
+  public TestItineraryBuilder rail(int tripId, int startTime, int endTime, Place to) {
+    return rail(tripId, startTime, endTime, to, null);
   }
 
   public TestItineraryBuilder faresV2Rail(
@@ -465,13 +476,45 @@ public class TestItineraryBuilder implements PlanTestConstants {
     Integer headwaySecs,
     ConstrainedTransfer transferFromPreviousLeg
   ) {
+    return transit(
+      route,
+      tripId,
+      start,
+      end,
+      fromStopIndex,
+      toStopIndex,
+      to,
+      serviceDate,
+      headwaySecs,
+      transferFromPreviousLeg,
+      null
+    );
+  }
+
+  public TestItineraryBuilder transit(
+    Route route,
+    String tripId,
+    int start,
+    int end,
+    int fromStopIndex,
+    int toStopIndex,
+    Place to,
+    LocalDate serviceDate,
+    Integer headwaySecs,
+    ConstrainedTransfer transferFromPreviousLeg,
+    @Nullable Integer cost
+  ) {
     if (lastPlace == null) {
       throw new IllegalStateException("Trip from place is unknown!");
     }
     int waitTime = start - lastEndTime(start);
     int legCost = 0;
-    legCost += cost(WAIT_RELUCTANCE_FACTOR, waitTime);
-    legCost += cost(1.0f, end - start) + BOARD_COST;
+    if (cost != null) {
+      legCost = cost;
+    } else {
+      legCost += cost(WAIT_RELUCTANCE_FACTOR, waitTime);
+      legCost += cost(1.0f, end - start) + BOARD_COST;
+    }
 
     Trip trip = trip(tripId, route);
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCostTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCostTest.java
@@ -22,4 +22,36 @@ class RemoveOtherThanSameLegsMaxGeneralizedCostTest implements PlanTestConstants
     var subject = new RemoveOtherThanSameLegsMaxGeneralizedCost(2.0);
     assertEquals(List.of(second), subject.flagForRemoval(List.of(first, second)));
   }
+
+  @Test
+  public void testFilterNothingInCommon() {
+    Itinerary first = newItinerary(A)
+      .rail(20, T11_05, T11_14, B)
+      .bus(30, T11_16, T11_20, C)
+      .build();
+
+    Itinerary second = newItinerary(A).rail(40, T11_05, T11_14, B).walk(D10m, C).build();
+
+    var subject = new RemoveOtherThanSameLegsMaxGeneralizedCost(2.0);
+    assertEquals(List.of(), subject.flagForRemoval(List.of(first, second)));
+  }
+
+  @Test
+  public void testFilterInaccurateLegCosts() {
+    // Regression test that verifies that we don't crash in the case where the sum of the leg costs
+    // is larger than the itinerary cost.
+    int itineraryCost = 100;
+    Itinerary first = newItinerary(A)
+      .rail(20, T11_05, T11_14, B, 400)
+      .walk(60 * 4, C)
+      .build(itineraryCost);
+
+    Itinerary second = newItinerary(A)
+      .rail(20, T11_05, T11_14, B, 400)
+      .walk(D10m, C)
+      .build(itineraryCost);
+
+    var subject = new RemoveOtherThanSameLegsMaxGeneralizedCost(2.0);
+    assertEquals(List.of(), subject.flagForRemoval(List.of(first, second)));
+  }
 }


### PR DESCRIPTION
### Summary

Fixes a bug in `RemoveOtherThanSameLegsMaxGeneralizedCost`-filter.

The core reason for the issue is that the leg cost in OTP is not guaranteed to be accurate and the sum of the leg costs might be significantly higher than the cost for the itinerary in some cases.

This can cause the filter to create a negative `Cost`, and the `Cost` constructor throws an IllegalArgumentException on negative values.

The PR fixes this by enforcing the costs to be non-negative.

An example of an itinerary where the leg costs are higher than the itinerary cost is: if we have a transit leg that ends at a stop with a high `stopBoardAlightTransferCost` followed by an egress leg. In this case raptor puts the alight cost on the transit leg and then reduces the cost of the egress leg by the same amount (because the transferCost shouldn't apply if we are not doing a transfer). In raptor this is consistent but when we map the raptor legs to transit model legs we use the astar cost of the egress leg instead of the raptor cost.

Also:
- Renamed some variables to make the logic clearer.

### Issue

Fixes #6657 

### Unit tests

Added a test for the issue.

### Bumping the serialization version id

Nope
