### PR TITLE
Allow fares V1 and V2 feeds in the same deployment

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresServiceTest.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.ext.fares.impl.gtfs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
+
+import com.google.common.collect.ImmutableMultimap;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.impl._support.FareModelForTest;
+import org.opentripplanner.ext.fares.model.FareAttribute;
+import org.opentripplanner.ext.fares.model.FareLegRule;
+import org.opentripplanner.ext.fares.model.FareRuleSet;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.TestItineraryBuilder;
+import org.opentripplanner.routing.core.FareType;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.basic.Money;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.GroupOfRoutes;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.organization.Agency;
+
+class GtfsFaresServiceTest implements PlanTestConstants {
+
+  private static final FeedScopedId NETWORK = TimetableRepositoryForTest.id("network");
+  private static final Route ROUTE = TimetableRepositoryForTest.route("r1")
+    .withGroupOfRoutes(List.of(GroupOfRoutes.of(NETWORK).build()))
+    .build();
+  private static final Itinerary ITIN = TestItineraryBuilder.newItinerary(A)
+    .bus(ROUTE, 1, 0, 50, B)
+    .build();
+  private static final Agency AGENCY = ITIN.transitLeg(0).agency();
+  public static final Money V1_PRICE = Money.usDollars(1);
+  public static final Money V2_PRICE = FareModelForTest.FARE_PRODUCT_A.price();
+  private static final FareRuleSet FRS = new FareRuleSet(
+    FareAttribute.of(id("1")).setPrice(V1_PRICE).setAgency(AGENCY.getId()).build()
+  );
+  private static final FareLegRule LEG_RULE = FareLegRule.of(
+    id("2"),
+    List.of(FareModelForTest.FARE_PRODUCT_A)
+  ).build();
+
+  @Test
+  void combineV1andV2() {
+    var v1 = new DefaultFareService();
+
+    v1.addFareRules(FareType.regular, List.of(FRS));
+
+    var v2 = new GtfsFaresV2Service(List.of(LEG_RULE), List.of(), ImmutableMultimap.of());
+    var service = new GtfsFaresService(v1, v2);
+
+    var fare = service.calculateFares(ITIN);
+    assertThat(fare.getLegProducts()).hasSize(2);
+
+    var prices = fare
+      .getLegProducts()
+      .values()
+      .stream()
+      .map(fp -> fp.fareProduct().price())
+      .toList();
+    assertThat(prices).containsExactly(V1_PRICE, V2_PRICE);
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/DefaultFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/DefaultFareService.java
@@ -179,7 +179,7 @@ public class DefaultFareService implements FareService {
   ) {
     FareSearch r = performSearch(fareType, legs, fareRules);
 
-    Multimap<Leg, FareOffer> fareProductUses = LinkedHashMultimap.create();
+    Multimap<Leg, FareOffer> fareOffers = LinkedHashMultimap.create();
     int start = 0;
     int end = legs.size() - 1;
     while (start <= end) {
@@ -218,14 +218,14 @@ public class DefaultFareService implements FareService {
 
       if (!applicableLegs.isEmpty()) {
         var offer = FareOffer.of(applicableLegs.getFirst().startTime(), product);
-        applicableLegs.forEach(leg -> fareProductUses.put(leg, offer));
+        applicableLegs.forEach(leg -> fareOffers.put(leg, offer));
       }
 
       start = via + 1;
     }
 
     var fare = ItineraryFare.empty();
-    fare.addFareProductUses(fareProductUses);
+    fare.addFareOffers(fareOffers);
     return fare;
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresService.java
@@ -3,12 +3,20 @@ package org.opentripplanner.ext.fares.impl.gtfs;
 import com.google.common.collect.Multimap;
 import java.io.Serial;
 import java.util.Objects;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.fares.FareService;
 
+/**
+ * A combined fare service that combines the results of the GTFS V1 and V2 fares services.
+ * <p>
+ * The import process makes sure that only those feeds which do not V2 are importing
+ * fares V2.
+ * @see org.opentripplanner.gtfs.mapping.GTFSToOtpTransitServiceMapper#shouldImportFaresV1(GtfsRelationalDao)
+ */
 public final class GtfsFaresService implements FareService {
 
   private final DefaultFareService faresV1;

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresService.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.fares.impl.gtfs;
 
 import com.google.common.collect.Multimap;
+import java.io.Serial;
 import java.util.Objects;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.fare.ItineraryFare;
@@ -8,22 +9,31 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.fares.FareService;
 
-public record GtfsFaresService(DefaultFareService faresV1, GtfsFaresV2Service faresV2)
-  implements FareService {
+public final class GtfsFaresService implements FareService {
+
+  private final DefaultFareService faresV1;
+  private final GtfsFaresV2Service faresV2;
+
+  public GtfsFaresService(DefaultFareService faresV1, GtfsFaresV2Service faresV2) {
+    this.faresV1 = faresV1;
+    this.faresV2 = faresV2;
+  }
+
   @Override
   public ItineraryFare calculateFares(Itinerary itinerary) {
-    var fare = ItineraryFare.empty();
-    if (faresV2.isEmpty()) {
-      fare = Objects.requireNonNullElse(faresV1.calculateFares(itinerary), ItineraryFare.empty());
-    } else {
-      var products = faresV2.calculateFares(itinerary);
-      fare.addItineraryProducts(products.itineraryProducts());
-      if (products.itineraryProducts().isEmpty()) {
-        addLegProducts(products.legProducts(), fare);
-      }
+    var fare = Objects.requireNonNullElse(faresV1.calculateFares(itinerary), ItineraryFare.empty());
+    var products = faresV2.calculateFares(itinerary);
+    fare.addItineraryProducts(products.itineraryProducts());
+    if (products.itineraryProducts().isEmpty()) {
+      addLegProducts(products.legProducts(), fare);
     }
     return fare;
   }
+
+  public DefaultFareService faresV1() {
+    return faresV1;
+  }
+
   /**
    * Add a complex set of fare products for a specific leg;
    */

--- a/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/impl/gtfs/GtfsFaresService.java
@@ -1,9 +1,7 @@
 package org.opentripplanner.ext.fares.impl.gtfs;
 
 import com.google.common.collect.Multimap;
-import java.io.Serial;
 import java.util.Objects;
-import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Itinerary;
@@ -15,7 +13,7 @@ import org.opentripplanner.routing.fares.FareService;
  * <p>
  * The import process makes sure that only those feeds which do not V2 are importing
  * fares V2.
- * @see org.opentripplanner.gtfs.mapping.GTFSToOtpTransitServiceMapper#shouldImportFaresV1(GtfsRelationalDao)
+ * @see org.opentripplanner.gtfs.mapping.GTFSToOtpTransitServiceMapper#shouldImportFaresV1(org.onebusaway.gtfs.services.GtfsRelationalDao)
  */
 public final class GtfsFaresService implements FareService {
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -187,7 +187,7 @@ public class GTFSToOtpTransitServiceMapper {
     builder.getFlexTimePenalty().putAll(tripMapper.flexSafeTimePenalties());
     builder.getTripsById().addAll(tripMapper.map(data.getAllTrips()));
 
-    // Fares v1
+    // Fares V1
     if (shouldImportFaresV1(data)) {
       fareRulesBuilder
         .fareAttributes()

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -234,7 +234,7 @@ public class GTFSToOtpTransitServiceMapper {
   }
 
   /**
-   * Note! Trip-pattens must be added BEFORE mapping transfers
+   * Note! Trip patterns must be added BEFORE mapping transfers
    */
   public void mapAndAddTransfersToBuilder(GtfsDao data) {
     TransferMapper transferMapper = new TransferMapper(

--- a/application/src/main/java/org/opentripplanner/model/fare/ItineraryFare.java
+++ b/application/src/main/java/org/opentripplanner/model/fare/ItineraryFare.java
@@ -89,8 +89,8 @@ public class ItineraryFare {
     this.legProducts.put(leg, offer);
   }
 
-  public void addFareProductUses(Multimap<Leg, FareOffer> fareProducts) {
-    legProducts.putAll(fareProducts);
+  public void addFareOffers(Multimap<Leg, FareOffer> fareOffers) {
+    legProducts.putAll(fareOffers);
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapperTest.java
@@ -1,0 +1,108 @@
+package org.opentripplanner.gtfs.mapping;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.graph_builder.issue.api.DataImportIssueStore.NOOP;
+
+import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.FareAttribute;
+import org.onebusaway.gtfs.model.FareLegRule;
+import org.onebusaway.gtfs.model.FareProduct;
+import org.onebusaway.gtfs.model.FareRule;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
+import org.opentripplanner.transit.model.site.StopTransferPriority;
+import org.opentripplanner.transit.service.SiteRepository;
+
+class GTFSToOtpTransitServiceMapperTest {
+
+  private static final AgencyAndId OBA_ID = new AgencyAndId("f", "1");
+
+  @Test
+  void faresV1only() {
+    var mapper = mapper();
+    var fareData = mapper.fareRulesData();
+    assertThat(fareData.fareRules()).isEmpty();
+    assertThat(fareData.fareAttributes()).isEmpty();
+
+    var dao = new GtfsRelationalDaoImpl();
+    dao.saveEntity(fareRule());
+    dao.saveEntity(fareAttribute());
+    assertTrue(dao.hasFaresV1());
+    assertFalse(dao.hasFaresV2());
+
+    mapper.mapStopTripAndRouteDataIntoBuilder(dao);
+
+    assertThat(fareData.fareRules()).isNotEmpty();
+    assertThat(fareData.fareAttributes()).isNotEmpty();
+  }
+
+  /**
+   * Tests that if you have both V1 and V2 fares, the V1 fares are ignored.
+   */
+  @Test
+  void faresV1andV2() {
+    OTPFeature.FaresV2.testOn(() -> {
+      var mapper = mapper();
+      var fareData = mapper.fareRulesData();
+
+      var dao = new GtfsRelationalDaoImpl();
+      dao.saveEntity(fareRule());
+      dao.saveEntity(fareAttribute());
+      dao.saveEntity(fareProduct());
+      dao.saveEntity(fareLegRule());
+
+      mapper.mapStopTripAndRouteDataIntoBuilder(dao);
+
+      assertThat(fareData.fareRules()).isEmpty();
+      assertThat(fareData.fareAttributes()).isEmpty();
+      assertThat(fareData.fareLegRules()).isNotEmpty();
+    });
+  }
+
+  private static GTFSToOtpTransitServiceMapper mapper() {
+    var builder = new OtpTransitServiceBuilder(SiteRepository.of().build(), NOOP);
+    return new GTFSToOtpTransitServiceMapper(
+      builder,
+      "f",
+      NOOP,
+      true,
+      StopTransferPriority.PREFERRED
+    );
+  }
+
+  private static FareProduct fareProduct() {
+    var p = new FareProduct();
+    p.setId(OBA_ID);
+    p.setName("A fare product");
+    p.setFareProductId(OBA_ID);
+    p.setCurrency("EUR");
+    p.setAmount(10);
+    return p;
+  }
+
+  private static FareLegRule fareLegRule() {
+    var f = new FareLegRule();
+    f.setFareProductId(OBA_ID);
+    f.setLegGroupId(OBA_ID);
+    return f;
+  }
+
+  private static FareRule fareRule() {
+    var r = new FareRule();
+    r.setId(1);
+    r.setFare(fareAttribute());
+    return r;
+  }
+
+  private static FareAttribute fareAttribute() {
+    var a = new FareAttribute();
+    a.setId(OBA_ID);
+    a.setPrice(1);
+    a.setCurrencyType("EUR");
+    return a;
+  }
+}


### PR DESCRIPTION
### Summary

It allows deployments to use fares v1 as well as v2. 

During graph build we find out if a feed contains both then use v2, otherwise use v1. This means that feed A's v1 data can be combined with feed B's v2, even in the same itinerary.

### Unit tests

Added.

### Documentation

Javadoc.

### Changelog

No, sandbox feature.

cc @miles-grant-ibigroup @fpurcell 