### PR TITLE
Re-enable parsing of legacy GBFS 1.1 feeds

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/GbfsFeedLoaderAndMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/GbfsFeedLoaderAndMapper.java
@@ -54,7 +54,14 @@ public class GbfsFeedLoaderAndMapper {
           params
         );
       }
-      case "2.2", "2.3" -> {
+      case "1.1", "2.2", "2.3" -> {
+        if (gbfsFeedVersion.startsWith("1")) {
+          LOG.warn(
+            "GBFS feed {} is of deprecated version {}. Support for this version will be removed soon.",
+            params.url(),
+            gbfsFeedVersion
+          );
+        }
         var loaderv23 =
           new org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v2.GbfsFeedLoader(
             params.url(),


### PR DESCRIPTION
### Summary

In #6735 we enabled version checks for the GBFS parsers and GBFS version 1.1 was not on the list of approved versions.

It turns out that one of my deployments used a feed of version 1.1 and this works fine with the GBFS v2 parsing code.

For this reason I'm adding 1.1 to the list of versions and add a scary warning to is encouraging users to migrate their feeds.

### Changelog

Skip.