### PR TITLE
VehicleRental: allow translating name fields

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/VehicleRentalLayerTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/VehicleRentalLayerTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.i18n.TranslatedString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -121,7 +122,7 @@ public class VehicleRentalLayerTest {
   private static RentalVehicleType vehicleType(RentalFormFactor formFactor) {
     return RentalVehicleType.of()
       .withId(new FeedScopedId("1", formFactor.name()))
-      .withName("bicycle")
+      .withName(I18NString.of("bicycle"))
       .withFormFactor(formFactor)
       .withPropulsionType(RentalVehicleType.PropulsionType.HUMAN)
       .withMaxRangeMeters(1000d)

--- a/application/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.smoovebikerental;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -48,8 +49,7 @@ public class SmooveBikeRentalDataSource
     overloadingAllowed = config.overloadingAllowed();
     system = VehicleRentalSystem.of()
       .withSystemId(networkName)
-      .withLanguage("fi")
-      .withName("Helsinki/Espoo")
+      .withName(I18NString.of("Helsinki/Espoo"))
       .withTimezone("Europe/Helsinki")
       .build();
   }

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/model/GeofencingZone.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/model/GeofencingZone.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.service.vehiclerental.model;
 
 import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /**
@@ -9,6 +10,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  */
 public record GeofencingZone(
   FeedScopedId id,
+  I18NString name,
   Geometry geometry,
   boolean dropOffBanned,
   boolean traversalBanned

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/model/RentalVehicleType.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/model/RentalVehicleType.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -26,7 +27,7 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
   private final FeedScopedId id;
 
   @Nullable
-  private final String name;
+  private final I18NString name;
 
   private final RentalFormFactor formFactor;
   private final PropulsionType propulsionType;
@@ -36,7 +37,7 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
 
   private RentalVehicleType() {
     this.id = new FeedScopedId("DEFAULT", "DEFAULT");
-    this.name = "Default vehicle type";
+    this.name = I18NString.of("Default vehicle type");
     this.formFactor = RentalFormFactor.BICYCLE;
     this.propulsionType = PropulsionType.HUMAN;
     this.maxRangeMeters = null;
@@ -52,7 +53,7 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
 
   public RentalVehicleType(
     FeedScopedId id,
-    String name,
+    I18NString name,
     RentalFormFactor formFactor,
     PropulsionType propulsionType,
     Double maxRangeMeters
@@ -78,7 +79,7 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
       (id ->
           new RentalVehicleType(
             new FeedScopedId(id, "DEFAULT"),
-            "Default vehicle type",
+            I18NString.of("Default vehicle type"),
             RentalFormFactor.BICYCLE,
             PropulsionType.HUMAN,
             null
@@ -91,7 +92,7 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
   }
 
   @Nullable
-  public String name() {
+  public I18NString name() {
     return name;
   }
 
@@ -133,7 +134,7 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
   public String toString() {
     return ToStringBuilder.of(RentalVehicleType.class)
       .addObj("id", id, DEFAULT.id)
-      .addStr("name", name, DEFAULT.name)
+      .addObj("name", name, DEFAULT.name)
       .addEnum("formFactor", formFactor, DEFAULT.formFactor)
       .addEnum("propulsionType", propulsionType, DEFAULT.propulsionType)
       .addObj("maxRangeMeters", maxRangeMeters, DEFAULT.maxRangeMeters)
@@ -144,7 +145,7 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
 
     private final RentalVehicleType original;
     private FeedScopedId id;
-    private String name;
+    private I18NString name;
     private RentalFormFactor formFactor;
     private PropulsionType propulsionType;
     private Double maxRangeMeters;
@@ -167,11 +168,11 @@ public final class RentalVehicleType implements Serializable, Comparable<RentalV
       return this;
     }
 
-    public String name() {
+    public I18NString name() {
       return name;
     }
 
-    public Builder withName(@Nullable String name) {
+    public Builder withName(@Nullable I18NString name) {
       this.name = name;
       return this;
     }

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStation.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStation.java
@@ -28,7 +28,7 @@ public final class VehicleRentalStation implements VehicleRentalPlace {
   // GBFS Static information
   private final FeedScopedId id;
   private final I18NString name;
-  private final String shortName;
+  private final I18NString shortName;
   private final double longitude;
   private final double latitude;
   private final String address;
@@ -151,7 +151,7 @@ public final class VehicleRentalStation implements VehicleRentalPlace {
   }
 
   @Nullable
-  public String shortName() {
+  public I18NString shortName() {
     return shortName;
   }
 

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStationBuilder.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStationBuilder.java
@@ -14,7 +14,7 @@ public class VehicleRentalStationBuilder {
   private final VehicleRentalStation original;
   private FeedScopedId id;
   private I18NString name;
-  private String shortName;
+  private I18NString shortName;
   private Double longitude;
   private Double latitude;
   private String address;
@@ -88,7 +88,7 @@ public class VehicleRentalStationBuilder {
     return name;
   }
 
-  public String shortName() {
+  public I18NString shortName() {
     return shortName;
   }
 
@@ -214,7 +214,7 @@ public class VehicleRentalStationBuilder {
     return this;
   }
 
-  public VehicleRentalStationBuilder withShortName(@Nullable String shortName) {
+  public VehicleRentalStationBuilder withShortName(@Nullable I18NString shortName) {
     this.shortName = shortName;
     return this;
   }

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalSystem.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalSystem.java
@@ -3,6 +3,7 @@ package org.opentripplanner.service.vehiclerental.model;
 import java.util.Objects;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
@@ -17,16 +18,13 @@ public final class VehicleRentalSystem {
   private final String systemId;
 
   @Nullable
-  private final String language;
+  private final I18NString name;
 
   @Nullable
-  private final String name;
+  private final I18NString shortName;
 
   @Nullable
-  private final String shortName;
-
-  @Nullable
-  private final String operator;
+  private final I18NString operator;
 
   @Nullable
   private final String url;
@@ -57,7 +55,6 @@ public final class VehicleRentalSystem {
 
   private VehicleRentalSystem() {
     this.systemId = null;
-    this.language = null;
     this.name = null;
     this.shortName = null;
     this.operator = null;
@@ -75,7 +72,6 @@ public final class VehicleRentalSystem {
 
   private VehicleRentalSystem(Builder builder) {
     this.systemId = builder.systemId;
-    this.language = builder.language;
     this.name = builder.name;
     this.shortName = builder.shortName;
     this.operator = builder.operator;
@@ -93,10 +89,9 @@ public final class VehicleRentalSystem {
 
   public VehicleRentalSystem(
     String systemId,
-    String language,
-    String name,
-    String shortName,
-    String operator,
+    I18NString name,
+    I18NString shortName,
+    I18NString operator,
     String url,
     String purchaseUrl,
     String startDate,
@@ -109,7 +104,6 @@ public final class VehicleRentalSystem {
     VehicleRentalSystemAppInformation iosApp
   ) {
     this.systemId = systemId;
-    this.language = language;
     this.name = name;
     this.shortName = shortName;
     this.operator = operator;
@@ -139,22 +133,17 @@ public final class VehicleRentalSystem {
   }
 
   @Nullable
-  public String language() {
-    return language;
-  }
-
-  @Nullable
-  public String name() {
+  public I18NString name() {
     return name;
   }
 
   @Nullable
-  public String shortName() {
+  public I18NString shortName() {
     return shortName;
   }
 
   @Nullable
-  public String operator() {
+  public I18NString operator() {
     return operator;
   }
 
@@ -219,7 +208,6 @@ public final class VehicleRentalSystem {
     VehicleRentalSystem that = (VehicleRentalSystem) o;
     return (
       Objects.equals(systemId, that.systemId) &&
-      Objects.equals(language, that.language) &&
       Objects.equals(name, that.name) &&
       Objects.equals(shortName, that.shortName) &&
       Objects.equals(operator, that.operator) &&
@@ -240,7 +228,6 @@ public final class VehicleRentalSystem {
   public int hashCode() {
     return Objects.hash(
       systemId,
-      language,
       name,
       shortName,
       operator,
@@ -261,10 +248,9 @@ public final class VehicleRentalSystem {
   public String toString() {
     return ToStringBuilder.of(VehicleRentalSystem.class)
       .addStr("systemId", systemId, DEFAULT.systemId)
-      .addStr("language", language, DEFAULT.language)
-      .addStr("name", name, DEFAULT.name)
-      .addStr("shortName", shortName, DEFAULT.shortName)
-      .addStr("operator", operator, DEFAULT.operator)
+      .addObj("name", name, DEFAULT.name)
+      .addObj("shortName", shortName, DEFAULT.shortName)
+      .addObj("operator", operator, DEFAULT.operator)
       .addStr("url", url, DEFAULT.url)
       .addStr("purchaseUrl", purchaseUrl, DEFAULT.purchaseUrl)
       .addStr("startDate", startDate, DEFAULT.startDate)
@@ -282,10 +268,9 @@ public final class VehicleRentalSystem {
 
     private final VehicleRentalSystem original;
     private String systemId;
-    private String language;
-    private String name;
-    private String shortName;
-    private String operator;
+    private I18NString name;
+    private I18NString shortName;
+    private I18NString operator;
     private String url;
     private String purchaseUrl;
     private String startDate;
@@ -300,7 +285,6 @@ public final class VehicleRentalSystem {
     private Builder(VehicleRentalSystem original) {
       this.original = original;
       this.systemId = original.systemId;
-      this.language = original.language;
       this.name = original.name;
       this.shortName = original.shortName;
       this.operator = original.operator;
@@ -325,38 +309,29 @@ public final class VehicleRentalSystem {
       return this;
     }
 
-    public String language() {
-      return language;
-    }
-
-    public Builder withLanguage(@Nullable String language) {
-      this.language = language;
-      return this;
-    }
-
-    public String name() {
+    public I18NString name() {
       return name;
     }
 
-    public Builder withName(@Nullable String name) {
+    public Builder withName(@Nullable I18NString name) {
       this.name = name;
       return this;
     }
 
-    public String shortName() {
+    public I18NString shortName() {
       return shortName;
     }
 
-    public Builder withShortName(@Nullable String shortName) {
+    public Builder withShortName(@Nullable I18NString shortName) {
       this.shortName = shortName;
       return this;
     }
 
-    public String operator() {
+    public I18NString operator() {
       return operator;
     }
 
-    public Builder withOperator(@Nullable String operator) {
+    public Builder withOperator(@Nullable I18NString operator) {
       this.operator = operator;
       return this;
     }

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSBike;
 import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSRentalUris;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleFuel;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -75,7 +76,7 @@ public class GbfsFreeVehicleStatusMapper {
       var builder = VehicleRentalVehicle.of()
         .withId(new FeedScopedId(system.systemId(), vehicle.getBikeId()))
         .withSystem(system)
-        .withName(new NonLocalizedString(getName(vehicle)))
+        .withName(getName(vehicle))
         .withLongitude(vehicle.getLon())
         .withLatitude(vehicle.getLat())
         .withVehicleType(
@@ -119,7 +120,7 @@ public class GbfsFreeVehicleStatusMapper {
     }
   }
 
-  private String getName(GBFSBike vehicle) {
+  private I18NString getName(GBFSBike vehicle) {
     var typeId = vehicle.getVehicleTypeId();
     if (typeId != null) {
       var type = vehicleTypes.get(typeId);

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsGeofencingZoneMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsGeofencingZoneMapper.java
@@ -11,7 +11,6 @@ import org.mobilitydata.gbfs.v2_3.geofencing_zones.GBFSGeofencingZones;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.UnsupportedGeometryException;
 import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.utils.lang.StringUtils;

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsGeofencingZoneMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsGeofencingZoneMapper.java
@@ -10,6 +10,8 @@ import org.mobilitydata.gbfs.v2_3.geofencing_zones.GBFSFeature;
 import org.mobilitydata.gbfs.v2_3.geofencing_zones.GBFSGeofencingZones;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.UnsupportedGeometryException;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.utils.lang.StringUtils;
@@ -60,6 +62,7 @@ class GbfsGeofencingZoneMapper {
     var passThroughBanned = !f.getProperties().getRules().get(0).getRideThroughAllowed();
     return new GeofencingZone(
       new FeedScopedId(systemId, name),
+      I18NString.of(name),
       g,
       dropOffBanned,
       passThroughBanned

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.mobilitydata.gbfs.v2_3.station_information.GBFSRentalUris;
 import org.mobilitydata.gbfs.v2_3.station_information.GBFSStation;
-import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.mobilitydata.gbfs.v2_3.station_information.GBFSRentalUris;
 import org.mobilitydata.gbfs.v2_3.station_information.GBFSStation;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
@@ -59,7 +60,7 @@ public class GbfsStationInformationMapper {
       .withLongitude(station.getLon())
       .withLatitude(station.getLat())
       .withName(new NonLocalizedString(station.getName()))
-      .withShortName(station.getShortName())
+      .withShortName(NonLocalizedString.ofNullable(station.getShortName()))
       .withAddress(station.getAddress())
       .withCrossStreet(station.getCrossStreet())
       .withRegionId(station.getRegionId())

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.updater.vehicle_rental.datasources;
 
 import org.mobilitydata.gbfs.v2_3.system_information.GBFSData;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalSystem;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalSystemAppInformation;
 
@@ -29,10 +31,9 @@ public class GbfsSystemInformationMapper {
 
     return new VehicleRentalSystem(
       systemId,
-      systemInformation.getLanguage(),
-      systemInformation.getName(),
-      systemInformation.getShortName(),
-      systemInformation.getOperator(),
+      I18NString.of(systemInformation.getName()),
+      NonLocalizedString.ofNullable(systemInformation.getShortName()),
+      NonLocalizedString.ofNullable(systemInformation.getOperator()),
       systemInformation.getUrl(),
       systemInformation.getPurchaseUrl(),
       systemInformation.getStartDate(),

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleTypeMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleTypeMapper.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.updater.vehicle_rental.datasources;
 
 import org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -16,7 +18,7 @@ public class GbfsVehicleTypeMapper {
   public RentalVehicleType mapRentalVehicleType(GBFSVehicleType vehicleType) {
     return new RentalVehicleType(
       new FeedScopedId(systemId, vehicleType.getVehicleTypeId()),
-      vehicleType.getName(),
+      NonLocalizedString.ofNullable(vehicleType.getName()),
       fromGbfs(vehicleType.getFormFactor()),
       RentalVehicleType.PropulsionType.fromGbfs(vehicleType.getPropulsionType()),
       vehicleType.getMaxRangeMeters()

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleTypeMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleTypeMapper.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.updater.vehicle_rental.datasources;
 
 import org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType;
-import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.street.model.RentalFormFactor;

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestFreeFloatingRentalVehicleBuilder.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestFreeFloatingRentalVehicleBuilder.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import javax.annotation.Nullable;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.transit.model.basic.Distance;
@@ -74,7 +75,6 @@ public class TestFreeFloatingRentalVehicleBuilder {
       null,
       null,
       null,
-      null,
       url,
       null,
       null,
@@ -125,7 +125,7 @@ public class TestFreeFloatingRentalVehicleBuilder {
       .withId(
         new FeedScopedId(TestFreeFloatingRentalVehicleBuilder.NETWORK_1, rentalFormFactor.name())
       )
-      .withName(rentalFormFactor.name())
+      .withName(I18NString.of(rentalFormFactor.name()))
       .withFormFactor(rentalFormFactor)
       .withPropulsionType(RentalVehicleType.PropulsionType.ELECTRIC)
       .withMaxRangeMeters(100000d)

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestVehicleRentalStationBuilder.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestVehicleRentalStationBuilder.java
@@ -2,6 +2,7 @@ package org.opentripplanner.service.vehiclerental.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -100,7 +101,7 @@ public class TestVehicleRentalStationBuilder {
           String.format("%s-%s", rentalFormFactor.name(), propulsionType.name())
         )
       )
-      .withName(rentalFormFactor.name())
+      .withName(I18NString.of(rentalFormFactor.name()))
       .withFormFactor(rentalFormFactor)
       .withPropulsionType(propulsionType)
       .withMaxRangeMeters(100000d)

--- a/application/src/test/java/org/opentripplanner/street/model/edge/RentalRestrictionExtensionTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/RentalRestrictionExtensionTest.java
@@ -54,7 +54,7 @@ class RentalRestrictionExtensionTest {
     var edge = streetEdge(V1, V2);
     V2.addRentalRestriction(
       new GeofencingZoneExtension(
-        new GeofencingZone(new FeedScopedId(network, "a-park"), null, true, true)
+        new GeofencingZone(new FeedScopedId(network, "a-park"), null, null, true, true)
       )
     );
     var result = traverse(edge)[0];
@@ -73,7 +73,7 @@ class RentalRestrictionExtensionTest {
     editor.beginFloatingVehicleRenting(RentalFormFactor.SCOOTER, network, false);
     restrictedEdge.addRentalRestriction(
       new GeofencingZoneExtension(
-        new GeofencingZone(new FeedScopedId(network, "a-park"), null, true, false)
+        new GeofencingZone(new FeedScopedId(network, "a-park"), null, null, true, false)
       )
     );
 
@@ -100,7 +100,7 @@ class RentalRestrictionExtensionTest {
   public void dontFinishInNoDropOffZone() {
     var edge = streetEdge(V1, V2);
     var ext = new GeofencingZoneExtension(
-      new GeofencingZone(new FeedScopedId(network, "a-park"), null, true, false)
+      new GeofencingZone(new FeedScopedId(network, "a-park"), null, null, true, false)
     );
     V2.addRentalRestriction(ext);
     edge.addRentalRestriction(ext);
@@ -179,7 +179,7 @@ class RentalRestrictionExtensionTest {
     RentalRestrictionExtension a = new BusinessAreaBorder("a");
     RentalRestrictionExtension b = new BusinessAreaBorder("b");
     RentalRestrictionExtension c = new GeofencingZoneExtension(
-      new GeofencingZone(new FeedScopedId(network, "a-park"), null, true, false)
+      new GeofencingZone(new FeedScopedId(network, "a-park"), null, null, true, false)
     );
 
     @Test

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeGeofencingTest.java
@@ -37,7 +37,7 @@ class StreetEdgeGeofencingTest {
   static String NETWORK_BIRD = "bird-oslo";
   static RentalRestrictionExtension NO_DROP_OFF_TIER = noDropOffRestriction(NETWORK_TIER);
   static RentalRestrictionExtension NO_TRAVERSAL = new GeofencingZoneExtension(
-    new GeofencingZone(new FeedScopedId(NETWORK_TIER, "a-park"), null, false, true)
+    new GeofencingZone(new FeedScopedId(NETWORK_TIER, "a-park"), null, null, false, true)
   );
   StreetVertex V1 = intersectionVertex("V1", 0, 0);
   StreetVertex V2 = intersectionVertex("V2", 1, 1);
@@ -120,7 +120,7 @@ class StreetEdgeGeofencingTest {
       var edge = streetEdge(V1, V2);
       V2.addRentalRestriction(
         new GeofencingZoneExtension(
-          new GeofencingZone(new FeedScopedId(NETWORK_TIER, "a-park"), null, true, true)
+          new GeofencingZone(new FeedScopedId(NETWORK_TIER, "a-park"), null, null, true, true)
         )
       );
       State result = traverseFromV1(edge)[0];
@@ -442,7 +442,7 @@ class StreetEdgeGeofencingTest {
 
   private static GeofencingZoneExtension noDropOffRestriction(String networkTier) {
     return new GeofencingZoneExtension(
-      new GeofencingZone(new FeedScopedId(networkTier, "a-park"), null, true, false)
+      new GeofencingZone(new FeedScopedId(networkTier, "a-park"), null, null, true, false)
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
@@ -17,6 +17,7 @@ import static org.opentripplanner.street.model.RentalFormFactor.SCOOTER;
 import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -231,7 +232,7 @@ class VehicleRentalEdgeTest {
       .withVehicleType(
         RentalVehicleType.of()
           .withId(new FeedScopedId(NETWORK, "scooter"))
-          .withName("scooter")
+          .withName(I18NString.of("scooter"))
           .withFormFactor(RentalFormFactor.SCOOTER)
           .withPropulsionType(RentalVehicleType.PropulsionType.ELECTRIC)
           .withMaxRangeMeters(100000d)
@@ -270,7 +271,7 @@ class VehicleRentalEdgeTest {
 
     private GeofencingZoneExtension noDropOffZone() {
       return new GeofencingZoneExtension(
-        new GeofencingZone(new FeedScopedId(NETWORK, "zone"), null, true, false)
+        new GeofencingZone(new FeedScopedId(NETWORK, "zone"), null, null, true, false)
       );
     }
   }

--- a/application/src/test/java/org/opentripplanner/street/model/vertex/RentalRestrictionExtensionTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/vertex/RentalRestrictionExtensionTest.java
@@ -19,7 +19,7 @@ class RentalRestrictionExtensionTest {
   RentalRestrictionExtension a = new BusinessAreaBorder("a");
   RentalRestrictionExtension b = new BusinessAreaBorder("b");
   RentalRestrictionExtension c = new GeofencingZoneExtension(
-    new GeofencingZone(new FeedScopedId(network, "a-park"), null, true, false)
+    new GeofencingZone(new FeedScopedId(network, "a-park"), null, null, true, false)
   );
 
   @Test

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_rental/GeofencingVertexUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_rental/GeofencingVertexUpdaterTest.java
@@ -39,6 +39,7 @@ class GeofencingVertexUpdaterTest {
   static GeometryFactory fac = GeometryUtils.getGeometryFactory();
   final GeofencingZone zone = new GeofencingZone(
     id("frogner-park"),
+    null,
     Polygons.OSLO_FROGNER_PARK,
     true,
     false
@@ -47,6 +48,7 @@ class GeofencingVertexUpdaterTest {
   MultiPolygon osloMultiPolygon = fac.createMultiPolygon(new Polygon[] { Polygons.OSLO });
   final GeofencingZone businessArea = new GeofencingZone(
     id("oslo"),
+    null,
     osloMultiPolygon,
     false,
     false

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSBike;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalSystem;
 import org.opentripplanner.street.model.RentalFormFactor;
@@ -14,10 +15,9 @@ class GbfsFreeVehicleStatusMapperTest {
 
   public static final VehicleRentalSystem SYSTEM = new VehicleRentalSystem(
     "123",
-    "de",
-    "123",
-    "123",
-    "123",
+    I18NString.of("123"),
+    I18NString.of("123"),
+    I18NString.of("123"),
     "https://example.com",
     "https://example.com",
     null,
@@ -35,7 +35,7 @@ class GbfsFreeVehicleStatusMapperTest {
       "scooter",
       new RentalVehicleType(
         new FeedScopedId("1", "scooter"),
-        "Scooter",
+        I18NString.of("Scooter"),
         RentalFormFactor.SCOOTER,
         RentalVehicleType.PropulsionType.COMBUSTION,
         null


### PR DESCRIPTION
### Summary

(Note: this is based on #6734)

[GBFS 3.0](https://gbfs.org/documentation/reference/#field-types) adds support for translations within a single feed.
>  Localized String - A JSON element representing a String value that has been translated into a specific language. The element consists of the following name-value pairs:

This prepares by using `I18NString` for user-visible fields:
 * `GeofencingZone`
   * `name`
 * `RentalVehicleType`
   * `name`
 * `VehicleRentalStation`
   * `name` is already an `I18NString`
   * `shortName`
 * `VehicleRentalSystem`
   * `name`
   * `shortName`
   * `operator`
   * `language` is removed, since it was unused

Do the GraphQL APIs need to be updated to support the translated fields?
The Transmodel `RentalVehicleTypeType` uses `RentalVehicleType#name`.

### Issue

#6708

### Unit tests

Existing tests were updated to match the changed types.

### Documentation

No changes.