### PR TITLE
Simplify fetching entire trip from an estimatedCall

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.opentripplanner.apis.transmodel.mapping.OccupancyStatusMapper;
 import org.opentripplanner.apis.transmodel.model.EnumTypes;
@@ -257,6 +258,21 @@ public class EstimatedCallType {
           .type(new GraphQLNonNull(TransmodelScalars.DATE_SCALAR))
           .description("The date the estimated call is valid for.")
           .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getServiceDay())
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition.newFieldDefinition()
+          .name("serviceJourneyEstimatedCalls")
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(REF))))
+          .description("All estimated calls for the ServiceJourney on this date.")
+          .dataFetcher(environment -> {
+            return GqlUtil.getTransitService(environment)
+              .findTripTimesOnDate(
+                environment.<TripTimeOnDate>getSource().getTrip(),
+                environment.<TripTimeOnDate>getSource().getServiceDay()
+              )
+              .orElse(List.of());
+          })
           .build()
       )
       .field(

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -253,6 +253,8 @@ type EstimatedCall {
   "Whether vehicle will only stop on request."
   requestStop: Boolean!
   serviceJourney: ServiceJourney!
+  "All estimated calls for the ServiceJourney on this date."
+  serviceJourneyEstimatedCalls: [EstimatedCall!]!
   "Get all relevant situations for this EstimatedCall."
   situations: [PtSituationElement!]! @timingData
   stopPositionInPattern: Int!


### PR DESCRIPTION
We frequently get questions on how the fetch the rest of the trip - for the correct date - on e.g. departure-board-queries.

This PR adds the possibility to fetch this more easily.