### PR TITLE
Azure delete subscription fix

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
@@ -17,7 +17,6 @@ import jakarta.xml.bind.JAXBException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -219,7 +218,7 @@ public class SiriAzureUpdater implements GraphUpdater {
       setPrimed();
 
       ApplicationShutdownSupport.addShutdownHook("azure-siri-updater-shutdown", () -> {
-        LOG.info("Calling shutdownHook on AbstractAzureSiriUpdater");
+        LOG.info("Calling shutdownHook on {} updater", updaterType);
         if (eventProcessor != null) {
           eventProcessor.close();
         }
@@ -352,7 +351,7 @@ public class SiriAzureUpdater implements GraphUpdater {
     }
     serviceBusAdmin.createSubscription(topicName, subscriptionName, options);
 
-    LOG.info("{} created subscription {}", getClass().getSimpleName(), subscriptionName);
+    LOG.info("{} updater created subscription {}", updaterType, subscriptionName);
   }
 
   /**


### PR DESCRIPTION
### Summary

Pure sandbox code.

This fixes an issue with cleaning up of subscriptions in the azure siri code. The azure credential provider by default uses a shared executor service that has its own shutdown hook. This makes it unusable in our shutdown hook (where it is used to clean up subscriptions) since the executor service is being shut down at the same time as our shutdown code is run.

Solve this by using an executor service that uses the current thread for execution.

Also:
- Switch to synchronous ServiceBusAdministrationClient since we are blocking on all calls anyway.
- Improve some logging.


### Unit tests

This piece of code is very hard to unit test.

### Bumping the serialization version id

No