### PR TITLE
POC : Use @TableTest in a Raptor unit test to improve readability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,12 @@
                 <artifactId>java-snapshot-testing-junit5</artifactId>
                 <version>2.3.0</version>
             </dependency>
-
+            <dependency>
+                <groupId>io.github.nchaugen</groupId>
+                <artifactId>tabletest-junit</artifactId>
+                <version>0.5.1</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/raptor/pom.xml
+++ b/raptor/pom.xml
@@ -55,5 +55,10 @@
             <artifactId>archunit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.nchaugen</groupId>
+            <artifactId>tabletest-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestTripScheduleSearchTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestTripScheduleSearchTest.java
@@ -4,14 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.raptor.api.model.RaptorConstants.NOT_FOUND;
-import static org.opentripplanner.raptor.api.model.SearchDirection.FORWARD;
-import static org.opentripplanner.raptor.api.model.SearchDirection.REVERSE;
 
+import io.github.nchaugen.tabletest.junit.FactorySources;
+import io.github.nchaugen.tabletest.junit.TableTest;
 import java.util.List;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
+import org.opentripplanner.raptor._support.TableTestValueParser;
 import org.opentripplanner.raptor.api.model.SearchDirection;
 import org.opentripplanner.utils.time.TimeUtils;
 
@@ -19,17 +17,10 @@ import org.opentripplanner.utils.time.TimeUtils;
  * This tests another test class - we do it to make sure the
  * {@link TestTripScheduleSearch} is following the Raptor SPI contract.
  */
-class TestTripScheduleSearchTest implements RaptorTestConstants {
+@FactorySources(TableTestValueParser.class)
+public class TestTripScheduleSearchTest implements RaptorTestConstants {
 
-  private static final int NOT_DEFINED = -999_999;
   private static final int T09_59_59 = TimeUtils.time("09:59:59");
-  private static final int T10_00_00 = TimeUtils.time("10:00:00");
-  private static final int T10_00_01 = TimeUtils.time("10:00:01");
-  private static final int T10_09_59 = TimeUtils.time("10:09:59");
-  private static final int T10_10_00 = TimeUtils.time("10:10:00");
-  private static final int T10_10_01 = TimeUtils.time("10:10:01");
-  private static final int T10_19_59 = TimeUtils.time("10:19:59");
-  private static final int T10_20_00 = TimeUtils.time("10:20:00");
   private static final int T10_20_01 = TimeUtils.time("10:20:01");
 
   private static final int TRIP_ONE = 0;
@@ -46,25 +37,23 @@ class TestTripScheduleSearchTest implements RaptorTestConstants {
     TestTripSchedule.schedule(PATTERN).times("10:10 10:20").build()
   );
 
-  static List<Arguments> tripSearchWithOneTripTestCases() {
-    return List.of(
-      Arguments.of(FORWARD, STOP_POS_0, T09_59_59, T10_00_00, Status.OK),
-      Arguments.of(FORWARD, STOP_POS_0, T10_00_00, T10_00_00, Status.OK),
-      Arguments.of(FORWARD, STOP_POS_0, T10_00_01, NOT_DEFINED, Status.EMPTY),
-      Arguments.of(FORWARD, STOP_POS_1, T10_09_59, T10_10_00, Status.OK),
-      Arguments.of(FORWARD, STOP_POS_1, T10_10_00, T10_10_00, Status.OK),
-      Arguments.of(FORWARD, STOP_POS_1, T10_10_01, NOT_DEFINED, Status.EMPTY),
-      Arguments.of(REVERSE, STOP_POS_0, T09_59_59, NOT_DEFINED, Status.EMPTY),
-      Arguments.of(REVERSE, STOP_POS_0, T10_00_00, T10_00_00, Status.OK),
-      Arguments.of(REVERSE, STOP_POS_0, T10_00_01, T10_00_00, Status.OK),
-      Arguments.of(REVERSE, STOP_POS_1, T10_09_59, NOT_DEFINED, Status.EMPTY),
-      Arguments.of(REVERSE, STOP_POS_1, T10_10_00, T10_10_00, Status.OK),
-      Arguments.of(REVERSE, STOP_POS_1, T10_10_01, T10_10_00, Status.OK)
-    );
-  }
-
-  @ParameterizedTest
-  @MethodSource("tripSearchWithOneTripTestCases")
+  @TableTest(
+    """
+    Direction | Stop Pos | Search Time | Exp Time  | Exp Status
+    FORWARD   | 0        | 09:59:59    | 10:00:00  | OK
+    FORWARD   | 0        | 10:00:00    | 10:00:00  | OK
+    FORWARD   | 0        | 10:00:01    | UNDEFINED | EMPTY
+    FORWARD   | 1        | 10:09:59    | 10:10:00  | OK
+    FORWARD   | 1        | 10:10:00    | 10:10:00  | OK
+    FORWARD   | 1        | 10:10:01    | UNDEFINED | EMPTY
+    REVERSE   | 0        | 09:59:59    | UNDEFINED | EMPTY
+    REVERSE   | 0        | 10:00:00    | 10:00:00  | OK
+    REVERSE   | 0        | 10:00:01    | 10:00:00  | OK
+    REVERSE   | 1        | 10:09:59    | UNDEFINED | EMPTY
+    REVERSE   | 1        | 10:10:00    | 10:10:00  | OK
+    REVERSE   | 1        | 10:10:01    | 10:10:00  | OK
+    """
+  )
   void tripSearchWithOneTrip(
     SearchDirection direction,
     int stopPos,
@@ -95,37 +84,37 @@ class TestTripScheduleSearchTest implements RaptorTestConstants {
     }
   }
 
-  static List<Arguments> tripSearchWithTwoTripsTestCases() {
-    return List.of(
-      Arguments.of(FORWARD, STOP_POS_0, T09_59_59, T10_00_00, TRIP_ONE),
-      Arguments.of(FORWARD, STOP_POS_0, T10_00_00, T10_00_00, TRIP_ONE),
-      Arguments.of(FORWARD, STOP_POS_0, T10_00_01, T10_10_00, TRIP_TWO),
-      Arguments.of(FORWARD, STOP_POS_0, T10_09_59, T10_10_00, TRIP_TWO),
-      Arguments.of(FORWARD, STOP_POS_0, T10_10_00, T10_10_00, TRIP_TWO),
-      Arguments.of(FORWARD, STOP_POS_0, T10_10_01, NOT_DEFINED, NOT_FOUND),
-      Arguments.of(FORWARD, STOP_POS_1, T10_09_59, T10_10_00, TRIP_ONE),
-      Arguments.of(FORWARD, STOP_POS_1, T10_10_00, T10_10_00, TRIP_ONE),
-      Arguments.of(FORWARD, STOP_POS_1, T10_10_01, T10_20_00, TRIP_TWO),
-      Arguments.of(FORWARD, STOP_POS_1, T10_19_59, T10_20_00, TRIP_TWO),
-      Arguments.of(FORWARD, STOP_POS_1, T10_20_00, T10_20_00, TRIP_TWO),
-      Arguments.of(FORWARD, STOP_POS_1, T10_20_01, NOT_DEFINED, NOT_FOUND),
-      Arguments.of(REVERSE, STOP_POS_0, T09_59_59, NOT_DEFINED, NOT_FOUND),
-      Arguments.of(REVERSE, STOP_POS_0, T10_00_00, T10_00_00, TRIP_ONE),
-      Arguments.of(REVERSE, STOP_POS_0, T10_00_01, T10_00_00, TRIP_ONE),
-      Arguments.of(REVERSE, STOP_POS_0, T10_09_59, T10_00_00, TRIP_ONE),
-      Arguments.of(REVERSE, STOP_POS_0, T10_10_00, T10_10_00, TRIP_TWO),
-      Arguments.of(REVERSE, STOP_POS_0, T10_10_01, T10_10_00, TRIP_TWO),
-      Arguments.of(REVERSE, STOP_POS_1, T10_09_59, NOT_DEFINED, NOT_FOUND),
-      Arguments.of(REVERSE, STOP_POS_1, T10_10_00, T10_10_00, TRIP_ONE),
-      Arguments.of(REVERSE, STOP_POS_1, T10_10_01, T10_10_00, TRIP_ONE),
-      Arguments.of(REVERSE, STOP_POS_1, T10_19_59, T10_10_00, TRIP_ONE),
-      Arguments.of(REVERSE, STOP_POS_1, T10_20_00, T10_20_00, TRIP_TWO),
-      Arguments.of(REVERSE, STOP_POS_1, T10_20_01, T10_20_00, TRIP_TWO)
-    );
-  }
-
-  @ParameterizedTest
-  @MethodSource("tripSearchWithTwoTripsTestCases")
+  @TableTest(
+    """
+    Direction | Stop Pos | Search Time | Exp Time  | Exp Trip Index
+    FORWARD   | 0        | 09:59:59    | 10:00:00  | 0
+    FORWARD   | 0        | 10:00:00    | 10:00:00  | 0
+    FORWARD   | 0        | 09:59:59    | 10:00:00  | 0
+    FORWARD   | 0        | 10:00:00    | 10:00:00  | 0
+    FORWARD   | 0        | 10:00:01    | 10:10:00  | 1
+    FORWARD   | 0        | 10:09:59    | 10:10:00  | 1
+    FORWARD   | 0        | 10:10:00    | 10:10:00  | 1
+    FORWARD   | 0        | 10:10:01    | UNDEFINED | NOT_FOUND
+    FORWARD   | 1        | 10:09:59    | 10:10:00  | 0
+    FORWARD   | 1        | 10:10:00    | 10:10:00  | 0
+    FORWARD   | 1        | 10:10:01    | 10:20:00  | 1
+    FORWARD   | 1        | 10:19:59    | 10:20:00  | 1
+    FORWARD   | 1        | 10:20:00    | 10:20:00  | 1
+    FORWARD   | 1        | 10:20:01    | UNDEFINED | NOT_FOUND
+    REVERSE   | 0        | 09:59:59    | UNDEFINED | NOT_FOUND
+    REVERSE   | 0        | 10:00:00    | 10:00:00  | 0
+    REVERSE   | 0        | 10:00:01    | 10:00:00  | 0
+    REVERSE   | 0        | 10:09:59    | 10:00:00  | 0
+    REVERSE   | 0        | 10:10:00    | 10:10:00  | 1
+    REVERSE   | 0        | 10:10:01    | 10:10:00  | 1
+    REVERSE   | 1        | 10:09:59    | UNDEFINED | NOT_FOUND
+    REVERSE   | 1        | 10:10:00    | 10:10:00  | 0
+    REVERSE   | 1        | 10:10:01    | 10:10:00  | 0
+    REVERSE   | 1        | 10:19:59    | 10:10:00  | 0
+    REVERSE   | 1        | 10:20:00    | 10:20:00  | 1
+    REVERSE   | 1        | 10:20:01    | 10:20:00  | 1
+    """
+  )
   void tripSearchWithTwoTrips(
     SearchDirection direction,
     int stopPos,

--- a/raptor/src/test/java/org/opentripplanner/raptor/_support/TableTestValueParser.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_support/TableTestValueParser.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.raptor._support;
+
+import java.util.Map;
+import org.opentripplanner.raptor.api.model.RaptorConstants;
+import org.opentripplanner.utils.time.TimeUtils;
+
+
+/**
+ * This is used by the {@link io.github.nchaugen.tabletest.junit.TableTest} to parse
+ * string and convert them to frequently used types and values.
+ * <p/>
+ * The following mappings exist:
+ * <ul>
+ *   <li>
+ *     Constant integers like {@code UNDEFINED}, {@code NOT_FOUND} and {@code NOT_SET} is mapped
+ *     to an int value.
+ *   </li>
+ *   <li>
+ *     Time format {@code hh:mm:ss} is mapped to seconds-after-midnight.
+ *   </li>
+ * </ul>
+ *
+ */
+
+@SuppressWarnings("unused")
+public class TableTestValueParser {
+    public static final int UNDEFINED = -987_987_987;
+
+    private static final Map<String, Integer> INT_CONSTANTS = Map.ofEntries(
+      Map.entry("UNDEFINED", UNDEFINED),
+      Map.entry("NOT_FOUND", RaptorConstants.NOT_FOUND),
+      Map.entry("NOT_SET", RaptorConstants.NOT_SET),
+      Map.entry("TIME_NOT_SET", RaptorConstants.TIME_NOT_SET),
+      Map.entry("TIME_UNREACHED_FORWARD", RaptorConstants.TIME_UNREACHED_FORWARD),
+      Map.entry("TIME_UNREACHED_REVERSE", RaptorConstants.TIME_UNREACHED_REVERSE)
+  );
+
+  public static Integer parseInteger(String value) {
+    if (INT_CONSTANTS.containsKey(value)) {
+      return INT_CONSTANTS.get(value);
+    }
+    if (value.contains(":")) {
+      return TimeUtils.time(value);
+    }
+    return Integer.parseInt(value);
+  }
+}


### PR DESCRIPTION
### Summary

This is a POC to demonstrate [TableTest](https://github.com/nchaugen/tabletest) in OTP. We can discuss if this is something we want to use in a dev meeting. 

The [TableTest](https://github.com/nchaugen/tabletest) is written by a colleague of mine in Scienta. The TableTest is inspired by the Spock framework.

#### Pros
 - More readable tests. Most of the "ugly looking" `@ParameterizedTest` can be replaced by `@TableTest`

#### Cons
 - Depend on a small utility with limited support

There is a IntelliJ plugin witch must be installed to get syntax highlighting and editing support for the tables.

In IntelliJ the test will look like this:

<img width="546" height="529" alt="Skjermbilde 2025-09-05 kl  13 02 32" src="https://github.com/user-attachments/assets/7317e551-6af7-4503-915c-6db97325c64e" />

The custom parsing of the `int` values is achieved by adding a `@FactorySource` to the class:

```Java
@FactorySources(TableTestValueParser.class)
public class TestTripScheduleSearchTest implements RaptorTestConstants {
```

### Issue
 - This improve unit tests, no issue.


### Unit tests

Improve

### Documentation

JavaDoc added

### Changelog

Not relevant

### Bumping the serialization version id

Not needed