### PR TITLE
Fix route filter application for stations in GTFS API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.GraphQLUtils;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
@@ -486,6 +487,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
     );
   }
 
+  @Nullable
   private Collection<Route> getRoutes(DataFetchingEnvironment environment) {
     return getValue(
       environment,

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -36,6 +36,7 @@ import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.ArrivalDeparture;
 import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.utils.collection.CollectionUtils;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
 public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
@@ -243,7 +244,10 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
     return env -> {
       var args = new GraphQLTypes.GraphQLStopRoutesArgs(env.getArguments());
       var routes = getRoutes(env);
-      if (LocalDateRangeUtil.hasServiceDateFilter(args.getGraphQLServiceDates())) {
+      if (
+        LocalDateRangeUtil.hasServiceDateFilter(args.getGraphQLServiceDates()) &&
+        !CollectionUtils.isEmpty(routes)
+      ) {
         var filter = PatternByDateFilterUtil.ofGraphQL(
           args.getGraphQLServiceDates(),
           getTransitService(env)

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -103,6 +103,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -117,6 +118,7 @@ class GraphQLIntegrationTest {
 
   private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
 
+  private static final Station OMEGA = TEST_MODEL.station("Omega").build();
   private static final Place A = TEST_MODEL.place("A", 5.0, 8.0);
   private static final Place B = TEST_MODEL.place("B", 6.0, 8.5);
   private static final Place C = TEST_MODEL.place("C", 7.0, 9.0);
@@ -155,8 +157,6 @@ class GraphQLIntegrationTest {
       .withCurrentFuelPercent(null)
       .build();
 
-  static final Graph GRAPH = new Graph();
-
   static final Instant ALERT_START_TIME = OffsetDateTime.parse(
     "2023-02-15T12:03:28+01:00"
   ).toInstant();
@@ -187,6 +187,7 @@ class GraphQLIntegrationTest {
 
     var siteRepositoryBuilder = TEST_MODEL.siteRepositoryBuilder();
     STOP_LOCATIONS.forEach(siteRepositoryBuilder::withRegularStop);
+    siteRepositoryBuilder.withStation(OMEGA);
     var siteRepository = siteRepositoryBuilder.build();
     var timetableRepository = new TimetableRepository(siteRepository, DEDUPLICATOR);
 

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/stations.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/stations.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "stations": [
+      {
+        "gtfsId": "F:Omega",
+        "lat": 60.0,
+        "lon": 10.0,
+        "name": "Omega",
+        "vehicleMode": null,
+        "allRoutes": null,
+        "routesWithinRange": null
+      }
+    ]
+  }
+}

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stations.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stations.graphql
@@ -1,0 +1,21 @@
+{
+  stations {
+    gtfsId
+    lat
+    lon
+    name
+    vehicleMode
+    allRoutes: routes {
+      gtfsId
+      longName
+      shortName
+    }
+    routesWithinRange: routes(
+      serviceDates: { start: "2024-09-10", end: "2024-09-10" }
+    ) {
+      gtfsId
+      longName
+      shortName
+    }
+  }
+}


### PR DESCRIPTION
### Summary

When a station is returned by the `nearest` query _and_ you apply a filter to the `routes` resolver a NPE occurs as the routes of a station are defined to be `null`.

Sadly, `Station` uses the same GraphQL type as `Stop` so you can apply a filter even though the routes are always null.

This PR fixes the problem.

### Issue

None.

### Unit tests

Added.

### Documentation

Nullability annotation added.

cc @miles-grant-ibigroup @fpurcell 