### PR TITLE
Fix initialization bug in DebugRaptor request DTO

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/interactivelauncher/debug/raptor/RaptorDebugModel.java
+++ b/application/src/ext/java/org/opentripplanner/ext/interactivelauncher/debug/raptor/RaptorDebugModel.java
@@ -89,7 +89,7 @@ public class RaptorDebugModel implements LauncherRequestDecorator {
           )
         )
       )
-      .buildRequest();
+      .buildDefault();
   }
 
   private void save() {

--- a/application/src/main/java/org/opentripplanner/routing/api/request/DebugRaptor.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/DebugRaptor.java
@@ -1,11 +1,13 @@
 package org.opentripplanner.routing.api.request;
 
+import static org.opentripplanner.routing.api.request.DebugEventType.DESTINATION_ARRIVALS;
+import static org.opentripplanner.routing.api.request.DebugEventType.STOP_ARRIVALS;
+
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.opentripplanner.utils.collection.EnumSetUtils;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
@@ -37,6 +39,11 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 public class DebugRaptor implements Serializable {
 
   private static final int FIRST_STOP_INDEX = 0;
+  private static final int DEFAULT_DEBUG_PATH_FROM_STOP_INDEX = 0;
+  private static final Set<DebugEventType> DEFAULT_EVENT_TYPES = Set.of(
+    STOP_ARRIVALS,
+    DESTINATION_ARRIVALS
+  );
   private static final DebugRaptor DEFAULT = new DebugRaptor();
 
   private final List<Integer> stops;
@@ -53,11 +60,11 @@ public class DebugRaptor implements Serializable {
     this.stops = List.copyOf(stops);
     this.path = List.copyOf(path);
     this.debugPathFromStopIndex = debugPathFromStopIndex;
-    this.eventTypes = Collections.unmodifiableSet(eventTypes);
+    this.eventTypes = EnumSetUtils.unmodifiableEnumSet(eventTypes, DebugEventType.class);
   }
 
   public DebugRaptor() {
-    this(List.of(), List.of(), 0, EnumSet.noneOf(DebugEventType.class));
+    this(List.of(), List.of(), DEFAULT_DEBUG_PATH_FROM_STOP_INDEX, DEFAULT_EVENT_TYPES);
   }
 
   public static DebugRaptor defaltValue() {
@@ -116,7 +123,7 @@ public class DebugRaptor implements Serializable {
     return ToStringBuilder.of(DebugRaptor.class)
       .addObj("stops", stopsToString(stops, FIRST_STOP_INDEX))
       .addObj("path", stopsToString(path, debugPathFromStopIndex))
-      .addCol("eventType", eventTypes)
+      .addCol("eventType", eventTypes, DEFAULT_EVENT_TYPES)
       .toString();
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/api/request/DebugRaptorBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/DebugRaptorBuilder.java
@@ -18,6 +18,7 @@ public class DebugRaptorBuilder implements Serializable {
 
   private static final Pattern FIRST_STOP_PATTERN = Pattern.compile("(\\d+)\\*");
   private static final int FIRST_STOP_INDEX = 0;
+  private static final int NOT_SET = -999_999_999;
 
   private List<Integer> stops;
   private List<Integer> path;
@@ -30,7 +31,7 @@ public class DebugRaptorBuilder implements Serializable {
 
     this.stops = null;
     this.path = null;
-    this.debugPathFromStopIndex = original.debugPathFromStopIndex();
+    this.debugPathFromStopIndex = NOT_SET;
     this.eventTypes = null;
   }
 
@@ -68,8 +69,7 @@ public class DebugRaptorBuilder implements Serializable {
   }
 
   public DebugRaptorBuilder withEventTypes(Collection<DebugEventType> eventTypes) {
-    this.eventTypes.clear();
-    this.eventTypes.addAll(eventTypes);
+    this.eventTypes = Set.copyOf(eventTypes);
     return this;
   }
 
@@ -82,7 +82,9 @@ public class DebugRaptorBuilder implements Serializable {
     var value = new DebugRaptor(
       ifNotNull(stops, original.stops()),
       ifNotNull(path, original.path()),
-      debugPathFromStopIndex,
+      debugPathFromStopIndex == NOT_SET
+        ? original.debugPathFromStopIndex()
+        : debugPathFromStopIndex,
       ifNotNull(eventTypes, original.eventTypes())
     );
     return original.equals(value) ? original : value;

--- a/application/src/test/java/org/opentripplanner/routing/api/request/DebugRaptorTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/DebugRaptorTest.java
@@ -1,8 +1,12 @@
 package org.opentripplanner.routing.api.request;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.routing.api.request.DebugEventType.DESTINATION_ARRIVALS;
+import static org.opentripplanner.routing.api.request.DebugEventType.PATTERN_RIDES;
+import static org.opentripplanner.routing.api.request.DebugEventType.STOP_ARRIVALS;
 
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class DebugRaptorTest {
@@ -33,12 +37,33 @@ class DebugRaptorTest {
   }
 
   @Test
+  void withEvents() {
+    assertEquals(
+      Set.of(STOP_ARRIVALS, DESTINATION_ARRIVALS),
+      DebugRaptor.defaltValue().eventTypes()
+    );
+    assertEquals(Set.of(), subject().withEventTypes(List.of()).build().eventTypes());
+    assertEquals(
+      Set.of(DESTINATION_ARRIVALS),
+      subject().withEventTypes(List.of(DESTINATION_ARRIVALS)).build().eventTypes()
+    );
+    assertEquals(
+      Set.of(STOP_ARRIVALS, PATTERN_RIDES),
+      subject().withEventTypes(List.of(STOP_ARRIVALS, PATTERN_RIDES)).build().eventTypes()
+    );
+  }
+
+  @Test
   void testToString() {
     assertEquals("DebugRaptor{stops: 12}", subject().withStops("12").build().toString());
     assertEquals("DebugRaptor{path: 13, 22*}", subject().withPath("13 22*").build().toString());
     assertEquals(
       "DebugRaptor{path: 17, 2*, 32}",
       subject().withPath("17 2* 32*").build().toString()
+    );
+    assertEquals(
+      "DebugRaptor{stops: 12, eventType: [STOP_ARRIVALS]}",
+      subject().withEventTypes(Set.of(STOP_ARRIVALS)).withStops("12").build().toString()
     );
   }
 

--- a/utils/src/main/java/org/opentripplanner/utils/collection/EnumSetUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/EnumSetUtils.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.utils.collection;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+public class EnumSetUtils {
+
+  /**
+   * This is private to avoid instansiation of static utility classs.
+   */
+  private EnumSetUtils() {}
+
+  /**
+   * Create an {@link EnumSet} wrapped using {@link Collections#unmodifiableSet(Set)}. The
+   * retuned set has almost the same efficiensy as EnumSet and is immutable, witch EnumSet is not.
+   */
+  public static <E extends Enum> Set<E> unmodifiableEnumSet(Collection<E> values, Class<E> type) {
+    var enumSet = values.isEmpty() ? EnumSet.noneOf(type) : EnumSet.copyOf(values);
+    return Collections.unmodifiableSet(enumSet);
+  }
+}

--- a/utils/src/main/java/org/opentripplanner/utils/collection/EnumSetUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/EnumSetUtils.java
@@ -8,13 +8,13 @@ import java.util.Set;
 public class EnumSetUtils {
 
   /**
-   * This is private to avoid instansiation of static utility classs.
+   * This is private to avoid instantiation of static utility class.
    */
   private EnumSetUtils() {}
 
   /**
    * Create an {@link EnumSet} wrapped using {@link Collections#unmodifiableSet(Set)}. The
-   * retuned set has almost the same efficiensy as EnumSet and is immutable, witch EnumSet is not.
+   * returned set has almost the same efficiency as EnumSet and is immutable, which EnumSet is not.
    */
   public static <E extends Enum> Set<E> unmodifiableEnumSet(Collection<E> values, Class<E> type) {
     var enumSet = values.isEmpty() ? EnumSet.noneOf(type) : EnumSet.copyOf(values);

--- a/utils/src/test/java/org/opentripplanner/utils/collection/EnumSetUtilsTest.java
+++ b/utils/src/test/java/org/opentripplanner/utils/collection/EnumSetUtilsTest.java
@@ -1,0 +1,27 @@
+package org.opentripplanner.utils.collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.utils.collection.EnumSetUtilsTest.Foo.BAR;
+import static org.opentripplanner.utils.collection.EnumSetUtilsTest.Foo.CODE;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class EnumSetUtilsTest {
+
+  @Test
+  void unmodifiableEnumSet() {
+    assertEquals(Set.of(), EnumSetUtils.unmodifiableEnumSet(List.of(), Foo.class));
+    assertEquals(Set.of(BAR), EnumSetUtils.unmodifiableEnumSet(List.of(BAR), Foo.class));
+    assertEquals(
+      Set.of(BAR, CODE),
+      EnumSetUtils.unmodifiableEnumSet(List.of(BAR, CODE), Foo.class)
+    );
+  }
+
+  enum Foo {
+    BAR,
+    CODE,
+  }
+}


### PR DESCRIPTION
### Summary

The DebugRaptor class fails with an NullPointerException when initialized.

<details>
<summary>StackTrace</summary>
<pre>
java.lang.NullPointerException: Cannot invoke "java.util.Set.clear()" because "this.eventTypes" is null

	at org.opentripplanner.routing.api.request.DebugRaptorBuilder.withEventTypes(DebugRaptorBuilder.java:71)
	at org.opentripplanner.routing.api.request.DebugRaptorTest.testToString(DebugRaptorTest.java:66)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
</pre>
</details>
	
	
### Issue

🟥  No issue, detected when debugging production problem

### Unit tests

✅  Regression unit tests added.

### Documentation

✅  JavaDoc

### Changelog

🟥  Not relevant

### Bumping the serialization version id

🟥  The DebugRaptor request is part of the serialized graph, but the state has not changes so there is no need to update the _serialization-version-id_.