### PR TITLE
Fix NPE in old deprecated via search (Transmodel API)

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaRequestMapper.java
@@ -57,7 +57,7 @@ public class ViaRequestMapper {
     return RouteViaRequest.of(vias, requests)
       .withDateTime(
         Instant.ofEpochMilli(
-          environment.getArgumentOrDefault("dateTime", request.dateTime().toEpochMilli())
+          environment.getArgumentOrDefault("dateTime", Instant.now().toEpochMilli())
         )
       )
       .withSearchWindow(environment.getArgumentOrDefault("searchWindow", request.searchWindow()))


### PR DESCRIPTION
### Summary

The old via search fails with a NPE, because the `dateTime` in the default request is not set. This worked in OTP `dev-2.x` in May, but we are unsure what cased this to fail. The old via search in the Transmodel API is deprecated, so we do not want to spend too much time on fixing it. This PR fixes the problem by calling `Instant.now()` instead of using the `dateTime` from the default request - which seams like an error in the first place. 

We need this fix, because it is used due to some limitation to the new via search (see issue #6839).


<details>
<summary>StackTrace</summary>
<pre>
An uncaught error occurred inside OTP: null
java.lang.NullPointerException: null
	at dagger.internal.Preconditions.checkNotNull(Preconditions.java:35)
	at org.opentripplanner.standalone.configure.DaggerConstructApplicationFactory$Builder.empiricalDelayRepository(DaggerConstructApplicationFactory.java:199)
	at org.opentripplanner.standalone.configure.DaggerConstructApplicationFactory$Builder.empiricalDelayRepository(DaggerConstructApplicationFactory.java:115)
	at org.opentripplanner.standalone.configure.ConstructApplication.<init>(ConstructApplication.java:112)
	at org.opentripplanner.standalone.configure.LoadApplication.createAppConstruction(LoadApplication.java:122)
	at org.opentripplanner.standalone.configure.LoadApplication.appConstruction(LoadApplication.java:76)
	at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:131)
	at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:55)
</pre>
</details>

<details>
<summary>GraphQL Query</summary>
<pre>
query via {
    viaTrip(
    searchWindow :"2h"
    from : {
      place: "NSR:StopPlace:18128"
    }
    via : {
      place: "NSR:StopPlace:17693"
    }
    to : {
      place: "NSR:StopPlace:18128"
    }
  ) {
    tripPatternsPerSegment {
      tripPatterns {
        legs {
          fromPlace {
            name
          }
          toPlace {
            name
          }
          mode
        }
      }
    }
    tripPatternCombinations {
      to
      from
    }
    routingErrors {
      code
      description
    }    
  }
}
</pre>
</details>


### Issue

🟥  I have not created an issue for this, since this is a very simple bug fix in a deprecated Transmodel API call. We will hopefully soon remove this api call.


### Unit tests

🟥  No test is added - hopefully we can increase test coverage soon by deleting this code.


### Documentation

🟥  No doc is touched .

### Changelog

✅  Minor, but included in the changelog since it might be a problem somewhere...

### Bumping the serialization version id

🟥  Not needed