### PR TITLE
Simplify Hashcode in TripPatternForDate

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
@@ -158,16 +158,18 @@ public class TripPatternForDate implements Comparable<TripPatternForDate> {
     return serviceDate.compareTo(other.serviceDate);
   }
 
+  /**
+   * The natural key of a TripPatternForDate is the pair (routing trip pattern id, service date).
+   */
   @Override
   public int hashCode() {
-    return Objects.hash(
-      tripPattern,
-      serviceDate,
-      Arrays.hashCode(tripTimes),
-      Arrays.hashCode(frequencies)
-    );
+    return Objects.hash(tripPattern, serviceDate);
   }
 
+  /**
+   * The natural key of a TripPatternForDate is the pair (routing trip pattern id, service date).
+   * TODO: align equals and hashcode to use only the pair (routing trip pattern id, service date)
+   */
   @Override
   public boolean equals(Object o) {
     if (this == o) {


### PR DESCRIPTION
### Summary
As detailed in #6820, recent changes in the hashcode methods of RealtimeTripTimes and ScheduledTriptimes significantly increased the CPU consumption of the real-time updaters (both GTFS-RT and SIRI).
This is due to frequent additions/removals of TripPatternForDate objects from a Set, which triggers the execution of the TripPatternForDate.hashcode(), which in turn calls RealtimeTripTimes.hashcode() and ScheduledTriptimes.hashcode().

A possible solution would be to cache the hashcode in RealtimeTripTimes and ScheduledTriptimes.
Another possible solution would be to cache the hashcode in TripPatternForDate.
Both solutions have been tested and work as expected.

However, it does not seem that the hashcode method in TripPatternForDate needs to be so exhaustive/complex as it is today.
The natural key of TripPatternForDate should be the pair (trip pattern id, service date), and the hashcode and equals methods should reflect exactly that.
Reviewing the places in the code where hashing/equality are used (in RealTimeRaptorTransitDataUpdater) seems to confirm this hypothesis.

The solution proposed here is:
- in this PR, to simplify TripPatternForDate.hashcode() by hashing only (trip pattern id, service date)
- in a follow-up PR, to simplify TripPatternForDate.equals() by comparing only (trip pattern id, service date)

While the first PR induces limited risk and will solve the performance issue, the second PR is not strictly required and may break the logic.
We believe however that it is important for code quality to align hashcode() and equals(), confirm that that the natural key of TripPatternForDate is (trip pattern id, service date), and document it.  

### Issue

Close #6820

### Unit tests
No
### Documentation

Updated Javadoc

### Changelog

skip

