### PR TITLE
Crosswalk naming

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamer.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamer.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.graph_builder.module.osm.naming;
+
+import gnu.trove.list.TLongList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.graph_builder.module.osm.StreetEdgePair;
+import org.opentripplanner.graph_builder.services.osm.EdgeNamer;
+import org.opentripplanner.osm.model.OsmEntity;
+import org.opentripplanner.osm.model.OsmWay;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A namer that assigns names to crosswalks using the name of the crossed street, if available.
+ * <p>
+ * The algorithm works as follows:
+ *  - For each crosswalk, we find the intersecting street edge that shares a node.
+ *  - (To be completed)
+ * <p>
+ * In North America, it is common for a street to have turn lanes (slip lanes)
+ * that are their own OSM ways because they are separate from the main streets they join.
+ * The resulting crosswalk name is "Crossing over turn lane" or equivalent in other locales.
+ */
+public class CrosswalkNamer implements EdgeNamer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CrosswalkNamer.class);
+
+  @Override
+  public I18NString name(OsmEntity way) {
+    return way.getAssumedName();
+  }
+
+  @Override
+  public void recordEdges(OsmEntity way, StreetEdgePair pair) {
+
+  }
+
+  @Override
+  public void postprocess() {
+
+  }
+
+  /** Gets the intersecting street, if any, for the given way and candidate streets. */
+  public static Optional<OsmWay> getIntersectingStreet(OsmWay way, List<OsmWay> streets) {
+    TLongList nodeRefs = way.getNodeRefs();
+    if (nodeRefs.size() >= 3) {
+      // There needs to be at least three nodes: 2 extremities that are on the sidewalk,
+      // and one somewhere in the middle that joins the crossing with the street.
+      // We exclude the first and last node which are on the sidewalk.
+      long[] nodeRefsArray = nodeRefs.toArray(1, nodeRefs.size() - 2);
+      return streets
+        .stream()
+        .filter(w -> Arrays.stream(nodeRefsArray).anyMatch(nid -> w.getNodeRefs().contains(nid)))
+        .findFirst();
+    }
+    return Optional.empty();
+  }
+}

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamer.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamer.java
@@ -1,14 +1,23 @@
 package org.opentripplanner.graph_builder.module.osm.naming;
 
+import static org.opentripplanner.osm.model.TraverseDirection.FORWARD;
+
 import gnu.trove.list.TLongList;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.graph_builder.module.osm.StreetEdgePair;
 import org.opentripplanner.graph_builder.services.osm.EdgeNamer;
 import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.OsmWay;
+import org.opentripplanner.osm.model.TraverseDirection;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.utils.lang.DoubleUtils;
+import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +36,9 @@ public class CrosswalkNamer implements EdgeNamer {
 
   private static final Logger LOG = LoggerFactory.getLogger(CrosswalkNamer.class);
 
+  private Collection<OsmWay> streets = new ArrayList<>();
+  private Collection<EdgeOnLevel> unnamedCrosswalks = new ArrayList<>();
+
   @Override
   public I18NString name(OsmEntity way) {
     return way.getAssumedName();
@@ -34,16 +46,88 @@ public class CrosswalkNamer implements EdgeNamer {
 
   @Override
   public void recordEdges(OsmEntity way, StreetEdgePair pair) {
-
+    if (way instanceof OsmWay osmWay) {
+      // Record unnamed crossings to a list.
+      if (
+        osmWay.isFootway() &&
+        osmWay.isMarkedCrossing() &&
+          way.hasNoName() &&
+          !way.isExplicitlyUnnamed()
+      ) {
+        pair
+          .asIterable()
+          .forEach(edge -> unnamedCrosswalks.add(new EdgeOnLevel(osmWay, edge, way.getLevels())));
+      }
+      // Record named streets, service roads, and slip/turn lanes to a list.
+      else if (!osmWay.isFootway()) {
+        Optional<TraverseDirection> oneWayCar = osmWay.isOneWay("motorcar");
+        if (way.isNamed() || osmWay.isServiceRoad() || oneWayCar.isPresent() && FORWARD.equals(oneWayCar.get())) {
+          streets.add(osmWay);
+        }
+      }
+    }
   }
 
   @Override
   public void postprocess() {
+    ProgressTracker progress = ProgressTracker.track(
+      "Assigning names to crosswalks",
+      500,
+      unnamedCrosswalks.size()
+    );
 
+    final AtomicInteger namesApplied = new AtomicInteger(0);
+    unnamedCrosswalks
+      .parallelStream()
+      .forEach(crosswalkOnLevel -> {
+        assignNameToCrosswalk(crosswalkOnLevel, namesApplied);
+
+        // Keep lambda! A method-ref would cause incorrect class and line number to be logged
+        // noinspection Convert2MethodRef
+        progress.step(m -> LOG.info(m));
+      });
+
+    LOG.info(
+      "Assigned names to {} of {} of crosswalks ({}%)",
+      namesApplied.get(),
+      unnamedCrosswalks.size(),
+      DoubleUtils.roundTo2Decimals(((double) namesApplied.get() / unnamedCrosswalks.size()) * 100)
+    );
+
+    LOG.info(progress.completeMessage());
+
+    // Set the indices to null so they can be garbage-collected
+    streets = null;
+    unnamedCrosswalks = null;
+  }
+
+  /**
+   * The actual worker method that runs the business logic on an individual sidewalk edge.
+   */
+  private void assignNameToCrosswalk(EdgeOnLevel crosswalkOnLevel, AtomicInteger namesApplied) {
+    var crosswalk = crosswalkOnLevel.edge;
+    var crossStreetOpt = getIntersectingStreet(crosswalkOnLevel.way, streets);
+
+    if (crossStreetOpt.isPresent()) {
+      OsmWay crossStreet = crossStreetOpt.get();
+      Optional<TraverseDirection> isOneWayCar;
+      // TODO: i18n
+      if (crossStreet.isNamed()) {
+        crosswalk.setName(I18NString.of(String.format("crossing over %s", crossStreet.getAssumedName())));
+      } else if (crossStreet.isServiceRoad()) {
+        crosswalk.setName(I18NString.of("crossing over service road"));
+      } else if ((isOneWayCar = crossStreet.isOneWay("motorcar")).isPresent() && FORWARD.equals(isOneWayCar.get())) {
+        crosswalk.setName(I18NString.of("crossing over turn lane"));
+      } else {
+        // Default on using the OSM way ID, which should not happen.
+        crosswalk.setName(I18NString.of(String.format("crossing %s", crosswalkOnLevel.way.getId())));
+      }
+      namesApplied.incrementAndGet();
+    }
   }
 
   /** Gets the intersecting street, if any, for the given way and candidate streets. */
-  public static Optional<OsmWay> getIntersectingStreet(OsmWay way, List<OsmWay> streets) {
+  public static Optional<OsmWay> getIntersectingStreet(OsmWay way, Collection<OsmWay> streets) {
     TLongList nodeRefs = way.getNodeRefs();
     if (nodeRefs.size() >= 3) {
       // There needs to be at least three nodes: 2 extremities that are on the sidewalk,
@@ -57,4 +141,14 @@ public class CrosswalkNamer implements EdgeNamer {
     }
     return Optional.empty();
   }
+
+  public Collection<EdgeOnLevel> getUnnamedCrosswalks() {
+    return unnamedCrosswalks;
+  }
+
+  public Collection<OsmWay> getStreets() {
+    return streets;
+  }
+
+  public record EdgeOnLevel(OsmWay way, StreetEdge edge, Set<String> levels) {}
 }

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmWay.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmWay.java
@@ -104,6 +104,45 @@ public class OsmWay extends OsmEntity {
     return hasTag("barrier");
   }
 
+  public boolean isFootway() {
+    return isTag("highway", "footway");
+  }
+
+  public boolean isMarkedCrossing() {
+    String crossingMarkingsTag = getTag("crossing:markings");
+    return (
+      isTag("footway", "crossing") &&
+      ((crossingMarkingsTag != null && !"no".equals(crossingMarkingsTag)) ||
+        isTag("crossing","marked"))
+    );
+  }
+
+  public boolean isServiceRoad() {
+    return isTag("highway", "service");
+  }
+
+  /** Whether this way is connected to the given way through their extremities. */
+  public boolean isAdjacentTo(OsmWay way) {
+    if (nodes.isEmpty() || way.nodes.isEmpty()) return false;
+
+    long wayFirstNode = way.nodes.get(0);
+    long wayLastNode = way.nodes.get(way.nodes.size() - 1);
+
+    long firstNode = nodes.get(0);
+    long lastNode = nodes.get(nodes.size() - 1);
+
+    return (
+      (firstNode == wayFirstNode && lastNode != wayLastNode) ||
+      (firstNode == wayLastNode && lastNode != wayFirstNode) ||
+      (lastNode == wayFirstNode && firstNode != wayLastNode) ||
+      (lastNode == wayLastNode && firstNode != wayFirstNode)
+    );
+  }
+
+  public boolean isTransitPlatform() {
+    return isTag("railway", "platform") || isTag("public_transport", "platform");
+  }
+
   @Override
   public String url() {
     return String.format("https://www.openstreetmap.org/way/%d", getId());

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmWay.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmWay.java
@@ -139,10 +139,6 @@ public class OsmWay extends OsmEntity {
     );
   }
 
-  public boolean isTransitPlatform() {
-    return isTag("railway", "platform") || isTag("public_transport", "platform");
-  }
-
   @Override
   public String url() {
     return String.format("https://www.openstreetmap.org/way/%d", getId());

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
@@ -1,0 +1,35 @@
+package org.opentripplanner.graph_builder.module.osm.naming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.osm.model.OsmWay;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class CrosswalkNamerTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CrosswalkNamerTest.class);
+
+  @Test
+  void testGetIntersectingStreet() {
+    OsmWay way = new OsmWay();
+    way.getNodeRefs().add(new long[] { 10001, 10002, 10003, 10004 });
+    OsmWay street = new OsmWay();
+    street.setId(50001);
+    street.getNodeRefs().add(new long[] { 20001, 20002, 20003, 10002, 20004, 20005 });
+    OsmWay otherStreet = new OsmWay();
+    otherStreet.setId(50002);
+    otherStreet.getNodeRefs().add(new long[] { 30001, 30002, 30003, 30004, 30005 });
+
+    var intersectingStreet = CrosswalkNamer.getIntersectingStreet(way, List.of(street, otherStreet));
+    assertTrue(intersectingStreet.isPresent());
+    assertEquals(50001, intersectingStreet.get().getId());
+
+    var intersectingStreet2 = CrosswalkNamer.getIntersectingStreet(way, List.of(otherStreet));
+    assertFalse(intersectingStreet2.isPresent());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.osm.model.OsmWay;
 import org.slf4j.Logger;
@@ -14,22 +15,32 @@ class CrosswalkNamerTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(CrosswalkNamerTest.class);
 
+  private static final OsmWay CROSSWALK = new OsmWay();
+  private static final OsmWay STREET = new OsmWay();
+  private static final OsmWay OTHER_STREET = new OsmWay();
+
+
+  @BeforeAll
+  static void setUp() {
+    CROSSWALK.addTag("highway", "footway");
+    CROSSWALK.getNodeRefs().add(new long[] { 10001, 10002, 10003, 10004 });
+
+    STREET.setId(50001);
+    STREET.addTag("highway", "primary");
+    STREET.addTag("name", "3rd Street");
+    STREET.getNodeRefs().add(new long[] { 20001, 20002, 20003, 10002, 20004, 20005 });
+
+    OTHER_STREET.setId(50002);
+    OTHER_STREET.getNodeRefs().add(new long[] { 30001, 30002, 30003, 30004, 30005 });
+  }
+
   @Test
   void testGetIntersectingStreet() {
-    OsmWay way = new OsmWay();
-    way.getNodeRefs().add(new long[] { 10001, 10002, 10003, 10004 });
-    OsmWay street = new OsmWay();
-    street.setId(50001);
-    street.getNodeRefs().add(new long[] { 20001, 20002, 20003, 10002, 20004, 20005 });
-    OsmWay otherStreet = new OsmWay();
-    otherStreet.setId(50002);
-    otherStreet.getNodeRefs().add(new long[] { 30001, 30002, 30003, 30004, 30005 });
-
-    var intersectingStreet = CrosswalkNamer.getIntersectingStreet(way, List.of(street, otherStreet));
+    var intersectingStreet = CrosswalkNamer.getIntersectingStreet(CROSSWALK, List.of(STREET, OTHER_STREET));
     assertTrue(intersectingStreet.isPresent());
     assertEquals(50001, intersectingStreet.get().getId());
 
-    var intersectingStreet2 = CrosswalkNamer.getIntersectingStreet(way, List.of(otherStreet));
+    var intersectingStreet2 = CrosswalkNamer.getIntersectingStreet(CROSSWALK, List.of(OTHER_STREET));
     assertFalse(intersectingStreet2.isPresent());
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
@@ -4,17 +4,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.geometry.GeometryUtils;
+import org.opentripplanner.framework.geometry.WgsCoordinate;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.graph_builder.module.osm.StreetEdgePair;
+import org.opentripplanner.graph_builder.services.osm.EdgeNamer;
 import org.opentripplanner.osm.model.OsmWay;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model._data.StreetModelForTest;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 
 class CrosswalkNamerTest {
-
-  private static final Logger LOG = LoggerFactory.getLogger(CrosswalkNamerTest.class);
-
   private static final OsmWay CROSSWALK = new OsmWay();
   private static final OsmWay STREET = new OsmWay();
   private static final OsmWay OTHER_STREET = new OsmWay();
@@ -23,6 +29,8 @@ class CrosswalkNamerTest {
   @BeforeAll
   static void setUp() {
     CROSSWALK.addTag("highway", "footway");
+    CROSSWALK.addTag("footway", "crossing");
+    CROSSWALK.addTag("crossing:markings", "yes");
     CROSSWALK.getNodeRefs().add(new long[] { 10001, 10002, 10003, 10004 });
 
     STREET.setId(50001);
@@ -31,6 +39,8 @@ class CrosswalkNamerTest {
     STREET.getNodeRefs().add(new long[] { 20001, 20002, 20003, 10002, 20004, 20005 });
 
     OTHER_STREET.setId(50002);
+    OTHER_STREET.addTag("highway", "primary");
+    OTHER_STREET.addTag("name", "Other Street");
     OTHER_STREET.getNodeRefs().add(new long[] { 30001, 30002, 30003, 30004, 30005 });
   }
 
@@ -43,4 +53,69 @@ class CrosswalkNamerTest {
     var intersectingStreet2 = CrosswalkNamer.getIntersectingStreet(CROSSWALK, List.of(OTHER_STREET));
     assertFalse(intersectingStreet2.isPresent());
   }
+
+  @Test
+  void recordEdgesAndPostprocess() {
+    var builder = new ModelBuilder();
+    var crosswalk = builder.addWay(
+      CROSSWALK,
+      new WgsCoordinate(33.9527949, -83.9954059),
+      new WgsCoordinate(33.9527436, -83.9954582)
+    );
+    builder.addWay(
+      STREET,
+      new WgsCoordinate( 33.9528839, -83.9956473),
+      new WgsCoordinate(33.9526837, -83.9953494)
+    );
+    builder.addWay(
+      OTHER_STREET,
+      new WgsCoordinate(33.9528839, -83.9956473),
+      new WgsCoordinate(33.9521700, -83.9954001)
+    );
+
+    CrosswalkNamer namer = new CrosswalkNamer();
+    builder.recordEdges(namer);
+    assertEquals(1, namer.getUnnamedCrosswalks().size());
+    assertEquals(2, namer.getStreets().size());
+
+    namer.postprocess();
+    assertEquals("crossing over 3rd Street", crosswalk.edge.getName().toString());
+    assertFalse(crosswalk.edge.nameIsDerived());
+  }
+
+  private static class ModelBuilder {
+
+    private final List<EdgePair> pairs = new ArrayList<>();
+
+    EdgePair addWay(OsmWay way, WgsCoordinate... coordinates) {
+      var edge = edgeBuilder(coordinates)
+        .withPermission(way.isFootway() ? StreetTraversalPermission.PEDESTRIAN : StreetTraversalPermission.CAR)
+        .withName(way.isNamed() ? way.getAssumedName() : I18NString.of("path"))
+        .withBogusName(!way.isNamed())
+        .buildAndConnect();
+
+      var p = new EdgePair(way, edge);
+      pairs.add(p);
+      return p;
+    }
+
+    void recordEdges(EdgeNamer namer) {
+      pairs.forEach(p -> namer.recordEdges(p.way, new StreetEdgePair(p.edge, null)));
+    }
+
+    private static StreetEdgeBuilder<?> edgeBuilder(WgsCoordinate... c) {
+      var coordinates = Arrays.stream(c).toList();
+      var ls = GeometryUtils.makeLineString(c);
+      return new StreetEdgeBuilder<>()
+        .withFromVertex(
+          StreetModelForTest.intersectionVertex(coordinates.getFirst().asJtsCoordinate())
+        )
+        .withToVertex(
+          StreetModelForTest.intersectionVertex(coordinates.getLast().asJtsCoordinate())
+        )
+        .withGeometry(ls);
+    }
+  }
+
+  private record EdgePair(OsmWay way, StreetEdge edge) {}
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/naming/CrosswalkNamerTest.java
@@ -7,8 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
@@ -23,6 +27,8 @@ import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 class CrosswalkNamerTest {
   private static final OsmWay CROSSWALK = new OsmWay();
   private static final OsmWay STREET = new OsmWay();
+  private static final OsmWay SERVICE_ROAD = new OsmWay();
+  private static final OsmWay TURN_LANE = new OsmWay();
   private static final OsmWay OTHER_STREET = new OsmWay();
 
 
@@ -42,6 +48,16 @@ class CrosswalkNamerTest {
     OTHER_STREET.addTag("highway", "primary");
     OTHER_STREET.addTag("name", "Other Street");
     OTHER_STREET.getNodeRefs().add(new long[] { 30001, 30002, 30003, 30004, 30005 });
+
+    // Reusing ids and nodes for SERVICE_ROAD and TURN_LANE as they are not used together with STREET.
+    SERVICE_ROAD.setId(50001);
+    SERVICE_ROAD.addTag("highway", "service");
+    SERVICE_ROAD.getNodeRefs().add(new long[] { 20001, 20002, 20003, 10002, 20004, 20005 });
+
+    TURN_LANE.setId(50001);
+    TURN_LANE.addTag("highway", "primary_link");
+    TURN_LANE.addTag("oneway", "yes");
+    TURN_LANE.getNodeRefs().add(new long[] { 20001, 20002, 20003, 10002, 20004, 20005 });
   }
 
   @Test
@@ -54,8 +70,9 @@ class CrosswalkNamerTest {
     assertFalse(intersectingStreet2.isPresent());
   }
 
-  @Test
-  void recordEdgesAndPostprocess() {
+  @ParameterizedTest
+  @MethodSource("streetTypes")
+  void recordEdgesAndPostprocess(OsmWay crossStreet, String name) {
     var builder = new ModelBuilder();
     var crosswalk = builder.addWay(
       CROSSWALK,
@@ -63,7 +80,7 @@ class CrosswalkNamerTest {
       new WgsCoordinate(33.9527436, -83.9954582)
     );
     builder.addWay(
-      STREET,
+      crossStreet,
       new WgsCoordinate( 33.9528839, -83.9956473),
       new WgsCoordinate(33.9526837, -83.9953494)
     );
@@ -79,8 +96,16 @@ class CrosswalkNamerTest {
     assertEquals(2, namer.getStreets().size());
 
     namer.postprocess();
-    assertEquals("crossing over 3rd Street", crosswalk.edge.getName().toString());
+    assertEquals(String.format("crossing over %s", name), crosswalk.edge.getName().toString());
     assertFalse(crosswalk.edge.nameIsDerived());
+  }
+
+  private static Stream<Arguments> streetTypes() {
+    return Stream.of(
+      Arguments.of(STREET, STREET.getTag("name")),
+      Arguments.of(SERVICE_ROAD, "service road"),
+      Arguments.of(TURN_LANE, "turn lane")
+    );
   }
 
   private static class ModelBuilder {

--- a/application/src/test/java/org/opentripplanner/osm/model/OsmWayTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/model/OsmWayTest.java
@@ -319,27 +319,6 @@ class OsmWayTest {
     );
   }
 
-  private static OsmWay createPlatform(String kind) {
-    var way = new OsmWay();
-    way.addTag(kind, "platform");
-    return way;
-  }
-
-  @ParameterizedTest
-  @MethodSource("createTransitPlatformCases")
-  void transitPlatform(OsmWay way, boolean result) {
-    assertEquals(result, way.isTransitPlatform());
-  }
-
-  static Stream<Arguments> createTransitPlatformCases() {
-    return Stream.of(
-      Arguments.of(createGenericHighway(), false),
-      Arguments.of(createGenericFootway(), false),
-      Arguments.of(createPlatform("railway"), true),
-      Arguments.of(createPlatform("public_transport"), true)
-    );
-  }
-
   @Test
   void adjacentTo() {
     final long nodeId1 = 10001L;

--- a/application/src/test/java/org/opentripplanner/osm/model/OsmWayTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/model/OsmWayTest.java
@@ -7,10 +7,14 @@ import static org.opentripplanner.osm.model.TraverseDirection.BACKWARD;
 import static org.opentripplanner.osm.model.TraverseDirection.FORWARD;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.osm.wayproperty.specifier.WayTestData;
 
-public class OsmWayTest {
+class OsmWayTest {
 
   @Test
   void testIsBicycleDismountForced() {
@@ -256,5 +260,104 @@ public class OsmWayTest {
     way.addNodeRef(3);
     way.addNodeRef(1);
     return way;
+  }
+
+  private static OsmWay createGenericHighway() {
+    var way = new OsmWay();
+    way.addTag("highway", "primary");
+    return way;
+  }
+
+  private static OsmWay createGenericFootway() {
+    var way = new OsmWay();
+    way.addTag("highway", "footway");
+    return way;
+  }
+
+  private static OsmWay createFootway(
+    String footwayValue,
+    String crossingTag,
+    String crossingValue
+  ) {
+    var way = createGenericFootway();
+    way.addTag("footway", footwayValue);
+    way.addTag(crossingTag, crossingValue);
+    return way;
+  }
+
+  @Test
+  void footway() {
+    assertFalse(createGenericHighway().isFootway());
+    assertTrue(createGenericFootway().isFootway());
+  }
+
+  @Test
+  void serviceRoad() {
+    assertFalse(createGenericHighway().isServiceRoad());
+
+    var way = new OsmWay();
+    way.addTag("highway", "service");
+    assertTrue(way.isServiceRoad());
+  }
+
+  @ParameterizedTest
+  @MethodSource("createCrossingCases")
+  void markedCrossing(OsmWay way, boolean result) {
+    assertEquals(result, way.isMarkedCrossing());
+  }
+
+  static Stream<Arguments> createCrossingCases() {
+    return Stream.of(
+      Arguments.of(createGenericFootway(), false),
+      Arguments.of(createFootway("whatever", "unused", "unused"), false),
+      Arguments.of(createFootway("crossing", "crossing", "marked"), true),
+      Arguments.of(createFootway("crossing", "crossing", "other"), false),
+      Arguments.of(createFootway("crossing", "crossing:markings", "yes"), true),
+      Arguments.of(createFootway("crossing", "crossing:markings", "marking-details"), true),
+      Arguments.of(createFootway("crossing", "crossing:markings", null), false),
+      Arguments.of(createFootway("crossing", "crossing:markings", "no"), false)
+    );
+  }
+
+  private static OsmWay createPlatform(String kind) {
+    var way = new OsmWay();
+    way.addTag(kind, "platform");
+    return way;
+  }
+
+  @ParameterizedTest
+  @MethodSource("createTransitPlatformCases")
+  void transitPlatform(OsmWay way, boolean result) {
+    assertEquals(result, way.isTransitPlatform());
+  }
+
+  static Stream<Arguments> createTransitPlatformCases() {
+    return Stream.of(
+      Arguments.of(createGenericHighway(), false),
+      Arguments.of(createGenericFootway(), false),
+      Arguments.of(createPlatform("railway"), true),
+      Arguments.of(createPlatform("public_transport"), true)
+    );
+  }
+
+  @Test
+  void adjacentTo() {
+    final long nodeId1 = 10001L;
+    final long nodeId2 = 20002L;
+    final long sharedNodeId = 30003L;
+
+    OsmWay way1 = new OsmWay();
+    OsmWay way2 = new OsmWay();
+    assertFalse(way1.isAdjacentTo(way2));
+
+    var nodes1 = way1.getNodeRefs();
+    var nodes2 = way2.getNodeRefs();
+    nodes1.add(sharedNodeId);
+    nodes1.add(nodeId1);
+    nodes2.add(nodeId2);
+    assertFalse(way1.isAdjacentTo(way2));
+
+    nodes2.add(sharedNodeId);
+    assertTrue(way1.isAdjacentTo(way2));
   }
 }


### PR DESCRIPTION
### Summary

This PR adds a `CrosswalkNamer` class to assign names to crosswalks, such as "crossing over 10th Street", so that they have better names than just "path" for turn-by-turn directions. As of writing, only non-unmarked crosswalks that have 3 or more nodes in OSM and a shared node with a street are covered.

The `CrosswalkNamer` is copied over from from `SidewalkNamer`, and a few supporting helper methods are added to `OsmWay` for determining footways and adjacent ways.

### Issue

Closes #6864

### Things to discuss/resolve
- Should the PR cover unmarked crosswalks? (Should unmarked crosswalks carry a higher cost vs. marked crosswalks?)
- Should the PR cover crosswalks that are split into multiple ways (e.g. sidewalk-to-street, street-to-sidewalk)

### Unit tests

Unit tests are added for the process for finding and applying names to various types of crosswalks (over a named street, over a service road, over a turn lane).

### Documentation

Added.

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add the label `+Skip Changelog` to the PR.

### Bumping the serialization version id

Not necessary