### PR TITLE
Reduce log verbosity in GBFS station mapper

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsStationInformationMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsStationInformationMapper.java
@@ -43,12 +43,10 @@ class GbfsStationInformationMapper {
       station.getLon() == null ||
       station.getLat() == null
     ) {
-      LOG.info(
-        String.format(
-          "GBFS station for %s system has issues with required fields: \n%s",
-          system.systemId(),
-          station
-        )
+      LOG.debug(
+        "GBFS station for {} system has issues with required fields: \n{}",
+        system.systemId(),
+        station
       );
       return null;
     }

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapper.java
@@ -44,12 +44,10 @@ class GbfsStationInformationMapper {
       station.getLon() == null ||
       station.getLat() == null
     ) {
-      LOG.info(
-        String.format(
-          "GBFS station for %s system has issues with required fields: \n%s",
-          system.systemId(),
-          station
-        )
+      LOG.debug(
+        "GBFS station for {} system has issues with required fields: \n{}",
+        system.systemId(),
+        station
       );
       return null;
     }


### PR DESCRIPTION
### Summary

When a GBFS feed contains invalid stations, the corresponding entries are ignored and the event is logged.
This can lead to a large number of messages in the logs.
This PR reduces the verbosity of this log message from INFO to DEBUG.
The PR also rewrites the log format so that it uses the built-in parameterization support in slf4j.

### Issue
No

### Unit tests

No
### Documentation

No

### Changelog

skip
