### PR TITLE
Finetune CSS layout of search bar

### DIFF
--- a/client/src/components/SearchBar/AccessSelect.tsx
+++ b/client/src/components/SearchBar/AccessSelect.tsx
@@ -16,6 +16,7 @@ export function AccessSelect({
       <Form.Select
         id="accessSelect"
         size="sm"
+        className="input-medium"
         onChange={(e) => {
           if (e.target.value !== 'not_selected') {
             setTripQueryVariables({

--- a/client/src/components/SearchBar/DepartureArrivalSelect.tsx
+++ b/client/src/components/SearchBar/DepartureArrivalSelect.tsx
@@ -22,6 +22,7 @@ export function DepartureArrivalSelect({
       </Form.Label>
       <Form.Select
         size="sm"
+        className="input-medium"
         onChange={(e) => (e.target.value === 'arrival' ? onChange(true) : onChange(false))}
         value={tripQueryVariables.arriveBy ? 'arrival' : 'departure'}
         style={{ verticalAlign: 'bottom' }}

--- a/client/src/components/SearchBar/DirectModeSelect.tsx
+++ b/client/src/components/SearchBar/DirectModeSelect.tsx
@@ -16,6 +16,7 @@ export function DirectModeSelect({
       <Form.Select
         id="directModeSelect"
         size="sm"
+        className="input-medium"
         onChange={(e) => {
           if (e.target.value !== 'not_selected') {
             setTripQueryVariables({

--- a/client/src/components/SearchBar/EgressSelect.tsx
+++ b/client/src/components/SearchBar/EgressSelect.tsx
@@ -16,6 +16,7 @@ export function EgressSelect({
       <Form.Select
         id="egressSelect"
         size="sm"
+        className="input-medium"
         onChange={(e) => {
           if (e.target.value !== 'not_selected') {
             setTripQueryVariables({

--- a/client/src/components/SearchBar/ItineraryFilterDebugSelect.tsx
+++ b/client/src/components/SearchBar/ItineraryFilterDebugSelect.tsx
@@ -16,7 +16,7 @@ export function ItineraryFilterDebugSelect({
       <Form.Select
         id="itineraryDebugFilterSelect"
         size="sm"
-        className="input-medium"
+        className="input-small"
         onChange={(e) => {
           setTripQueryVariables({
             ...tripQueryVariables,

--- a/client/src/components/SearchBar/MultiSelectDropdown.tsx
+++ b/client/src/components/SearchBar/MultiSelectDropdown.tsx
@@ -40,6 +40,7 @@ const MultiSelectDropdown = <T = unknown,>({ label, options, values, onChange }:
         type="text"
         id="multiSelectDropdown"
         size="sm"
+        className="input-medium"
         value={values.length > 0 ? values.join(', ') : 'Not selected'}
         onClick={toggleDropdown}
         onChange={() => {}}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -58,17 +58,17 @@
   max-width: 50px;
 }
 
-.search-bar input.input-small {
+.search-bar .input-small {
   max-width: 100px;
 }
 
-.search-bar input.input-medium {
+.search-bar .input-medium {
   max-width: 130px;
 }
 
 .search-bar-route-button-wrapper {
   height: 5rem;
-  padding-top: 25px;
+  padding-top: 37px;
 }
 
 .search-bar-route-button-wrapper a.btn img {


### PR DESCRIPTION
### Summary

On my screen the debug UI search fields always overflow into two rows:

![Screenshot From 2025-07-08 08-08-27](https://github.com/user-attachments/assets/d64cc835-f8a5-429b-bbf2-4464ca8b7c13)

With a little bit of CSS, this looks nicer:

![Screenshot From 2025-07-08 08-08-52](https://github.com/user-attachments/assets/dd924169-07d5-40ec-ad8a-3974ef80d88b)