### PR TITLE
Add ZoneIdFallback to the Transmodel API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
@@ -10,6 +10,7 @@ import org.opentripplanner.api.model.transit.FeedScopedIdMapper;
 import org.opentripplanner.api.model.transit.HideFeedIdMapper;
 import org.opentripplanner.apis.transmodel.TransmodelGraphQLSchemaFactory;
 import org.opentripplanner.apis.transmodel.mapping.FixedFeedIdGenerator;
+import org.opentripplanner.framework.time.ZoneIdFallback;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.transit.service.TimetableRepository;
@@ -36,7 +37,7 @@ public class TransmodelSchemaModule {
 
     TransmodelGraphQLSchemaFactory factory = new TransmodelGraphQLSchemaFactory(
       defaultRouteRequest,
-      timetableRepository.getTimeZone(),
+      ZoneIdFallback.zoneId(timetableRepository.getTimeZone()),
       routerConfig.transitTuningConfig(),
       feedIdMapper,
       routerConfig.server().apiDocumentationProfile()


### PR DESCRIPTION
### Summary

Adds `ZoneIdFallback.zoneId()` to the Transmodel API so that if the graph doesn't have any transit data planning a street-only itinerary is still possible using the debug ui.

The following exception while planning is resolved:
```
14:54:11.076 ERROR [grizzly-6]  (TransmodelGraph.java:80) zone
java.lang.NullPointerException: zone
	at java.base/java.util.Objects.requireNonNull(Objects.java:259)
	at java.base/java.time.ZonedDateTime.ofInstant(ZonedDateTime.java:410)
	at java.base/java.time.Instant.atZone(Instant.java:1238)
	at org.opentripplanner.apis.transmodel.model.scalars.DateTimeScalarFactory$1.serialize(DateTimeScalarFactory.java:44)
	at org.opentripplanner.apis.transmodel.model.scalars.DateTimeScalarFactory$1.serialize(DateTimeScalarFactory.java:40)
	at ...
	at org.opentripplanner.apis.transmodel.TransmodelGraph.executeGraphQL(TransmodelGraph.java:69)
	at org.opentripplanner.apis.transmodel.TransmodelAPI.getGraphQL(TransmodelAPI.java:104)
	at ...
```

### Unit tests

No changes.

### Documentation

No changes.