### PR TITLE
Allow location groups without names

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/resources/ResourceBundleSingleton.java
+++ b/application/src/main/java/org/opentripplanner/framework/resources/ResourceBundleSingleton.java
@@ -15,14 +15,15 @@ public enum ResourceBundleSingleton {
   static final ResourceBundle.Control noFallbackControl = Control.getNoFallbackControl(
     Control.FORMAT_PROPERTIES
   );
-  private final Set<String> internalKeys = Set.of(
+  private static final Set<String> INTERNAL_KEYS = Set.of(
     "corner",
     "unnamedStreet",
     "origin",
     "destination",
     "partOf",
     "price.free",
-    "price.startMain"
+    "price.startMain",
+    "locationGroup"
   );
 
   //in singleton because resurce bundles are cached based on calling class
@@ -36,7 +37,7 @@ public enum ResourceBundleSingleton {
     }
     try {
       ResourceBundle resourceBundle;
-      if (internalKeys.contains(key)) {
+      if (INTERNAL_KEYS.contains(key)) {
         resourceBundle = ResourceBundle.getBundle("internals", locale, noFallbackControl);
       } else {
         resourceBundle = ResourceBundle.getBundle("WayProperties", locale, noFallbackControl);

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
@@ -8,15 +8,15 @@ import javax.annotation.Nullable;
 import org.onebusaway.gtfs.model.Location;
 import org.onebusaway.gtfs.model.LocationGroup;
 import org.onebusaway.gtfs.model.Stop;
+import org.opentripplanner.framework.i18n.LocalizedString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.GroupStop;
-import org.opentripplanner.transit.model.site.GroupStopBuilder;
 import org.opentripplanner.transit.service.SiteRepositoryBuilder;
 import org.opentripplanner.utils.collection.MapUtils;
 
 class LocationGroupMapper {
 
+  private static final LocalizedString FALLBACK_NAME = new LocalizedString("locationGroup");
   private final IdFactory idFactory;
   private final StopMapper stopMapper;
   private final LocationMapper locationMapper;
@@ -48,7 +48,7 @@ class LocationGroupMapper {
   private GroupStop doMap(LocationGroup element) {
     var id = idFactory.createId(element.getId());
     // the GTFS spec allows name-less location groups: https://gtfs.org/documentation/schedule/reference/#location_groupstxt
-    var name = NonLocalizedString.ofNullableOrElse(element.getName(), id.toString());
+    var name = NonLocalizedString.ofNullableOrElse(element.getName(), FALLBACK_NAME);
     var groupStopBuilder = siteRepositoryBuilder.groupStop(id).withName(name);
 
     for (var location : element.getLocations()) {

--- a/application/src/main/resources/internals.properties
+++ b/application/src/main/resources/internals.properties
@@ -3,6 +3,7 @@ unnamedStreet = unnamed
 origin = Origin
 destination = Destination
 partOf = %s (part of %s)
+locationGroup = Location group
 
 # used in the Bikely bike parking updater
 price.free = Free of charge

--- a/application/src/main/resources/internals_de.properties
+++ b/application/src/main/resources/internals_de.properties
@@ -1,3 +1,4 @@
 corner = Kreuzung %s mit %s
 unnamedStreet = unbekannte Strasse
 partOf = %s (Teil von %s)
+locationGroup = Location Group

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationGroupMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationGroupMapperTest.java
@@ -45,7 +45,7 @@ class LocationGroupMapperTest {
 
     lg.addLocation(stop());
     var groupStop = mapper.map(lg);
-    assertEquals("F:group-1", groupStop.getName().toString());
+    assertEquals("Location group", groupStop.getName().toString());
   }
 
   private static LocationGroupMapper defaultMapper() {


### PR DESCRIPTION
### Summary

The GTFS spec allows Flex allows name-less location groups but OTP throws an exception. This fixes it.

### Issue

Closes #6673

### Unit tests

Added.

### Documentation

Line comments.