### PR TITLE
 Add OTP version when updaters are ready log event

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/application/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -273,8 +274,9 @@ public class GraphUpdaterManager implements WriteToGraphCallback, GraphUpdaterSt
         try {
           if (updaterList.stream().allMatch(GraphUpdater::isPrimed)) {
             LOG.info(
-              "OTP UPDATERS INITIALIZED ({} updaters) - OTP is ready for routing!",
-              updaterList.size()
+              "OTP UPDATERS INITIALIZED ({} updaters) - OTP {} is ready for routing!",
+              updaterList.size(),
+              OtpProjectInfo.projectInfo().version
             );
             return;
           }


### PR DESCRIPTION
### Summary

Improve logging when updaters are ready! This is the log event witch tell us that OTP is ready to process planning requests. In deployments with many OTP instances it is useful to see the versio of OTP during rollout. 

##### New
> ... OTP UPDATERS INITIALIZED (1 updaters) - OTP 2.8.0-SNAPSHOT is ready for routing!
 
##### Before
> ... OTP UPDATERS INITIALIZED (1 updaters) - OTP is ready for routing!


### Issue

No issue for this, this is just a small improvement.


### Unit tests

🟥  There is not test for this.


### Documentation

🟥  This is not relevant


### Changelog

🟥  Too small to be notable.

### Bumping the serialization version id

🟥  Graph not changed.