### PR TITLE
fix: use PreparedGeometry in geofencing zone <-> street edge intersect check

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/GeofencingVertexUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/GeofencingVertexUpdater.java
@@ -11,6 +11,8 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.street.BusinessAreaBorder;
@@ -117,8 +119,11 @@ class GeofencingVertexUpdater {
     } else {
       candidates = Set.copyOf(getEdgesForEnvelope.apply(geom.getEnvelopeInternal()));
     }
+
+    PreparedGeometry preparedZone = PreparedGeometryFactory.prepare(geom);
+
     for (var e : candidates) {
-      if (e instanceof StreetEdge streetEdge && streetEdge.getGeometry().intersects(geom)) {
+      if (e instanceof StreetEdge streetEdge && preparedZone.intersects(streetEdge.getGeometry())) {
         streetEdge.addRentalRestriction(ext);
         edgesUpdated.put(streetEdge, ext);
       }


### PR DESCRIPTION
### Summary

Replaces expensive geometry.intersects() calls with JTS PreparedGeometry to pre-compute spatial indices. This improves performance by more than two orders of magnitude according to my local tests.

### Unit tests

No unit tests added.

### Documentation

No new methods, configuration or api.