### PR TITLE
Fix serialization of FeedScopedId in geocoder sandbox

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/geocoder/SerializationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/geocoder/SerializationTest.java
@@ -1,0 +1,86 @@
+package org.opentripplanner.ext.geocoder;
+
+import static org.opentripplanner.ext.geocoder.StopCluster.LocationType.STOP;
+import static org.opentripplanner.test.support.JsonAssertions.assertEqualJson;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.json.ObjectMappers;
+
+class SerializationTest {
+
+  private static final String STOP_CLUSTER_JSON =
+    """
+      {
+        "primary" : {
+          "id" : "F:123",
+          "code" : "aaa",
+          "type" : "STOP",
+          "name" : "A stop",
+          "coordinate" : {
+            "lat" : 1.0,
+            "lon" : 2.0
+          },
+          "modes" : [
+            "RAIL"
+          ],
+          "agencies" : [
+            {
+              "id" : "F:a1",
+              "name" : "Agency"
+            }
+          ],
+          "feedPublisher" : {
+            "name" : "Publisher"
+          }
+        },
+        "secondaries" : [
+          {
+            "id" : "F:123",
+            "code" : "aaa",
+            "type" : "STOP",
+            "name" : "A stop",
+            "coordinate" : {
+              "lat" : 1.0,
+              "lon" : 2.0
+            },
+            "modes" : [
+              "RAIL"
+            ],
+            "agencies" : [
+              {
+                "id" : "F:a1",
+                "name" : "Agency"
+              }
+            ],
+            "feedPublisher" : {
+              "name" : "Publisher"
+            }
+          }
+        ]
+      }
+    """;
+
+  @Test
+  void serialize() {
+    var mapper = ObjectMappers.ignoringExtraFields();
+
+    var loc = new StopCluster.Location(
+      id("123"),
+      "aaa",
+      STOP,
+      "A stop",
+      new StopCluster.Coordinate(1.0d, 2.0d),
+      Set.of("RAIL"),
+      List.of(new StopCluster.Agency(id("a1"), "Agency")),
+      new StopCluster.FeedPublisher("Publisher")
+    );
+    var cluster = new StopCluster(loc, List.of(loc));
+
+    var json = mapper.valueToTree(cluster);
+
+    assertEqualJson(STOP_CLUSTER_JSON, json);
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/geocoder/StopCluster.java
+++ b/application/src/ext/java/org/opentripplanner/ext/geocoder/StopCluster.java
@@ -1,5 +1,10 @@
 package org.opentripplanner.ext.geocoder;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -24,7 +29,10 @@ record StopCluster(Location primary, Collection<Location> secondaries) {
   /**
    * Easily serializable version of an agency
    */
-  public record Agency(FeedScopedId id, String name) {}
+  public record Agency(
+    @JsonSerialize(using = FeedScopedIdSerializer.class) FeedScopedId id,
+    String name
+  ) {}
 
   /**
    * Easily serializable version of a feed publisher
@@ -37,7 +45,7 @@ record StopCluster(Location primary, Collection<Location> secondaries) {
   }
 
   public record Location(
-    FeedScopedId id,
+    @JsonSerialize(using = FeedScopedIdSerializer.class) FeedScopedId id,
     @Nullable String code,
     LocationType type,
     String name,
@@ -53,6 +61,15 @@ record StopCluster(Location primary, Collection<Location> secondaries) {
       Objects.requireNonNull(coordinate);
       Objects.requireNonNull(modes);
       Objects.requireNonNull(agencies);
+    }
+  }
+
+  private static class FeedScopedIdSerializer extends JsonSerializer<FeedScopedId> {
+
+    @Override
+    public void serialize(FeedScopedId value, JsonGenerator gen, SerializerProvider provider)
+      throws IOException {
+      gen.writeString(value.toString());
     }
   }
 }


### PR DESCRIPTION
### Summary

When we removed the REST API in #6578 we missed that the geocoder sandbox feature, used by Arcadis, had a dependency on the custom serializer for feed-scoped ids. This meant that the output for IDs in the geocoder endpoint changed.

This PR restores the old behaviour by adding a custom serializer to the sandbox code.

### Issue

Not issue, since this is a sandbox feature.

### Unit tests

Added.