### PR TITLE
ORCA September fare updates

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/OrcaFareServiceTest.java
@@ -313,12 +313,12 @@ public class OrcaFareServiceTest {
     calculateFare(rides, FareType.electronicYouth, Money.ZERO_USD);
 
     rides = List.of(getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "404", "west"));
-    calculateFare(rides, regular, usDollars(10f));
-    calculateFare(rides, FareType.senior, usDollars(5f));
+    calculateFare(rides, regular, usDollars(12f));
+    calculateFare(rides, FareType.senior, usDollars(6f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
-    calculateFare(rides, FareType.electronicSpecial, usDollars(5f));
-    calculateFare(rides, FareType.electronicRegular, usDollars(10f));
-    calculateFare(rides, FareType.electronicSenior, usDollars(5f));
+    calculateFare(rides, FareType.electronicSpecial, usDollars(6f));
+    calculateFare(rides, FareType.electronicRegular, usDollars(12f));
+    calculateFare(rides, FareType.electronicSenior, usDollars(6f));
     calculateFare(rides, FareType.electronicYouth, Money.ZERO_USD);
   }
 
@@ -439,17 +439,16 @@ public class OrcaFareServiceTest {
   @Test
   void calculateTransferExtension() {
     List<Leg> rides = List.of(
-      getLeg(KITSAP_TRANSIT_AGENCY_ID, 0, 4, "Kitsap Fast Ferry", "east"), // 2.00
-      getLeg(KC_METRO_AGENCY_ID, 100), // Default ride price, extends transfer for regular fare
-      getLeg(KITSAP_TRANSIT_AGENCY_ID, 150, 4, "Kitsap Fast Ferry", "west") // 10.00
+      getLeg(KC_METRO_AGENCY_ID, 0), // extended transfer due to middle leg
+      getLeg(KC_METRO_AGENCY_ID, "973", 100), // higher fare, extends transfer
+      getLeg(KC_METRO_AGENCY_ID, 219) // extended transfer due to middle leg
     );
-    var regularFare = usDollars(2.00f).plus(DEFAULT_TEST_RIDE_PRICE).plus(usDollars(10f));
-    calculateFare(rides, regular, regularFare);
-    calculateFare(rides, FareType.senior, usDollars(7f));
+    calculateFare(rides, regular, usDollars(12.73f));
+    calculateFare(rides, FareType.senior, usDollars(4.50f));
     calculateFare(rides, FareType.youth, Money.ZERO_USD);
-    calculateFare(rides, FareType.electronicSpecial, usDollars(6f));
-    calculateFare(rides, FareType.electronicRegular, usDollars(10f)); // transfer extended on second leg
-    calculateFare(rides, FareType.electronicSenior, usDollars(6f));
+    calculateFare(rides, FareType.electronicSpecial, usDollars(3.75f));
+    calculateFare(rides, FareType.electronicRegular, usDollars(5f)); // transfer extended on second leg
+    calculateFare(rides, FareType.electronicSenior, usDollars(2.50f));
     calculateFare(rides, FareType.electronicYouth, Money.ZERO_USD);
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -59,6 +59,10 @@ public class OrcaFareService extends DefaultFareService {
   // TODO: Remove after mar 1
   private static final LocalDate CT_FARE_CHANGE_DATE = LocalDate.of(2025, 3, 1);
 
+  private static final LocalDate SEPT_FARE_CHANGE_DATE = LocalDate.of(2025, 9, 1);
+
+  private static final LocalDate KITSAP_FAST_FERRY_CHANGE_DATE = LocalDate.of(2025, 10, 1);
+
   protected enum TransferType {
     ORCA_INTERAGENCY_TRANSFER,
     SAME_AGENCY_TRANSFER,
@@ -89,8 +93,8 @@ public class OrcaFareService extends DefaultFareService {
     SKAGIT_CROSS_COUNTY,
     UNKNOWN;
 
-    public TransferType getTransferType(FareType fareType) {
-      if (usesOrca(fareType) && this.permitsFreeTransfers()) {
+    public TransferType getTransferType(FareType fareType, ZonedDateTime startTime) {
+      if (usesOrca(fareType) && this.permitsFreeTransfers(startTime)) {
         return TransferType.ORCA_INTERAGENCY_TRANSFER;
       } else if (this == KC_METRO || this == KITSAP_TRANSIT) {
         return TransferType.SAME_AGENCY_TRANSFER;
@@ -100,14 +104,19 @@ public class OrcaFareService extends DefaultFareService {
 
     /**
      * All transit agencies permit free transfers, apart from these.
+     * This overload includes startTime to handle time-based transfer restrictions.
      */
-    public boolean permitsFreeTransfers() {
+    public boolean permitsFreeTransfers(ZonedDateTime startTime) {
       return switch (this) {
         case WASHINGTON_STATE_FERRIES,
           SKAGIT_TRANSIT,
           WHATCOM_LOCAL,
           WHATCOM_CROSS_COUNTY,
           SKAGIT_CROSS_COUNTY -> false;
+        case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND,
+          KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> !startTime.isAfter(
+            KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(startTime.getZone())
+          );
         default -> true;
       };
     }
@@ -246,11 +255,11 @@ public class OrcaFareService extends DefaultFareService {
   private Optional<Money> getLegFare(
     FareType fareType,
     RideType rideType,
-    Money defaultFare,
+    Optional<Money> defaultFare,
     Leg leg
   ) {
     if (rideType == null) {
-      return Optional.of(defaultFare);
+      return defaultFare;
     }
     // Filter out agencies that don't accept ORCA from the electronic fare type
     if (usesOrca(fareType) && !rideType.agencyAcceptsOrca()) {
@@ -261,7 +270,7 @@ public class OrcaFareService extends DefaultFareService {
       case electronicSpecial -> getLiftFare(rideType, defaultFare, leg);
       case electronicSenior, senior -> getSeniorFare(fareType, rideType, defaultFare, leg);
       case regular, electronicRegular -> getRegularFare(fareType, rideType, defaultFare, leg);
-      default -> Optional.of(defaultFare);
+      default -> defaultFare;
     };
   }
 
@@ -277,52 +286,74 @@ public class OrcaFareService extends DefaultFareService {
     }
   }
 
+
+
+
   /**
    * Apply regular discount fares. If the ride type cannot be matched the default fare is used.
    */
   private Optional<Money> getRegularFare(
     FareType fareType,
     RideType rideType,
-    Money defaultFare,
+    Optional<Money> defaultFare,
     Leg leg
   ) {
     Route route = leg.route();
     if (route == null) {
-      return Optional.of(defaultFare);
+      return defaultFare;
     }
     return switch (rideType) {
-      case KC_WATER_TAXI_VASHON_ISLAND -> usesOrca(fareType)
-        ? optionalUSD(5.75f)
-        : optionalUSD(6.75f);
-      case KC_WATER_TAXI_WEST_SEATTLE -> usesOrca(fareType) ? optionalUSD(5f) : optionalUSD(5.75f);
+      case KC_WATER_TAXI_VASHON_ISLAND -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? usesOrca(fareType)
+          ? optionalUSD(5.75f)
+          : optionalUSD(6.75f)
+        : usesOrca(fareType)
+          ? optionalUSD(6.00f)
+          : optionalUSD(7.00f);
+      case KC_WATER_TAXI_WEST_SEATTLE -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? usesOrca(fareType)
+          ? optionalUSD(5.00f) // before change orca
+          : optionalUSD(5.75f) // before change cash
+        : usesOrca(fareType)
+          ? optionalUSD(5.25f) // after change orca
+          : optionalUSD( 6.25f); // after change cash
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND -> optionalUSD(2f);
-      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> optionalUSD(10f);
-      case WASHINGTON_STATE_FERRIES -> Optional.of(
-        getWashingtonStateFerriesFare(route.getLongName(), fareType, defaultFare)
-      );
+      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> leg
+        .startTime()
+        .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? optionalUSD(12.00f)
+        : optionalUSD(13.00f);
+      case WASHINGTON_STATE_FERRIES ->
+        defaultFare.map(
+          df -> getWashingtonStateFerriesFare(route.getLongName(), fareType, df)
+        );
       case SOUND_TRANSIT_BUS -> optionalUSD(3.25f);
       case WHATCOM_LOCAL,
         WHATCOM_CROSS_COUNTY,
         SKAGIT_LOCAL,
         SKAGIT_CROSS_COUNTY -> fareType.equals(FareType.electronicRegular)
         ? Optional.empty()
-        : Optional.of(defaultFare);
-      default -> Optional.of(defaultFare);
+        : defaultFare;
+      default -> defaultFare;
     };
   }
 
   /**
    * Apply Orca lift discount fares based on the ride type.
    */
-  private Optional<Money> getLiftFare(RideType rideType, Money defaultFare, Leg leg) {
+  private Optional<Money> getLiftFare(RideType rideType, Optional<Money> defaultFare, Leg leg) {
     var route = leg.route();
     if (route == null) {
-      return Optional.of(defaultFare);
+      return defaultFare;
     }
     return switch (rideType) {
       case COMM_TRANS_LOCAL_SWIFT -> getCTLocalReducedFare(leg);
-      case KC_WATER_TAXI_VASHON_ISLAND -> optionalUSD(4.5f);
-      case KC_WATER_TAXI_WEST_SEATTLE -> optionalUSD(3.75f);
+      case KC_WATER_TAXI_VASHON_ISLAND -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? optionalUSD(4.50f)
+        : optionalUSD(1.00f);
+      case KC_WATER_TAXI_WEST_SEATTLE -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? optionalUSD(3.75f)
+        : optionalUSD(1.00f);
       case KC_METRO,
         SOUND_TRANSIT,
         SOUND_TRANSIT_BUS,
@@ -333,16 +364,20 @@ public class OrcaFareService extends DefaultFareService {
         EVERETT_TRANSIT,
         PIERCE_COUNTY_TRANSIT,
         SEATTLE_STREET_CAR -> optionalUSD(1.00f);
-      case WASHINGTON_STATE_FERRIES -> Optional.of(
-        getWashingtonStateFerriesFare(route.getLongName(), FareType.electronicSpecial, defaultFare)
+      case WASHINGTON_STATE_FERRIES -> defaultFare.map(
+        df -> getWashingtonStateFerriesFare(route.getLongName(), FareType.electronicSpecial, df)
       );
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND -> optionalUSD((1f));
-      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> optionalUSD((5f));
+      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> leg
+        .startTime()
+        .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? optionalUSD(6.00f)
+        : optionalUSD(6.50f);
       case SKAGIT_LOCAL,
         SKAGIT_CROSS_COUNTY,
         WHATCOM_CROSS_COUNTY,
         WHATCOM_LOCAL -> Optional.empty();
-      default -> Optional.of(defaultFare);
+      default -> defaultFare;
     };
   }
 
@@ -352,12 +387,12 @@ public class OrcaFareService extends DefaultFareService {
   private Optional<Money> getSeniorFare(
     FareType fareType,
     RideType rideType,
-    Money defaultFare,
+    Optional<Money> defaultFare,
     Leg leg
   ) {
     var route = leg.route();
     if (route == null) {
-      return Optional.of(defaultFare);
+      return defaultFare;
     }
     // Many agencies only provide senior discount if using ORCA
     return switch (rideType) {
@@ -376,13 +411,17 @@ public class OrcaFareService extends DefaultFareService {
         KITSAP_TRANSIT -> optionalUSD(1f);
       case KC_WATER_TAXI_VASHON_ISLAND -> optionalUSD(3f);
       case KC_WATER_TAXI_WEST_SEATTLE -> optionalUSD(2.5f);
-      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> optionalUSD(5f);
+      case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> leg
+        .startTime()
+        .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? optionalUSD(6.00f)
+        : optionalUSD(6.50f);
       // Discount specific to Skagit transit and not Orca.
-      case WASHINGTON_STATE_FERRIES -> Optional.of(
-        getWashingtonStateFerriesFare(route.getLongName(), fareType, defaultFare)
+      case WASHINGTON_STATE_FERRIES -> defaultFare.map(
+        df -> getWashingtonStateFerriesFare(route.getLongName(), fareType, df)
       );
-      case WHATCOM_CROSS_COUNTY, SKAGIT_CROSS_COUNTY -> Optional.of(defaultFare.half());
-      default -> Optional.of(defaultFare);
+      case WHATCOM_CROSS_COUNTY, SKAGIT_CROSS_COUNTY -> defaultFare.map(Money::half);
+      default -> defaultFare;
     };
   }
 
@@ -452,16 +491,14 @@ public class OrcaFareService extends DefaultFareService {
       RideType rideType = getRideType(leg);
       assert rideType != null;
       Optional<Money> singleLegPrice = getRidePrice(leg, FareType.regular, fareRules);
-      Optional<Money> optionalLegFare = singleLegPrice.flatMap(slp ->
-        getLegFare(fareType, rideType, slp, leg)
-      );
+      Optional<Money> optionalLegFare = getLegFare(fareType, rideType, singleLegPrice, leg);
       if (optionalLegFare.isEmpty()) {
         // If there is no fare for this leg then skip the rest of the logic.
         continue;
       }
       Money legFare = optionalLegFare.get();
 
-      var transferType = rideType.getTransferType(fareType);
+      var transferType = rideType.getTransferType(fareType, leg.startTime());
       if (transferType == TransferType.ORCA_INTERAGENCY_TRANSFER) {
         // Important to get transfer discount before calculating next leg price
         var transferDiscount = orcaFareDiscount.getTransferDiscount();

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/OrcaFareService.java
@@ -115,8 +115,8 @@ public class OrcaFareService extends DefaultFareService {
           SKAGIT_CROSS_COUNTY -> false;
         case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND,
           KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> !startTime.isAfter(
-            KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(startTime.getZone())
-          );
+          KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(startTime.getZone())
+        );
         default -> true;
       };
     }
@@ -286,9 +286,6 @@ public class OrcaFareService extends DefaultFareService {
     }
   }
 
-
-
-
   /**
    * Apply regular discount fares. If the ride type cannot be matched the default fare is used.
    */
@@ -303,30 +300,29 @@ public class OrcaFareService extends DefaultFareService {
       return defaultFare;
     }
     return switch (rideType) {
-      case KC_WATER_TAXI_VASHON_ISLAND -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
-        ? usesOrca(fareType)
-          ? optionalUSD(5.75f)
-          : optionalUSD(6.75f)
-        : usesOrca(fareType)
-          ? optionalUSD(6.00f)
-          : optionalUSD(7.00f);
-      case KC_WATER_TAXI_WEST_SEATTLE -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+      case KC_WATER_TAXI_VASHON_ISLAND -> leg
+          .startTime()
+          .isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+        ? usesOrca(fareType) ? optionalUSD(5.75f) : optionalUSD(6.75f)
+        : usesOrca(fareType) ? optionalUSD(6.00f) : optionalUSD(7.00f);
+      case KC_WATER_TAXI_WEST_SEATTLE -> leg
+          .startTime()
+          .isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
         ? usesOrca(fareType)
           ? optionalUSD(5.00f) // before change orca
           : optionalUSD(5.75f) // before change cash
         : usesOrca(fareType)
           ? optionalUSD(5.25f) // after change orca
-          : optionalUSD( 6.25f); // after change cash
+          : optionalUSD(6.25f); // after change cash
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND -> optionalUSD(2f);
       case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> leg
-        .startTime()
-        .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+          .startTime()
+          .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
         ? optionalUSD(12.00f)
         : optionalUSD(13.00f);
-      case WASHINGTON_STATE_FERRIES ->
-        defaultFare.map(
-          df -> getWashingtonStateFerriesFare(route.getLongName(), fareType, df)
-        );
+      case WASHINGTON_STATE_FERRIES -> defaultFare.map(df ->
+        getWashingtonStateFerriesFare(route.getLongName(), fareType, df)
+      );
       case SOUND_TRANSIT_BUS -> optionalUSD(3.25f);
       case WHATCOM_LOCAL,
         WHATCOM_CROSS_COUNTY,
@@ -348,10 +344,14 @@ public class OrcaFareService extends DefaultFareService {
     }
     return switch (rideType) {
       case COMM_TRANS_LOCAL_SWIFT -> getCTLocalReducedFare(leg);
-      case KC_WATER_TAXI_VASHON_ISLAND -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+      case KC_WATER_TAXI_VASHON_ISLAND -> leg
+          .startTime()
+          .isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
         ? optionalUSD(4.50f)
         : optionalUSD(1.00f);
-      case KC_WATER_TAXI_WEST_SEATTLE -> leg.startTime().isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+      case KC_WATER_TAXI_WEST_SEATTLE -> leg
+          .startTime()
+          .isBefore(SEPT_FARE_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
         ? optionalUSD(3.75f)
         : optionalUSD(1.00f);
       case KC_METRO,
@@ -364,13 +364,13 @@ public class OrcaFareService extends DefaultFareService {
         EVERETT_TRANSIT,
         PIERCE_COUNTY_TRANSIT,
         SEATTLE_STREET_CAR -> optionalUSD(1.00f);
-      case WASHINGTON_STATE_FERRIES -> defaultFare.map(
-        df -> getWashingtonStateFerriesFare(route.getLongName(), FareType.electronicSpecial, df)
+      case WASHINGTON_STATE_FERRIES -> defaultFare.map(df ->
+        getWashingtonStateFerriesFare(route.getLongName(), FareType.electronicSpecial, df)
       );
       case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND -> optionalUSD((1f));
       case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> leg
-        .startTime()
-        .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+          .startTime()
+          .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
         ? optionalUSD(6.00f)
         : optionalUSD(6.50f);
       case SKAGIT_LOCAL,
@@ -412,13 +412,13 @@ public class OrcaFareService extends DefaultFareService {
       case KC_WATER_TAXI_VASHON_ISLAND -> optionalUSD(3f);
       case KC_WATER_TAXI_WEST_SEATTLE -> optionalUSD(2.5f);
       case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND -> leg
-        .startTime()
-        .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
+          .startTime()
+          .isBefore(KITSAP_FAST_FERRY_CHANGE_DATE.atStartOfDay(leg.startTime().getZone()))
         ? optionalUSD(6.00f)
         : optionalUSD(6.50f);
       // Discount specific to Skagit transit and not Orca.
-      case WASHINGTON_STATE_FERRIES -> defaultFare.map(
-        df -> getWashingtonStateFerriesFare(route.getLongName(), fareType, df)
+      case WASHINGTON_STATE_FERRIES -> defaultFare.map(df ->
+        getWashingtonStateFerriesFare(route.getLongName(), fareType, df)
       );
       case WHATCOM_CROSS_COUNTY, SKAGIT_CROSS_COUNTY -> defaultFare.map(Money::half);
       default -> defaultFare;


### PR DESCRIPTION
### Summary

  September 1st, 2025 - ORCA Region Changes:

  - West Seattle Water Taxi ORCA fare: $5.00 → $5.25
  - Vashon Water Taxi ORCA fare: $5.75 → $6.00
  - West Seattle ORCA LIFT fare: $3.75 → $1.00
  - Vashon ORCA LIFT fare: $4.50 → $1.00
  - King County Metro Bus/Flex and Seattle Streetcar: Fares come from GTFS data automatically

  October 1st, 2025 - Kitsap Transit Fast Ferry Changes:

  - Westbound adult fare: $12.00 → $13.00
  - Westbound reduced fare (LIFT & senior): $6.00 → $6.50
  - ORCA transfers disabled: Fast ferries no longer accept ORCA transfers
  - PugetPasses disabled: Fast ferries no longer accept PugetPasses

### Unit tests
Unit tests pass for now but they will start failing as these changes come into effect. Should we wait to merge this? There are a set of changes on sept 1 and another oct 1 that will cause failing tests. Setting up the infrastructure for date based testing seems like too much for a temporary change like this. 

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add the label `skip changelog` to the PR.
