### PR TITLE
Doc: Update JavaDoc RaptorTransfer

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorTransfer.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorTransfer.java
@@ -4,6 +4,7 @@ import org.opentripplanner.utils.time.DurationUtils;
 
 /**
  * Encapsulate information about a transfer path.
+ * Time dependent transfers are not supported.
  */
 public interface RaptorTransfer {
   /**
@@ -26,11 +27,6 @@ public interface RaptorTransfer {
    * the journey origin, but just stop to stop.
    */
   int durationInSeconds();
-
-  /* TIME-DEPENDENT ACCESS/TRANSFER/EGRESS */
-  // The methods below should be only overridden when a RaptorTransfer is only available at
-  // specific times, such as flexible transit, TNC or shared vehicle schemes with limited opening
-  // hours, not for regular access/transfer/egress.
 
   /** Call this from toString */
   default String asString() {


### PR DESCRIPTION
### Summary

Small JavaDoc change. The comment deleted was forgotten when the RaptorTransfer was split in two (Transfer and AccessEgress), it only apply to access and egress.

### Issue

Closes #6823

This issue is NOT fixed, but I will explain way in the issue.


### Unit tests

No code changed

### Documentation

✅ 

### Changelog

🟥 

### Bumping the serialization version id

Not needed