### PR TITLE
Make leg's startTime, endTime, serviceDate required

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/model/ConsolidatedStopLegBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/model/ConsolidatedStopLegBuilderTest.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.ext.fares.impl.FareModelForTest.FARE_PRODUCT_U
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 
 class ConsolidatedStopLegBuilderTest implements PlanTestConstants {
 
+  private static final ZonedDateTime TIME = ZonedDateTime.parse("2025-06-25T08:33:36+02:00");
   private static final Set<TransitAlert> ALERTS = Set.of(
     TransitAlert.of(id("alert")).withDescriptionText(I18NString.of("alert")).build()
   );
@@ -35,6 +37,9 @@ class ConsolidatedStopLegBuilderTest implements PlanTestConstants {
       .withBoardStopIndexInPattern(0)
       .withDistanceMeters(1000)
       .withAlightStopIndexInPattern(1)
+      .withStartTime(TIME)
+      .withEndTime(TIME)
+      .withServiceDate(TIME.toLocalDate())
       .build();
   private static final List<FareProductUse> FARES = List.of(FARE_PRODUCT_USE);
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/model/ConsolidatedStopLegBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/model/ConsolidatedStopLegBuilderTest.java
@@ -32,7 +32,6 @@ class ConsolidatedStopLegBuilderTest implements PlanTestConstants {
   private static final ScheduledTransitLeg SCHEDULED_TRANSIT_LEG =
     new ScheduledTransitLegBuilder<>()
       .withZoneId(ZoneIds.BERLIN)
-      .withServiceDate(LocalDate.of(2025, 1, 15))
       .withTripPattern(PATTERN)
       .withBoardStopIndexInPattern(0)
       .withDistanceMeters(1000)

--- a/application/src/main/java/org/opentripplanner/model/plan/leg/ScheduledTransitLeg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/leg/ScheduledTransitLeg.java
@@ -94,16 +94,9 @@ public class ScheduledTransitLeg implements TransitLeg {
       "alightStopPosInPattern"
     );
 
-    // TODO - Add requireNonNull for start-time. Some tests fails when this is done, these tests
-    //        should be fixed.
-    this.startTime = builder.startTime();
-    // TODO - Add requireNonNull for end-tTime. Some tests fails when this is done, these tests
-    //        should be fixed.
-    this.endTime = builder.endTime();
-
-    // TODO - Add requireNonNull for service-date. Some tests fails when this is done, these tests
-    //        should be fixed.
-    this.serviceDate = builder.serviceDate();
+    this.startTime = Objects.requireNonNull(builder.startTime());
+    this.endTime = Objects.requireNonNull(builder.endTime());
+    this.serviceDate = Objects.requireNonNull(builder.serviceDate());
     this.zoneId = Objects.requireNonNull(builder.zoneId());
 
     this.tripOnServiceDate = builder.tripOnServiceDate();

--- a/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTripSchedule.java
+++ b/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTripSchedule.java
@@ -25,6 +25,7 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 public class TestTripSchedule implements TripSchedule {
 
   private static final int DEFAULT_DEPARTURE_DELAY = 10;
+  private static final LocalDate DATE = LocalDate.of(2025, 6, 25);
   private final DefaultTripPattern pattern;
   private final int[] arrivalTimes;
   private final int[] departureTimes;
@@ -113,7 +114,7 @@ public class TestTripSchedule implements TripSchedule {
 
   @Override
   public LocalDate getServiceDate() {
-    return null;
+    return DATE;
   }
 
   @Override


### PR DESCRIPTION
### Summary

This resolves a bit of technical debt by making `startTime`, `endTime` and `serviceDate` required.

It needed some light refactoring of tests.
