### PR TITLE
Show GBFS Geofencing zones in debug UI

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -1,6 +1,10 @@
 package org.opentripplanner.apis.vectortiles;
 
 import static org.opentripplanner.inspector.vector.edge.EdgePropertyMapper.streetPermissionAsString;
+import static org.opentripplanner.inspector.vector.geofencing.GeofencingZonesPropertyMapper.GEOFENCING_ZONE_TYPE;
+import static org.opentripplanner.inspector.vector.geofencing.GeofencingZonesPropertyMapper.GEOFENCING_ZONE_TYPE_BUSINESS_AREA;
+import static org.opentripplanner.inspector.vector.geofencing.GeofencingZonesPropertyMapper.GEOFENCING_ZONE_TYPE_NO_DROP_OFF;
+import static org.opentripplanner.inspector.vector.geofencing.GeofencingZonesPropertyMapper.GEOFENCING_ZONE_TYPE_NO_TRAVERSAL;
 
 import java.util.Arrays;
 import java.util.List;
@@ -287,7 +291,7 @@ public class DebugStyleSpec {
         .group(RENTAL_GROUP)
         .typeFill()
         .vectorSourceLayer(geofencingZones)
-        .filterValueInProperty("type", "no-drop-off")
+        .filterValueInProperty(GEOFENCING_ZONE_TYPE, GEOFENCING_ZONE_TYPE_NO_DROP_OFF)
         .fillColor(LIGHT_RED)
         .fillOpacity(0.3f)
         .fillOutlineColor(DARK_RED)
@@ -298,7 +302,7 @@ public class DebugStyleSpec {
         .group(RENTAL_GROUP)
         .typeFill()
         .vectorSourceLayer(geofencingZones)
-        .filterValueInProperty("type", "no-traversal")
+        .filterValueInProperty(GEOFENCING_ZONE_TYPE, GEOFENCING_ZONE_TYPE_NO_TRAVERSAL)
         .fillColor(ORANGE)
         .fillOpacity(0.3f)
         .fillOutlineColor(DARK_ORANGE)
@@ -309,7 +313,7 @@ public class DebugStyleSpec {
         .group(RENTAL_GROUP)
         .typeFill()
         .vectorSourceLayer(geofencingZones)
-        .filterValueInProperty("type", "business-area")
+        .filterValueInProperty(GEOFENCING_ZONE_TYPE, GEOFENCING_ZONE_TYPE_BUSINESS_AREA)
         .fillColor(LIGHT_BLUE)
         .fillOpacity(0.2f)
         .fillOutlineColor(DARK_BLUE)

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -148,7 +148,7 @@ public class DebugStyleSpec {
       allSources,
       ListUtils.combine(
         backgroundLayers(extraRasterSources),
-        rental(rental),
+        rental(rental, vertices),
         wheelchair(edges),
         noThruTraffic(edges),
         bicycleSafety(edges),
@@ -243,12 +243,12 @@ public class DebugStyleSpec {
     );
   }
 
-  private static List<StyleBuilder> rental(VectorSourceLayer layer) {
+  private static List<StyleBuilder> rental(VectorSourceLayer rentalLayer, VectorSourceLayer vertices) {
     return List.of(
       StyleBuilder.ofId("rental-vehicle")
         .group(RENTAL_GROUP)
         .typeCircle()
-        .vectorSourceLayer(layer)
+        .vectorSourceLayer(rentalLayer)
         .classFilter(VehicleRentalVehicle.class)
         .circleStroke(BLACK, CIRCLE_STROKE)
         .circleRadius(MEDIUM_CIRCLE_RADIUS)
@@ -259,12 +259,20 @@ public class DebugStyleSpec {
       StyleBuilder.ofId("rental-station")
         .group(RENTAL_GROUP)
         .typeCircle()
-        .vectorSourceLayer(layer)
+        .vectorSourceLayer(rentalLayer)
         .classFilter(VehicleRentalStation.class)
         .circleStroke(BLACK, LARGE_CIRCLE_LINE_WIDTH)
         .circleRadius(LARGE_CIRCLE_RADIUS)
         .circleColor(TURQUOISE)
         .minZoom(13)
+        .maxZoom(MAX_ZOOM)
+        .intiallyHidden(),
+      StyleBuilder.ofId("rental-restrictions")
+        .group(RENTAL_GROUP)
+        .typeSymbol()
+        .symbolText("rentalRestrictions")
+        .vectorSourceLayer(vertices)
+        .minZoom(17)
         .maxZoom(MAX_ZOOM)
         .intiallyHidden()
     );

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -126,7 +126,13 @@ public class DebugStyleSpec {
     VectorSourceLayer rental,
     List<BackgroundTileLayer> extraLayers
   ) {
-    List<TileSource> vectorSources = Stream.of(regularStops, edges, vertices, geofencingZones, rental)
+    List<TileSource> vectorSources = Stream.of(
+      regularStops,
+      edges,
+      vertices,
+      geofencingZones,
+      rental
+    )
       .map(VectorSourceLayer::vectorSource)
       .map(TileSource.class::cast)
       .toList();
@@ -244,7 +250,10 @@ public class DebugStyleSpec {
     );
   }
 
-  private static List<StyleBuilder> rental(VectorSourceLayer rentalLayer, VectorSourceLayer geofencingZones) {
+  private static List<StyleBuilder> rental(
+    VectorSourceLayer rentalLayer,
+    VectorSourceLayer geofencingZones
+  ) {
     return List.of(
       StyleBuilder.ofId("rental-vehicle")
         .group(RENTAL_GROUP)

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -122,10 +122,11 @@ public class DebugStyleSpec {
     VectorSourceLayer groupStops,
     VectorSourceLayer edges,
     VectorSourceLayer vertices,
+    VectorSourceLayer geofencingZones,
     VectorSourceLayer rental,
     List<BackgroundTileLayer> extraLayers
   ) {
-    List<TileSource> vectorSources = Stream.of(regularStops, edges, vertices, rental)
+    List<TileSource> vectorSources = Stream.of(regularStops, edges, vertices, geofencingZones, rental)
       .map(VectorSourceLayer::vectorSource)
       .map(TileSource.class::cast)
       .toList();
@@ -148,7 +149,7 @@ public class DebugStyleSpec {
       allSources,
       ListUtils.combine(
         backgroundLayers(extraRasterSources),
-        rental(rental, vertices),
+        rental(rental, geofencingZones),
         wheelchair(edges),
         noThruTraffic(edges),
         bicycleSafety(edges),
@@ -243,7 +244,7 @@ public class DebugStyleSpec {
     );
   }
 
-  private static List<StyleBuilder> rental(VectorSourceLayer rentalLayer, VectorSourceLayer vertices) {
+  private static List<StyleBuilder> rental(VectorSourceLayer rentalLayer, VectorSourceLayer geofencingZones) {
     return List.of(
       StyleBuilder.ofId("rental-vehicle")
         .group(RENTAL_GROUP)
@@ -267,12 +268,37 @@ public class DebugStyleSpec {
         .minZoom(13)
         .maxZoom(MAX_ZOOM)
         .intiallyHidden(),
-      StyleBuilder.ofId("rental-restrictions")
+      StyleBuilder.ofId("geofencing-zones-no-drop-off")
         .group(RENTAL_GROUP)
-        .typeSymbol()
-        .symbolText("rentalRestrictions")
-        .vectorSourceLayer(vertices)
-        .minZoom(17)
+        .typeFill()
+        .vectorSourceLayer(geofencingZones)
+        .filterValueInProperty("type", "no-drop-off")
+        .fillColor("#ff6b6b")
+        .fillOpacity(0.3f)
+        .fillOutlineColor("#cc0000")
+        .minZoom(10)
+        .maxZoom(MAX_ZOOM)
+        .intiallyHidden(),
+      StyleBuilder.ofId("geofencing-zones-no-traversal")
+        .group(RENTAL_GROUP)
+        .typeFill()
+        .vectorSourceLayer(geofencingZones)
+        .filterValueInProperty("type", "no-traversal")
+        .fillColor("#ffa500")
+        .fillOpacity(0.3f)
+        .fillOutlineColor("#ff8c00")
+        .minZoom(10)
+        .maxZoom(MAX_ZOOM)
+        .intiallyHidden(),
+      StyleBuilder.ofId("geofencing-zones-business-area")
+        .group(RENTAL_GROUP)
+        .typeFill()
+        .vectorSourceLayer(geofencingZones)
+        .filterValueInProperty("type", "business-area")
+        .fillColor("#4a9eff")
+        .fillOpacity(0.2f)
+        .fillOutlineColor("#0066cc")
+        .minZoom(10)
         .maxZoom(MAX_ZOOM)
         .intiallyHidden()
     );

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -66,6 +66,12 @@ public class DebugStyleSpec {
   private static final String RED = "#fc0f2a";
   private static final String PURPLE = "#BC55F2";
   private static final String BLACK = "#140d0e";
+  private static final String LIGHT_RED = "#ff6b6b";
+  private static final String DARK_RED = "#cc0000";
+  private static final String ORANGE = "#ffa500";
+  private static final String DARK_ORANGE = "#ff8c00";
+  private static final String LIGHT_BLUE = "#4a9eff";
+  private static final String DARK_BLUE = "#0066cc";
 
   private static final int MAX_ZOOM = 23;
   private static final ZoomDependentNumber LARGE_CIRCLE_LINE_WIDTH = new ZoomDependentNumber(
@@ -282,9 +288,9 @@ public class DebugStyleSpec {
         .typeFill()
         .vectorSourceLayer(geofencingZones)
         .filterValueInProperty("type", "no-drop-off")
-        .fillColor("#ff6b6b")
+        .fillColor(LIGHT_RED)
         .fillOpacity(0.3f)
-        .fillOutlineColor("#cc0000")
+        .fillOutlineColor(DARK_RED)
         .minZoom(10)
         .maxZoom(MAX_ZOOM)
         .intiallyHidden(),
@@ -293,9 +299,9 @@ public class DebugStyleSpec {
         .typeFill()
         .vectorSourceLayer(geofencingZones)
         .filterValueInProperty("type", "no-traversal")
-        .fillColor("#ffa500")
+        .fillColor(ORANGE)
         .fillOpacity(0.3f)
-        .fillOutlineColor("#ff8c00")
+        .fillOutlineColor(DARK_ORANGE)
         .minZoom(10)
         .maxZoom(MAX_ZOOM)
         .intiallyHidden(),
@@ -304,9 +310,9 @@ public class DebugStyleSpec {
         .typeFill()
         .vectorSourceLayer(geofencingZones)
         .filterValueInProperty("type", "business-area")
-        .fillColor("#4a9eff")
+        .fillColor(LIGHT_BLUE)
         .fillOpacity(0.2f)
-        .fillOutlineColor("#0066cc")
+        .fillOutlineColor(DARK_BLUE)
         .minZoom(10)
         .maxZoom(MAX_ZOOM)
         .intiallyHidden()

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
@@ -141,6 +141,7 @@ public class DebugVectorTilesResource {
       GROUP_STOPS.toVectorSourceLayer(stopsSource),
       EDGES.toVectorSourceLayer(streetSource),
       VERTICES.toVectorSourceLayer(streetSource),
+      GEOFENCING_ZONES.toVectorSourceLayer(streetSource),
       RENTAL.toVectorSourceLayer(rentalSource),
       serverContext.debugUiConfig().additionalBackgroundLayers()
     );

--- a/application/src/main/java/org/opentripplanner/inspector/vector/KeyValue.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/KeyValue.java
@@ -3,6 +3,7 @@ package org.opentripplanner.inspector.vector;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /**
@@ -25,7 +26,7 @@ public record KeyValue(String key, Object value) {
   public static KeyValue kv(String key, @Nullable Object value) {
     if (value == null) {
       return new KeyValue(key, null);
-    } else if (value instanceof FeedScopedId || value instanceof Enum<?>) {
+    } else if (value instanceof FeedScopedId || value instanceof Enum<?> || value instanceof I18NString) {
       return new KeyValue(key, value.toString());
     } else {
       return new KeyValue(key, value);

--- a/application/src/main/java/org/opentripplanner/inspector/vector/KeyValue.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/KeyValue.java
@@ -26,7 +26,9 @@ public record KeyValue(String key, Object value) {
   public static KeyValue kv(String key, @Nullable Object value) {
     if (value == null) {
       return new KeyValue(key, null);
-    } else if (value instanceof FeedScopedId || value instanceof Enum<?> || value instanceof I18NString) {
+    } else if (
+      value instanceof FeedScopedId || value instanceof Enum<?> || value instanceof I18NString
+    ) {
       return new KeyValue(key, value.toString());
     } else {
       return new KeyValue(key, value);

--- a/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesLayerBuilder.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesLayerBuilder.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.inspector.vector.LayerBuilder;
 import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.routing.graph.Graph;
@@ -13,8 +12,6 @@ import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;
 import org.opentripplanner.service.vehiclerental.street.NoRestriction;
 import org.opentripplanner.street.model.RentalRestrictionExtension;
-import org.opentripplanner.street.model.vertex.Vertex;
-import org.opentripplanner.transit.model.site.AreaStop;
 
 /**
  * A vector tile layer containing all {@link GeofencingZone}s inside the vector tile bounds.
@@ -55,7 +52,10 @@ public class GeofencingZonesLayerBuilder extends LayerBuilder<GeofencingZone> {
       .toList();
   }
 
-  private void extractGeofencingZones(RentalRestrictionExtension extension, Map<String, GeofencingZone> uniqueZones) {
+  private void extractGeofencingZones(
+    RentalRestrictionExtension extension,
+    Map<String, GeofencingZone> uniqueZones
+  ) {
     for (RentalRestrictionExtension ext : extension.toList()) {
       if (ext instanceof GeofencingZoneExtension zoneExt) {
         GeofencingZone zone = zoneExt.zone();

--- a/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesLayerBuilder.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesLayerBuilder.java
@@ -1,20 +1,25 @@
 package org.opentripplanner.inspector.vector.geofencing;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.inspector.vector.LayerBuilder;
 import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
+import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;
 import org.opentripplanner.service.vehiclerental.street.NoRestriction;
+import org.opentripplanner.street.model.RentalRestrictionExtension;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.transit.model.site.AreaStop;
 
 /**
- * A vector tile layer containing all {@link AreaStop}s inside the vector tile bounds.
+ * A vector tile layer containing all {@link GeofencingZone}s inside the vector tile bounds.
  */
-public class GeofencingZonesLayerBuilder extends LayerBuilder<Vertex> {
+public class GeofencingZonesLayerBuilder extends LayerBuilder<GeofencingZone> {
 
   private final Graph graph;
 
@@ -29,15 +34,33 @@ public class GeofencingZonesLayerBuilder extends LayerBuilder<Vertex> {
 
   @Override
   protected List<Geometry> getGeometries(Envelope query) {
-    return graph
+    Map<String, GeofencingZone> uniqueZones = new HashMap<>();
+
+    graph
       .findVertices(query)
       .stream()
-      .filter(se -> !(se.rentalRestrictions() instanceof NoRestriction))
-      .map(vertex -> {
-        Geometry geometry = GeometryUtils.getGeometryFactory().createPoint(vertex.getCoordinate());
-        geometry.setUserData(vertex);
+      .filter(v -> !(v.rentalRestrictions() instanceof NoRestriction))
+      .forEach(vertex -> {
+        extractGeofencingZones(vertex.rentalRestrictions(), uniqueZones);
+      });
+
+    return uniqueZones
+      .values()
+      .stream()
+      .map(zone -> {
+        Geometry geometry = zone.geometry();
+        geometry.setUserData(zone);
         return geometry;
       })
       .toList();
+  }
+
+  private void extractGeofencingZones(RentalRestrictionExtension extension, Map<String, GeofencingZone> uniqueZones) {
+    for (RentalRestrictionExtension ext : extension.toList()) {
+      if (ext instanceof GeofencingZoneExtension zoneExt) {
+        GeofencingZone zone = zoneExt.zone();
+        uniqueZones.put(zone.id().toString(), zone);
+      }
+    }
   }
 }

--- a/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
@@ -1,38 +1,35 @@
 package org.opentripplanner.inspector.vector.geofencing;
 
-import static org.opentripplanner.street.model.RentalRestrictionExtension.RestrictionType.BUSINESS_AREA_BORDER;
-import static org.opentripplanner.street.model.RentalRestrictionExtension.RestrictionType.NO_DROP_OFF;
-import static org.opentripplanner.street.model.RentalRestrictionExtension.RestrictionType.NO_TRAVERSAL;
-
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
 import org.opentripplanner.inspector.vector.KeyValue;
-import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 
 /**
  * A {@link PropertyMapper} for the {@link GeofencingZonesLayerBuilder} for the OTP debug client.
  */
-public class GeofencingZonesPropertyMapper extends PropertyMapper<Vertex> {
+public class GeofencingZonesPropertyMapper extends PropertyMapper<GeofencingZone> {
 
   @Override
-  protected Collection<KeyValue> map(Vertex input) {
-    var ext = input.rentalRestrictions();
+  protected Collection<KeyValue> map(GeofencingZone zone) {
+    var properties = new ArrayList<KeyValue>();
 
-    // this logic does a best effort attempt at a simple mapping
-    // once you have several networks on the same vertex it breaks down.
-    // for that you would really need several layers.
-    // still, for a quick visualization it is useful
-    var debug = ext.debugTypes();
-    var networks = new KeyValue("networks", String.join(",", ext.networks()));
-    if (debug.contains(BUSINESS_AREA_BORDER)) {
-      return List.of(new KeyValue("type", "business-area-border"), networks);
-    } else if (debug.contains(NO_TRAVERSAL)) {
-      return List.of(new KeyValue("type", "traversal-banned"), networks);
-    } else if (debug.contains(NO_DROP_OFF)) {
-      return List.of(new KeyValue("type", "drop-off-banned"), networks);
-    } else {
-      return List.of();
+    properties.add(new KeyValue("id", zone.id().toString()));
+    properties.add(new KeyValue("name", zone.name().toString()));
+    properties.add(new KeyValue("network", zone.id().getFeedId()));
+
+    if (zone.isBusinessArea()) {
+      properties.add(new KeyValue("type", "business-area"));
+    } else if (zone.traversalBanned()) {
+      properties.add(new KeyValue("type", "no-traversal"));
+    } else if (zone.dropOffBanned()) {
+      properties.add(new KeyValue("type", "no-drop-off"));
     }
+
+    properties.add(new KeyValue("traversalBanned", String.valueOf(zone.traversalBanned())));
+    properties.add(new KeyValue("dropOffBanned", String.valueOf(zone.dropOffBanned())));
+
+    return properties;
   }
 }

--- a/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
@@ -27,9 +27,6 @@ public class GeofencingZonesPropertyMapper extends PropertyMapper<GeofencingZone
       properties.add(new KeyValue("type", "no-drop-off"));
     }
 
-    properties.add(new KeyValue("traversalBanned", String.valueOf(zone.traversalBanned())));
-    properties.add(new KeyValue("dropOffBanned", String.valueOf(zone.dropOffBanned())));
-
     return properties;
   }
 }

--- a/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
@@ -13,20 +13,28 @@ import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
  */
 public class GeofencingZonesPropertyMapper extends PropertyMapper<GeofencingZone> {
 
+  public static final String GEOFENCING_ZONE_TYPE_BUSINESS_AREA = "business-area";
+  public static final String GEOFENCING_ZONE_TYPE_NO_TRAVERSAL = "no-traversal";
+  public static final String GEOFENCING_ZONE_TYPE_NO_DROP_OFF = "no-drop-off";
+  public static final String GEOFENCING_ZONE_TYPE = "type";
+  public static final String GEOFENCING_ZONE_ID = "id";
+  public static final String GEOFENCING_ZONE_NAME = "name";
+  public static final String GEOFENCING_ZONE_NETWORK = "network";
+
   @Override
   protected Collection<KeyValue> map(GeofencingZone zone) {
     var properties = new ArrayList<KeyValue>();
 
-    properties.add(kv("id", zone.id()));
-    properties.add(kv("name", zone.name()));
-    properties.add(kv("network", zone.id().getFeedId()));
+    properties.add(kv(GEOFENCING_ZONE_ID, zone.id()));
+    properties.add(kv(GEOFENCING_ZONE_NAME, zone.name()));
+    properties.add(kv(GEOFENCING_ZONE_NETWORK, zone.id().getFeedId()));
 
     if (zone.isBusinessArea()) {
-      properties.add(kv("type", "business-area"));
+      properties.add(kv(GEOFENCING_ZONE_TYPE, GEOFENCING_ZONE_TYPE_BUSINESS_AREA));
     } else if (zone.traversalBanned()) {
-      properties.add(kv("type", "no-traversal"));
+      properties.add(kv(GEOFENCING_ZONE_TYPE, GEOFENCING_ZONE_TYPE_NO_TRAVERSAL));
     } else if (zone.dropOffBanned()) {
-      properties.add(kv("type", "no-drop-off"));
+      properties.add(kv(GEOFENCING_ZONE_TYPE, GEOFENCING_ZONE_TYPE_NO_DROP_OFF));
     }
 
     return properties;

--- a/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/geofencing/GeofencingZonesPropertyMapper.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.inspector.vector.geofencing;
 
+import static org.opentripplanner.inspector.vector.KeyValue.kv;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
@@ -15,16 +17,16 @@ public class GeofencingZonesPropertyMapper extends PropertyMapper<GeofencingZone
   protected Collection<KeyValue> map(GeofencingZone zone) {
     var properties = new ArrayList<KeyValue>();
 
-    properties.add(new KeyValue("id", zone.id().toString()));
-    properties.add(new KeyValue("name", zone.name().toString()));
-    properties.add(new KeyValue("network", zone.id().getFeedId()));
+    properties.add(kv("id", zone.id()));
+    properties.add(kv("name", zone.name()));
+    properties.add(kv("network", zone.id().getFeedId()));
 
     if (zone.isBusinessArea()) {
-      properties.add(new KeyValue("type", "business-area"));
+      properties.add(kv("type", "business-area"));
     } else if (zone.traversalBanned()) {
-      properties.add(new KeyValue("type", "no-traversal"));
+      properties.add(kv("type", "no-traversal"));
     } else if (zone.dropOffBanned()) {
-      properties.add(new KeyValue("type", "no-drop-off"));
+      properties.add(kv("type", "no-drop-off"));
     }
 
     return properties;

--- a/application/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
@@ -39,6 +39,9 @@ public class VertexPropertyMapper extends PropertyMapper<Vertex> {
           kColl("spacesFor", spacesFor(v.getVehicleParking())),
           kColl("traversalPermission", traversalPermissions(v.getParkingEntrance()))
         );
+        case StreetVertex v -> List.of(
+          kColl("rentalRestrictions", v.getParent().rentalRestrictions().toList())
+        );
         default -> List.of();
       };
 

--- a/application/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/vertex/VertexPropertyMapper.java
@@ -39,9 +39,6 @@ public class VertexPropertyMapper extends PropertyMapper<Vertex> {
           kColl("spacesFor", spacesFor(v.getVehicleParking())),
           kColl("traversalPermission", traversalPermissions(v.getParkingEntrance()))
         );
-        case StreetVertex v -> List.of(
-          kColl("rentalRestrictions", v.getParent().rentalRestrictions().toList())
-        );
         default -> List.of();
       };
 

--- a/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -28,7 +28,7 @@ class DebugStyleSpecTest {
     var groupStops = new VectorSourceLayer(vectorSource, "stops");
     var edges = new VectorSourceLayer(vectorSource, "edges");
     var vertices = new VectorSourceLayer(vectorSource, "vertices");
-    var geofencingZones = new VectorSourceLayer(vectorSource,"geofencingZones");
+    var geofencingZones = new VectorSourceLayer(vectorSource, "geofencingZones");
     var rental = new VectorSourceLayer(vectorSource, "rental");
     var spec = DebugStyleSpec.build(
       regularStops,

--- a/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -28,6 +28,7 @@ class DebugStyleSpecTest {
     var groupStops = new VectorSourceLayer(vectorSource, "stops");
     var edges = new VectorSourceLayer(vectorSource, "edges");
     var vertices = new VectorSourceLayer(vectorSource, "vertices");
+    var geofencingZones = new VectorSourceLayer(vectorSource,"geofencingZones");
     var rental = new VectorSourceLayer(vectorSource, "rental");
     var spec = DebugStyleSpec.build(
       regularStops,
@@ -35,6 +36,7 @@ class DebugStyleSpecTest {
       groupStops,
       edges,
       vertices,
+      geofencingZones,
       rental,
       List.of()
     );

--- a/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -216,39 +216,6 @@
       }
     },
     {
-      "id" : "geofencing-zones-no-go",
-      "type" : "fill",
-      "source" : "vectorSource",
-      "source-layer" : "geofencingZones",
-      "minzoom" : 10,
-      "maxzoom" : 23,
-      "paint" : {
-        "fill-color" : "#8b0000",
-        "fill-opacity" : 0.4,
-        "fill-outline-color" : "#660000"
-      },
-      "filter" : [
-        "any",
-        [
-          "in",
-          "no-go-zone",
-          [
-            "string",
-            [
-              "get",
-              "type"
-            ]
-          ]
-        ]
-      ],
-      "layout" : {
-        "visibility" : "none"
-      },
-      "metadata" : {
-        "group" : "Rental"
-      }
-    },
-    {
       "id" : "geofencing-zones-business-area",
       "type" : "fill",
       "source" : "vectorSource",

--- a/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -150,6 +150,138 @@
       }
     },
     {
+      "id" : "geofencing-zones-no-drop-off",
+      "type" : "fill",
+      "source" : "vectorSource",
+      "source-layer" : "geofencingZones",
+      "minzoom" : 10,
+      "maxzoom" : 23,
+      "paint" : {
+        "fill-color" : "#ff6b6b",
+        "fill-opacity" : 0.3,
+        "fill-outline-color" : "#cc0000"
+      },
+      "filter" : [
+        "any",
+        [
+          "in",
+          "no-drop-off",
+          [
+            "string",
+            [
+              "get",
+              "type"
+            ]
+          ]
+        ]
+      ],
+      "layout" : {
+        "visibility" : "none"
+      },
+      "metadata" : {
+        "group" : "Rental"
+      }
+    },
+    {
+      "id" : "geofencing-zones-no-traversal",
+      "type" : "fill",
+      "source" : "vectorSource",
+      "source-layer" : "geofencingZones",
+      "minzoom" : 10,
+      "maxzoom" : 23,
+      "paint" : {
+        "fill-color" : "#ffa500",
+        "fill-opacity" : 0.3,
+        "fill-outline-color" : "#ff8c00"
+      },
+      "filter" : [
+        "any",
+        [
+          "in",
+          "no-traversal",
+          [
+            "string",
+            [
+              "get",
+              "type"
+            ]
+          ]
+        ]
+      ],
+      "layout" : {
+        "visibility" : "none"
+      },
+      "metadata" : {
+        "group" : "Rental"
+      }
+    },
+    {
+      "id" : "geofencing-zones-no-go",
+      "type" : "fill",
+      "source" : "vectorSource",
+      "source-layer" : "geofencingZones",
+      "minzoom" : 10,
+      "maxzoom" : 23,
+      "paint" : {
+        "fill-color" : "#8b0000",
+        "fill-opacity" : 0.4,
+        "fill-outline-color" : "#660000"
+      },
+      "filter" : [
+        "any",
+        [
+          "in",
+          "no-go-zone",
+          [
+            "string",
+            [
+              "get",
+              "type"
+            ]
+          ]
+        ]
+      ],
+      "layout" : {
+        "visibility" : "none"
+      },
+      "metadata" : {
+        "group" : "Rental"
+      }
+    },
+    {
+      "id" : "geofencing-zones-business-area",
+      "type" : "fill",
+      "source" : "vectorSource",
+      "source-layer" : "geofencingZones",
+      "minzoom" : 10,
+      "maxzoom" : 23,
+      "paint" : {
+        "fill-color" : "#4a9eff",
+        "fill-opacity" : 0.2,
+        "fill-outline-color" : "#0066cc"
+      },
+      "filter" : [
+        "any",
+        [
+          "in",
+          "business-area",
+          [
+            "string",
+            [
+              "get",
+              "type"
+            ]
+          ]
+        ]
+      ],
+      "layout" : {
+        "visibility" : "none"
+      },
+      "metadata" : {
+        "group" : "Rental"
+      }
+    },
+    {
       "id" : "wheelchair-accessible",
       "source" : "vectorSource",
       "source-layer" : "edges",


### PR DESCRIPTION
### Summary

This adds geofencing zones layers to the debug ui's map style spec, by refitting the old geofencing zones property mapper that was left unused from the previous debug client. Turns out we actually keep the zone geometry in otp. 

Note that this PR does not add any new zone properties. OTP only uses "no-drop-off" and "no-traversal", even though zone rules have become more complex since this was implemented. Everything that doesn't fit these two are considered a "business area", which could be misleading with newer data.

Styling is up for discussion / feedback.

_Note: My proposal is that we deal with Debug UI changes in a follow up PR - specifically handling showing popups for overlapping areas._

<img width="835" height="579" alt="Screenshot 2025-09-22 at 12 34 53" src="https://github.com/user-attachments/assets/09ef8b84-5e11-4056-8cd7-29af0589753b" />

<img width="258" height="175" alt="Screenshot 2025-09-22 at 12 38 53" src="https://github.com/user-attachments/assets/bef79e25-f327-4a6e-9100-55320473e428" />

