### PR TITLE
Deprecate vehicle type in GTFS API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -453,7 +453,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
     };
   }
 
-  // TODO
+  @Deprecated
   @Override
   public DataFetcher<Integer> vehicleType() {
     return environment -> null;

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2263,7 +2263,7 @@ type Stop implements Node & PlaceInterface {
   https://developers.google.com/transit/gtfs/reference/#routestxt and
   https://developers.google.com/transit/gtfs/reference/extended-route-types
   """
-  vehicleType: Int
+  vehicleType: Int @deprecated(reason : "Not implemented. Use `vehicleMode`.")
   "Whether wheelchair boarding is possible for at least some of vehicles on this stop"
   wheelchairBoarding: WheelchairBoarding
   "ID of the zone where this stop is located"


### PR DESCRIPTION
### Summary

The field `Stop.vehicleType` always returns null and there is an alternative, so I want to deprecate it.