### PR TITLE
Fix error message in StreetModeMapper

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapper.java
@@ -29,7 +29,7 @@ public class StreetModeMapper {
   public static StreetMode getStreetModeForRouting(List<StreetMode> modes) {
     if (modes.size() > 2) {
       throw new IllegalArgumentException(
-        "Only one or two modes can be specified for a leg, got: %.".formatted(modes)
+        "Only one or two modes can be specified for a leg, got: %s.".formatted(modes)
       );
     }
     if (modes.size() == 1) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapper.java
@@ -29,7 +29,7 @@ public class StreetModeMapper {
   public static StreetMode getStreetModeForRouting(List<StreetMode> modes) {
     if (modes.size() > 2) {
       throw new IllegalArgumentException(
-        "Only one or two modes can be specified for a leg, got: %s.".formatted(modes)
+        "Only one or two modes can be specified for a leg, got: " + modes + "."
       );
     }
     if (modes.size() == 1) {
@@ -39,28 +39,26 @@ public class StreetModeMapper {
       // only walking.
       if (!isAlwaysPresentInLeg(mode)) {
         throw new IllegalArgumentException(
-          "For the time being, %s needs to be combined with WALK mode for the same leg.".formatted(
-              mode
-            )
+          "For the time being, " + mode + " needs to be combined with WALK mode for the same leg."
         );
       }
       return mode;
     }
     if (modes.contains(StreetMode.BIKE)) {
       throw new IllegalArgumentException(
-        "Bicycle can't be combined with other modes for the same leg: %s.".formatted(modes)
+        "Bicycle can't be combined with other modes for the same leg: " + modes + "."
       );
     }
     if (modes.contains(StreetMode.CAR)) {
       throw new IllegalArgumentException(
-        "Car can't be combined with other modes for the same leg: %s.".formatted(modes)
+        "Car can't be combined with other modes for the same leg: " + modes + "."
       );
     }
     if (!modes.contains(StreetMode.WALK)) {
       throw new IllegalArgumentException(
-        "For the time being, WALK needs to be added as a mode for a leg when using %s and these two can't be used in the same leg.".formatted(
-            modes
-          )
+        "For the time being, WALK needs to be added as a mode for a leg when using " +
+        modes +
+        " and these two can't be used in the same leg."
       );
     }
     // Walk is currently always used as an implied mode when mode is not car.

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapperTest.java
@@ -1,0 +1,106 @@
+package org.opentripplanner.apis.gtfs.mapping.routerequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.api.request.StreetMode;
+
+class StreetModeMapperTest {
+
+  @Test
+  void testGetStreetModeForRoutingWithWalkOnly() {
+    assertEquals(
+      StreetMode.WALK,
+      StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.WALK))
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithBikeOnly() {
+    assertEquals(
+      StreetMode.BIKE,
+      StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.BIKE))
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithCarOnly() {
+    assertEquals(StreetMode.CAR, StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.CAR)));
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithParkingOnly() {
+    assertEquals(
+      StreetMode.BIKE_TO_PARK,
+      StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.BIKE_TO_PARK))
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithRentalOnly() {
+    var exception = assertThrows(IllegalArgumentException.class, () ->
+      StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.BIKE_RENTAL))
+    );
+    assertEquals(
+      "For the time being, BIKE_RENTAL needs to be combined with WALK mode for the same leg.",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithTwoModesAndWalk() {
+    assertEquals(
+      StreetMode.SCOOTER_RENTAL,
+      StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.WALK, StreetMode.SCOOTER_RENTAL))
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithTwoModesAndNoWalk() {
+    var exception = assertThrows(IllegalArgumentException.class, () ->
+      StreetModeMapper.getStreetModeForRouting(
+        List.of(StreetMode.BIKE_RENTAL, StreetMode.SCOOTER_RENTAL)
+      )
+    );
+    assertEquals(
+      "For the time being, WALK needs to be added as a mode for a leg when using [BIKE_RENTAL, SCOOTER_RENTAL] and these two can't be used in the same leg.",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithCarAndWalk() {
+    var exception = assertThrows(IllegalArgumentException.class, () ->
+      StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.CAR, StreetMode.WALK))
+    );
+    assertEquals(
+      "Car can't be combined with other modes for the same leg: [CAR, WALK].",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithBicycleAndWalk() {
+    var exception = assertThrows(IllegalArgumentException.class, () ->
+      StreetModeMapper.getStreetModeForRouting(List.of(StreetMode.BIKE, StreetMode.WALK))
+    );
+    assertEquals(
+      "Bicycle can't be combined with other modes for the same leg: [BIKE, WALK].",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  void testGetStreetModeForRoutingWithMoreThanTwoModes() {
+    var exception = assertThrows(IllegalArgumentException.class, () ->
+      StreetModeMapper.getStreetModeForRouting(
+        List.of(StreetMode.WALK, StreetMode.BIKE_TO_PARK, StreetMode.CAR_TO_PARK)
+      )
+    );
+    assertEquals(
+      "Only one or two modes can be specified for a leg, got: [WALK, BIKE_TO_PARK, CAR_TO_PARK].",
+      exception.getMessage()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/StreetModeMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.gtfs.mapping.routerequest;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### Summary

Fix the string formatting of an error message in StreetModeMapper

### Issue

Fixes #6322

### Unit tests

added for `StreetModeMapper.getStreetModeForRouting`

### Documentation

Not needed

### Changelog

Not needed

### Bumping the serialization version id

Not needed