### PR TITLE
Enforce flex rule: at least two stop times per trip

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
@@ -31,7 +31,7 @@ class FlexTripsMapperTest {
   }
 
   /**
-   * Checks that a flex trip with a single stop time is not mapped to a flex trip and an issue is reported.
+   * Checks that a trip with a single stop time is not mapped to a flex trip and an issue is reported.
    */
   @Test
   void tooFewStopTimes() {

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
@@ -41,7 +41,7 @@ class FlexTripsMapperTest {
     var trips = FlexTripsMapper.createFlexTrips(builder, issueStore);
     assertEquals(0, trips.size());
     assertEquals(
-      "[Issue{type: 'InvalidFlexTrip', message: 'Trip F:flex defines only a single flex stop time, which is invalid: https://gtfs.org/documentation/schedule/examples/flex/'}]",
+      "[Issue{type: 'InvalidFlexTrip', message: 'Trip F:flex defines only a single stop time, which is invalid: https://gtfs.org/documentation/schedule/examples/flex/'}]",
       issueStore.listIssues().toString()
     );
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/FlexTripsMapperTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.flex.trip;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.opentripplanner.ext.flex.FlexStopTimesForTest.area;
 import static org.opentripplanner.graph_builder.issue.api.DataImportIssueStore.NOOP;
 
 import java.util.List;
@@ -9,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.flex.FlexStopTimesForTest;
 import org.opentripplanner.ext.flex.FlexTripsMapper;
 import org.opentripplanner.ext.flex.flexpathcalculator.DirectFlexPathCalculator;
-import org.opentripplanner.model.StopTime;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.service.SiteRepository;
 
 class FlexTripsMapperTest {
@@ -19,19 +20,29 @@ class FlexTripsMapperTest {
   @Test
   void defaultTimePenalty() {
     var builder = new OtpTransitServiceBuilder(SiteRepository.of().build(), NOOP);
-    var stopTimes = List.of(stopTime(0), stopTime(1));
-    builder.getStopTimesSortedByTrip().addAll(stopTimes);
+    builder
+      .getStopTimesSortedByTrip()
+      .addAll(List.of(area("10:00", "18:00"), area("10:00", "18:00")));
     var trips = FlexTripsMapper.createFlexTrips(builder, NOOP);
-    assertEquals("[UnscheduledTrip{F:flex-1}]", trips.toString());
+    assertEquals("[UnscheduledTrip{F:flex}]", trips.toString());
     var unscheduled = (UnscheduledTrip) trips.getFirst();
     var unchanged = unscheduled.decorateFlexPathCalculator(new DirectFlexPathCalculator());
     assertInstanceOf(DirectFlexPathCalculator.class, unchanged);
   }
 
-  private static StopTime stopTime(int seq) {
-    var st = FlexStopTimesForTest.area("08:00", "18:00");
-    st.setTrip(TimetableRepositoryForTest.trip("flex-1").build());
-    st.setStopSequence(seq);
-    return st;
+  /**
+   * Checks that a flex trip with a single stop time is not mapped to a flex trip and an issue is reported.
+   */
+  @Test
+  void tooFewStopTimes() {
+    var issueStore = new DefaultDataImportIssueStore();
+    var builder = new OtpTransitServiceBuilder(SiteRepository.of().build(), issueStore);
+    builder.getStopTimesSortedByTrip().addAll(List.of(area("10:00", "18:00")));
+    var trips = FlexTripsMapper.createFlexTrips(builder, issueStore);
+    assertEquals(0, trips.size());
+    assertEquals(
+      "[Issue{type: 'InvalidFlexTrip', message: 'Trip F:flex defines only a single flex stop time, which is invalid: https://gtfs.org/documentation/schedule/examples/flex/'}]",
+      issueStore.listIssues().toString()
+    );
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripTest.java
@@ -45,7 +45,8 @@ class ScheduledDeviatedTripTest {
         areaWithContinuousStopping("10:40"),
         regularStop("10:50", "11:00")
       ),
-      List.of(regularStop("10:10"), regularStop("10:20"))
+      List.of(regularStop("10:10"), regularStop("10:20")),
+      List.of(area("10:00", "18:00"))
     );
   }
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledDrivingDurationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledDrivingDurationTest.java
@@ -27,7 +27,7 @@ class UnscheduledDrivingDurationTest {
 
   @Test
   void noPenalty() {
-    var trip = UnscheduledTrip.of(id("1")).withStopTimes(List.of(STOP_TIME)).build();
+    var trip = UnscheduledTrip.of(id("1")).withStopTimes(List.of(STOP_TIME, STOP_TIME)).build();
 
     var calculator = trip.decorateFlexPathCalculator(STATIC_CALCULATOR);
     var path = calculator.calculateFlexPath(V1, V2, 0, 0);
@@ -37,7 +37,7 @@ class UnscheduledDrivingDurationTest {
   @Test
   void withPenalty() {
     var trip = UnscheduledTrip.of(id("1"))
-      .withStopTimes(List.of(STOP_TIME))
+      .withStopTimes(List.of(STOP_TIME, STOP_TIME))
       .withTimePenalty(TimePenalty.of(Duration.ofMinutes(2), 1.5f))
       .build();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
@@ -62,6 +62,7 @@ class UnscheduledTripTest {
     static List<List<StopTime>> notUnscheduled() {
       return List.of(
         List.of(),
+        List.of(UNSCHEDULED_STOP),
         List.of(SCHEDULED_STOP),
         List.of(SCHEDULED_STOP, SCHEDULED_STOP),
         List.of(SCHEDULED_STOP, SCHEDULED_STOP, SCHEDULED_STOP),
@@ -80,7 +81,6 @@ class UnscheduledTripTest {
 
     static List<List<StopTime>> unscheduled() {
       return List.of(
-        List.of(UNSCHEDULED_STOP),
         List.of(UNSCHEDULED_STOP, SCHEDULED_STOP),
         List.of(SCHEDULED_STOP, UNSCHEDULED_STOP),
         List.of(UNSCHEDULED_STOP, UNSCHEDULED_STOP),

--- a/application/src/ext-test/resources/org/opentripplanner/ext/flex/aspen-flex-on-demand.gtfs/calendar_dates.txt
+++ b/application/src/ext-test/resources/org/opentripplanner/ext/flex/aspen-flex-on-demand.gtfs/calendar_dates.txt
@@ -1,1 +1,0 @@
-date,service_id,holiday_name,exception_type

--- a/application/src/ext-test/resources/org/opentripplanner/ext/flex/aspen-flex-on-demand.gtfs/stop_times.txt
+++ b/application/src/ext-test/resources/org/opentripplanner/ext/flex/aspen-flex-on-demand.gtfs/stop_times.txt
@@ -1,3 +1,5 @@
 trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,shape_dist_traveled,timepoint,continuous_pickup,continuous_drop_off,pickup_booking_rule_id,drop_off_booking_rule_id,start_pickup_drop_off_window,end_pickup_drop_off_window,mean_duration_factor,mean_duration_offset,safe_duration_factor,safe_duration_offset
 t_1289257_b_28352_tn_0,,,area_294,1,,2,2,0,0,1,1,booking_route_17102,booking_route_17102,08:00:00,23:00:00,1,9.00,1,20.00
+t_1289257_b_28352_tn_0,,,area_294,1,,2,2,0,0,1,1,booking_route_17102,booking_route_17102,08:00:00,23:00:00,1,9.00,1,20.00
+t_1289262_b_29084_tn_0,,,area_294,1,,2,2,0,0,1,1,booking_route_17102,booking_route_17102,11:00:00,23:00:00,1,9.00,1,20.00
 t_1289262_b_29084_tn_0,,,area_294,1,,2,2,0,0,1,1,booking_route_17102,booking_route_17102,11:00:00,23:00:00,1,9.00,1,20.00

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -53,7 +53,7 @@ public class FlexTripsMapper {
         );
         // result.add(new ContinuousPickupDropOffTrip(trip, stopTimes));
       } else if (
-        stopTimes.size() >= 2 &&
+        stopTimes.size() < 2 &&
         stopTimes.stream().anyMatch(st -> st.hasFlexWindow() || st.hasFlexibleStop())
       ) {
         store.add(

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -58,7 +58,7 @@ public class FlexTripsMapper {
       ) {
         store.add(
           "InvalidFlexTrip",
-          "Trip %s defines only a single flex stop time, which is invalid: https://gtfs.org/documentation/schedule/examples/flex/",
+          "Trip %s defines only a single stop time, which is invalid: https://gtfs.org/documentation/schedule/examples/flex/",
           trip.getId()
         );
       }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.ext.flex;
 
-import static org.opentripplanner.model.PickDrop.NONE;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
@@ -54,6 +52,15 @@ public class FlexTripsMapper {
           trip.getId()
         );
         // result.add(new ContinuousPickupDropOffTrip(trip, stopTimes));
+      } else if (
+        stopTimes.size() >= 2 &&
+        stopTimes.stream().anyMatch(st -> st.hasFlexWindow() || st.hasFlexibleStop())
+      ) {
+        store.add(
+          "InvalidFlexTrip",
+          "Trip %s defines only a single flex stop time, which is invalid: https://gtfs.org/documentation/schedule/examples/flex/",
+          trip.getId()
+        );
       }
 
       //Keep lambda! A method-ref would cause incorrect class and line number to be logged
@@ -63,13 +70,5 @@ public class FlexTripsMapper {
     LOG.info(progress.completeMessage());
     LOG.info("Done creating flex trips. Created a total of {} trips.", result.size());
     return result;
-  }
-
-  private static boolean hasContinuousStops(List<StopTime> stopTimes) {
-    return stopTimes
-      .stream()
-      .anyMatch(
-        st -> st.getFlexContinuousPickup() != NONE || st.getFlexContinuousDropOff() != NONE
-      );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexTemplateFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexTemplateFactory.java
@@ -99,7 +99,7 @@ class FlexTemplateFactory {
   }
 
   /**
-   * With respect to one journey/itinerary this method retuns {@code true} if a passenger can
+   * With respect to one journey/itinerary this method returns {@code true} if a passenger can
    * board and alight at the same stop in the journey pattern. This is not allowed for regular
    * stops, but it would make sense to allow it for area stops or group stops.
    * <p>

--- a/application/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -55,9 +55,9 @@ public class ScheduledDeviatedTrip
   }
 
   public static boolean isScheduledDeviatedFlexTrip(List<StopTime> stopTimes) {
-    Predicate<StopTime> notFixedStop = Predicate.not(st -> st.getStop() instanceof RegularStop);
     return (
-      stopTimes.stream().anyMatch(notFixedStop) &&
+      stopTimes.size() >= 2 &&
+      stopTimes.stream().anyMatch(StopTime::hasFlexibleStop) &&
       stopTimes.stream().noneMatch(StopTime::combinesContinuousStoppingWithFlexWindow)
     );
   }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -36,8 +36,6 @@ import org.opentripplanner.utils.time.DurationUtils;
  */
 public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBuilder> {
 
-  private static final Set<Integer> N_STOPS = Set.of(2);
-
   private final StopTimeWindow[] stopTimes;
 
   private final BookingInfo[] dropOffBookingInfos;
@@ -83,7 +81,8 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
       return false;
     } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlexWindow)) {
       return false;
-    } else if (N_STOPS.contains(stopTimes.size())) {
+      // special case: one fixed stop and a flexible window
+    } else if (stopTimes.size() == 2) {
       return stopTimes.stream().anyMatch(StopTime::hasFlexWindow);
     } else {
       return stopTimes.stream().allMatch(StopTime::hasFlexWindow);

--- a/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -36,7 +36,7 @@ import org.opentripplanner.utils.time.DurationUtils;
  */
 public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBuilder> {
 
-  private static final Set<Integer> N_STOPS = Set.of(1, 2);
+  private static final Set<Integer> N_STOPS = Set.of(2);
 
   private final StopTimeWindow[] stopTimes;
 
@@ -79,7 +79,7 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
    *  - One or more stop times with a flexible time window but no fixed stop in between them
    */
   public static boolean isUnscheduledTrip(List<StopTime> stopTimes) {
-    if (stopTimes.isEmpty()) {
+    if (stopTimes.size() < 2) {
       return false;
     } else if (stopTimes.stream().anyMatch(StopTime::combinesContinuousStoppingWithFlexWindow)) {
       return false;

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -5,6 +5,8 @@ import static org.opentripplanner.model.PickDrop.NONE;
 
 import java.util.List;
 import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.StopTimeKey;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -248,11 +250,6 @@ public final class StopTime implements Comparable<StopTime> {
     return this.getStopSequence() - o.getStopSequence();
   }
 
-  public void cancel() {
-    pickupType = PickDrop.CANCELLED;
-    dropOffType = PickDrop.CANCELLED;
-  }
-
   @Override
   public String toString() {
     return (
@@ -297,5 +294,12 @@ public final class StopTime implements Comparable<StopTime> {
 
   public boolean hasContinuousStopping() {
     return this.flexContinuousPickup != NONE || flexContinuousDropOff != NONE;
+  }
+
+  /**
+   * Does this stop time define either an area stop or a group of stops?
+   */
+  public boolean hasFlexibleStop() {
+    return stop instanceof AreaStop || stop instanceof GroupStop;
   }
 }

--- a/application/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/application/src/main/java/org/opentripplanner/model/StopTime.java
@@ -206,16 +206,8 @@ public final class StopTime implements Comparable<StopTime> {
     return getAvailableTime(getFlexWindowEnd(), getArrivalTime());
   }
 
-  public PickDrop getFlexContinuousPickup() {
-    return flexContinuousPickup;
-  }
-
   public void setFlexContinuousPickup(PickDrop flexContinuousPickup) {
     this.flexContinuousPickup = flexContinuousPickup;
-  }
-
-  public PickDrop getFlexContinuousDropOff() {
-    return flexContinuousDropOff;
   }
 
   public void setFlexContinuousDropOff(PickDrop flexContinuousDropOff) {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
@@ -83,7 +83,8 @@ class StreetLinkerModuleTest {
   void linkFlexStop() {
     OTPFeature.FlexRouting.testOn(() -> {
       var model = new TestModel();
-      var flexTrip = TimetableRepositoryForTest.of().unscheduledTrip("flex", model.stop());
+      var flexTrip = TimetableRepositoryForTest.of()
+        .unscheduledTrip("flex", model.stop(), model.stop());
       model.withFlexTrip(flexTrip);
 
       var module = model.streetLinkerModule();
@@ -112,7 +113,8 @@ class StreetLinkerModuleTest {
   void linkFlexStopWithBoardingLocation() {
     OTPFeature.FlexRouting.testOn(() -> {
       var model = new TestModel().withStopLinkedToBoardingLocation();
-      var flexTrip = TimetableRepositoryForTest.of().unscheduledTrip("flex", model.stop());
+      var flexTrip = TimetableRepositoryForTest.of()
+        .unscheduledTrip("flex", model.stop(), model.stop());
       model.withFlexTrip(flexTrip);
 
       var module = model.streetLinkerModule();


### PR DESCRIPTION
### Summary

Both the GTFS and NeTEx specs require flex trips, just like regular ones, to have at least 2 stop times/passing times.

Even though our flex routing engine doesn't produce a result when you have a trip with a single stop time, we nevertheless import the data anyway and then do nothing with it. It may end up in API response which can be quite confusing.

For this reason, this PR rejects flex trips with fewer than 2 stop times and adds an issue to the store.

### Issue

No.

### Unit tests

Added.
