### PR TITLE
Use Java 24 for container image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,7 @@
                     <container>
                         <mainClass>org.opentripplanner.standalone.OTPMain</mainClass>
                         <entrypoint>/docker-entrypoint.sh</entrypoint>
+                        <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         <volumes>
                             <volume>
                                 /var/opentripplanner/
@@ -329,7 +330,7 @@
                         </ports>
                     </container>
                     <from>
-                        <image>eclipse-temurin:21-jre</image>
+                        <image>eclipse-temurin:24-jre</image>
                         <platforms>
                             <platform>
                                 <architecture>amd64</architecture>


### PR DESCRIPTION
### Summary

This upgrades the container image with jib to Java 24, which has a few features to reduce memory consumption.

The language level remains at Java 21 and you can keep using Java 21 for all your deployments if you want.

I've also configured the build to use the current timestamp for the image. This isn't configured by default as it would make the image non-reproducible, but since we are using a tag as the base image, which can change every now and again, it isn't reproducible anyway.