### PR TITLE
fix: Close all data sources after graph build, not before.

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
@@ -10,7 +10,9 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.io.Closeable;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.EnumSet;
 import java.util.Optional;
@@ -49,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * OTP startup early, before spending time on loading any data - like the streetGraph.
  */
 @Singleton
-public class GraphBuilderDataSources {
+public class GraphBuilderDataSources implements Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(GraphBuilderDataSources.class);
   private static final String BULLET_POINT = "- ";
@@ -143,6 +145,29 @@ public class GraphBuilderDataSources {
 
   public File getCacheDirectory() {
     return cacheDirectory;
+  }
+
+  /**
+   * We close all datasources after the entire graph build is compleate. We do this
+   * because a datsource (GFTS zip file) might be accessed by more than one graph
+   * builder module. This also allows us to cache remote files(downloaded over http), not
+   * downloading the files more than one time.
+   */
+  public void close() {
+    for (DataSource dataSource : inputData.values()) {
+      try {
+        if (dataSource instanceof Closeable closeable) {
+          closeable.close();
+        }
+      } catch (IOException e) {
+        LOG.error(
+          "Failed to close datasource {}, details: {}",
+          dataSource.path(),
+          e.getLocalizedMessage(),
+          e
+        );
+      }
+    }
   }
 
   /* private methods */

--- a/application/src/main/java/org/opentripplanner/graph_builder/configure/ConfigureGraphBuilderModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/configure/ConfigureGraphBuilderModule.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.graph_builder.configure;
+
+import dagger.Module;
+import dagger.Provides;
+import jakarta.inject.Singleton;
+import org.opentripplanner.graph_builder.GraphBuilder;
+import org.opentripplanner.graph_builder.GraphBuilderDataSources;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TimetableRepository;
+
+@Module
+public class ConfigureGraphBuilderModule {
+
+  @Provides
+  @Singleton
+  static GraphBuilder provideGraphBuilder(
+    Graph baseGraph,
+    TimetableRepository timetableRepository,
+    DataImportIssueStore issueStore,
+    GraphBuilderDataSources closeDataSourcesHandle
+  ) {
+    return new GraphBuilder(baseGraph, timetableRepository, issueStore, closeDataSourcesHandle);
+  }
+}

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderFactory.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderFactory.java
@@ -16,6 +16,7 @@ import org.opentripplanner.ext.stopconsolidation.StopConsolidationRepository;
 import org.opentripplanner.ext.transferanalyzer.DirectTransferAnalyzer;
 import org.opentripplanner.graph_builder.GraphBuilder;
 import org.opentripplanner.graph_builder.GraphBuilderDataSources;
+import org.opentripplanner.graph_builder.configure.ConfigureGraphBuilderModule;
 import org.opentripplanner.graph_builder.issue.report.DataImportIssueReporter;
 import org.opentripplanner.graph_builder.module.DirectTransferGenerator;
 import org.opentripplanner.graph_builder.module.GraphCoherencyCheckerModule;
@@ -44,6 +45,7 @@ import org.opentripplanner.transit.service.TimetableRepository;
 @Singleton
 @Component(
   modules = {
+    ConfigureGraphBuilderModule.class,
     GraphBuilderModules.class,
     OsmInfoGraphBuildServiceModule.class,
     EmissionGraphBuilderModule.class,

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsBundle.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsBundle.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.gtfs.graphbuilder;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import javax.annotation.Nullable;
 import org.onebusaway.csv_entities.CsvInputSource;
@@ -13,7 +12,7 @@ import org.opentripplanner.gtfs.config.GtfsFeedParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GtfsBundle {
+public final class GtfsBundle {
 
   private static final Logger LOG = LoggerFactory.getLogger(GtfsBundle.class);
 
@@ -94,19 +93,6 @@ public class GtfsBundle {
       };
     }
     return csvInputSource;
-  }
-
-  public void close() {
-    try {
-      dataSource.close();
-    } catch (IOException e) {
-      LOG.warn(
-        "Failed to close datasource {}, details: {}",
-        dataSource.path(),
-        e.getLocalizedMessage(),
-        e
-      );
-    }
   }
 
   public String feedInfo() {

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -207,10 +207,6 @@ public class GtfsModule implements GraphBuilderModule {
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
-    } finally {
-      // Note the close method of each bundle should NOT throw an exception, so this
-      // code should be safe without the try/catch block.
-      gtfsBundles.forEach(GtfsBundle::close);
     }
 
     timetableRepository.validateTimeZones();

--- a/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -8,7 +8,6 @@ import org.geotools.referencing.factory.DeferredAuthorityFactory;
 import org.geotools.util.WeakCollectionCleaner;
 import org.opentripplanner.framework.application.ApplicationShutdownSupport;
 import org.opentripplanner.framework.application.OtpAppException;
-import org.opentripplanner.graph_builder.GraphBuilder;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueSummary;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.graph.SerializedGraphObject;
@@ -139,13 +138,10 @@ public class OTPMain {
         app.graphOutputDataSource()
       );
 
-      GraphBuilder graphBuilder = app.createGraphBuilder();
-      if (graphBuilder != null) {
-        graphBuilder.run();
-        graphAvailable = true;
-      } else {
-        throw new IllegalStateException("An error occurred while building the graph.");
-      }
+      var graphBuilder = app.createGraphBuilder();
+      graphBuilder.run();
+      graphAvailable = true;
+
       // Store graph and config used to build it, also store router-config for easy deployment
       // with using the embedded router config.
       new SerializedGraphObject(

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -164,6 +164,10 @@ public class ConstructApplication {
     return graphBuilderDataSources.getOutputGraph();
   }
 
+  public GraphBuilderDataSources graphBuilderDataSources() {
+    return graphBuilderDataSources;
+  }
+
   private Application createApplication() {
     LOG.info("Wiring up and configuring server.");
     setupTransitRoutingServer();


### PR DESCRIPTION
### Summary

The datasource cache downloaded GTFS data sources, when multiple graph modules access the same feed OTP crash because the data source is closed by the first graph builder module, BEFORE all modules are done. 

To fix this I moved the responsibility to close data source to the `GraphBuilderDataSources` and call it from the OTPMain and removed the close method from the GraphBuildModule. Not all modules did clean up after them self, so I think this is an improvement.


### Issue

Closes #6730

### Unit tests

I have not added any test, but I changed the design so it is no longer possible to do this mistake.

### Documentation

Some JavaDoc i added.

### Changelog

✅  This should be part of the change log.

### Bumping the serialization version id

🟥  Not needed.