### PR TITLE
Skip new ser-ver-id for --release option (custom-release)

### DIFF
--- a/script/CUSTOM_RELEASE_README.md
+++ b/script/CUSTOM_RELEASE_README.md
@@ -1,7 +1,7 @@
 # README - OTP Custom/Fork Release Scripts
 
-**Note! This describes how you can set up and release OTP in your own GitHub fork, not how OTP in the
-main repo is released.**
+**Note! This describes how you can set up and release OTP in your own GitHub fork, not how OTP in
+the main repo is released.**
 
 
 ## Introduction
@@ -24,22 +24,23 @@ The release is made in the `release branch` in the forked git repository. The re
 based on the `base revision` - a branch, tag or commit, for example `otp/dev-2.x`. 
 
 1. The release script will start by _resetting_ the `release branch` to the given `base revision`.
-  **Nothing is kept from previous releases.**
+   **Nothing is kept from previous releases.**
 2. Then all pending PRs tagged with your `TEST` label is meged in. The name of the label is 
-  configured in the `custom-release-env.json` file.
+   configured in the `custom-release-env.json` file.
 3. Then all your extension branches are meged in. These are normally branchech with your deployment
-  config and GitHub workflow files. The name of these branches is configured in the 
-  `custom-release-env.json` file.
+   config and GitHub workflow files. The name of these branches is configured in the 
+   `custom-release-env.json` file.
 4. The `custom-release-extension` script is run, if it exist. For example you may delete 
-  workflow scripts comming from the upstream `base revision`. 
+   workflow scripts comming from the upstream `base revision`. 
 5. The old release is then merged with an _empty merge_, this is done to create a continuous line
-  of releases in the release branch for easy viewing and navigation of the git history. Nothing
-  from the previous release is copied into the new release. We call this an _empty merge_.
-6. Then the script update the _otp-serialization-version-id_ and OTP _version_. Each release is 
-  given a unique version number specific to your fork, like `v2.7.0-MY_ORG-1`. The release script
-  uses both the git history and the GitHub GraphQL API (PRs labeled `bump serialization id`) to 
-  resolve the versions numbers. 
-7. The script finally push the release.
+   of releases in the release branch for easy viewing and navigation of the git history. Nothing
+   from the previous release is copied into the new release. We call this an _empty merge_.
+6. Then the script update the _otp-serialization-version-id_ and the OTP _version_ in the pom.xml 
+   file. Each release is given a unique version number specific to your fork, like 
+   `v2.7.0-MY_ORG-1`. The release script uses both the git history and the GitHub GraphQL API 
+   (PRs labeled `bump serialization id`) to resolve the serialization version number. 
+7. Finally the release is tagged and pushed to the remote Git repository. The repository is 
+   configured in the `custom-release-env.json` file.
 
 Do not worry about deleting more recent versions, the release script will preserve the history so
 nothing is lost.

--- a/script/custom-release.py
+++ b/script/custom-release.py
@@ -330,7 +330,7 @@ def print_summary():
             print("## Pull Requests", file=f)
             print(f"These PRs are tagged with {config.include_prs_label}.\n", file=f)
         for pr in pullRequests:
-            print(f"  -  {pr.link()}", file=f)
+            print(f"  -  {pr.description_link()}", file=f)
         p = execute(
             "./script/changelog-diff.py",
             state.latest_version_tag(),

--- a/script/custom-release.py
+++ b/script/custom-release.py
@@ -259,10 +259,12 @@ def merge_in_old_release_with_no_changes():
 def run_custom_release_extensions():
     section('Run custom release extensions bash script ...')
     ext_script = 'script/custom-release-extension'
-    if os.path.exists(ext_script):
-        execute(ext_script)
+    if not os.path.exists(ext_script):
+        warn(f"Script '{ext_script}' not found!")
     else:
-        print(f"Script '{ext_script}' not found!")
+        p = subprocess.run(ext_script, text=True, timeout=20)
+        if p.returncode != 0:
+            error(f'Custom script {ext_script} failed. Return code: {p.returncode}')
 
 
 def set_maven_pom_version():
@@ -808,6 +810,10 @@ def section(msg: str):
 
 def info(msg):
     print(f'{msg}', flush=True)
+
+
+def warn(msg):
+    print(f'\nWARNING {msg}\n', flush=True)
 
 
 def error(msg):

--- a/script/custom-release.py
+++ b/script/custom-release.py
@@ -692,13 +692,17 @@ def git_dr(*cmd, error_msg=None):
     if options.dry_run:
         return git(*cmd, '--dry-run', error_msg=error_msg)
     else:
-        return execute('git', *cmd, error_msg=error_msg)
+        return git(*cmd, error_msg=error_msg)
 
 
 # Similar as 'git_dr()', but the command is just printed, not executed with the git '--dry-run'
-# flag set. This is required if the git command do not support the '--dry-run' flag.
+# flag set. This is required if the git command do not support the '--dry-run' flag. Note!
+# Return None if the command is not run.
 def git_im(*cmd, error_msg=None):
-    return execute('git', *cmd, error_msg=error_msg, impact=True)
+    if options.dry_run:
+        info(f'=> {cmd}  (--dryRun SKIPPED)')
+        return None
+    return git(*cmd, error_msg=error_msg)
 
 
 # Run maven and pipe the output to sdtout and stderr
@@ -710,10 +714,7 @@ def mvn(*cmd):
         exit(p.returncode)
 
 
-def execute(*cmd, quiet=True, quiet_err=False, error_msg=None, impact=False):
-    if options.dry_run and impact:
-        info(f'=> {cmd}  (--dryRun SKIPPED)')
-        return
+def execute(*cmd, quiet=True, quiet_err=False, error_msg=None):
     info(f'Run: {cmd}')
     p = subprocess.run(args=list(cmd), capture_output=True, text=True, timeout=20)
 

--- a/script/custom-release.py
+++ b/script/custom-release.py
@@ -477,6 +477,7 @@ def list_labeled_prs():
           nodes {
             number, 
             title, 
+            headRefOid,
             labels(first: 20) {
               nodes {
                 name


### PR DESCRIPTION
### Summary

This PR improve the`custom_release.py` with enhanced logic on setting the correct `serialization.version.id`. The new logic work as follows:

> The script will resolve what the next serialization version id (SID) should be. This is a complex task.
> Here is an overview:
>  1. If the --serVerId option exist, then the latest SID is bumped and used.
>  2. If the --release option exist, then the current pom.xml SID is validated, if ok it is used,
>     if not the script exit.
>  3. All merged in PRs are checked. If a PR is labeled with 'bump serialization id' and the the
>     HEAD commit is not in the latest release, then the last release SID is bumped and used.
>  4. Finally, the script look at the upstream SID for the last release and the base. If the SID
>     is not the same the SID of the last release is bumped. To find the *upstream* SIDs the script
>     look at the git history/log NOT matching the project serialization version id prefix - this
>     is assumed to be the latest SID for the upstream project.
>
> Tip! If the '--release' option is used, then the serialization version id is NOT updated. Use the
> '--serVerId' option together with the '--release' to force update the serialization version id.


The terms "current release" and "new release" was slightly misleading. I changed them to:
 
  -  `latest release` (was `current release`). The last tagged release. 
  -  `next release` (was `new release`) . The new release to be created next. Current is still used to refer to the current content of e.g. pom.xml - next refer to the what the value will be after the release is made.
  
  In addition to these terms the `base release` is used to refer to the release used as the starting point for the next release - witch might be the latest release, but could be any commit. 
 

### Issue

🟥  There is no issue for this.

### Unit tests

🟥  There are no tests on the custom release script.


### Documentation

✅  The doc is updated.


### Changelog

🟥  This is to technical and minor to end up in the release notes.

### Bumping the serialization version id

🟥  Does not have any effect on OTP at all.
