### PR TITLE
Flex trip times

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
@@ -137,7 +137,7 @@ public class GenerateTripPatternsOperation {
     var staticTripWithFewerThan2Stops =
       !FlexTrip.containsFlexStops(stopTimes) && stopTimes.size() < 2;
     // flex trips are allowed to have a single stop because that can be an area or a group of stops
-    var flexTripWithZeroStops = FlexTrip.containsFlexStops(stopTimes) && stopTimes.size() < 1;
+    var flexTripWithZeroStops = FlexTrip.containsFlexStops(stopTimes) && stopTimes.isEmpty();
     if (staticTripWithFewerThan2Stops || flexTripWithZeroStops) {
       issueStore.add(new TripDegenerate(trip));
       return;
@@ -149,14 +149,14 @@ public class GenerateTripPatternsOperation {
     TripPatternBuilder tripPatternBuilder = findOrCreateTripPattern(stopPattern, trip);
 
     // Create a TripTimes object for this list of stoptimes, which form one trip.
-    ScheduledTripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, deduplicator);
+    var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, deduplicator);
 
     // If this trip is referenced by one or more lines in frequencies.txt, wrap it in a FrequencyEntry.
     List<Frequency> frequencies = frequenciesForTrip.get(trip);
     if (!frequencies.isEmpty()) {
       for (Frequency freq : frequencies) {
         tripPatternBuilder.withScheduledTimeTableBuilder(builder ->
-          builder.addFrequencyEntry(new FrequencyEntry(freq, tripTimes))
+          builder.addFrequencyEntry(new FrequencyEntry(freq, (ScheduledTripTimes) tripTimes))
         );
         freqCount++;
       }

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -259,6 +259,13 @@ public final class StopTime implements Comparable<StopTime> {
     );
   }
 
+  /**
+   * Does this stop time uses a non-fixed stop?
+   */
+  public boolean hasFlexStop() {
+    return !(stop instanceof RegularStop);
+  }
+
   private static int getAvailableTime(int... times) {
     for (var time : times) {
       if (time != MISSING_VALUE) {

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -4,6 +4,7 @@ package org.opentripplanner.model;
 import static org.opentripplanner.model.PickDrop.NONE;
 
 import java.util.List;
+import java.util.Objects;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.GroupStop;
@@ -263,6 +264,7 @@ public final class StopTime implements Comparable<StopTime> {
    * Does this stop time uses a non-fixed stop?
    */
   public boolean hasFlexStop() {
+    Objects.requireNonNull(stop);
     return !(stop instanceof RegularStop);
   }
 

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -4,7 +4,6 @@ package org.opentripplanner.model;
 import static org.opentripplanner.model.PickDrop.NONE;
 
 import java.util.List;
-import java.util.Objects;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.GroupStop;
@@ -258,14 +257,6 @@ public final class StopTime implements Comparable<StopTime> {
       TimeUtils.timeToStrLong(getDepartureTime()) +
       ")"
     );
-  }
-
-  /**
-   * Does this stop time uses a non-fixed stop?
-   */
-  public boolean hasFlexStop() {
-    Objects.requireNonNull(stop);
-    return !(stop instanceof RegularStop);
   }
 
   private static int getAvailableTime(int... times) {

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/AbstractTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/AbstractTripTimesBuilder.java
@@ -1,0 +1,219 @@
+package org.opentripplanner.transit.model.timetable;
+
+import java.util.BitSet;
+import java.util.List;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.transit.model.framework.DeduplicatorService;
+import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
+import org.opentripplanner.utils.time.TimeUtils;
+
+public abstract class AbstractTripTimesBuilder<
+  T extends TripTimes, B extends AbstractTripTimesBuilder<T, B>
+> {
+
+  protected static final int NOT_SET = -1;
+  private static final BitSet EMPTY_BIT_SET = new BitSet(0);
+  protected final DeduplicatorService deduplicator;
+  protected int timeShift;
+  protected int serviceCode;
+  protected int[] arrivalTimes;
+  protected int[] departureTimes;
+  protected BitSet timepoints;
+  protected Trip trip;
+  protected List<BookingInfo> dropOffBookingInfos;
+  protected List<BookingInfo> pickupBookingInfos;
+  protected I18NString[] headsigns;
+  protected String[][] headsignVias;
+  protected int[] gtfsSequenceOfStopIndex;
+
+  public AbstractTripTimesBuilder(
+    int timeShift,
+    int serviceCode,
+    int[] arrivalTimes,
+    int[] departureTimes,
+    BitSet timepoints,
+    Trip trip,
+    List<BookingInfo> dropOffBookingInfos,
+    List<BookingInfo> pickupBookingInfos,
+    I18NString[] headsigns,
+    String[][] headsignVias,
+    int[] gtfsSequenceOfStopIndex,
+    DeduplicatorService deduplicator
+  ) {
+    this.timeShift = timeShift;
+    this.serviceCode = serviceCode;
+    this.arrivalTimes = arrivalTimes;
+    this.departureTimes = departureTimes;
+    this.timepoints = timepoints;
+    this.trip = trip;
+    this.dropOffBookingInfos = dropOffBookingInfos;
+    this.pickupBookingInfos = pickupBookingInfos;
+    this.headsigns = headsigns;
+    this.headsignVias = headsignVias;
+    this.gtfsSequenceOfStopIndex = gtfsSequenceOfStopIndex;
+    this.deduplicator = deduplicator == null ? DeduplicatorService.NOOP : deduplicator;
+  }
+
+  abstract T build();
+
+  public int timeShift() {
+    return timeShift;
+  }
+
+  public B withTimeShift(int timeShift) {
+    this.timeShift = timeShift;
+    return instance();
+  }
+
+  private B instance() {
+    return (B) this;
+  }
+
+  /**
+   * Add the {@code delta} to the existing timeShift. This is useful when moving a trip from one
+   * time-zone to another.
+   */
+  public B plusTimeShift(int delta) {
+    this.timeShift += delta;
+    return instance();
+  }
+
+  public int serviceCode() {
+    return serviceCode;
+  }
+
+  public B withServiceCode(int serviceCode) {
+    this.serviceCode = serviceCode;
+    return instance();
+  }
+
+  public int[] arrivalTimes() {
+    return arrivalTimes;
+  }
+
+  public B withArrivalTimes(int[] arrivalTimes) {
+    this.arrivalTimes = deduplicator.deduplicateIntArray(arrivalTimes);
+    return instance();
+  }
+
+  /** For unit testing, uses {@link TimeUtils#time(String)}. */
+  public B withArrivalTimes(String arrivalTimes) {
+    return withArrivalTimes(TimeUtils.times(arrivalTimes));
+  }
+
+  public int[] departureTimes() {
+    return departureTimes;
+  }
+
+  public B withDepartureTimes(int[] departureTimes) {
+    this.departureTimes = deduplicator.deduplicateIntArray(departureTimes);
+    return instance();
+  }
+
+  /** For unit testing, uses {@link TimeUtils#time(String)}. */
+  public B withDepartureTimes(String departureTimes) {
+    return withDepartureTimes(TimeUtils.times(departureTimes));
+  }
+
+  public BitSet timepoints() {
+    return timepoints == null ? EMPTY_BIT_SET : timepoints;
+  }
+
+  public B withTimepoints(BitSet timepoints) {
+    this.timepoints = deduplicator.deduplicateBitSet(timepoints);
+    return instance();
+  }
+
+  public Trip trip() {
+    return trip;
+  }
+
+  public B withTrip(Trip trip) {
+    this.trip = trip;
+    return instance();
+  }
+
+  public List<BookingInfo> dropOffBookingInfos() {
+    return dropOffBookingInfos == null ? List.of() : dropOffBookingInfos;
+  }
+
+  public B withDropOffBookingInfos(List<BookingInfo> dropOffBookingInfos) {
+    this.dropOffBookingInfos = deduplicator.deduplicateImmutableList(
+      BookingInfo.class,
+      dropOffBookingInfos
+    );
+    return instance();
+  }
+
+  public List<BookingInfo> pickupBookingInfos() {
+    return pickupBookingInfos == null ? List.of() : pickupBookingInfos;
+  }
+
+  public B withPickupBookingInfos(List<BookingInfo> pickupBookingInfos) {
+    this.pickupBookingInfos = deduplicator.deduplicateImmutableList(
+      BookingInfo.class,
+      pickupBookingInfos
+    );
+    return instance();
+  }
+
+  public I18NString[] headsigns() {
+    return headsigns;
+  }
+
+  public B withHeadsigns(I18NString[] headsigns) {
+    this.headsigns = deduplicator.deduplicateObjectArray(I18NString.class, headsigns);
+    return instance();
+  }
+
+  public String[][] headsignVias() {
+    return headsignVias;
+  }
+
+  public B withHeadsignVias(String[][] headsignVias) {
+    this.headsignVias = deduplicator.deduplicateString2DArray(headsignVias);
+    return instance();
+  }
+
+  public int[] gtfsSequenceOfStopIndex() {
+    return gtfsSequenceOfStopIndex;
+  }
+
+  public B withGtfsSequenceOfStopIndex(int[] gtfsSequenceOfStopIndex) {
+    this.gtfsSequenceOfStopIndex = deduplicator.deduplicateIntArray(gtfsSequenceOfStopIndex);
+    return instance();
+  }
+
+  /**
+   * Times are always shifted to zero based on the first departure time. This is essential for
+   * frequencies and deduplication.
+   */
+  protected void normalizeTimes() {
+    if (departureTimes == null) {
+      this.departureTimes = arrivalTimes;
+    }
+    if (arrivalTimes == null) {
+      this.arrivalTimes = departureTimes;
+    }
+
+    int shift = departureTimes[0];
+    if (shift == 0) {
+      return;
+    }
+    this.departureTimes = timeShift(departureTimes, shift);
+    if (arrivalTimes != departureTimes) {
+      this.arrivalTimes = timeShift(arrivalTimes, shift);
+    }
+    this.timeShift += shift;
+  }
+
+  int[] timeShift(int[] a, int shift) {
+    if (shift == 0) {
+      return a;
+    }
+    for (int i = 0; i < a.length; i++) {
+      a[i] -= shift;
+    }
+    return a;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/FlexibleTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/FlexibleTripTimes.java
@@ -73,7 +73,7 @@ public final class FlexibleTripTimes implements TripTimes {
 
   private final int[] gtfsSequenceOfStopIndex;
 
-  FlexibleTripTimes(ScheduledTripTimesBuilder builder) {
+  FlexibleTripTimes(AbstractTripTimesBuilder builder) {
     this.timeShift = builder.timeShift();
     this.serviceCode = builder.serviceCode();
     this.arrivalTimes = Objects.requireNonNull(builder.arrivalTimes());
@@ -93,16 +93,16 @@ public final class FlexibleTripTimes implements TripTimes {
    * simple fields like {@code timeShift} and {@code serviceCode} or even the prefered way in an
    * unittest.
    */
-  public static ScheduledTripTimesBuilder of() {
-    return new ScheduledTripTimesBuilder(null);
+  public static FlexibleTripTimesBuilder of() {
+    return new FlexibleTripTimesBuilder(null);
   }
 
-  public static ScheduledTripTimesBuilder of(DeduplicatorService deduplicator) {
-    return new ScheduledTripTimesBuilder(deduplicator);
+  public static FlexibleTripTimesBuilder of(DeduplicatorService deduplicator) {
+    return new FlexibleTripTimesBuilder(deduplicator);
   }
 
-  public ScheduledTripTimesBuilder copyOf(Deduplicator deduplicator) {
-    return new ScheduledTripTimesBuilder(
+  public FlexibleTripTimesBuilder copyOf(Deduplicator deduplicator) {
+    return new FlexibleTripTimesBuilder(
       timeShift,
       serviceCode,
       arrivalTimes,
@@ -121,7 +121,7 @@ public final class FlexibleTripTimes implements TripTimes {
   /**
    * @see #copyOf(Deduplicator) copyOf(null)
    */
-  public ScheduledTripTimesBuilder copyOfNoDuplication() {
+  public FlexibleTripTimesBuilder copyOfNoDuplication() {
     return copyOf(null);
   }
 
@@ -137,9 +137,7 @@ public final class FlexibleTripTimes implements TripTimes {
 
   @Override
   public FlexibleTripTimes adjustTimesToGraphTimeZone(Duration shiftDelta) {
-    return copyOfNoDuplication()
-      .plusTimeShift((int) shiftDelta.toSeconds())
-      .buildScheduledDeviated();
+    return copyOfNoDuplication().plusTimeShift((int) shiftDelta.toSeconds()).build();
   }
 
   @Override
@@ -149,7 +147,7 @@ public final class FlexibleTripTimes implements TripTimes {
 
   @Override
   public FlexibleTripTimes withServiceCode(int serviceCode) {
-    return this.copyOfNoDuplication().withServiceCode(serviceCode).buildScheduledDeviated();
+    return this.copyOfNoDuplication().withServiceCode(serviceCode).build();
   }
 
   @Override
@@ -316,7 +314,7 @@ public final class FlexibleTripTimes implements TripTimes {
    * Returns a time-shifted copy of this TripTimes in which the vehicle passes the given stop index
    * at the given time.
    */
-  public ScheduledTripTimes timeShift(final int stop, final int time, final boolean depart) {
+  public FlexibleTripTimes timeShift(final int stop, final int time, final boolean depart) {
     // Adjust 0-based times to match desired stoptime.
     final int shift = time - (depart ? getDepartureTime(stop) : getArrivalTime(stop));
 

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/FlexibleTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/FlexibleTripTimesBuilder.java
@@ -6,7 +6,6 @@ import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.framework.DeduplicatorService;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
-import org.opentripplanner.utils.time.TimeUtils;
 
 public class FlexibleTripTimesBuilder
   extends AbstractTripTimesBuilder<FlexibleTripTimes, FlexibleTripTimesBuilder> {

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/FlexibleTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/FlexibleTripTimesBuilder.java
@@ -8,14 +8,14 @@ import org.opentripplanner.transit.model.framework.DeduplicatorService;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 import org.opentripplanner.utils.time.TimeUtils;
 
-public class ScheduledTripTimesBuilder
-  extends AbstractTripTimesBuilder<ScheduledTripTimes, ScheduledTripTimesBuilder> {
+public class FlexibleTripTimesBuilder
+  extends AbstractTripTimesBuilder<FlexibleTripTimes, FlexibleTripTimesBuilder> {
 
-  ScheduledTripTimesBuilder(@Nullable DeduplicatorService deduplicator) {
+  FlexibleTripTimesBuilder(@Nullable DeduplicatorService deduplicator) {
     this(0, NOT_SET, null, null, null, null, null, null, null, null, null, deduplicator);
   }
 
-  ScheduledTripTimesBuilder(
+  FlexibleTripTimesBuilder(
     int timeShift,
     int serviceCode,
     int[] arrivalTimes,
@@ -46,8 +46,8 @@ public class ScheduledTripTimesBuilder
   }
 
   @Override
-  public ScheduledTripTimes build() {
+  public FlexibleTripTimes build() {
     normalizeTimes();
-    return new ScheduledTripTimes(this);
+    return new FlexibleTripTimes(this);
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/FrequencyEntry.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/FrequencyEntry.java
@@ -131,7 +131,7 @@ public class FrequencyEntry implements Serializable {
       endTime,
       headway,
       exactTimes,
-      tripTimes.withServiceCode(serviceCode)
+      (ScheduledTripTimes) tripTimes.withServiceCode(serviceCode)
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
@@ -206,10 +206,6 @@ public final class RealTimeTripTimes implements TripTimes {
     return this.occupancyStatus[stop];
   }
 
-  OccupancyStatus[] copyOccupancyStatus() {
-    return occupancyStatus.clone();
-  }
-
   @Override
   public BookingInfo getDropOffBookingInfo(int stop) {
     return scheduledTripTimes.getDropOffBookingInfo(stop);
@@ -329,10 +325,6 @@ public final class RealTimeTripTimes implements TripTimes {
   @Override
   public Trip getTrip() {
     return scheduledTripTimes.getTrip();
-  }
-
-  StopRealTimeState[] copyStopRealTimeStates() {
-    return stopRealTimeStates.clone();
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
@@ -212,6 +212,11 @@ public class RealTimeTripTimesBuilder {
     return tripHeadsign;
   }
 
+  public RealTimeTripTimesBuilder withTripHeadsign(I18NString headsign) {
+    tripHeadsign = headsign;
+    return this;
+  }
+
   public @Nullable I18NString[] stopHeadsigns() {
     var result = scheduledTripTimes.copyHeadsigns(() ->
       new I18NString[scheduledTripTimes.getNumStops()]

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
@@ -212,11 +212,6 @@ public class RealTimeTripTimesBuilder {
     return tripHeadsign;
   }
 
-  public RealTimeTripTimesBuilder withTripHeadsign(I18NString headsign) {
-    tripHeadsign = headsign;
-    return this;
-  }
-
   public @Nullable I18NString[] stopHeadsigns() {
     var result = scheduledTripTimes.copyHeadsigns(() ->
       new I18NString[scheduledTripTimes.getNumStops()]
@@ -258,10 +253,12 @@ public class RealTimeTripTimesBuilder {
   }
 
   public RealTimeTripTimesBuilder withServiceCode(int serviceCode) {
-    this.scheduledTripTimes = scheduledTripTimes
-      .copyOfNoDuplication()
-      .withServiceCode(serviceCode)
-      .build();
+    var tripTimes = scheduledTripTimes.copyOfNoDuplication().withServiceCode(serviceCode).build();
+    if (tripTimes instanceof ScheduledTripTimes tt) {
+      this.scheduledTripTimes = tt;
+    } else {
+      throw new UnsupportedOperationException("Cannot apply real-time updates to flex trips.");
+    }
     return this;
   }
 

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
@@ -136,7 +136,7 @@ public final class ScheduledTripTimes implements TripTimes {
   }
 
   @Override
-  public ScheduledTripTimes adjustTimesToGraphTimeZone(Duration shiftDelta) {
+  public TripTimes adjustTimesToGraphTimeZone(Duration shiftDelta) {
     return copyOfNoDuplication().plusTimeShift((int) shiftDelta.toSeconds()).build();
   }
 
@@ -146,7 +146,7 @@ public final class ScheduledTripTimes implements TripTimes {
   }
 
   @Override
-  public ScheduledTripTimes withServiceCode(int serviceCode) {
+  public TripTimes withServiceCode(int serviceCode) {
     return this.copyOfNoDuplication().withServiceCode(serviceCode).build();
   }
 
@@ -375,6 +375,9 @@ public final class ScheduledTripTimes implements TripTimes {
   /* private methods */
 
   private void validate() {
+    // Validate at least two times
+    IntUtils.requireInRange(arrivalTimes.length, 1, Integer.MAX_VALUE, "arrivalTimes.length");
+    IntUtils.requireInRange(departureTimes.length, 1, Integer.MAX_VALUE, "arrivalTimes.length");
     // Validate first departure time and last arrival time
     validateTimeInRange("departureTime", departureTimes, 0);
     validateTimeInRange("arrivalTime", arrivalTimes, arrivalTimes.length - 1);
@@ -390,12 +393,6 @@ public final class ScheduledTripTimes implements TripTimes {
   private void validateNonIncreasingTimes() {
     final int lastStop = arrivalTimes.length - 1;
 
-    // This check is currently used since Flex trips may have only one stop. This class should
-    // not be used to represent FLEX, so remove this check and create new data classes for FLEX
-    // trips.
-    if (lastStop < 1) {
-      return;
-    }
     int prevDep = getDepartureTime(0);
 
     for (int i = 1; true; ++i) {

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesBuilder.java
@@ -187,6 +187,11 @@ public class ScheduledTripTimesBuilder {
     return new ScheduledTripTimes(this);
   }
 
+  public FlexibleTripTimes buildScheduledDeviated() {
+    normalizeTimes();
+    return new FlexibleTripTimes(this);
+  }
+
   /**
    * Times are always shifted to zero based on the first departure time. This is essential for
    * frequencies and deduplication.

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesBuilder.java
@@ -6,7 +6,6 @@ import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.framework.DeduplicatorService;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
-import org.opentripplanner.utils.time.TimeUtils;
 
 public class ScheduledTripTimesBuilder
   extends AbstractTripTimesBuilder<ScheduledTripTimes, ScheduledTripTimesBuilder> {

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/StopTimeToScheduledTripTimesMapper.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/StopTimeToScheduledTripTimesMapper.java
@@ -23,7 +23,7 @@ class StopTimeToScheduledTripTimesMapper {
     DeduplicatorService deduplicator,
     Collection<StopTime> stopTimes
   ) {
-    var isFlex = stopTimes.stream().anyMatch(st -> st.hasFlexStop() || st.hasFlexWindow());
+    var isFlex = stopTimes.stream().anyMatch(st -> st.hasFlexibleStop() || st.hasFlexWindow());
     if (isFlex) {
       this.builder = FlexibleTripTimes.of(deduplicator).withTrip(trip);
     } else {

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/StopTimeToScheduledTripTimesMapper.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/StopTimeToScheduledTripTimesMapper.java
@@ -27,7 +27,7 @@ class StopTimeToScheduledTripTimesMapper {
    * The non-interpolated stoptimes should already be marked at timepoints by a previous filtering
    * step.
    */
-  public static ScheduledTripTimes map(
+  public static TripTimes map(
     Trip trip,
     Collection<StopTime> stopTimes,
     DeduplicatorService deduplicator
@@ -35,7 +35,7 @@ class StopTimeToScheduledTripTimesMapper {
     return new StopTimeToScheduledTripTimesMapper(trip, deduplicator).doMap(stopTimes);
   }
 
-  private ScheduledTripTimes doMap(Collection<StopTime> stopTimes) {
+  private TripTimes doMap(Collection<StopTime> stopTimes) {
     final int nStops = stopTimes.size();
     final int[] departures = new int[nStops];
     final int[] arrivals = new int[nStops];
@@ -65,7 +65,13 @@ class StopTimeToScheduledTripTimesMapper {
       .withPickupBookingInfos(pickupBookingInfos)
       .withTimepoints(timepoints);
 
-    return builder.build();
+    var isFlex = stopTimes.stream().anyMatch(st -> st.hasFlexStop() || st.hasFlexWindow());
+    if (isFlex) {
+      return builder.buildScheduledDeviated();
+    }
+    {
+      return builder.build();
+    }
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimesFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimesFactory.java
@@ -18,7 +18,7 @@ public class TripTimesFactory {
    * non-interpolated stoptimes should already be marked at timepoints by a previous filtering
    * step.
    */
-  public static ScheduledTripTimes tripTimes(
+  public static TripTimes tripTimes(
     Trip trip,
     List<StopTime> stopTimes,
     DeduplicatorService deduplicator

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
@@ -225,7 +225,6 @@ class AddedTripBuilder {
       aimedStopTimes,
       transitService.getDeduplicator()
     ).withServiceCode(transitService.getServiceCode(trip.getServiceId()));
-    tripTimes.validateNonIncreasingTimes();
 
     TripPattern pattern = TripPattern.of(getTripPatternId.apply(trip))
       .withRoute(trip.getRoute())

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
@@ -140,11 +140,6 @@ class ExtraCallTripBuilder {
       aimedStopTimes,
       transitService.getDeduplicator()
     ).withServiceCode(transitService.getServiceCode(trip.getServiceId()));
-    // validate the scheduled trip times
-    // they are in general superseded by real-time trip times
-    // but in case of trip cancellation, OTP will fall back to scheduled trip times
-    // therefore they must be valid
-    tripTimes.validateNonIncreasingTimes();
     TripPattern pattern = TripPattern.of(generateTripPatternId.apply(trip))
       .withRoute(trip.getRoute())
       .withMode(trip.getMode())

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
@@ -157,7 +157,7 @@ class StreetLinkerModuleTest {
       .trip("carsAllowedTrip")
       .withCarsAllowed(CarAccess.ALLOWED)
       .build();
-    model.withCarsAllowedTrip(carsAllowedTrip, model.stop());
+    model.withCarsAllowedTrip(carsAllowedTrip, model.stop(), model.stop());
 
     var module = model.streetLinkerModule();
 
@@ -257,7 +257,7 @@ class StreetLinkerModuleTest {
           var stopTime = new StopTime();
           stopTime.setStop(s);
           stopTime.setArrivalTime(30);
-          stopTime.setDepartureTime(60);
+          stopTime.setDepartureTime(30);
           stopTime.setTrip(trip);
           return stopTime;
         })

--- a/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
@@ -72,7 +72,7 @@ public class TimetableSnapshotTest {
 
     TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
       trip,
-      List.of(STOP_TIME),
+      List.of(STOP_TIME, STOP_TIME),
       new Deduplicator()
     );
     RealTimeTripUpdate realTimeTripUpdate = new RealTimeTripUpdate(
@@ -161,7 +161,7 @@ public class TimetableSnapshotTest {
     );
     TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
       trip,
-      List.of(STOP_TIME),
+      List.of(STOP_TIME, STOP_TIME),
       new Deduplicator()
     );
     RealTimeTripUpdate realTimeTripUpdate = new RealTimeTripUpdate(

--- a/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
@@ -22,6 +22,7 @@ import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RealTimeRaptorTransitDataUpdater;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -35,7 +36,8 @@ import org.opentripplanner.transit.service.TimetableRepository;
 public class TimetableSnapshotTest {
 
   private static final ZoneId timeZone = ZoneIds.GMT;
-  public static final LocalDate SERVICE_DATE = LocalDate.of(2024, 1, 1);
+  private static final LocalDate SERVICE_DATE = LocalDate.of(2024, 1, 1);
+  private static final StopTime STOP_TIME = TimetableRepositoryForTest.of().stopTime("A");
   private static Map<FeedScopedId, TripPattern> patternIndex;
   static String feedId;
 
@@ -70,7 +72,7 @@ public class TimetableSnapshotTest {
 
     TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
       trip,
-      List.of(new StopTime()),
+      List.of(STOP_TIME),
       new Deduplicator()
     );
     RealTimeTripUpdate realTimeTripUpdate = new RealTimeTripUpdate(
@@ -159,7 +161,7 @@ public class TimetableSnapshotTest {
     );
     TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
       trip,
-      List.of(new StopTime()),
+      List.of(STOP_TIME),
       new Deduplicator()
     );
     RealTimeTripUpdate realTimeTripUpdate = new RealTimeTripUpdate(

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitDataTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitDataTest.java
@@ -38,7 +38,7 @@ class RaptorTransitDataTest {
       .getRoutingTripPattern();
     TRIP_TIMES = TripTimesFactory.tripTimes(
       TimetableRepositoryForTest.trip("1").withRoute(route).build(),
-      List.of(stopTime),
+      List.of(stopTime, stopTime),
       new Deduplicator()
     );
   }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitDataTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitDataTest.java
@@ -38,7 +38,7 @@ class RaptorTransitDataTest {
       .getRoutingTripPattern();
     TRIP_TIMES = TripTimesFactory.tripTimes(
       TimetableRepositoryForTest.trip("1").withRoute(route).build(),
-      List.of(new StopTime()),
+      List.of(stopTime),
       new Deduplicator()
     );
   }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -30,7 +30,7 @@ class TripPatternForDateTest {
   private static final ScheduledTripTimes tripTimes =
     (ScheduledTripTimes) TripTimesFactory.tripTimes(
       TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build(),
-      List.of(TEST_MODEL.stopTime("A")),
+      List.of(TEST_MODEL.stopTime("A"), TEST_MODEL.stopTime("B")),
       new Deduplicator()
     );
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -27,11 +27,21 @@ class TripPatternForDateTest {
   private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
   private static final RegularStop STOP = TEST_MODEL.stop("TEST:STOP", 0, 0).build();
   private static final Route ROUTE = TimetableRepositoryForTest.route("1").build();
-  private static final ScheduledTripTimes tripTimes = TripTimesFactory.tripTimes(
-    TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build(),
-    List.of(new StopTime()),
-    new Deduplicator()
-  );
+  private static final ScheduledTripTimes tripTimes =
+    (ScheduledTripTimes) TripTimesFactory.tripTimes(
+      TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build(),
+      List.of(stopTime()),
+      new Deduplicator()
+    );
+
+  private static StopTime stopTime() {
+    var stop = TimetableRepositoryForTest.of().stop("a").build();
+    var st = new StopTime();
+    st.setStop(stop);
+    st.setArrivalTime(0);
+    st.setArrivalTime(1);
+    return st;
+  }
 
   static Stream<Arguments> testCases() {
     return Stream.of(

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -30,18 +30,9 @@ class TripPatternForDateTest {
   private static final ScheduledTripTimes tripTimes =
     (ScheduledTripTimes) TripTimesFactory.tripTimes(
       TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build(),
-      List.of(stopTime()),
+      List.of(TEST_MODEL.stopTime("A")),
       new Deduplicator()
     );
-
-  private static StopTime stopTime() {
-    var stop = TimetableRepositoryForTest.of().stop("a").build();
-    var st = new StopTime();
-    st.setStop(stop);
-    st.setArrivalTime(0);
-    st.setArrivalTime(1);
-    return st;
-  }
 
   static Stream<Arguments> testCases() {
     return Stream.of(

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
@@ -931,7 +931,7 @@ class RouteRequestTransitDataProviderFilterTest {
 
     TripTimes tripTimes = TripTimesFactory.tripTimes(
       TimetableRepositoryForTest.trip("1").withRoute(route).build(),
-      List.of(stopTime),
+      List.of(stopTime, stopTime),
       new Deduplicator()
     );
 
@@ -1000,7 +1000,7 @@ class RouteRequestTransitDataProviderFilterTest {
     stopTime.setDepartureTime(60);
     stopTime.setStopSequence(0);
 
-    return TripTimesFactory.tripTimes(trip, List.of(stopTime), new Deduplicator());
+    return TripTimesFactory.tripTimes(trip, List.of(stopTime, stopTime), new Deduplicator());
   }
 
   private TripTimes createTestTripTimesWithSubmode(String submode) {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
@@ -43,7 +43,6 @@ import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
-import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
 import org.opentripplanner.transit.model.timetable.TripBuilder;

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
@@ -931,7 +931,7 @@ class RouteRequestTransitDataProviderFilterTest {
 
     TripTimes tripTimes = TripTimesFactory.tripTimes(
       TimetableRepositoryForTest.trip("1").withRoute(route).build(),
-      List.of(new StopTime()),
+      List.of(stopTime),
       new Deduplicator()
     );
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
@@ -974,7 +974,7 @@ class RouteRequestTransitDataProviderFilterTest {
     );
   }
 
-  private ScheduledTripTimes createTestTripTimes(
+  private TripTimes createTestTripTimes(
     FeedScopedId tripId,
     Route route,
     BikeAccess bikeAccess,

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
@@ -89,7 +89,13 @@ class TripPatternForDatesTest {
       new Deduplicator()
     );
 
-    var frequency = new Frequency(trip, FREQUENCY_START, FREQUENCY_END, HEADWAY, true);
+    var frequency = new Frequency(
+      tripTimes.getTrip(),
+      FREQUENCY_START,
+      FREQUENCY_END,
+      HEADWAY,
+      true
+    );
 
     var boardingAndAlightingPossible = new BitSet(2);
     boardingAndAlightingPossible.set(0);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
@@ -84,9 +84,8 @@ class TripPatternForDatesTest {
       .build()
       .getRoutingTripPattern();
 
-    Trip trip = TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build();
-    final ScheduledTripTimes tripTimes = TripTimesFactory.tripTimes(
-      trip,
+    var tripTimes = (ScheduledTripTimes) TripTimesFactory.tripTimes(
+      TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build(),
       List.of(stopTime1, stopTime2),
       new Deduplicator()
     );

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
@@ -18,7 +18,6 @@ import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
-import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class TripPatternForDatesTest {

--- a/application/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
@@ -44,7 +44,11 @@ public class FrequencyEntryTest {
       stopTimes.add(stopTime);
     }
 
-    tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
+    tripTimes = (ScheduledTripTimes) TripTimesFactory.tripTimes(
+      trip,
+      stopTimes,
+      new Deduplicator()
+    );
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryForTest.java
@@ -87,6 +87,8 @@ public class TimetableRepositoryForTest {
     .withTimezone(TIME_ZONE_ID)
     .withUrl("https:/www.otherfeedagency.com")
     .build();
+  public static final LocalTime TEN_AM = LocalTime.of(10, 0);
+  public static final LocalTime SIX_PM = LocalTime.of(18, 0);
 
   private final SiteRepositoryBuilder siteRepositoryBuilder;
 
@@ -217,6 +219,15 @@ public class TimetableRepositoryForTest {
     return stopTime;
   }
 
+  public StopTime stopTime(String id) {
+    var stop = stop(id).build();
+    var st = new StopTime();
+    st.setStop(stop);
+    st.setArrivalTime(TEN_AM.toSecondOfDay());
+    st.setDepartureTime(TEN_AM.toSecondOfDay());
+    return st;
+  }
+
   public Place place(String name, Consumer<RegularStopBuilder> stopBuilder) {
     var stop = stop(name);
     stopBuilder.accept(stop);
@@ -278,8 +289,8 @@ public class TimetableRepositoryForTest {
       .map(s -> {
         var st = new StopTime();
         st.setStop(s);
-        st.setFlexWindowStart(LocalTime.of(10, 0).toSecondOfDay());
-        st.setFlexWindowEnd(LocalTime.of(18, 0).toSecondOfDay());
+        st.setFlexWindowStart(TEN_AM.toSecondOfDay());
+        st.setFlexWindowEnd(SIX_PM.toSecondOfDay());
 
         return st;
       })

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesTest.java
@@ -61,16 +61,14 @@ class RealTimeTripTimesTest {
   @Nested
   class Headsign {
 
-    private static final NonLocalizedString STOP_TEST_DIRECTION = new NonLocalizedString(
-      "STOP TEST DIRECTION"
-    );
+    private static final I18NString STOP_TEST_DIRECTION = I18NString.of("STOP TEST DIRECTION");
     private static final NonLocalizedString DIRECTION = new NonLocalizedString("DIRECTION");
-    private static final StopTime EMPTY_STOPPOINT = new StopTime();
+    private static final StopTime EMPTY_STOPTIME = TEST_MODEL.stopTime("empty");
 
     @Test
     void shouldHandleBothNullScenario() {
       Trip trip = TimetableRepositoryForTest.trip("TRIP").build();
-      List<StopTime> stopTimes = List.of(EMPTY_STOPPOINT, EMPTY_STOPPOINT, EMPTY_STOPPOINT);
+      List<StopTime> stopTimes = List.of(EMPTY_STOPTIME, EMPTY_STOPTIME, EMPTY_STOPTIME);
 
       TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
 
@@ -81,7 +79,7 @@ class RealTimeTripTimesTest {
     @Test
     void shouldHandleTripOnlyHeadSignScenario() {
       Trip trip = TimetableRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
-      List<StopTime> stopTimes = List.of(EMPTY_STOPPOINT, EMPTY_STOPPOINT, EMPTY_STOPPOINT);
+      List<StopTime> stopTimes = List.of(EMPTY_STOPTIME, EMPTY_STOPTIME, EMPTY_STOPTIME);
 
       TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
 
@@ -92,9 +90,8 @@ class RealTimeTripTimesTest {
     @Test
     void shouldHandleStopsOnlyHeadSignScenario() {
       Trip trip = TimetableRepositoryForTest.trip("TRIP").build();
-      StopTime stopWithHeadsign = new StopTime();
-      stopWithHeadsign.setStopHeadsign(STOP_TEST_DIRECTION);
-      List<StopTime> stopTimes = List.of(stopWithHeadsign, stopWithHeadsign, stopWithHeadsign);
+      var stopTime = stopTime(STOP_TEST_DIRECTION);
+      List<StopTime> stopTimes = List.of(stopTime, stopTime, stopTime);
 
       TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
 
@@ -105,8 +102,7 @@ class RealTimeTripTimesTest {
     @Test
     void shouldHandleStopsEqualToTripHeadSignScenario() {
       Trip trip = TimetableRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
-      StopTime stopWithHeadsign = new StopTime();
-      stopWithHeadsign.setStopHeadsign(DIRECTION);
+      StopTime stopWithHeadsign = stopTime(DIRECTION);
       List<StopTime> stopTimes = List.of(stopWithHeadsign, stopWithHeadsign, stopWithHeadsign);
 
       TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
@@ -118,9 +114,8 @@ class RealTimeTripTimesTest {
     @Test
     void shouldHandleDifferingTripAndStopHeadSignScenario() {
       Trip trip = TimetableRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
-      StopTime stopWithHeadsign = new StopTime();
-      stopWithHeadsign.setStopHeadsign(STOP_TEST_DIRECTION);
-      List<StopTime> stopTimes = List.of(stopWithHeadsign, EMPTY_STOPPOINT, EMPTY_STOPPOINT);
+      StopTime stopWithHeadsign = stopTime(STOP_TEST_DIRECTION);
+      List<StopTime> stopTimes = List.of(stopWithHeadsign, EMPTY_STOPTIME, EMPTY_STOPTIME);
 
       TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
 
@@ -129,6 +124,12 @@ class RealTimeTripTimesTest {
 
       I18NString headsignSecondStop = tripTimes.getHeadsign(1);
       assertEquals(DIRECTION, headsignSecondStop);
+    }
+
+    private StopTime stopTime(I18NString stopHeadsign) {
+      StopTime stopWithHeadsign = TEST_MODEL.stopTime("A");
+      stopWithHeadsign.setStopHeadsign(stopHeadsign);
+      return stopWithHeadsign;
     }
   }
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayAlwaysInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayAlwaysInterpolatorTest.java
@@ -8,15 +8,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class BackwardsDelayAlwaysInterpolatorTest {
 
   static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP_ID").build();
   static final int STOP_COUNT = 5;
-  static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
+  static final TripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
     TRIP,
     TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
     new Deduplicator()

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayRequiredInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayRequiredInterpolatorTest.java
@@ -8,16 +8,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.StopRealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class BackwardsDelayRequiredInterpolatorTest {
 
   static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP_ID").build();
   public static final int STOP_COUNT = 5;
-  static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
+  static final TripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
     TRIP,
     TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
     new Deduplicator()

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/DefaultForwardsDelayInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/DefaultForwardsDelayInterpolatorTest.java
@@ -11,16 +11,16 @@ import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.StopRealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class DefaultForwardsDelayInterpolatorTest {
 
   static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP_ID").build();
   static final int STOP_COUNT = 20;
-  static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
+  static final TripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
     TRIP,
     TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
     new Deduplicator()

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/TimetableHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/TimetableHelperTest.java
@@ -63,6 +63,8 @@ public class TimetableHelperTest {
       .withParentStation(station)
       .build();
     stopTime.setStop(stop);
+    stopTime.setArrivalTime(7200);
+    stopTime.setDepartureTime(7200);
 
     Agency agency = Agency.of(SCOPED_AGENCY_ID).withName(AGENCY_NAME).withTimezone("CET").build();
 
@@ -75,7 +77,7 @@ public class TimetableHelperTest {
     Trip trip = Trip.of(new FeedScopedId(FEED_ID, "TRIP_ID")).withRoute(route).build();
     builder = TripTimesFactory.tripTimes(
       trip,
-      List.of(stopTime),
+      List.of(stopTime, stopTime),
       new Deduplicator()
     ).createRealTimeFromScheduledTimes();
   }


### PR DESCRIPTION
### Summary

This PR introduces separate trip times for flex trips, which allows us to be a lot stricter when validating the regular, non-flex trip times.

New validations for `ScheduledTripTimes` are:

- 2 or more stops
- Times must be increasing


### Design question:

- Should there be a common super type for `ScheduledTripTimes` and `FlexTripTimes`?

Perhaps we want to talk about it in one of the design meetings when @t2gran is back.

### Unit tests

There were lots of tests which created invalid trip times and they are updated.

### Bumping the serialization version id

Yes, a new object is introduced.