### PR TITLE
Add test cleanup method to fix flaky test

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/mapping/TransmodelMappingUtilTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/mapping/TransmodelMappingUtilTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.apis.transmodel.mapping.TransitIdMapper;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
@@ -37,5 +38,10 @@ public class TransmodelMappingUtilTest {
       .copy()
       .withId(new FeedScopedId(feedScope, Integer.toString(id)))
       .build();
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    TransitIdMapper.clearFixedFeedId();
   }
 }


### PR DESCRIPTION
### Summary

The TransitFilterOldWayMapperTest was failing on our build server. After investigating, I found out that the test assumes that the fixedFeedId in the TransitIdMapper is null. However, the TransmodelMappingUtilTest sets the fixedFeedId. So every time the TransitFilterOldWayMapperTest runs after the TransmodelMappingUtilTest it will be failing. I added a cleanup method to the TransmodelMappingUtilTest.

### Unit tests

I managed to force a specific test order by adding a temporary class and then running only that class. Two more dependencies are needed to make that work.

```xml
        <dependency>
            <groupId>org.junit.platform</groupId>
            <artifactId>junit-platform-suite</artifactId>
            <version>1.13.1</version>
        </dependency>
        <dependency>
            <groupId>org.junit.jupiter</groupId>
            <artifactId>junit-jupiter-engine</artifactId>
            <version>${junit.version}</version>
        </dependency>
```

```java
import org.junit.platform.suite.api.Suite;
import org.junit.platform.suite.api.SelectClasses;

@Suite
@SelectClasses({
  org.opentripplanner.ext.mapping.TransmodelMappingUtilTest.class,
  org.opentripplanner.apis.transmodel.mapping.TransitFilterOldWayMapperTest.class
})
public class DebugOrderedSuite {
}
```

That way you can reproduce the issue.

### Documentation

-

### Changelog

-

### Bumping the serialization version id

-
