### PR TITLE
Improve performance of trip updates by caching hashes

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/i18n/TranslatedString.java
+++ b/application/src/main/java/org/opentripplanner/framework/i18n/TranslatedString.java
@@ -27,6 +27,7 @@ public class TranslatedString implements I18NString, Serializable {
   private static final HashMap<Map<String, String>, I18NString> translationCache = new HashMap<>();
 
   private final Map<String, String> translations = new HashMap<>();
+  private final int hashCode;
 
   private TranslatedString(Map<String, String> translations) {
     for (Map.Entry<String, String> i : translations.entrySet()) {
@@ -36,6 +37,7 @@ public class TranslatedString implements I18NString, Serializable {
         this.translations.put(i.getKey().toLowerCase(), i.getValue());
       }
     }
+    this.hashCode = Objects.hash(translations);
   }
 
   public static I18NString getI18NString(String untranslated, String... translations) {
@@ -98,7 +100,7 @@ public class TranslatedString implements I18NString, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(translations);
+    return hashCode;
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
@@ -38,6 +38,7 @@ public final class RealTimeTripTimes implements TripTimes {
   private final I18NString[] stopHeadsigns;
   private final OccupancyStatus[] occupancyStatus;
   private final Accessibility wheelchairAccessibility;
+  private final int hash;
 
   RealTimeTripTimes(RealTimeTripTimesBuilder builder) {
     scheduledTripTimes = builder.scheduledTripTimes();
@@ -50,6 +51,7 @@ public final class RealTimeTripTimes implements TripTimes {
     occupancyStatus = builder.occupancyStatus();
     wheelchairAccessibility = builder.wheelchairAccessibility();
     validateNonIncreasingTimes();
+    hash = hash();
   }
 
   /**
@@ -65,6 +67,7 @@ public final class RealTimeTripTimes implements TripTimes {
     this.stopHeadsigns = original.stopHeadsigns;
     this.occupancyStatus = original.occupancyStatus;
     this.wheelchairAccessibility = original.wheelchairAccessibility;
+    hash = hash();
   }
 
   /**
@@ -83,6 +86,7 @@ public final class RealTimeTripTimes implements TripTimes {
     this.stopHeadsigns = original.stopHeadsigns;
     this.occupancyStatus = original.occupancyStatus;
     this.wheelchairAccessibility = original.wheelchairAccessibility;
+    hash = hash();
   }
 
   ScheduledTripTimes scheduledTripTimes() {
@@ -370,6 +374,10 @@ public final class RealTimeTripTimes implements TripTimes {
 
   @Override
   public int hashCode() {
+    return hash;
+  }
+
+  public int hash() {
     return Objects.hash(
       scheduledTripTimes,
       Arrays.hashCode(arrivalTimes),

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
@@ -53,6 +53,7 @@ public final class ScheduledTripTimes implements TripTimes {
   private final Trip trip;
   private final List<BookingInfo> dropOffBookingInfos;
   private final List<BookingInfo> pickupBookingInfos;
+  private final int hash;
 
   /**
    * Any number of array elements may point to the same I18NString instance if the headsign remains
@@ -86,6 +87,7 @@ public final class ScheduledTripTimes implements TripTimes {
     this.headsignVias = builder.headsignVias();
     this.gtfsSequenceOfStopIndex = builder.gtfsSequenceOfStopIndex();
     validate();
+    this.hash = hash();
   }
 
   /**
@@ -343,6 +345,10 @@ public final class ScheduledTripTimes implements TripTimes {
 
   @Override
   public int hashCode() {
+    return hash;
+  }
+
+  private int hash() {
     return Objects.hash(
       timeShift,
       serviceCode,


### PR DESCRIPTION
### Summary

Cache hashes so they don't need to computed on each trip update. Computing hashes for stop time based headsigns (especially with translations) is quite slow.

### Issue

Closes #6820 

### Unit tests

Not sure if needed

### Documentation

Not needed

### Changelog

From title

