### PR TITLE
Improve error message for null IDs during GTFS mapping

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/AgencyMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/AgencyMapper.java
@@ -27,7 +27,7 @@ class AgencyMapper {
   }
 
   private Agency doMap(org.onebusaway.gtfs.model.Agency rhs) {
-    return Agency.of(idFactory.createId(rhs.getId()))
+    return Agency.of(idFactory.createId(rhs.getId(), "agency"))
       .withName(rhs.getName())
       .withTimezone(rhs.getTimezone())
       .withUrl(rhs.getUrl())

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareAttributeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareAttributeMapper.java
@@ -35,7 +35,9 @@ class FareAttributeMapper {
       Currency.getInstance(rhs.getCurrencyType()),
       rhs.getPrice()
     );
-    FareAttributeBuilder builder = FareAttribute.of(idFactory.createId(rhs.getId()))
+    FareAttributeBuilder builder = FareAttribute.of(
+      idFactory.createId(rhs.getId(), "fare attribute")
+    )
       .setPrice(price)
       .setPaymentMethod(rhs.getPaymentMethod());
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
@@ -35,14 +35,14 @@ final class FareLegRuleMapper {
     return allFareLegRules
       .stream()
       .map(r -> {
-        var fareProductId = idFactory.createId(r.getFareProductId());
+        var fareProductId = idFactory.createNullableId(r.getFareProductId());
         var productsForRule = fareProductMapper.getByFareProductId(fareProductId);
 
         if (!productsForRule.isEmpty()) {
           FareDistance fareDistance = createFareDistance(r);
           var ruleId = new FeedScopedId(fareProductId.getFeedId(), r.getId());
           return FareLegRule.of(ruleId, productsForRule)
-            .withLegGroupId(idFactory.createId(r.getLegGroupId()))
+            .withLegGroupId(idFactory.createNullableId(r.getLegGroupId()))
             .withNetworkId(idFactory.createNullableId(r.getNetworkId()))
             .withFromAreaId(areaId(r.getFromArea()))
             .withToAreaId(areaId(r.getToArea()))
@@ -66,7 +66,7 @@ final class FareLegRuleMapper {
     if (area == null) {
       return null;
     } else {
-      return idFactory.createId(area.getAreaId());
+      return idFactory.createId(area.getAreaId(), "area");
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
@@ -35,8 +35,11 @@ final class FareLegRuleMapper {
     return allFareLegRules
       .stream()
       .map(r -> {
-        var fareProductId = idFactory.createNullableId(r.getFareProductId());
-        var productsForRule = fareProductMapper.getByFareProductId(fareProductId);
+        var fareProductId = idFactory.createId(
+          r.getFareProductId(),
+          "fare leg rule's fare product id"
+        );
+        var productsForRule = fareProductMapper.findFareProducts(fareProductId);
 
         if (!productsForRule.isEmpty()) {
           FareDistance fareDistance = createFareDistance(r);

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareProductMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareProductMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.gtfs.mapping;
 
-import com.esotericsoftware.kryo.util.Null;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Currency;

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareProductMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareProductMapper.java
@@ -1,10 +1,12 @@
 package org.opentripplanner.gtfs.mapping;
 
+import com.esotericsoftware.kryo.util.Null;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Currency;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.RiderCategory;
@@ -30,7 +32,11 @@ class FareProductMapper {
     if (rhs.getDurationUnit() != NOT_SET) {
       duration = toDuration(rhs.getDurationUnit(), rhs.getDurationAmount());
     }
-    var fp = FareProduct.of(idFactory.createId(rhs.getFareProductId()), rhs.getName(), price)
+    var fp = FareProduct.of(
+      idFactory.createId(rhs.getFareProductId(), "fare product"),
+      rhs.getName(),
+      price
+    )
       .withValidity(duration)
       .withCategory(toInternalModel(rhs.getRiderCategory()))
       .withMedium(toInternalModel(rhs.getFareMedium()))
@@ -49,12 +55,15 @@ class FareProductMapper {
     return mappedFareProducts.stream().filter(p -> p.id().equals(fareProductId)).toList();
   }
 
-  private RiderCategory toInternalModel(org.onebusaway.gtfs.model.RiderCategory riderCategory) {
+  @Nullable
+  private RiderCategory toInternalModel(
+    @Nullable org.onebusaway.gtfs.model.RiderCategory riderCategory
+  ) {
     if (riderCategory == null) {
       return null;
     } else {
       return new RiderCategory(
-        idFactory.createId(riderCategory.getId()),
+        idFactory.createId(riderCategory.getId(), "rider category"),
         riderCategory.getName(),
         riderCategory.getEligibilityUrl()
       );
@@ -76,11 +85,12 @@ class FareProductMapper {
     };
   }
 
-  private FareMedium toInternalModel(org.onebusaway.gtfs.model.FareMedium c) {
+  @Nullable
+  private FareMedium toInternalModel(@Nullable org.onebusaway.gtfs.model.FareMedium c) {
     if (c == null) {
       return null;
     } else {
-      return new FareMedium(idFactory.createId(c.getId()), c.getName());
+      return new FareMedium(idFactory.createId(c.getId(), "fare medium"), c.getName());
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareProductMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareProductMapper.java
@@ -50,7 +50,7 @@ class FareProductMapper {
     return allFareProducts.stream().map(this::map).toList();
   }
 
-  public Collection<FareProduct> getByFareProductId(FeedScopedId fareProductId) {
+  public Collection<FareProduct> findFareProducts(FeedScopedId fareProductId) {
     return mappedFareProducts.stream().filter(p -> p.id().equals(fareProductId)).toList();
   }
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareTransferRuleMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareTransferRuleMapper.java
@@ -28,7 +28,7 @@ class FareTransferRuleMapper {
   }
 
   private FareTransferRule doMap(org.onebusaway.gtfs.model.FareTransferRule rhs) {
-    var fareProductId = idFactory.createId(rhs.getFareProductId());
+    var fareProductId = idFactory.createNullableId(rhs.getFareProductId());
     final var products = findFareProducts(fareProductId, rhs.getId());
 
     Duration duration = null;
@@ -36,9 +36,9 @@ class FareTransferRuleMapper {
       duration = Duration.ofSeconds(rhs.getDurationLimit());
     }
     return new FareTransferRule(
-      idFactory.createId(rhs.getId()),
-      idFactory.createId(rhs.getFromLegGroupId()),
-      idFactory.createId(rhs.getToLegGroupId()),
+      idFactory.createId(rhs.getId(), "fare transfer rule"),
+      idFactory.createNullableId(rhs.getFromLegGroupId()),
+      idFactory.createNullableId(rhs.getToLegGroupId()),
       rhs.getTransferCount(),
       duration,
       products

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareTransferRuleMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareTransferRuleMapper.java
@@ -53,7 +53,7 @@ class FareTransferRuleMapper {
     if (fareProductId == null) {
       return List.of();
     }
-    var products = fareProductMapper.getByFareProductId(fareProductId);
+    var products = fareProductMapper.findFareProducts(fareProductId);
     if (products.isEmpty()) {
       throw new IllegalArgumentException(
         "Cannot find fare product '%s' for transfer rule '%s'".formatted(fareProductId, ruleId)

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/IdFactory.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/IdFactory.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.utils.lang.StringUtils;
 
 /**
  * Responsible for creating feed-scoped from OBA's {@code AgencyAndId} or strings.
@@ -32,7 +33,9 @@ class IdFactory {
    *                   in case of invalid values.
    */
   FeedScopedId createId(String id, String entityName) {
-    Objects.requireNonNull(id, idErrorMessage(entityName));
+    if (StringUtils.hasNoValue(id)) {
+      throw new IllegalArgumentException(idErrorMessage(entityName));
+    }
     return new FeedScopedId(feedId, id);
   }
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/IdFactory.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/IdFactory.java
@@ -22,7 +22,7 @@ class IdFactory {
    *                   in case of invalid values.
    */
   FeedScopedId createId(AgencyAndId id, String entityName) {
-    Objects.requireNonNull(id, "id of %s must not be null".formatted(entityName));
+    Objects.requireNonNull(id, idErrorMessage(entityName));
     return createId(id.getId(), entityName);
   }
 
@@ -32,7 +32,7 @@ class IdFactory {
    *                   in case of invalid values.
    */
   FeedScopedId createId(String id, String entityName) {
-    Objects.requireNonNull(id, "id of %s must not be null".formatted(entityName));
+    Objects.requireNonNull(id, idErrorMessage(entityName));
     return new FeedScopedId(feedId, id);
   }
 
@@ -48,5 +48,9 @@ class IdFactory {
   @Nullable
   FeedScopedId createNullableId(@Nullable String id) {
     return id == null ? null : new FeedScopedId(feedId, id);
+  }
+
+  private static String idErrorMessage(String entityName) {
+    return "Error during GTFS processing: id of %s must not be null".formatted(entityName);
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/IdFactory.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/IdFactory.java
@@ -16,18 +16,30 @@ class IdFactory {
     this.feedId = Objects.requireNonNull(feedId);
   }
 
-  /** Map from GTFS to OTP model, {@code null} safe. */
-  @Nullable
-  FeedScopedId createId(@Nullable AgencyAndId id) {
-    return id == null ? null : new FeedScopedId(feedId, id.getId());
+  /**
+   * Maps from OBA AgencyAndId to feed-scoped ids. Values must not be null.
+   * @param entityName The name of the entity being mapped. Improves the error message being thrown
+   *                   in case of invalid values.
+   */
+  FeedScopedId createId(AgencyAndId id, String entityName) {
+    Objects.requireNonNull(id, "id of %s must not be null".formatted(entityName));
+    return createId(id.getId(), entityName);
   }
 
   /**
    * Maps from OBA strings to feed-scoped ids. Parameter must not be null.
+   * @param entityName The name of the entity being mapped. Improves the error message being thrown
+   *                   in case of invalid values.
    */
-  FeedScopedId createId(String id) {
-    Objects.requireNonNull(id, "id must not be null");
+  FeedScopedId createId(String id, String entityName) {
+    Objects.requireNonNull(id, "id of %s must not be null".formatted(entityName));
     return new FeedScopedId(feedId, id);
+  }
+
+  /** Map from GTFS to OTP model, {@code null} safe. */
+  @Nullable
+  FeedScopedId createNullableId(@Nullable AgencyAndId id) {
+    return id == null ? null : new FeedScopedId(feedId, id.getId());
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
@@ -46,7 +46,7 @@ class LocationGroupMapper {
   }
 
   private GroupStop doMap(LocationGroup element) {
-    var id = idFactory.createId(element.getId());
+    var id = idFactory.createId(element.getId(), "location group");
     // the GTFS spec allows name-less location groups: https://gtfs.org/documentation/schedule/reference/#location_groupstxt
     var name = NonLocalizedString.ofNullableOrElse(element.getName(), FALLBACK_NAME);
     var groupStopBuilder = siteRepositoryBuilder.groupStop(id).withName(name);

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
@@ -45,7 +45,7 @@ class LocationMapper {
   private AreaStop doMap(Location gtfsLocation) {
     var name = NonLocalizedString.ofNullable(gtfsLocation.getName());
     try {
-      var id = idFactory.createId(gtfsLocation.getId().getId(), "location");
+      var id = idFactory.createId(gtfsLocation.getId(), "location");
       Geometry geometry = GeometryUtils.convertGeoJsonToJtsGeometry(gtfsLocation.getGeometry());
       var isValidOp = new IsValidOp(geometry);
       if (!isValidOp.isValid()) {

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
@@ -45,7 +45,7 @@ class LocationMapper {
   private AreaStop doMap(Location gtfsLocation) {
     var name = NonLocalizedString.ofNullable(gtfsLocation.getName());
     try {
-      var id = idFactory.createId(gtfsLocation.getId());
+      var id = idFactory.createId(gtfsLocation.getId().getId(), "location");
       Geometry geometry = GeometryUtils.convertGeoJsonToJtsGeometry(gtfsLocation.getGeometry());
       var isValidOp = new IsValidOp(geometry);
       if (!isValidOp.isValid()) {

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
@@ -47,7 +47,7 @@ class PathwayMapper {
   }
 
   private Pathway doMap(org.onebusaway.gtfs.model.Pathway rhs) {
-    PathwayBuilder pathway = Pathway.of(idFactory.createId(rhs.getId()))
+    PathwayBuilder pathway = Pathway.of(idFactory.createId(rhs.getId(), "pathway"))
       .withPathwayMode(PathwayModeMapper.map(rhs.getPathwayMode()))
       .withFromStop(mapStationElement(rhs.getFromStop()))
       .withToStop(mapStationElement(rhs.getToStop()))

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
@@ -44,7 +44,7 @@ class RouteMapper {
   }
 
   private Route doMap(org.onebusaway.gtfs.model.Route rhs) {
-    var lhs = Route.of(idFactory.createId(rhs.getId()));
+    var lhs = Route.of(idFactory.createId(rhs.getId(), "route"));
     I18NString longName = null;
     if (rhs.getLongName() != null) {
       longName = translationHelper.getTranslation(
@@ -82,7 +82,9 @@ class RouteMapper {
     lhs.withTextColor(rhs.getTextColor());
     lhs.withBikesAllowed(BikeAccessMapper.mapForRoute(rhs));
     if (rhs.getNetworkId() != null) {
-      var networkId = GroupOfRoutes.of(idFactory.createId(rhs.getNetworkId())).build();
+      var networkId = GroupOfRoutes.of(
+        idFactory.createId(rhs.getNetworkId(), "network_id")
+      ).build();
       lhs.getGroupsOfRoutes().add(networkId);
     }
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarDateMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarDateMapper.java
@@ -33,7 +33,7 @@ class ServiceCalendarDateMapper {
 
   private ServiceCalendarDate doMap(org.onebusaway.gtfs.model.ServiceCalendarDate rhs) {
     return new ServiceCalendarDate(
-      idFactory.createNullableId(rhs.getServiceId()),
+      idFactory.createId(rhs.getServiceId(), "calendar date"),
       ServiceDateMapper.mapLocalDate(rhs.getDate()),
       rhs.getExceptionType()
     );

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarDateMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarDateMapper.java
@@ -33,7 +33,7 @@ class ServiceCalendarDateMapper {
 
   private ServiceCalendarDate doMap(org.onebusaway.gtfs.model.ServiceCalendarDate rhs) {
     return new ServiceCalendarDate(
-      idFactory.createId(rhs.getServiceId()),
+      idFactory.createNullableId(rhs.getServiceId()),
       ServiceDateMapper.mapLocalDate(rhs.getDate()),
       rhs.getExceptionType()
     );

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarMapper.java
@@ -31,7 +31,7 @@ class ServiceCalendarMapper {
   private ServiceCalendar doMap(org.onebusaway.gtfs.model.ServiceCalendar rhs) {
     ServiceCalendar lhs = new ServiceCalendar();
 
-    lhs.setServiceId(idFactory.createNullableId(rhs.getServiceId()));
+    lhs.setServiceId(idFactory.createId(rhs.getServiceId(), "service calendar"));
     lhs.setMonday(rhs.getMonday());
     lhs.setTuesday(rhs.getTuesday());
     lhs.setWednesday(rhs.getWednesday());

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceCalendarMapper.java
@@ -31,7 +31,7 @@ class ServiceCalendarMapper {
   private ServiceCalendar doMap(org.onebusaway.gtfs.model.ServiceCalendar rhs) {
     ServiceCalendar lhs = new ServiceCalendar();
 
-    lhs.setServiceId(idFactory.createId(rhs.getServiceId()));
+    lhs.setServiceId(idFactory.createNullableId(rhs.getServiceId()));
     lhs.setMonday(rhs.getMonday());
     lhs.setTuesday(rhs.getTuesday());
     lhs.setWednesday(rhs.getWednesday());

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/ShapePointMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/ShapePointMapper.java
@@ -29,7 +29,7 @@ class ShapePointMapper {
   private ShapePoint doMap(org.onebusaway.gtfs.model.ShapePoint rhs) {
     ShapePoint lhs = new ShapePoint();
 
-    lhs.setShapeId(idFactory.createNullableId(rhs.getShapeId()));
+    lhs.setShapeId(idFactory.createId(rhs.getShapeId(), "shape point"));
     lhs.setSequence(rhs.getSequence());
     lhs.setLat(rhs.getLat());
     lhs.setLon(rhs.getLon());

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/ShapePointMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/ShapePointMapper.java
@@ -29,7 +29,7 @@ class ShapePointMapper {
   private ShapePoint doMap(org.onebusaway.gtfs.model.ShapePoint rhs) {
     ShapePoint lhs = new ShapePoint();
 
-    lhs.setShapeId(idFactory.createId(rhs.getShapeId()));
+    lhs.setShapeId(idFactory.createNullableId(rhs.getShapeId()));
     lhs.setSequence(rhs.getSequence());
     lhs.setLat(rhs.getLat());
     lhs.setLon(rhs.getLon());

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/StationMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/StationMapper.java
@@ -51,7 +51,7 @@ class StationMapper {
           )
       );
     }
-    StationBuilder builder = Station.of(idFactory.createId(rhs.getId()))
+    StationBuilder builder = Station.of(idFactory.createId(rhs.getId(), "station"))
       .withCoordinate(WgsCoordinateMapper.mapToDomain(rhs))
       .withCode(rhs.getCode());
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/StopMappingWrapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/StopMappingWrapper.java
@@ -21,7 +21,7 @@ class StopMappingWrapper {
   }
 
   public FeedScopedId getId() {
-    return idFactory.createId(stop.getId());
+    return idFactory.createNullableId(stop.getId());
   }
 
   public String getName() {

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -53,10 +53,10 @@ class TripMapper {
   }
 
   private Trip doMap(org.onebusaway.gtfs.model.Trip rhs) {
-    var lhs = Trip.of(idFactory.createId(rhs.getId()));
+    var lhs = Trip.of(idFactory.createId(rhs.getId(), "trip"));
 
     lhs.withRoute(routeMapper.map(rhs.getRoute()));
-    lhs.withServiceId(idFactory.createId(rhs.getServiceId()));
+    lhs.withServiceId(idFactory.createNullableId(rhs.getServiceId()));
     lhs.withShortName(rhs.getTripShortName());
     I18NString tripHeadsign = null;
     if (rhs.getTripHeadsign() != null) {
@@ -70,7 +70,7 @@ class TripMapper {
     lhs.withHeadsign(tripHeadsign);
     lhs.withDirection(directionMapper.map(rhs.getDirectionId(), lhs.getId()));
     lhs.withGtfsBlockId(rhs.getBlockId());
-    lhs.withShapeId(idFactory.createId(rhs.getShapeId()));
+    lhs.withShapeId(idFactory.createNullableId(rhs.getShapeId()));
     lhs.withWheelchairBoarding(WheelchairAccessibilityMapper.map(rhs.getWheelchairAccessible()));
     lhs.withBikesAllowed(BikeAccessMapper.mapForTrip(rhs));
     lhs.withCarsAllowed(CarAccessMapper.mapForTrip(rhs));

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -56,7 +56,7 @@ class TripMapper {
     var lhs = Trip.of(idFactory.createId(rhs.getId(), "trip"));
 
     lhs.withRoute(routeMapper.map(rhs.getRoute()));
-    lhs.withServiceId(idFactory.createNullableId(rhs.getServiceId()));
+    lhs.withServiceId(idFactory.createId(rhs.getServiceId(), "trip's service id"));
     lhs.withShortName(rhs.getTripShortName());
     I18NString tripHeadsign = null;
     if (rhs.getTripHeadsign() != null) {

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
@@ -120,13 +120,4 @@ class FareLegRuleMapperTest {
     assert (otpRule.fareProducts().contains(internalCashProduct));
     assert (otpRule.fareProducts().contains(internalCreditProduct));
   }
-
-  @Test
-  void noProducts() {
-    var productMapper = new FareProductMapper(ID_FACTORY);
-    var ruleMapper = new FareLegRuleMapper(ID_FACTORY, productMapper, DataImportIssueStore.NOOP);
-    var obaRule = new FareLegRule();
-    var mappedRules = List.copyOf(ruleMapper.map(List.of(obaRule)));
-    assertEquals(0, mappedRules.size());
-  }
 }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/GtfsTestData.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/GtfsTestData.java
@@ -39,9 +39,11 @@ public class GtfsTestData {
 
     trip.setId(new AgencyAndId("F", "T1"));
     trip.setRoute(route);
+    trip.setServiceId(new AgencyAndId("F", "SID1"));
 
     trip_2.setId(new AgencyAndId("F", "T2"));
     trip_2.setRoute(route_2);
+    trip_2.setServiceId(new AgencyAndId("F", "SID1"));
 
     stop.setId(new AgencyAndId("F", "S1"));
     stop_2.setId(new AgencyAndId("F", "S2"));

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/IdFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/IdFactoryTest.java
@@ -19,7 +19,7 @@ class IdFactoryTest {
       "1"
     );
 
-    FeedScopedId mappedId = FACTORY.createId(inputId);
+    FeedScopedId mappedId = FACTORY.createNullableId(inputId);
 
     assertEquals("B", mappedId.getFeedId());
     assertEquals("1", mappedId.getId());
@@ -28,12 +28,12 @@ class IdFactoryTest {
   @Test
   public void emptyAgencyAndId() {
     assertThrows(IllegalArgumentException.class, () ->
-      FACTORY.createId(new org.onebusaway.gtfs.model.AgencyAndId())
+      FACTORY.createNullableId(new org.onebusaway.gtfs.model.AgencyAndId())
     );
   }
 
   @Test
   public void nullAgencyAndId() {
-    assertNull(FACTORY.createId((AgencyAndId) null));
+    assertNull(FACTORY.createNullableId((AgencyAndId) null));
   }
 }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/IdFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/IdFactoryTest.java
@@ -4,9 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.onebusaway.gtfs.model.AgencyAndId;
+import org.opentripplanner._support.geometry.Polygons;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.SiteRepository;
 
 class IdFactoryTest {
 
@@ -26,14 +32,30 @@ class IdFactoryTest {
   }
 
   @Test
-  public void emptyAgencyAndId() {
+  void emptyAgencyAndId() {
     assertThrows(IllegalArgumentException.class, () ->
       FACTORY.createNullableId(new org.onebusaway.gtfs.model.AgencyAndId())
     );
   }
 
   @Test
-  public void nullAgencyAndId() {
+  void nullAgencyAndId() {
     assertNull(FACTORY.createNullableId((AgencyAndId) null));
+  }
+
+  private static Stream<AgencyAndId> invalidCases() {
+    return Stream.of(
+      null,
+      new AgencyAndId("1", null),
+      new AgencyAndId("1", ""),
+      new AgencyAndId("1", "\t")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidCases")
+  void invalidId(AgencyAndId id) {
+    var ex = assertThrows(RuntimeException.class, () -> FACTORY.createId(id, "thing"));
+    assertEquals("Error during GTFS processing: id of thing must not be null", ex.getMessage());
   }
 }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationMapperTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -58,6 +59,21 @@ class LocationMapperTest {
       ).toString(),
       issueStore.listIssues().toString()
     );
+  }
+
+  private static Stream<AgencyAndId> nullCases() {
+    return Stream.of(null, new AgencyAndId("1", null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nullCases")
+  void nullId() {
+    var gtfsLocation = getLocation("invalid", Polygons.OSLO);
+    gtfsLocation.setId(null);
+    var issueStore = new DefaultDataImportIssueStore();
+    var mapper = new LocationMapper(ID_FACTORY, SiteRepository.of(), issueStore);
+    var ex = assertThrows(NullPointerException.class, () -> mapper.map(gtfsLocation));
+    assertEquals("Error during GTFS processing: id of location must not be null", ex.getMessage());
   }
 
   private static Location getLocation(String name, Polygon polygon) {

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationMapperTest.java
@@ -61,18 +61,13 @@ class LocationMapperTest {
     );
   }
 
-  private static Stream<AgencyAndId> nullCases() {
-    return Stream.of(null, new AgencyAndId("1", null));
-  }
-
-  @ParameterizedTest
-  @MethodSource("nullCases")
+  @Test
   void nullId() {
     var gtfsLocation = getLocation("invalid", Polygons.OSLO);
     gtfsLocation.setId(null);
     var issueStore = new DefaultDataImportIssueStore();
     var mapper = new LocationMapper(ID_FACTORY, SiteRepository.of(), issueStore);
-    var ex = assertThrows(NullPointerException.class, () -> mapper.map(gtfsLocation));
+    var ex = assertThrows(RuntimeException.class, () -> mapper.map(gtfsLocation));
     assertEquals("Error during GTFS processing: id of location must not be null", ex.getMessage());
   }
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/ServiceCalendarDateMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/ServiceCalendarDateMapperTest.java
@@ -55,11 +55,12 @@ public class ServiceCalendarDateMapperTest {
   @Test
   public void testMapWithNulls() {
     ServiceCalendarDate input = new ServiceCalendarDate();
+    input.setServiceId(AGENCY_AND_ID);
     org.opentripplanner.model.calendar.ServiceCalendarDate result = subject.map(input);
 
     assertNull(result.getDate());
     assertEquals(0, result.getExceptionType());
-    assertNull(result.getServiceId());
+    assertEquals("A:1", result.getServiceId().toString());
   }
 
   /** Mapping the same object twice, should return the the same instance. */

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/ServiceCalendarMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/ServiceCalendarMapperTest.java
@@ -87,6 +87,7 @@ public class ServiceCalendarMapperTest {
   @Test
   public void testMapWithNulls() {
     ServiceCalendar input = new ServiceCalendar();
+    input.setServiceId(AGENCY_AND_ID);
     org.opentripplanner.model.calendar.ServiceCalendar result = subject.map(input);
 
     assertEquals(0, result.getMonday());

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/ShapePointMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/ShapePointMapperTest.java
@@ -58,13 +58,15 @@ public class ShapePointMapperTest {
 
   @Test
   public void testMapWithNulls() throws Exception {
-    org.opentripplanner.model.ShapePoint result = subject.map(new ShapePoint());
+    var orginal = new ShapePoint();
+    orginal.setShapeId(AGENCY_AND_ID);
+    org.opentripplanner.model.ShapePoint result = subject.map(orginal);
 
     assertFalse(result.isDistTraveledSet());
     assertEquals(0d, result.getLat(), 0.00001);
     assertEquals(0d, result.getLon(), 0.00001);
     assertEquals(0d, result.getSequence(), 0.00001);
-    assertNull(result.getShapeId());
+    assertEquals("A:1", result.getShapeId().toString());
   }
 
   /** Mapping the same object twice, should return the the same instance. */

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -100,6 +100,7 @@ public class TripMapperTest {
   void testMapWithNulls() throws Exception {
     Trip input = new Trip();
     input.setId(AGENCY_AND_ID);
+    input.setServiceId(AGENCY_AND_ID);
     input.setRoute(new GtfsTestData().route);
 
     org.opentripplanner.transit.model.timetable.Trip result = subject.map(input);
@@ -108,7 +109,7 @@ public class TripMapperTest {
     assertNotNull(result.getRoute());
 
     assertNull(result.getGtfsBlockId());
-    assertNull(result.getServiceId());
+    assertEquals("FEED:1", result.getServiceId().toString());
     assertNull(result.getShapeId());
     assertNull(result.getHeadsign());
     assertNull(result.getShortName());
@@ -144,6 +145,7 @@ public class TripMapperTest {
   ) {
     var flexTrip = new Trip();
     flexTrip.setId(new AgencyAndId("1", "1"));
+    flexTrip.setServiceId(AGENCY_AND_ID);
     flexTrip.setSafeDurationFactor(inputFactor);
     flexTrip.setSafeDurationOffset(inputOffset);
     flexTrip.setRoute(new GtfsTestData().route);


### PR DESCRIPTION
### Summary

@daniel-heppner-ibigroup has reported that it's difficult to read error messages of null IDs during the GTFS mapping process. He wasn't sure if the problem was with OTP or his feed.

@habrahamsson-skanetrafiken has also mentioned in #6586 that we are too tolerant of null values when mapping GTFS IDs and it's not clear which IDs are truly nullable.

For this reason I've reworked the GTFS import's `IdFactory`:

- it now adds the name of the entity that has a null id to the error message
- it distinguishes between nullable and non-nullable ids and it's clear from the method name which one is which

I changed many method calls to make the null handling more strict but there are a few where I'm not sure. I've left those as they were.

It should be noted that the core data model already enforces the non-nullness and this is just quality-of-life improvement to get better error messages and clarity during development.

### Unit tests

Added.

### Documentation

Javadoc.