### PR TITLE
Use prepared geometries to speed up flex zone computation

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/flex/AreaStopsToVerticesMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/AreaStopsToVerticesMapper.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMultimap;
 import jakarta.inject.Inject;
 import java.util.stream.Stream;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.routing.graph.Graph;
@@ -74,6 +75,7 @@ public class AreaStopsToVerticesMapper implements GraphBuilderModule {
   }
 
   private static Stream<MatchResult> matchingVerticesForStop(Graph graph, AreaStop areaStop) {
+    var geom = PreparedGeometryFactory.prepare(areaStop.getGeometry());
     return graph
       .findVertices(areaStop.getGeometry().getEnvelopeInternal())
       .stream()
@@ -83,7 +85,7 @@ public class AreaStopsToVerticesMapper implements GraphBuilderModule {
       .filter(vertx -> {
         // The street index overselects, so need to check for exact geometry inclusion
         Point p = GeometryUtils.getGeometryFactory().createPoint(vertx.getCoordinate());
-        return areaStop.getGeometry().intersects(p);
+        return geom.intersects(p);
       })
       .map(vertx -> new MatchResult(vertx, areaStop));
   }


### PR DESCRIPTION
### Summary

This PR has gone through a few iterations but I just noticed that there is an extremely simple solution to my problem: JTS has so-called prepared geometries which speed up the expensive `contains` checks enormously. This makes it really easy to achieve massive speed ups.

### Documentation

Javadoc.

### Changelog

No.

### Bumping the serialization version id

No.