### PR TITLE
Add `code` to station vector tile layer

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
@@ -17,6 +17,8 @@ import org.opentripplanner.transit.service.TimetableRepository;
 
 public class DigitransitStationPropertyMapperTest {
 
+  private static final String CODE = "ABC";
+
   @Test
   void map() {
     var deduplicator = new Deduplicator();
@@ -28,6 +30,7 @@ public class DigitransitStationPropertyMapperTest {
 
     var station = Station.of(id("a-station"))
       .withCoordinate(1, 1)
+      .withCode(CODE)
       .withName(I18NString.of("A station"))
       .build();
 
@@ -38,6 +41,7 @@ public class DigitransitStationPropertyMapperTest {
 
     assertEquals("F:a-station", map.get("gtfsId"));
     assertEquals("A station", map.get("name"));
+    assertEquals(CODE, map.get("code"));
     assertEquals("", map.get("type"));
     assertEquals("[{\"mode\":\"RAIL\",\"gtfsType\":100,\"shortName\":\"R1\"}]", map.get("routes"));
     assertEquals("[\"F:stop-1\"]", map.get("stops"));

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.vectortiles.layers.stations;
 
+import static org.opentripplanner.inspector.vector.KeyValue.kv;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
@@ -38,7 +40,8 @@ public class DigitransitStationPropertyMapper extends PropertyMapper<Station> {
     try {
       var childStops = station.getChildStops();
       return List.of(
-        new KeyValue("gtfsId", station.getId().toString()),
+        kv("gtfsId", station.getId()),
+        kv("code", station.getCode()),
         new KeyValue("name", i18NStringMapper.mapNonnullToApi(station.getName())),
         new KeyValue(
           "type",


### PR DESCRIPTION
### Summary

@josh-willis-arcadis has requested that the field `code` is added to the station vector tiles layer. This is because sometimes stations have a different code from their ID or no code at all and Arcadis would like to indicate this in their UI.

While we want to keep the vector tiles data small and fast, we made an exception here, because we also include the code in the stop layer.

### Unit tests

Added.

### Changelog

Skip, because it's a sandbox feature.