### PR TITLE
Test encapsulate service date

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/trias/service/OjpServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/trias/service/OjpServiceTest.java
@@ -19,6 +19,9 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.graphfinder.PlaceAtDistance;
 import org.opentripplanner.routing.graphfinder.PlaceType;
 import org.opentripplanner.street.search.state.TestStateBuilder;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.EntityNotFoundException;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -26,13 +29,10 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.ArrivalDeparture;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 
 class OjpServiceTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder envBuilder = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder envBuilder = TransitTestEnvironment.of();
 
   private final RegularStop STOP_A = envBuilder.stopAtStation(STOP_A_ID, STATION_OMEGA_ID);
   private final RegularStop STOP_B = envBuilder.stop(STOP_B_ID);
@@ -44,7 +44,7 @@ class OjpServiceTest implements RealtimeTestConstants {
     .addStop(STOP_C, "12:20", "12:21")
     .build();
 
-  private OjpService.StopEventRequestParams params(RealtimeTestEnvironment env, int departures) {
+  private OjpService.StopEventRequestParams params(TransitTestEnvironment env, int departures) {
     return new OjpService.StopEventRequestParams(
       env.getDateTimeHelper().instant("12:00"),
       ArrivalDeparture.BOTH,

--- a/application/src/test/java/org/opentripplanner/DateTimeHelper.java
+++ b/application/src/test/java/org/opentripplanner/DateTimeHelper.java
@@ -1,9 +1,12 @@
 package org.opentripplanner;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.opentripplanner.utils.time.DateUtils;
+import org.opentripplanner.utils.time.TimeUtils;
 
 public class DateTimeHelper {
 
@@ -26,5 +29,14 @@ public class DateTimeHelper {
       throw new IllegalArgumentException("Invalid time format");
     }
     return defaultDate.atTime(time).atZone(zone);
+  }
+
+  /**
+   * Takes local time on different formats like "12:34:00" or "12:34" and returns the corresponding
+   * instant at the given date on the specific timezone.
+   */
+  public Instant instant(String timeString) {
+    var localTime = LocalTime.ofSecondOfDay(TimeUtils.time(timeString));
+    return localTime.atDate(defaultDate).atZone(zone).toInstant();
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/StopCallImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/StopCallImplTest.java
@@ -3,7 +3,9 @@ package org.opentripplanner.apis.gtfs.datafetchers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.apis.gtfs.model.CallSchedule;
@@ -22,13 +24,18 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
 
 class StopCallImplTest implements RealtimeTestConstants {
 
+  private static final LocalDate SERVICE_DATE = LocalDate.of(2023, 6, 3);
+  private static final ZoneId TIME_ZONE = ZoneId.of("Europe/Paris");
   private static final Instant MIDNIGHT = ServiceDateUtils.asStartOfService(
     SERVICE_DATE,
     TIME_ZONE
   ).toInstant();
-  private static final OffsetDateTime NOON = OffsetDateTime.parse("2024-05-08T12:00+02:00");
+
+  private static final OffsetDateTime NOON = OffsetDateTime.parse("2023-06-03T12:00+02:00");
   private static final OffsetDateTime TEN_AM = NOON.minusHours(2);
-  private final RealtimeTestEnvironmentBuilder envBuilder = RealtimeTestEnvironment.of();
+  private final RealtimeTestEnvironmentBuilder envBuilder = RealtimeTestEnvironment.of(
+    SERVICE_DATE
+  );
   private final RegularStop STOP_A = envBuilder.stop(STOP_A_ID);
   private final RegularStop STOP_B = envBuilder.stop(STOP_B_ID);
   private final RegularStop STOP_C = envBuilder.stop(STOP_C_ID);

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/StopCallImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/StopCallImplTest.java
@@ -13,13 +13,13 @@ import org.opentripplanner.apis.gtfs.model.CallScheduledTime.ArrivalDepartureTim
 import org.opentripplanner.apis.gtfs.model.CallScheduledTime.TimeWindow;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.model.TripTimeOnDate;
+import org.opentripplanner.transit.model._data.FlexTripInput;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.RegularStop;
-import org.opentripplanner.updater.trip.FlexTripInput;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
 class StopCallImplTest implements RealtimeTestConstants {
@@ -33,9 +33,7 @@ class StopCallImplTest implements RealtimeTestConstants {
 
   private static final OffsetDateTime NOON = OffsetDateTime.parse("2023-06-03T12:00+02:00");
   private static final OffsetDateTime TEN_AM = NOON.minusHours(2);
-  private final RealtimeTestEnvironmentBuilder envBuilder = RealtimeTestEnvironment.of(
-    SERVICE_DATE
-  );
+  private final TransitTestEnvironmentBuilder envBuilder = TransitTestEnvironment.of(SERVICE_DATE);
   private final RegularStop STOP_A = envBuilder.stop(STOP_A_ID);
   private final RegularStop STOP_B = envBuilder.stop(STOP_B_ID);
   private final RegularStop STOP_C = envBuilder.stop(STOP_C_ID);

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -19,13 +19,13 @@ import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
 import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.street.search.TraverseMode;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.ArrivalDeparture;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
 
 /**
@@ -41,9 +41,7 @@ class ApiTransitServiceTest implements RealtimeTestConstants {
   private static final LocalDate SERVICE_DATE = LocalDate.of(2024, 5, 8);
   private static final ZoneId TIME_ZONE = ZoneId.of("Europe/Paris");
   private static final ZonedDateTime ANY_TIME = ZonedDateTime.parse("2022-01-01T12:00:00+00:00");
-  private final RealtimeTestEnvironmentBuilder envBuilder = RealtimeTestEnvironment.of(
-    SERVICE_DATE
-  );
+  private final TransitTestEnvironmentBuilder envBuilder = TransitTestEnvironment.of(SERVICE_DATE);
   private final RegularStop STOP_A = envBuilder.stop(STOP_A_ID);
   private final RegularStop STOP_B = envBuilder.stop(STOP_B_ID);
   private final RegularStop STOP_C = envBuilder.stop(STOP_C_ID);

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -21,6 +21,7 @@ import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.ArrivalDeparture;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
@@ -91,10 +92,12 @@ class ApiTransitServiceTest implements RealtimeTestConstants {
   @Test
   void skipStopInMultipleTripsInPattern() {
     var env = envBuilder.addTrip(TRIP1_INPUT).addTrip(TRIP2_INPUT).build();
-    var res = env.applyTripUpdates(
+    var rt = GtfsRtTestHelper.of(env);
+
+    var res = rt.applyTripUpdates(
       List.of(
-        skipSecondStop(env.tripUpdateScheduled(TRIP_1_ID)),
-        skipSecondStop(env.tripUpdateScheduled(TRIP_2_ID))
+        skipSecondStop(rt.tripUpdateScheduled(TRIP_1_ID)),
+        skipSecondStop(rt.tripUpdateScheduled(TRIP_2_ID))
       ),
       FULL_DATASET
     );

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/FlexTripInput.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/FlexTripInput.java
@@ -1,8 +1,7 @@
-package org.opentripplanner.updater.trip;
+package org.opentripplanner.transit.model._data;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.utils.time.TimeUtils;

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TransitTestEnvironment.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TransitTestEnvironment.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.updater.trip;
+package org.opentripplanner.transit.model._data;
 
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
 
@@ -7,7 +7,6 @@ import java.time.ZoneId;
 import java.util.Objects;
 import org.opentripplanner.DateTimeHelper;
 import org.opentripplanner.model.TimetableSnapshot;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -17,12 +16,12 @@ import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TimetableRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.TimetableSnapshotParameters;
-import org.opentripplanner.updater.trip.gtfs.GtfsRealTimeTripUpdateAdapter;
+import org.opentripplanner.updater.trip.TimetableSnapshotManager;
 
 /**
- * This class exists so that you can share the data building logic for GTFS and Siri tests.
+ * A helper class for creating and fetching transit entities
  */
-public final class RealtimeTestEnvironment {
+public final class TransitTestEnvironment {
 
   private final TimetableRepository timetableRepository;
   private final TimetableSnapshotManager snapshotManager;
@@ -30,23 +29,23 @@ public final class RealtimeTestEnvironment {
   private final LocalDate serviceDate;
   private final ZoneId timeZone;
 
-  public static RealtimeTestEnvironmentBuilder of() {
-    return new RealtimeTestEnvironmentBuilder(
+  public static TransitTestEnvironmentBuilder of() {
+    return new TransitTestEnvironmentBuilder(
       "F",
       ZoneId.of("Europe/Paris"),
       LocalDate.of(2024, 5, 7)
     );
   }
 
-  public static RealtimeTestEnvironmentBuilder of(LocalDate serviceDate) {
-    return new RealtimeTestEnvironmentBuilder("F", ZoneId.of("Europe/Paris"), serviceDate);
+  public static TransitTestEnvironmentBuilder of(LocalDate serviceDate) {
+    return new TransitTestEnvironmentBuilder("F", ZoneId.of("Europe/Paris"), serviceDate);
   }
 
-  public static RealtimeTestEnvironmentBuilder of(LocalDate serviceDate, ZoneId timeZone) {
-    return new RealtimeTestEnvironmentBuilder("F", timeZone, serviceDate);
+  public static TransitTestEnvironmentBuilder of(LocalDate serviceDate, ZoneId timeZone) {
+    return new TransitTestEnvironmentBuilder("F", timeZone, serviceDate);
   }
 
-  RealtimeTestEnvironment(
+  TransitTestEnvironment(
     TimetableRepository timetableRepository,
     LocalDate defaultServiceDate,
     ZoneId zoneId

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TransitTestEnvironmentBuilder.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TransitTestEnvironmentBuilder.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.updater.trip;
+package org.opentripplanner.transit.model._data;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -19,7 +19,7 @@ import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.FlexTripInput.FlexStop;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -37,9 +37,8 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.SiteRepository;
 import org.opentripplanner.transit.service.SiteRepositoryBuilder;
 import org.opentripplanner.transit.service.TimetableRepository;
-import org.opentripplanner.updater.trip.FlexTripInput.FlexStop;
 
-public class RealtimeTestEnvironmentBuilder {
+public class TransitTestEnvironmentBuilder {
 
   private static final WgsCoordinate ANY_COORDINATE = new WgsCoordinate(60.0, 10.0);
   private static final Polygon ANY_POLYGON = GeometryUtils.getGeometryFactory()
@@ -64,7 +63,7 @@ public class RealtimeTestEnvironmentBuilder {
   private final ZoneId timeZone;
   private final LocalDate defaultServiceDate;
 
-  RealtimeTestEnvironmentBuilder(
+  TransitTestEnvironmentBuilder(
     String defaultFeedId,
     ZoneId timeZone,
     LocalDate defaultServiceDate
@@ -75,12 +74,12 @@ public class RealtimeTestEnvironmentBuilder {
     this.defaultServiceDate = defaultServiceDate;
   }
 
-  public RealtimeTestEnvironmentBuilder addTrip(TripInput trip) {
+  public TransitTestEnvironmentBuilder addTrip(TripInput trip) {
     this.tripInputs.add(trip);
     return this;
   }
 
-  public RealtimeTestEnvironment build() {
+  public TransitTestEnvironment build() {
     for (var stop : stops) {
       switch (stop) {
         case RegularStop rs -> siteRepositoryBuilder.withRegularStop(rs);
@@ -133,10 +132,10 @@ public class RealtimeTestEnvironmentBuilder {
     timetableRepository.addScheduledStopPointMapping(scheduledStopPointMapping);
 
     timetableRepository.index();
-    return new RealtimeTestEnvironment(timetableRepository, defaultServiceDate, timeZone);
+    return new TransitTestEnvironment(timetableRepository, defaultServiceDate, timeZone);
   }
 
-  public RealtimeTestEnvironmentBuilder withStops(String... stopIds) {
+  public TransitTestEnvironmentBuilder withStops(String... stopIds) {
     Arrays.stream(stopIds).forEach(this::stop);
     return this;
   }
@@ -182,12 +181,12 @@ public class RealtimeTestEnvironmentBuilder {
     return stop;
   }
 
-  public RealtimeTestEnvironmentBuilder addFlexTrip(FlexTripInput tripInput) {
+  public TransitTestEnvironmentBuilder addFlexTrip(FlexTripInput tripInput) {
     flexTripInputs.add(tripInput);
     return this;
   }
 
-  public RealtimeTestEnvironmentBuilder addScheduledStopPointMapping(
+  public TransitTestEnvironmentBuilder addScheduledStopPointMapping(
     Map<FeedScopedId, RegularStop> mapping
   ) {
     scheduledStopPointMapping.putAll(mapping);

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TripInput.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TripInput.java
@@ -1,10 +1,9 @@
-package org.opentripplanner.updater.trip;
+package org.opentripplanner.transit.model._data;
 
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -12,7 +11,7 @@ import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.utils.time.TimeUtils;
 
 /**
- * A simple data structure that is used by the {@link RealtimeTestEnvironment} to create
+ * A simple data structure that is used by the {@link TransitTestEnvironment} to create
  * trips, trips on date and patterns.
  */
 public record TripInput(

--- a/application/src/test/java/org/opentripplanner/transit/service/TripTimesOnDateTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/TripTimesOnDateTest.java
@@ -4,8 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
@@ -14,7 +12,6 @@ import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.utils.time.TimeUtils;
 
 public class TripTimesOnDateTest implements RealtimeTestConstants {
 
@@ -47,8 +44,9 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
   void onFirstStop() {
     var env = envBuilder.addTrip(TRIP_INPUT1).addTrip(TRIP_INPUT2).build();
     var transitService = env.getTransitService();
+    var dt = env.getDateTimeHelper();
 
-    var instant = instant("12:00");
+    var instant = dt.instant("12:00");
     {
       var result = transitService.findTripTimesOnDate(
         TripTimeOnDateRequest.of(List.of(STOP_A)).withTime(instant).build()
@@ -56,7 +54,7 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
 
       assertThat(result).hasSize(1);
       var tt = result.getFirst();
-      assertEquals(instant("12:01"), tt.scheduledDeparture());
+      assertEquals(dt.instant("12:01"), tt.scheduledDeparture());
     }
     {
       var result = transitService.findTripTimesOnDate(
@@ -64,7 +62,7 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
       );
       assertThat(result).hasSize(1);
       var tt = result.getFirst();
-      assertEquals(instant("12:11"), tt.scheduledDeparture());
+      assertEquals(dt.instant("12:11"), tt.scheduledDeparture());
     }
   }
 
@@ -72,22 +70,25 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
   void nextDay() {
     var env = envBuilder.addTrip(TRIP_INPUT1).addTrip(TRIP_INPUT2).build();
     var transitService = env.getTransitService();
+    var dt = env.getDateTimeHelper();
 
-    var instant = instant("12:00").plus(Duration.ofDays(1));
+    var instant = dt.instant("12:00").plus(Duration.ofDays(1));
     var result = transitService.findTripTimesOnDate(
       TripTimeOnDateRequest.of(List.of(STOP_A)).withTime(instant).build()
     );
 
     assertThat(result).hasSize(1);
     var tt = result.getFirst();
-    assertEquals(instant("12:01").plus(Duration.ofDays(1)), tt.scheduledDeparture());
+    assertEquals(dt.instant("12:01").plus(Duration.ofDays(1)), tt.scheduledDeparture());
   }
 
   @Test
   void tooLate() {
-    var transitService = envBuilder.addTrip(TRIP_INPUT1).build().getTransitService();
+    var env = envBuilder.addTrip(TRIP_INPUT1).build();
+    var transitService = env.getTransitService();
+    var dt = env.getDateTimeHelper();
 
-    var instant = instant("18:00");
+    var instant = dt.instant("18:00");
     var result = transitService.findTripTimesOnDate(
       TripTimeOnDateRequest.of(List.of(STOP_A)).withTime(instant).build()
     );
@@ -96,9 +97,11 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
 
   @Test
   void shortWindow() {
-    var transitService = envBuilder.addTrip(TRIP_INPUT1).build().getTransitService();
+    var env = envBuilder.addTrip(TRIP_INPUT1).build();
+    var transitService = env.getTransitService();
+    var dt = env.getDateTimeHelper();
 
-    var instant = instant("11:00");
+    var instant = dt.instant("11:00");
     var result = transitService.findTripTimesOnDate(
       TripTimeOnDateRequest.of(List.of(STOP_A))
         .withTime(instant)
@@ -110,9 +113,11 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
 
   @Test
   void longerWindow() {
-    var transitService = envBuilder.addTrip(TRIP_INPUT1).build().getTransitService();
+    var env = envBuilder.addTrip(TRIP_INPUT1).build();
+    var transitService = env.getTransitService();
+    var dt = env.getDateTimeHelper();
 
-    var instant = instant("11:00");
+    var instant = dt.instant("11:00");
     var result = transitService.findTripTimesOnDate(
       TripTimeOnDateRequest.of(List.of(STOP_A))
         .withTime(instant)
@@ -124,13 +129,11 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
 
   @Test
   void several() {
-    var transitService = envBuilder
-      .addTrip(TRIP_INPUT2)
-      .addTrip(TRIP_INPUT3)
-      .build()
-      .getTransitService();
+    var env = envBuilder.addTrip(TRIP_INPUT2).addTrip(TRIP_INPUT3).build();
+    var transitService = env.getTransitService();
+    var dt = env.getDateTimeHelper();
 
-    var instant = instant("12:10");
+    var instant = dt.instant("12:10");
     var result = transitService.findTripTimesOnDate(
       TripTimeOnDateRequest.of(List.of(STOP_F))
         .withTime(instant)
@@ -138,10 +141,5 @@ public class TripTimesOnDateTest implements RealtimeTestConstants {
         .build()
     );
     assertThat(result).hasSize(2);
-  }
-
-  private static Instant instant(String time) {
-    var localTime = LocalTime.ofSecondOfDay(TimeUtils.time(time));
-    return localTime.atDate(SERVICE_DATE).atZone(TIME_ZONE).toInstant();
   }
 }

--- a/application/src/test/java/org/opentripplanner/transit/service/TripTimesOnDateTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/TripTimesOnDateTest.java
@@ -7,15 +7,15 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 
 public class TripTimesOnDateTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder envBuilder = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder envBuilder = TransitTestEnvironment.of();
 
   private final RegularStop STOP_A = envBuilder.stop(STOP_A_ID);
   private final RegularStop STOP_B = envBuilder.stop(STOP_B_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/GtfsRtTestHelper.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/GtfsRtTestHelper.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.updater.trip.UpdateIncrementality.FULL_DATASET
 
 import com.google.transit.realtime.GtfsRealtime;
 import java.util.List;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.trip.gtfs.BackwardsDelayPropagationType;
 import org.opentripplanner.updater.trip.gtfs.ForwardsDelayPropagationType;
@@ -11,20 +12,20 @@ import org.opentripplanner.updater.trip.gtfs.GtfsRealTimeTripUpdateAdapter;
 
 public class GtfsRtTestHelper {
 
-  private final RealtimeTestEnvironment realtimeTestEnvironment;
+  private final TransitTestEnvironment transitTestEnvironment;
   private final GtfsRealTimeTripUpdateAdapter gtfsAdapter;
 
-  GtfsRtTestHelper(RealtimeTestEnvironment realtimeTestEnvironment) {
-    this.realtimeTestEnvironment = realtimeTestEnvironment;
+  GtfsRtTestHelper(TransitTestEnvironment transitTestEnvironment) {
+    this.transitTestEnvironment = transitTestEnvironment;
     this.gtfsAdapter = new GtfsRealTimeTripUpdateAdapter(
-      realtimeTestEnvironment.timetableRepository(),
-      realtimeTestEnvironment.timetableSnapshotManager(),
-      () -> realtimeTestEnvironment.serviceDate()
+      transitTestEnvironment.timetableRepository(),
+      transitTestEnvironment.timetableSnapshotManager(),
+      () -> transitTestEnvironment.serviceDate()
     );
   }
 
-  public static GtfsRtTestHelper of(RealtimeTestEnvironment realtimeTestEnvironment) {
-    return new GtfsRtTestHelper(realtimeTestEnvironment);
+  public static GtfsRtTestHelper of(TransitTestEnvironment transitTestEnvironment) {
+    return new GtfsRtTestHelper(transitTestEnvironment);
   }
 
   public TripUpdateBuilder tripUpdateScheduled(String tripId) {
@@ -37,9 +38,9 @@ public class GtfsRtTestHelper {
   ) {
     return new TripUpdateBuilder(
       tripId,
-      realtimeTestEnvironment.serviceDate(),
+      transitTestEnvironment.serviceDate(),
       scheduleRelationship,
-      realtimeTestEnvironment.timeZone()
+      transitTestEnvironment.timeZone()
     );
   }
 
@@ -64,13 +65,13 @@ public class GtfsRtTestHelper {
       BackwardsDelayPropagationType.REQUIRED_NO_DATA,
       incrementality,
       updates,
-      realtimeTestEnvironment.getFeedId()
+      transitTestEnvironment.getFeedId()
     );
     commitTimetableSnapshot();
     return updateResult;
   }
 
   private void commitTimetableSnapshot() {
-    realtimeTestEnvironment.timetableSnapshotManager().purgeAndCommit();
+    transitTestEnvironment.timetableSnapshotManager().purgeAndCommit();
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/GtfsRtTestHelper.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/GtfsRtTestHelper.java
@@ -1,0 +1,76 @@
+package org.opentripplanner.updater.trip;
+
+import static org.opentripplanner.updater.trip.UpdateIncrementality.FULL_DATASET;
+
+import com.google.transit.realtime.GtfsRealtime;
+import java.util.List;
+import org.opentripplanner.updater.spi.UpdateResult;
+import org.opentripplanner.updater.trip.gtfs.BackwardsDelayPropagationType;
+import org.opentripplanner.updater.trip.gtfs.ForwardsDelayPropagationType;
+import org.opentripplanner.updater.trip.gtfs.GtfsRealTimeTripUpdateAdapter;
+
+public class GtfsRtTestHelper {
+
+  private final RealtimeTestEnvironment realtimeTestEnvironment;
+  private final GtfsRealTimeTripUpdateAdapter gtfsAdapter;
+
+  GtfsRtTestHelper(RealtimeTestEnvironment realtimeTestEnvironment) {
+    this.realtimeTestEnvironment = realtimeTestEnvironment;
+    this.gtfsAdapter = new GtfsRealTimeTripUpdateAdapter(
+      realtimeTestEnvironment.timetableRepository(),
+      realtimeTestEnvironment.timetableSnapshotManager(),
+      () -> realtimeTestEnvironment.serviceDate()
+    );
+  }
+
+  public static GtfsRtTestHelper of(RealtimeTestEnvironment realtimeTestEnvironment) {
+    return new GtfsRtTestHelper(realtimeTestEnvironment);
+  }
+
+  public TripUpdateBuilder tripUpdateScheduled(String tripId) {
+    return tripUpdate(tripId, GtfsRealtime.TripDescriptor.ScheduleRelationship.SCHEDULED);
+  }
+
+  public TripUpdateBuilder tripUpdate(
+    String tripId,
+    GtfsRealtime.TripDescriptor.ScheduleRelationship scheduleRelationship
+  ) {
+    return new TripUpdateBuilder(
+      tripId,
+      realtimeTestEnvironment.serviceDate(),
+      scheduleRelationship,
+      realtimeTestEnvironment.timeZone()
+    );
+  }
+
+  public UpdateResult applyTripUpdate(GtfsRealtime.TripUpdate update) {
+    return applyTripUpdates(List.of(update), FULL_DATASET);
+  }
+
+  public UpdateResult applyTripUpdate(
+    GtfsRealtime.TripUpdate update,
+    UpdateIncrementality incrementality
+  ) {
+    return applyTripUpdates(List.of(update), incrementality);
+  }
+
+  public UpdateResult applyTripUpdates(
+    List<GtfsRealtime.TripUpdate> updates,
+    UpdateIncrementality incrementality
+  ) {
+    UpdateResult updateResult = gtfsAdapter.applyTripUpdates(
+      null,
+      ForwardsDelayPropagationType.DEFAULT,
+      BackwardsDelayPropagationType.REQUIRED_NO_DATA,
+      incrementality,
+      updates,
+      realtimeTestEnvironment.getFeedId()
+    );
+    commitTimetableSnapshot();
+    return updateResult;
+  }
+
+  private void commitTimetableSnapshot() {
+    realtimeTestEnvironment.timetableSnapshotManager().purgeAndCommit();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestConstants.java
@@ -1,13 +1,6 @@
 package org.opentripplanner.updater.trip;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
-
 public interface RealtimeTestConstants {
-  LocalDate SERVICE_DATE = LocalDate.of(2024, 5, 8);
-  ZoneId TIME_ZONE = ZoneId.of(TimetableRepositoryForTest.TIME_ZONE_ID);
-
   String TRIP_1_ID = "TestTrip1";
   String TRIP_2_ID = "TestTrip2";
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/RealtimeTestEnvironmentBuilder.java
@@ -64,7 +64,11 @@ public class RealtimeTestEnvironmentBuilder {
   private final ZoneId timeZone;
   private final LocalDate defaultServiceDate;
 
-  RealtimeTestEnvironmentBuilder(String defaultFeedId, ZoneId timeZone, LocalDate defaultServiceDate) {
+  RealtimeTestEnvironmentBuilder(
+    String defaultFeedId,
+    ZoneId timeZone,
+    LocalDate defaultServiceDate
+  ) {
     this.defaultFeedId = defaultFeedId;
     this.timeZone = timeZone;
     this.defaultServiceId = id("CAL_1");

--- a/application/src/test/java/org/opentripplanner/updater/trip/SiriTestHelper.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/SiriTestHelper.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL
 
 import java.util.List;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
 import org.opentripplanner.updater.DefaultRealTimeUpdateContext;
 import org.opentripplanner.updater.spi.UpdateResult;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
@@ -13,23 +14,23 @@ import uk.org.siri.siri21.EstimatedTimetableDeliveryStructure;
 
 public class SiriTestHelper {
 
-  private final RealtimeTestEnvironment realtimeTestEnvironment;
+  private final TransitTestEnvironment transitTestEnvironment;
   private final SiriRealTimeTripUpdateAdapter siriAdapter;
 
-  SiriTestHelper(RealtimeTestEnvironment realtimeTestEnvironment) {
-    this.realtimeTestEnvironment = realtimeTestEnvironment;
+  SiriTestHelper(TransitTestEnvironment transitTestEnvironment) {
+    this.transitTestEnvironment = transitTestEnvironment;
     this.siriAdapter = new SiriRealTimeTripUpdateAdapter(
-      realtimeTestEnvironment.timetableRepository(),
-      realtimeTestEnvironment.timetableSnapshotManager()
+      transitTestEnvironment.timetableRepository(),
+      transitTestEnvironment.timetableSnapshotManager()
     );
   }
 
-  public static SiriTestHelper of(RealtimeTestEnvironment realtimeTestEnvironment) {
-    return new SiriTestHelper(realtimeTestEnvironment);
+  public static SiriTestHelper of(TransitTestEnvironment transitTestEnvironment) {
+    return new SiriTestHelper(transitTestEnvironment);
   }
 
   public SiriEtBuilder etBuilder() {
-    return new SiriEtBuilder(realtimeTestEnvironment.getDateTimeHelper());
+    return new SiriEtBuilder(transitTestEnvironment.getDateTimeHelper());
   }
 
   public UpdateResult applyEstimatedTimetableWithFuzzyMatcher(
@@ -42,8 +43,8 @@ public class SiriTestHelper {
     return applyEstimatedTimetable(updates, false);
   }
 
-  public RealtimeTestEnvironment realtimeTestEnvironment() {
-    return realtimeTestEnvironment;
+  public TransitTestEnvironment realtimeTestEnvironment() {
+    return transitTestEnvironment;
   }
 
   private UpdateResult applyEstimatedTimetable(
@@ -55,8 +56,8 @@ public class SiriTestHelper {
       DIFFERENTIAL,
       new DefaultRealTimeUpdateContext(
         new Graph(),
-        realtimeTestEnvironment.timetableRepository(),
-        realtimeTestEnvironment.timetableSnapshotManager().getTimetableSnapshotBuffer()
+        transitTestEnvironment.timetableRepository(),
+        transitTestEnvironment.timetableSnapshotManager().getTimetableSnapshotBuffer()
       )
     );
     commitTimetableSnapshot();
@@ -67,11 +68,11 @@ public class SiriTestHelper {
     return new EstimatedTimetableHandler(
       siriAdapter,
       fuzzyMatching,
-      realtimeTestEnvironment.getFeedId()
+      transitTestEnvironment.getFeedId()
     );
   }
 
   private void commitTimetableSnapshot() {
-    realtimeTestEnvironment.timetableSnapshotManager().purgeAndCommit();
+    transitTestEnvironment.timetableSnapshotManager().purgeAndCommit();
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/SiriTestHelper.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/SiriTestHelper.java
@@ -1,0 +1,77 @@
+package org.opentripplanner.updater.trip;
+
+import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL;
+
+import java.util.List;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.updater.DefaultRealTimeUpdateContext;
+import org.opentripplanner.updater.spi.UpdateResult;
+import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
+import org.opentripplanner.updater.trip.siri.SiriRealTimeTripUpdateAdapter;
+import org.opentripplanner.updater.trip.siri.updater.EstimatedTimetableHandler;
+import uk.org.siri.siri21.EstimatedTimetableDeliveryStructure;
+
+public class SiriTestHelper {
+
+  private final RealtimeTestEnvironment realtimeTestEnvironment;
+  private final SiriRealTimeTripUpdateAdapter siriAdapter;
+
+  SiriTestHelper(RealtimeTestEnvironment realtimeTestEnvironment) {
+    this.realtimeTestEnvironment = realtimeTestEnvironment;
+    this.siriAdapter = new SiriRealTimeTripUpdateAdapter(
+      realtimeTestEnvironment.timetableRepository(),
+      realtimeTestEnvironment.timetableSnapshotManager()
+    );
+  }
+
+  public static SiriTestHelper of(RealtimeTestEnvironment realtimeTestEnvironment) {
+    return new SiriTestHelper(realtimeTestEnvironment);
+  }
+
+  public SiriEtBuilder etBuilder() {
+    return new SiriEtBuilder(realtimeTestEnvironment.getDateTimeHelper());
+  }
+
+  public UpdateResult applyEstimatedTimetableWithFuzzyMatcher(
+    List<EstimatedTimetableDeliveryStructure> updates
+  ) {
+    return applyEstimatedTimetable(updates, true);
+  }
+
+  public UpdateResult applyEstimatedTimetable(List<EstimatedTimetableDeliveryStructure> updates) {
+    return applyEstimatedTimetable(updates, false);
+  }
+
+  public RealtimeTestEnvironment realtimeTestEnvironment() {
+    return realtimeTestEnvironment;
+  }
+
+  private UpdateResult applyEstimatedTimetable(
+    List<EstimatedTimetableDeliveryStructure> updates,
+    boolean fuzzyMatching
+  ) {
+    UpdateResult updateResult = getEstimatedTimetableHandler(fuzzyMatching).applyUpdate(
+      updates,
+      DIFFERENTIAL,
+      new DefaultRealTimeUpdateContext(
+        new Graph(),
+        realtimeTestEnvironment.timetableRepository(),
+        realtimeTestEnvironment.timetableSnapshotManager().getTimetableSnapshotBuffer()
+      )
+    );
+    commitTimetableSnapshot();
+    return updateResult;
+  }
+
+  private EstimatedTimetableHandler getEstimatedTimetableHandler(boolean fuzzyMatching) {
+    return new EstimatedTimetableHandler(
+      siriAdapter,
+      fuzzyMatching,
+      realtimeTestEnvironment.getFeedId()
+    );
+  }
+
+  private void commitTimetableSnapshot() {
+    realtimeTestEnvironment.timetableSnapshotManager().purgeAndCommit();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/TripUpdateBuilder.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TripUpdateBuilder.java
@@ -39,23 +39,6 @@ public class TripUpdateBuilder {
     this.midnight = ServiceDateUtils.asStartOfService(serviceDate, zoneId);
   }
 
-  public TripUpdateBuilder(
-    String tripId,
-    LocalDate serviceDate,
-    GtfsRealtime.TripDescriptor.ScheduleRelationship scheduleRelationship,
-    ZoneId zoneId,
-    String tripHeadsign,
-    String tripShortName
-  ) {
-    this(tripId, serviceDate, scheduleRelationship, zoneId);
-    tripUpdateBuilder.setTripProperties(
-      GtfsRealtime.TripUpdate.TripProperties.newBuilder()
-        .setTripHeadsign(tripHeadsign)
-        .setTripShortName(tripShortName)
-        .build()
-    );
-  }
-
   public TripUpdateBuilder addStopTime(String stopId, String time) {
     return addStopTime(
       stopId,
@@ -353,6 +336,16 @@ public class TripUpdateBuilder {
     tripDescriptorBuilder.setExtension(MfdzRealtimeExtensions.tripDescriptor, ext);
     tripDescriptorBuilder.setRouteId("dynamically-added-trip");
 
+    return this;
+  }
+
+  public TripUpdateBuilder withTripProperties(String tripHeadsign, String tripShortName) {
+    tripUpdateBuilder.setTripProperties(
+      GtfsRealtime.TripUpdate.TripProperties.newBuilder()
+        .setTripHeadsign(tripHeadsign)
+        .setTripShortName(tripShortName)
+        .build()
+    );
     return this;
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
@@ -27,14 +28,13 @@ import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.UpdateSuccess;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
 import org.opentripplanner.utils.time.TimeUtils;
 
 class AddedTest implements RealtimeTestConstants {
 
   private static final String ADDED_TRIP_ID = "added_trip";
-  private final RealtimeTestEnvironment env = RealtimeTestEnvironment.of()
+  private final TransitTestEnvironment env = TransitTestEnvironment.of()
     .withStops(STOP_A_ID, STOP_B_ID, STOP_C_ID, STOP_D_ID)
     .build();
   private final GtfsRtTestHelper gtfsRt = GtfsRtTestHelper.of(env);
@@ -195,13 +195,13 @@ class AddedTest implements RealtimeTestConstants {
     assertEquals(TimeUtils.time("09:10"), tripTimes.getArrivalTime(2));
   }
 
-  private static TripPattern assertAddedTrip(String tripId, RealtimeTestEnvironment env) {
+  private static TripPattern assertAddedTrip(String tripId, TransitTestEnvironment env) {
     return assertAddedTrip(tripId, env, RealTimeState.ADDED);
   }
 
   static TripPattern assertAddedTrip(
     String tripId,
-    RealtimeTestEnvironment env,
+    TransitTestEnvironment env,
     RealTimeState realTimeState
   ) {
     var snapshot = env.getTimetableSnapshot();

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
@@ -25,6 +25,7 @@ import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.UpdateSuccess;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
@@ -36,23 +37,24 @@ class AddedTest implements RealtimeTestConstants {
   private final RealtimeTestEnvironment env = RealtimeTestEnvironment.of()
     .withStops(STOP_A_ID, STOP_B_ID, STOP_C_ID, STOP_D_ID)
     .build();
+  private final GtfsRtTestHelper gtfsRt = GtfsRtTestHelper.of(env);
 
   @Test
   void addedTrip() {
-    var tripUpdate = env
+    var tripUpdate = gtfsRt
       .tripUpdate(ADDED_TRIP_ID, ADDED)
       .addStopTime(STOP_A_ID, "00:30")
       .addStopTime(STOP_B_ID, "00:40")
       .addStopTime(STOP_C_ID, "00:55")
       .build();
 
-    assertSuccess(env.applyTripUpdate(tripUpdate));
+    assertSuccess(gtfsRt.applyTripUpdate(tripUpdate));
     assertAddedTrip(ADDED_TRIP_ID, env);
   }
 
   @Test
   void addedTripWithNewRoute() {
-    var tripUpdate = env
+    var tripUpdate = gtfsRt
       .tripUpdate(ADDED_TRIP_ID, ADDED)
       .addTripExtension()
       .addStopTime(STOP_A_ID, "00:30", DropOffPickupType.PHONE_AGENCY)
@@ -60,7 +62,7 @@ class AddedTest implements RealtimeTestConstants {
       .addStopTime(STOP_B_ID, "00:55", DropOffPickupType.NONE)
       .build();
 
-    var result = env.applyTripUpdate(tripUpdate);
+    var result = gtfsRt.applyTripUpdate(tripUpdate);
     assertSuccess(result);
     assertTrue(result.warnings().isEmpty());
 
@@ -87,7 +89,7 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   void addedWithUnknownStop() {
-    var tripUpdate = env
+    var tripUpdate = gtfsRt
       .tripUpdate(ADDED_TRIP_ID, ADDED)
       // add extension to set route name, url, mode
       .addTripExtension()
@@ -96,7 +98,7 @@ class AddedTest implements RealtimeTestConstants {
       .addStopTime(STOP_C_ID, "00:55", DropOffPickupType.NONE)
       .build();
 
-    var result = env.applyTripUpdate(tripUpdate);
+    var result = gtfsRt.applyTripUpdate(tripUpdate);
     assertSuccess(result);
 
     assertEquals(
@@ -111,7 +113,7 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   void repeatedlyAddedTripWithNewRoute() {
-    var tripUpdate = env
+    var tripUpdate = gtfsRt
       .tripUpdate(ADDED_TRIP_ID, ADDED)
       // add extension to set route name, url, mode
       .addTripExtension()
@@ -120,12 +122,12 @@ class AddedTest implements RealtimeTestConstants {
       .addStopTime(STOP_C_ID, "00:55", DropOffPickupType.NONE)
       .build();
 
-    assertSuccess(env.applyTripUpdate(tripUpdate));
+    assertSuccess(gtfsRt.applyTripUpdate(tripUpdate));
     var pattern = assertAddedTrip(ADDED_TRIP_ID, env);
     var firstRoute = pattern.getRoute();
 
     // apply the update a second time to check that no new route instance is created but the old one is reused
-    env.applyTripUpdate(tripUpdate);
+    gtfsRt.applyTripUpdate(tripUpdate);
     var secondPattern = assertAddedTrip(ADDED_TRIP_ID, env);
     var secondRoute = secondPattern.getRoute();
 
@@ -135,7 +137,7 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   public void addedTripWithSkippedStop() {
-    var tripUpdate = env
+    var tripUpdate = gtfsRt
       .tripUpdate(ADDED_TRIP_ID, ADDED)
       .withTripProperties("A loop", "SW1234")
       .addStopTime(STOP_A_ID, "00:30", DropOffPickupType.PHONE_AGENCY)
@@ -145,7 +147,7 @@ class AddedTest implements RealtimeTestConstants {
       .addStopTime(STOP_A_ID, "01:00")
       .build();
 
-    env.applyTripUpdate(tripUpdate);
+    gtfsRt.applyTripUpdate(tripUpdate);
 
     // THEN
     final TripPattern tripPattern = assertAddedTrip(ADDED_TRIP_ID, env);
@@ -170,7 +172,7 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   public void addedTripWithDelay() {
-    var builder = env.tripUpdate(ADDED_TRIP_ID, ADDED);
+    var builder = gtfsRt.tripUpdate(ADDED_TRIP_ID, ADDED);
 
     builder
       .addStopTime(STOP_A_ID, "08:00")
@@ -178,7 +180,7 @@ class AddedTest implements RealtimeTestConstants {
       .addStopTimeWithScheduled(STOP_C_ID, "09:10", "09:00");
 
     var tripUpdate = builder.build();
-    env.applyTripUpdate(tripUpdate);
+    gtfsRt.applyTripUpdate(tripUpdate);
 
     // THEN
     var tripPattern = assertAddedTrip(ADDED_TRIP_ID, env);

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
@@ -39,7 +39,8 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   void addedTrip() {
-    var tripUpdate = new TripUpdateBuilder(ADDED_TRIP_ID, SERVICE_DATE, ADDED, TIME_ZONE)
+    var tripUpdate = env
+      .tripUpdate(ADDED_TRIP_ID, ADDED)
       .addStopTime(STOP_A_ID, "00:30")
       .addStopTime(STOP_B_ID, "00:40")
       .addStopTime(STOP_C_ID, "00:55")
@@ -51,7 +52,8 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   void addedTripWithNewRoute() {
-    var tripUpdate = new TripUpdateBuilder(ADDED_TRIP_ID, SERVICE_DATE, ADDED, TIME_ZONE)
+    var tripUpdate = env
+      .tripUpdate(ADDED_TRIP_ID, ADDED)
       .addTripExtension()
       .addStopTime(STOP_A_ID, "00:30", DropOffPickupType.PHONE_AGENCY)
       .addStopTime(STOP_B_ID, "00:40", COORDINATE_WITH_DRIVER)
@@ -85,7 +87,8 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   void addedWithUnknownStop() {
-    var tripUpdate = new TripUpdateBuilder(ADDED_TRIP_ID, SERVICE_DATE, ADDED, TIME_ZONE)
+    var tripUpdate = env
+      .tripUpdate(ADDED_TRIP_ID, ADDED)
       // add extension to set route name, url, mode
       .addTripExtension()
       .addStopTime(STOP_A_ID, "00:30", DropOffPickupType.PHONE_AGENCY)
@@ -108,7 +111,8 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   void repeatedlyAddedTripWithNewRoute() {
-    var tripUpdate = new TripUpdateBuilder(ADDED_TRIP_ID, SERVICE_DATE, ADDED, TIME_ZONE)
+    var tripUpdate = env
+      .tripUpdate(ADDED_TRIP_ID, ADDED)
       // add extension to set route name, url, mode
       .addTripExtension()
       .addStopTime(STOP_A_ID, "00:30", DropOffPickupType.PHONE_AGENCY)
@@ -131,21 +135,15 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   public void addedTripWithSkippedStop() {
-    var builder = new TripUpdateBuilder(
-      ADDED_TRIP_ID,
-      SERVICE_DATE,
-      ADDED,
-      TIME_ZONE,
-      "A loop",
-      "SW1234"
-    );
-    builder
+    var tripUpdate = env
+      .tripUpdate(ADDED_TRIP_ID, ADDED)
+      .withTripProperties("A loop", "SW1234")
       .addStopTime(STOP_A_ID, "00:30", DropOffPickupType.PHONE_AGENCY)
       .addSkippedStop(STOP_B_ID, "00:40", DropOffPickupType.COORDINATE_WITH_DRIVER)
       .addSkippedStop(STOP_C_ID, "00:48")
       .addStopTime(STOP_D_ID, "00:55", "A (non-stop)")
-      .addStopTime(STOP_A_ID, "01:00");
-    var tripUpdate = builder.build();
+      .addStopTime(STOP_A_ID, "01:00")
+      .build();
 
     env.applyTripUpdate(tripUpdate);
 
@@ -158,7 +156,7 @@ class AddedTest implements RealtimeTestConstants {
     assertEquals(PickDrop.CANCELLED, tripPattern.getBoardType(2));
     assertEquals(PickDrop.SCHEDULED, tripPattern.getAlightType(3));
     var snapshot = env.getTimetableSnapshot();
-    var forToday = snapshot.resolve(tripPattern, SERVICE_DATE);
+    var forToday = snapshot.resolve(tripPattern, env.serviceDate());
     var tripTimes = forToday.getTripTimes(id(ADDED_TRIP_ID));
     var trip = env.getTransitService().getTrip(TimetableRepositoryForTest.id(ADDED_TRIP_ID));
     assertEquals(I18NString.of("A loop"), Objects.requireNonNull(trip).getHeadsign());
@@ -172,7 +170,7 @@ class AddedTest implements RealtimeTestConstants {
 
   @Test
   public void addedTripWithDelay() {
-    var builder = new TripUpdateBuilder(ADDED_TRIP_ID, SERVICE_DATE, ADDED, TIME_ZONE);
+    var builder = env.tripUpdate(ADDED_TRIP_ID, ADDED);
 
     builder
       .addStopTime(STOP_A_ID, "08:00")
@@ -185,7 +183,7 @@ class AddedTest implements RealtimeTestConstants {
     // THEN
     var tripPattern = assertAddedTrip(ADDED_TRIP_ID, env);
     var snapshot = env.getTimetableSnapshot();
-    var forToday = snapshot.resolve(tripPattern, SERVICE_DATE);
+    var forToday = snapshot.resolve(tripPattern, env.serviceDate());
     var tripTimes = forToday.getTripTimes(id(ADDED_TRIP_ID));
     assertEquals(0, tripTimes.getDepartureDelay(0));
     assertEquals(TimeUtils.time("08:00"), tripTimes.getDepartureTime(0));
@@ -220,7 +218,7 @@ class AddedTest implements RealtimeTestConstants {
     assertEquals(1, patternsAtA.size());
     var tripPattern = patternsAtA.stream().findFirst().get();
 
-    var forToday = snapshot.resolve(tripPattern, SERVICE_DATE);
+    var forToday = snapshot.resolve(tripPattern, env.serviceDate());
     var schedule = snapshot.resolve(tripPattern, null);
 
     assertNotSame(forToday, schedule);

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/ReplacementTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/ReplacementTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.TripInput;
@@ -32,7 +33,9 @@ public class ReplacementTest implements RealtimeTestConstants {
       .withStops(STOP_A_ID, STOP_B_ID, STOP_C_ID, STOP_D_ID)
       .addTrip(TRIP_INPUT)
       .build();
-    var tripUpdate = env
+    var rt = GtfsRtTestHelper.of(env);
+
+    var tripUpdate = rt
       .tripUpdate(TRIP_1_ID, REPLACEMENT)
       .withTripProperties(
         "New Headsign",
@@ -43,7 +46,7 @@ public class ReplacementTest implements RealtimeTestConstants {
       .addStopTime(STOP_C_ID, "01:00")
       .build();
 
-    env.applyTripUpdate(tripUpdate);
+    rt.applyTripUpdate(tripUpdate);
 
     // THEN
     var snapshot = env.getTimetableSnapshot();

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/ReplacementTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/ReplacementTest.java
@@ -14,11 +14,11 @@ import static org.opentripplanner.updater.trip.gtfs.moduletests.addition.AddedTe
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.TripInput;
 
 public class ReplacementTest implements RealtimeTestConstants {
 
@@ -29,7 +29,7 @@ public class ReplacementTest implements RealtimeTestConstants {
       .addStop(STOP_B, "8:40:00", "8:40:00")
       .withHeadsign(I18NString.of("Original Headsign"))
       .build();
-    var env = RealtimeTestEnvironment.of()
+    var env = TransitTestEnvironment.of()
       .withStops(STOP_A_ID, STOP_B_ID, STOP_C_ID, STOP_D_ID)
       .addTrip(TRIP_INPUT)
       .build();

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
@@ -8,6 +8,7 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSucce
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
@@ -27,11 +28,12 @@ public class CanceledTripTest implements RealtimeTestConstants {
         .addStop(STOP_B, "0:00:20", "0:00:21")
         .build()
     ).build();
+    var rt = GtfsRtTestHelper.of(env);
 
     assertThat(env.getTransitService().listCanceledTrips()).isEmpty();
 
-    var update = env.tripUpdate(TRIP_1_ID, CANCELED).build();
-    assertSuccess(env.applyTripUpdate(update));
+    var update = rt.tripUpdate(TRIP_1_ID, CANCELED).build();
+    assertSuccess(rt.applyTripUpdate(update));
 
     var canceled = env.getTransitService().listCanceledTrips();
     assertThat(canceled).hasSize(1);

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
@@ -7,16 +7,16 @@ import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 
 public class CanceledTripTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
@@ -12,7 +12,6 @@ import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.TripUpdateBuilder;
 
 public class CanceledTripTest implements RealtimeTestConstants {
 
@@ -31,13 +30,13 @@ public class CanceledTripTest implements RealtimeTestConstants {
 
     assertThat(env.getTransitService().listCanceledTrips()).isEmpty();
 
-    var update = new TripUpdateBuilder(TRIP_1_ID, SERVICE_DATE, CANCELED, TIME_ZONE).build();
+    var update = env.tripUpdate(TRIP_1_ID, CANCELED).build();
     assertSuccess(env.applyTripUpdate(update));
 
     var canceled = env.getTransitService().listCanceledTrips();
     assertThat(canceled).hasSize(1);
     var trip = canceled.getFirst();
     assertEquals(id(TRIP_1_ID), trip.getTrip().getId());
-    assertEquals(SERVICE_DATE, trip.getServiceDate());
+    assertEquals(env.serviceDate(), trip.getServiceDate());
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
@@ -14,13 +14,13 @@ import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 
 /**
  * Cancellations and deletions should end up in the internal data model and make trips unavailable
@@ -28,7 +28,7 @@ import org.opentripplanner.updater.trip.TripInput;
  */
 class CancellationDeletionTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancellationDeletionTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
@@ -48,9 +49,10 @@ class CancellationDeletionTest implements RealtimeTestConstants {
         .build()
     ).build();
     var pattern1 = env.getPatternForTrip(TRIP_1_ID);
+    var rt = GtfsRtTestHelper.of(env);
 
-    var update = env.tripUpdate(TRIP_1_ID, relationship).build();
-    assertSuccess(env.applyTripUpdate(update));
+    var update = rt.tripUpdate(TRIP_1_ID, relationship).build();
+    assertSuccess(rt.applyTripUpdate(update));
 
     var snapshot = env.getTimetableSnapshot();
     var forToday = snapshot.resolve(pattern1, env.serviceDate());
@@ -78,20 +80,22 @@ class CancellationDeletionTest implements RealtimeTestConstants {
   @MethodSource("cases")
   void cancelingAddedTrip(ScheduleRelationship relationship, RealTimeState state) {
     var env = ENV_BUILDER.build();
+    var rt = GtfsRtTestHelper.of(env);
+
     var addedTripId = "added-trip";
     // First add ADDED trip
-    var update = env
+    var update = rt
       .tripUpdate(addedTripId, ScheduleRelationship.ADDED)
       .addStopTime(STOP_A_ID, "00:30")
       .addStopTime(STOP_B_ID, "00:40")
       .addStopTime(STOP_C_ID, "00:55")
       .build();
 
-    assertSuccess(env.applyTripUpdate(update, DIFFERENTIAL));
+    assertSuccess(rt.applyTripUpdate(update, DIFFERENTIAL));
 
     // Cancel or delete the added trip
-    update = env.tripUpdate(addedTripId, relationship).build();
-    assertSuccess(env.applyTripUpdate(update, DIFFERENTIAL));
+    update = rt.tripUpdate(addedTripId, relationship).build();
+    assertSuccess(rt.applyTripUpdate(update, DIFFERENTIAL));
 
     var snapshot = env.getTimetableSnapshot();
     // Get the trip pattern of the added trip which goes through stopA

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.trip.gtfs.moduletests.delay;
 
-import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.SCHEDULED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,7 +15,6 @@ import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.TripUpdateBuilder;
 
 /**
  * Delays should be applied to the first trip but should leave the second trip untouched.
@@ -40,7 +38,8 @@ class DelayedTest implements RealtimeTestConstants {
       .build();
     var env = ENV_BUILDER.addTrip(tripInput).build();
 
-    var tripUpdate = new TripUpdateBuilder(TRIP_1_ID, SERVICE_DATE, SCHEDULED, TIME_ZONE)
+    var tripUpdate = env
+      .tripUpdateScheduled(TRIP_1_ID)
       .addDelayedStopTime(STOP_SEQUENCE, DELAY)
       .build();
 
@@ -51,7 +50,7 @@ class DelayedTest implements RealtimeTestConstants {
     var pattern1 = env.getPatternForTrip(TRIP_1_ID);
 
     var snapshot = env.getTimetableSnapshot();
-    var trip1Realtime = snapshot.resolve(pattern1, SERVICE_DATE);
+    var trip1Realtime = snapshot.resolve(pattern1, env.serviceDate());
     var trip1Scheduled = snapshot.resolve(pattern1, null);
 
     assertNotSame(trip1Realtime, trip1Scheduled);
@@ -83,7 +82,8 @@ class DelayedTest implements RealtimeTestConstants {
       .build();
     var env = ENV_BUILDER.addTrip(tripInput).build();
 
-    var tripUpdate = new TripUpdateBuilder(TRIP_2_ID, SERVICE_DATE, SCHEDULED, TIME_ZONE)
+    var tripUpdate = env
+      .tripUpdateScheduled(TRIP_2_ID)
       .addDelayedStopTime(0, 0)
       .addDelayedStopTime(1, 60, 80)
       .addDelayedStopTime(2, 90, 90)
@@ -96,7 +96,7 @@ class DelayedTest implements RealtimeTestConstants {
     var trip2 = env.getTransitService().getTrip(id(TRIP_2_ID));
     var originalTripPattern = env.getTransitService().findPattern(trip2);
 
-    var originalTimetableForToday = snapshot.resolve(originalTripPattern, SERVICE_DATE);
+    var originalTimetableForToday = snapshot.resolve(originalTripPattern, env.serviceDate());
     var originalTimetableScheduled = snapshot.resolve(originalTripPattern, null);
 
     assertNotSame(originalTimetableForToday, originalTimetableScheduled);

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
@@ -8,21 +8,21 @@ import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 
 /**
  * Delays should be applied to the first trip but should leave the second trip untouched.
  */
 class DelayedTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
   private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DelayedTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
@@ -37,13 +38,14 @@ class DelayedTest implements RealtimeTestConstants {
       .addStop(STOP_B, "0:00:20", "0:00:21")
       .build();
     var env = ENV_BUILDER.addTrip(tripInput).build();
+    var rt = GtfsRtTestHelper.of(env);
 
-    var tripUpdate = env
+    var tripUpdate = rt
       .tripUpdateScheduled(TRIP_1_ID)
       .addDelayedStopTime(STOP_SEQUENCE, DELAY)
       .build();
 
-    var result = env.applyTripUpdate(tripUpdate);
+    var result = rt.applyTripUpdate(tripUpdate);
 
     assertEquals(1, result.successful());
 
@@ -81,15 +83,16 @@ class DelayedTest implements RealtimeTestConstants {
       .addStop(STOP_C, "0:01:20", "0:01:21")
       .build();
     var env = ENV_BUILDER.addTrip(tripInput).build();
+    var rt = GtfsRtTestHelper.of(env);
 
-    var tripUpdate = env
+    var tripUpdate = rt
       .tripUpdateScheduled(TRIP_2_ID)
       .addDelayedStopTime(0, 0)
       .addDelayedStopTime(1, 60, 80)
       .addDelayedStopTime(2, 90, 90)
       .build();
 
-    assertSuccess(env.applyTripUpdate(tripUpdate));
+    assertSuccess(rt.applyTripUpdate(tripUpdate));
 
     var snapshot = env.getTimetableSnapshot();
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
@@ -11,21 +11,21 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSucce
 import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.TripTimesStringBuilder;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 
 /**
  * A mixture of delayed and skipped stops should result in both delayed and cancelled stops.
  */
 class SkippedTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
   private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);
@@ -143,7 +143,7 @@ class SkippedTest implements RealtimeTestConstants {
   }
 
   private static void assertOriginalTripPatternIsDeleted(
-    RealtimeTestEnvironment env,
+    TransitTestEnvironment env,
     String tripId
   ) {
     var trip = env.getTransitService().getTrip(id(tripId));
@@ -179,7 +179,7 @@ class SkippedTest implements RealtimeTestConstants {
     assertEquals(RealTimeState.DELETED, scheduledTripTimes.getRealTimeState());
   }
 
-  private static void assertNewTripTimesIsUpdated(RealtimeTestEnvironment env, String tripId) {
+  private static void assertNewTripTimesIsUpdated(TransitTestEnvironment env, String tripId) {
     var trip = env.getTransitService().getTrip(id(tripId));
     var originalTripPattern = env.getTransitService().findPattern(trip);
     var snapshot = env.getTimetableSnapshot();

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.TripTimesStringBuilder;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
@@ -38,15 +39,16 @@ class SkippedTest implements RealtimeTestConstants {
   @Test
   void scheduledTripWithSkippedAndScheduled() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var rt = GtfsRtTestHelper.of(env);
 
-    var tripUpdate = env
+    var tripUpdate = rt
       .tripUpdateScheduled(TRIP_2_ID)
       .addDelayedStopTime(0, 0)
       .addSkippedStop(1)
       .addDelayedStopTime(2, 90)
       .build();
 
-    assertSuccess(env.applyTripUpdate(tripUpdate));
+    assertSuccess(rt.applyTripUpdate(tripUpdate));
 
     assertOriginalTripPatternIsDeleted(env, TRIP_2_ID);
 
@@ -70,18 +72,19 @@ class SkippedTest implements RealtimeTestConstants {
   @Test
   void scheduledTripWithPreviouslySkipped() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var rt = GtfsRtTestHelper.of(env);
 
-    var tripUpdate = env
+    var tripUpdate = rt
       .tripUpdateScheduled(TRIP_2_ID)
       .addDelayedStopTime(0, 0)
       .addSkippedStop(1)
       .addDelayedStopTime(2, 90)
       .build();
 
-    assertSuccess(env.applyTripUpdate(tripUpdate, DIFFERENTIAL));
+    assertSuccess(rt.applyTripUpdate(tripUpdate, DIFFERENTIAL));
 
     // Create update to the same trip but now the skipped stop is no longer skipped
-    var scheduledBuilder = env
+    var scheduledBuilder = rt
       .tripUpdateScheduled(TRIP_2_ID)
       .addDelayedStopTime(0, 0)
       .addDelayedStopTime(1, 50)
@@ -90,7 +93,7 @@ class SkippedTest implements RealtimeTestConstants {
     tripUpdate = scheduledBuilder.build();
 
     // apply the update with the previously skipped stop now scheduled
-    assertSuccess(env.applyTripUpdate(tripUpdate, DIFFERENTIAL));
+    assertSuccess(rt.applyTripUpdate(tripUpdate, DIFFERENTIAL));
 
     // Check that the there is no longer a realtime added trip pattern for the trip and that the
     // stoptime updates have gone through
@@ -116,17 +119,18 @@ class SkippedTest implements RealtimeTestConstants {
   @Test
   void skippedNoData() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var rt = GtfsRtTestHelper.of(env);
 
     String tripId = TRIP_2_ID;
 
-    var tripUpdate = env
+    var tripUpdate = rt
       .tripUpdateScheduled(tripId)
       .addNoDataStop(0)
       .addSkippedStop(1)
       .addNoDataStop(2)
       .build();
 
-    assertSuccess(env.applyTripUpdate(tripUpdate));
+    assertSuccess(rt.applyTripUpdate(tripUpdate));
 
     assertOriginalTripPatternIsDeleted(env, tripId);
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSucce
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
@@ -31,15 +32,16 @@ class SkippedWithRepeatedTimesTest implements RealtimeTestConstants {
   @Test
   void skippedWithRepeatedTimes() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var rt = GtfsRtTestHelper.of(env);
 
-    var tripUpdate = env
+    var tripUpdate = rt
       .tripUpdateScheduled(TRIP_1_ID)
       .addStopTime(STOP_A_ID, "10:00:00")
       .addSkippedStop(STOP_B_ID, "10:01:00")
       .addStopTime(STOP_C_ID, "10:01:00")
       .build();
 
-    assertSuccess(env.applyTripUpdate(tripUpdate));
+    assertSuccess(rt.applyTripUpdate(tripUpdate));
 
     assertEquals(
       "UPDATED | A 10:00 10:00 | B [C] 10:00 10:00 | C 10:01 10:01",

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 
 /**
  * Tests that stops can be SKIPPED for a trip which repeats times for consecutive stops.
@@ -18,7 +18,7 @@ import org.opentripplanner.updater.trip.TripInput;
  */
 class SkippedWithRepeatedTimesTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
   private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.trip.gtfs.moduletests.delay;
 
-import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.SCHEDULED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
@@ -10,7 +9,6 @@ import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.TripUpdateBuilder;
 
 /**
  * Tests that stops can be SKIPPED for a trip which repeats times for consecutive stops.
@@ -34,7 +32,8 @@ class SkippedWithRepeatedTimesTest implements RealtimeTestConstants {
   void skippedWithRepeatedTimes() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
 
-    var tripUpdate = new TripUpdateBuilder(TRIP_1_ID, SERVICE_DATE, SCHEDULED, TIME_ZONE)
+    var tripUpdate = env
+      .tripUpdateScheduled(TRIP_1_ID)
       .addStopTime(STOP_A_ID, "10:00:00")
       .addSkippedStop(STOP_B_ID, "10:01:00")
       .addStopTime(STOP_C_ID, "10:01:00")

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
@@ -9,12 +9,12 @@ import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.TripUpdateBuilder;
 
 /**
@@ -24,9 +24,7 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
 class InvalidInputTest implements RealtimeTestConstants {
 
   private static final LocalDate SERVICE_DATE = LocalDate.of(2025, 7, 8);
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of(
-    SERVICE_DATE
-  );
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of(SERVICE_DATE);
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
@@ -41,12 +42,13 @@ class InvalidInputTest implements RealtimeTestConstants {
       .addStop(STOP_B, "0:00:20", "0:00:21")
       .build();
     var env = ENV_BUILDER.addTrip(tripInput).build();
+    var rt = GtfsRtTestHelper.of(env);
 
     var update = new TripUpdateBuilder(TRIP_1_ID, date, SCHEDULED, env.timeZone())
       .addDelayedStopTime(2, 60, 80)
       .build();
 
-    var result = env.applyTripUpdate(update);
+    var result = rt.applyTripUpdate(update);
 
     var snapshot = env.getTimetableSnapshot();
     assertTrue(snapshot.isEmpty());

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidInputTest.java
@@ -22,7 +22,10 @@ import org.opentripplanner.updater.trip.TripUpdateBuilder;
  */
 class InvalidInputTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private static final LocalDate SERVICE_DATE = LocalDate.of(2025, 7, 8);
+  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of(
+    SERVICE_DATE
+  );
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 
@@ -39,7 +42,7 @@ class InvalidInputTest implements RealtimeTestConstants {
       .build();
     var env = ENV_BUILDER.addTrip(tripInput).build();
 
-    var update = new TripUpdateBuilder(TRIP_1_ID, date, SCHEDULED, TIME_ZONE)
+    var update = new TripUpdateBuilder(TRIP_1_ID, date, SCHEDULED, env.timeZone())
       .addDelayedStopTime(2, 60, 80)
       .build();
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidTripIdTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidTripIdTest.java
@@ -8,6 +8,7 @@ import com.google.transit.realtime.GtfsRealtime;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 
 class InvalidTripIdTest {
@@ -23,6 +24,7 @@ class InvalidTripIdTest {
   @MethodSource("invalidCases")
   void invalidTripId(String tripId) {
     var env = RealtimeTestEnvironment.of().build();
+    var rt = GtfsRtTestHelper.of(env);
     var tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
     if (tripId != null) {
       tripDescriptorBuilder.setTripId(tripId);
@@ -33,6 +35,6 @@ class InvalidTripIdTest {
     tripUpdateBuilder.setTrip(tripDescriptorBuilder);
     var tripUpdate = tripUpdateBuilder.build();
 
-    assertFailure(INVALID_INPUT_STRUCTURE, env.applyTripUpdate(tripUpdate));
+    assertFailure(INVALID_INPUT_STRUCTURE, rt.applyTripUpdate(tripUpdate));
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidTripIdTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/rejection/InvalidTripIdTest.java
@@ -8,8 +8,8 @@ import com.google.transit.realtime.GtfsRealtime;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
 import org.opentripplanner.updater.trip.GtfsRtTestHelper;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 
 class InvalidTripIdTest {
 
@@ -23,7 +23,7 @@ class InvalidTripIdTest {
   @ParameterizedTest(name = "tripId=\"{0}\"")
   @MethodSource("invalidCases")
   void invalidTripId(String tripId) {
-    var env = RealtimeTestEnvironment.of().build();
+    var env = TransitTestEnvironment.of().build();
     var rt = GtfsRtTestHelper.of(env);
     var tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
     if (tripId != null) {

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
@@ -8,18 +8,18 @@ import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.NO_FUZ
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.framework.Result;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
-import org.opentripplanner.updater.trip.TripInput;
 import uk.org.siri.siri21.EstimatedVehicleJourney;
 
 class SiriFuzzyTripMatcherTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 
@@ -94,7 +94,7 @@ class SiriFuzzyTripMatcherTest implements RealtimeTestConstants {
 
   private static Result<TripAndPattern, UpdateError.UpdateErrorType> match(
     EstimatedVehicleJourney evj,
-    RealtimeTestEnvironment env
+    TransitTestEnvironment env
   ) {
     var transitService = env.getTransitService();
     var fuzzyMatcher = new SiriFuzzyTripMatcher(transitService);
@@ -106,7 +106,7 @@ class SiriFuzzyTripMatcherTest implements RealtimeTestConstants {
     );
   }
 
-  private EstimatedVehicleJourney estimatedVehicleJourney(RealtimeTestEnvironment env) {
+  private EstimatedVehicleJourney estimatedVehicleJourney(TransitTestEnvironment env) {
     return new SiriEtBuilder(env.getDateTimeHelper())
       .withEstimatedCalls(builder ->
         builder

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
@@ -3,19 +3,19 @@ package org.opentripplanner.updater.trip.siri.moduletests.cancellation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class CancellationTest implements RealtimeTestConstants {
 
   private static final String ADDED_TRIP_ID = "newJourney";
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stopAtStation(STOP_B_ID, STATION_OMEGA_ID);
   private final RegularStop STOP_C = ENV_BUILDER.stopAtStation(STOP_D_ID, STATION_OMEGA_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
@@ -8,8 +8,8 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
+import org.opentripplanner.updater.trip.SiriTestHelper;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class CancelledStopTest implements RealtimeTestConstants {
 
@@ -27,8 +27,10 @@ class CancelledStopTest implements RealtimeTestConstants {
   @Test
   void testCancelStop() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_1_ID)
       .withEstimatedCalls(builder ->
         builder
@@ -41,7 +43,7 @@ class CancelledStopTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertSuccess(result);
     assertEquals(

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelledStopTest.java
@@ -4,16 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 
 class CancelledStopTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
   private final RegularStop STOP_D = ENV_BUILDER.stop(STOP_D_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
@@ -5,19 +5,19 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailu
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 import uk.org.siri.siri21.EstimatedTimetableDeliveryStructure;
 
 class ExtraCallTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stopAtStation(STOP_A_ID, "A");
   private final RegularStop STOP_B = ENV_BUILDER.stopAtStation(STOP_B_ID, "B");
   private final RegularStop STOP_C = ENV_BUILDER.stopAtStation(STOP_C_ID, "C");

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -7,6 +7,9 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailu
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Operator;
@@ -17,10 +20,7 @@ import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class ExtraJourneyTest implements RealtimeTestConstants {
@@ -30,7 +30,7 @@ class ExtraJourneyTest implements RealtimeTestConstants {
     .withOperator(Operator.of(id("o2")).withName("o").build())
     .build();
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
   private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -62,7 +62,7 @@ class ExtraJourneyTest implements RealtimeTestConstants {
     assertNotNull(transitService.findPattern(trip));
     assertNotNull(transitService.getTripOnServiceDate(tripId));
     assertNotNull(
-      transitService.getTripOnServiceDate(new TripIdAndServiceDate(tripId, SERVICE_DATE))
+      transitService.getTripOnServiceDate(new TripIdAndServiceDate(tripId, env.serviceDate()))
     );
     assertEquals(
       numPatternForRoute + 1,

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
@@ -46,7 +46,7 @@ class FuzzyTripMatchingTest implements RealtimeTestConstants {
 
     var updates = new SiriEtBuilder(env.getDateTimeHelper())
       .withFramedVehicleJourneyRef(builder ->
-        builder.withServiceDate(SERVICE_DATE).withVehicleJourneyRef("XXX")
+        builder.withServiceDate(env.serviceDate()).withVehicleJourneyRef("XXX")
       )
       .withEstimatedCalls(builder ->
         builder

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
@@ -4,17 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 
 class FuzzyTripMatchingTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 
@@ -74,7 +74,7 @@ class FuzzyTripMatchingTest implements RealtimeTestConstants {
     assertFailure(UpdateError.UpdateErrorType.NO_FUZZY_TRIP_MATCH, result);
   }
 
-  private static void assertTripUpdated(RealtimeTestEnvironment env) {
+  private static void assertTripUpdated(TransitTestEnvironment env) {
     assertEquals(
       "UPDATED | A 0:00:15 0:00:15 | B 0:00:25 0:00:25",
       env.getRealtimeTimetable(TRIP_1_ID)

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
@@ -14,8 +14,8 @@ import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
+import org.opentripplanner.updater.trip.SiriTestHelper;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class InvalidCallsTest implements RealtimeTestConstants {
 
@@ -38,8 +38,10 @@ class InvalidCallsTest implements RealtimeTestConstants {
   @Test
   void testTooFewCalls() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_1_ID)
       .withEstimatedCalls(builder ->
         builder
@@ -50,7 +52,7 @@ class InvalidCallsTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertEquals(1, result.failed());
     assertEquals(Set.of(TOO_FEW_STOPS), result.failures().keySet());
@@ -59,8 +61,10 @@ class InvalidCallsTest implements RealtimeTestConstants {
   @Test
   void testTooManyCalls() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_1_ID)
       .withEstimatedCalls(builder ->
         builder
@@ -75,7 +79,7 @@ class InvalidCallsTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertEquals(1, result.failed());
     assertEquals(Set.of(TOO_MANY_STOPS), result.failures().keySet());
@@ -84,8 +88,10 @@ class InvalidCallsTest implements RealtimeTestConstants {
   @Test
   void testMismatchedStop() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_1_ID)
       .withEstimatedCalls(builder ->
         builder
@@ -98,7 +104,7 @@ class InvalidCallsTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertEquals(1, result.failed());
     assertEquals(Set.of(STOP_MISMATCH), result.failures().keySet());
@@ -107,8 +113,10 @@ class InvalidCallsTest implements RealtimeTestConstants {
   @Test
   void testUnknownStop() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_1_ID)
       .withEstimatedCalls(builder ->
         builder
@@ -121,7 +129,7 @@ class InvalidCallsTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertEquals(1, result.failed());
     assertEquals(Set.of(UNKNOWN_STOP), result.failures().keySet());

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidCallsTest.java
@@ -9,17 +9,17 @@ import static org.opentripplanner.updater.spi.UpdateError.UpdateErrorType.UNKNOW
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 
 class InvalidCallsTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final String TRIP_1_ID = "TestTrip1";
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
@@ -7,8 +7,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
 import org.opentripplanner.updater.spi.UpdateError;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.SiriTestHelper;
 
 class InvalidStopPointRefTest {
@@ -22,7 +22,7 @@ class InvalidStopPointRefTest {
   @ParameterizedTest(name = "invalid id of ''{0}'', extraJourney={1}")
   @MethodSource("cases")
   void rejectEmptyStopPointRef(String invalidRef, boolean extraJourney) {
-    var env = RealtimeTestEnvironment.of().build();
+    var env = TransitTestEnvironment.of().build();
     var siri = SiriTestHelper.of(env);
 
     // journey contains empty stop point ref elements

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/InvalidStopPointRefTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
+import org.opentripplanner.updater.trip.SiriTestHelper;
 
 class InvalidStopPointRefTest {
 
@@ -23,10 +23,12 @@ class InvalidStopPointRefTest {
   @MethodSource("cases")
   void rejectEmptyStopPointRef(String invalidRef, boolean extraJourney) {
     var env = RealtimeTestEnvironment.of().build();
+    var siri = SiriTestHelper.of(env);
 
     // journey contains empty stop point ref elements
     // happens in the South Tyrolian feed: https://github.com/noi-techpark/odh-mentor-otp/issues/213
-    var invalidJourney = new SiriEtBuilder(env.getDateTimeHelper())
+    var invalidJourney = siri
+      .etBuilder()
       .withEstimatedVehicleJourneyCode("invalid-journey")
       .withOperatorRef("unknown-operator")
       .withLineRef("unknown-line")
@@ -40,7 +42,7 @@ class InvalidStopPointRefTest {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(invalidJourney);
+    var result = siri.applyEstimatedTimetable(invalidJourney);
     assertEquals(0, result.successful());
     assertFailure(UpdateError.UpdateErrorType.EMPTY_STOP_POINT_REF, result);
   }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
@@ -3,17 +3,17 @@ package org.opentripplanner.updater.trip.siri.moduletests.rejection;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 
 class NegativeTimesTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
   private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NegativeTimesTest.java
@@ -8,8 +8,8 @@ import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
+import org.opentripplanner.updater.trip.SiriTestHelper;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class NegativeTimesTest implements RealtimeTestConstants {
 
@@ -32,8 +32,10 @@ class NegativeTimesTest implements RealtimeTestConstants {
   @Test
   void testNegativeHopTime() {
     var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_1_ID)
       .withRecordedCalls(builder ->
         builder
@@ -44,7 +46,7 @@ class NegativeTimesTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertFailure(UpdateError.UpdateErrorType.NEGATIVE_HOP_TIME, result);
   }
@@ -52,8 +54,10 @@ class NegativeTimesTest implements RealtimeTestConstants {
   @Test
   void testNegativeDwellTime() {
     var env = ENV_BUILDER.addTrip(TRIP_2_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_2_ID)
       .withRecordedCalls(builder ->
         builder
@@ -67,7 +71,7 @@ class NegativeTimesTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertFailure(UpdateError.UpdateErrorType.NEGATIVE_DWELL_TIME, result);
   }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
@@ -8,8 +8,8 @@ import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
+import org.opentripplanner.updater.trip.SiriTestHelper;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class NotMonitoredTest implements RealtimeTestConstants {
 
@@ -25,12 +25,11 @@ class NotMonitoredTest implements RealtimeTestConstants {
   @Test
   void testNotMonitored() {
     var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
-      .withMonitored(false)
-      .buildEstimatedTimetableDeliveries();
+    var updates = siri.etBuilder().withMonitored(false).buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertFailure(UpdateError.UpdateErrorType.NOT_MONITORED, result);
   }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/rejection/NotMonitoredTest.java
@@ -3,17 +3,17 @@ package org.opentripplanner.updater.trip.siri.moduletests.rejection;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 
 class NotMonitoredTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
@@ -3,16 +3,16 @@ package org.opentripplanner.updater.trip.siri.moduletests.update;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 
 class QuayChangeTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stopAtStation(STOP_B_ID, STATION_OMEGA_ID);
   private final RegularStop STOP_C = ENV_BUILDER.stopAtStation(STOP_C_ID, STATION_OMEGA_ID);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/QuayChangeTest.java
@@ -7,8 +7,8 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
 import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
+import org.opentripplanner.updater.trip.SiriTestHelper;
 import org.opentripplanner.updater.trip.TripInput;
-import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class QuayChangeTest implements RealtimeTestConstants {
 
@@ -28,8 +28,10 @@ class QuayChangeTest implements RealtimeTestConstants {
   @Test
   void testChangeQuay() {
     var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
 
-    var updates = new SiriEtBuilder(env.getDateTimeHelper())
+    var updates = siri
+      .etBuilder()
       .withDatedVehicleJourneyRef(TRIP_1_ID)
       .withRecordedCalls(builder -> builder.call(STOP_A).departAimedActual("00:00:11", "00:00:15"))
       .withEstimatedCalls(builder ->
@@ -37,7 +39,7 @@ class QuayChangeTest implements RealtimeTestConstants {
       )
       .buildEstimatedTimetableDeliveries();
 
-    var result = env.applyEstimatedTimetable(updates);
+    var result = siri.applyEstimatedTimetable(updates);
 
     assertEquals(1, result.successful());
     assertEquals(

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
@@ -51,7 +51,7 @@ class UpdatedTimesTest implements RealtimeTestConstants {
 
     var updates = updatedJourneyBuilder(env)
       .withFramedVehicleJourneyRef(builder ->
-        builder.withServiceDate(SERVICE_DATE).withVehicleJourneyRef(TRIP_1_ID)
+        builder.withServiceDate(env.serviceDate()).withVehicleJourneyRef(TRIP_1_ID)
       )
       .buildEstimatedTimetableDeliveries();
     var result = env.applyEstimatedTimetable(updates);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
@@ -4,18 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironment;
-import org.opentripplanner.updater.trip.RealtimeTestEnvironmentBuilder;
 import org.opentripplanner.updater.trip.SiriTestHelper;
-import org.opentripplanner.updater.trip.TripInput;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
 
 class UpdatedTimesTest implements RealtimeTestConstants {
 
-  private final RealtimeTestEnvironmentBuilder ENV_BUILDER = RealtimeTestEnvironment.of();
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
 
@@ -88,7 +88,7 @@ class UpdatedTimesTest implements RealtimeTestConstants {
       );
   }
 
-  private static void assertTripUpdated(RealtimeTestEnvironment env) {
+  private static void assertTripUpdated(TransitTestEnvironment env) {
     assertEquals(
       "UPDATED | A 0:00:15 0:00:15 | B 0:00:25 0:00:25",
       env.getRealtimeTimetable(TRIP_1_ID)


### PR DESCRIPTION
### Summary

This is a first refactor of the RealtimeTestEnvironment after discussion with @t2gran and @leonardehrenfried.

The purpose is to make the RealtimeTestEnvironment into a more general framework for setting up and testing transit entities.

It only touches tests and should be a pure refactor.

- Separate gtfs-rt and siri specific methods in their own classes.
- Rename RealtimeTestEnvironment to TransitTestEnvironment
- Reduce dependencies on `TimetableRepositoryForTest`.
- Encapsulate date and timezone in the test environment

### Issue

#6887 

### Bumping the serialization version id

No
