### PR TITLE
Simplify equals in TripPatternForDate

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
@@ -168,7 +168,6 @@ public class TripPatternForDate implements Comparable<TripPatternForDate> {
 
   /**
    * The natural key of a TripPatternForDate is the pair (routing trip pattern id, service date).
-   * TODO: align equals and hashcode to use only the pair (routing trip pattern id, service date)
    */
   @Override
   public boolean equals(Object o) {
@@ -180,12 +179,7 @@ public class TripPatternForDate implements Comparable<TripPatternForDate> {
     }
     TripPatternForDate that = (TripPatternForDate) o;
 
-    return (
-      tripPattern.equals(that.tripPattern) &&
-      serviceDate.equals(that.serviceDate) &&
-      Arrays.equals(tripTimes, that.tripTimes) &&
-      Arrays.equals(frequencies, that.frequencies)
-    );
+    return (tripPattern.equals(that.tripPattern) && serviceDate.equals(that.serviceDate));
   }
 
   @Override

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -2,8 +2,6 @@ package org.opentripplanner.routing.algorithm.mapping;
 
 import static au.com.origin.snapshots.SnapshotMatcher.expect;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import au.com.origin.snapshots.serializers.SerializerType;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;


### PR DESCRIPTION
### Summary

Follow-up after #6868:
This PR simplifies the equals() method in TripPatternForDate to align it on the hashcode method.
The natural key of a TripPatternForDate is the pair (routing trip pattern id, service date)

### Issue

Relates to #6820

### Unit tests
No

### Documentation

Updated Javadoc

### Changelog
skip

