### PR TITLE
VehicleRental: simplify form factor mapping to allow moped rentals

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/StreetModeToFormFactorMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/StreetModeToFormFactorMapper.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.routing.algorithm.mapping;
+
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.street.model.RentalFormFactor;
+
+public class StreetModeToFormFactorMapper {
+
+  /**
+   * Maps street mode to rental form factor (i.e. CAR_RENTAL -> CAR).
+   */
+  public static RentalFormFactor map(StreetMode streetMode) {
+    return switch (streetMode) {
+      case BIKE_RENTAL -> RentalFormFactor.BICYCLE;
+      case SCOOTER_RENTAL -> RentalFormFactor.SCOOTER;
+      case CAR_RENTAL -> RentalFormFactor.CAR;
+      // there is no default here, so you get a compiler error when you add a new value to the enum
+      case NOT_SET,
+        WALK,
+        BIKE,
+        BIKE_TO_PARK,
+        CAR,
+        CAR_TO_PARK,
+        CAR_PICKUP,
+        CAR_HAILING,
+        FLEXIBLE -> throw new IllegalStateException(
+        "Cannot convert street mode %s to a form factor".formatted(streetMode)
+      );
+    };
+  }
+}

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
@@ -1,8 +1,7 @@
 package org.opentripplanner.service.vehiclerental.street;
 
-import java.util.Collections;
-import java.util.Set;
 import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.routing.algorithm.mapping.StreetModeToRentalTraverseModeMapper;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.street.model.RentalFormFactor;
@@ -37,8 +36,7 @@ public class VehicleRentalEdge extends Edge {
       return State.empty();
     }
 
-    var allowedRentalFormFactors = allowedModes(s0.getRequest().mode());
-    if (!allowedRentalFormFactors.isEmpty() && !allowedRentalFormFactors.contains(formFactor)) {
+    if (!isFormFactorAllowed(s0.getRequest().mode(), formFactor)) {
       return State.empty();
     }
 
@@ -146,12 +144,6 @@ public class VehicleRentalEdge extends Edge {
           ) {
             return State.empty();
           }
-          if (
-            !allowedRentalFormFactors.isEmpty() &&
-            Collections.disjoint(allowedRentalFormFactors, formFactors)
-          ) {
-            return State.empty();
-          }
           s1.dropOffRentedVehicleAtStation(formFactor, network, false);
           pickedUp = false;
         }
@@ -190,16 +182,7 @@ public class VehicleRentalEdge extends Edge {
     return rentedNetwork.equals(stationNetwork);
   }
 
-  private static Set<RentalFormFactor> allowedModes(StreetMode streetMode) {
-    return switch (streetMode) {
-      case BIKE_RENTAL -> Set.of(RentalFormFactor.BICYCLE, RentalFormFactor.CARGO_BICYCLE);
-      case SCOOTER_RENTAL -> Set.of(
-        RentalFormFactor.SCOOTER,
-        RentalFormFactor.SCOOTER_SEATED,
-        RentalFormFactor.SCOOTER_STANDING
-      );
-      case CAR_RENTAL -> Set.of(RentalFormFactor.CAR);
-      default -> Set.of();
-    };
+  private static boolean isFormFactorAllowed(StreetMode streetMode, RentalFormFactor formFactor) {
+    return formFactor.traverseMode == StreetModeToRentalTraverseModeMapper.map(streetMode);
   }
 }

--- a/application/src/main/java/org/opentripplanner/street/search/state/StateData.java
+++ b/application/src/main/java/org/opentripplanner/street/search/state/StateData.java
@@ -8,6 +8,7 @@ import static org.opentripplanner.street.search.state.VehicleRentalState.RENTING
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.opentripplanner.routing.algorithm.mapping.StreetModeToFormFactorMapper;
 import org.opentripplanner.routing.algorithm.mapping.StreetModeToRentalTraverseModeMapper;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.street.model.RentalFormFactor;
@@ -159,6 +160,7 @@ public class StateData implements Cloneable {
     else if (requestMode.includesRenting()) {
       if (arriveBy) {
         var vehicleMode = StreetModeToRentalTraverseModeMapper.map(requestMode);
+        var formFactor = StreetModeToFormFactorMapper.map(requestMode);
         if (allowArrivingInRentedVehicleAtDestination) {
           var keptVehicleStateData = proto.clone();
           keptVehicleStateData.vehicleRentalState = RENTING_FROM_STATION;
@@ -168,7 +170,7 @@ public class StateData implements Cloneable {
         }
         var floatingRentalStateData = proto.clone();
         floatingRentalStateData.vehicleRentalState = RENTING_FLOATING;
-        floatingRentalStateData.rentalVehicleFormFactor = toFormFactor(requestMode);
+        floatingRentalStateData.rentalVehicleFormFactor = formFactor;
         floatingRentalStateData.currentMode = vehicleMode;
         res.add(floatingRentalStateData);
         var stationReturnedStateData = proto.clone();
@@ -196,26 +198,6 @@ public class StateData implements Cloneable {
     }
 
     return res;
-  }
-
-  private static RentalFormFactor toFormFactor(StreetMode streetMode) {
-    return switch (streetMode) {
-      case BIKE_RENTAL -> RentalFormFactor.BICYCLE;
-      case SCOOTER_RENTAL -> RentalFormFactor.SCOOTER;
-      case CAR_RENTAL -> RentalFormFactor.CAR;
-      // there is no default here, so you get a compiler error when you add a new value to the enum
-      case NOT_SET,
-        WALK,
-        BIKE,
-        BIKE_TO_PARK,
-        CAR,
-        CAR_TO_PARK,
-        CAR_PICKUP,
-        CAR_HAILING,
-        FLEXIBLE -> throw new IllegalStateException(
-        "Cannot convert street mode %s to a form factor".formatted(streetMode)
-      );
-    };
   }
 
   protected StateData clone() {

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestVehicleRentalStationBuilder.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/model/TestVehicleRentalStationBuilder.java
@@ -74,7 +74,7 @@ public class TestVehicleRentalStationBuilder {
   }
 
   public TestVehicleRentalStationBuilder withVehicleTypeBicycle(int numAvailable, int numSpaces) {
-    return buildVehicleType(
+    return withVehicleType(
       RentalFormFactor.BICYCLE,
       RentalVehicleType.PropulsionType.HUMAN,
       numAvailable,
@@ -86,7 +86,7 @@ public class TestVehicleRentalStationBuilder {
     int numAvailable,
     int numSpaces
   ) {
-    return buildVehicleType(
+    return withVehicleType(
       RentalFormFactor.BICYCLE,
       RentalVehicleType.PropulsionType.ELECTRIC,
       numAvailable,
@@ -95,7 +95,7 @@ public class TestVehicleRentalStationBuilder {
   }
 
   public TestVehicleRentalStationBuilder withVehicleTypeCar(int numAvailable, int numSpaces) {
-    return buildVehicleType(
+    return withVehicleType(
       RentalFormFactor.CAR,
       RentalVehicleType.PropulsionType.ELECTRIC,
       numAvailable,
@@ -103,7 +103,7 @@ public class TestVehicleRentalStationBuilder {
     );
   }
 
-  private TestVehicleRentalStationBuilder buildVehicleType(
+  public TestVehicleRentalStationBuilder withVehicleType(
     RentalFormFactor rentalFormFactor,
     RentalVehicleType.PropulsionType propulsionType,
     int numAvailable,

--- a/application/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
@@ -215,10 +215,6 @@ class VehicleRentalEdgeTest {
     assertTrue(State.isEmpty(s1));
   }
 
-  private void initBicycleEdgeAndRequest(int vehicles, int spaces) {
-    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, HUMAN, vehicles, spaces, false, true, true, false);
-  }
-
   @Nested
   class StartedReverseSearchInNoGeofencingZone {
 
@@ -277,6 +273,10 @@ class VehicleRentalEdgeTest {
         new GeofencingZone(new FeedScopedId(NETWORK, "zone"), null, true, false)
       );
     }
+  }
+
+  private void initBicycleEdgeAndRequest(int vehicles, int spaces) {
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, HUMAN, vehicles, spaces, false, true, true, false);
   }
 
   private void initBicycleEdgeAndRequest(

--- a/application/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
@@ -4,6 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.opentripplanner.routing.api.request.StreetMode.BIKE_RENTAL;
+import static org.opentripplanner.routing.api.request.StreetMode.CAR_RENTAL;
+import static org.opentripplanner.routing.api.request.StreetMode.SCOOTER_RENTAL;
+import static org.opentripplanner.street.model.RentalFormFactor.BICYCLE;
+import static org.opentripplanner.street.model.RentalFormFactor.CAR;
+import static org.opentripplanner.street.model.RentalFormFactor.MOPED;
+import static org.opentripplanner.street.model.RentalFormFactor.SCOOTER;
 
 import java.util.Set;
 import org.junit.jupiter.api.Nested;
@@ -30,8 +37,26 @@ class VehicleRentalEdgeTest {
   VehicleRentalPlaceVertex vertex;
 
   @Test
+  void testBicycleMopedRental() {
+    initEdgeAndRequest(BIKE_RENTAL, MOPED, 3, 3);
+
+    var s1 = rent();
+
+    assertFalse(State.isEmpty(s1));
+  }
+
+  @Test
+  void testScooterBicycleRental() {
+    initEdgeAndRequest(SCOOTER_RENTAL, BICYCLE, 3, 3);
+
+    var s1 = rent();
+
+    assertTrue(State.isEmpty(s1));
+  }
+
+  @Test
   void testRentingWithAvailableBikes() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 3);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 3);
 
     var s1 = rent();
 
@@ -40,7 +65,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testRentingWithNoAvailableVehicles() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 0, 3);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 0, 3);
 
     var s1 = rent();
 
@@ -49,7 +74,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testRentingWithNoAvailableVehiclesAndNoRealtimeUsage() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 0, 3, false, true, false, false);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 0, 3, false, true, false, false);
 
     var s1 = rent();
 
@@ -58,7 +83,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testReturningWithAvailableSpaces() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 3);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 3);
 
     var s1 = rentAndDropOff();
 
@@ -67,7 +92,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testReturningWithNoAvailableSpaces() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 0);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 0);
 
     var s1 = rentAndDropOff();
 
@@ -76,7 +101,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testReturningWithNoAvailableSpacesAndOverloading() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 0, true, true, true, false);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 0, true, true, true, false);
 
     var s1 = rentAndDropOff();
 
@@ -85,7 +110,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testReturningWithNoAvailableSpacesAndNoRealtimeUsage() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 0, false, true, false, false);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 0, false, true, false, false);
 
     var s1 = rentAndDropOff();
 
@@ -94,7 +119,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testRentingFromClosedStation() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 0, true, false, true, false);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 0, true, false, true, false);
 
     var s1 = rent();
 
@@ -103,13 +128,13 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testReturningToClosedStation() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 3, true, true, true, false);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 3, true, true, true, false);
 
     var s1 = rent();
 
     assertFalse(State.isEmpty(s1));
 
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 3, true, false, true, false);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 3, true, false, true, false);
 
     var s2 = dropOff(s1[0]);
 
@@ -118,7 +143,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testReturningAndReturningToClosedStationWithNoRealtimeUsage() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 3, false, true, false, false);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 3, false, true, false, false);
 
     var s1 = rentAndDropOff();
 
@@ -127,7 +152,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testRentingWithFreeFloatingBicycle() {
-    initFreeFloatingEdgeAndRequest(StreetMode.BIKE_RENTAL, RentalFormFactor.BICYCLE, false);
+    initFreeFloatingEdgeAndRequest(BIKE_RENTAL, BICYCLE, false);
 
     var s1 = rent();
 
@@ -136,7 +161,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testRentingWithFreeFloatingScooter() {
-    initFreeFloatingEdgeAndRequest(StreetMode.SCOOTER_RENTAL, RentalFormFactor.SCOOTER, false);
+    initFreeFloatingEdgeAndRequest(SCOOTER_RENTAL, SCOOTER, false);
 
     var s1 = rent();
 
@@ -145,7 +170,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testRentingWithFreeFloatingCar() {
-    initFreeFloatingEdgeAndRequest(StreetMode.CAR_RENTAL, RentalFormFactor.CAR, false);
+    initFreeFloatingEdgeAndRequest(CAR_RENTAL, CAR, false);
 
     var s1 = rent();
 
@@ -154,7 +179,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testBannedBicycleNetworkStation() {
-    initEdgeAndRequest(StreetMode.BIKE_RENTAL, 3, 3, false, true, true, true);
+    initEdgeAndRequest(BIKE_RENTAL, BICYCLE, 3, 3, false, true, true, true);
 
     var s1 = rent();
 
@@ -163,7 +188,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testBannedBicycleNetworkFreeFloating() {
-    initFreeFloatingEdgeAndRequest(StreetMode.BIKE_RENTAL, RentalFormFactor.BICYCLE, true);
+    initFreeFloatingEdgeAndRequest(BIKE_RENTAL, BICYCLE, true);
 
     var s1 = rent();
 
@@ -172,7 +197,7 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testBannedScooterNetworkFreeFloating() {
-    initFreeFloatingEdgeAndRequest(StreetMode.SCOOTER_RENTAL, RentalFormFactor.SCOOTER, true);
+    initFreeFloatingEdgeAndRequest(SCOOTER_RENTAL, SCOOTER, true);
 
     var s1 = rent();
 
@@ -181,15 +206,20 @@ class VehicleRentalEdgeTest {
 
   @Test
   void testBannedCarNetworkFreeFloating() {
-    initFreeFloatingEdgeAndRequest(StreetMode.CAR_RENTAL, RentalFormFactor.CAR, true);
+    initFreeFloatingEdgeAndRequest(CAR_RENTAL, CAR, true);
 
     var s1 = rent();
 
     assertTrue(State.isEmpty(s1));
   }
 
-  private void initEdgeAndRequest(StreetMode mode, int vehicles, int spaces) {
-    initEdgeAndRequest(mode, vehicles, spaces, false, true, true, false);
+  private void initEdgeAndRequest(
+    StreetMode mode,
+    RentalFormFactor formFactor,
+    int vehicles,
+    int spaces
+  ) {
+    initEdgeAndRequest(mode, formFactor, vehicles, spaces, false, true, true, false);
   }
 
   @Nested
@@ -197,7 +227,7 @@ class VehicleRentalEdgeTest {
 
     private static final String NETWORK = "tier";
     private static final StreetSearchRequest SEARCH_REQUEST = StreetSearchRequest.of()
-      .withMode(StreetMode.SCOOTER_RENTAL)
+      .withMode(SCOOTER_RENTAL)
       .withArriveBy(true)
       .build();
 
@@ -219,10 +249,7 @@ class VehicleRentalEdgeTest {
     @Test
     void startedInNoDropOffZone() {
       var rentalVertex = new VehicleRentalPlaceVertex(RENTAL_PLACE);
-      var rentalEdge = VehicleRentalEdge.createVehicleRentalEdge(
-        rentalVertex,
-        RentalFormFactor.SCOOTER
-      );
+      var rentalEdge = VehicleRentalEdge.createVehicleRentalEdge(rentalVertex, SCOOTER);
 
       rentalVertex.addRentalRestriction(noDropOffZone());
 
@@ -236,10 +263,7 @@ class VehicleRentalEdgeTest {
     @Test
     void startedOutsideNoDropOffZone() {
       var rentalVertex = new VehicleRentalPlaceVertex(RENTAL_PLACE);
-      var rentalEdge = VehicleRentalEdge.createVehicleRentalEdge(
-        rentalVertex,
-        RentalFormFactor.SCOOTER
-      );
+      var rentalEdge = VehicleRentalEdge.createVehicleRentalEdge(rentalVertex, SCOOTER);
       var state = new State(rentalVertex, SEARCH_REQUEST);
 
       assertEquals(Set.of(), state.stateData.noRentalDropOffZonesAtStartOfReverseSearch);
@@ -260,6 +284,7 @@ class VehicleRentalEdgeTest {
 
   private void initEdgeAndRequest(
     StreetMode mode,
+    RentalFormFactor formFactor,
     int vehicles,
     int spaces,
     boolean overloadingAllowed,
@@ -268,15 +293,14 @@ class VehicleRentalEdgeTest {
     boolean banNetwork
   ) {
     var station = TestVehicleRentalStationBuilder.of()
-      .withVehicles(vehicles)
-      .withSpaces(spaces)
+      .withVehicleType(formFactor, RentalVehicleType.PropulsionType.HUMAN, vehicles, spaces)
       .withOverloadingAllowed(overloadingAllowed)
       .withStationOn(stationOn)
       .build();
 
     this.vertex = new VehicleRentalPlaceVertex(station);
 
-    vehicleRentalEdge = VehicleRentalEdge.createVehicleRentalEdge(vertex, RentalFormFactor.BICYCLE);
+    vehicleRentalEdge = VehicleRentalEdge.createVehicleRentalEdge(vertex, formFactor);
 
     Set<String> bannedNetworks = banNetwork ? Set.of(station.getNetwork()) : Set.of();
 


### PR DESCRIPTION
### Summary

Due to differing `StreetMode` / `TraverseMode` / `RentalFormFactor` mappings `MOPED` rentals were not found.

Since both a `StreetMode → TraverseMode` and a `RentalFormFactor → TraverseMode` mapping exists, a (third) `StreetMode → RentalFormFactor` mapping is replaced with checking that the `TraverseMode` for the `StreetMode` and `RentalFormFactor` matches.

### Issue

Closes #6719

### Unit tests

A test is added for MOPED rentals.

### Documentation

No changes.