### PR TITLE
Minor improvements in vertex to area linking

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/SafetyValueNormalizer.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/SafetyValueNormalizer.java
@@ -62,8 +62,8 @@ class SafetyValueNormalizer {
           if (seenAreas.contains(areaGroup)) continue;
           seenAreas.add(areaGroup);
           for (Area area : areaGroup.getAreas()) {
-            area.setBicycleSafetyMultiplier(area.getBicycleSafetyMultiplier() / bestBikeSafety);
-            area.setWalkSafetyMultiplier(area.getWalkSafetyMultiplier() / bestWalkSafety);
+            area.setBicycleSafety(area.getBicycleSafety() / bestBikeSafety);
+            area.setWalkSafety(area.getWalkSafety() / bestWalkSafety);
           }
         }
         applyFactors(seenEdges, e);

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/SafetyValueNormalizer.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/SafetyValueNormalizer.java
@@ -62,8 +62,8 @@ class SafetyValueNormalizer {
           if (seenAreas.contains(areaGroup)) continue;
           seenAreas.add(areaGroup);
           for (Area area : areaGroup.getAreas()) {
-            area.setBicycleSafety(area.getBicycleSafety() / bestBikeSafety);
-            area.setWalkSafety(area.getWalkSafety() / bestWalkSafety);
+            area.setBicycleSafety((float) (area.getBicycleSafety() / bestBikeSafety));
+            area.setWalkSafety((float) (area.getWalkSafety() / bestWalkSafety));
           }
         }
         applyFactors(seenEdges, e);

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -548,11 +548,8 @@ class WalkableAreaBuilder {
       namedArea.setName(name);
 
       WayProperties wayData = findAreaProperties(areaEntity);
-      double bicycleSafety = wayData.bicycleSafety();
-      namedArea.setBicycleSafety(bicycleSafety);
-
-      double walkSafety = wayData.walkSafety();
-      namedArea.setWalkSafety(walkSafety);
+      namedArea.setBicycleSafety((float) wayData.bicycleSafety());
+      namedArea.setWalkSafety((float) wayData.walkSafety());
       namedArea.setGeometry(intersection);
       namedArea.setPermission(wayData.getPermission());
       areaGroup.addArea(namedArea);

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -186,9 +186,10 @@ class WalkableAreaBuilder {
       HashSet<IntersectionVertex> platformLinkingVertices = new HashSet<>();
       HashSet<IntersectionVertex> visibilityVertices = new HashSet<>();
       GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
-      OsmEntity areaEntity = group.getSomeOsmObject();
 
       for (OsmArea area : group.areas) {
+        OsmEntity areaEntity = area.parent;
+
         // test if area is inside the current ring
         if (!group.isSimpleAreaGroup()) {
           if (!polygon.contains(area.jtsMultiPolygon)) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -553,7 +553,7 @@ class WalkableAreaBuilder {
 
       double walkSafety = wayData.walkSafety();
       namedArea.setWalkSafety(walkSafety);
-      namedArea.setOriginalEdges(intersection);
+      namedArea.setGeometry(intersection);
       namedArea.setPermission(wayData.getPermission());
       areaGroup.addArea(namedArea);
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -549,10 +549,10 @@ class WalkableAreaBuilder {
 
       WayProperties wayData = findAreaProperties(areaEntity);
       double bicycleSafety = wayData.bicycleSafety();
-      namedArea.setBicycleSafetyMultiplier(bicycleSafety);
+      namedArea.setBicycleSafety(bicycleSafety);
 
       double walkSafety = wayData.walkSafety();
-      namedArea.setWalkSafetyMultiplier(walkSafety);
+      namedArea.setWalkSafety(walkSafety);
       namedArea.setOriginalEdges(intersection);
       namedArea.setPermission(wayData.getPermission());
       areaGroup.addArea(namedArea);

--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -753,8 +753,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor(hit.getBicycleSafetyMultiplier())
-      .withWalkSafetyFactor(hit.getWalkSafetyMultiplier())
+      .withBicycleSafetyFactor(hit.getBicycleSafety())
+      .withWalkSafetyFactor(hit.getWalkSafety())
       .withBack(false)
       .withArea(ag);
     for (TraverseMode tm : outgoingNoThruModes) {
@@ -772,8 +772,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor(hit.getBicycleSafetyMultiplier())
-      .withWalkSafetyFactor(hit.getWalkSafetyMultiplier())
+      .withBicycleSafetyFactor(hit.getBicycleSafety())
+      .withWalkSafetyFactor(hit.getWalkSafety())
       .withBack(true)
       .withArea(ag);
     for (TraverseMode tm : incomingNoThruModes) {

--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -753,6 +753,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
+      .withBicycleSafetyFactor(hit.getBicycleSafetyMultiplier())
+      .withWalkSafetyFactor(hit.getWalkSafetyMultiplier())
       .withBack(false)
       .withArea(ag);
     for (TraverseMode tm : outgoingNoThruModes) {
@@ -770,6 +772,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
+      .withBicycleSafetyFactor(hit.getBicycleSafetyMultiplier())
+      .withWalkSafetyFactor(hit.getWalkSafetyMultiplier())
       .withBack(true)
       .withArea(ag);
     for (TraverseMode tm : incomingNoThruModes) {

--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -753,8 +753,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor((float) hit.getBicycleSafety())
-      .withWalkSafetyFactor((float) hit.getWalkSafety())
+      .withBicycleSafetyFactor(hit.getBicycleSafety())
+      .withWalkSafetyFactor(hit.getWalkSafety())
       .withBack(false)
       .withArea(ag);
     for (TraverseMode tm : outgoingNoThruModes) {
@@ -772,8 +772,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor((float) hit.getBicycleSafety())
-      .withWalkSafetyFactor((float) hit.getWalkSafety())
+      .withBicycleSafetyFactor(hit.getBicycleSafety())
+      .withWalkSafetyFactor(hit.getWalkSafety())
       .withBack(true)
       .withArea(ag);
     for (TraverseMode tm : incomingNoThruModes) {

--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -743,8 +743,9 @@ public class VertexLinker {
     double length = SphericalDistanceLibrary.distance(to.getCoordinate(), from.getCoordinate());
     // apply consistent NoThru restrictions
     // if all joining edges are nothru, then the new edge should be as well
+    // 'from' is the new vertex to be connected, so check the 'to' vertex connections
     var incomingNoThruModes = getNoThruModes(to.getIncoming());
-    var outgoingNoThruModes = getNoThruModes(to.getIncoming());
+    var outgoingNoThruModes = getNoThruModes(to.getOutgoing());
     AreaEdgeBuilder areaEdgeBuilder = new AreaEdgeBuilder()
       .withFromVertex(from)
       .withToVertex(to)

--- a/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/VertexLinker.java
@@ -753,8 +753,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor(hit.getBicycleSafety())
-      .withWalkSafetyFactor(hit.getWalkSafety())
+      .withBicycleSafetyFactor((float) hit.getBicycleSafety())
+      .withWalkSafetyFactor((float) hit.getWalkSafety())
       .withBack(false)
       .withArea(ag);
     for (TraverseMode tm : outgoingNoThruModes) {
@@ -772,8 +772,8 @@ public class VertexLinker {
       .withName(hit.getName())
       .withMeterLength(length)
       .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor(hit.getBicycleSafety())
-      .withWalkSafetyFactor(hit.getWalkSafety())
+      .withBicycleSafetyFactor((float) hit.getBicycleSafety())
+      .withWalkSafetyFactor((float) hit.getWalkSafety())
       .withBack(true)
       .withArea(ag);
     for (TraverseMode tm : incomingNoThruModes) {

--- a/application/src/main/java/org/opentripplanner/street/model/edge/Area.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/Area.java
@@ -13,8 +13,8 @@ public final class Area implements Serializable {
 
   private Geometry geometry;
   private I18NString name;
-  private double bicycleSafetyMultiplier;
-  private double walkSafetyMultiplier;
+  private double bicycleSafety;
+  private double walkSafety;
   private StreetTraversalPermission permission;
 
   public I18NString getName() {
@@ -33,20 +33,20 @@ public final class Area implements Serializable {
     this.geometry = geometry;
   }
 
-  public double getBicycleSafetyMultiplier() {
-    return bicycleSafetyMultiplier;
+  public double getBicycleSafety() {
+    return bicycleSafety;
   }
 
-  public void setBicycleSafetyMultiplier(double bicycleSafetyMultiplier) {
-    this.bicycleSafetyMultiplier = bicycleSafetyMultiplier;
+  public void setBicycleSafety(double bicycleSafety) {
+    this.bicycleSafety = bicycleSafety;
   }
 
-  public double getWalkSafetyMultiplier() {
-    return walkSafetyMultiplier;
+  public double getWalkSafety() {
+    return walkSafety;
   }
 
-  public void setWalkSafetyMultiplier(double walkSafetyMultiplier) {
-    this.walkSafetyMultiplier = walkSafetyMultiplier;
+  public void setWalkSafety(double walkSafety) {
+    this.walkSafety = walkSafety;
   }
 
   public StreetTraversalPermission getPermission() {

--- a/application/src/main/java/org/opentripplanner/street/model/edge/Area.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/Area.java
@@ -29,7 +29,7 @@ public final class Area implements Serializable {
     return geometry;
   }
 
-  public void setOriginalEdges(Geometry geometry) {
+  public void setGeometry(Geometry geometry) {
     this.geometry = geometry;
   }
 

--- a/application/src/main/java/org/opentripplanner/street/model/edge/Area.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/Area.java
@@ -13,8 +13,8 @@ public final class Area implements Serializable {
 
   private Geometry geometry;
   private I18NString name;
-  private double bicycleSafety;
-  private double walkSafety;
+  private float bicycleSafety;
+  private float walkSafety;
   private StreetTraversalPermission permission;
 
   public I18NString getName() {
@@ -33,19 +33,19 @@ public final class Area implements Serializable {
     this.geometry = geometry;
   }
 
-  public double getBicycleSafety() {
+  public float getBicycleSafety() {
     return bicycleSafety;
   }
 
-  public void setBicycleSafety(double bicycleSafety) {
+  public void setBicycleSafety(float bicycleSafety) {
     this.bicycleSafety = bicycleSafety;
   }
 
-  public double getWalkSafety() {
+  public float getWalkSafety() {
     return walkSafety;
   }
 
-  public void setWalkSafety(double walkSafety) {
+  public void setWalkSafety(float walkSafety) {
     this.walkSafety = walkSafety;
   }
 

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
@@ -25,6 +25,7 @@ import org.opentripplanner.street.model.edge.AreaEdgeBuilder;
 import org.opentripplanner.street.model.edge.AreaGroup;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.LinkingDirection;
+import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
@@ -74,6 +75,8 @@ public class LinkStopToPlatformTest {
     // AreaGroup must include a valid Area which defines area attributes
     Area area = new Area();
     area.setName(new LocalizedString("test platform"));
+    area.setWalkSafety(0.5);
+    area.setBicycleSafety(0.5);
     area.setPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
     area.setGeometry(polygon);
     areaGroup.addArea(area);
@@ -250,6 +253,17 @@ public class LinkStopToPlatformTest {
 
     // vertex links to the single visibility point with 2 edges
     assertEquals(10, graph.getEdges().size());
+
+    // check that link edges obey area safety factors
+    var out = v.getOutgoing();
+    assertEquals(out.size(), 1);
+    StreetEdge streetEdge = null;
+    if (out.iterator().next() instanceof StreetEdge se) {
+      streetEdge = se;
+      assertEquals(0.5, se.getWalkSafetyFactor());
+      assertEquals(0.5, se.getBicycleSafetyFactor());
+    }
+    assertNotNull(streetEdge);
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
@@ -75,7 +75,7 @@ public class LinkStopToPlatformTest {
     Area area = new Area();
     area.setName(new LocalizedString("test platform"));
     area.setPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-    area.setOriginalEdges(polygon);
+    area.setGeometry(polygon);
     areaGroup.addArea(area);
 
     for (int i = 0; i < platform.length; i++) {

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkStopToPlatformTest.java
@@ -75,8 +75,8 @@ public class LinkStopToPlatformTest {
     // AreaGroup must include a valid Area which defines area attributes
     Area area = new Area();
     area.setName(new LocalizedString("test platform"));
-    area.setWalkSafety(0.5);
-    area.setBicycleSafety(0.5);
+    area.setWalkSafety(0.5f);
+    area.setBicycleSafety(0.5f);
     area.setPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
     area.setGeometry(polygon);
     areaGroup.addArea(area);


### PR DESCRIPTION
### Summary

- No through traffic properties are now assigned more accurately to created edges 
- Area safety properties are now assigned as well
- Walkable area builder uses consistent parent entity in vertex generation. previously,  a random entity from the area group was used.  
- Some method renaming  

### Unit tests

One unit test added to verify that area safety factors are considered

NOTE: The test is a bit flaky, apparently because of double to float conversion. Test values are chosen to avoid value drifting.

### Documentation

Javadoc added to explain the no through logic.
