### PR TITLE
Remove preferred agencies and routes

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
@@ -175,13 +175,6 @@ public class LegacyRouteRequestMapper {
       callWith.argument("wheelchair", journeyBuilder::withWheelchair);
 
       journeyBuilder.withTransit(transitBuilder -> {
-        callWith.argument("preferred.routes", (String v) ->
-          transitBuilder.withPreferredRoutes(FeedScopedId.parseList(v))
-        );
-
-        callWith.argument("preferred.agencies", (String v) ->
-          transitBuilder.withPreferredAgencies(FeedScopedId.parseList(v))
-        );
         callWith.argument("unpreferred.routes", (String v) ->
           transitBuilder.withUnpreferredRoutes(FeedScopedId.parseList(v))
         );

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -72,16 +72,10 @@ public class TripRequestMapper {
       callWith.argument("wheelchairAccessible", journeyBuilder::withWheelchair);
 
       journeyBuilder.withTransit(transitBuilder -> {
-        callWith.argument("preferred.authorities", (Collection<String> authorities) ->
-          transitBuilder.withPreferredAgencies(idMapper.parseListNullSafe(authorities))
-        );
         callWith.argument("unpreferred.authorities", (Collection<String> authorities) ->
           transitBuilder.withUnpreferredAgencies(idMapper.parseListNullSafe(authorities))
         );
 
-        callWith.argument("preferred.lines", (List<String> lines) ->
-          transitBuilder.withPreferredRoutes(idMapper.parseListNullSafe(lines))
-        );
         callWith.argument("unpreferred.lines", (List<String> lines) ->
           transitBuilder.withUnpreferredRoutes(idMapper.parseListNullSafe(lines))
         );

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
@@ -26,23 +26,12 @@ public class TransitRequest implements Serializable {
     List.of(),
     List.of(),
     List.of(),
-    List.of(),
-    List.of(),
     DebugRaptor.defaltValue()
   );
 
   private final List<TransitFilter> filters;
 
-  @Deprecated
-  private final List<FeedScopedId> preferredAgencies;
-
   private final List<FeedScopedId> unpreferredAgencies;
-
-  /**
-   * @deprecated TODO OTP2 Needs to be implemented
-   */
-  @Deprecated
-  private final List<FeedScopedId> preferredRoutes;
 
   private final List<FeedScopedId> unpreferredRoutes;
   private final List<FeedScopedId> bannedTrips;
@@ -52,9 +41,7 @@ public class TransitRequest implements Serializable {
 
   TransitRequest(
     List<TransitFilter> filters,
-    List<FeedScopedId> preferredAgencies,
     List<FeedScopedId> unpreferredAgencies,
-    List<FeedScopedId> preferredRoutes,
     List<FeedScopedId> unpreferredRoutes,
     List<FeedScopedId> bannedTrips,
     List<TransitGroupSelect> priorityGroupsByAgency,
@@ -62,9 +49,7 @@ public class TransitRequest implements Serializable {
     DebugRaptor raptorDebugging
   ) {
     this.filters = filters;
-    this.preferredAgencies = preferredAgencies;
     this.unpreferredAgencies = unpreferredAgencies;
-    this.preferredRoutes = preferredRoutes;
     this.unpreferredRoutes = unpreferredRoutes;
     this.bannedTrips = bannedTrips;
     this.priorityGroupsByAgency = priorityGroupsByAgency;
@@ -109,24 +94,8 @@ public class TransitRequest implements Serializable {
     return priorityGroupsGlobal;
   }
 
-  /**
-   * List of preferred agencies by user.
-   */
-  @Deprecated
-  public List<FeedScopedId> preferredAgencies() {
-    return preferredAgencies;
-  }
-
   public List<FeedScopedId> unpreferredAgencies() {
     return unpreferredAgencies;
-  }
-
-  /**
-   * Set of preferred routes by user and configuration.
-   */
-  @Deprecated
-  public List<FeedScopedId> preferredRoutes() {
-    return preferredRoutes;
   }
 
   /**
@@ -158,9 +127,7 @@ public class TransitRequest implements Serializable {
     TransitRequest that = (TransitRequest) o;
     return (
       Objects.equals(filters, that.filters) &&
-      Objects.equals(preferredAgencies, that.preferredAgencies) &&
       Objects.equals(unpreferredAgencies, that.unpreferredAgencies) &&
-      Objects.equals(preferredRoutes, that.preferredRoutes) &&
       Objects.equals(unpreferredRoutes, that.unpreferredRoutes) &&
       Objects.equals(bannedTrips, that.bannedTrips) &&
       Objects.equals(priorityGroupsByAgency, that.priorityGroupsByAgency) &&
@@ -173,9 +140,7 @@ public class TransitRequest implements Serializable {
   public int hashCode() {
     return Objects.hash(
       filters,
-      preferredAgencies,
       unpreferredAgencies,
-      preferredRoutes,
       unpreferredRoutes,
       bannedTrips,
       priorityGroupsByAgency,
@@ -188,9 +153,7 @@ public class TransitRequest implements Serializable {
   public String toString() {
     return ToStringBuilder.ofEmbeddedType()
       .addCol("filters", filters, DEFAULT.filters)
-      .addCol("preferredAgencies", preferredAgencies)
       .addCol("unpreferredAgencies", unpreferredAgencies)
-      .addCol("preferredRoutes", preferredRoutes)
       .addCol("unpreferredRoutes", unpreferredRoutes)
       .addCol("bannedTrips", bannedTrips)
       .addCol("priorityGroupsByAgency", priorityGroupsByAgency)

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequestBuilder.java
@@ -13,9 +13,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 public class TransitRequestBuilder {
 
   private List<TransitFilter> filters;
-  private List<FeedScopedId> preferredAgencies;
   private List<FeedScopedId> unpreferredAgencies;
-  private List<FeedScopedId> preferredRoutes;
   private List<FeedScopedId> unpreferredRoutes;
   private List<FeedScopedId> bannedTrips;
   private List<TransitGroupSelect> priorityGroupsByAgency;
@@ -26,9 +24,7 @@ public class TransitRequestBuilder {
   public TransitRequestBuilder(TransitRequest original) {
     this.original = original;
     this.filters = null;
-    this.preferredAgencies = null;
     this.unpreferredAgencies = null;
-    this.preferredRoutes = null;
     this.unpreferredRoutes = null;
     this.bannedTrips = null;
     this.priorityGroupsByAgency = null;
@@ -54,20 +50,8 @@ public class TransitRequestBuilder {
     return setFilters(List.of(ExcludeAllTransitFilter.of()));
   }
 
-  @Deprecated
-  public TransitRequestBuilder withPreferredAgencies(List<FeedScopedId> preferredAgencies) {
-    this.preferredAgencies = preferredAgencies;
-    return this;
-  }
-
   public TransitRequestBuilder withUnpreferredAgencies(List<FeedScopedId> unpreferredAgencies) {
     this.unpreferredAgencies = unpreferredAgencies;
-    return this;
-  }
-
-  @Deprecated
-  public TransitRequestBuilder withPreferredRoutes(List<FeedScopedId> preferredRoutes) {
-    this.preferredRoutes = preferredRoutes;
     return this;
   }
 
@@ -104,9 +88,7 @@ public class TransitRequestBuilder {
   public TransitRequest build() {
     var newValue = new TransitRequest(
       ifNotNull(filters, original.filters()),
-      ifNotNull(preferredAgencies, original.preferredAgencies()),
       ifNotNull(unpreferredAgencies, original.unpreferredAgencies()),
-      ifNotNull(preferredRoutes, original.preferredRoutes()),
       ifNotNull(unpreferredRoutes, original.unpreferredRoutes()),
       ifNotNull(bannedTrips, original.bannedTrips()),
       ifNotNull(priorityGroupsByAgency, original.priorityGroupsByAgency()),

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1584,7 +1584,7 @@ type QueryType {
     "Preferences for vehicle parking"
     parking: VehicleParkingInput,
     "List of routes and agencies which are given higher preference when planning the itinerary"
-    preferred: InputPreferred,
+    preferred: InputPreferred @deprecated(reason: "Not implemented"),
     """
     **Consider this argument experimental** – setting this argument to true
     causes timeouts and unoptimal routes in many cases.
@@ -4263,15 +4263,15 @@ input InputModeWeight {
 
 input InputPreferred {
   "A comma-separated list of ids of the agencies preferred by the user."
-  agencies: String
+  agencies: String @deprecated(reason: "Not implemented")
   """
   Penalty added for using every route that is not preferred if user set any
   route as preferred. We return number of seconds that we are willing to wait
   for preferred route.
   """
-  otherThanPreferredRoutesPenalty: Int
+  otherThanPreferredRoutesPenalty: Int @deprecated(reason: "Not implemented")
   "A comma-separated list of ids of the routes preferred by the user."
-  routes: String
+  routes: String @deprecated(reason: "Not implemented")
 }
 
 """

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1584,7 +1584,7 @@ type QueryType {
     "Preferences for vehicle parking"
     parking: VehicleParkingInput,
     "List of routes and agencies which are given higher preference when planning the itinerary"
-    preferred: InputPreferred @deprecated(reason: "Not implemented"),
+    preferred: InputPreferred @deprecated(reason : "Not implemented"),
     """
     **Consider this argument experimental** – setting this argument to true
     causes timeouts and unoptimal routes in many cases.
@@ -4263,15 +4263,15 @@ input InputModeWeight {
 
 input InputPreferred {
   "A comma-separated list of ids of the agencies preferred by the user."
-  agencies: String @deprecated(reason: "Not implemented")
+  agencies: String @deprecated(reason : "Not implemented")
   """
   Penalty added for using every route that is not preferred if user set any
   route as preferred. We return number of seconds that we are willing to wait
   for preferred route.
   """
-  otherThanPreferredRoutesPenalty: Int @deprecated(reason: "Not implemented")
+  otherThanPreferredRoutesPenalty: Int @deprecated(reason : "Not implemented")
   "A comma-separated list of ids of the routes preferred by the user."
-  routes: String @deprecated(reason: "Not implemented")
+  routes: String @deprecated(reason : "Not implemented")
 }
 
 """

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/TransitRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/TransitRequestTest.java
@@ -38,8 +38,6 @@ class TransitRequestTest {
 
   private final TransitRequest subject = TransitRequest.of()
     .setFilters(FILTERS)
-    .withPreferredAgencies(AGENCIES)
-    .withPreferredRoutes(ROUTES)
     .withBannedTrips(BANNED_TRIPS)
     .withPriorityGroupsByAgency(PRIORITY_GROUP_BY_AGENCY)
     .addPriorityGroupsGlobal(PRIORITY_GROUP_GLOBAL)
@@ -58,19 +56,9 @@ class TransitRequestTest {
   }
 
   @Test
-  void preferredAgencies() {
-    assertEquals(AGENCIES, subject.preferredAgencies());
-  }
-
-  @Test
   void unpreferredAgencies() {
     var subject = TransitRequest.of().withUnpreferredAgencies(AGENCIES).build();
     assertEquals(AGENCIES, subject.unpreferredAgencies());
-  }
-
-  @Test
-  void preferredRoutes() {
-    assertEquals(ROUTES, subject.preferredRoutes());
   }
 
   @Test
@@ -127,8 +115,6 @@ class TransitRequestTest {
       """
       (
         filters: [(select: [(transportModes: EMPTY, agencies: [A:1])])],
-        preferredAgencies: [F:A:1],
-        preferredRoutes: [F:R:1],
         bannedTrips: [F:T:1],
         priorityGroupsByAgency: [(subModeRegexp: [A.*])],
         priorityGroupsGlobal: [(subModeRegexp: [G.*])],


### PR DESCRIPTION
### Summary

This feature has never worked in OTP2 so I'm deprecating it in the GTFS API schema (since some US users were confused).

I'm also removing it from the internal model because it isn't used at all.

I also removed the mapping code from the Transmodel API. In its schema doesn't it doesn't even exist so this is copy and paste code from ancient times.