### PR TITLE
Fix modes filter

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
@@ -21,7 +21,7 @@ class RequestModesMapper {
    * <p>
    * This only maps access, egress, direct & transfer modes. Transport modes are set using filters.
    */
-  static RequestModes mapRequestModes(Map<String, ?> modesInput) {
+  static RequestModes mapRequestStreetModes(Map<String, ?> modesInput) {
     RequestModesBuilder mBuilder = RequestModes.of();
 
     final StreetMode accessMode = (StreetMode) modesInput.get(ACCESS_MODE_KEY);

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapper.java
@@ -12,9 +12,9 @@ class RequestModesMapper {
 
   private static final Predicate<StreetMode> IS_BIKE_OR_CAR = m ->
     m == StreetMode.BIKE || m == StreetMode.CAR;
-  private static final String accessModeKey = "accessMode";
-  private static final String egressModeKey = "egressMode";
-  private static final String directModeKey = "directMode";
+  private static final String ACCESS_MODE_KEY = "accessMode";
+  private static final String EGRESS_MODE_KEY = "egressMode";
+  private static final String DIRECT_MODE_KEY = "directMode";
 
   /**
    * Maps GraphQL Modes input type to RequestModes.
@@ -24,10 +24,10 @@ class RequestModesMapper {
   static RequestModes mapRequestModes(Map<String, ?> modesInput) {
     RequestModesBuilder mBuilder = RequestModes.of();
 
-    final StreetMode accessMode = (StreetMode) modesInput.get(accessModeKey);
+    final StreetMode accessMode = (StreetMode) modesInput.get(ACCESS_MODE_KEY);
     ensureValueAndSet(accessMode, mBuilder::withAccessMode);
-    ensureValueAndSet((StreetMode) modesInput.get(egressModeKey), mBuilder::withEgressMode);
-    ensureValueAndSet((StreetMode) modesInput.get(directModeKey), mBuilder::withDirectMode);
+    ensureValueAndSet((StreetMode) modesInput.get(EGRESS_MODE_KEY), mBuilder::withEgressMode);
+    ensureValueAndSet((StreetMode) modesInput.get(DIRECT_MODE_KEY), mBuilder::withDirectMode);
     // The only cases in which the transferMode isn't WALK are when the accessMode is either BIKE or CAR.
     // In these cases, the transferMode is the same as the accessMode. This check is not strictly necessary
     // if there is a need for more freedom for specifying the transferMode.

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestStreetModesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/RequestStreetModesMapper.java
@@ -8,7 +8,7 @@ import org.opentripplanner.routing.api.request.RequestModes;
 import org.opentripplanner.routing.api.request.RequestModesBuilder;
 import org.opentripplanner.routing.api.request.StreetMode;
 
-class RequestModesMapper {
+class RequestStreetModesMapper {
 
   private static final Predicate<StreetMode> IS_BIKE_OR_CAR = m ->
     m == StreetMode.BIKE || m == StreetMode.CAR;

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapper.java
@@ -12,27 +12,26 @@ public class TransitFilterNewWayMapper {
   private TransitFilterNewWayMapper() {}
 
   @SuppressWarnings("unchecked")
-  static List<TransitFilter> mapFilterNewWay(List<Map<String, ?>> filters) {
+  static List<TransitFilter> mapFilter(List<Map<String, ?>> filters) {
     var filterRequests = new ArrayList<TransitFilter>();
 
     for (var filterInput : filters) {
       var filterRequestBuilder = TransitFilterRequest.of();
 
       if (filterInput.containsKey("select")) {
-        for (var selectInput : (List<Map<String, List<?>>>) filterInput.get("select")) {
-          filterRequestBuilder.addSelect(SelectRequestMapper.mapSelectRequest(selectInput));
+        var select = (List<Map<String, List<?>>>) filterInput.get("select");
+        for (var it : select) {
+          filterRequestBuilder.addSelect(SelectRequestMapper.mapSelectRequest(it));
         }
       }
-
       if (filterInput.containsKey("not")) {
-        for (var selectInput : (List<Map<String, List<?>>>) filterInput.get("not")) {
-          filterRequestBuilder.addNot(SelectRequestMapper.mapSelectRequest(selectInput));
+        var not = (List<Map<String, List<?>>>) filterInput.get("not");
+        for (var it : not) {
+          filterRequestBuilder.addNot(SelectRequestMapper.mapSelectRequest(it));
         }
       }
-
       filterRequests.add(filterRequestBuilder.build());
     }
-
     return filterRequests;
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapper.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
+import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
+
+public class TransitFilterNewWayMapper {
+
+  /** This is a utility class, only static methods */
+  private TransitFilterNewWayMapper() {}
+
+  @SuppressWarnings("unchecked")
+  static List<TransitFilter> mapFilterNewWay(List<Map<String, ?>> filters) {
+    var filterRequests = new ArrayList<TransitFilter>();
+
+    for (var filterInput : filters) {
+      var filterRequestBuilder = TransitFilterRequest.of();
+
+      if (filterInput.containsKey("select")) {
+        for (var selectInput : (List<Map<String, List<?>>>) filterInput.get("select")) {
+          filterRequestBuilder.addSelect(SelectRequestMapper.mapSelectRequest(selectInput));
+        }
+      }
+
+      if (filterInput.containsKey("not")) {
+        for (var selectInput : (List<Map<String, List<?>>>) filterInput.get("not")) {
+          filterRequestBuilder.addNot(SelectRequestMapper.mapSelectRequest(selectInput));
+        }
+      }
+
+      filterRequests.add(filterRequestBuilder.build());
+    }
+
+    return filterRequests;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapper.java
@@ -23,7 +23,7 @@ class TransitFilterOldWayMapper {
   private TransitFilterOldWayMapper() {}
 
   @SuppressWarnings("unchecked")
-  static void mapFilterOldWay(
+  static void mapFilter(
     DataFetchingEnvironment environment,
     DataFetcherDecorator callWith,
     TransitRequestBuilder transitBuilder
@@ -36,14 +36,6 @@ class TransitFilterOldWayMapper {
     ) {
       return;
     }
-    mapFilter(environment, callWith, transitBuilder);
-  }
-
-  private static void mapFilter(
-    DataFetchingEnvironment environment,
-    DataFetcherDecorator callWith,
-    TransitRequestBuilder transitBuilder
-  ) {
     var selectorBuilders = new ArrayList<SelectRequest.Builder>();
 
     var whiteListedAgencies = new ArrayList<FeedScopedId>();

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapper.java
@@ -12,14 +12,15 @@ import org.opentripplanner.apis.transmodel.support.DataFetcherDecorator;
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.routing.api.request.request.TransitRequestBuilder;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
-import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
-import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
-class FilterMapper {
+class TransitFilterOldWayMapper {
+
+  /** This is a utility class, only static methods */
+  private TransitFilterOldWayMapper() {}
 
   @SuppressWarnings("unchecked")
   static void mapFilterOldWay(
@@ -145,30 +146,5 @@ class FilterMapper {
       .peek(it -> it.withTransportModes(tModes))
       .map(it -> it.build())
       .toList();
-  }
-
-  @SuppressWarnings("unchecked")
-  static List<TransitFilter> mapFilterNewWay(List<Map<String, ?>> filters) {
-    var filterRequests = new ArrayList<TransitFilter>();
-
-    for (var filterInput : filters) {
-      var filterRequestBuilder = TransitFilterRequest.of();
-
-      if (filterInput.containsKey("select")) {
-        for (var selectInput : (List<Map<String, List<?>>>) filterInput.get("select")) {
-          filterRequestBuilder.addSelect(SelectRequestMapper.mapSelectRequest(selectInput));
-        }
-      }
-
-      if (filterInput.containsKey("not")) {
-        for (var selectInput : (List<Map<String, List<?>>>) filterInput.get("not")) {
-          filterRequestBuilder.addNot(SelectRequestMapper.mapSelectRequest(selectInput));
-        }
-      }
-
-      filterRequests.add(filterRequestBuilder.build());
-    }
-
-    return filterRequests;
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -81,7 +81,7 @@ public class TripRequestMapper {
             FilterMapper.mapFilterNewWay(environment.getArgument("filters"))
           );
         } else {
-          FilterMapper.mapFilterOldWay(environment, callWith, requestBuilder);
+          FilterMapper.mapFilterOldWay(environment, callWith, transitBuilder);
         }
       });
 

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -78,10 +78,10 @@ public class TripRequestMapper {
 
         if (GqlUtil.hasArgument(environment, "filters")) {
           transitBuilder.setFilters(
-            TransitFilterNewWayMapper.mapFilterNewWay(environment.getArgument("filters"))
+            TransitFilterNewWayMapper.mapFilter(environment.getArgument("filters"))
           );
         } else {
-          TransitFilterOldWayMapper.mapFilterOldWay(environment, callWith, transitBuilder);
+          TransitFilterOldWayMapper.mapFilter(environment, callWith, transitBuilder);
         }
       });
 

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -87,7 +87,7 @@ public class TripRequestMapper {
 
       if (GqlUtil.hasArgument(environment, "modes")) {
         journeyBuilder.setModes(
-          RequestModesMapper.mapRequestStreetModes(environment.getArgument("modes"))
+          RequestStreetModesMapper.mapRequestStreetModes(environment.getArgument("modes"))
         );
       }
     });

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -87,7 +87,7 @@ public class TripRequestMapper {
 
       if (GqlUtil.hasArgument(environment, "modes")) {
         journeyBuilder.setModes(
-          RequestModesMapper.mapRequestModes(environment.getArgument("modes"))
+          RequestModesMapper.mapRequestStreetModes(environment.getArgument("modes"))
         );
       }
     });

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -78,10 +78,10 @@ public class TripRequestMapper {
 
         if (GqlUtil.hasArgument(environment, "filters")) {
           transitBuilder.setFilters(
-            FilterMapper.mapFilterNewWay(environment.getArgument("filters"))
+            TransitFilterNewWayMapper.mapFilterNewWay(environment.getArgument("filters"))
           );
         } else {
-          FilterMapper.mapFilterOldWay(environment, callWith, transitBuilder);
+          TransitFilterOldWayMapper.mapFilterOldWay(environment, callWith, transitBuilder);
         }
       });
 

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
@@ -11,7 +11,7 @@ public class ViaSegmentMapper {
     var journey = defaultRequest.journey().copyOf();
     if (viaSegment.containsKey("modes")) {
       Map<String, Object> modesInput = (Map<String, Object>) viaSegment.get("modes");
-      journey.setModes(RequestModesMapper.mapRequestStreetModes(modesInput));
+      journey.setModes(RequestStreetModesMapper.mapRequestStreetModes(modesInput));
     }
     if (viaSegment.containsKey("filters")) {
       journey.withTransit(tb -> {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
@@ -11,7 +11,7 @@ public class ViaSegmentMapper {
     var journey = defaultRequest.journey().copyOf();
     if (viaSegment.containsKey("modes")) {
       Map<String, Object> modesInput = (Map<String, Object>) viaSegment.get("modes");
-      journey.setModes(RequestModesMapper.mapRequestModes(modesInput));
+      journey.setModes(RequestModesMapper.mapRequestStreetModes(modesInput));
     }
     if (viaSegment.containsKey("filters")) {
       journey.withTransit(tb -> {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
@@ -16,7 +16,7 @@ public class ViaSegmentMapper {
     if (viaSegment.containsKey("filters")) {
       journey.withTransit(tb -> {
         List<Map<String, ?>> filters = (List<Map<String, ?>>) viaSegment.get("filters");
-        tb.setFilters(TransitFilterNewWayMapper.mapFilterNewWay(filters));
+        tb.setFilters(TransitFilterNewWayMapper.mapFilter(filters));
       });
     }
     return journey.build();

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
@@ -16,7 +16,7 @@ public class ViaSegmentMapper {
     if (viaSegment.containsKey("filters")) {
       journey.withTransit(tb -> {
         List<Map<String, ?>> filters = (List<Map<String, ?>>) viaSegment.get("filters");
-        tb.setFilters(FilterMapper.mapFilterNewWay(filters));
+        tb.setFilters(TransitFilterNewWayMapper.mapFilterNewWay(filters));
       });
     }
     return journey.build();

--- a/application/src/main/java/org/opentripplanner/model/modes/AllowAllModesFilter.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/AllowAllModesFilter.java
@@ -22,6 +22,6 @@ class AllowAllModesFilter implements AllowTransitModeFilter {
 
   @Override
   public String toString() {
-    return "AllowAllModesFilter{}";
+    return AllowAllModesFilter.class.getSimpleName();
   }
 }

--- a/application/src/main/java/org/opentripplanner/model/modes/ExcludeAllTransitFilter.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/ExcludeAllTransitFilter.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripTimes;
-import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
  * This filter will exclude everything.
@@ -31,6 +30,6 @@ public final class ExcludeAllTransitFilter implements Serializable, TransitFilte
 
   @Override
   public String toString() {
-    return ToStringBuilder.of(ExcludeAllTransitFilter.class).toString();
+    return ExcludeAllTransitFilter.class.getSimpleName();
   }
 }

--- a/application/src/main/java/org/opentripplanner/model/modes/FilterFactory.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/FilterFactory.java
@@ -38,7 +38,7 @@ class FilterFactory {
    * </ul>
    */
   static AllowTransitModeFilter create(Collection<MainAndSubMode> allowedModes) {
-    var filters = allowedModes.stream().map(FilterFactory::of).toList();
+    var filters = allowedModes.stream().distinct().map(FilterFactory::of).toList();
 
     if (filters.isEmpty()) {
       throw new IllegalArgumentException("Can not match an empty set of modes!");

--- a/application/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
+++ b/application/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
@@ -265,7 +265,7 @@ public class TransferConstraint implements Serializable, RaptorTransferConstrain
       return "(no constraints)";
     }
 
-    return ToStringBuilder.of()
+    return ToStringBuilder.ofEmbeddedType()
       .addEnum("priority", priority, ALLOWED)
       .addBoolIfTrue("staySeated", staySeated)
       .addBoolIfTrue("guaranteed", guaranteed)

--- a/application/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
+++ b/application/src/main/java/org/opentripplanner/model/transfer/TransferConstraint.java
@@ -262,7 +262,7 @@ public class TransferConstraint implements Serializable, RaptorTransferConstrain
 
   public String toString() {
     if (isRegularTransfer()) {
-      return "{no constraints}";
+      return "(no constraints)";
     }
 
     return ToStringBuilder.of()

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/JourneyRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/JourneyRequest.java
@@ -106,7 +106,7 @@ public class JourneyRequest implements Serializable {
 
   @Override
   public String toString() {
-    return ToStringBuilder.of(JourneyRequest.class)
+    return ToStringBuilder.ofEmbeddedType()
       .addObj("transit", transit, DEFAULT.transit)
       .addObj("access", access, DEFAULT.access)
       .addObj("egress", egress, DEFAULT.egress)

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/StreetRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/StreetRequest.java
@@ -38,6 +38,6 @@ public class StreetRequest implements Serializable {
 
   @Override
   public String toString() {
-    return ToStringBuilder.of(StreetRequest.class).addEnum("mode", mode, DEFAULT.mode).toString();
+    return ToStringBuilder.ofEmbeddedType().addEnum("mode", mode, DEFAULT.mode).toString();
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
@@ -186,7 +186,7 @@ public class TransitRequest implements Serializable {
 
   @Override
   public String toString() {
-    return ToStringBuilder.of(TransitRequest.class)
+    return ToStringBuilder.ofEmbeddedType()
       .addCol("filters", filters, DEFAULT.filters)
       .addCol("preferredAgencies", preferredAgencies)
       .addCol("unpreferredAgencies", unpreferredAgencies)

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/filter/SelectRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/filter/SelectRequest.java
@@ -96,7 +96,7 @@ public class SelectRequest implements Serializable {
 
   @Override
   public String toString() {
-    return ToStringBuilder.of(SelectRequest.class)
+    return ToStringBuilder.ofEmbeddedType()
       .addObj("transportModes", transportModesToString(), null)
       .addCol("agencies", agencies, List.of())
       .addObj("routes", routes, List.of())
@@ -123,11 +123,14 @@ public class SelectRequest implements Serializable {
     if (transportModes == null) {
       return null;
     }
+    if (transportModes.isEmpty()) {
+      return "EMPTY";
+    }
     if (transportModes.stream().allMatch(MainAndSubMode::isMainModeOnly)) {
       int size = transportModes.size();
       int total = MainAndSubMode.all().size();
       if (size == total) {
-        return "ALL-MAIN-MODES";
+        return "ALL";
       }
       if (size + 3 >= total) {
         // If 3 or less of the main modes are *excluded* we guess that the user did exclude, and

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequest.java
@@ -111,7 +111,10 @@ public class TransitFilterRequest implements Serializable, TransitFilter {
 
   @Override
   public String toString() {
-    return ToStringBuilder.of(TransitFilterRequest.class)
+    if (select.length == 0 && not.length == 0) {
+      return "ALL";
+    }
+    return ToStringBuilder.ofEmbeddedType()
       .addCol("select", Arrays.asList(select))
       .addCol("not", Arrays.asList(not))
       .toString();

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitGroupSelect.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/filter/TransitGroupSelect.java
@@ -93,8 +93,8 @@ public class TransitGroupSelect {
   @Override
   public String toString() {
     return isEmpty()
-      ? "TransitGroupSelect{ EMPTY }"
-      : ToStringBuilder.of(TransitGroupSelect.class)
+      ? "EMPTY"
+      : ToStringBuilder.ofEmbeddedType()
         .addCol("modes", modes)
         .addCol("subModeRegexp", subModeRegexp)
         .addCol("agencyIds", agencyIds)

--- a/application/src/test/java/org/opentripplanner/_support/asserts/AssertEqualsAndHashCode.java
+++ b/application/src/test/java/org/opentripplanner/_support/asserts/AssertEqualsAndHashCode.java
@@ -1,6 +1,7 @@
 package org.opentripplanner._support.asserts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class AssertEqualsAndHashCode {
@@ -16,7 +17,8 @@ public class AssertEqualsAndHashCode {
 
   public static AssertEqualsAndHashCode verify(Object subject) {
     assertEquals(subject, subject);
-    assertNotEquals(otherClass, subject);
+    assertFalse(subject.equals(otherClass), "Equals should handle other types, and return false");
+    assertFalse(subject.equals(null), "Equals should handle null, and return false");
     return new AssertEqualsAndHashCode(subject);
   }
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapperTest.java
@@ -26,7 +26,7 @@ class FilterMapperTest {
     );
     var result = FilterMapper.mapFilters(MainAndSubMode.all(), List.of(filter)).stream().toList();
     assertEquals(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: ALL-MAIN-MODES, agencies: [feed:A]}], not: [SelectRequest{transportModes: [], routes: [feed:A]}]}]",
+      "[(select: [(transportModes: ALL, agencies: [feed:A])], not: [(transportModes: EMPTY, routes: [feed:A])])]",
       result.toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
@@ -111,22 +111,19 @@ class LegacyRouteRequestMapperTest implements PlanTestConstants {
 
   static Stream<Arguments> banningCases() {
     return Stream.of(
-      of(Map.of(), "[TransitFilterRequest{}]"),
+      of(Map.of(), "[ALL]"),
       of(
         Map.of("routes", "trimet:555"),
-        "[TransitFilterRequest{not: [SelectRequest{transportModes: [], routes: [trimet:555]}]}]"
+        "[(not: [(transportModes: EMPTY, routes: [trimet:555])])]"
       ),
-      of(
-        Map.of("agencies", ""),
-        "[TransitFilterRequest{not: [SelectRequest{transportModes: []}]}]"
-      ),
+      of(Map.of("agencies", ""), "[(not: [(transportModes: EMPTY)])]"),
       of(
         Map.of("agencies", "trimet:666"),
-        "[TransitFilterRequest{not: [SelectRequest{transportModes: [], agencies: [trimet:666]}]}]"
+        "[(not: [(transportModes: EMPTY, agencies: [trimet:666])])]"
       ),
       of(
         Map.of("agencies", "trimet:666", "routes", "trimet:444"),
-        "[TransitFilterRequest{not: [SelectRequest{transportModes: [], routes: [trimet:444]}, SelectRequest{transportModes: [], agencies: [trimet:666]}]}]"
+        "[(not: [(transportModes: EMPTY, routes: [trimet:444]), (transportModes: EMPTY, agencies: [trimet:666])])]"
       )
     );
   }
@@ -147,20 +144,11 @@ class LegacyRouteRequestMapperTest implements PlanTestConstants {
 
   static Stream<Arguments> transportModesCases() {
     return Stream.of(
-      of(List.of(), "[ExcludeAllTransitFilter{}]"),
-      of(List.of(mode("BICYCLE")), "[ExcludeAllTransitFilter{}]"),
-      of(
-        List.of(mode("BUS")),
-        "[TransitFilterRequest{select: [SelectRequest{transportModes: [BUS]}]}]"
-      ),
-      of(
-        List.of(mode("BUS"), mode("COACH")),
-        "[TransitFilterRequest{select: [SelectRequest{transportModes: [BUS, COACH]}]}]"
-      ),
-      of(
-        List.of(mode("BUS"), mode("MONORAIL")),
-        "[TransitFilterRequest{select: [SelectRequest{transportModes: [BUS, MONORAIL]}]}]"
-      )
+      of(List.of(), "[ExcludeAllTransitFilter]"),
+      of(List.of(mode("BICYCLE")), "[ExcludeAllTransitFilter]"),
+      of(List.of(mode("BUS")), "[(select: [(transportModes: [BUS])])]"),
+      of(List.of(mode("BUS"), mode("COACH")), "[(select: [(transportModes: [BUS, COACH])])]"),
+      of(List.of(mode("BUS"), mode("MONORAIL")), "[(select: [(transportModes: [BUS, MONORAIL])])]")
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperFiltersTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperFiltersTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.routing.api.request.RouteRequest;
 
 class RouteRequestMapperFiltersTest {
 
@@ -38,30 +37,21 @@ class RouteRequestMapperFiltersTest {
     var args = testCtx.basicRequest();
     args.put("modes", TRAM_AND_FERRY_MODES);
     args.put("preferences", INCLUDE_ROUTE_FILTERS);
-    assertTransitFilters(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: [FERRY, TRAM], routes: [f:r1]}]}]",
-      args
-    );
+    assertTransitFilters("[(select: [(transportModes: [FERRY, TRAM], routes: [f:r1])])]", args);
   }
 
   @Test
   void modesOnly() {
     var args = testCtx.basicRequest();
     args.put("modes", TRAM_AND_FERRY_MODES);
-    assertTransitFilters(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: [FERRY, TRAM]}]}]",
-      args
-    );
+    assertTransitFilters("[(select: [(transportModes: [FERRY, TRAM])])]", args);
   }
 
   @Test
   void filtersOnly() {
     var args = testCtx.basicRequest();
     args.put("preferences", INCLUDE_ROUTE_FILTERS);
-    assertTransitFilters(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: ALL-MAIN-MODES, routes: [f:r1]}]}]",
-      args
-    );
+    assertTransitFilters("[(select: [(transportModes: ALL, routes: [f:r1])])]", args);
   }
 
   @Test
@@ -69,7 +59,7 @@ class RouteRequestMapperFiltersTest {
     var args = testCtx.basicRequest();
     args.put("preferences", INCLUDE_ROUTE_EXCLUDE_AGENCY_FILTERS);
     assertTransitFilters(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: ALL-MAIN-MODES, routes: [f:r1]}]}, TransitFilterRequest{select: [SelectRequest{transportModes: ALL-MAIN-MODES}], not: [SelectRequest{transportModes: [], agencies: [f:a1]}]}]",
+      "[(select: [(transportModes: ALL, routes: [f:r1])]), (select: [(transportModes: ALL)], not: [(transportModes: EMPTY, agencies: [f:a1])])]",
       args
     );
   }
@@ -80,7 +70,7 @@ class RouteRequestMapperFiltersTest {
     args.put("modes", TRAM_AND_FERRY_MODES);
     args.put("preferences", INCLUDE_ROUTE_EXCLUDE_AGENCY_FILTERS);
     assertTransitFilters(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: [FERRY, TRAM], routes: [f:r1]}]}, TransitFilterRequest{select: [SelectRequest{transportModes: [FERRY, TRAM]}], not: [SelectRequest{transportModes: [], agencies: [f:a1]}]}]",
+      "[(select: [(transportModes: [FERRY, TRAM], routes: [f:r1])]), (select: [(transportModes: [FERRY, TRAM])], not: [(transportModes: EMPTY, agencies: [f:a1])])]",
       args
     );
   }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperModesTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperModesTest.java
@@ -171,7 +171,7 @@ class RouteRequestMapperModesTest {
     assertEquals(tramCost, reluctanceForMode.get(TransitMode.TRAM));
     assertNull(reluctanceForMode.get(TransitMode.FERRY));
     assertEquals(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: [FERRY, TRAM]}]}]",
+      "[(select: [(transportModes: [FERRY, TRAM])])]",
       routeRequest.journey().transit().filters().toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTransitTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTransitTest.java
@@ -96,7 +96,7 @@ class RouteRequestMapperTransitTest {
     assertEquals(maximumAdditionalTransfers, transferPreferences.maxAdditionalTransfers());
     assertEquals(maximumTransfers + 1, transferPreferences.maxTransfers());
     assertEquals(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: ALL-MAIN-MODES}], not: [SelectRequest{transportModes: [], routes: [f:route1]}]}]",
+      "[(select: [(transportModes: ALL)], not: [(transportModes: EMPTY, routes: [f:route1])])]",
       routeRequest.journey().transit().filters().toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/_support/RequestHelper.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/_support/RequestHelper.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.apis.transmodel._support;
+
+import java.util.List;
+import java.util.Map;
+
+public class RequestHelper {
+
+  public static <T> List<T> list(T... values) {
+    return List.of(values);
+  }
+
+  public static <T> Map<String, T> map(Map.Entry<String, ? extends T>... entries) {
+    return Map.ofEntries(entries);
+  }
+
+  public static <T> Map<String, T> map(String key, T value) {
+    return Map.of(key, value);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestModesMapperTest.java
@@ -19,7 +19,7 @@ class RequestModesMapperTest {
   void testMapRequestModesEmptyMapReturnsDefaults() {
     Map<String, StreetMode> inputModes = Map.of();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(MODES_NOT_SET, mappedModes);
   }
@@ -34,7 +34,7 @@ class RequestModesMapperTest {
       .withDirectMode(null)
       .build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }
@@ -49,7 +49,7 @@ class RequestModesMapperTest {
       .withDirectMode(null)
       .build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }
@@ -63,7 +63,7 @@ class RequestModesMapperTest {
       .withDirectMode(null)
       .build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }
@@ -74,7 +74,7 @@ class RequestModesMapperTest {
 
     RequestModes wantModes = MODES_NOT_SET.copyOf().withDirectMode(StreetMode.CAR).build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestModes(inputModes);
+    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestStreetModesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/RequestStreetModesMapperTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.api.request.RequestModes;
 import org.opentripplanner.routing.api.request.StreetMode;
 
-class RequestModesMapperTest {
+class RequestStreetModesMapperTest {
 
   private static final RequestModes MODES_NOT_SET = RequestModes.of()
     .withAccessMode(StreetMode.NOT_SET)
@@ -19,7 +19,7 @@ class RequestModesMapperTest {
   void testMapRequestModesEmptyMapReturnsDefaults() {
     Map<String, StreetMode> inputModes = Map.of();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
+    RequestModes mappedModes = RequestStreetModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(MODES_NOT_SET, mappedModes);
   }
@@ -34,7 +34,7 @@ class RequestModesMapperTest {
       .withDirectMode(null)
       .build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
+    RequestModes mappedModes = RequestStreetModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }
@@ -49,7 +49,7 @@ class RequestModesMapperTest {
       .withDirectMode(null)
       .build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
+    RequestModes mappedModes = RequestStreetModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }
@@ -63,7 +63,7 @@ class RequestModesMapperTest {
       .withDirectMode(null)
       .build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
+    RequestModes mappedModes = RequestStreetModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }
@@ -74,7 +74,7 @@ class RequestModesMapperTest {
 
     RequestModes wantModes = MODES_NOT_SET.copyOf().withDirectMode(StreetMode.CAR).build();
 
-    RequestModes mappedModes = RequestModesMapper.mapRequestStreetModes(inputModes);
+    RequestModes mappedModes = RequestStreetModesMapper.mapRequestStreetModes(inputModes);
 
     assertEquals(wantModes, mappedModes);
   }

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/SelectRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/SelectRequestMapperTest.java
@@ -1,0 +1,48 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.apis.transmodel._support.RequestHelper.list;
+import static org.opentripplanner.apis.transmodel._support.RequestHelper.map;
+import static org.opentripplanner.apis.transmodel.model.TransmodelTransportSubmode.LOCAL;
+import static org.opentripplanner.apis.transmodel.model.TransmodelTransportSubmode.REGIONAL_RAIL;
+import static org.opentripplanner.transit.model.basic.TransitMode.BUS;
+import static org.opentripplanner.transit.model.basic.TransitMode.RAIL;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SelectRequestMapperTest {
+
+  @Test
+  void mapFullSelectRequest() throws JsonProcessingException {
+    var result = SelectRequestMapper.mapSelectRequest(
+      map(
+        entry("lines", list("F:Line:1", "F:Line:2")),
+        entry("authorities", list("F:Auth:1", "F:Auth:1")),
+        entry("groupOfLines", list("F:GOL:1")),
+        entry(
+          "transportModes",
+          list(
+            map(entry("transportMode", BUS)),
+            map(
+              entry("transportMode", RAIL),
+              entry("transportSubModes", List.of(LOCAL, REGIONAL_RAIL))
+            )
+          )
+        )
+      )
+    );
+    assertEquals(
+      "SelectRequest{transportModes: [BUS, RAIL::local, RAIL::regionalRail], agencies: [F:Auth:1, F:Auth:1], routes: [F:Line:1, F:Line:2]}",
+      result.toString()
+    );
+  }
+
+  @Test
+  void mapEmptySelectRequest() throws JsonProcessingException {
+    var result = SelectRequestMapper.mapSelectRequest(map());
+    assertEquals("SelectRequest{transportModes: []}", result.toString());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/SelectRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/SelectRequestMapperTest.java
@@ -35,7 +35,7 @@ class SelectRequestMapperTest {
       )
     );
     assertEquals(
-      "SelectRequest{transportModes: [BUS, RAIL::local, RAIL::regionalRail], agencies: [F:Auth:1, F:Auth:1], routes: [F:Line:1, F:Line:2]}",
+      "(transportModes: [BUS, RAIL::local, RAIL::regionalRail], agencies: [F:Auth:1, F:Auth:1], routes: [F:Line:1, F:Line:2])",
       result.toString()
     );
   }
@@ -43,6 +43,6 @@ class SelectRequestMapperTest {
   @Test
   void mapEmptySelectRequest() throws JsonProcessingException {
     var result = SelectRequestMapper.mapSelectRequest(map());
-    assertEquals("SelectRequest{transportModes: []}", result.toString());
+    assertEquals("(transportModes: EMPTY)", result.toString());
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapperTest.java
@@ -1,0 +1,59 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.apis.transmodel._support.RequestHelper.list;
+import static org.opentripplanner.apis.transmodel._support.RequestHelper.map;
+import static org.opentripplanner.transit.model.basic.TransitMode.BUS;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TransitFilterNewWayMapperTest {
+
+  @Test
+  void mapEmptyFilter() {
+    var result = TransitFilterNewWayMapper.mapFilter(List.of());
+    assertEquals("[]", result.toString());
+  }
+
+  @Test
+  void mapIncludeLineFilter() {
+    var result = TransitFilterNewWayMapper.mapFilter(
+      list(map("select", list(map("lines", list("F:Line:1")))))
+    );
+    assertEquals(
+      "[TransitFilterRequest{select: [SelectRequest{transportModes: [], routes: [F:Line:1]}]}]",
+      result.toString()
+    );
+  }
+
+  @Test
+  void mapFilterWithModes() {
+    var result = TransitFilterNewWayMapper.mapFilter(
+      list(map("select", list(map(entry("transportModes", list(map("transportMode", BUS)))))))
+    );
+
+    assertEquals(
+      "[TransitFilterRequest{select: [SelectRequest{transportModes: [BUS]}]}]",
+      result.toString()
+    );
+  }
+
+  @Test
+  void mapExcludeLineFilter() {
+    var result = TransitFilterNewWayMapper.mapFilter(
+      list(map("not", list(map("lines", list("F:Line:1")))))
+    );
+    assertEquals(
+      "[TransitFilterRequest{not: [SelectRequest{transportModes: [], routes: [F:Line:1]}]}]",
+      result.toString()
+    );
+  }
+
+  private static <T> Map.Entry<String, List<T>> e(String key, T... values) {
+    return entry(key, Arrays.asList(values));
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterNewWayMapperTest.java
@@ -24,10 +24,7 @@ class TransitFilterNewWayMapperTest {
     var result = TransitFilterNewWayMapper.mapFilter(
       list(map("select", list(map("lines", list("F:Line:1")))))
     );
-    assertEquals(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: [], routes: [F:Line:1]}]}]",
-      result.toString()
-    );
+    assertEquals("[(select: [(transportModes: EMPTY, routes: [F:Line:1])])]", result.toString());
   }
 
   @Test
@@ -36,10 +33,7 @@ class TransitFilterNewWayMapperTest {
       list(map("select", list(map(entry("transportModes", list(map("transportMode", BUS)))))))
     );
 
-    assertEquals(
-      "[TransitFilterRequest{select: [SelectRequest{transportModes: [BUS]}]}]",
-      result.toString()
-    );
+    assertEquals("[(select: [(transportModes: [BUS])])]", result.toString());
   }
 
   @Test
@@ -47,10 +41,7 @@ class TransitFilterNewWayMapperTest {
     var result = TransitFilterNewWayMapper.mapFilter(
       list(map("not", list(map("lines", list("F:Line:1")))))
     );
-    assertEquals(
-      "[TransitFilterRequest{not: [SelectRequest{transportModes: [], routes: [F:Line:1]}]}]",
-      result.toString()
-    );
+    assertEquals("[(not: [(transportModes: EMPTY, routes: [F:Line:1])])]", result.toString());
   }
 
   private static <T> Map.Entry<String, List<T>> e(String key, T... values) {

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapperTest.java
@@ -1,0 +1,187 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.apis.transmodel._support.RequestHelper.list;
+import static org.opentripplanner.apis.transmodel._support.RequestHelper.map;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.transmodel.model.TransmodelTransportSubmode;
+import org.opentripplanner.apis.transmodel.support.DataFetcherDecorator;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.request.TransitRequest;
+import org.opentripplanner.routing.api.request.request.TransitRequestBuilder;
+import org.opentripplanner.transit.model.basic.TransitMode;
+
+class TransitFilterOldWayMapperTest {
+
+  private TransitRequestBuilder transitBuilder = TransitRequest.of();
+
+  @Test
+  void mapEmptyFilter() {
+    var env = envOf(Map.of());
+
+    // If nothing is passed in the mapper will do nothing
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals("()", transitBuilder.build().toString());
+  }
+
+  @Test
+  void mapFilterEmptyWhiteListed() {
+    // setting one of the old filters will triger the old filter mapping
+    var env = envOf(map(entry("whiteListed", Map.of())));
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: ALL)])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  @Test
+  void mapFilterEmptyBanned() {
+    // setting one of the old filters will triger the old filter mapping
+    var env = envOf(map(entry("banned", Map.of())));
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: ALL)])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  @Test
+  void mapFilterWhiteListedAuthoritiesAndLines() {
+    var env = envOf(
+      map(entry("whiteListed", map(entry("authorities", list("A:1")), entry("lines", list("L:1")))))
+    );
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: ALL, agencies: [A:1]), (transportModes: ALL, routes: [L:1])])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  @Test
+  void mapFilterBannedAuthoritiesAndLines() {
+    var env = envOf(
+      map(entry("banned", map(entry("authorities", list("A:1")), entry("lines", list("L:1")))))
+    );
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: ALL)], not: [(transportModes: EMPTY, agencies: [A:1]), (transportModes: EMPTY, routes: [L:1])])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  @Test
+  void mapFilterIncludeEverythingIfModeIsNotSet() {
+    var env = envOf(
+      map(
+        entry("modes", Map.of()),
+        // This is ignored:
+        entry("banned", map(entry("lines", list("L:1"))))
+      )
+    );
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: ALL)], not: [(transportModes: EMPTY, routes: [L:1])])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  @Test
+  void mapFilterSkipTransitIfTransportModesIsEmpty() {
+    var env = envOf(
+      map(
+        entry("modes", map("transportModes", list())),
+        // This is ignored:
+        entry("banned", map(entry("lines", list("L:1"))))
+      )
+    );
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals("(filters: [ExcludeAllTransitFilter])", transitBuilder.build().toString());
+  }
+
+  @Test
+  void mapFilterSelectTransportModes() {
+    var env = envOf(
+      map(
+        entry(
+          "modes",
+          map(
+            entry(
+              "transportModes",
+              list(
+                map("transportMode", TransitMode.AIRPLANE),
+                map("transportMode", TransitMode.COACH),
+                map("transportMode", TransitMode.CABLE_CAR)
+              )
+            ),
+            // Ignored by subject
+            entry("accessMode", StreetMode.BIKE)
+          )
+        )
+      )
+    );
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: [AIRPLANE, CABLE_CAR, COACH])])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  @Test
+  void mapFilterSelectTransportModesWithSubmodes() {
+    var env = envOf(
+      map(
+        entry(
+          "modes",
+          map(
+            entry(
+              "transportModes",
+              list(
+                map(
+                  entry("transportMode", TransitMode.RAIL),
+                  entry(
+                    "transportSubModes",
+                    list(TransmodelTransportSubmode.LOCAL, TransmodelTransportSubmode.REGIONAL_RAIL)
+                  )
+                )
+              )
+            ),
+            // Ignored by subject
+            entry("accessMode", StreetMode.BIKE)
+          )
+        )
+      )
+    );
+
+    TransitFilterOldWayMapper.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: [RAIL::local, RAIL::regionalRail])])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  private static DataFetchingEnvironment envOf(Map<String, Object> arguments) {
+    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/gtfs/interlining/InterlineProcessorTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/interlining/InterlineProcessorTest.java
@@ -51,9 +51,9 @@ class InterlineProcessorTest implements PlanTestConstants {
           List.of(LocalDate.of(2023, Month.JANUARY, 1))
         ),
         "[ConstrainedTransfer{from: TripTP{F:trip-2, stopPos 2}, to: TripTP{F:trip-3, stopPos 0}, " +
-        "constraint: {staySeated}}, ConstrainedTransfer{from: TripTP{F:trip-1, stopPos 2}, " +
-        "to: TripTP{F:trip-2, stopPos 0}, constraint: {staySeated}}, " +
-        "ConstrainedTransfer{from: TripTP{F:trip-3, stopPos 2}, to: TripTP{F:trip-4, stopPos 0}, constraint: {staySeated}}]"
+        "constraint: (staySeated)}, ConstrainedTransfer{from: TripTP{F:trip-1, stopPos 2}, " +
+        "to: TripTP{F:trip-2, stopPos 0}, constraint: (staySeated)}, " +
+        "ConstrainedTransfer{from: TripTP{F:trip-3, stopPos 2}, to: TripTP{F:trip-4, stopPos 0}, constraint: (staySeated)}]"
       ),
       Arguments.of(
         List.of(
@@ -69,9 +69,9 @@ class InterlineProcessorTest implements PlanTestConstants {
           List.of(LocalDate.of(2023, Month.JANUARY, 1))
         ),
         "[ConstrainedTransfer{from: TripTP{F:trip-2, stopPos 2}, to: TripTP{F:trip-3, stopPos 0}, " +
-        "constraint: {staySeated}}, ConstrainedTransfer{from: TripTP{F:trip-1, stopPos 2}, " +
-        "to: TripTP{F:trip-2, stopPos 0}, constraint: {staySeated}}, " +
-        "ConstrainedTransfer{from: TripTP{F:trip-2, stopPos 2}, to: TripTP{F:trip-4, stopPos 0}, constraint: {staySeated}}]"
+        "constraint: (staySeated)}, ConstrainedTransfer{from: TripTP{F:trip-1, stopPos 2}, " +
+        "to: TripTP{F:trip-2, stopPos 0}, constraint: (staySeated)}, " +
+        "ConstrainedTransfer{from: TripTP{F:trip-2, stopPos 2}, to: TripTP{F:trip-4, stopPos 0}, constraint: (staySeated)}]"
       ),
       // No common days between services
       Arguments.of(
@@ -87,7 +87,7 @@ class InterlineProcessorTest implements PlanTestConstants {
           List.of(LocalDate.of(2023, Month.JANUARY, 3)),
           List.of(LocalDate.of(2023, Month.JANUARY, 1))
         ),
-        "[ConstrainedTransfer{from: TripTP{F:trip-1, stopPos 2}, to: TripTP{F:trip-2, stopPos 0}, constraint: {staySeated}}]"
+        "[ConstrainedTransfer{from: TripTP{F:trip-1, stopPos 2}, to: TripTP{F:trip-2, stopPos 0}, constraint: (staySeated)}]"
       )
     );
   }

--- a/application/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
+++ b/application/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
@@ -81,13 +81,13 @@ public class OtpTransitServiceImplTest {
 
     assertEquals(
       """
-      ConstrainedTransfer{from: RouteTP{2, stop D}, to: RouteTP{5, stop I}, constraint: {guaranteed}}
-      ConstrainedTransfer{from: StopTP{F}, to: StopTP{E}, constraint: {minTransferTime: 20m}}
-      ConstrainedTransfer{from: StopTP{K}, to: StopTP{L}, constraint: {priority: RECOMMENDED}}
-      ConstrainedTransfer{from: StopTP{K}, to: StopTP{M}, constraint: {priority: NOT_ALLOWED}}
-      ConstrainedTransfer{from: StopTP{L}, to: StopTP{K}, constraint: {priority: RECOMMENDED}}
-      ConstrainedTransfer{from: StopTP{M}, to: StopTP{K}, constraint: {priority: NOT_ALLOWED}}
-      ConstrainedTransfer{from: TripTP{1.1, stopPos 1}, to: TripTP{2.2, stopPos 0}, constraint: {guaranteed}}""",
+      ConstrainedTransfer{from: RouteTP{2, stop D}, to: RouteTP{5, stop I}, constraint: (guaranteed)}
+      ConstrainedTransfer{from: StopTP{F}, to: StopTP{E}, constraint: (minTransferTime: 20m)}
+      ConstrainedTransfer{from: StopTP{K}, to: StopTP{L}, constraint: (priority: RECOMMENDED)}
+      ConstrainedTransfer{from: StopTP{K}, to: StopTP{M}, constraint: (priority: NOT_ALLOWED)}
+      ConstrainedTransfer{from: StopTP{L}, to: StopTP{K}, constraint: (priority: RECOMMENDED)}
+      ConstrainedTransfer{from: StopTP{M}, to: StopTP{K}, constraint: (priority: NOT_ALLOWED)}
+      ConstrainedTransfer{from: TripTP{1.1, stopPos 1}, to: TripTP{2.2, stopPos 0}, constraint: (guaranteed)}""",
       result
     );
   }

--- a/application/src/test/java/org/opentripplanner/model/modes/AllowAllModesFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/model/modes/AllowAllModesFilterTest.java
@@ -28,6 +28,6 @@ class AllowAllModesFilterTest {
 
   @Test
   void testToString() {
-    assertEquals(subject.getClass().getSimpleName() + "{}", subject.toString());
+    assertEquals("AllowAllModesFilter", subject.toString());
   }
 }

--- a/application/src/test/java/org/opentripplanner/model/transfer/ConstrainedTransferTest.java
+++ b/application/src/test/java/org/opentripplanner/model/transfer/ConstrainedTransferTest.java
@@ -107,7 +107,7 @@ public class ConstrainedTransferTest {
   @Test
   public void testToString() {
     assertEquals(
-      "ConstrainedTransfer{from: StopTP{F:A}, to: StopTP{F:B}, constraint: {no constraints}}",
+      "ConstrainedTransfer{from: StopTP{F:A}, to: StopTP{F:B}, constraint: (no constraints)}",
       TX_A_TO_B.toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/model/transfer/TransferConstraintTest.java
+++ b/application/src/test/java/org/opentripplanner/model/transfer/TransferConstraintTest.java
@@ -113,9 +113,9 @@ public class TransferConstraintTest {
 
   @Test
   public void testToString() {
-    assertEquals("{no constraints}", NO_CONSTRAINS.toString());
+    assertEquals("(no constraints)", NO_CONSTRAINS.toString());
     assertEquals(
-      "{priority: PREFERRED, staySeated, guaranteed, maxWaitTime: 1h}",
+      "(priority: PREFERRED, staySeated, guaranteed, maxWaitTime: 1h)",
       EVERYTHING.toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTransferPoint.java
+++ b/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTransferPoint.java
@@ -44,7 +44,7 @@ public class TestTransferPoint implements TransferPoint {
 
   @Override
   public String toString() {
-    return ToStringBuilder.of()
+    return ToStringBuilder.ofEmbeddedType()
       .addNum("stop", stop)
       .addObj("trip", schedule.pattern().debugInfo())
       .toString();

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
@@ -151,7 +151,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
       "Walk 3m 10:00:15 10:03:15 C₁360 ~ A 45s " +
       "~ BUS L11 10:04 10:35 31m C₁1_998 ~ B 15s " +
       "~ Walk 2m 10:35:15 10:37:15 C₁240 ~ C 22m45s " +
-      "~ BUS L21 11:00 11:23 23m C₁2_724 ~ D 17m {staySeated} " +
+      "~ BUS L21 11:00 11:23 23m C₁2_724 ~ D 17m (staySeated) " +
       "~ BUS L31 11:40 11:52 12m C₁1_737 ~ E 15s " +
       "~ Walk 7m45s 11:52:15 12:00 C₁930 " +
       "[10:00:15 12:00 1h59m45s Tₓ1 C₁7_989 Tₚ4_600 wtC₁-93_137]";

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
@@ -254,7 +254,7 @@ public class OptimizePathDomainServiceTest implements RaptorTestConstants {
     );
     // Verify the attached Transfer is exist and is valid
     assertEquals(
-      "ConstrainedTransfer{from: TripTP{F:BUS T1:10:02, stopPos 2}, to: TripTP{F:BUS T2:10:13, stopPos 1}, constraint: {guaranteed}}",
+      "ConstrainedTransfer{from: TripTP{F:BUS T1:10:02, stopPos 2}, to: TripTP{F:BUS T2:10:13, stopPos 1}, constraint: (guaranteed)}",
       it.accessLeg().nextLeg().asTransitLeg().getConstrainedTransferAfterLeg().toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/JourneyRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/JourneyRequestTest.java
@@ -107,14 +107,14 @@ class JourneyRequestTest {
   void testToString() {
     assertEqualsIgnoreWhitespace(
       """
-      JourneyRequest{
-        transit: TransitRequest{filters: [TransitFilterRequest{select: [SelectRequest{transportModes: [], routes: [F:R:1]}]}]},
-        access: StreetRequest{mode: BIKE_TO_PARK},
-        egress: StreetRequest{mode: SCOOTER_RENTAL},
-        transfer:StreetRequest{mode:BIKE},
-        direct:StreetRequest{mode:CAR},
+      (
+        transit: (filters: [(select: [(transportModes: EMPTY, routes: [F:R:1])])]),
+        access: (mode: BIKE_TO_PARK),
+        egress: (mode: SCOOTER_RENTAL),
+        transfer:(mode:BIKE),
+        direct:(mode:CAR),
         wheelchair
-      }
+      )
       """,
       subject.toString()
     );

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/StreetRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/StreetRequestTest.java
@@ -1,0 +1,33 @@
+package org.opentripplanner.routing.api.request.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner._support.asserts.AssertEqualsAndHashCode;
+import org.opentripplanner.routing.api.request.StreetMode;
+
+class StreetRequestTest {
+
+  private static final StreetMode STREET_MODE = StreetMode.BIKE_RENTAL;
+
+  private final StreetRequest subject = new StreetRequest(STREET_MODE);
+
+  @Test
+  void mode() {
+    assertEquals(STREET_MODE, subject.mode());
+    assertEquals(StreetMode.WALK, StreetRequest.DEFAULT.mode());
+  }
+
+  @Test
+  void testEqualsAndHashCode() {
+    AssertEqualsAndHashCode.verify(subject)
+      .sameAs(new StreetRequest(STREET_MODE))
+      .differentFrom(StreetRequest.DEFAULT, new StreetRequest(StreetMode.CAR));
+  }
+
+  @Test
+  void testToString() {
+    assertEquals("(mode: BIKE_RENTAL)", subject.toString());
+    assertEquals("()", StreetRequest.DEFAULT.toString());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/TransitRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/TransitRequestTest.java
@@ -125,18 +125,18 @@ class TransitRequestTest {
   void testToString() {
     assertEqualsIgnoreWhitespace(
       """
-      TransitRequest{
-        filters: [TransitFilterRequest{select: [SelectRequest{transportModes: [], agencies: [A:1]}]}],
+      (
+        filters: [(select: [(transportModes: EMPTY, agencies: [A:1])])],
         preferredAgencies: [F:A:1],
         preferredRoutes: [F:R:1],
         bannedTrips: [F:T:1],
-        priorityGroupsByAgency: [TransitGroupSelect{subModeRegexp: [A.*]}],
-        priorityGroupsGlobal: [TransitGroupSelect{subModeRegexp: [G.*]}],
+        priorityGroupsByAgency: [(subModeRegexp: [A.*])],
+        priorityGroupsGlobal: [(subModeRegexp: [G.*])],
         raptorDebugging: DebugRaptor{stops: 1, 2}
-      }
+      )
       """,
       subject.toString()
     );
-    assertEquals("TransitRequest{}", TransitRequest.DEFAULT.toString());
+    assertEquals("()", TransitRequest.DEFAULT.toString());
   }
 }

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/SelectRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/SelectRequestTest.java
@@ -27,23 +27,23 @@ class SelectRequestTest {
 
   @Test
   void testModesToString() {
-    assertEquals("SelectRequest{transportModes: []}", modesSelect().toString());
-    assertEquals("SelectRequest{transportModes: [BUS]}", modesSelect(TC_BUS).toString());
+    assertEquals("(transportModes: EMPTY)", modesSelect().toString());
+    assertEquals("(transportModes: [BUS])", modesSelect(TC_BUS).toString());
     assertEquals(
-      "SelectRequest{transportModes: [BUS::LOCAL, FERRY]}",
+      "(transportModes: [BUS::LOCAL, FERRY])",
       modesSelect(TC_FERRY, TC_LOCAL_BUS).toString()
     );
     assertEquals(
-      "SelectRequest{transportModes: ALL-MAIN-MODES}",
+      "(transportModes: ALL)",
       SelectRequest.of().withTransportModes(MainAndSubMode.all()).build().toString()
     );
-    assertEquals("SelectRequest{transportModes: NOT [FERRY]}", notModesSelect(TC_FERRY).toString());
+    assertEquals("(transportModes: NOT [FERRY])", notModesSelect(TC_FERRY).toString());
     assertEquals(
-      "SelectRequest{transportModes: NOT [BUS, FERRY, TRAM]}",
+      "(transportModes: NOT [BUS, FERRY, TRAM])",
       notModesSelect(TC_BUS, TC_TRAM, TC_FERRY).toString()
     );
     assertEquals(
-      "SelectRequest{transportModes: [AIRPLANE, CABLE_CAR, CARPOOL, COACH, FUNICULAR, GONDOLA, MONORAIL, SUBWAY, TAXI, TROLLEYBUS]}",
+      "(transportModes: [AIRPLANE, CABLE_CAR, CARPOOL, COACH, FUNICULAR, GONDOLA, MONORAIL, SUBWAY, TAXI, TROLLEYBUS])",
       notModesSelect(TC_BUS, TC_FERRY, TC_TRAM, TC_RAIL).toString()
     );
     var list = new ArrayList<>(
@@ -51,7 +51,7 @@ class SelectRequestTest {
     );
     list.add(TC_LOCAL_BUS);
     assertEquals(
-      "SelectRequest{transportModes: [AIRPLANE, BUS::LOCAL, CABLE_CAR, CARPOOL, COACH, FERRY, FUNICULAR, GONDOLA, MONORAIL, RAIL, SUBWAY, TAXI, TROLLEYBUS]}",
+      "(transportModes: [AIRPLANE, BUS::LOCAL, CABLE_CAR, CARPOOL, COACH, FERRY, FUNICULAR, GONDOLA, MONORAIL, RAIL, SUBWAY, TAXI, TROLLEYBUS])",
       SelectRequest.of().withTransportModes(list).build().toString()
     );
   }

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/TransitFilterRequestTest.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.routing.api.request.request.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TransitFilterRequestTest {
+
+  private static final SelectRequest SELECT = SelectRequest.of()
+    .withAgenciesFromString("A:1")
+    .build();
+
+  @Test
+  void testToString() {
+    assertEquals("ALL", TransitFilterRequest.of().build().toString());
+    assertEquals(
+      "(select: [(transportModes: EMPTY, agencies: [A:1])])",
+      TransitFilterRequest.of().addSelect(SELECT).build().toString()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/TransitGroupSelectTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/TransitGroupSelectTest.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.routing.api.request.request.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+class TransitGroupSelectTest {
+
+  @Test
+  void testToString() {
+    assertEquals("EMPTY", TransitGroupSelect.of().build().toString());
+    assertEquals(
+      "(modes: [BUS], subModeRegexp: [local.*], agencyIds: [A:1])",
+      TransitGroupSelect.of()
+        .addModes(List.of(TransitMode.BUS))
+        .addSubModeRegexp(List.of("local.*"))
+        .addAgencyIds(List.of(new FeedScopedId("A", "1")))
+        .build()
+        .toString()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/core/RouteRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/core/RouteRequestTest.java
@@ -231,7 +231,7 @@ class RouteRequestTest {
         bookingTime:2025-05-17T11:15:00Z,
         numItineraries:10,
         preferences:RoutingPreferences{transfer:TransferPreferences{maxTransfers:10}},
-        journey:JourneyRequest{access:StreetRequest{mode:BIKE}}
+        journey:(access:(mode:BIKE))
       }
       """,
       subject.toString()

--- a/utils/src/main/java/org/opentripplanner/utils/tostring/ToStringBuilder.java
+++ b/utils/src/main/java/org/opentripplanner/utils/tostring/ToStringBuilder.java
@@ -48,9 +48,14 @@ public class ToStringBuilder {
   private final OtpNumberFormat numFormat = new OtpNumberFormat();
 
   boolean first = true;
+  private final char sufix;
 
-  private ToStringBuilder(String name) {
-    sb.append(name).append("{");
+  private ToStringBuilder(String name, char open, char close) {
+    this.sufix = close;
+    if (name != null) {
+      sb.append(name);
+    }
+    sb.append(open);
   }
 
   /**
@@ -58,7 +63,7 @@ public class ToStringBuilder {
    * field names) when building the to string.
    */
   public static ToStringBuilder of(Class<?> clazz) {
-    return new ToStringBuilder(clazz.getSimpleName());
+    return of(clazz.getSimpleName());
   }
 
   /**
@@ -66,16 +71,19 @@ public class ToStringBuilder {
    * but this can be used if the type is unknown or irrelevant.
    */
   public static ToStringBuilder of(String name) {
-    return new ToStringBuilder(name);
+    return new ToStringBuilder(name, '{', '}');
   }
 
   /**
-   * Create a ToStringBuilder for a regular POJO type without including the type in the name. Some
-   * classes are always embedded in other classes and the type is given, for these cases this
+   * Create a ToStringBuilder for a ValueObject/POJO type without including the type in the name.
+   * Some classes are always embedded in other classes and the type is given, for these cases this
    * builder make the toString a bit easier to read.
+   * <p>
+   * Using this builder enforce "name : value", if you only want to print the value use
+   * {@link ValueObjectToStringBuilder}.
    */
   public static ToStringBuilder of() {
-    return new ToStringBuilder("");
+    return new ToStringBuilder(null, '(', ')');
   }
 
   /* General purpose formatters */
@@ -345,7 +353,7 @@ public class ToStringBuilder {
 
   @Override
   public String toString() {
-    return sb.append("}").toString();
+    return sb.append(sufix).toString();
   }
 
   /** private methods */

--- a/utils/src/main/java/org/opentripplanner/utils/tostring/ToStringBuilder.java
+++ b/utils/src/main/java/org/opentripplanner/utils/tostring/ToStringBuilder.java
@@ -82,7 +82,7 @@ public class ToStringBuilder {
    * Using this builder enforce "name : value", if you only want to print the value use
    * {@link ValueObjectToStringBuilder}.
    */
-  public static ToStringBuilder of() {
+  public static ToStringBuilder ofEmbeddedType() {
     return new ToStringBuilder(null, '(', ')');
   }
 

--- a/utils/src/test/java/org/opentripplanner/utils/tostring/ToStringBuilderTest.java
+++ b/utils/src/test/java/org/opentripplanner/utils/tostring/ToStringBuilderTest.java
@@ -90,9 +90,9 @@ public class ToStringBuilderTest {
 
   @Test
   public void addStr() {
-    assertEquals("(a: 'text')", ToStringBuilder.of().addStr("a", "text").toString());
-    assertEquals("()", ToStringBuilder.of().addStr("a", null).toString());
-    assertEquals("()", ToStringBuilder.of().addStr("a", "text", "text").toString());
+    assertEquals("(a: 'text')", ToStringBuilder.ofEmbeddedType().addStr("a", "text").toString());
+    assertEquals("()", ToStringBuilder.ofEmbeddedType().addStr("a", null).toString());
+    assertEquals("()", ToStringBuilder.ofEmbeddedType().addStr("a", "text", "text").toString());
   }
 
   @Test

--- a/utils/src/test/java/org/opentripplanner/utils/tostring/ToStringBuilderTest.java
+++ b/utils/src/test/java/org/opentripplanner/utils/tostring/ToStringBuilderTest.java
@@ -90,9 +90,9 @@ public class ToStringBuilderTest {
 
   @Test
   public void addStr() {
-    assertEquals("{a: 'text'}", ToStringBuilder.of().addStr("a", "text").toString());
-    assertEquals("{}", ToStringBuilder.of().addStr("a", null).toString());
-    assertEquals("{}", ToStringBuilder.of().addStr("a", "text", "text").toString());
+    assertEquals("(a: 'text')", ToStringBuilder.of().addStr("a", "text").toString());
+    assertEquals("()", ToStringBuilder.of().addStr("a", null).toString());
+    assertEquals("()", ToStringBuilder.of().addStr("a", "text", "text").toString());
   }
 
   @Test


### PR DESCRIPTION
### Summary

After #6653 the modes mapping in the Transmodel API is not working correct. The case is that the request is updated using multiple sub-request builders. These builders will copy the request state when created, and when build they will write bask any changes. If two bilders are created with the same scope (or overlapping scope) the builder written back last will overwrite the previous one.

I have fixed this by cleaning up the code and made sure the only one builder is in scope at all times - then it becomes impossible to change two builders.

I have added tests for the mapping code involved and some test on ToString() methods I have changed.

I have changed the `toString()` objects for some of the "embedded" request objects. There is not need to print the type 
for these objects. They are indeed ValueObjects, but some of them are complex to using the convention "field-name : value" is kept. I changed the paremphases to '(' and ')' instead of '{' and '}'. This is done if the `ToStringBuilder.ofEmbedded()` is used. It look like this:

```
RouteRequest{..., journey: (transit: (filters: [(select: [(transportModes: NOT [CABLE_CAR, CARPOOL])])], ..}
```


### Issue

🟥  I have not created an issue for this. This issue where detected at Entur yesterday.


### Unit tests

✅  Unit tests are updated.


### Documentation

✅  JavaDoc is updated.


### Changelog

This is a fix for a PR in the same release, hence should not be in the changelog.


### Bumping the serialization version id

Not needed, I have changed the `toString()` methods of some of the Request objects, no other changes.
