### PR TITLE
Set access/egress mode when setting transit mode

### DIFF
--- a/client/src/hooks/useTripQueryVariables.ts
+++ b/client/src/hooks/useTripQueryVariables.ts
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Locale, TripQueryVariables } from '../gql/graphql.ts';
+import { TripQueryVariables } from '../gql/graphql.ts';
 
 const DEFAULT_VARIABLES: TripQueryVariables = {
   from: {},
   to: {},
   dateTime: new Date().toISOString(),
-  locale: Locale.Us,
 };
 
 const getInitialVariables = () => {


### PR DESCRIPTION
### Summary

This fixes an annoyance that I keep forgetting about: when you set a transit mode, the access and egress is automatically set to `foot`.


https://github.com/user-attachments/assets/3c8f30ac-82c7-4e8e-a67b-c3a1b0217acf



It also defaults to the `Us` locale.