### PR TITLE
Do not add turn duration into walk distance

### DIFF
--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1037,10 +1037,6 @@ public class StreetEdge
         turnDuration = 0;
       }
 
-      if (!traverseMode.isInCar()) {
-        s1.incrementWalkDistance(turnDuration / 100); // just a tie-breaker
-      }
-
       time_ms += (long) Math.ceil(1000.0 * turnDuration);
       weight += preferences.street().turnReluctance() * turnDuration;
     }

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -205,6 +205,25 @@ public class StreetEdgeTest {
   }
 
   /**
+   * Test that a turn will not add walk distance.
+   */
+  @Test
+  void testTraverseWalkDistance() {
+    var vWithTrafficLight = new LabelledIntersectionVertex("maple_1st", 2.0, 2.0, false, true);
+    StreetEdge e0 = streetEdge(v0, vWithTrafficLight, 50.0, StreetTraversalPermission.PEDESTRIAN);
+    StreetEdge e1 = streetEdge(vWithTrafficLight, v2, 50.0, StreetTraversalPermission.PEDESTRIAN);
+
+    StreetSearchRequestBuilder forward = StreetSearchRequest.copyOf(proto);
+    forward.withPreferences(p -> p.withBike(it -> it.withSpeed(3.0f)));
+
+    State s0 = new State(v0, forward.withMode(StreetMode.WALK).build());
+    State s1 = e0.traverse(s0)[0];
+    State s2 = e1.traverse(s1)[0];
+
+    assertEquals(100.00, s2.getWalkDistance());
+  }
+
+  /**
    * Test the bike switching penalty feature, both its cost penalty and its separate time penalty.
    */
   @Test


### PR DESCRIPTION
### Summary

Remove the code which adds walk distance at turns. It results in inaccurate walk distance being returned.

### Issue

None

### Unit tests

Added

### Documentation

None

### Changelog

### Bumping the serialization version id
Not needed