### PR TITLE
Add OTP Badge to ServerInfo

### DIFF
--- a/application/src/main/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGenerator.java
+++ b/application/src/main/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGenerator.java
@@ -40,8 +40,8 @@ public class OtpBadgeGenerator {
    * @return A string containing the svg xml document.
    */
   public static String generateOtpBadgeSvg(String label, String labelBgColor, String body) {
-    int labelLength = fontWith(label);
-    int versionLength = fontWith(body);
+    int labelLength = fontWidth(label);
+    int versionLength = fontWidth(body);
     int totalWidth = 4 * MARGIN + labelLength + versionLength;
 
     return TEMPLATE.replace("{{body}}", body)
@@ -61,7 +61,7 @@ public class OtpBadgeGenerator {
    * This method estimates the width needed for the given {@code text}. It is not accurate,
    * but the text will be stretched/compressed to match the width.
    */
-  private static int fontWith(String text) {
+  private static int fontWidth(String text) {
     int length = text.length();
     int small = text.replaceAll("[^ .il1\\()\\[\\]{}!,:;]", "").length();
     int big = length - small;

--- a/application/src/main/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGenerator.java
+++ b/application/src/main/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGenerator.java
@@ -1,0 +1,70 @@
+package org.opentripplanner.api.model.serverinfo;
+
+/**
+ * This class is used to generate a SVG badge.
+ */
+public class OtpBadgeGenerator {
+
+  private static final int MARGIN = 50;
+  private static final int TEXT_INSET = 5;
+  private static final int FONT_WIDTH = 82;
+  private static final String TEMPLATE =
+    """
+    <svg width="{{svgWidth}}" height="20" viewBox="0 0 {{width}} 200"
+        xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{label}}: {{body}}">
+      <title>{{label}}: {{body}}</title>
+      <linearGradient id="grad1" x2="0" y2="100%">
+        <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+        <stop offset="1" stop-opacity=".1"/>
+      </linearGradient>
+      <mask id="mask1"><rect width="{{width}}" height="200" rx="30" fill="#FFF"/></mask>
+      <g mask="url(#mask1)">
+        <rect width="{{labelWidth}}" height="200" fill="{{labelBgColor}}"/>
+        <rect width="{{versionWidth}}" height="200" fill="#2179BF" x="{{labelWidth}}"/>
+        <rect width="{{width}}" height="200" fill="url(#grad1)"/>
+      </g>
+      <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+        <text x="60" y="148" textLength="{{labelLength}}" fill="#000" opacity="0.25">{{label}}</text>
+        <text x="50" y="138" textLength="{{labelLength}}">{{label}}</text>
+        <text x="{{versionOffsetA}}" y="148" textLength="{{versionLength}}" fill="#000" opacity="0.25">{{body}}</text>
+        <text x="{{versionOffsetB}}" y="138" textLength="{{versionLength}}">{{body}}</text>
+      </g>
+    </svg>
+    """;
+
+  /**
+   *
+   * @param label The label in the
+   * @param labelBgColor The background color for the label using a valid SVG color format.
+   * @param body The text for the body. The background color will be in OTP blue.
+   * @return A string containing the svg xml document.
+   */
+  public static String generateOtpBadgeSvg(String label, String labelBgColor, String body) {
+    int labelLength = fontWith(label);
+    int versionLength = fontWith(body);
+    int totalWidth = 4 * MARGIN + labelLength + versionLength;
+
+    return TEMPLATE.replace("{{body}}", body)
+      .replace("{{labelBgColor}}", labelBgColor)
+      .replace("{{label}}", label)
+      .replace("{{svgWidth}}", Double.toString(totalWidth / 10.0))
+      .replace("{{width}}", Integer.toString(totalWidth))
+      .replace("{{labelWidth}}", Integer.toString(labelLength + 2 * MARGIN))
+      .replace("{{versionWidth}}", Integer.toString(versionLength + 2 * MARGIN))
+      .replace("{{labelLength}}", Integer.toString(labelLength))
+      .replace("{{versionLength}}", Integer.toString(versionLength))
+      .replace("{{versionOffsetA}}", Integer.toString(labelLength + 3 * MARGIN + TEXT_INSET))
+      .replace("{{versionOffsetB}}", Integer.toString(labelLength + 3 * MARGIN - TEXT_INSET));
+  }
+
+  /**
+   * This method estimates the width needed for the given {@code text}. It is not accurate,
+   * but the text will be stretched/compressed to match the width.
+   */
+  private static int fontWith(String text) {
+    int length = text.length();
+    int small = text.replaceAll("[^ .il1\\()\\[\\]{}!,:;]", "").length();
+    int big = length - small;
+    return big * FONT_WIDTH + small * ((FONT_WIDTH * 3) / 5);
+  }
+}

--- a/application/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
+++ b/application/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
@@ -1,14 +1,21 @@
 package org.opentripplanner.api.resource;
 
+import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.generateOtpBadgeSvg;
+
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import org.opentripplanner.api.model.serverinfo.ApiServerInfo;
 import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 
@@ -46,5 +53,22 @@ public class ServerInfo {
   @Produces(MediaType.APPLICATION_JSON)
   public ApiServerInfo getServerInfo() {
     return SERVER_INFO;
+  }
+
+  @GET
+  @Path("version-badge.svg")
+  @Produces("image/svg+xml;charset=utf-8")
+  public Response getVersionBadge(
+    @QueryParam("color") @DefaultValue("#E43") String color,
+    @QueryParam("label") @DefaultValue("OTP Version") String label
+  ) {
+    var version =
+      "%s (%s)".formatted(SERVER_INFO.version.getVersion(), SERVER_INFO.otpSerializationVersionId);
+    var svg = generateOtpBadgeSvg(label, color, version);
+    var cacheControl = new CacheControl();
+    cacheControl.setNoCache(true);
+    // The "Cache-Control: no-cache" and "Last-Modified" is required by GitHub to avoid aggressive
+    // caching.
+    return Response.ok(svg).cacheControl(cacheControl).lastModified(new Date()).build();
   }
 }

--- a/application/src/main/java/org/opentripplanner/api/resource/ServerInfoResource.java
+++ b/application/src/main/java/org/opentripplanner/api/resource/ServerInfoResource.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.api.resource;
 
 import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.generateOtpBadgeSvg;
+import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.isValidColor;
+import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.isValidLabel;
 
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -62,6 +64,16 @@ public class ServerInfoResource {
     @QueryParam("color") @DefaultValue("#E43") String color,
     @QueryParam("label") @DefaultValue("OTP Version") String label
   ) {
+    if (!isValidColor(color)) {
+      return Response.status(Response.Status.BAD_REQUEST)
+        .entity("The 'color' parameter contains unexpected characters...")
+        .build();
+    }
+    if (!isValidLabel(label)) {
+      return Response.status(Response.Status.BAD_REQUEST)
+        .entity("The 'label' parameter contains unexpected characters...")
+        .build();
+    }
     var version =
       "%s (%s)".formatted(SERVER_INFO.version.getVersion(), SERVER_INFO.otpSerializationVersionId);
     var svg = generateOtpBadgeSvg(label, color, version);

--- a/application/src/main/java/org/opentripplanner/api/resource/ServerInfoResource.java
+++ b/application/src/main/java/org/opentripplanner/api/resource/ServerInfoResource.java
@@ -20,7 +20,7 @@ import org.opentripplanner.api.model.serverinfo.ApiServerInfo;
 import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 
 @Path("/")
-public class ServerInfo {
+public class ServerInfoResource {
 
   private static final ApiServerInfo SERVER_INFO = createServerInfo();
 

--- a/application/src/main/java/org/opentripplanner/apis/APIEndpoints.java
+++ b/application/src/main/java/org/opentripplanner/apis/APIEndpoints.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import org.opentripplanner.api.resource.ServerInfo;
+import org.opentripplanner.api.resource.ServerInfoResource;
 import org.opentripplanner.api.resource.UpdaterStatusResource;
 import org.opentripplanner.apis.gtfs.GtfsGraphQLAPI;
 import org.opentripplanner.apis.transmodel.TransmodelAPI;
@@ -41,7 +41,7 @@ public class APIEndpoints {
   private APIEndpoints() {
     // Add feature enabled APIs, these can be enabled by default, some is not.
     // See the OTPFeature enum for details.
-    addIfEnabled(APIServerInfo, ServerInfo.class);
+    addIfEnabled(APIServerInfo, ServerInfoResource.class);
     addIfEnabled(APIUpdaterStatus, UpdaterStatusResource.class);
     addIfEnabled(DebugUi, DebugVectorTilesResource.class);
     addIfEnabled(GtfsGraphQlApi, GtfsGraphQLAPI.class);

--- a/application/src/test/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGeneratorTest.java
+++ b/application/src/test/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGeneratorTest.java
@@ -1,0 +1,44 @@
+package org.opentripplanner.api.model.serverinfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.generateOtpBadgeSvg;
+
+import org.junit.jupiter.api.Test;
+
+public class OtpBadgeGeneratorTest {
+
+  @Test
+  void getVersionBadge() {
+    String result = generateOtpBadgeSvg(
+      "OTP version/ser.ver.id",
+      "firebrick",
+      "2.8.0-SNAPSHOT-237"
+    );
+
+    assertEquals(
+      """
+      <svg width="324.9" height="20" viewBox="0 0 3249 200"
+          xmlns="http://www.w3.org/2000/svg" role="img" aria-label="OTP version/ser.ver.id: 2.8.0-SNAPSHOT-237">
+        <title>OTP version/ser.ver.id: 2.8.0-SNAPSHOT-237</title>
+        <linearGradient id="grad1" x2="0" y2="100%">
+          <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+          <stop offset="1" stop-opacity=".1"/>
+        </linearGradient>
+        <mask id="mask1"><rect width="3249" height="200" rx="30" fill="#FFF"/></mask>
+        <g mask="url(#mask1)">
+          <rect width="1739" height="200" fill="firebrick"/>
+          <rect width="1510" height="200" fill="#2179BF" x="1739"/>
+          <rect width="3249" height="200" fill="url(#grad1)"/>
+        </g>
+        <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+          <text x="60" y="148" textLength="1639" fill="#000" opacity="0.25">OTP version/ser.ver.id</text>
+          <text x="50" y="138" textLength="1639">OTP version/ser.ver.id</text>
+          <text x="1794" y="148" textLength="1410" fill="#000" opacity="0.25">2.8.0-SNAPSHOT-237</text>
+          <text x="1784" y="138" textLength="1410">2.8.0-SNAPSHOT-237</text>
+        </g>
+      </svg>
+      """,
+      result
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGeneratorTest.java
+++ b/application/src/test/java/org/opentripplanner/api/model/serverinfo/OtpBadgeGeneratorTest.java
@@ -1,7 +1,11 @@
 package org.opentripplanner.api.model.serverinfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.generateOtpBadgeSvg;
+import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.isValidColor;
+import static org.opentripplanner.api.model.serverinfo.OtpBadgeGenerator.isValidLabel;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,35 +14,61 @@ public class OtpBadgeGeneratorTest {
   @Test
   void getVersionBadge() {
     String result = generateOtpBadgeSvg(
-      "OTP version/ser.ver.id",
+      "🦋 OTP <version>/<ser.ver.id>",
       "firebrick",
       "2.8.0-SNAPSHOT-237"
     );
 
     assertEquals(
       """
-      <svg width="324.9" height="20" viewBox="0 0 3249 200"
-          xmlns="http://www.w3.org/2000/svg" role="img" aria-label="OTP version/ser.ver.id: 2.8.0-SNAPSHOT-237">
-        <title>OTP version/ser.ver.id: 2.8.0-SNAPSHOT-237</title>
+      <svg width="379.0" height="20" viewBox="0 0 3790 200"
+          xmlns="http://www.w3.org/2000/svg" role="img" aria-label="🦋 OTP &lt;version&gt;/&lt;ser.ver.id&gt;: 2.8.0-SNAPSHOT-237">
+        <title>🦋 OTP &lt;version&gt;/&lt;ser.ver.id&gt;: 2.8.0-SNAPSHOT-237</title>
         <linearGradient id="grad1" x2="0" y2="100%">
           <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
           <stop offset="1" stop-opacity=".1"/>
         </linearGradient>
-        <mask id="mask1"><rect width="3249" height="200" rx="30" fill="#FFF"/></mask>
+        <mask id="mask1"><rect width="3790" height="200" rx="30" fill="#FFF"/></mask>
         <g mask="url(#mask1)">
-          <rect width="1739" height="200" fill="firebrick"/>
-          <rect width="1510" height="200" fill="#2179BF" x="1739"/>
-          <rect width="3249" height="200" fill="url(#grad1)"/>
+          <rect width="2280" height="200" fill="firebrick"/>
+          <rect width="1510" height="200" fill="#2179BF" x="2280"/>
+          <rect width="3790" height="200" fill="url(#grad1)"/>
         </g>
         <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-          <text x="60" y="148" textLength="1639" fill="#000" opacity="0.25">OTP version/ser.ver.id</text>
-          <text x="50" y="138" textLength="1639">OTP version/ser.ver.id</text>
-          <text x="1794" y="148" textLength="1410" fill="#000" opacity="0.25">2.8.0-SNAPSHOT-237</text>
-          <text x="1784" y="138" textLength="1410">2.8.0-SNAPSHOT-237</text>
+          <text x="60" y="148" textLength="2180" fill="#000" opacity="0.25">🦋 OTP &lt;version&gt;/&lt;ser.ver.id&gt;</text>
+          <text x="50" y="138" textLength="2180">🦋 OTP &lt;version&gt;/&lt;ser.ver.id&gt;</text>
+          <text x="2335" y="148" textLength="1410" fill="#000" opacity="0.25">2.8.0-SNAPSHOT-237</text>
+          <text x="2325" y="138" textLength="1410">2.8.0-SNAPSHOT-237</text>
         </g>
       </svg>
       """,
       result
     );
+  }
+
+  @Test
+  void testIsValidColor() {
+    assertTrue(isValidColor("red"));
+    assertTrue(isValidColor("lightgoldenrodyellow"));
+    assertTrue(isValidColor("#FF00A9"));
+    assertTrue(isValidColor("rgb( 255, 255, 0 )"));
+    assertTrue(isValidColor("rgba(0,0,0,0.5)"));
+    assertFalse(isValidColor("red!"));
+    assertFalse(isValidColor("#GGGGGG"));
+    assertFalse(isValidColor("rgb(A,0,0)"));
+  }
+
+  @Test
+  void testIsValidLabel() {
+    assertTrue(isValidLabel(""));
+    assertTrue(isValidLabel("A"));
+    String label120 =
+      "1234567 10 234567 20 234567 30 234567 40 234567 50 234567 60" +
+      " 234567 70 234567 80 234567 90 23456 100 23456 110 23456 120";
+    assertTrue(isValidLabel(label120));
+    assertFalse(isValidLabel(label120 + "1"));
+    assertTrue(isValidLabel("Label with <>§!\"#$%&/()=?+,.;:"));
+    assertTrue(isValidLabel("æøåÆØÅôòóö"));
+    assertTrue(isValidLabel("⚽️🦤🚌🦋⚙️☕️"));
   }
 }


### PR DESCRIPTION
### Summary

OTP already have an HTTP GET endpoint for fetching OTP server info (version info). This PR add a new endpoint witch return the version information (OTP server version and ser.ver.id) as an SVG xml image. This is useful in CI/CD pipelines where you can add the badge to your deployment status page or to the forked GitHub main README. 

The html to generate a badge:

> http://localhost:8080/otp/version-badge.svg?color=firebrick&label=My%20Label

The returned badge look like this:

> <img width="228" height="24" alt="Skjermbilde 2025-09-18 kl  14 01 26" src="https://github.com/user-attachments/assets/a040148c-86ef-4f44-91fa-7f726929024b" />

The background color used for the version is the same as the OTP logo.

### Issue

🟥  There is no issue for this. 

### Unit tests

✅  There is a unit test for the svg file generation.

### Documentation

This feature is only documented in the code(JavaDoc).


### Changelog
I am unsure if this should go in the changelog or not.

### Bumping the serialization version id

🟥  Not needed.