### PR TITLE
Improve csv parser

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/emission/EmissionTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/emission/EmissionTestData.java
@@ -33,11 +33,32 @@ public interface EmissionTestData {
   }
 
   default DataSource emissionOnRoutes() {
-    return resource().dataSource("em-on-routes.txt", FileType.EMISSION);
+    return DataStoreModule.dataSource(
+      "em-on-routes.txt",
+      FileType.EMISSION,
+      """
+      route_id,avg_co2_per_vehicle_per_km,avg_passenger_count
+      R1,12.0,2.0
+      R2,123,3
+      """
+    );
   }
 
   default DataSource emissionOnTripHops() {
-    return resource().dataSource("em-on-trip-hops.txt", FileType.EMISSION);
+    return DataStoreModule.dataSource(
+      "em-on-trip-hops.txt",
+      FileType.EMISSION,
+      """
+      trip_id,from_stop_id,from_stop_sequence,ignore_this_value,co2
+      T1,A,1,ignore,5.0
+      T1,B,2,999,7.0
+      T2,A,1,xyz,15.0
+      T2,B,2,xyz,17.0
+      E1,A,-1,xyz,25.0
+      E2,B,1,xyz,-1000001
+      E3,B,1,xyz,1000000001
+      """
+    );
   }
 
   /**

--- a/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteDataReaderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteDataReaderTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.emission.EmissionTestData;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.utils.lang.IntBox;
 
 class RouteDataReaderTest implements EmissionTestData {
 
@@ -26,14 +25,12 @@ class RouteDataReaderTest implements EmissionTestData {
 
   @Test
   void testCo2EmissionsFromGtfsDataSource() throws FileNotFoundException {
-    var lineCounter = new IntBox(0);
     var subject = new RouteDataReader(gtfsWithEmissionFile(), issueStore);
 
-    var emissions = subject.read(FEED_ID, lineCounter::inc);
+    var emissions = subject.read(FEED_ID, null);
 
     assertEquals(0.006, emissions.get(ROUTE_D_1001).co2().asDouble(), 0.0001);
     assertEquals(3, emissions.size());
-    assertEquals(3, lineCounter.get());
     var issues = issueStore.listIssues();
 
     var expected = List.of(
@@ -51,36 +48,26 @@ class RouteDataReaderTest implements EmissionTestData {
 
   @Test
   void testCo2EmissionsFromFeedDataSource() throws FileNotFoundException {
-    var lineCounter = new IntBox(0);
     var subject = new RouteDataReader(emissionOnRoutes(), issueStore);
 
-    var emissions = subject.read(FEED_ID, lineCounter::inc);
+    var emissions = subject.read(FEED_ID, null);
 
     assertEquals(0.006, emissions.get(ROUTE_F_R1).co2().asDouble(), 0.0001);
     assertTrue(issueStore.listIssues().isEmpty(), () -> issueStore.toString());
     assertEquals(2, emissions.size());
-    assertEquals(2, lineCounter.get());
   }
 
   @Test
   void handleMissingDataSource() {
-    var lineCounter = new IntBox(0);
     var subject = new RouteDataReader(emissionMissingFile(), issueStore);
-
-    var emissions = subject.read(FEED_ID, lineCounter::inc);
-
+    var emissions = subject.read(FEED_ID, null);
     assertTrue(emissions.isEmpty());
-    assertEquals(0, lineCounter.get());
   }
 
   @Test
   void ignoreDataSourceIfHeadersDoNotMatch() {
-    var lineCounter = new IntBox(0);
     var subject = new RouteDataReader(emissionOnTripHops(), issueStore);
-
-    var emissions = subject.read(FEED_ID, lineCounter::inc);
-
+    var emissions = subject.read(FEED_ID, null);
     assertTrue(emissions.isEmpty());
-    assertEquals(0, lineCounter.get());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripDataReaderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripDataReaderTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.emission.EmissionTestData;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
-import org.opentripplanner.utils.lang.IntBox;
 
 class TripDataReaderTest implements EmissionTestData {
 
@@ -17,10 +16,9 @@ class TripDataReaderTest implements EmissionTestData {
 
   @Test
   void testCo2EmissionsFromGtfsDataSource() throws FileNotFoundException {
-    var stepCounter = new IntBox(0);
     var subject = new TripDataReader(emissionOnTripHops(), issueStore);
 
-    var emissions = subject.read(stepCounter::inc);
+    var emissions = subject.read(null);
 
     assertEquals(
       "TripHopsRow[tripId=T1, fromStopId=A, fromStopSequence=1, co2=5g]",
@@ -32,7 +30,6 @@ class TripDataReaderTest implements EmissionTestData {
     );
     assertTrue(subject.isDataProcessed());
     assertEquals(4, emissions.size());
-    assertEquals(4, stepCounter.get());
 
     var issues = issueStore.listIssues();
 
@@ -49,24 +46,20 @@ class TripDataReaderTest implements EmissionTestData {
 
   @Test
   void handleMissingDataSource() {
-    var stepCounter = new IntBox(0);
     var subject = new TripDataReader(emissionMissingFile(), issueStore);
 
-    var emissions = subject.read(stepCounter::inc);
+    var emissions = subject.read(null);
     assertFalse(subject.isDataProcessed());
     assertTrue(emissions.isEmpty());
-    assertEquals(0, stepCounter.get());
   }
 
   @Test
   void ignoreDataSourceIfHeadersDoNotMatch() {
-    var stepCounter = new IntBox(0);
     var subject = new TripDataReader(emissionOnRoutes(), issueStore);
 
-    var emissions = subject.read(stepCounter::inc);
+    var emissions = subject.read(null);
 
     assertFalse(subject.isDataProcessed());
     assertTrue(emissions.isEmpty());
-    assertEquals(0, stepCounter.get());
   }
 }

--- a/application/src/ext-test/resources/org/opentripplanner/ext/emission/em-on-routes.txt
+++ b/application/src/ext-test/resources/org/opentripplanner/ext/emission/em-on-routes.txt
@@ -1,3 +1,0 @@
-route_id,avg_co2_per_vehicle_per_km,avg_passenger_count
-R1,12.0,2.0
-R2,123,3

--- a/application/src/ext-test/resources/org/opentripplanner/ext/emission/em-on-trip-hops.txt
+++ b/application/src/ext-test/resources/org/opentripplanner/ext/emission/em-on-trip-hops.txt
@@ -1,8 +1,0 @@
-trip_id,from_stop_id,from_stop_sequence,ignore_this_value,co2
-T1,A,1,ignore,5.0
-T1,B,2,999,7.0
-T2,A,1,xyz,15.0
-T2,B,2,xyz,17.0
-E1,A,-1,xyz,25.0
-E2,B,1,xyz,-1000001
-E3,B,1,xyz,1000000001

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/EmissionDataReader.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/EmissionDataReader.java
@@ -7,7 +7,6 @@ import org.opentripplanner.ext.emission.internal.csvdata.route.RouteDataReader;
 import org.opentripplanner.ext.emission.internal.csvdata.trip.TripDataReader;
 import org.opentripplanner.ext.emission.internal.csvdata.trip.TripHopMapper;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
-import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,21 +60,15 @@ public class EmissionDataReader {
       return;
     }
 
-    var progress = ProgressTracker.track("Read " + emissionDataSource.name(), 10_000, -1);
     // Assume input CO₂ emission data is Route average data
     var routeReader = new RouteDataReader(emissionDataSource, issueStore);
-    this.emissionRepository.addRouteEmissions(
-        routeReader.read(resolvedFeedId, () -> logProgress(progress))
-      );
+    this.emissionRepository.addRouteEmissions(routeReader.read(resolvedFeedId, LOG));
 
     // Assume input CO₂ emission data is per trip hop
     tripHopMapper.setCurrentFeedId(resolvedFeedId);
     var tripReader = new TripDataReader(emissionDataSource, issueStore);
-    this.emissionRepository.addTripPatternEmissions(
-        tripHopMapper.map(tripReader.read(() -> logProgress(progress)))
-      );
+    this.emissionRepository.addTripPatternEmissions(tripHopMapper.map(tripReader.read(LOG)));
 
-    LOG.info(progress.completeMessage());
     if (!(routeReader.isDataProcessed() || tripReader.isDataProcessed())) {
       LOG.error(
         "No emission data read from: " +
@@ -83,11 +76,5 @@ public class EmissionDataReader {
         ". Do the header columns match?"
       );
     }
-  }
-
-  private static void logProgress(ProgressTracker progress) {
-    // Do not convert this to a lambda expression. The logger will not be
-    // able to log the correct source and line number for the caller.
-    progress.step(m -> LOG.info(m));
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteCsvParser.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteCsvParser.java
@@ -26,7 +26,7 @@ class RouteCsvParser extends AbstractCsvParser<RouteRow> {
   );
 
   public RouteCsvParser(DataImportIssueStore issueStore, CsvReader reader) {
-    super(issueStore, reader);
+    super(issueStore, reader, "RouteEmission");
   }
 
   @Override

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteCsvParser.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteCsvParser.java
@@ -2,8 +2,8 @@ package org.opentripplanner.ext.emission.internal.csvdata.route;
 
 import com.csvreader.CsvReader;
 import java.util.List;
-import org.opentripplanner.ext.emission.internal.csvdata.csvparser.AbstractCsvParser;
-import org.opentripplanner.ext.emission.internal.csvdata.csvparser.EmissionHandledParseException;
+import org.opentripplanner.framework.csv.parser.AbstractCsvParser;
+import org.opentripplanner.framework.csv.parser.EmissionHandledParseException;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.utils.lang.DoubleRange;
 

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteCsvParser.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteCsvParser.java
@@ -3,7 +3,7 @@ package org.opentripplanner.ext.emission.internal.csvdata.route;
 import com.csvreader.CsvReader;
 import java.util.List;
 import org.opentripplanner.framework.csv.parser.AbstractCsvParser;
-import org.opentripplanner.framework.csv.parser.EmissionHandledParseException;
+import org.opentripplanner.framework.csv.parser.HandledCsvParseException;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.utils.lang.DoubleRange;
 
@@ -35,7 +35,7 @@ class RouteCsvParser extends AbstractCsvParser<RouteRow> {
   }
 
   @Override
-  protected RouteRow createNextRow() throws EmissionHandledParseException {
+  protected RouteRow createNextRow() throws HandledCsvParseException {
     return new RouteRow(
       getString(ROUTE_ID),
       getDouble(AVG_CO_2_PER_VEHICLE_PER_KM, AVG_CO_2_PER_VEHICLE_PER_KM_RANGE),

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteDataReader.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/route/RouteDataReader.java
@@ -1,13 +1,14 @@
 package org.opentripplanner.ext.emission.internal.csvdata.route;
 
-import com.csvreader.CsvReader;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.opentripplanner.datastore.api.DataSource;
+import org.opentripplanner.framework.csv.parser.OtpCsvReader;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.plan.Emission;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.slf4j.Logger;
 
 /**
  * This class handles reading the CO₂ emissions data from the files in the GTFS package
@@ -24,27 +25,21 @@ public class RouteDataReader {
     this.issueStore = issueStore;
   }
 
-  public Map<FeedScopedId, Emission> read(String resolvedFeedId, Runnable logStepCallback) {
-    if (!emissionDataSource.exists()) {
-      return Map.of();
-    }
+  public Map<FeedScopedId, Emission> read(String resolvedFeedId, @Nullable Logger logger) {
     var emissionData = new HashMap<FeedScopedId, Emission>();
-    var reader = new CsvReader(emissionDataSource.asInputStream(), StandardCharsets.UTF_8);
-    var parser = new RouteCsvParser(issueStore, reader);
 
-    if (!parser.headersMatch()) {
-      return Map.of();
-    }
-
-    while (parser.hasNext()) {
-      logStepCallback.run();
-      var value = parser.next();
-      emissionData.put(
-        new FeedScopedId(resolvedFeedId, value.routeId()),
-        Emission.of(value.calculatePassengerCo2PerMeter())
-      );
-      dataProcessed = true;
-    }
+    OtpCsvReader.<RouteRow>of()
+      .withDataSource(emissionDataSource)
+      .withLogger(logger)
+      .withParserFactory(r -> new RouteCsvParser(issueStore, r))
+      .withRowHandler(row -> {
+        emissionData.put(
+          new FeedScopedId(resolvedFeedId, row.routeId()),
+          Emission.of(row.calculatePassengerCo2PerMeter())
+        );
+        dataProcessed = true;
+      })
+      .read();
     return emissionData;
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripDataReader.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripDataReader.java
@@ -1,11 +1,11 @@
 package org.opentripplanner.ext.emission.internal.csvdata.trip;
 
-import com.csvreader.CsvReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.datastore.api.DataSource;
+import org.opentripplanner.framework.csv.parser.OtpCsvReader;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.slf4j.Logger;
 
 /**
  * This class handles reading the CO₂ emissions data from the files in the GTFS package
@@ -22,23 +22,17 @@ public class TripDataReader {
     this.issueStore = issueStore;
   }
 
-  public List<TripHopsRow> read(Runnable logStepCallback) {
-    if (!emissionDataSource.exists()) {
-      return List.of();
-    }
+  public List<TripHopsRow> read(Logger logger) {
     var emissionData = new ArrayList<TripHopsRow>();
-    var reader = new CsvReader(emissionDataSource.asInputStream(), StandardCharsets.UTF_8);
-    var parser = new TripHopsCsvParser(issueStore, reader);
-
-    if (!parser.headersMatch()) {
-      return List.of();
-    }
-
-    while (parser.hasNext()) {
-      logStepCallback.run();
-      emissionData.add(parser.next());
-      dataProcessed = true;
-    }
+    OtpCsvReader.<TripHopsRow>of()
+      .withLogger(logger)
+      .withDataSource(emissionDataSource)
+      .withParserFactory(r -> new TripHopsCsvParser(issueStore, r))
+      .withRowHandler(row -> {
+        emissionData.add(row);
+        dataProcessed = true;
+      })
+      .read();
     return emissionData;
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopsCsvParser.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopsCsvParser.java
@@ -2,8 +2,8 @@ package org.opentripplanner.ext.emission.internal.csvdata.trip;
 
 import com.csvreader.CsvReader;
 import java.util.List;
-import org.opentripplanner.ext.emission.internal.csvdata.csvparser.AbstractCsvParser;
-import org.opentripplanner.ext.emission.internal.csvdata.csvparser.EmissionHandledParseException;
+import org.opentripplanner.framework.csv.parser.AbstractCsvParser;
+import org.opentripplanner.framework.csv.parser.EmissionHandledParseException;
 import org.opentripplanner.framework.model.Gram;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.utils.lang.DoubleRange;

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopsCsvParser.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopsCsvParser.java
@@ -3,7 +3,7 @@ package org.opentripplanner.ext.emission.internal.csvdata.trip;
 import com.csvreader.CsvReader;
 import java.util.List;
 import org.opentripplanner.framework.csv.parser.AbstractCsvParser;
-import org.opentripplanner.framework.csv.parser.EmissionHandledParseException;
+import org.opentripplanner.framework.csv.parser.HandledCsvParseException;
 import org.opentripplanner.framework.model.Gram;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.utils.lang.DoubleRange;
@@ -38,7 +38,7 @@ class TripHopsCsvParser extends AbstractCsvParser<TripHopsRow> {
   }
 
   @Override
-  protected TripHopsRow createNextRow() throws EmissionHandledParseException {
+  protected TripHopsRow createNextRow() throws HandledCsvParseException {
     return new TripHopsRow(
       getString(TRIP_ID),
       getString(START_STOP_ID),

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopsCsvParser.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopsCsvParser.java
@@ -29,7 +29,7 @@ class TripHopsCsvParser extends AbstractCsvParser<TripHopsRow> {
   private static final DoubleRange CO2_RANGE = DoubleRange.of(-1_000_000.0, 1_000_000_000.0);
 
   public TripHopsCsvParser(DataImportIssueStore issueStore, CsvReader reader) {
-    super(issueStore, reader);
+    super(issueStore, reader, "TripEmission");
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/datastore/base/ByteArrayDataSource.java
+++ b/application/src/main/java/org/opentripplanner/datastore/base/ByteArrayDataSource.java
@@ -5,7 +5,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
 
@@ -42,18 +41,6 @@ public class ByteArrayDataSource implements DataSource {
     this.size = size;
     this.lastModified = lastModified;
     this.writable = writable;
-  }
-
-  public static ByteArrayDataSource testInput(String name, FileType type, String content) {
-    var buf = content.getBytes(StandardCharsets.UTF_8);
-    return new ByteArrayDataSource(
-      "",
-      name,
-      type,
-      buf.length,
-      System.currentTimeMillis(),
-      false
-    ).withBytes(buf);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/datastore/base/ByteArrayDataSource.java
+++ b/application/src/main/java/org/opentripplanner/datastore/base/ByteArrayDataSource.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
 
@@ -41,6 +42,18 @@ public class ByteArrayDataSource implements DataSource {
     this.size = size;
     this.lastModified = lastModified;
     this.writable = writable;
+  }
+
+  public static ByteArrayDataSource testInput(String name, FileType type, String content) {
+    var buf = content.getBytes(StandardCharsets.UTF_8);
+    return new ByteArrayDataSource(
+      "",
+      name,
+      type,
+      buf.length,
+      System.currentTimeMillis(),
+      false
+    ).withBytes(buf);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/datastore/base/ListCompositeDataSource.java
+++ b/application/src/main/java/org/opentripplanner/datastore/base/ListCompositeDataSource.java
@@ -1,0 +1,63 @@
+package org.opentripplanner.datastore.base;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import org.opentripplanner.datastore.api.CompositeDataSource;
+import org.opentripplanner.datastore.api.DataSource;
+import org.opentripplanner.datastore.api.FileType;
+
+/**
+ * This is a simple {@link CompositeDataSource} using a list of children. It is usefull
+ * for testing.
+ */
+public class ListCompositeDataSource implements CompositeDataSource {
+
+  private static final String URI_DELIMITER = "/";
+  private final String name;
+  private final FileType type;
+  private final List<DataSource> children;
+
+  public ListCompositeDataSource(String name, FileType type, List<DataSource> children) {
+    this.name = name;
+    this.type = type;
+    this.children = children;
+  }
+
+  @Override
+  @SuppressWarnings("ConstantConditions")
+  public Collection<DataSource> content() {
+    return children;
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Override
+  public DataSource entry(String name) {
+    return children.stream().filter(it -> name.equals(it.name())).findFirst().orElse(null);
+  }
+
+  @Override
+  public void close() {
+    /* Nothing to close */
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String path() {
+    return getClass().getSimpleName() + URI_DELIMITER + System.identityHashCode(this);
+  }
+
+  @Override
+  public URI uri() {
+    return URI.create(path() + URI_DELIMITER + name);
+  }
+
+  @Override
+  public FileType type() {
+    return type;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/datastore/configure/DataStoreModule.java
+++ b/application/src/main/java/org/opentripplanner/datastore/configure/DataStoreModule.java
@@ -4,16 +4,21 @@ import dagger.Module;
 import dagger.Provides;
 import jakarta.inject.Singleton;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.datastore.OtpDataStore;
 import org.opentripplanner.datastore.api.CompositeDataSource;
+import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.api.GoogleStorageDSRepository;
 import org.opentripplanner.datastore.api.OtpBaseDirectory;
 import org.opentripplanner.datastore.api.OtpDataStoreConfig;
+import org.opentripplanner.datastore.base.ByteArrayDataSource;
 import org.opentripplanner.datastore.base.DataSourceRepository;
+import org.opentripplanner.datastore.base.ListCompositeDataSource;
 import org.opentripplanner.datastore.file.FileDataSourceRepository;
 import org.opentripplanner.datastore.https.HttpsDataSourceRepository;
 
@@ -41,6 +46,36 @@ public abstract class DataStoreModule {
    */
   public static CompositeDataSource compositeSource(File file, FileType type) {
     return FileDataSourceRepository.compositeSource(file, type);
+  }
+
+  /**
+   * For test only.
+   * <p>
+   * Use this to get a composite data source. Pass in all child data sources.
+   */
+  public static CompositeDataSource compositeSource(
+    String name,
+    FileType type,
+    DataSource... children
+  ) {
+    return new ListCompositeDataSource(name, type, Arrays.asList(children));
+  }
+
+  /**
+   * For test only.
+   * <p>
+   * Use this to create a read-only data source backed by the given {@code content} string.
+   */
+  public static DataSource dataSource(String name, FileType type, String content) {
+    var buf = content.getBytes(StandardCharsets.UTF_8);
+    return new ByteArrayDataSource(
+      "",
+      name,
+      type,
+      buf.length,
+      System.currentTimeMillis(),
+      false
+    ).withBytes(buf);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/AbstractCsvParser.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/AbstractCsvParser.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.ext.emission.internal.csvdata.csvparser;
+package org.opentripplanner.framework.csv.parser;
 
 import com.csvreader.CsvReader;
 import java.io.IOException;

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/AbstractIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/AbstractIssue.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.framework.csv.parser;
+
+import org.opentripplanner.framework.error.OtpError;
+
+abstract class AbstractIssue implements OtpError {
+
+  private final String columnName;
+  private final String csvLine;
+  private final String issueType;
+
+  public AbstractIssue(String columnName, String csvLine, String issueType) {
+    this.columnName = columnName;
+    this.csvLine = csvLine;
+    this.issueType = issueType;
+  }
+
+  String columnName() {
+    return columnName;
+  }
+
+  String csvLine() {
+    return csvLine;
+  }
+
+  String issueType() {
+    return issueType;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/EmissionHandledParseException.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/EmissionHandledParseException.java
@@ -1,7 +1,0 @@
-package org.opentripplanner.framework.csv.parser;
-
-/**
- * Signal a handled parse exception. The error is added to the issue store - nothing needs to
- * be done, the parser may proceed to the next line.
- */
-public class EmissionHandledParseException extends Exception {}

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/EmissionHandledParseException.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/EmissionHandledParseException.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.ext.emission.internal.csvdata.csvparser;
+package org.opentripplanner.framework.csv.parser;
 
 /**
  * Signal a handled parse exception. The error is added to the issue store - nothing needs to

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/FormatIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/FormatIssue.java
@@ -2,12 +2,12 @@ package org.opentripplanner.framework.csv.parser;
 
 import java.util.Objects;
 
-final class NumberFormatIssue extends AbstractIssue {
+final class FormatIssue extends AbstractIssue {
 
   private final Object value;
   private final String valueType;
 
-  public NumberFormatIssue(
+  public FormatIssue(
     String columnName,
     Object value,
     String valueType,
@@ -21,7 +21,7 @@ final class NumberFormatIssue extends AbstractIssue {
 
   @Override
   public String errorCode() {
-    return issueType() + "NumberFormat";
+    return issueType() + "Format";
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/HandledCsvParseException.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/HandledCsvParseException.java
@@ -1,0 +1,7 @@
+package org.opentripplanner.framework.csv.parser;
+
+/**
+ * Signal a handled CSV parse exception. The error is added to the issue store - nothing needs to
+ * be done, the parser may proceed to the next line.
+ */
+public class HandledCsvParseException extends Exception {}

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/NumberFormatIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/NumberFormatIssue.java
@@ -1,25 +1,27 @@
 package org.opentripplanner.framework.csv.parser;
 
 import java.util.Objects;
-import org.opentripplanner.framework.error.OtpError;
 
-final class NumberFormatIssue implements OtpError {
+final class NumberFormatIssue extends AbstractIssue {
 
-  private final String columnName;
   private final Object value;
-  private final String type;
-  private final String csvLine;
+  private final String valueType;
 
-  public NumberFormatIssue(String columnName, Object value, String type, String csvLine) {
-    this.columnName = columnName;
+  public NumberFormatIssue(
+    String columnName,
+    Object value,
+    String valueType,
+    String csvLine,
+    String type
+  ) {
+    super(columnName, csvLine, type);
     this.value = value;
-    this.type = type;
-    this.csvLine = csvLine;
+    this.valueType = valueType;
   }
 
   @Override
   public String errorCode() {
-    return "EmissionNumberFormat";
+    return issueType() + "NumberFormat";
   }
 
   @Override
@@ -29,6 +31,6 @@ final class NumberFormatIssue implements OtpError {
 
   @Override
   public Object[] messageArguments() {
-    return new Object[] { Objects.toString(value), columnName, type, csvLine };
+    return new Object[] { Objects.toString(value), columnName(), valueType, csvLine() };
   }
 }

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/NumberFormatIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/NumberFormatIssue.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.ext.emission.internal.csvdata.csvparser;
+package org.opentripplanner.framework.csv.parser;
 
 import java.util.Objects;
 import org.opentripplanner.framework.error.OtpError;

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/OtpCsvReader.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/OtpCsvReader.java
@@ -1,0 +1,105 @@
+package org.opentripplanner.framework.csv.parser;
+
+import com.csvreader.CsvReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opentripplanner.datastore.api.DataSource;
+import org.opentripplanner.utils.logging.ProgressTracker;
+import org.slf4j.Logger;
+
+/**
+ * Use this class to read in a CSV file from a {@link DataSource}. You must provide (requierd):
+ * <ul>
+ *   <li>the {@code datasource} - the csv file to read</li>
+ *   <li>the {@code logger} - the logger ro write progress tracking events.</li>
+ *   <li>the {@code parserFactory} the factory to create a CSV parser for mapping into the row type.</li>
+ *   <li>the {@code rowHandler} a handler for each row read. </li>
+ * </ul>
+ *
+ * The class is responsible for processing the CSV file and orcastrating the parsing process.
+ * A progress tracker is created and will be used to track the reading of the datasource.
+ *
+ * @param <T> The row type.
+ */
+public class OtpCsvReader<T> {
+
+  private DataSource dataSource;
+  private Function<CsvReader, AbstractCsvParser<T>> parserFactory;
+  private Consumer<T> rowHandler;
+  @Nullable
+  private Logger logger;
+
+  private OtpCsvReader() {}
+
+  public static <S> OtpCsvReader<S> of() {
+    return new OtpCsvReader<S>();
+  }
+
+  public OtpCsvReader<T> withDataSource(DataSource dataSource) {
+    this.dataSource = dataSource;
+    return this;
+  }
+
+  /**
+   * The logger is optional. If pressent, a {@link ProgressTracker} is created and the
+   * log events is written to the logger.
+   */
+  public OtpCsvReader<T> withLogger(Logger logger) {
+    this.logger = logger;
+    return this;
+  }
+
+  public OtpCsvReader<T> withParserFactory(
+    Function<com.csvreader.CsvReader, AbstractCsvParser<T>> parserFactory
+  ) {
+    this.parserFactory = parserFactory;
+    return this;
+  }
+
+  public OtpCsvReader<T> withRowHandler(Consumer<T> rowHandler) {
+    this.rowHandler = rowHandler;
+    return this;
+  }
+
+  public void read() {
+    Objects.requireNonNull(dataSource);
+    Objects.requireNonNull(parserFactory);
+    Objects.requireNonNull(rowHandler);
+    read(rowHandler);
+  }
+
+  private void read(Consumer<T> rowHandler) {
+    ProgressTracker progress = null;
+
+    if (!dataSource.exists()) {
+      return;
+    }
+    if (logger != null) {
+      progress = ProgressTracker.track("Read " + dataSource.name(), 10_000, -1);
+      logger.info(progress.startMessage());
+    }
+    var reader = new com.csvreader.CsvReader(dataSource.asInputStream(), StandardCharsets.UTF_8);
+    var parser = parserFactory.apply(reader);
+
+    if (!parser.headersMatch()) {
+      return;
+    }
+
+    while (parser.hasNext()) {
+      // Do not convert this to a lambda expression. The logger will not be
+      // able to log the correct source and line number for the caller.
+      if (progress != null) {
+        progress.step(m -> logger.info(m));
+      }
+      rowHandler.accept(parser.next());
+    }
+
+    if (progress != null) {
+      logger.info(progress.completeMessage());
+    }
+    return;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/OtpCsvReader.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/OtpCsvReader.java
@@ -29,6 +29,7 @@ public class OtpCsvReader<T> {
   private DataSource dataSource;
   private Function<CsvReader, AbstractCsvParser<T>> parserFactory;
   private Consumer<T> rowHandler;
+
   @Nullable
   private Logger logger;
 

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueMissingIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueMissingIssue.java
@@ -1,20 +1,14 @@
 package org.opentripplanner.framework.csv.parser;
 
-import org.opentripplanner.framework.error.OtpError;
+class ValueMissingIssue extends AbstractIssue {
 
-class ValueMissingIssue implements OtpError {
-
-  private final String columnName;
-  private final String csvLine;
-
-  public ValueMissingIssue(String columnName, String csvLine) {
-    this.columnName = columnName;
-    this.csvLine = csvLine;
+  public ValueMissingIssue(String columnName, String csvLine, String issueType) {
+    super(columnName, csvLine, issueType);
   }
 
   @Override
   public String errorCode() {
-    return "EmissionValueMissing";
+    return issueType() + "ValueMissing";
   }
 
   @Override
@@ -24,6 +18,6 @@ class ValueMissingIssue implements OtpError {
 
   @Override
   public Object[] messageArguments() {
-    return new Object[] { columnName, csvLine };
+    return new Object[] { columnName(), csvLine() };
   }
 }

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueMissingIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueMissingIssue.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.ext.emission.internal.csvdata.csvparser;
+package org.opentripplanner.framework.csv.parser;
 
 import org.opentripplanner.framework.error.OtpError;
 

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueOutsideRangeIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueOutsideRangeIssue.java
@@ -1,33 +1,30 @@
 package org.opentripplanner.framework.csv.parser;
 
 import java.util.Objects;
-import org.opentripplanner.framework.error.OtpError;
 
-class ValueOutsideRangeIssue implements OtpError {
+class ValueOutsideRangeIssue extends AbstractIssue {
 
-  private final String columnName;
   private final Number value;
-  private final String type;
+  private final String valueType;
   private final Object range;
-  private final String csvLine;
 
   public ValueOutsideRangeIssue(
     String columnName,
     Number value,
-    String type,
+    String valueType,
     Object range,
-    String csvLine
+    String csvLine,
+    String issueType
   ) {
-    this.columnName = columnName;
+    super(columnName, csvLine, issueType);
     this.value = value;
-    this.type = type;
+    this.valueType = valueType;
     this.range = range;
-    this.csvLine = csvLine;
   }
 
   @Override
   public String errorCode() {
-    return "EmissionOutsideRange";
+    return issueType() + "OutsideRange";
   }
 
   @Override
@@ -38,11 +35,11 @@ class ValueOutsideRangeIssue implements OtpError {
   @Override
   public Object[] messageArguments() {
     return new Object[] {
-      type,
+      valueType,
       Objects.toString(value),
-      columnName,
+      columnName(),
       Objects.toString(range),
-      csvLine,
+      csvLine(),
     };
   }
 }

--- a/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueOutsideRangeIssue.java
+++ b/application/src/main/java/org/opentripplanner/framework/csv/parser/ValueOutsideRangeIssue.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.ext.emission.internal.csvdata.csvparser;
+package org.opentripplanner.framework.csv.parser;
 
 import java.util.Objects;
 import org.opentripplanner.framework.error.OtpError;

--- a/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/EnumMapSerializer.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/EnumMapSerializer.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.routing.graph.kryosupport;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.util.EnumMap;
+import java.util.HashMap;
+
+/**
+ * A custom serializer for {@link EnumMap} witch fails to serialize properly with Kryo. A regular
+ * {@link HashMap} is used, since there are build in functions in Java to convert between the two
+ * classes.
+ */
+public class EnumMapSerializer extends Serializer<EnumMap<? extends Enum<?>, ?>> {
+
+  @Override
+  public void write(Kryo kryo, Output output, EnumMap<? extends Enum<?>, ?> obj) {
+    kryo.writeObject(output, new HashMap<>(obj));
+  }
+
+  @Override
+  public EnumMap read(Kryo kryo, Input input, Class<? extends EnumMap<?, ?>> type) {
+    return new EnumMap(kryo.readObject(input, HashMap.class));
+  }
+}

--- a/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/KryoBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/KryoBuilder.java
@@ -12,6 +12,7 @@ import de.javakaffee.kryoserializers.guava.HashMultimapSerializer;
 import gnu.trove.impl.hash.TPrimitiveHash;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.hash.TIntIntHashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,6 +58,7 @@ public final class KryoBuilder {
     kryo.register(Set.of(1).getClass(), new JavaImmutableSetSerializer());
     kryo.register(Map.of().getClass(), new JavaImmutableMapSerializer());
     kryo.register(Map.of(1, 1).getClass(), new JavaImmutableMapSerializer());
+    kryo.register(EnumMap.class, new EnumMapSerializer());
 
     kryo.register(HashMultimap.class, new HashMultimapSerializer());
     kryo.register(ArrayListMultimap.class, new ArrayListMultimapSerializer());

--- a/application/src/test/java/org/opentripplanner/datastore/base/ListCompositeDataSourceTest.java
+++ b/application/src/test/java/org/opentripplanner/datastore/base/ListCompositeDataSourceTest.java
@@ -2,25 +2,29 @@ package org.opentripplanner.datastore.base;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.datastore.api.CompositeDataSource;
+import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
+import org.opentripplanner.datastore.configure.DataStoreModule;
 
 class ListCompositeDataSourceTest {
 
   private static final String LEAF_NAME = "leaf";
-  private static final ByteArrayDataSource LEAF = ByteArrayDataSource.testInput(
+  private static final DataSource LEAF = DataStoreModule.dataSource(
     LEAF_NAME,
     FileType.GTFS,
     "Test"
   );
 
-  private final ListCompositeDataSource subjectEmpty = new ListCompositeDataSource(
+  private final CompositeDataSource subjectEmpty = new ListCompositeDataSource(
     "empty",
     FileType.GTFS,
     List.of()
   );
-  private final ListCompositeDataSource subjectOne = new ListCompositeDataSource(
+  private final CompositeDataSource subjectOne = new ListCompositeDataSource(
     "one",
     FileType.GTFS,
     List.of(LEAF)
@@ -39,7 +43,7 @@ class ListCompositeDataSourceTest {
   }
 
   @Test
-  void close() {
+  void close() throws IOException {
     // Nothing happens (exceptions not thrown)
     subjectEmpty.close();
     subjectOne.close();
@@ -53,20 +57,14 @@ class ListCompositeDataSourceTest {
 
   @Test
   void path() {
-    assertEquals("ListCompositeReadOnlyDataSource/NNN", replaceHash(subjectEmpty.path()));
-    assertEquals("ListCompositeReadOnlyDataSource/NNN", replaceHash(subjectOne.path()));
+    assertEquals("ListCompositeDataSource/NNN", replaceHash(subjectEmpty.path()));
+    assertEquals("ListCompositeDataSource/NNN", replaceHash(subjectOne.path()));
   }
 
   @Test
   void uri() {
-    assertEquals(
-      "ListCompositeReadOnlyDataSource/NNN/empty",
-      replaceHash(subjectEmpty.uri().toString())
-    );
-    assertEquals(
-      "ListCompositeReadOnlyDataSource/NNN/one",
-      replaceHash(subjectOne.uri().toString())
-    );
+    assertEquals("ListCompositeDataSource/NNN/empty", replaceHash(subjectEmpty.uri().toString()));
+    assertEquals("ListCompositeDataSource/NNN/one", replaceHash(subjectOne.uri().toString()));
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/datastore/base/ListCompositeDataSourceTest.java
+++ b/application/src/test/java/org/opentripplanner/datastore/base/ListCompositeDataSourceTest.java
@@ -1,0 +1,81 @@
+package org.opentripplanner.datastore.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.datastore.api.FileType;
+
+class ListCompositeDataSourceTest {
+
+  private static final String LEAF_NAME = "leaf";
+  private static final ByteArrayDataSource LEAF = ByteArrayDataSource.testInput(
+    LEAF_NAME,
+    FileType.GTFS,
+    "Test"
+  );
+
+  private final ListCompositeDataSource subjectEmpty = new ListCompositeDataSource(
+    "empty",
+    FileType.GTFS,
+    List.of()
+  );
+  private final ListCompositeDataSource subjectOne = new ListCompositeDataSource(
+    "one",
+    FileType.GTFS,
+    List.of(LEAF)
+  );
+
+  @Test
+  void content() {
+    assertEquals(List.of(), subjectEmpty.content());
+    assertEquals(List.of(LEAF), subjectOne.content());
+  }
+
+  @Test
+  void entry() {
+    assertEquals(null, subjectEmpty.entry(LEAF_NAME));
+    assertEquals(LEAF, subjectOne.entry(LEAF_NAME));
+  }
+
+  @Test
+  void close() {
+    // Nothing happens (exceptions not thrown)
+    subjectEmpty.close();
+    subjectOne.close();
+  }
+
+  @Test
+  void name() {
+    assertEquals("empty", subjectEmpty.name());
+    assertEquals("one", subjectOne.name());
+  }
+
+  @Test
+  void path() {
+    assertEquals("ListCompositeReadOnlyDataSource/NNN", replaceHash(subjectEmpty.path()));
+    assertEquals("ListCompositeReadOnlyDataSource/NNN", replaceHash(subjectOne.path()));
+  }
+
+  @Test
+  void uri() {
+    assertEquals(
+      "ListCompositeReadOnlyDataSource/NNN/empty",
+      replaceHash(subjectEmpty.uri().toString())
+    );
+    assertEquals(
+      "ListCompositeReadOnlyDataSource/NNN/one",
+      replaceHash(subjectOne.uri().toString())
+    );
+  }
+
+  @Test
+  void type() {
+    assertEquals(FileType.GTFS, subjectEmpty.type());
+    assertEquals(FileType.GTFS, subjectOne.type());
+  }
+
+  private String replaceHash(String name) {
+    return name.replaceAll("\\d{6,}", "NNN");
+  }
+}

--- a/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
@@ -98,7 +98,7 @@ class AbstractCsvParserTest {
 
     var missingValue = issueStore.listIssues().getFirst();
 
-    assertEquals("EmissionValueMissing", missingValue.getType());
+    assertEquals("TestValueMissing", missingValue.getType());
     assertEquals("Value for 'id' is missing: ', 1, 28.0' (@line:2)", missingValue.getMessage());
     assertEquals(1, issueStore.listIssues().size());
   }
@@ -123,7 +123,7 @@ class AbstractCsvParserTest {
 
     var intParseError = issueStore.listIssues().getFirst();
 
-    assertEquals("EmissionNumberFormat", intParseError.getType());
+    assertEquals("TestNumberFormat", intParseError.getType());
     assertEquals(
       "Unable to parse value 'not an int' for 'intValue' of type int: " +
       "'F:2, not an int, 38.0' (@line:3)",
@@ -154,8 +154,8 @@ class AbstractCsvParserTest {
     var valueTooSmall = issueStore.listIssues().getFirst();
     var valueTooBig = issueStore.listIssues().getLast();
 
-    assertEquals("EmissionOutsideRange", valueTooSmall.getType());
-    assertEquals("EmissionOutsideRange", valueTooBig.getType());
+    assertEquals("TestOutsideRange", valueTooSmall.getType());
+    assertEquals("TestOutsideRange", valueTooBig.getType());
     assertEquals(
       "The int value '-1' for intValue is outside expected range [0, 100]: 'F:1, -1, 1.0' (@line:2)",
       valueTooSmall.getMessage()
@@ -185,7 +185,7 @@ class AbstractCsvParserTest {
 
     var doubleParseError = issueStore.listIssues().getFirst();
 
-    assertEquals("EmissionNumberFormat", doubleParseError.getType());
+    assertEquals("TestNumberFormat", doubleParseError.getType());
     assertEquals(
       "Unable to parse value 'not a double' for 'doubleValue' of type double: " +
       "'F:2, 2, not a double' (@line:3)",
@@ -216,8 +216,8 @@ class AbstractCsvParserTest {
     var valueTooSmall = issueStore.listIssues().getFirst();
     var valueTooBig = issueStore.listIssues().getLast();
 
-    assertEquals("EmissionOutsideRange", valueTooSmall.getType());
-    assertEquals("EmissionOutsideRange", valueTooBig.getType());
+    assertEquals("TestOutsideRange", valueTooSmall.getType());
+    assertEquals("TestOutsideRange", valueTooBig.getType());
     assertEquals(
       "The double value '-1.0E-6' for doubleValue is outside expected range [0.0, 100.0): 'F:1, 1, -0.000001' (@line:2)",
       valueTooSmall.getMessage()
@@ -251,7 +251,7 @@ class AbstractCsvParserTest {
     }
 
     public TestCsvParser(DataImportIssueStore issueStore, String csvText) {
-      super(issueStore, CsvReader.parse(csvText));
+      super(issueStore, CsvReader.parse(csvText), "Test");
     }
 
     @Override

--- a/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.csvreader.CsvReader;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -18,20 +19,28 @@ import org.opentripplanner.utils.lang.IntRange;
 class AbstractCsvParserTest {
 
   private static final String ID = "id";
-  private static final String INT_VALUE = "intValue";
+  private static final String INT_COLUMN = "int";
   private static final IntRange INT_RANGE = IntRange.ofInclusive(0, 100);
-  private static final String DOUBLE_VALUE = "doubleValue";
+  private static final String DOUBLE_COLUMN = "double";
   private static final DoubleRange DOUBLE_RANGE = DoubleRange.of(0.0, 100.0);
+  private static final String BOOLEAN_COLUMN = "boolean";
+  private static final String LOCAL_DATE_COLUMN = "localDate";
 
-  private static final List<String> HEADERS = List.of(ID, INT_VALUE, DOUBLE_VALUE);
+  private static final List<String> HEADERS = List.of(
+    ID,
+    INT_COLUMN,
+    DOUBLE_COLUMN,
+    BOOLEAN_COLUMN,
+    LOCAL_DATE_COLUMN
+  );
   private static final String FILE_HEADER =
     HEADERS.stream().collect(Collectors.joining(", ")) + "\n";
   private static final String VALID_DATA =
     FILE_HEADER +
     """
-    F:1, 1, 28.0
-    F:2, 2, 38.0
-    F:3, 3, 48.0
+    F:1, 1, 28.0, 1, 2025-10-31
+    F:2, 2, 38.0, 0, 20250101
+    F:3, 3, 48.0, 1, 2025-02-28
     """;
 
   @Test
@@ -64,9 +73,9 @@ class AbstractCsvParserTest {
   void hasNextValidData() {
     var subject = new TestCsvParser(VALID_DATA);
     assertTrue(subject.headersMatch());
-    assertRow("F:1", 1, 28.0, subject);
-    assertRow("F:2", 2, 38.0, subject);
-    assertRow("F:3", 3, 48.0, subject);
+    assertRow("F:1", 1, 28.0, true, LocalDate.of(2025, 10, 31), subject);
+    assertRow("F:2", 2, 38.0, false, LocalDate.of(2025, 1, 1), subject);
+    assertRow("F:3", 3, 48.0, true, LocalDate.of(2025, 2, 28), subject);
     assertFalse(subject.hasNext());
   }
 
@@ -87,8 +96,8 @@ class AbstractCsvParserTest {
       issueStore,
       FILE_HEADER +
       """
-      , 1, 28.0
-      F:2, 2, 38.0
+      , 1, 28.0, 1, 2025-01-01
+      F:2, 2, 38.0, 1, 2025-01-01
       """
     );
 
@@ -99,7 +108,10 @@ class AbstractCsvParserTest {
     var missingValue = issueStore.listIssues().getFirst();
 
     assertEquals("TestValueMissing", missingValue.getType());
-    assertEquals("Value for 'id' is missing: ', 1, 28.0' (@line:2)", missingValue.getMessage());
+    assertEquals(
+      "Value for 'id' is missing: ', 1, 28.0, 1, 2025-01-01' (@line:2)",
+      missingValue.getMessage()
+    );
     assertEquals(1, issueStore.listIssues().size());
   }
 
@@ -110,9 +122,9 @@ class AbstractCsvParserTest {
       issueStore,
       FILE_HEADER +
       """
-      F:1, 1, 28.0
-      F:2, not an int, 38.0
-      F:3, 3, 48.0
+      F:1, 1, 28.0, 1, 2025-01-01
+      F:2, not an int, 38.0, 1, 2025-01-01
+      F:3, 1, 28.0, 1, 2025-01-01
       """
     );
 
@@ -123,13 +135,46 @@ class AbstractCsvParserTest {
 
     var intParseError = issueStore.listIssues().getFirst();
 
-    assertEquals("TestNumberFormat", intParseError.getType());
+    assertEquals("TestFormat", intParseError.getType());
     assertEquals(
-      "Unable to parse value 'not an int' for 'intValue' of type int: " +
-      "'F:2, not an int, 38.0' (@line:3)",
+      "Unable to parse value 'not an int' for 'int' of type int: 'F:2, not an int, 38.0, 1, " +
+      "2025-01-01' (@line:3)",
       intParseError.getMessage()
     );
     assertEquals(1, issueStore.listIssues().size());
+  }
+
+  @Test
+  void testLocalDateParsingIssue() {
+    var issueStore = new DefaultDataImportIssueStore();
+    var subject = new TestCsvParser(
+      issueStore,
+      FILE_HEADER +
+      """
+      F:1, 1, 3.0, 1, 2025-01-32
+      F:2, 2, 5.0, 0, 87-01-01
+      """
+    );
+
+    subject.headersMatch();
+    while (subject.hasNext());
+
+    var error1 = issueStore.listIssues().getFirst();
+    var error2 = issueStore.listIssues().getLast();
+
+    assertEquals("TestFormat", error1.getType());
+    //assertEquals("TestFormat", error2.getType());
+    assertEquals(
+      "Unable to parse value '2025-01-32' for 'localDate' of type local-date: " +
+      "'F:1, 1, 3.0, 1, 2025-01-32' (@line:2)",
+      error1.getMessage()
+    );
+    assertEquals(
+      "Unable to parse value '87-01-01' for 'localDate' of type local-date: " +
+      "'F:2, 2, 5.0, 0, 87-01-01' (@line:3)",
+      error2.getMessage()
+    );
+    assertEquals(2, issueStore.listIssues().size());
   }
 
   @Test
@@ -139,10 +184,10 @@ class AbstractCsvParserTest {
       issueStore,
       FILE_HEADER +
       """
-      F:1, -1, 1.0
-      F:2, 0, 1.0
-      F:3, 100, 1.0
-      F:4, 101, 1.0
+      F:1, -1, 1.0, 1, 20250101
+      F:2, 0, 1.0, 1, 20250101
+      F:3, 100, 1.0, 1, 2025-01-01
+      F:4, 101, 1.0, 1, 2025-01-01
       """
     );
 
@@ -157,11 +202,13 @@ class AbstractCsvParserTest {
     assertEquals("TestOutsideRange", valueTooSmall.getType());
     assertEquals("TestOutsideRange", valueTooBig.getType());
     assertEquals(
-      "The int value '-1' for intValue is outside expected range [0, 100]: 'F:1, -1, 1.0' (@line:2)",
+      "The int value '-1' for int is outside expected range [0, 100]: 'F:1, -1, 1.0, 1, " +
+      "20250101' (@line:2)",
       valueTooSmall.getMessage()
     );
     assertEquals(
-      "The int value '101' for intValue is outside expected range [0, 100]: 'F:4, 101, 1.0' (@line:5)",
+      "The int value '101' for int is outside expected range [0, 100]: 'F:4, 101, 1.0, 1, " +
+      "2025-01-01' (@line:5)",
       valueTooBig.getMessage()
     );
     assertEquals(2, issueStore.listIssues().size(), () -> issueStore.listIssues().toString());
@@ -174,8 +221,8 @@ class AbstractCsvParserTest {
       issueStore,
       FILE_HEADER +
       """
-      F:1, 1, 28.0
-      F:2, 2, not a double
+      F:1, 1, 28.0, 1, 2025-01-01
+      F:2, 2, not a double, 1, 2025-01-01
       """
     );
 
@@ -185,10 +232,10 @@ class AbstractCsvParserTest {
 
     var doubleParseError = issueStore.listIssues().getFirst();
 
-    assertEquals("TestNumberFormat", doubleParseError.getType());
+    assertEquals("TestFormat", doubleParseError.getType());
     assertEquals(
-      "Unable to parse value 'not a double' for 'doubleValue' of type double: " +
-      "'F:2, 2, not a double' (@line:3)",
+      "Unable to parse value 'not a double' for 'double' of type double: 'F:2, 2, " +
+      "not a double, 1, 2025-01-01' (@line:3)",
       doubleParseError.getMessage()
     );
     assertEquals(1, issueStore.listIssues().size());
@@ -201,10 +248,10 @@ class AbstractCsvParserTest {
       issueStore,
       FILE_HEADER +
       """
-      F:1, 1, -0.000001
-      F:2, 2, 0.0
-      F:3, 3, 99.999999
-      F:4, 4, 100.0
+      F:1, 1, -0.000001, 1, 2025-01-01
+      F:2, 2, 0.0, 1, 2025-01-01
+      F:3, 3, 99.999999, 1, 2025-01-01
+      F:4, 4, 100.0, 1, 2025-01-01
       """
     );
 
@@ -219,11 +266,11 @@ class AbstractCsvParserTest {
     assertEquals("TestOutsideRange", valueTooSmall.getType());
     assertEquals("TestOutsideRange", valueTooBig.getType());
     assertEquals(
-      "The double value '-1.0E-6' for doubleValue is outside expected range [0.0, 100.0): 'F:1, 1, -0.000001' (@line:2)",
+      "The double value '-1.0E-6' for double is outside expected range [0.0, 100.0): 'F:1, 1, -0.000001, 1, 2025-01-01' (@line:2)",
       valueTooSmall.getMessage()
     );
     assertEquals(
-      "The double value '100.0' for doubleValue is outside expected range [0.0, 100.0): 'F:4, 4, 100.0' (@line:5)",
+      "The double value '100.0' for double is outside expected range [0.0, 100.0): 'F:4, 4, 100.0, 1, 2025-01-01' (@line:5)",
       valueTooBig.getMessage()
     );
     assertEquals(2, issueStore.listIssues().size(), () -> issueStore.listIssues().toString());
@@ -236,12 +283,21 @@ class AbstractCsvParserTest {
     );
   }
 
-  private void assertRow(String id, int intValue, double doubleValue, TestCsvParser subject) {
+  private void assertRow(
+    String id,
+    int intValue,
+    double doubleValue,
+    boolean booleanValue,
+    LocalDate localDateValue,
+    TestCsvParser subject
+  ) {
     assertTrue(subject.hasNext(), subject::toString);
     var r = subject.next();
     assertEquals(id, r.id());
     assertEquals(intValue, r.intValue());
     assertEquals(doubleValue, r.doubleValue());
+    assertEquals(booleanValue, r.gtfsBooleanValue());
+    assertEquals(localDateValue, r.localDate());
   }
 
   private static class TestCsvParser extends AbstractCsvParser<Row> {
@@ -264,11 +320,19 @@ class AbstractCsvParserTest {
     protected Row createNextRow() throws HandledCsvParseException {
       return new Row(
         getString(ID),
-        getInt(INT_VALUE, INT_RANGE),
-        getDouble(DOUBLE_VALUE, DOUBLE_RANGE)
+        getInt(INT_COLUMN, INT_RANGE),
+        getDouble(DOUBLE_COLUMN, DOUBLE_RANGE),
+        getGtfsBoolean(BOOLEAN_COLUMN),
+        getLocalDate(LOCAL_DATE_COLUMN)
       );
     }
   }
 
-  private static record Row(String id, int intValue, double doubleValue) {}
+  private static record Row(
+    String id,
+    int intValue,
+    double doubleValue,
+    boolean gtfsBooleanValue,
+    LocalDate localDate
+  ) {}
 }

--- a/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.ext.emission.internal.csvdata.csvparser;
+package org.opentripplanner.framework.csv.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/csv/parser/AbstractCsvParserTest.java
@@ -261,7 +261,7 @@ class AbstractCsvParserTest {
 
     @Nullable
     @Override
-    protected Row createNextRow() throws EmissionHandledParseException {
+    protected Row createNextRow() throws HandledCsvParseException {
       return new Row(
         getString(ID),
         getInt(INT_VALUE, INT_RANGE),

--- a/application/src/test/java/org/opentripplanner/framework/csv/parser/OtpCsvReaderTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/csv/parser/OtpCsvReaderTest.java
@@ -3,13 +3,12 @@ package org.opentripplanner.framework.csv.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.csvreader.CsvReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.datastore.api.FileType;
-import org.opentripplanner.datastore.base.ByteArrayDataSource;
+import org.opentripplanner.datastore.configure.DataStoreModule;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.utils.lang.IntRange;
 import org.slf4j.Logger;
@@ -21,20 +20,14 @@ class OtpCsvReaderTest {
 
   @Test
   void read() {
-    var ds = new ByteArrayDataSource(
-      "path",
-      "OtpCsvReaderTestDataSource",
+    var ds = DataStoreModule.dataSource(
+      "OtpCsvReaderTest",
       FileType.GTFS,
-      2,
-      System.currentTimeMillis(),
-      false
-    );
-    ds.withBytes(
       """
       a,b,c
       1, "Cat", 1
       2, "Boot", 0
-      """.getBytes(StandardCharsets.UTF_8)
+      """
     );
     var expected = List.of(new AType(1, "Cat", true), new AType(2, "Boot", false));
 

--- a/application/src/test/java/org/opentripplanner/framework/csv/parser/OtpCsvReaderTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/csv/parser/OtpCsvReaderTest.java
@@ -1,0 +1,87 @@
+package org.opentripplanner.framework.csv.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.csvreader.CsvReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.datastore.api.FileType;
+import org.opentripplanner.datastore.base.ByteArrayDataSource;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.utils.lang.IntRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OtpCsvReaderTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OtpCsvReaderTest.class);
+
+  @Test
+  void read() {
+    var ds = new ByteArrayDataSource(
+      "path",
+      "OtpCsvReaderTestDataSource",
+      FileType.GTFS,
+      2,
+      System.currentTimeMillis(),
+      false
+    );
+    ds.withBytes(
+      """
+      a,b,c
+      1, "Cat", 1
+      2, "Boot", 0
+      """.getBytes(StandardCharsets.UTF_8)
+    );
+    var expected = List.of(new AType(1, "Cat", true), new AType(2, "Boot", false));
+
+    var list = new ArrayList<AType>();
+
+    // Without logger
+    OtpCsvReader.<AType>of()
+      .withLogger(null)
+      .withDataSource(ds)
+      .withParserFactory(Parser::new)
+      .withRowHandler(row -> list.add(row))
+      .read();
+
+    assertEquals(expected, list);
+
+    // With logger
+    list.clear();
+    OtpCsvReader.<AType>of()
+      .withLogger(LOG)
+      .withDataSource(ds)
+      .withParserFactory(Parser::new)
+      .withRowHandler(row -> list.add(row))
+      .read();
+    assertEquals(expected, list);
+  }
+
+  static class Parser extends AbstractCsvParser<AType> {
+
+    public Parser(CsvReader reader) {
+      super(DataImportIssueStore.NOOP, reader, "issueType");
+    }
+
+    @Override
+    protected List<String> headers() {
+      return List.of("a", "b", "c");
+    }
+
+    @Nullable
+    @Override
+    protected AType createNextRow() throws HandledCsvParseException {
+      return new AType(
+        getInt("a", IntRange.ofInclusive(0, 10)),
+        getString("b"),
+        getGtfsBoolean("c")
+      );
+    }
+  }
+
+  record AType(int nr, String name, boolean ok) {}
+}


### PR DESCRIPTION
### Summary

This PR contains cleanup of the CSV parsing framework support. I will be using this in a upcoming PR on empirical delays. There are no functional changes in this PR. The new `OTPCsvReader` ensure consistent integration with the data-sources component, performance logging and csv parsing. 

I have also added a few utilities to simplify testing. The `DataStoreModule` `#compositeSource(...)` and `#dataSource(...)` provide simple methods for creating data-sources for unit-tests. No resources of file-backed datasources is required. The content is provided as an input string.

### Issue

🟥  There is not issue for this.


### Unit tests

Unit-tests are added on new code, and existing tests are updated - and simplified. There are a few unit-test in the emission sandbox witch more or less only test the data-source framework. These should be migrated over to the data-source tests. I left these tests for now. The `EmissionDataReaderTest` uses file resources. I have not converted this test to use the new inline data-datasources, because this test mainly test the data-source zip/directory features - not the emissions logic.

### Documentation

JavaDoc is added/updated.

### Changelog

This is not relevant for product owners.

### Bumping the serialization version id. 

- No model object are changed.
- The new `EnumMapSerializer` is unused, but I will use it in the upcomming empirical delay PR.

