### PR TITLE
use North-based angle in internal representation

### DIFF
--- a/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -558,14 +558,15 @@ public class StreetEdge
   }
 
   /**
-   * Return the azimuth of the first segment in this edge in integer degrees clockwise from South.
-   * TODO change everything to clockwise from North
+   * Return the azimuth of the first segment in this edge in integer degrees clockwise from North.
    */
   public int getInAngle() {
     return IntUtils.round((this.inAngle * 180) / 128.0);
   }
 
-  /** Return the azimuth of the last segment in this edge in integer degrees clockwise from South. */
+  /**
+   * Return the azimuth of the last segment in this edge in integer degrees clockwise from North.
+   */
   public int getOutAngle() {
     return IntUtils.round((this.outAngle * 180) / 128.0);
   }
@@ -1231,14 +1232,12 @@ public class StreetEdge
 
     /**
      * Conversion from radians to internal representation as a single signed byte.
-     * We also reorient the angles since OTP seems to use South as a reference
-     * while the azimuth functions use North.
-     * FIXME Use only North as a reference, not a mix of North and South!
+     * <p>
      * Range restriction happens automatically due to Java signed overflow behavior.
      * 180 degrees exists as a negative rather than a positive due to the integer range.
      */
     private static byte convertRadianToByte(double angleRadians) {
-      return (byte) Math.round((angleRadians * 128) / Math.PI + 128);
+      return (byte) Math.round((angleRadians * 128) / Math.PI);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdge.java
@@ -83,6 +83,6 @@ public final class TemporaryPartialStreetEdge extends StreetEdge implements Temp
    */
   @Override
   public int getOutAngle() {
-    return parentEdge.getInAngle();
+    return parentEdge.getOutAngle();
   }
 }

--- a/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
@@ -59,15 +59,33 @@ class WalkRoutingTest {
     var end = GenericLocation.fromCoordinate(59.94641, 10.77522);
     var base = dateTime.truncatedTo(ChronoUnit.SECONDS);
     var time = base.plusMillis(offset);
-    var results = route(roundabout, start, end, time, true);
-    assertEquals(1, results.size());
-    var states = results.get(0).states;
-    var diff = ChronoUnit.MILLIS.between(
-      states.getFirst().getTimeAccurate(),
-      states.getLast().getTimeAccurate()
+
+    var baseResults = route(roundabout, start, end, base, false);
+    assertEquals(1, baseResults.size());
+    var baseStates = baseResults.get(0).states;
+    var baseDiff = ChronoUnit.MILLIS.between(
+      baseStates.getFirst().getTimeAccurate(),
+      baseStates.getLast().getTimeAccurate()
     );
-    // should be same for every parametrized offset, otherwise irrelevant
-    assertEquals(13926, diff);
+
+    var departFromResults = route(roundabout, start, end, time, false);
+    assertEquals(1, departFromResults.size());
+    var departAtStates = departFromResults.get(0).states;
+    var departFromDiff = ChronoUnit.MILLIS.between(
+      departAtStates.getFirst().getTimeAccurate(),
+      departAtStates.getLast().getTimeAccurate()
+    );
+
+    var arriveByResults = route(roundabout, start, end, time, true);
+    assertEquals(1, arriveByResults.size());
+    var arriveByStates = arriveByResults.get(0).states;
+    var arriveByDiff = ChronoUnit.MILLIS.between(
+      arriveByStates.getFirst().getTimeAccurate(),
+      arriveByStates.getLast().getTimeAccurate()
+    );
+    // should be same for every parametrized offset and both depart at and arrive by
+    assertEquals(baseDiff, departFromDiff);
+    assertEquals(baseDiff, arriveByDiff);
   }
 
   private static List<GraphPath<State, Edge, Vertex>> route(

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.street.model.edge;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
@@ -11,7 +10,6 @@ import static org.opentripplanner.street.model._data.StreetModelForTest.intersec
 import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdge;
 import static org.opentripplanner.street.model._data.StreetModelForTest.streetEdgeBuilder;
 
-import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -25,7 +23,6 @@ import org.opentripplanner.routing.core.VehicleRoutingOptimizeType;
 import org.opentripplanner.routing.util.ElevationUtils;
 import org.opentripplanner.routing.util.SlopeCosts;
 import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.street.model.TurnRestriction;
 import org.opentripplanner.street.model._data.StreetModelForTest;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.LabelledIntersectionVertex;
@@ -35,7 +32,6 @@ import org.opentripplanner.street.search.TraverseModeSet;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.request.StreetSearchRequestBuilder;
 import org.opentripplanner.street.search.state.State;
-import org.opentripplanner.street.search.state.StateData;
 
 public class StreetEdgeTest {
 
@@ -68,15 +64,15 @@ public class StreetEdgeTest {
     StreetEdge e1 = streetEdge(v1, v2, 1.0, ALL);
 
     // Edge has same first and last angle.
-    assertEquals(90, e1.getInAngle());
-    assertEquals(90, e1.getOutAngle());
+    assertEquals(-90, e1.getInAngle());
+    assertEquals(-90, e1.getOutAngle());
 
     // 2 new ones
     StreetVertex u = intersectionVertex("test1", 1.0, 2.0);
     StreetVertex v = intersectionVertex("test2", 2.0, 2.0);
 
-    // Second edge, heading straight North
-    StreetEdge e2 = streetEdge(u, v, 1.0, ALL);
+    // Second edge, heading straight South
+    StreetEdge e2 = streetEdge(v, u, 1.0, ALL);
 
     // 180 degrees could be expressed as 180 or -180. Our implementation happens to use -180.
     assertEquals(180, Math.abs(e2.getInAngle()));

--- a/application/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
+++ b/application/src/test/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculatorTest.java
@@ -48,8 +48,8 @@ public class SimpleIntersectionTraversalCalculatorTest {
     edge(v2, v3, 1.0, false);
 
     // Edge has same first and last angle.
-    assertEquals(90, e1.getInAngle());
-    assertEquals(90, e1.getOutAngle());
+    assertEquals(-90, e1.getInAngle());
+    assertEquals(-90, e1.getOutAngle());
 
     // 2 new ones
     IntersectionVertex v4 = vertex("test2", new Coordinate(1.0, 1.0), false, false);
@@ -57,8 +57,8 @@ public class SimpleIntersectionTraversalCalculatorTest {
     // Third edge
     StreetEdge e3 = edge(v2, v4, 1.0, false);
 
-    assertEquals(0, e3.getInAngle());
-    assertEquals(0, e3.getOutAngle());
+    assertEquals(-180, e3.getInAngle());
+    assertEquals(-180, e3.getOutAngle());
 
     // Difference should be about 90.
     int diff = (e1.getOutAngle() - e3.getInAngle());


### PR DESCRIPTION
### Summary

This changes the internal representation of angles from south-based to north-based. This is a removal of technical debt.

In addition, a mistake on the angle on a temporary street edge is also fixed.

### Issue

None

### Unit tests

A wrong test has been fixed to better reflect its intention.

### Documentation

None

### Changelog


### Bumping the serialization version id

Required. The internal representation has changed.