### PR TITLE
Allow filtering of intermediate stops in GraphQL API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -135,17 +135,7 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
 
   @Override
   public DataFetcher<Iterable<StopArrival>> intermediatePlaces() {
-    return env -> {
-      var args = new GraphQLTypes.GraphQLLegIntermediatePlacesArgs(env.getArguments());
-      var intermediateStops = getSource(env).listIntermediateStops();
-      if (args.getGraphQLInclude() != null) {
-        var types = args.getGraphQLInclude().getGraphQLStopTypes();
-        var filter = new StopArrivalByTypeFilter(types);
-        return filter.filter(intermediateStops);
-      } else {
-        return intermediateStops;
-      }
-    };
+    return environment -> getSource(environment).listIntermediateStops();
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -149,7 +149,7 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
       if (intermediateStops == null) {
         return null;
       }
-      var args = new GraphQLTypes.GraphQLLegIntermediatePlacesArgs(env.getArguments());
+      var args = new GraphQLTypes.GraphQLLegIntermediateStopsArgs(env.getArguments());
       var filter = new StopArrivalByTypeFilter(args.getGraphQLInclude());
       return filter
         .filter(intermediateStops)

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -137,8 +137,14 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
   public DataFetcher<Iterable<StopArrival>> intermediatePlaces() {
     return env -> {
       var args = new GraphQLTypes.GraphQLLegIntermediatePlacesArgs(env.getArguments());
-      var filter = new StopArrivalByTypeFilter(args.getGraphQLInclude());
-      return filter.filter(getSource(env).listIntermediateStops());
+      var intermediateStops = getSource(env).listIntermediateStops();
+      if (args.getGraphQLInclude() != null) {
+        var types = args.getGraphQLInclude().getGraphQLStopTypes();
+        var filter = new StopArrivalByTypeFilter(types);
+        return filter.filter(intermediateStops);
+      } else {
+        return intermediateStops;
+      }
     };
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LegImpl.java
@@ -12,7 +12,7 @@ import org.opentripplanner.apis.gtfs.mapping.LocalDateMapper;
 import org.opentripplanner.apis.gtfs.mapping.NumberMapper;
 import org.opentripplanner.apis.gtfs.mapping.PickDropMapper;
 import org.opentripplanner.apis.gtfs.mapping.RealtimeStateMapper;
-import org.opentripplanner.apis.gtfs.support.filter.StopsByTypeFilter;
+import org.opentripplanner.apis.gtfs.support.filter.StopArrivalByTypeFilter;
 import org.opentripplanner.ext.ridehailing.model.RideEstimate;
 import org.opentripplanner.ext.ridehailing.model.RideHailingLeg;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
@@ -137,7 +137,7 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
   public DataFetcher<Iterable<StopArrival>> intermediatePlaces() {
     return env -> {
       var args = new GraphQLTypes.GraphQLLegIntermediatePlacesArgs(env.getArguments());
-      var filter = new StopsByTypeFilter(args.getGraphQLInclude());
+      var filter = new StopArrivalByTypeFilter(args.getGraphQLInclude());
       return filter.filter(getSource(env).listIntermediateStops());
     };
   }
@@ -150,7 +150,7 @@ public class LegImpl implements GraphQLDataFetchers.GraphQLLeg {
         return null;
       }
       var args = new GraphQLTypes.GraphQLLegIntermediatePlacesArgs(env.getArguments());
-      var filter = new StopsByTypeFilter(args.getGraphQLInclude());
+      var filter = new StopArrivalByTypeFilter(args.getGraphQLInclude());
       return filter
         .filter(intermediateStops)
         .stream()

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -1328,6 +1328,32 @@ public class GraphQLTypes {
     }
   }
 
+  public static class GraphQLIntermediatePlaceFilterInput {
+
+    private List<GraphQLStopType> stopTypes;
+
+    public GraphQLIntermediatePlaceFilterInput(Map<String, Object> args) {
+      if (args != null) {
+        if (args.get("stopTypes") != null) {
+          this.stopTypes = ((List<Object>) args.get("stopTypes")).stream()
+            .map(item ->
+              item instanceof GraphQLStopType ? item : GraphQLStopType.valueOf((String) item)
+            )
+            .map(GraphQLStopType.class::cast)
+            .collect(Collectors.toList());
+        }
+      }
+    }
+
+    public List<GraphQLStopType> getGraphQLStopTypes() {
+      return this.stopTypes;
+    }
+
+    public void setGraphQLStopTypes(List<GraphQLStopType> stopTypes) {
+      this.stopTypes = stopTypes;
+    }
+  }
+
   /**
    * Enable this to attach a system notice to itineraries instead of removing them. This is very
    * convenient when tuning the itinerary-filter-chain.
@@ -1341,26 +1367,21 @@ public class GraphQLTypes {
 
   public static class GraphQLLegIntermediatePlacesArgs {
 
-    private List<GraphQLStopType> include;
+    private GraphQLIntermediatePlaceFilterInput include;
 
     public GraphQLLegIntermediatePlacesArgs(Map<String, Object> args) {
       if (args != null) {
-        if (args.get("include") != null) {
-          this.include = ((List<Object>) args.get("include")).stream()
-            .map(item ->
-              item instanceof GraphQLStopType ? item : GraphQLStopType.valueOf((String) item)
-            )
-            .map(GraphQLStopType.class::cast)
-            .collect(Collectors.toList());
-        }
+        this.include = new GraphQLIntermediatePlaceFilterInput(
+          (Map<String, Object>) args.get("include")
+        );
       }
     }
 
-    public List<GraphQLStopType> getGraphQLInclude() {
+    public GraphQLIntermediatePlaceFilterInput getGraphQLInclude() {
       return this.include;
     }
 
-    public void setGraphQLInclude(List<GraphQLStopType> include) {
+    public void setGraphQLInclude(GraphQLIntermediatePlaceFilterInput include) {
       this.include = include;
     }
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -1339,6 +1339,58 @@ public class GraphQLTypes {
     OFF,
   }
 
+  public static class GraphQLLegIntermediatePlacesArgs {
+
+    private List<GraphQLStopType> include;
+
+    public GraphQLLegIntermediatePlacesArgs(Map<String, Object> args) {
+      if (args != null) {
+        if (args.get("include") != null) {
+          this.include = ((List<Object>) args.get("include")).stream()
+            .map(item ->
+              item instanceof GraphQLStopType ? item : GraphQLStopType.valueOf((String) item)
+            )
+            .map(GraphQLStopType.class::cast)
+            .collect(Collectors.toList());
+        }
+      }
+    }
+
+    public List<GraphQLStopType> getGraphQLInclude() {
+      return this.include;
+    }
+
+    public void setGraphQLInclude(List<GraphQLStopType> include) {
+      this.include = include;
+    }
+  }
+
+  public static class GraphQLLegIntermediateStopsArgs {
+
+    private List<GraphQLStopType> include;
+
+    public GraphQLLegIntermediateStopsArgs(Map<String, Object> args) {
+      if (args != null) {
+        if (args.get("include") != null) {
+          this.include = ((List<Object>) args.get("include")).stream()
+            .map(item ->
+              item instanceof GraphQLStopType ? item : GraphQLStopType.valueOf((String) item)
+            )
+            .map(GraphQLStopType.class::cast)
+            .collect(Collectors.toList());
+        }
+      }
+    }
+
+    public List<GraphQLStopType> getGraphQLInclude() {
+      return this.include;
+    }
+
+    public void setGraphQLInclude(List<GraphQLStopType> include) {
+      this.include = include;
+    }
+  }
+
   public static class GraphQLLegNextLegsArgs {
 
     private List<GraphQLTransitMode> destinationModesWithParentStation;
@@ -5001,6 +5053,12 @@ public class GraphQLTypes {
     STOP_ON_ROUTES,
     STOP_ON_TRIPS,
     TRIPS,
+  }
+
+  public enum GraphQLStopType {
+    LOCATION,
+    LOCATION_GROUP,
+    STOP,
   }
 
   public static class GraphQLStoptimeHeadsignArgs {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -1328,32 +1328,6 @@ public class GraphQLTypes {
     }
   }
 
-  public static class GraphQLIntermediatePlaceFilterInput {
-
-    private List<GraphQLStopType> stopTypes;
-
-    public GraphQLIntermediatePlaceFilterInput(Map<String, Object> args) {
-      if (args != null) {
-        if (args.get("stopTypes") != null) {
-          this.stopTypes = ((List<Object>) args.get("stopTypes")).stream()
-            .map(item ->
-              item instanceof GraphQLStopType ? item : GraphQLStopType.valueOf((String) item)
-            )
-            .map(GraphQLStopType.class::cast)
-            .collect(Collectors.toList());
-        }
-      }
-    }
-
-    public List<GraphQLStopType> getGraphQLStopTypes() {
-      return this.stopTypes;
-    }
-
-    public void setGraphQLStopTypes(List<GraphQLStopType> stopTypes) {
-      this.stopTypes = stopTypes;
-    }
-  }
-
   /**
    * Enable this to attach a system notice to itineraries instead of removing them. This is very
    * convenient when tuning the itinerary-filter-chain.
@@ -1363,27 +1337,6 @@ public class GraphQLTypes {
     LIMIT_TO_SEARCH_WINDOW,
     LIST_ALL,
     OFF,
-  }
-
-  public static class GraphQLLegIntermediatePlacesArgs {
-
-    private GraphQLIntermediatePlaceFilterInput include;
-
-    public GraphQLLegIntermediatePlacesArgs(Map<String, Object> args) {
-      if (args != null) {
-        this.include = new GraphQLIntermediatePlaceFilterInput(
-          (Map<String, Object>) args.get("include")
-        );
-      }
-    }
-
-    public GraphQLIntermediatePlaceFilterInput getGraphQLInclude() {
-      return this.include;
-    }
-
-    public void setGraphQLInclude(GraphQLIntermediatePlaceFilterInput include) {
-      this.include = include;
-    }
   }
 
   public static class GraphQLLegIntermediateStopsArgs {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilter.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilter.java
@@ -8,17 +8,19 @@ import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.model.plan.leg.StopArrival;
 import org.opentripplanner.transit.model.site.StopType;
+import org.opentripplanner.utils.collection.CollectionUtils;
 import org.opentripplanner.utils.collection.EnumSetUtils;
 
 /**
  * A filter for {@link StopArrival} objects based on their {@link StopType}.
  */
-public class StopsByTypeFilter {
+public class StopArrivalByTypeFilter {
 
   @Nullable
   private final Set<StopType> allowedTypes;
 
-  public StopsByTypeFilter(Collection<GraphQLTypes.GraphQLStopType> types) {
+  public StopArrivalByTypeFilter(Collection<GraphQLTypes.GraphQLStopType> types) {
+    CollectionUtils.requireNullOrNonEmpty(types, "Stop types must be non-empty or null");
     allowedTypes = map(types);
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilter.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilter.java
@@ -19,7 +19,7 @@ public class StopArrivalByTypeFilter {
   @Nullable
   private final Set<StopType> allowedTypes;
 
-  public StopArrivalByTypeFilter(Collection<GraphQLTypes.GraphQLStopType> types) {
+  public StopArrivalByTypeFilter(@Nullable Collection<GraphQLTypes.GraphQLStopType> types) {
     CollectionUtils.requireNullOrNonEmpty(types, "Stop types must be non-empty or null");
     allowedTypes = map(types);
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/StopsByTypeFilter.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/StopsByTypeFilter.java
@@ -1,0 +1,58 @@
+package org.opentripplanner.apis.gtfs.support.filter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.model.plan.leg.StopArrival;
+import org.opentripplanner.transit.model.site.StopType;
+import org.opentripplanner.utils.collection.EnumSetUtils;
+
+/**
+ * A filter for {@link StopArrival} objects based on their {@link StopType}.
+ */
+public class StopsByTypeFilter {
+
+  @Nullable
+  private final Set<StopType> allowedTypes;
+
+  public StopsByTypeFilter(Collection<GraphQLTypes.GraphQLStopType> types) {
+    allowedTypes = map(types);
+  }
+
+  /**
+   * Filters a list of {@link StopArrival} objects based on allowed stop types.
+   * If the list of arrivals is null or no allowed stop types are configured, the
+   * original list of arrivals is returned.
+   */
+  public List<StopArrival> filter(@Nullable List<StopArrival> arrivals) {
+    if (allowedTypes == null || arrivals == null) {
+      return arrivals;
+    } else {
+      return arrivals
+        .stream()
+        .filter(arrival -> allowedTypes.contains(arrival.place.stop.getStopType()))
+        .toList();
+    }
+  }
+
+  private static Set<StopType> map(@Nullable Collection<GraphQLTypes.GraphQLStopType> types) {
+    if (types == null) {
+      return null;
+    } else {
+      var allowed = types
+        .stream()
+        .map(type ->
+          switch (type) {
+            case LOCATION -> StopType.FLEXIBLE_AREA;
+            case LOCATION_GROUP -> StopType.FLEXIBLE_GROUP;
+            case STOP -> StopType.REGULAR;
+          }
+        )
+        .collect(Collectors.toSet());
+      return EnumSetUtils.unmodifiableEnumSet(allowed, StopType.class);
+    }
+  }
+}

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -769,14 +769,20 @@ type Leg {
   """
   For transit legs, intermediate stops between the Place where the leg
   originates and the Place where the leg ends. For non-transit legs, null.
-  Returns Place type, which has fields for e.g. departure and arrival times
+  Returns Place type, which has fields for e.g. departure and arrival times.
+    
+  The `include` parameter allows filtering of the returned places by stop type. If not, it returns
+  all types. An empty list is not permitted.
   """
-  intermediatePlaces: [Place]
+  intermediatePlaces(include: [StopType!]): [Place]
   """
   For transit legs, intermediate stops between the Place where the leg
   originates and the Place where the leg ends. For non-transit legs, null.
+    
+  The `include` parameter allows filtering of the returned places by stop type. If not, it returns
+  all types. An empty list is not permitted.
   """
-  intermediateStops: [Stop]
+  intermediateStops(include: [StopType!]): [Stop]
   "The leg's geometry."
   legGeometry: Geometry
   "The mode (e.g. `WALK`) used when traversing this leg."
@@ -3736,6 +3742,15 @@ enum StopAlertType {
   STOP_ON_TRIPS
   "Alerts affecting the trips that go through this stop"
   TRIPS
+}
+
+enum StopType {
+  "An area or zone represented by a polygon. Introduced by the GTFS-Flex spec process."
+  LOCATION
+  "A group of stops. Introduced by the GTFS-Flex spec process."
+  LOCATION_GROUP
+  "A fixed stop represented by a coordinate."
+  STOP
 }
 
 """

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -771,10 +771,10 @@ type Leg {
   originates and the Place where the leg ends. For non-transit legs, null.
   Returns Place type, which has fields for e.g. departure and arrival times.
     
-  The `include` parameter allows filtering of the returned places by stop type. If not provided, the
-  field returns all types. An empty list is not permitted.
+  The `include` parameter allows filtering of the returned places. If not provided, the
+  field returns all types.
   """
-  intermediatePlaces(include: [StopType!]): [Place]
+  intermediatePlaces(include: IntermediatePlaceFilterInput): [Place]
   """
   For transit legs, intermediate stops between the Place where the leg
   originates and the Place where the leg ends. For non-transit legs, null.
@@ -4225,6 +4225,16 @@ input InputUnpreferred {
   Deprecated: Use `unpreferredCost` instead.
   """
   useUnpreferredRoutesPenalty: Int @deprecated(reason : "Use unpreferredCost instead")
+}
+
+"Filter for including only certain intermediate places."
+input IntermediatePlaceFilterInput {
+  """
+  Filter the intermediate places by stop type.
+  
+  An empty list is not permitted.
+  """
+  stopTypes: [StopType!]!
 }
 
 "Filters an entity by a date range."

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -769,12 +769,8 @@ type Leg {
   """
   For transit legs, intermediate stops between the Place where the leg
   originates and the Place where the leg ends. For non-transit legs, null.
-  Returns Place type, which has fields for e.g. departure and arrival times.
-    
-  The `include` parameter allows filtering of the returned places. If not provided, the
-  field returns all types.
   """
-  intermediatePlaces(include: IntermediatePlaceFilterInput): [Place]
+  intermediatePlaces: [Place]
   """
   For transit legs, intermediate stops between the Place where the leg
   originates and the Place where the leg ends. For non-transit legs, null.
@@ -4225,16 +4221,6 @@ input InputUnpreferred {
   Deprecated: Use `unpreferredCost` instead.
   """
   useUnpreferredRoutesPenalty: Int @deprecated(reason : "Use unpreferredCost instead")
-}
-
-"Filter for including only certain intermediate places."
-input IntermediatePlaceFilterInput {
-  """
-  Filter the intermediate places by stop type.
-  
-  An empty list is not permitted.
-  """
-  stopTypes: [StopType!]!
 }
 
 "Filters an entity by a date range."

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -771,16 +771,16 @@ type Leg {
   originates and the Place where the leg ends. For non-transit legs, null.
   Returns Place type, which has fields for e.g. departure and arrival times.
     
-  The `include` parameter allows filtering of the returned places by stop type. If not, it returns
-  all types. An empty list is not permitted.
+  The `include` parameter allows filtering of the returned places by stop type. If not provided, the
+  field returns all types. An empty list is not permitted.
   """
   intermediatePlaces(include: [StopType!]): [Place]
   """
   For transit legs, intermediate stops between the Place where the leg
   originates and the Place where the leg ends. For non-transit legs, null.
     
-  The `include` parameter allows filtering of the returned places by stop type. If not, it returns
-  all types. An empty list is not permitted.
+  The `include` parameter allows filtering of the returned places by stop type. If not provided, the
+  field returns all types. An empty list is not permitted.
   """
   intermediateStops(include: [StopType!]): [Stop]
   "The leg's geometry."

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.apis.gtfs.datafetchers.DataFetchingSupport.dataFetchingEnvironment;
 
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -18,28 +19,28 @@ class BookingInfoImplTest {
 
   @Test
   void emptyNoticeSeconds() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(BookingInfo.of().build());
+    var env = dataFetchingEnvironment(BookingInfo.of().build());
     assertNull(SUBJECT.minimumBookingNoticeSeconds().get(env));
     assertNull(SUBJECT.maximumBookingNoticeSeconds().get(env));
   }
 
   @Test
   void emptyNoticeDurations() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(BookingInfo.of().build());
+    var env = dataFetchingEnvironment(BookingInfo.of().build());
     assertNull(SUBJECT.minimumBookingNotice().get(env));
     assertNull(SUBJECT.maximumBookingNotice().get(env));
   }
 
   @Test
   void seconds() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
+    var env = dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
     assertEquals(600, SUBJECT.minimumBookingNoticeSeconds().get(env));
     assertEquals(600, SUBJECT.maximumBookingNoticeSeconds().get(env));
   }
 
   @Test
   void durations() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
+    var env = dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
     assertEquals(TEN_MINUTES, SUBJECT.minimumBookingNotice().get(env));
     assertEquals(TEN_MINUTES, SUBJECT.maximumBookingNotice().get(env));
   }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/BookingInfoImplTest.java
@@ -1,12 +1,8 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
-import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import graphql.execution.ExecutionId;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
@@ -22,38 +18,29 @@ class BookingInfoImplTest {
 
   @Test
   void emptyNoticeSeconds() throws Exception {
-    var env = dataFetchingEnvironment(BookingInfo.of().build());
+    var env = DataFetchingSupport.dataFetchingEnvironment(BookingInfo.of().build());
     assertNull(SUBJECT.minimumBookingNoticeSeconds().get(env));
     assertNull(SUBJECT.maximumBookingNoticeSeconds().get(env));
   }
 
   @Test
   void emptyNoticeDurations() throws Exception {
-    var env = dataFetchingEnvironment(BookingInfo.of().build());
+    var env = DataFetchingSupport.dataFetchingEnvironment(BookingInfo.of().build());
     assertNull(SUBJECT.minimumBookingNotice().get(env));
     assertNull(SUBJECT.maximumBookingNotice().get(env));
   }
 
   @Test
   void seconds() throws Exception {
-    var env = dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
+    var env = DataFetchingSupport.dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
     assertEquals(600, SUBJECT.minimumBookingNoticeSeconds().get(env));
     assertEquals(600, SUBJECT.maximumBookingNoticeSeconds().get(env));
   }
 
   @Test
   void durations() throws Exception {
-    var env = dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
+    var env = DataFetchingSupport.dataFetchingEnvironment(WITH_NOTICE_DURATIONS);
     assertEquals(TEN_MINUTES, SUBJECT.minimumBookingNotice().get(env));
     assertEquals(TEN_MINUTES, SUBJECT.maximumBookingNotice().get(env));
-  }
-
-  private DataFetchingEnvironment dataFetchingEnvironment(BookingInfo bookingInfo) {
-    var executionContext = newExecutionContextBuilder()
-      .executionId(ExecutionId.from(this.getClass().getName()))
-      .build();
-    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(executionContext)
-      .source(bookingInfo)
-      .build();
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/DataFetchingSupport.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/DataFetchingSupport.java
@@ -5,15 +5,24 @@ import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuild
 import graphql.execution.ExecutionId;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
+import java.util.Map;
 
 class DataFetchingSupport {
 
   static DataFetchingEnvironment dataFetchingEnvironment(Object source) {
+    return dataFetchingEnvironment(source, Map.of());
+  }
+
+  static DataFetchingEnvironment dataFetchingEnvironment(
+    Object source,
+    Map<String, Object> arguments
+  ) {
     var executionContext = newExecutionContextBuilder()
       .executionId(ExecutionId.from("test"))
       .build();
     return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(executionContext)
       .source(source)
+      .arguments(arguments)
       .build();
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/DataFetchingSupport.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/DataFetchingSupport.java
@@ -7,6 +7,9 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import java.util.Map;
 
+/**
+ * Support class for building data fetching environments for testing data fetchers.
+ */
 class DataFetchingSupport {
 
   static DataFetchingEnvironment dataFetchingEnvironment(Object source) {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/DataFetchingSupport.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/DataFetchingSupport.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.apis.gtfs.datafetchers;
+
+import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
+
+import graphql.execution.ExecutionId;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+
+class DataFetchingSupport {
+
+  static DataFetchingEnvironment dataFetchingEnvironment(Object source) {
+    var executionContext = newExecutionContextBuilder()
+      .executionId(ExecutionId.from("test"))
+      .build();
+    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(executionContext)
+      .source(source)
+      .build();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
@@ -1,0 +1,70 @@
+package org.opentripplanner.apis.gtfs.datafetchers;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
+import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.network.StopPattern;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.model.site.GroupStop;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
+import org.opentripplanner.transit.model.timetable.Trip;
+
+class LegImplTest implements PlanTestConstants {
+
+  private static final TimetableRepositoryForTest MODEL = TimetableRepositoryForTest.of();
+  private static final AreaStop AREA_STOP = MODEL.areaStop("a1").build();
+  private static final RegularStop REGULAR_STOP = MODEL.stop("r1").build();
+  private static final GroupStop GROUP_STOP = MODEL.groupStop(
+    "g1",
+    REGULAR_STOP,
+    REGULAR_STOP,
+    REGULAR_STOP
+  );
+  private static final StopPattern STOP_PATTERN = TimetableRepositoryForTest.stopPattern(
+    REGULAR_STOP,
+    REGULAR_STOP,
+    AREA_STOP,
+    GROUP_STOP,
+    REGULAR_STOP
+  );
+  private static final Trip TRIP = TimetableRepositoryForTest.trip("trip1").build();
+  private static final TripPattern PATTERN = TimetableRepositoryForTest.tripPattern(
+    "p",
+    TRIP.getRoute()
+  )
+    .withStopPattern(STOP_PATTERN)
+    .build();
+
+  private static final ScheduledTripTimes TRIP_TIMES = ScheduledTripTimes.of()
+    .withArrivalTimes("10:00 11:00 12:00 13:00 14:00")
+    .withGtfsSequenceOfStopIndex(new int[] { 0, 1, 2, 3 })
+    .withTrip(TRIP)
+    .build();
+  private static final ZonedDateTime TIME = ZonedDateTime.parse("2025-06-26T10:25:28+02:00");
+  private static final ScheduledTransitLeg LEG = new ScheduledTransitLegBuilder<>()
+    .withStartTime(TIME)
+    .withEndTime(TIME)
+    .withZoneId(TIME.getZone())
+    .withServiceDate(TIME.toLocalDate())
+    .withDistanceMeters(1000)
+    .withTripTimes(TRIP_TIMES)
+    .withBoardStopIndexInPattern(0)
+    .withAlightStopIndexInPattern(4)
+    .withTripPattern(PATTERN)
+    .build();
+  private static final LegImpl SUBJECT = new LegImpl();
+
+  @Test
+  void intermediateLegs() throws Exception {
+    var env = DataFetchingSupport.dataFetchingEnvironment(LEG);
+    var stops = SUBJECT.intermediateStops().get(env);
+    assertThat(stops).containsExactly(REGULAR_STOP, AREA_STOP, GROUP_STOP);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -13,6 +14,8 @@ import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
 import org.opentripplanner.model.plan.leg.StopArrival;
+import org.opentripplanner.model.plan.leg.StreetLeg;
+import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -66,6 +69,7 @@ class LegImplTest implements PlanTestConstants {
     "include",
     List.of(GraphQLTypes.GraphQLStopType.STOP)
   );
+  private static final StreetLeg WALK_LEG = StreetLeg.of().withMode(TraverseMode.WALK).build();
 
   @Test
   void intermediateStops() throws Exception {
@@ -93,6 +97,18 @@ class LegImplTest implements PlanTestConstants {
     var env = DataFetchingSupport.dataFetchingEnvironment(LEG, INCLUDE_STOP_ONLY);
     var stops = toStops(SUBJECT.intermediatePlaces().get(env));
     assertThat(stops).containsExactly(REGULAR_STOP);
+  }
+
+  @Test
+  void walkLeg() throws Exception {
+    var env = DataFetchingSupport.dataFetchingEnvironment(WALK_LEG);
+    assertNull(SUBJECT.intermediatePlaces().get(env));
+  }
+
+  @Test
+  void walkLegWithInclude() throws Exception {
+    var env = DataFetchingSupport.dataFetchingEnvironment(WALK_LEG, INCLUDE_STOP_ONLY);
+    assertNull(SUBJECT.intermediatePlaces().get(env));
   }
 
   private static Stream<StopLocation> toStops(Iterable<StopArrival> stopArrivals) {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
@@ -69,6 +69,10 @@ class LegImplTest implements PlanTestConstants {
     "include",
     List.of(GraphQLTypes.GraphQLStopType.STOP)
   );
+  private static final Map<String, Object> FILTER = Map.of(
+    "include",
+    Map.of("stopTypes", List.of(GraphQLTypes.GraphQLStopType.STOP))
+  );
   private static final StreetLeg WALK_LEG = StreetLeg.of().withMode(TraverseMode.WALK).build();
 
   @Test
@@ -94,7 +98,7 @@ class LegImplTest implements PlanTestConstants {
 
   @Test
   void intermediatePlacesWithInclude() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(LEG, INCLUDE_STOP_ONLY);
+    var env = DataFetchingSupport.dataFetchingEnvironment(LEG, FILTER);
     var stops = toStops(SUBJECT.intermediatePlaces().get(env));
     assertThat(stops).containsExactly(REGULAR_STOP);
   }
@@ -107,7 +111,7 @@ class LegImplTest implements PlanTestConstants {
 
   @Test
   void walkLegWithInclude() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(WALK_LEG, INCLUDE_STOP_ONLY);
+    var env = DataFetchingSupport.dataFetchingEnvironment(WALK_LEG, FILTER);
     assertNull(SUBJECT.intermediatePlaces().get(env));
   }
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.apis.gtfs.datafetchers.DataFetchingSupport.dataFetchingEnvironment;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -69,50 +70,39 @@ class LegImplTest implements PlanTestConstants {
     "include",
     List.of(GraphQLTypes.GraphQLStopType.STOP)
   );
-  private static final Map<String, Object> FILTER = Map.of(
-    "include",
-    Map.of("stopTypes", List.of(GraphQLTypes.GraphQLStopType.STOP))
-  );
   private static final StreetLeg WALK_LEG = StreetLeg.of().withMode(TraverseMode.WALK).build();
 
   @Test
   void intermediateStops() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(LEG);
+    var env = dataFetchingEnvironment(LEG);
     var stops = SUBJECT.intermediateStops().get(env);
     assertThat(stops).containsExactly(REGULAR_STOP, AREA_STOP, GROUP_STOP);
   }
 
   @Test
   void intermediateStopsWithInclude() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(LEG, INCLUDE_STOP_ONLY);
+    var env = dataFetchingEnvironment(LEG, INCLUDE_STOP_ONLY);
     var stops = SUBJECT.intermediateStops().get(env);
     assertThat(stops).containsExactly(REGULAR_STOP);
   }
 
   @Test
   void intermediatePlaces() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(LEG);
+    var env = dataFetchingEnvironment(LEG);
     var stops = toStops(SUBJECT.intermediatePlaces().get(env));
     assertThat(stops).containsExactly(REGULAR_STOP, AREA_STOP, GROUP_STOP);
   }
 
   @Test
-  void intermediatePlacesWithInclude() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(LEG, FILTER);
-    var stops = toStops(SUBJECT.intermediatePlaces().get(env));
-    assertThat(stops).containsExactly(REGULAR_STOP);
-  }
-
-  @Test
   void walkLeg() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(WALK_LEG);
+    var env = dataFetchingEnvironment(WALK_LEG);
     assertNull(SUBJECT.intermediatePlaces().get(env));
   }
 
   @Test
   void walkLegWithInclude() throws Exception {
-    var env = DataFetchingSupport.dataFetchingEnvironment(WALK_LEG, FILTER);
-    assertNull(SUBJECT.intermediatePlaces().get(env));
+    var env = dataFetchingEnvironment(WALK_LEG, INCLUDE_STOP_ONLY);
+    assertNull(SUBJECT.intermediateStops().get(env));
   }
 
   private static Stream<StopLocation> toStops(Iterable<StopArrival> stopArrivals) {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
@@ -2,8 +2,13 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.truth.StreamSubject;
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
@@ -62,9 +67,45 @@ class LegImplTest implements PlanTestConstants {
   private static final LegImpl SUBJECT = new LegImpl();
 
   @Test
-  void intermediateLegs() throws Exception {
+  void intermediateStops() throws Exception {
     var env = DataFetchingSupport.dataFetchingEnvironment(LEG);
     var stops = SUBJECT.intermediateStops().get(env);
     assertThat(stops).containsExactly(REGULAR_STOP, AREA_STOP, GROUP_STOP);
+  }
+
+  @Test
+  void intermediateStopsWithInclude() throws Exception {
+    var env = DataFetchingSupport.dataFetchingEnvironment(
+      LEG,
+      Map.of("include", List.of(GraphQLTypes.GraphQLStopType.STOP))
+    );
+    var stops = StreamSupport.stream(
+      SUBJECT.intermediatePlaces().get(env).spliterator(),
+      false
+    ).map(s -> s.place.stop);
+    assertThat(stops).containsExactly(REGULAR_STOP);
+  }
+
+  @Test
+  void intermediatePlaces() throws Exception {
+    var env = DataFetchingSupport.dataFetchingEnvironment(LEG);
+    var stops = StreamSupport.stream(
+      SUBJECT.intermediatePlaces().get(env).spliterator(),
+      false
+    ).map(s -> s.place.stop);
+    assertThat(stops).containsExactly(REGULAR_STOP, AREA_STOP, GROUP_STOP);
+  }
+
+  @Test
+  void intermediatePlacesWithInclude() throws Exception {
+    var env = DataFetchingSupport.dataFetchingEnvironment(
+      LEG,
+      Map.of("include", List.of(GraphQLTypes.GraphQLStopType.STOP))
+    );
+    var stops = StreamSupport.stream(
+      SUBJECT.intermediatePlaces().get(env).spliterator(),
+      false
+    ).map(s -> s.place.stop);
+    assertThat(stops).containsExactly(REGULAR_STOP);
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
@@ -81,7 +81,7 @@ class LegImplTest implements PlanTestConstants {
   @Test
   void intermediateStopsWithInclude() throws Exception {
     var env = DataFetchingSupport.dataFetchingEnvironment(LEG, INCLUDE_STOP_ONLY);
-    var stops = toStops(SUBJECT.intermediatePlaces().get(env));
+    var stops = SUBJECT.intermediateStops().get(env);
     assertThat(stops).containsExactly(REGULAR_STOP);
   }
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.gtfs.support.filter;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopType.LOCATION;
 import static org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopType.LOCATION_GROUP;
@@ -32,6 +33,11 @@ class StopArrivalByTypeFilterTest {
   @Test
   void emptyList() {
     assertThrows(IllegalArgumentException.class, () -> new StopArrivalByTypeFilter(Set.of()));
+  }
+
+  @Test
+  void nullValue() {
+    assertNull(new StopArrivalByTypeFilter(null).filter(null));
   }
 
   private static List<Arguments> filterCases() {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
@@ -1,0 +1,70 @@
+package org.opentripplanner.apis.gtfs.support.filter;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopType.LOCATION;
+import static org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopType.LOCATION_GROUP;
+import static org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopType.STOP;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopType;
+import org.opentripplanner.model.plan.Place;
+import org.opentripplanner.model.plan.leg.StopArrival;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.model.site.GroupStop;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.StopLocation;
+
+class StopArrivalByTypeFilterTest {
+
+  public static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  public static final RegularStop REGULAR = TEST_MODEL.stop("r").build();
+  public static final AreaStop AREA = TEST_MODEL.areaStop("a").build();
+  public static final GroupStop GROUP = TEST_MODEL.groupStop("g", REGULAR, REGULAR);
+
+  @Test
+  void emptyList() {
+    assertThrows(IllegalArgumentException.class, () -> new StopArrivalByTypeFilter(Set.of()));
+  }
+
+  private static List<Arguments> filterCases() {
+    return List.of(
+      Arguments.of(List.of(REGULAR), Set.of(STOP), List.of(REGULAR)),
+      Arguments.of(List.of(REGULAR, AREA), Set.of(STOP), List.of(REGULAR)),
+      Arguments.of(List.of(AREA, AREA), Set.of(STOP), List.of()),
+      Arguments.of(List.of(GROUP), Set.of(STOP), List.of()),
+      Arguments.of(List.of(GROUP), Set.of(LOCATION_GROUP), List.of(GROUP)),
+      Arguments.of(List.of(GROUP, AREA), Set.of(LOCATION_GROUP), List.of(GROUP)),
+      Arguments.of(List.of(GROUP, REGULAR, AREA), Set.of(LOCATION_GROUP), List.of(GROUP)),
+      Arguments.of(
+        List.of(GROUP, REGULAR, AREA),
+        Set.of(LOCATION_GROUP, STOP),
+        List.of(GROUP, REGULAR)
+      ),
+      Arguments.of(
+        List.of(GROUP, REGULAR, AREA),
+        Set.of(LOCATION_GROUP, STOP, LOCATION),
+        List.of(GROUP, REGULAR, AREA)
+      )
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("filterCases")
+  void filter(List<StopLocation> stops, Set<GraphQLStopType> include, List<StopLocation> expected) {
+    var filter = new StopArrivalByTypeFilter(include);
+    var filtered = filter.filter(stopArrivals(stops)).stream().map(sa -> sa.place.stop).toList();
+    assertThat(filtered).containsExactlyElementsIn(expected);
+  }
+
+  private static List<StopArrival> stopArrivals(Collection<StopLocation> stops) {
+    return stops.stream().map(s -> new StopArrival(Place.forStop(s), null, null, 0, 1)).toList();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
@@ -36,10 +36,13 @@ class StopArrivalByTypeFilterTest {
 
   private static List<Arguments> filterCases() {
     return List.of(
+      Arguments.of(List.of(GROUP, REGULAR, AREA), null, List.of(GROUP, REGULAR, AREA)),
+      Arguments.of(List.of(REGULAR), null, List.of(REGULAR)),
       Arguments.of(List.of(REGULAR), Set.of(STOP), List.of(REGULAR)),
       Arguments.of(List.of(REGULAR, AREA), Set.of(STOP), List.of(REGULAR)),
       Arguments.of(List.of(AREA, AREA), Set.of(STOP), List.of()),
       Arguments.of(List.of(GROUP), Set.of(STOP), List.of()),
+      Arguments.of(List.of(GROUP, GROUP, GROUP, AREA), Set.of(STOP), List.of()),
       Arguments.of(List.of(GROUP), Set.of(LOCATION_GROUP), List.of(GROUP)),
       Arguments.of(List.of(GROUP, AREA), Set.of(LOCATION_GROUP), List.of(GROUP)),
       Arguments.of(List.of(GROUP, REGULAR, AREA), Set.of(LOCATION_GROUP), List.of(GROUP)),

--- a/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
@@ -106,7 +106,7 @@ class TripTimeOnDateTest {
   private static TripTimeOnDate tripTimeOnDate() {
     var trip = TimetableRepositoryForTest.trip("123").build();
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(5, trip, "11:00");
-    var stops = stopTimes.stream().map(StopTime::getStop).map(RegularStop.class::cast).toList();
+    var stops = stopTimes.stream().map(StopTime::getStop).toList();
     var pattern = TEST_MODEL.pattern(TransitMode.BUS)
       .withStopPattern(TimetableRepositoryForTest.stopPattern(stops))
       .build();

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
@@ -242,11 +242,11 @@ public class TimetableRepositoryForTest {
     return builder.build();
   }
 
-  public static StopPattern stopPattern(RegularStop... stops) {
+  public static StopPattern stopPattern(StopLocation... stops) {
     return stopPattern(Arrays.asList(stops));
   }
 
-  public static StopPattern stopPattern(List<RegularStop> stops) {
+  public static StopPattern stopPattern(List<StopLocation> stops) {
     var builder = StopPattern.create(stops.size());
     for (int i = 0; i < stops.size(); i++) {
       builder.stops.with(i, stops.get(i));

--- a/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TripInput.java
@@ -6,6 +6,7 @@ import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.utils.time.TimeUtils;
 
 /**
@@ -63,5 +64,5 @@ public record TripInput(String id, Route route, List<StopCall> stops) {
     }
   }
 
-  record StopCall(RegularStop stop, int arrivalTime, int departureTime) {}
+  record StopCall(StopLocation stop, int arrivalTime, int departureTime) {}
 }


### PR DESCRIPTION
### Summary

Allows the itinerary's `intermediatePlaces` and `intermediateStops` fields to be optionally filtered by stop type.

This is useful if you have trips that mix flex and static stops and you're only interested in seeing a particular type.

### Unit tests

Lots added.

### Documentation

Schema and Javadoc.

Requested by @miles-grant-ibigroup 