### PR TITLE
Automatically remove unused imports

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -15,9 +15,7 @@ on:
       - dev-1.x
       - dev-2.x
 env:
-  # Since version 3.9.0 of Maven it will automatically understand this environment variable.
-  # However, as of 2024-11 the latest versions of Ubuntu and Debian were on 3.8.8 so it will take some
-  # time until we can remove the $MAVEN_ARGS below.
+  # maven default arguments to make the log quieter and colourful
   MAVEN_ARGS: "--no-transfer-progress -Dstyle.color=always"
 
 jobs:
@@ -52,8 +50,8 @@ jobs:
         # https://github.com/actions/runner-images/issues/1499
         # we set nodePath and npmPath to skip downloading the node binary, which frequently times out
         run: |
-          mvn $MAVEN_ARGS jacoco:prepare-agent test jacoco:report -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
-          mvn $MAVEN_ARGS package -Dmaven.test.skip -P prettierSkip
+          mvn jacoco:prepare-agent test jacoco:report -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm spotless:check
+          mvn package -Dmaven.test.skip -P prettierSkip
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner'
@@ -74,7 +72,7 @@ jobs:
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn $MAVEN_ARGS deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierSkip -P deployGitHub
+        run: mvn deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierSkip -P deployGitHub
 
   build-windows:
     timeout-minutes: 20
@@ -92,7 +90,7 @@ jobs:
       - name: Configure Windows Pagefile
         uses: al-cheb/configure-pagefile-action@v1.4
       - name: Run tests
-        run: mvn $MAVEN_ARGS test -P prettierSkip
+        run: mvn test -P prettierSkip
 
   docs:
     if: github.repository_owner == 'opentripplanner'
@@ -205,7 +203,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Compile Java code
-        run: mvn $MAVEN_ARGS compile -DskipTests -P prettierSkip
+        run: mvn compile -DskipTests -P prettierSkip
 
   container-image:
     if: github.repository_owner == 'opentripplanner' && github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
@@ -250,4 +248,4 @@ jobs:
           
           MAVEN_SKIP_ARGS="-P prettierSkip -Dmaven.test.skip=true -Dmaven.source.skip=true"
           
-          mvn $MAVEN_ARGS $MAVEN_SKIP_ARGS package com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,$image_version
+          mvn $MAVEN_SKIP_ARGS package com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,$image_version

--- a/application/src/main/java/org/opentripplanner/api/model/transit/FeedScopedIdMapper.java
+++ b/application/src/main/java/org/opentripplanner/api/model/transit/FeedScopedIdMapper.java
@@ -3,7 +3,6 @@ package org.opentripplanner.api.model.transit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.framework.FeedScopedId;

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertEntityTypeResolver.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertEntityTypeResolver.java
@@ -11,7 +11,6 @@ import org.opentripplanner.apis.gtfs.model.UnknownModel;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
-import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopLocationsGroup;
 import org.opentripplanner.transit.model.timetable.Trip;

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LocationGroupImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/LocationGroupImpl.java
@@ -2,13 +2,10 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.Collections;
 import java.util.List;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
-import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.GroupStop;
-import org.opentripplanner.utils.collection.ListUtils;
 
 public class LocationGroupImpl implements GraphQLDataFetchers.GraphQLLocationGroup {
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopCallImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopCallImpl.java
@@ -9,7 +9,6 @@ import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.apis.gtfs.model.CallRealTime;
 import org.opentripplanner.apis.gtfs.model.CallSchedule;
-import org.opentripplanner.apis.gtfs.model.CallScheduledTime;
 import org.opentripplanner.apis.gtfs.model.CallScheduledTime.ArrivalDepartureTime;
 import org.opentripplanner.apis.gtfs.model.CallScheduledTime.TimeWindow;
 import org.opentripplanner.model.TripTimeOnDate;

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/AlertCauseMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/AlertCauseMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.apis.gtfs.mapping;
 
-import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertCauseType;
 import org.opentripplanner.routing.alertpatch.AlertCause;
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/AlertEffectMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/AlertEffectMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.apis.gtfs.mapping;
 
-import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertEffectType;
 import org.opentripplanner.routing.alertpatch.AlertEffect;
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/SelectRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/SelectRequestMapper.java
@@ -3,11 +3,8 @@ package org.opentripplanner.apis.gtfs.mapping.routerequest;
 import static org.opentripplanner.utils.collection.CollectionUtils.requireNullOrNonEmpty;
 
 import org.opentripplanner.apis.gtfs.GraphQLUtils;
-import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTransitFilterSelectInput;
-import org.opentripplanner.apis.gtfs.mapping.TransitModeMapper;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
-import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.utils.collection.CollectionUtils;
 

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -15,7 +15,6 @@ import org.opentripplanner.apis.vectortiles.model.ZoomDependentNumber.ZoomStop;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalVehicle;
 import org.opentripplanner.service.vehiclerental.street.StreetVehicleRentalLink;
-import org.opentripplanner.service.vehiclerental.street.VehicleRentalEdge;
 import org.opentripplanner.standalone.config.debuguiconfig.BackgroundTileLayer;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.AreaEdge;

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/BarrierEdgeBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/BarrierEdgeBuilder.java
@@ -14,7 +14,6 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.OsmVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
-import org.opentripplanner.street.search.TraverseMode;
 
 public class BarrierEdgeBuilder {
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmAreaGroup.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmAreaGroup.java
@@ -2,7 +2,6 @@ package org.opentripplanner.graph_builder.module.osm;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import gnu.trove.list.TLongList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/CompactShape.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/CompactShape.java
@@ -4,10 +4,7 @@ import gnu.trove.list.TDoubleList;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TIntArrayList;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.opentripplanner.model.ShapePoint;
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareTransferRuleMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareTransferRuleMapper.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
-import org.opentripplanner.ext.fares.model.FareTransferRuleBuilder;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 

--- a/application/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
@@ -7,7 +7,6 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
-import org.apache.hc.core5.http.ContentType;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.api.resource.WebMercatorTile;
 import org.opentripplanner.framework.io.HttpUtils;

--- a/application/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
@@ -15,7 +15,6 @@ import org.opentripplanner.service.vehicleparking.model.VehicleParkingEntrance;
 import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.vertex.BarrierVertex;
-import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;

--- a/application/src/main/java/org/opentripplanner/model/calendar/CalendarService.java
+++ b/application/src/main/java/org/opentripplanner/model/calendar/CalendarService.java
@@ -3,7 +3,6 @@ package org.opentripplanner.model.calendar;
 import java.time.LocalDate;
 import java.util.Set;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.organization.Agency;
 
 public interface CalendarService {
   /**

--- a/application/src/main/java/org/opentripplanner/netex/mapping/GroupNetexMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/GroupNetexMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.netex.mapping;
 
-import com.google.common.collect.ArrayListMultimap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapper.java
@@ -14,7 +14,6 @@ import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.timetable.StopTimeKey;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.rutebanken.netex.model.NoticeAssignment;
 import org.rutebanken.netex.model.ServiceJourney;

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/ConstantSpeedMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/ConstantSpeedMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.osm.tagmapping;
 
-import javax.annotation.Nullable;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.TraverseDirection;
 import org.opentripplanner.osm.wayproperty.WayPropertySet;

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
@@ -11,7 +11,6 @@ import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
 
-import javax.annotation.Nullable;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.TraverseDirection;
 import org.opentripplanner.osm.wayproperty.WayProperties;

--- a/application/src/main/java/org/opentripplanner/osm/wayproperty/specifier/BestMatchSpecifier.java
+++ b/application/src/main/java/org/opentripplanner/osm/wayproperty/specifier/BestMatchSpecifier.java
@@ -2,7 +2,6 @@ package org.opentripplanner.osm.wayproperty.specifier;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.TraverseDirection;
 import org.opentripplanner.utils.tostring.ToStringBuilder;

--- a/application/src/main/java/org/opentripplanner/osm/wayproperty/specifier/LogicalOrSpecifier.java
+++ b/application/src/main/java/org/opentripplanner/osm/wayproperty/specifier/LogicalOrSpecifier.java
@@ -3,7 +3,6 @@ package org.opentripplanner.osm.wayproperty.specifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.TraverseDirection;
 

--- a/application/src/main/java/org/opentripplanner/osm/wayproperty/specifier/OsmSpecifier.java
+++ b/application/src/main/java/org/opentripplanner/osm/wayproperty/specifier/OsmSpecifier.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.osm.wayproperty.specifier;
 
 import java.util.Arrays;
-import javax.annotation.Nullable;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.TraverseDirection;
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCost.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/group/RemoveOtherThanSameLegsMaxGeneralizedCost.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.algorithm.filterchain.filters.transit.group;
 
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/application/src/main/java/org/opentripplanner/routing/api/request/RequestModesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/RequestModesBuilder.java
@@ -1,11 +1,5 @@
 package org.opentripplanner.routing.api.request;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import org.opentripplanner.transit.model.basic.MainAndSubMode;
-import org.opentripplanner.transit.model.basic.SubMode;
-import org.opentripplanner.transit.model.basic.TransitMode;
 
 public class RequestModesBuilder {
 

--- a/application/src/main/java/org/opentripplanner/routing/api/request/RequestModesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/RequestModesBuilder.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.api.request;
 
-
 public class RequestModesBuilder {
 
   private StreetMode accessMode;

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/MqttGtfsRealtimeUpdaterConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/MqttGtfsRealtimeUpdaterConfig.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_8;
 
-import org.opentripplanner.standalone.config.framework.json.EnumMapper;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.opentripplanner.updater.trip.gtfs.BackwardsDelayPropagationType;
 import org.opentripplanner.updater.trip.gtfs.ForwardsDelayPropagationType;

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.OptionalInt;
-import java.util.function.IntUnaryOperator;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.basic.Accessibility;

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
@@ -2,7 +2,6 @@ package org.opentripplanner.transit.model.timetable;
 
 import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.MISSING_ARRIVAL_TIME;
 import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.MISSING_DEPARTURE_TIME;
-import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.NEGATIVE_DWELL_TIME;
 
 import java.util.Arrays;
 import javax.annotation.Nullable;

--- a/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TimetableRepository.java
@@ -39,7 +39,6 @@ import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.util.ConcurrentPublished;
 import org.opentripplanner.transit.model.basic.Notice;
-import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
@@ -2,11 +2,7 @@ package org.opentripplanner.transit.service;
 
 import java.time.LocalDate;
 import javax.annotation.Nullable;
-import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 /**

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.ext.flex.FlexIndex;

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
@@ -61,7 +61,6 @@ import org.opentripplanner.updater.trip.TimetableSnapshotManager;
 import org.opentripplanner.updater.trip.UpdateIncrementality;
 import org.opentripplanner.updater.trip.gtfs.model.AddedRoute;
 import org.opentripplanner.updater.trip.gtfs.model.TripUpdate;
-import org.opentripplanner.utils.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;

--- a/application/src/main/java/org/opentripplanner/updater/trip/metrics/StreamingTripUpdateMetrics.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/metrics/StreamingTripUpdateMetrics.java
@@ -4,8 +4,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
-import java.util.Arrays;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.spi.UpdateResult;

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
@@ -5,7 +5,6 @@ import static java.lang.Boolean.TRUE;
 import java.time.ZonedDateTime;
 import java.util.function.Supplier;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
-import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimesBuilder;
 import org.opentripplanner.updater.trip.siri.mapping.OccupancyMapper;
 import org.opentripplanner.utils.time.ServiceDateUtils;

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
@@ -3,7 +3,6 @@ package org.opentripplanner.updater.vehicle_position;
 import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
 import org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig;

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
@@ -2,7 +2,6 @@ package org.opentripplanner.updater.vehicle_rental.datasources;
 
 import static java.util.Objects.requireNonNullElse;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -10,7 +9,6 @@ import javax.annotation.Nullable;
 import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSBike;
 import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSRentalUris;
 import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleFuel;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStationUris;

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -55,7 +55,6 @@ import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareOffer;
-import org.opentripplanner.model.fare.FareOffer.DefaultFareOffer;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.fare.RiderCategory;

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
@@ -22,7 +22,6 @@ import org.opentripplanner.graph_builder.module.linking.TestVertexLinker;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graphfinder.GraphFinder;
-import org.opentripplanner.routing.linking.VertexLinker;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleService;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingService;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
@@ -37,7 +37,6 @@ import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.SiteRepository;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/TurnRestrictionModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/TurnRestrictionModuleTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.graph_builder.module;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
@@ -9,10 +9,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.opentripplanner.graph_builder.module.osm.VertexGeneratorTest.getBarrierLevelIssues;
 import static org.opentripplanner.osm.wayproperty.WayPropertiesBuilder.withModes;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
-import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
-import static org.opentripplanner.transit.model.basic.Accessibility.NOT_POSSIBLE;
 
 import java.io.File;
 import java.util.Collection;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/VertexGeneratorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/VertexGeneratorTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.opentripplanner.graph_builder.module.osm.LinearBarrierNodeType.NORMAL;
 import static org.opentripplanner.graph_builder.module.osm.LinearBarrierNodeType.SPLIT;
-import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
 
 import java.util.Comparator;
 import java.util.Map;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilderTest.java
@@ -19,7 +19,6 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
-import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.graph_builder.module.osm.naming.DefaultNamer;
 import org.opentripplanner.osm.DefaultOsmProvider;
 import org.opentripplanner.osm.model.OsmLevel;

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/CarAccessMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/CarAccessMapperTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.gtfs.mapping;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Trip;
 import org.opentripplanner.transit.model.network.CarAccess;
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/FareProductMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/FareProductMapperTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.FareProduct;

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/IdFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/IdFactoryTest.java
@@ -9,10 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.onebusaway.gtfs.model.AgencyAndId;
-import org.opentripplanner._support.geometry.Polygons;
-import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.service.SiteRepository;
 
 class IdFactoryTest {
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/ShapePointMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/ShapePointMapperTest.java
@@ -1,9 +1,6 @@
 package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;

--- a/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
@@ -15,7 +15,6 @@ import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;

--- a/application/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.Frequency;
-import org.opentripplanner.model.ShapePoint;
 import org.opentripplanner.model.calendar.ServiceCalendar;
 import org.opentripplanner.model.calendar.ServiceCalendarDate;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;

--- a/application/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
@@ -4,7 +4,6 @@ import static java.time.Duration.ZERO;
 import static java.time.Duration.ofMinutes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newTime;

--- a/application/src/test/java/org/opentripplanner/netex/index/hierarchy/HierarchicalVersionMapByIdTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/index/hierarchy/HierarchicalVersionMapByIdTest.java
@@ -17,7 +17,6 @@ import com.google.common.collect.Multimap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class HierarchicalVersionMapByIdTest {

--- a/application/src/test/java/org/opentripplanner/netex/mapping/support/NetexObjectDecoratorTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/support/NetexObjectDecoratorTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.netex.mapping.support;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class NetexObjectDecoratorTest {

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/PortlandMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/PortlandMapperTest.java
@@ -19,7 +19,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.osm.wayproperty.WayPropertySet;
 

--- a/application/src/test/java/org/opentripplanner/osm/wayproperty/specifier/ExactMatchSpecifierTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/wayproperty/specifier/ExactMatchSpecifierTest.java
@@ -4,7 +4,6 @@ import static org.opentripplanner.osm.model.TraverseDirection.DIRECTIONLESS;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.osm.model.OsmEntity;
-import org.opentripplanner.osm.model.TraverseDirection;
 
 class ExactMatchSpecifierTest extends SpecifierTest {
 

--- a/application/src/test/java/org/opentripplanner/osm/wayproperty/specifier/LogicalOrSpecifierTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/wayproperty/specifier/LogicalOrSpecifierTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.osm.wayproperty.specifier;
 import static org.opentripplanner.osm.model.TraverseDirection.DIRECTIONLESS;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.osm.model.TraverseDirection;
 
 class LogicalOrSpecifierTest extends SpecifierTest {
 

--- a/application/src/test/java/org/opentripplanner/osm/wayproperty/specifier/SpecifierTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/wayproperty/specifier/SpecifierTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.osm.wayproperty.specifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import javax.annotation.Nullable;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.TraverseDirection;
 

--- a/application/src/test/java/org/opentripplanner/routing/alertpatch/EntitySelectorTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/alertpatch/EntitySelectorTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.framework.FeedScopedId;

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -20,7 +20,6 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
-import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class TripPatternForDateTest {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
@@ -18,7 +18,6 @@ import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
-import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class TripPatternForDatesTest {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripTimesForDaysIndexTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripTimesForDaysIndexTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripTimesForDaysIndex.applyOffsets;
 
-import com.google.common.base.Splitter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/application/src/test/java/org/opentripplanner/routing/graph/StreetIndexTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graph/StreetIndexTest.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.routing.graph;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 
 import org.junit.jupiter.api.Test;

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalServiceTest.java
@@ -8,7 +8,6 @@ import org.opentripplanner.service.vehiclerental.model.TestFreeFloatingRentalVeh
 import org.opentripplanner.service.vehiclerental.model.TestVehicleRentalStationBuilder;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalVehicle;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 class DefaultVehicleRentalServiceTest {
 

--- a/application/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
@@ -1,9 +1,7 @@
 package org.opentripplanner.street.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model._data.StreetModelForTest.intersectionVertex;
 
 import java.util.List;

--- a/application/src/test/java/org/opentripplanner/street/search/TraverseModeSetTest.java
+++ b/application/src/test/java/org/opentripplanner/street/search/TraverseModeSetTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.street.search.TraverseModeSet;
 
 public class TraverseModeSetTest {
 

--- a/application/src/test/java/org/opentripplanner/test/support/GeoJsonIo.java
+++ b/application/src/test/java/org/opentripplanner/test/support/GeoJsonIo.java
@@ -5,14 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.json.ObjectMappers;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.street.model.edge.Edge;
-import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.utils.collection.ListUtils;
 
 /**

--- a/application/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotManagerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotManagerTest.java
@@ -17,7 +17,6 @@ import org.opentripplanner.model.RealTimeTripUpdate;
 import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.updater.TimetableSnapshotParameters;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
-import com.google.transit.realtime.GtfsRealtime;
 import de.mfdz.MfdzRealtimeExtensions.StopTimePropertiesExtension.DropOffPickupType;
 import java.util.List;
 import java.util.Objects;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
@@ -2,11 +2,6 @@ package org.opentripplanner.updater.trip.gtfs.moduletests.delay;
 
 import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.SCHEDULED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import org.junit.jupiter.api.Test;

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/EntityResolverTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/EntityResolverTest.java
@@ -12,7 +12,6 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
 import org.opentripplanner.transit.service.TimetableRepository;
-import org.opentripplanner.updater.trip.siri.EntityResolver;
 
 class EntityResolverTest {
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.updater.spi.UpdateError;
-import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationStatusMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationStatusMapperTest.java
@@ -22,10 +22,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mobilitydata.gbfs.v2_3.station_status.GBFSStation;
 import org.mobilitydata.gbfs.v2_3.station_status.GBFSVehicleDocksAvailable;
 import org.mobilitydata.gbfs.v2_3.station_status.GBFSVehicleTypesAvailable;
-import org.opentripplanner.service.vehiclerental.model.RentalVehicleEntityCounts;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleTypeCount;
-import org.opentripplanner.service.vehiclerental.model.ReturnPolicy;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.street.model.RentalFormFactor;
 

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,24 @@
             </plugin>
 
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <removeUnusedImports/>
+                    </java>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
                 <configuration>
@@ -313,23 +331,7 @@
                 </executions>
             </plugin>
             
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>apply</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <java>
-                        <removeUnusedImports/>
-                    </java>
-                </configuration>
-            </plugin>
+
 
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
                     <artifactId>prettier-maven-plugin</artifactId>
                     <version>${plugin.prettier.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>2.46.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -307,6 +312,25 @@
                     </execution>
                 </executions>
             </plugin>
+            
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <removeUnusedImports/>
+                    </java>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -330,9 +330,6 @@
                     </execution>
                 </executions>
             </plugin>
-            
-
-
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -13,7 +13,6 @@ import org.opentripplanner.raptor.rangeraptor.multicriteria.arrivals.McStopArriv
 import org.opentripplanner.raptor.rangeraptor.multicriteria.arrivals.McStopArrivalFactory;
 import org.opentripplanner.raptor.rangeraptor.transit.ViaConnections;
 import org.opentripplanner.raptor.util.paretoset.ParetoSetEventListener;
-import org.opentripplanner.utils.collection.ListUtils;
 
 /**
  * This class is used to listen for stop arrivals in one raptor state and then copy

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTransitDataProvider.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTransitDataProvider.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.raptor.spi;
 
 import java.util.Iterator;
-import javax.annotation.Nonnull;
 import org.opentripplanner.raptor.api.model.RaptorStopNameResolver;
 import org.opentripplanner.raptor.api.model.RaptorTransfer;
 import org.opentripplanner.raptor.api.model.RaptorTransferConstraint;

--- a/renovate.json5
+++ b/renovate.json5
@@ -76,7 +76,8 @@
         "org.apache.maven.plugins:maven-shade-plugin",
         "org.apache.maven.plugins:maven-compiler-plugin",
         "org.apache.maven.plugins:maven-jar-plugin",
-        "org.sonatype.plugins:nexus-staging-maven-plugin"
+        "org.sonatype.plugins:nexus-staging-maven-plugin",
+        "com.diffplug.spotless:spotless-maven-plugin"
       ],
       "schedule": "on the 23rd day of the month",
       "automerge": true


### PR DESCRIPTION
### Summary

In Helsinki at the developer days we have decided that we want to use spotless to automatically remove unused imports.

### Changelog

I would skip it.

### Bumping the serialization version id

No.