### PR TITLE
Fix hashcode in NonLocalizedString

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/i18n/NonLocalizedString.java
+++ b/application/src/main/java/org/opentripplanner/framework/i18n/NonLocalizedString.java
@@ -78,7 +78,7 @@ public class NonLocalizedString implements I18NString, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return name.hashCode();
   }
 
   @Override

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/CarSnapshotTest.snap
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/CarSnapshotTest.snap
@@ -280,7 +280,7 @@ org.opentripplanner.routing.algorithm.mapping.CarSnapshotTest.directCarPickupWit
             "departure" : "2009-10-21T23:11:27.000+00:00",
             "lat" : 45.5325089,
             "lon" : -122.7048383,
-            "name" : "corner of path and Northwest Pettygrove Street",
+            "name" : "corner of Northwest Pettygrove Street and path",
             "vertexType" : "NORMAL"
           },
           "transitLeg" : false,
@@ -297,7 +297,7 @@ org.opentripplanner.routing.algorithm.mapping.CarSnapshotTest.directCarPickupWit
             "departure" : "2009-10-21T23:11:27.000+00:00",
             "lat" : 45.5325089,
             "lon" : -122.7048383,
-            "name" : "corner of path and Northwest Pettygrove Street",
+            "name" : "corner of Northwest Pettygrove Street and path",
             "vertexType" : "NORMAL"
           },
           "generalizedCost" : 290,
@@ -475,7 +475,7 @@ org.opentripplanner.routing.algorithm.mapping.CarSnapshotTest.directCarPickupWit
             "departure" : "2009-10-21T23:13:20.000+00:00",
             "lat" : 45.5325089,
             "lon" : -122.7048383,
-            "name" : "corner of path and Northwest Pettygrove Street",
+            "name" : "corner of Northwest Pettygrove Street and path",
             "vertexType" : "NORMAL"
           },
           "transitLeg" : false,
@@ -492,7 +492,7 @@ org.opentripplanner.routing.algorithm.mapping.CarSnapshotTest.directCarPickupWit
             "departure" : "2009-10-21T23:13:20.000+00:00",
             "lat" : 45.5325089,
             "lon" : -122.7048383,
-            "name" : "corner of path and Northwest Pettygrove Street",
+            "name" : "corner of Northwest Pettygrove Street and path",
             "vertexType" : "NORMAL"
           },
           "generalizedCost" : 286,


### PR DESCRIPTION
### Summary

Minor performance improvement: the hashcode() method in NonLocalizedString unnecessarily re-hashes the wrapped String, which also defeats hashcode caching in the String class.

### Issue

No

### Unit tests

Updated snapshot for CarSnapshotTest.
The generated name for a "from" and "to" location ("corner of A and B") depends on the arbitrary order of A and B when iterating a HashSet of I18NString:
https://github.com/OpenTripPlanner/OpenTripPlanner/blob/0d92ded063ab6c7537748e82665058d47b5d7905/application/src/main/java/org/opentripplanner/street/model/vertex/StreetVertex.java#L46

Thus changing the hashcode may change the order.

### Documentation

No

### Changelog

skipped

### Bumping the serialization version id

No
