### PR TITLE
Make Frequency class immutable and remove unused field

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
@@ -120,7 +120,7 @@ public class GenerateTripPatternsOperation {
    */
   private void collectFrequencyByTrip() {
     for (Frequency freq : transitServiceBuilder.getFrequencies()) {
-      frequenciesForTrip.put(freq.getTrip(), freq);
+      frequenciesForTrip.put(freq.trip(), freq);
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FrequencyMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FrequencyMapper.java
@@ -28,15 +28,12 @@ class FrequencyMapper {
   }
 
   private Frequency doMap(org.onebusaway.gtfs.model.Frequency rhs) {
-    Frequency lhs = new Frequency();
-
-    lhs.setTrip(tripMapper.map(rhs.getTrip()));
-    lhs.setStartTime(rhs.getStartTime());
-    lhs.setEndTime(rhs.getEndTime());
-    lhs.setHeadwaySecs(rhs.getHeadwaySecs());
-    lhs.setExactTimes(rhs.getExactTimes());
-    lhs.setLabelOnly(rhs.getLabelOnly());
-
-    return lhs;
+    return new Frequency(
+      tripMapper.map(rhs.getTrip()),
+      rhs.getStartTime(),
+      rhs.getEndTime(),
+      rhs.getHeadwaySecs(),
+      rhs.getExactTimes() != 0
+    );
   }
 }

--- a/application/src/main/java/org/opentripplanner/model/Frequency.java
+++ b/application/src/main/java/org/opentripplanner/model/Frequency.java
@@ -1,4 +1,3 @@
-/* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
 import java.io.Serializable;
@@ -9,69 +8,43 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 public final class Frequency implements Serializable {
 
-  private Trip trip;
+  private final Trip trip;
+  private final int startTime;
+  private final int endTime;
+  private final int headwaySecs;
+  private final boolean exactTimes;
 
-  private int startTime;
-
-  private int endTime;
-
-  private int headwaySecs;
-
-  private int exactTimes = 0;
-
-  private int labelOnly = 0;
-
-  public Trip getTrip() {
-    return trip;
-  }
-
-  public void setTrip(Trip trip) {
+  public Frequency(Trip trip, int startTime, int endTime, int headwaySecs, boolean exactTimes) {
     this.trip = trip;
-  }
-
-  public int getStartTime() {
-    return startTime;
-  }
-
-  public void setStartTime(int startTime) {
     this.startTime = startTime;
-  }
-
-  public int getEndTime() {
-    return endTime;
-  }
-
-  public void setEndTime(int endTime) {
     this.endTime = endTime;
-  }
-
-  public int getHeadwaySecs() {
-    return headwaySecs;
-  }
-
-  public void setHeadwaySecs(int headwaySecs) {
     this.headwaySecs = headwaySecs;
-  }
-
-  public int getExactTimes() {
-    return exactTimes;
-  }
-
-  public void setExactTimes(int exactTimes) {
     this.exactTimes = exactTimes;
   }
 
-  public int getLabelOnly() {
-    return labelOnly;
+  public Trip trip() {
+    return trip;
   }
 
-  public void setLabelOnly(int labelOnly) {
-    this.labelOnly = labelOnly;
+  public int startTime() {
+    return startTime;
+  }
+
+  public int endTime() {
+    return endTime;
+  }
+
+  public int headwaySecs() {
+    return headwaySecs;
+  }
+
+  public boolean exactTimes() {
+    return exactTimes;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(trip, startTime, endTime, headwaySecs);
+    return Objects.hash(trip, startTime, endTime, headwaySecs, exactTimes);
   }
 
   @Override
@@ -87,6 +60,7 @@ public final class Frequency implements Serializable {
       startTime == frequency.startTime &&
       endTime == frequency.endTime &&
       headwaySecs == frequency.headwaySecs &&
+      exactTimes == frequency.exactTimes &&
       Objects.equals(trip, frequency.trip)
     );
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/FrequencyEntry.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/FrequencyEntry.java
@@ -18,10 +18,10 @@ public class FrequencyEntry implements Serializable {
   public final ScheduledTripTimes tripTimes;
 
   public FrequencyEntry(Frequency freq, ScheduledTripTimes tripTimes) {
-    this.startTime = freq.getStartTime();
-    this.endTime = freq.getEndTime();
-    this.headway = freq.getHeadwaySecs();
-    this.exactTimes = freq.getExactTimes() != 0;
+    this.startTime = freq.startTime();
+    this.endTime = freq.endTime();
+    this.headway = freq.headwaySecs();
+    this.exactTimes = freq.exactTimes();
     this.tripTimes = tripTimes;
   }
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,11 +24,7 @@ public class FrequencyMapperTest {
 
   private static final int END_TIME = 2300;
 
-  private static final int EXACT_TIMES = 1;
-
   private static final int HEADWAY_SECS = 2;
-
-  private static final int LABEL_ONLY = 1;
 
   public static final DataImportIssueStore ISSUE_STORE = DataImportIssueStore.NOOP;
 
@@ -52,44 +49,41 @@ public class FrequencyMapperTest {
     FREQUENCY.setId(ID);
     FREQUENCY.setStartTime(START_TIME);
     FREQUENCY.setEndTime(END_TIME);
-    FREQUENCY.setExactTimes(EXACT_TIMES);
+    FREQUENCY.setExactTimes(1);
     FREQUENCY.setHeadwaySecs(HEADWAY_SECS);
-    FREQUENCY.setLabelOnly(LABEL_ONLY);
     FREQUENCY.setTrip(DATA.trip);
   }
 
   @Test
-  public void testMapCollection() throws Exception {
+  public void testMapCollection() {
     assertNull(subject.map((Collection<Frequency>) null));
     assertTrue(subject.map(Collections.emptyList()).isEmpty());
     assertEquals(1, subject.map(Collections.singleton(FREQUENCY)).size());
   }
 
   @Test
-  public void testMap() throws Exception {
+  public void testMap() {
     org.opentripplanner.model.Frequency result = subject.map(FREQUENCY);
 
-    assertEquals(START_TIME, result.getStartTime());
-    assertEquals(END_TIME, result.getEndTime());
-    assertEquals(EXACT_TIMES, result.getExactTimes());
-    assertEquals(HEADWAY_SECS, result.getHeadwaySecs());
-    assertEquals(LABEL_ONLY, result.getLabelOnly());
-    assertEquals(DATA.trip.getId().getId(), result.getTrip().getId().getId());
+    assertEquals(START_TIME, result.startTime());
+    assertEquals(END_TIME, result.endTime());
+    assertTrue(result.exactTimes());
+    assertEquals(HEADWAY_SECS, result.headwaySecs());
+    assertEquals(DATA.trip.getId().getId(), result.trip().getId().getId());
   }
 
   @Test
-  public void testMapWithNulls() throws Exception {
+  public void testMapWithNulls() {
     org.opentripplanner.model.Frequency result = subject.map(new Frequency());
 
-    assertEquals(0, result.getStartTime());
-    assertEquals(0, result.getEndTime());
-    assertEquals(0, result.getExactTimes());
-    assertEquals(0, result.getHeadwaySecs());
-    assertEquals(0, result.getLabelOnly());
-    assertNull(result.getTrip());
+    assertEquals(0, result.startTime());
+    assertEquals(0, result.endTime());
+    assertFalse(result.exactTimes());
+    assertEquals(0, result.headwaySecs());
+    assertNull(result.trip());
   }
 
-  /** Mapping the same object twice, should return the the same instance. */
+  /** Mapping the same object twice, should return the same instance. */
   @Test
   public void testMapCache() throws Exception {
     org.opentripplanner.model.Frequency result1 = subject.map(FREQUENCY);

--- a/application/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderTest.java
@@ -115,15 +115,15 @@ public class OtpTransitServiceBuilderTest {
   private static Comparator<Frequency> frequencyComp() {
     return (l, r) -> {
       int c;
-      c = l.getTrip().getId().toString().compareTo(r.getTrip().getId().toString());
+      c = l.trip().getId().toString().compareTo(r.trip().getId().toString());
       if (c != 0) {
         return c;
       }
-      c = l.getStartTime() - r.getStartTime();
+      c = l.startTime() - r.startTime();
       if (c != 0) {
         return c;
       }
-      return l.getEndTime() - r.getEndTime();
+      return l.endTime() - r.endTime();
     };
   }
 }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -34,9 +34,12 @@ class TripPatternForDateTest {
   );
 
   static Stream<Arguments> testCases() {
-    return Stream.of(List.of(new FrequencyEntry(new Frequency(), tripTimes)), List.of()).map(
-      Arguments::of
-    );
+    return Stream.of(
+      List.of(
+        new FrequencyEntry(new Frequency(tripTimes.getTrip(), 0, 86400, 600, false), tripTimes)
+      ),
+      List.of()
+    ).map(Arguments::of);
   }
 
   @ParameterizedTest(name = "trip with frequencies {0} should be correctly filtered")

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
@@ -18,6 +18,7 @@ import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
+import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class TripPatternForDatesTest {
@@ -83,17 +84,14 @@ class TripPatternForDatesTest {
       .build()
       .getRoutingTripPattern();
 
+    Trip trip = TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build();
     final ScheduledTripTimes tripTimes = TripTimesFactory.tripTimes(
-      TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build(),
+      trip,
       List.of(stopTime1, stopTime2),
       new Deduplicator()
     );
 
-    var frequency = new Frequency();
-    frequency.setStartTime(FREQUENCY_START);
-    frequency.setEndTime(FREQUENCY_END);
-    frequency.setHeadwaySecs(HEADWAY);
-    frequency.setExactTimes(1);
+    var frequency = new Frequency(trip, FREQUENCY_START, FREQUENCY_END, HEADWAY, true);
 
     var boardingAndAlightingPossible = new BitSet(2);
     boardingAndAlightingPossible.set(0);

--- a/application/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
@@ -99,12 +99,9 @@ public class FrequencyEntryTest {
   }
 
   private static FrequencyEntry make(int startTime, int endTime, int headwaySecs, boolean exact) {
-    Frequency f = new Frequency();
-    f.setStartTime(startTime);
-    f.setEndTime(endTime);
-    f.setHeadwaySecs(headwaySecs);
-    f.setExactTimes(exact ? 1 : 0);
-
-    return new FrequencyEntry(f, tripTimes);
+    return new FrequencyEntry(
+      new Frequency(tripTimes.getTrip(), startTime, endTime, headwaySecs, exact),
+      tripTimes
+    );
   }
 }


### PR DESCRIPTION
### Summary

Make `Frequency` class immutable.

The field `labelOnly` is removed as it is meaningless, not part of the standard and unused everywhere.

### Issue

None. This is a small clean up.

### Unit tests

Existing unit tests updated. There is no behavioural change so no new tests are added.

### Documentation

N/A

### Changelog

Not needed

### Bumping the serialization version id

Needed. A serialized class is changed.