### PR TITLE
Fix error for overlapping service days

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -88,7 +88,7 @@ public class TripPatternForDates
     this.numberOfTripSchedules = numberOfTripSchedules;
     this.isFrequencyBased = hasFrequencies;
 
-    wheelchairBoardings = new Accessibility[numberOfTripSchedules];
+    this.wheelchairBoardings = new Accessibility[numberOfTripSchedules];
 
     final int nStops = tripPattern.numberOfStopsInPattern();
     this.arrivalTimes = new int[nStops * numberOfTripSchedules];
@@ -119,8 +119,8 @@ public class TripPatternForDates
       : IntIterators.intDecIterator(tripPatternForDates.length, 0);
   }
 
-  public TripPatternForDate tripPatternForDate(int index) {
-    return tripPatternForDates[index];
+  public TripPatternForDate tripPatternForDate(int dayIndex) {
+    return tripPatternForDates[dayIndex];
   }
 
   /**
@@ -128,8 +128,8 @@ public class TripPatternForDates
    * an implementation detail that should not leak outside the class.
    */
   @Deprecated
-  public int tripPatternForDateOffsets(int index) {
-    return offsets[index];
+  public int tripPatternForDateOffsets(int dayIndex) {
+    return offsets[dayIndex];
   }
 
   // Implementing RaptorRoute
@@ -200,30 +200,30 @@ public class TripPatternForDates
   }
 
   @Override
-  public TripSchedule getTripSchedule(int index) {
-    return new TripScheduleWithOffset(this, index);
+  public TripSchedule getTripSchedule(int tripIndex) {
+    return new TripScheduleWithOffset(this, tripIndex);
   }
 
   @Override
   public IntUnaryOperator getArrivalTimes(int stopPositionInPattern) {
     final int base = stopPositionInPattern * numberOfTripSchedules;
-    return (int index) -> arrivalTimes[base + index];
+    return (int tripIndex) -> arrivalTimes[base + tripIndex];
   }
 
   @Override
   public IntUnaryOperator getDepartureTimes(int stopPositionInPattern) {
     final int base = stopPositionInPattern * numberOfTripSchedules;
-    return (int index) -> departureTimes[base + index];
+    return (int tripIndex) -> departureTimes[base + tripIndex];
   }
 
-  public IntUnaryOperator getArrivalTimesForTrip(int index) {
+  public IntUnaryOperator getArrivalTimesForTrip(int tripIndex) {
     return (int stopPositionInPattern) ->
-      arrivalTimes[stopPositionInPattern * numberOfTripSchedules + index];
+      arrivalTimes[stopPositionInPattern * numberOfTripSchedules + tripIndex];
   }
 
-  public IntUnaryOperator getDepartureTimesForTrip(int index) {
+  public IntUnaryOperator getDepartureTimesForTrip(int tripIndex) {
     return (int stopPositionInPattern) ->
-      departureTimes[stopPositionInPattern * numberOfTripSchedules + index];
+      departureTimes[stopPositionInPattern * numberOfTripSchedules + tripIndex];
   }
 
   @Override
@@ -270,7 +270,7 @@ public class TripPatternForDates
       .toString();
   }
 
-  public Accessibility wheelchairBoardingForTrip(int index) {
-    return wheelchairBoardings[index];
+  public Accessibility wheelchairBoardingForTrip(int tripIndex) {
+    return wheelchairBoardings[tripIndex];
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripSearchTimetable.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripSearchTimetable.java
@@ -6,7 +6,7 @@ import org.opentripplanner.raptor.spi.RaptorTimeTable;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 
 /**
- * This interface add two methods the the {@link RaptorTimeTable} to optimize the terip search
+ * This interface add two methods to the {@link RaptorTimeTable} to optimize the trip search
  * inside the transit model. They were previously in Raptor, but the trip Search is moded outside
  * of Raptor; We have keep these methods in an interface to be able to reuse the complex TripSearch
  * in tests, which do not use the transit model {@link TripSchedule}; Hence also the generic type

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripTimesForDaysIndex.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripTimesForDaysIndex.java
@@ -1,0 +1,130 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
+
+import java.util.List;
+
+/**
+ * This class build an tripIndex for {@link TripPatternForDates} to (day, tripIndexForDay).
+ * In most cases concatenating the depature times would be correct, but the last depature on a
+ * specific day, may depart after the first departure on the following day. In these cases we need
+ * to swap the two depatures in the timetable Raptor searches. The reason we need this, is that
+ * trips on two diffrent datys may have overlapping trip-times. A nightbus on Saturdays may leave
+ * at 04:05+1d, while the first bus on Sundays may leave at 03:00. Be aware, these two trips may
+ * not have the same service calendar, normally they are diffrent. For example "Sundays" might be
+ * all Sundays and public holidays.
+ * </p>
+ * The trip index is a sorted list of trips based on the first stop depature time. The index
+ * contains two pointers, the first is the day and the second is the trip index on that day:
+ * ```
+ *   tripIndexForTripPatternPerDates -> (day, tripIndexForTripPatternPerDate)
+ * ```
+ * </p>
+ * This class might at first look a bit complicated. A much easier approch would be to just sort
+ * on depature times using a Java build in sort, but sorting is expencive. This code will merge
+ * the  timetables instead - witch is faster. In 99% of the cases we will just do one extra
+ * comparasons for each depature time.
+ */
+final class TripTimesForDaysIndex {
+
+  private final int[] tripIndex;
+
+  static TripTimesForDaysIndex ofTripTimesForDay(List<int[]> departureTimes, int[] offsets) {
+    departureTimes = applyOffsets(departureTimes, offsets);
+    return new TripTimesForDaysIndex(departureTimes);
+  }
+
+  TripTimesForDaysIndex(List<int[]> firstStopDepartureTimesPerDay) {
+    // 'list' is an alias to make the logic below easier to read
+    final List<int[]> list = firstStopDepartureTimesPerDay;
+    this.tripIndex = new int[list.stream().mapToInt(a -> a.length).sum() * 2];
+    int[] a;
+
+    int day = 0;
+    a = list.get(day);
+    int tripIndexForDays = 0;
+    int i = 0;
+    int j = 0;
+    int v = a[i];
+    int u = safeValueNextDayAt(list, day, j);
+
+    do {
+      if (v <= u) {
+        tripIndexForDays = setIndexValue(tripIndexForDays, day, i);
+        ++i;
+        if (i < a.length) {
+          v = a[i];
+        } else {
+          ++day;
+          if (day == list.size()) {
+            break;
+          }
+          i = j;
+          a = list.get(day);
+          if (i == a.length) {
+            ++day;
+            if (day == list.size()) {
+              break;
+            }
+            i = 0;
+            a = list.get(day);
+          }
+          j = 0;
+          v = a[i];
+          u = safeValueNextDayAt(list, day, j);
+        }
+      }
+      // v > u
+      else {
+        tripIndexForDays = setIndexValue(tripIndexForDays, day + 1, j);
+        ++j;
+        u = safeValueNextDayAt(list, day, j);
+      }
+    } while (true);
+  }
+
+  private static int safeValueNextDayAt(List<int[]> list, int day, int trip) {
+    int nextDay = day + 1;
+    return nextDay == list.size() ? Integer.MAX_VALUE : safeValueAt(list.get(nextDay), trip);
+  }
+
+  private static int safeValueAt(int[] array, int index) {
+    return array.length == index ? Integer.MAX_VALUE : array[index];
+  }
+
+  int day(int tripIndexForDays) {
+    return this.tripIndex[tripIndexForDays * 2];
+  }
+
+  int tripIndexForDay(int tripIndexForDays) {
+    return tripIndex[tripIndexForDays * 2 + 1];
+  }
+
+  int size() {
+    return tripIndex.length / 2;
+  }
+
+  private int setIndexValue(int tripIndexForDays, int day, int tripIndexForDay) {
+    this.tripIndex[tripIndexForDays * 2] = day;
+    this.tripIndex[tripIndexForDays * 2 + 1] = tripIndexForDay;
+    return tripIndexForDays + 1;
+  }
+
+  static List<int[]> applyOffsets(List<int[]> list, int[] offsets) {
+    for (int i = 0; i < list.size(); ++i) {
+      int o = offsets[i];
+      int[] a = list.get(i);
+      for (int j = 0; j < a.length; ++j) {
+        a[j] = a[j] + o;
+      }
+    }
+    return list;
+  }
+
+  @Override
+  public String toString() {
+    var buf = new StringBuilder();
+    for (int i = 0; i < tripIndex.length; i += 2) {
+      buf.append(tripIndex[i]).append(':').append(tripIndex[i + 1]).append(' ');
+    }
+    return buf.substring(0, buf.length() - 1);
+  }
+}

--- a/application/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -15,15 +15,12 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.updater.TimetableSnapshotParameters;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.spi.UpdateSuccess;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A class which abstracts away locking, updating, committing and purging of the timetable snapshot.
  */
 public final class TimetableSnapshotManager {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TimetableSnapshotManager.class);
   private final RealTimeRaptorTransitDataUpdater realtimeRaptorTransitDataUpdater;
 
   /**
@@ -98,10 +95,7 @@ public final class TimetableSnapshotManager {
    */
   void commitTimetableSnapshot(final boolean force) {
     if (force || buffer.isDirty()) {
-      LOG.debug("Committing {}", buffer);
       snapshot.publish(buffer.commit(realtimeRaptorTransitDataUpdater, force));
-    } else {
-      LOG.debug("Buffer was unchanged, keeping old snapshot.");
     }
   }
 
@@ -162,8 +156,6 @@ public final class TimetableSnapshotManager {
     if (lastPurgeDate != null && lastPurgeDate.compareTo(previously) >= 0) {
       return false;
     }
-
-    LOG.debug("Purging expired realtime data");
 
     lastPurgeDate = previously;
 


### PR DESCRIPTION
### Summary

Trip schedules for a given pattern on two following days may overlap. The current TripPatternForDays class does not account for this, and the result is missed trips  in the beginning of the second day.

### Issue

Fixes #6664


### Unit tests

A new class is added to do the trip-times merging, this is written to be very fast and there are an extensive set of unit-tests on it. No other tests are added or updated. Testing this on a higer level is difficult due tho the big setup of such a test.


### Documentation

✅  JavaDoc is added


### Changelog
✅  This is a critical - low frequency bubfix.


### Bumping the serialization version id

🟥  Not needed
