### PR TITLE
Upgrade to OBA 7, remove unused fields

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -289,7 +289,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>6.1.2</version>
+            <version>7.0.0</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
@@ -92,7 +92,6 @@ class StopTimeMapper {
     lhs.setPickupType(PickDropMapper.map(rhs.getPickupType()));
     lhs.setDropOffType(PickDropMapper.map(rhs.getDropOffType()));
     lhs.setShapeDistTraveled(rhs.getShapeDistTraveled());
-    lhs.setFarePeriodId(rhs.getFarePeriodId());
     lhs.setFlexWindowStart(rhs.getStartPickupDropOffWindow());
     lhs.setFlexWindowEnd(rhs.getEndPickupDropOffWindow());
 

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -191,14 +191,6 @@ public final class StopTime implements Comparable<StopTime> {
     this.shapeDistTraveled = shapeDistTraveled;
   }
 
-  public String getFarePeriodId() {
-    return farePeriodId;
-  }
-
-  public void setFarePeriodId(String farePeriodId) {
-    this.farePeriodId = farePeriodId;
-  }
-
   public int getFlexWindowStart() {
     return flexWindowStart;
   }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/StopTimeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/StopTimeMapperTest.java
@@ -45,8 +45,6 @@ public class StopTimeMapperTest {
 
   private static final int DROP_OFF_TYPE = 2;
 
-  private static final String FARE_PERIOD_ID = "Fare Period Id";
-
   private static final int PICKUP_TYPE = 3;
 
   private static final String ROUTE_SHORT_NAME = "Route Short Name";
@@ -138,7 +136,6 @@ public class StopTimeMapperTest {
     stopTime.setArrivalTime(ARRIVAL_TIME);
     stopTime.setDepartureTime(DEPARTURE_TIME);
     stopTime.setDropOffType(DROP_OFF_TYPE);
-    stopTime.setFarePeriodId(FARE_PERIOD_ID);
     stopTime.setPickupType(PICKUP_TYPE);
     stopTime.setRouteShortName(ROUTE_SHORT_NAME);
     stopTime.setShapeDistTraveled(SHAPE_DIST_TRAVELED);
@@ -163,7 +160,6 @@ public class StopTimeMapperTest {
     assertEquals(ARRIVAL_TIME, result.getArrivalTime());
     assertEquals(DEPARTURE_TIME, result.getDepartureTime());
     assertEquals(PickDrop.CALL_AGENCY, result.getDropOffType());
-    assertEquals(FARE_PERIOD_ID, result.getFarePeriodId());
     assertEquals(PickDrop.COORDINATE_WITH_DRIVER, result.getPickupType());
     assertEquals(ROUTE_SHORT_NAME, result.getRouteShortName());
     assertEquals(SHAPE_DIST_TRAVELED, result.getShapeDistTraveled(), 0.0001d);
@@ -183,7 +179,6 @@ public class StopTimeMapperTest {
     assertFalse(result.isArrivalTimeSet());
     assertFalse(result.isDepartureTimeSet());
     assertEquals(PickDrop.SCHEDULED, result.getDropOffType());
-    assertNull(result.getFarePeriodId());
     assertEquals(PickDrop.SCHEDULED, result.getPickupType());
     assertNull(result.getRouteShortName());
     assertFalse(result.isShapeDistTraveledSet());


### PR DESCRIPTION
### Summary

It upgrades onebusaway to version 7. This version [stops parsing a lot of fields](https://github.com/OneBusAway/onebusaway-gtfs-modules/pull/346) that never made it into the GTFS spec and occasionally cause problems when parsing feeds that, for inexplicable reasons, still contain those fields.

We had a tiny bit of mapping code for those fields but it was only used in a test, so can go away, too.