### PR TITLE
Add prefix ! and + to GitHub labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,10 +61,10 @@ Write a few words on how the new code is tested.
 
 The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Changelog.md)
 is generated from the pull-request title, make sure the title describe the feature or issue fixed.
-To exclude the PR from the changelog add the label `skip changelog` to the PR.
+To exclude the PR from the changelog add the label `+Skip Changelog` to the PR.
 
 ### Bumping the serialization version id
 
 If you have made changes to the way the routing graph is serialized, for example by renaming a field
-in one of the edges, then you must add the label `bump serialization id` to the PR. With this label
+in one of the edges, then you must add the label `+Bump Serialization Id` to the PR. With this label
 Github Actions will increase the field `otp.serialization.version.id` in `pom.xml`.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   run:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'opentripplanner' && contains( github.event.pull_request.labels.*.name, 'Integration Test' )
+    if: github.repository_owner == 'opentripplanner' && contains( github.event.pull_request.labels.*.name, '+Integration Test' )
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   changelog-entry:
-    if: github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && !contains(github.event.pull_request.labels.*.name, 'skip changelog')
+    if: github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && !contains(github.event.pull_request.labels.*.name, '+Skip Changelog')
     runs-on: ubuntu-latest
     steps:
 
@@ -47,7 +47,7 @@ jobs:
     # if you have a dependent job that is skipped (ie. you want to bump the version but not have a changelog entry) you must add
     # always() before your actual condition you want for the job
     #   https://github.com/actions/runner/issues/491#issuecomment-660122693
-    if: always() && github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && contains(github.event.pull_request.labels.*.name, 'bump serialization id')
+    if: always() && github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && contains(github.event.pull_request.labels.*.name, '+Bump Serialization Id')
     runs-on: ubuntu-latest
     needs: [changelog-entry]
     steps:

--- a/doc/user/Developers-Guide.md
+++ b/doc/user/Developers-Guide.md
@@ -187,7 +187,7 @@ is generated from the pull-request(PR) _title_ using the
 [changelog workflow](https://github.com/opentripplanner/OpenTripPlanner/actions/workflows/automatic-changelog.yml)
 . The workflow runs after the PR is merged, and it changes, commits and pushes the _Changelog.md_. A
 secret _personal access token_ is used to bypass the "Require PR with 2 approvals" rule. To exclude
-a PR from the changelog add the label `skip changelog` to the PR.
+a PR from the changelog add the label `+Skip Changelog` to the PR.
 
 #### How-to update the CHANGELOG_TOKEN
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,7 @@
   ],
   "prConcurrentLimit": 3,
   "labels": [
-    "skip changelog"
+    "+Skip Changelog"
   ],
   "rebaseWhen": "conflicted",
   "enabledManagers": [
@@ -177,7 +177,7 @@
       ],
       "minimumReleaseAge": "1 week",
       "changelogUrl": "https://github.com/apache/httpcomponents-client/blob/master/RELEASE_NOTES.txt",
-      "addLabels": ["Integration Test"]
+      "addLabels": ["+Integration Test"]
     },
     {
       "groupName": "Jackson non-patch",
@@ -194,7 +194,7 @@
         "org.geotools:{/,}**"
       ],
       "minimumReleaseAge": "1 week",
-      "labels": ["skip changelog", "bump serialization id"]
+      "labels": ["+Skip Changelog", "+Bump Serialization Id"]
     },
     {
       "groupName": "Azure dependencies",

--- a/script/CUSTOM_RELEASE_README.md
+++ b/script/CUSTOM_RELEASE_README.md
@@ -38,7 +38,7 @@ based on the `base revision` - a branch, tag or commit, for example `otp/dev-2.x
 6. Then the script update the _otp-serialization-version-id_ and the OTP _version_ in the pom.xml 
    file. Each release is given a unique version number specific to your fork, like 
    `v2.7.0-MY_ORG-1`. The release script uses both the git history and the GitHub GraphQL API 
-   (PRs labeled `bump serialization id`) to resolve the serialization version number. 
+   (PRs labeled `+Bump Serialization Id`) to resolve the serialization version number. 
 7. Finally the release is tagged and pushed to the remote Git repository. The repository is 
    configured in the `custom-release-env.json` file.
 

--- a/script/custom-release.py
+++ b/script/custom-release.py
@@ -13,7 +13,7 @@ import sys
 
 POM_FILE_NAME = 'pom.xml'
 # GitHub label to indicate that a PR needs to be bumped
-LBL_BUMP_SER_VER_ID = 'bump serialization id'
+LBL_BUMP_SER_VER_ID = '+Bump Serialization Id'
 SER_VER_ID_PROPERTY = 'otp.serialization.version.id'
 SER_VER_ID_PROPERTY_PTN = SER_VER_ID_PROPERTY.replace('.', r'\.')
 SER_VER_ID_PATTERN = re.compile(
@@ -550,7 +550,7 @@ def read_pull_request_info_from_github():
                      error_msg='GitHub GraphQL Query failed!', quiet_err=True)
 
     # Example response
-    #   {"data":{"repository":{"pullRequests":{"nodes":[{"number":2222,"labels":{"nodes":[{"name":"bump serialization id"},{"name":"Entur Test"}]}}]}}}}
+    #   {"data":{"repository":{"pullRequests":{"nodes":[{"number":2222,"labels":{"nodes":[{"name":"+Bump Serialization Id"},{"name":"Entur Test"}]}}]}}}}
     json_doc = json.loads(result.stdout)
     defined_labels = [LBL_BUMP_SER_VER_ID.lower(), config.include_prs_label.lower()]
 
@@ -588,7 +588,7 @@ def check_if_prs_exist_in_latest_release():
 #  1. If the --serVerId option exist, then the latest SID is bumped and used.
 #  2. If the --release option exist, then the current pom.xml SID is validated, if ok it is used,
 #     if not the script exit.
-#  3. All merged in PRs are checked. If a PR is labeled with 'bump serialization id' and the the
+#  3. All merged in PRs are checked. If a PR is labeled with '+Bump Serialization Id' and the the
 #     HEAD commit is not in the latest release, then the last release SID is bumped and used.
 #  4. Finally, the script look at the upstream Git Repo SIDs for both this release(base) and the
 #     last release. If the SIDs are differnt the SID is bumped. To find the *upstream* SIDs we


### PR DESCRIPTION
### Summary

To make it easier to add labels I have divided the labels into 3 categoris:

 - `!` Type of issue or PR - exact one of these SHOULD be assigned to all PRs and Issues
 - `+` Classify a PR or Issue into categories we frequently use. Labels used in the CI/CD fall into this category, as well as the tagging components for easier review (+Roadmap, +Sandbox, +Debug UI, +Real-Time, +Skip Changelog, +Bump Serialization Id ...). PRs and Issues might have zero, one or more of these assigned.
 - Everything else. 

### Issue


Related to #6866
 
### Unit tests

🟥  Not relevant

### Documentation

Partly documented in  #6866

### Changelog

🟥  Not relevant

### Bumping the serialization version id

🟥  Not relevant
