### PR TITLE
Add raw gtfs type of routes to digitransit map stations

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
@@ -39,7 +39,7 @@ public class DigitransitStationPropertyMapperTest {
     assertEquals("F:a-station", map.get("gtfsId"));
     assertEquals("A station", map.get("name"));
     assertEquals("", map.get("type"));
-    assertEquals("[{\"mode\":\"RAIL\",\"shortName\":\"R1\"}]", map.get("routes"));
+    assertEquals("[{\"mode\":\"RAIL\",\"gtfsType\":100,\"shortName\":\"R1\"}]", map.get("routes"));
     assertEquals("[\"F:stop-1\"]", map.get("stops"));
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
@@ -65,6 +65,7 @@ public class DigitransitStationPropertyMapper extends PropertyMapper<Station> {
               .map(route -> {
                 var obj = OBJECT_MAPPER.createObjectNode();
                 obj.put("mode", route.getMode().name());
+                obj.put("gtfsType", route.getGtfsType());
                 if (route.getShortName() != null) {
                   obj.put("shortName", route.getShortName());
                 }


### PR DESCRIPTION
### Summary

Digitransit stop map layer already returned raw gtfs type of routes using the stop, but terminals did not have this information.  Nowadays there are tram terminals of a specific gtfs route type 900, and we need to be able to identify them. 

### Unit tests

Unit tests updated.