### PR TITLE
Update path for debug raster tiles

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/api/resource/DebugRasterTileResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/api/resource/DebugRasterTileResource.java
@@ -29,7 +29,7 @@ import org.opentripplanner.standalone.api.OtpServerRequestContext;
  * @see TileRendererManager
  * @see TileRenderer
  */
-@Path("/debugrastertiles")
+@Path("/debug/rastertiles")
 public class DebugRasterTileResource {
 
   private final TileRendererManager tileRendererManager;

--- a/doc/user/sandbox/DebugRasterTiles.md
+++ b/doc/user/sandbox/DebugRasterTiles.md
@@ -3,7 +3,7 @@
 <b>These are only meant to be used when using vector tiles is not an option (mainly JOSM).</b>
 
 The raster tiles are available with the following path structure:
-`/otp/debugrastertiles/{layer}/{z}/{x}/{y}.png`
+`/otp/debug/rastertiles/{layer}/{z}/{x}/{y}.png`
 
 The available layers are:
 
@@ -20,7 +20,8 @@ The available layers are:
 
 ## Changelog
 
-- 2024-02-13: Moved raster tiles from core code into sandbox.
+- 2025-02-13: Moved raster tiles from core code into sandbox.
+- 2025-05-16: Changed API path slightly.
 
 
 ### Configuration


### PR DESCRIPTION
### Summary

Updated path for debug raster tiles from `/otp/debugrastertiles/{layer}/{z}/{x}/{y}.png` to `/otp/debug/rastertiles/{layer}/{z}/{x}/{y}.png` (inspired by #6631)

### Issue

No issue

### Unit tests

No

### Documentation

Updated

### Changelog

Skipped
