### PR TITLE
Reduce graph build memory by gc-ing OsmDatabase early

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -75,7 +75,6 @@ public class GraphBuilderModules {
           osmConfiguredDataSource.dataSource(),
           osmConfiguredDataSource.config().osmTagMapper(),
           osmConfiguredDataSource.config().timeZone(),
-          osmConfiguredDataSource.config().includeOsmSubwayEntrances(),
           config.osmCacheDataInMem,
           issueStore
         )

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -110,6 +110,9 @@ public class OsmModule implements GraphBuilderModule {
 
   @Override
   public void buildGraph() {
+    // the OsmDatabase contains very large collections and should _not_ be stored as an instance
+    // variable of this class, because this prevents it from being garbage collected at the end of
+    // the build method.
     var osmdb = new OsmDatabase(issueStore);
     var vertexGenerator = new VertexGenerator(osmdb, graph, params.boardingAreaRefTags(), params.includeOsmSubwayEntrances());
     for (var provider : providers) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -20,7 +19,6 @@ import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.graph_builder.module.osm.parameters.OsmProcessingParameters;
-import org.opentripplanner.osm.DefaultOsmProvider;
 import org.opentripplanner.osm.OsmProvider;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.OsmLevel;
@@ -112,9 +110,14 @@ public class OsmModule implements GraphBuilderModule {
   public void buildGraph() {
     // the OsmDatabase contains very large collections and should _not_ be stored as an instance
     // variable of this class, because this prevents it from being garbage collected at the end of
-    // the build method.
+    // this method.
     var osmdb = new OsmDatabase(issueStore);
-    var vertexGenerator = new VertexGenerator(osmdb, graph, params.boardingAreaRefTags(), params.includeOsmSubwayEntrances());
+    var vertexGenerator = new VertexGenerator(
+      osmdb,
+      graph,
+      params.boardingAreaRefTags(),
+      params.includeOsmSubwayEntrances()
+    );
     for (var provider : providers) {
       LOG.info("Gathering OSM from provider: {}", provider);
       LOG.info(
@@ -227,7 +230,11 @@ public class OsmModule implements GraphBuilderModule {
     return OsmAreaGroup.groupAreas(areasLevels);
   }
 
-  private void buildWalkableAreas(OsmDatabase osmdb, VertexGenerator vertexGenerator, boolean skipVisibility) {
+  private void buildWalkableAreas(
+    OsmDatabase osmdb,
+    VertexGenerator vertexGenerator,
+    boolean skipVisibility
+  ) {
     if (skipVisibility) {
       LOG.info(
         "Skipping visibility graph construction for walkable areas and using just area rings for edges."

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -61,9 +61,6 @@ class WalkableAreaBuilder {
 
   private final VertexGenerator vertexBuilder;
 
-  private final HashMap<Coordinate, IntersectionVertex> areaBoundaryVertexForCoordinate =
-    new HashMap<>();
-
   private final boolean platformEntriesLinking;
 
   private final List<OsmVertex> platformLinkingPoints;

--- a/application/src/main/java/org/opentripplanner/osm/DefaultOsmProvider.java
+++ b/application/src/main/java/org/opentripplanner/osm/DefaultOsmProvider.java
@@ -36,7 +36,6 @@ public class DefaultOsmProvider implements OsmProvider {
 
   private final OsmTagMapper osmTagMapper;
 
-  private final boolean includeSubwayEntrances;
   private final WayPropertySet wayPropertySet;
   private byte[] cachedBytes = null;
 
@@ -46,7 +45,6 @@ public class DefaultOsmProvider implements OsmProvider {
       new FileDataSource(file, FileType.OSM),
       OsmTagMapperSource.DEFAULT,
       null,
-      false,
       cacheDataInMem,
       DataImportIssueStore.NOOP
     );
@@ -56,14 +54,12 @@ public class DefaultOsmProvider implements OsmProvider {
     DataSource dataSource,
     OsmTagMapperSource tagMapperSource,
     ZoneId zoneId,
-    boolean includeSubwayEntrances,
     boolean cacheDataInMem,
     DataImportIssueStore issueStore
   ) {
     this.source = dataSource;
     this.zoneId = zoneId;
     this.osmTagMapper = tagMapperSource.getInstance();
-    this.includeSubwayEntrances = includeSubwayEntrances;
     this.wayPropertySet = new WayPropertySet(issueStore);
     osmTagMapper.populateProperties(wayPropertySet);
     this.cacheDataInMem = cacheDataInMem;


### PR DESCRIPTION
### Summary

`OsmDatabase` is an object which contains some very large collections. This object is stored as an instance variable in `OsmModule` and therefore not garbage collected until the graph build is complete. For large graphs this is a problem because not only is the Graph itself stored in memory but also the raw OSM data, which is a massive waste.

For this reason, I'm changing it to be a local variable that is passed through method calls. This means that it is garbage-collected as soon as the module is finished.

There is also a very small clean up of `DefaultOsmProvider`.

### Unit tests

n/a

### Documentation

Comments on the variable.