### PR TITLE
Refactor set with

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/FareRuleSetTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/FareRuleSetTest.java
@@ -1,6 +1,9 @@
 package org.opentripplanner.ext.fares;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.HashSet;
@@ -21,10 +24,10 @@ class FareRuleSetTest {
   void setUp() {
     FeedScopedId id = new FeedScopedId("feed", "fare1");
     FareAttribute fareAttribute = FareAttribute.of(id)
-      .setPrice(TWO_FIFTY)
-      .setPaymentMethod(1)
-      .setTransfers(1)
-      .setTransferDuration(7200)
+      .withPrice(TWO_FIFTY)
+      .withPaymentMethod(1)
+      .withTransfers(1)
+      .withTransferDuration(7200)
       .build();
     fareRuleSet = new FareRuleSet(fareAttribute);
   }
@@ -175,9 +178,9 @@ class FareRuleSetTest {
   @Test
   void testMatchesWithJourneyDuration() {
     FareAttribute journeyFare = FareAttribute.of(new FeedScopedId("feed", "journey"))
-      .setPrice(Money.usDollars(3.00f))
-      .setPaymentMethod(1)
-      .setJourneyDuration(7200)
+      .withPrice(Money.usDollars(3.00f))
+      .withPaymentMethod(1)
+      .withJourneyDuration(7200)
       .build();
     FareRuleSet journeyRuleSet = new FareRuleSet(journeyFare);
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/HSLFareServiceTest.java
@@ -99,49 +99,49 @@ public class HSLFareServiceTest implements PlanTestConstants {
     // Fare attributes
 
     FareAttribute fareAttributeAB = FareAttribute.of(new FeedScopedId(FEED_ID, "AB"))
-      .setPrice(AB_PRICE)
-      .setTransferDuration(fiveMinutes)
+      .withPrice(AB_PRICE)
+      .withTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeBC = FareAttribute.of(new FeedScopedId(FEED_ID, "BC"))
-      .setPrice(BC_PRICE)
-      .setTransferDuration(fiveMinutes)
+      .withPrice(BC_PRICE)
+      .withTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeCD = FareAttribute.of(new FeedScopedId(FEED_ID, "CD"))
-      .setPrice(CD_PRICE)
-      .setTransferDuration(fiveMinutes)
+      .withPrice(CD_PRICE)
+      .withTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeD = FareAttribute.of(new FeedScopedId(FEED_ID, "D"))
-      .setPrice(D_PRICE)
-      .setTransferDuration(fiveMinutes)
+      .withPrice(D_PRICE)
+      .withTransferDuration(fiveMinutes)
       //.setAgency(agency1.getId().getId())
       .build();
 
     FareAttribute fareAttributeABC = FareAttribute.of(new FeedScopedId(FEED_ID, "ABC"))
-      .setPrice(ABC_PRICE)
-      .setTransferDuration(fiveMinutes)
+      .withPrice(ABC_PRICE)
+      .withTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeBCD = FareAttribute.of(new FeedScopedId(FEED_ID, "BCD"))
-      .setPrice(BCD_PRICE)
-      .setTransferDuration(fiveMinutes)
+      .withPrice(BCD_PRICE)
+      .withTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeABCD = FareAttribute.of(new FeedScopedId(FEED_ID, "ABCD"))
-      .setPrice(ABCD_PRICE)
-      .setTransferDuration(fiveMinutes)
+      .withPrice(ABCD_PRICE)
+      .withTransferDuration(fiveMinutes)
       .build();
 
     FareAttribute fareAttributeD2 = FareAttribute.of(new FeedScopedId(FEED_ID, "D2"))
-      .setPrice(Money.euros(0))
-      .setAgency(agency2.getId())
+      .withPrice(Money.euros(0))
+      .withAgency(agency2.getId())
       .build();
 
     FareAttribute fareAttributeAgency3 = FareAttribute.of(new FeedScopedId("FEED2", "attribute"))
-      .setPrice(Money.euros(0))
-      .setAgency(agency3.getId())
+      .withPrice(Money.euros(0))
+      .withAgency(agency3.getId())
       .build();
 
     // Fare rule sets
@@ -420,8 +420,8 @@ public class HSLFareServiceTest implements PlanTestConstants {
   @Test
   void unknownFare() {
     FareAttribute fareAttributeAB = FareAttribute.of(new FeedScopedId(FEED_ID, "AB"))
-      .setPrice(euros(2.80f))
-      .setTransferDuration(60 * 5)
+      .withPrice(euros(2.80f))
+      .withTransferDuration(60 * 5)
       .build();
 
     FareRuleSet ruleSetAB = new FareRuleSet(fareAttributeAB);

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -63,7 +63,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     FareAttribute oneDollarFareAttribute = FareAttribute.of(
       new FeedScopedId(FEED_ID, "oneDollarAttribute")
     )
-      .setPrice(oneDollar)
+      .withPrice(oneDollar)
       .build();
     FareRuleSet oneDollarRouteBasedFares = new FareRuleSet(oneDollarFareAttribute);
     oneDollarRouteBasedFares.addRoute(routeA.getId());
@@ -75,7 +75,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     FareAttribute twoDollarFareAttribute = FareAttribute.of(
       new FeedScopedId(FEED_ID, "twoDollarAttribute")
     )
-      .setPrice(twoDollars)
+      .withPrice(twoDollars)
       .build();
 
     FareRuleSet twoDollarRouteBasedFares = new FareRuleSet(twoDollarFareAttribute);

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/_support/FareModelForTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/impl/_support/FareModelForTest.java
@@ -70,21 +70,21 @@ public class FareModelForTest implements FareTestConstants {
     .addFareZones(OTHER_FEED_ZONE)
     .build();
   public static final FareAttribute TEN_DOLLARS = FareAttribute.of(id("airport-to-city-center"))
-    .setPrice(Money.usDollars(10))
-    .setTransfers(0)
+    .withPrice(Money.usDollars(10))
+    .withTransfers(0)
     .build();
 
   public static final FareAttribute FREE_TRANSFERS = FareAttribute.of(id("free-transfers"))
-    .setPrice(Money.usDollars(20))
-    .setTransfers(10)
+    .withPrice(Money.usDollars(20))
+    .withTransfers(10)
     .build();
 
   public static final FareAttribute OTHER_FEED_ATTRIBUTE = FareAttribute.of(
     FeedScopedId.ofNullable("F2", "other-feed-attribute")
   )
-    .setPrice(Money.usDollars(10))
-    .setTransfers(1)
-    .setAgency(OTHER_FEED_AGENCY.getId())
+    .withPrice(Money.usDollars(10))
+    .withTransfers(1)
+    .withAgency(OTHER_FEED_AGENCY.getId())
     .build();
   public static final FareOffer ANY_FARE_OFFER = FareOffer.of(
     ZonedDateTime.parse("2025-06-24T12:16:09+02:00"),

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -256,7 +256,7 @@ public class FlexIntegrationTest {
           modes.withEgressMode(FLEXIBLE);
         }
 
-        journeyBuilder.setModes(modes.build());
+        journeyBuilder.withModes(modes.build());
       })
       .buildRequest();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/ridehailing/RideHailingAccessShifterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/ridehailing/RideHailingAccessShifterTest.java
@@ -64,7 +64,7 @@ class RideHailingAccessShifterTest {
       .withFrom(TO)
       .withDateTime(searchTime)
       .withJourney(jb ->
-        jb.setModes(RequestModes.of().withAccessMode(StreetMode.CAR_HAILING).build())
+        jb.withModes(RequestModes.of().withAccessMode(StreetMode.CAR_HAILING).build())
       )
       .buildRequest();
 
@@ -134,7 +134,7 @@ class RideHailingAccessShifterTest {
       .withFrom(FROM)
       .withTo(TO)
       .withJourney(jb ->
-        jb.setModes(RequestModes.of().withAccessMode(StreetMode.CAR_HAILING).build())
+        jb.withModes(RequestModes.of().withAccessMode(StreetMode.CAR_HAILING).build())
       )
       .buildRequest();
   }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/model/FareAttributeBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/model/FareAttributeBuilder.java
@@ -36,7 +36,7 @@ public class FareAttributeBuilder
     return agency;
   }
 
-  public FareAttributeBuilder setAgency(FeedScopedId agency) {
+  public FareAttributeBuilder withAgency(FeedScopedId agency) {
     this.agency = agency;
     return this;
   }
@@ -45,7 +45,7 @@ public class FareAttributeBuilder
     return price;
   }
 
-  public FareAttributeBuilder setPrice(Money price) {
+  public FareAttributeBuilder withPrice(Money price) {
     this.price = price;
     return this;
   }
@@ -54,7 +54,7 @@ public class FareAttributeBuilder
     return paymentMethod;
   }
 
-  public FareAttributeBuilder setPaymentMethod(int paymentMethod) {
+  public FareAttributeBuilder withPaymentMethod(int paymentMethod) {
     this.paymentMethod = paymentMethod;
     return this;
   }
@@ -63,7 +63,7 @@ public class FareAttributeBuilder
     return transfers;
   }
 
-  public FareAttributeBuilder setTransfers(int transfers) {
+  public FareAttributeBuilder withTransfers(int transfers) {
     this.transfers = transfers;
     return this;
   }
@@ -72,7 +72,7 @@ public class FareAttributeBuilder
     return transferDuration;
   }
 
-  public FareAttributeBuilder setTransferDuration(int transferDuration) {
+  public FareAttributeBuilder withTransferDuration(int transferDuration) {
     this.transferDuration = transferDuration;
     return this;
   }
@@ -81,7 +81,7 @@ public class FareAttributeBuilder
     return journeyDuration;
   }
 
-  public FareAttributeBuilder setJourneyDuration(int journeyDuration) {
+  public FareAttributeBuilder withJourneyDuration(int journeyDuration) {
     this.journeyDuration = journeyDuration;
     return this;
   }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
@@ -82,12 +82,12 @@ public class StreetFlexPathCalculator implements FlexPathCalculator {
     var routingRequest = RouteRequest.of().withArriveBy(reverseDirection).buildDefault();
 
     return StreetSearchBuilder.of()
-      .setSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(maxFlexTripDuration))
-      .setDominanceFunction(new DominanceFunctions.EarliestArrival())
-      .setRequest(routingRequest)
-      .setStreetRequest(new StreetRequest(StreetMode.CAR))
-      .setFrom(reverseDirection ? null : vertex)
-      .setTo(reverseDirection ? vertex : null)
+      .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(maxFlexTripDuration))
+      .withDominanceFunction(new DominanceFunctions.EarliestArrival())
+      .withRequest(routingRequest)
+      .withStreetRequest(new StreetRequest(StreetMode.CAR))
+      .withFrom(reverseDirection ? null : vertex)
+      .withTo(reverseDirection ? vertex : null)
       .getShortestPathTree();
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
@@ -138,16 +138,16 @@ public class LegacyRouteRequestMapper {
         callWith.argument("alightSlack", tr::withDefaultAlightSlackSec);
         callWith.argument(
           "preferred.otherThanPreferredRoutesPenalty",
-          tr::setOtherThanPreferredRoutesPenalty
+          tr::withOtherThanPreferredRoutesPenalty
         );
         // This is deprecated, if both are set, the proper one will override this
         callWith.argument("unpreferred.useUnpreferredRoutesPenalty", (Integer v) ->
-          tr.setUnpreferredCost(CostLinearFunction.of(Duration.ofSeconds(v), 0.0))
+          tr.withUnpreferredCost(CostLinearFunction.of(Duration.ofSeconds(v), 0.0))
         );
-        callWith.argument("unpreferred.unpreferredCost", tr::setUnpreferredCostString);
-        callWith.argument("ignoreRealtimeUpdates", tr::setIgnoreRealtimeUpdates);
+        callWith.argument("unpreferred.unpreferredCost", tr::withUnpreferredCostString);
+        callWith.argument("ignoreRealtimeUpdates", tr::withIgnoreRealtimeUpdates);
         callWith.argument("modeWeight", (Map<String, Object> modeWeights) ->
-          tr.setReluctanceForMode(
+          tr.withReluctanceForMode(
             modeWeights
               .entrySet()
               .stream()

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
@@ -218,7 +218,7 @@ public class LegacyRouteRequestMapper {
               )
               .collect(Collectors.toSet());
 
-            journeyBuilder.setModes(modes.getRequestModes());
+            journeyBuilder.withModes(modes.getRequestModes());
 
             var tModes = modes.getTransitModes().stream().map(MainAndSubMode::new).toList();
             if (tModes.isEmpty()) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
@@ -231,7 +231,7 @@ public class LegacyRouteRequestMapper {
           if (transitDisabled) {
             transitBuilder.disable();
           } else {
-            transitBuilder.setFilters(List.of(filterRequestBuilder.build()));
+            transitBuilder.withFilters(List.of(filterRequestBuilder.build()));
           }
         }
       });

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/ModePreferencesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/ModePreferencesMapper.java
@@ -118,7 +118,7 @@ public class ModePreferencesMapper {
       .orElse(List.of());
     if (CollectionUtils.hasValue(graphQlFilters)) {
       var filters = FilterMapper.mapFilters(modes, graphQlFilters);
-      journey.withTransit(b -> b.setFilters(filters));
+      journey.withTransit(b -> b.withFilters(filters));
     }
     // if there isn't a transit filter or a mode set, then we can keep the default which is to include
     // everything
@@ -126,7 +126,7 @@ public class ModePreferencesMapper {
       var filter = TransitFilterRequest.of()
         .addSelect(SelectRequest.of().withTransportModes(modes).build())
         .build();
-      journey.withTransit(b -> b.setFilters(List.of(filter)));
+      journey.withTransit(b -> b.withFilters(List.of(filter)));
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/TransitPreferencesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/TransitPreferencesMapper.java
@@ -35,7 +35,7 @@ public class TransitPreferencesMapper {
             mode -> (Double) ((Map<String, Object>) mode.get("cost")).get("reluctance")
           )
         );
-      transitPreferences.setReluctanceForMode(reluctanceForMode);
+      transitPreferences.withReluctanceForMode(reluctanceForMode);
     }
     var transitArgs = args.getGraphQLPreferences().getGraphQLTransit();
     if (transitArgs == null) {
@@ -95,15 +95,15 @@ public class TransitPreferencesMapper {
     if (timetable != null) {
       var excludeUpdates = timetable.getGraphQLExcludeRealTimeUpdates();
       if (excludeUpdates != null) {
-        transitPreferences.setIgnoreRealtimeUpdates(excludeUpdates);
+        transitPreferences.withIgnoreRealtimeUpdates(excludeUpdates);
       }
       var includePlannedCancellations = timetable.getGraphQLIncludePlannedCancellations();
       if (includePlannedCancellations != null) {
-        transitPreferences.setIncludePlannedCancellations(includePlannedCancellations);
+        transitPreferences.withIncludePlannedCancellations(includePlannedCancellations);
       }
       var includeRealtimeCancellations = timetable.getGraphQLIncludeRealTimeCancellations();
       if (includeRealtimeCancellations != null) {
-        transitPreferences.setIncludeRealtimeCancellations(includeRealtimeCancellations);
+        transitPreferences.withIncludeRealtimeCancellations(includeRealtimeCancellations);
       }
     }
   }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -93,7 +93,7 @@ public class TripRequestMapper {
       });
 
       if (GqlUtil.hasArgument(environment, "modes")) {
-        journeyBuilder.setModes(
+        journeyBuilder.withModes(
           RequestStreetModesMapper.mapRequestStreetModes(environment.getArgument("modes"))
         );
       }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -84,7 +84,7 @@ public class TripRequestMapper {
         );
 
         if (GqlUtil.hasArgument(environment, "filters")) {
-          transitBuilder.setFilters(
+          transitBuilder.withFilters(
             transitFilterNewWayMapper.mapFilter(environment.getArgument("filters"))
           );
         } else {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
@@ -18,7 +18,7 @@ class ViaSegmentMapper {
     var journey = defaultRequest.journey().copyOf();
     if (viaSegment.containsKey("modes")) {
       Map<String, Object> modesInput = (Map<String, Object>) viaSegment.get("modes");
-      journey.setModes(RequestStreetModesMapper.mapRequestStreetModes(modesInput));
+      journey.withModes(RequestStreetModesMapper.mapRequestStreetModes(modesInput));
     }
     if (viaSegment.containsKey("filters")) {
       journey.withTransit(tb -> {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaSegmentMapper.java
@@ -23,7 +23,7 @@ class ViaSegmentMapper {
     if (viaSegment.containsKey("filters")) {
       journey.withTransit(tb -> {
         List<Map<String, ?>> filters = (List<Map<String, ?>>) viaSegment.get("filters");
-        tb.setFilters(transitFilterNewWayMapper.mapFilter(filters));
+        tb.withFilters(transitFilterNewWayMapper.mapFilter(filters));
       });
     }
     return journey.build();

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/preferences/TransitPreferencesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/preferences/TransitPreferencesMapper.java
@@ -17,7 +17,7 @@ public class TransitPreferencesMapper {
   ) {
     callWith.argument(
       "preferred.otherThanPreferredLinesPenalty",
-      transit::setOtherThanPreferredRoutesPenalty
+      transit::withOtherThanPreferredRoutesPenalty
     );
     transit.withBoardSlack(builder -> {
       callWith.argument("boardSlackDefault", builder::withDefaultSec);
@@ -31,9 +31,9 @@ public class TransitPreferencesMapper {
         TransportModeSlack.mapIntoDomain(builder, v)
       );
     });
-    callWith.argument("ignoreRealtimeUpdates", transit::setIgnoreRealtimeUpdates);
-    callWith.argument("includePlannedCancellations", transit::setIncludePlannedCancellations);
-    callWith.argument("includeRealtimeCancellations", transit::setIncludeRealtimeCancellations);
+    callWith.argument("ignoreRealtimeUpdates", transit::withIgnoreRealtimeUpdates);
+    callWith.argument("includePlannedCancellations", transit::withIncludePlannedCancellations);
+    callWith.argument("includeRealtimeCancellations", transit::withIncludeRealtimeCancellations);
     callWith.argument("relaxTransitGroupPriority", it ->
       transit.withRelaxTransitGroupPriority(
         RelaxCostType.mapToDomain((Map<String, Object>) it, CostLinearFunction.NORMAL)

--- a/application/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/application/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -42,22 +42,22 @@ public abstract class AStarBuilder<
     this.builder = builder;
   }
 
-  public Builder setHeuristic(RemainingWeightHeuristic<State> heuristic) {
+  public Builder withHeuristic(RemainingWeightHeuristic<State> heuristic) {
     this.heuristic = heuristic;
     return builder;
   }
 
-  public Builder setSkipEdgeStrategy(SkipEdgeStrategy<State, Edge> skipEdgeStrategy) {
+  public Builder withSkipEdgeStrategy(SkipEdgeStrategy<State, Edge> skipEdgeStrategy) {
     this.skipEdgeStrategy = skipEdgeStrategy;
     return builder;
   }
 
-  public Builder setTraverseVisitor(TraverseVisitor<State, Edge> traverseVisitor) {
+  public Builder withTraverseVisitor(TraverseVisitor<State, Edge> traverseVisitor) {
     this.traverseVisitor = traverseVisitor;
     return builder;
   }
 
-  public Builder setArriveBy(boolean arriveBy) {
+  public Builder withArriveBy(boolean arriveBy) {
     this.arriveBy = arriveBy;
     return builder;
   }
@@ -66,46 +66,41 @@ public abstract class AStarBuilder<
     return arriveBy;
   }
 
-  public Builder setFrom(Set<Vertex> fromVertices) {
+  public Builder withFrom(Set<Vertex> fromVertices) {
     this.fromVertices = fromVertices;
     return builder;
   }
 
-  public Builder setFrom(Vertex fromVertex) {
+  public Builder withFrom(Vertex fromVertex) {
     this.fromVertices = Collections.singleton(fromVertex);
     return builder;
   }
 
-  public Builder setTo(Set<Vertex> toVertices) {
+  public Builder withTo(Set<Vertex> toVertices) {
     this.toVertices = toVertices;
     return builder;
   }
 
-  public Builder setTo(Vertex toVertex) {
+  public Builder withTo(Vertex toVertex) {
     this.toVertices = Collections.singleton(toVertex);
     return builder;
   }
 
-  public Builder setTerminationStrategy(SearchTerminationStrategy<State> terminationStrategy) {
+  public Builder withTerminationStrategy(SearchTerminationStrategy<State> terminationStrategy) {
     this.terminationStrategy = terminationStrategy;
     return builder;
   }
 
   /** The function that compares paths converging on the same vertex to decide which ones continue to be explored. */
-  public Builder setDominanceFunction(DominanceFunction<State> dominanceFunction) {
+  public Builder withDominanceFunction(DominanceFunction<State> dominanceFunction) {
     this.dominanceFunction = dominanceFunction;
     return builder;
   }
 
   protected abstract Duration streetRoutingTimeout();
 
-  public Builder setOriginBackEdge(Edge originBackEdge) {
+  public Builder withOriginBackEdge(Edge originBackEdge) {
     this.originBackEdge = originBackEdge;
-    return builder;
-  }
-
-  public Builder setInitialStates(Collection<State> initialStates) {
-    this.initialStates = initialStates;
     return builder;
   }
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
@@ -118,17 +118,17 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
     stopsFound = new ArrayList<>(stopsFound);
 
     var streetSearch = StreetSearchBuilder.of()
-      .setSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(durationLimit))
-      .setDominanceFunction(new DominanceFunctions.MinimumWeight())
-      .setRequest(request)
-      .setArriveBy(reverseDirection)
-      .setStreetRequest(streetRequest)
-      .setFrom(reverseDirection ? null : originVertices)
-      .setTo(reverseDirection ? originVertices : null)
-      .setExtensionRequestContexts(extensionRequestContexts);
+      .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(durationLimit))
+      .withDominanceFunction(new DominanceFunctions.MinimumWeight())
+      .withRequest(request)
+      .withArriveBy(reverseDirection)
+      .withStreetRequest(streetRequest)
+      .withFrom(reverseDirection ? null : originVertices)
+      .withTo(reverseDirection ? originVertices : null)
+      .withExtensionRequestContexts(extensionRequestContexts);
 
     if (maxStopCount > 0) {
-      streetSearch.setTerminationStrategy(
+      streetSearch.withTerminationStrategy(
         new MaxCountTerminationStrategy<>(maxStopCount, this::hasReachedStop)
       );
     }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -382,11 +382,11 @@ class WalkableAreaBuilder {
     Set<Edge> usedEdges = new HashSet<>();
     for (Vertex vertex : startingVertices) {
       ShortestPathTree<State, Edge, Vertex> spt = StreetSearchBuilder.of()
-        .setSkipEdgeStrategy(new ListedEdgesOnly(edges))
-        .setDominanceFunction(new DominanceFunctions.EarliestArrival())
-        .setRequest(request)
-        .setStreetRequest(new StreetRequest(mode))
-        .setFrom(vertex)
+        .withSkipEdgeStrategy(new ListedEdgesOnly(edges))
+        .withDominanceFunction(new DominanceFunctions.EarliestArrival())
+        .withRequest(request)
+        .withStreetRequest(new StreetRequest(mode))
+        .withFrom(vertex)
         .getShortestPathTree();
 
       for (Vertex endVertex : startingVertices) {

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareAttributeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareAttributeMapper.java
@@ -38,20 +38,20 @@ class FareAttributeMapper {
     FareAttributeBuilder builder = FareAttribute.of(
       idFactory.createId(rhs.getId(), "fare attribute")
     )
-      .setPrice(price)
-      .setPaymentMethod(rhs.getPaymentMethod());
+      .withPrice(price)
+      .withPaymentMethod(rhs.getPaymentMethod());
 
     if (rhs.getId().getAgencyId() != null && rhs.getAgencyId() != null) {
-      builder.setAgency(new FeedScopedId(rhs.getId().getAgencyId(), rhs.getAgencyId()));
+      builder.withAgency(new FeedScopedId(rhs.getId().getAgencyId(), rhs.getAgencyId()));
     }
     if (rhs.isTransfersSet()) {
-      builder.setTransfers(rhs.getTransfers());
+      builder.withTransfers(rhs.getTransfers());
     }
     if (rhs.isTransferDurationSet()) {
-      builder.setTransferDuration(rhs.getTransferDuration());
+      builder.withTransferDuration(rhs.getTransferDuration());
     }
     if (rhs.isJourneyDurationSet()) {
-      builder.setJourneyDuration(rhs.getJourneyDuration());
+      builder.withJourneyDuration(rhs.getJourneyDuration());
     }
 
     return builder.build();

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
@@ -175,10 +175,10 @@ public class RaptorRequestMapper<T extends RaptorTripSchedule> {
       var debugLogger = new SystemErrDebugLogger(true, false);
 
       debug
-        .addStops(raptorDebugging.stops())
-        .setPath(raptorDebugging.path())
-        .debugPathFromStopIndex(raptorDebugging.debugPathFromStopIndex())
-        .logger(debugLogger);
+        .withStops(raptorDebugging.stops())
+        .withPath(raptorDebugging.path())
+        .withDebugPathFromStopIndex(raptorDebugging.debugPathFromStopIndex())
+        .withLogger(debugLogger);
 
       for (var type : raptorDebugging.eventTypes()) {
         addLogListenerForEachEventTypeRequested(debug, type, debugLogger);
@@ -296,9 +296,9 @@ public class RaptorRequestMapper<T extends RaptorTripSchedule> {
     SystemErrDebugLogger logger
   ) {
     switch (type) {
-      case STOP_ARRIVALS -> target.stopArrivalListener(logger::stopArrivalLister);
-      case PATTERN_RIDES -> target.patternRideDebugListener(logger::patternRideLister);
-      case DESTINATION_ARRIVALS -> target.pathFilteringListener(logger::pathFilteringListener);
+      case STOP_ARRIVALS -> target.withStopArrivalListener(logger::stopArrivalLister);
+      case PATTERN_RIDES -> target.withPatternRideDebugListener(logger::patternRideLister);
+      case DESTINATION_ARRIVALS -> target.withPathFilteringListener(logger::pathFilteringListener);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/TransitPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/TransitPreferences.java
@@ -285,24 +285,24 @@ public final class TransitPreferences implements Serializable {
       return withAlightSlack(it -> it.withDefaultSec(defaultValue));
     }
 
-    public Builder setReluctanceForMode(Map<TransitMode, Double> reluctanceForMode) {
+    public Builder withReluctanceForMode(Map<TransitMode, Double> reluctanceForMode) {
       this.reluctanceForMode = reluctanceForMode;
       return this;
     }
 
     @Deprecated
-    public Builder setOtherThanPreferredRoutesPenalty(int otherThanPreferredRoutesPenalty) {
+    public Builder withOtherThanPreferredRoutesPenalty(int otherThanPreferredRoutesPenalty) {
       this.otherThanPreferredRoutesPenalty = Cost.costOfSeconds(otherThanPreferredRoutesPenalty);
       return this;
     }
 
-    public Builder setUnpreferredCost(CostLinearFunction unpreferredCost) {
+    public Builder withUnpreferredCost(CostLinearFunction unpreferredCost) {
       this.unpreferredCost = unpreferredCost;
       return this;
     }
 
-    public Builder setUnpreferredCostString(String constFunction) {
-      return setUnpreferredCost(CostLinearFunction.of(constFunction));
+    public Builder withUnpreferredCostString(String constFunction) {
+      return withUnpreferredCost(CostLinearFunction.of(constFunction));
     }
 
     public Builder withRelaxTransitGroupPriority(CostLinearFunction value) {
@@ -310,17 +310,17 @@ public final class TransitPreferences implements Serializable {
       return this;
     }
 
-    public Builder setIgnoreRealtimeUpdates(boolean ignoreRealtimeUpdates) {
+    public Builder withIgnoreRealtimeUpdates(boolean ignoreRealtimeUpdates) {
       this.ignoreRealtimeUpdates = ignoreRealtimeUpdates;
       return this;
     }
 
-    public Builder setIncludePlannedCancellations(boolean includePlannedCancellations) {
+    public Builder withIncludePlannedCancellations(boolean includePlannedCancellations) {
       this.includePlannedCancellations = includePlannedCancellations;
       return this;
     }
 
-    public Builder setIncludeRealtimeCancellations(boolean includeRealtimeCancellations) {
+    public Builder withIncludeRealtimeCancellations(boolean includeRealtimeCancellations) {
       this.includeRealtimeCancellations = includeRealtimeCancellations;
       return this;
     }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/JourneyRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/JourneyRequestBuilder.java
@@ -67,7 +67,7 @@ public class JourneyRequestBuilder implements Serializable {
   /**
    * Set access, egress, transfer and direcet mode to a given mode.
    */
-  public JourneyRequestBuilder setAllModes(StreetMode mode) {
+  public JourneyRequestBuilder withAllModes(StreetMode mode) {
     var value = new StreetRequest(mode);
     withAccess(value);
     withEgress(value);
@@ -76,7 +76,7 @@ public class JourneyRequestBuilder implements Serializable {
     return this;
   }
 
-  public JourneyRequestBuilder setModes(RequestModes modes) {
+  public JourneyRequestBuilder withModes(RequestModes modes) {
     withAccess(new StreetRequest(modes.accessMode));
     withEgress(new StreetRequest(modes.egressMode));
     withTransfer(new StreetRequest(modes.transferMode));

--- a/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequestBuilder.java
@@ -32,7 +32,7 @@ public class TransitRequestBuilder {
     this.raptorDebugging = null;
   }
 
-  public TransitRequestBuilder setFilters(List<TransitFilter> filters) {
+  public TransitRequestBuilder withFilters(List<TransitFilter> filters) {
     this.filters = filters;
     return this;
   }
@@ -40,14 +40,14 @@ public class TransitRequestBuilder {
   public TransitRequestBuilder withFilter(Consumer<TransitFilterRequest.Builder> body) {
     var builder = TransitFilterRequest.of();
     body.accept(builder);
-    return setFilters(List.of(builder.build()));
+    return withFilters(List.of(builder.build()));
   }
 
   /**
    * Disables the transit search for this request, for example when you only want bike routes.
    */
   public TransitRequestBuilder disable() {
-    return setFilters(List.of(ExcludeAllTransitFilter.of()));
+    return withFilters(List.of(ExcludeAllTransitFilter.of()));
   }
 
   public TransitRequestBuilder withUnpreferredAgencies(List<FeedScopedId> unpreferredAgencies) {

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
@@ -110,11 +110,11 @@ public class StreetGraphFinder implements GraphFinder {
       )
     ) {
       StreetSearchBuilder.of()
-        .setSkipEdgeStrategy(skipEdgeStrategy)
-        .setTraverseVisitor(visitor)
-        .setDominanceFunction(new DominanceFunctions.LeastWalk())
-        .setRequest(request)
-        .setVerticesContainer(temporaryVertices)
+        .withSkipEdgeStrategy(skipEdgeStrategy)
+        .withTraverseVisitor(visitor)
+        .withDominanceFunction(new DominanceFunctions.LeastWalk())
+        .withRequest(request)
+        .withVerticesContainer(temporaryVertices)
         .getShortestPathTree();
     }
   }

--- a/application/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -85,24 +85,24 @@ public class GraphPathFinder {
     StreetPreferences preferences = request.preferences().street();
 
     StreetSearchBuilder aStar = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic(maxCarSpeed))
-      .setSkipEdgeStrategy(
+      .withHeuristic(new EuclideanRemainingWeightHeuristic(maxCarSpeed))
+      .withSkipEdgeStrategy(
         new DurationSkipEdgeStrategy(
           preferences.maxDirectDuration().valueOf(request.journey().direct().mode())
         )
       )
       // FORCING the dominance function to weight only
-      .setDominanceFunction(new DominanceFunctions.MinimumWeight())
-      .setRequest(request)
-      .setStreetRequest(request.journey().direct())
-      .setFrom(from)
-      .setTo(to)
-      .setExtensionRequestContexts(extensionRequestContexts);
+      .withDominanceFunction(new DominanceFunctions.MinimumWeight())
+      .withRequest(request)
+      .withStreetRequest(request.journey().direct())
+      .withFrom(from)
+      .withTo(to)
+      .withExtensionRequestContexts(extensionRequestContexts);
 
     // If the search has a traverseVisitor(GraphVisualizer) attached to it, set it as a callback
     // for the AStar search
     if (traverseVisitor != null) {
-      aStar.setTraverseVisitor(traverseVisitor);
+      aStar.withTraverseVisitor(traverseVisitor);
     }
 
     LOG.debug("rreq={}", request);

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -77,7 +77,7 @@ public class RouteRequestConfig {
     );
 
     requestBuilder.withJourney(b ->
-      b.setModes(
+      b.withModes(
         c
           .of("modes")
           .since(V2_0)

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -284,14 +284,14 @@ public class RouteRequestConfig {
               .asEnumMap(TransitMode.class, Duration.class)
           )
       )
-      .setIgnoreRealtimeUpdates(
+      .withIgnoreRealtimeUpdates(
         c
           .of("ignoreRealtimeUpdates")
           .since(V2_0)
           .summary("When true, real-time updates are ignored during this search.")
           .asBoolean(dft.ignoreRealtimeUpdates())
       )
-      .setOtherThanPreferredRoutesPenalty(
+      .withOtherThanPreferredRoutesPenalty(
         c
           .of("otherThanPreferredRoutesPenalty")
           .since(V2_0)
@@ -303,14 +303,14 @@ public class RouteRequestConfig {
           )
           .asInt(dft.otherThanPreferredRoutesPenalty())
       )
-      .setReluctanceForMode(
+      .withReluctanceForMode(
         c
           .of("transitReluctanceForMode")
           .since(V2_1)
           .summary("Transit reluctance for a given transport mode")
           .asEnumMap(TransitMode.class, Double.class)
       )
-      .setUnpreferredCost(
+      .withUnpreferredCost(
         c
           .of("unpreferredCost")
           .since(V2_2)

--- a/application/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
+++ b/application/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
@@ -36,31 +36,31 @@ public class StreetSearchBuilder extends AStarBuilder<State, Edge, Vertex, Stree
     setBuilder(this);
   }
 
-  public StreetSearchBuilder setRequest(RouteRequest request) {
+  public StreetSearchBuilder withRequest(RouteRequest request) {
     this.routeRequest = request;
-    setArriveBy(request.arriveBy());
+    withArriveBy(request.arriveBy());
     return this;
   }
 
-  public StreetSearchBuilder setStreetRequest(StreetRequest streetRequest) {
+  public StreetSearchBuilder withStreetRequest(StreetRequest streetRequest) {
     this.streetRequest = streetRequest;
     return this;
   }
 
-  public StreetSearchBuilder setVerticesContainer(TemporaryVerticesContainer container) {
-    setFrom(container.getFromVertices());
-    setTo(container.getToVertices());
+  public StreetSearchBuilder withVerticesContainer(TemporaryVerticesContainer container) {
+    withFrom(container.getFromVertices());
+    withTo(container.getToVertices());
     return this;
   }
 
-  public StreetSearchBuilder setIntersectionTraversalCalculator(
+  public StreetSearchBuilder withIntersectionTraversalCalculator(
     IntersectionTraversalCalculator intersectionTraversalCalculator
   ) {
     this.intersectionTraversalCalculator = intersectionTraversalCalculator;
     return this;
   }
 
-  public StreetSearchBuilder setExtensionRequestContexts(
+  public StreetSearchBuilder withExtensionRequestContexts(
     Collection<ExtensionRequestContext> extensionRequestContexts
   ) {
     this.extensionRequestContexts = List.copyOf(extensionRequestContexts);

--- a/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -476,7 +476,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
     // TODO: This should use the configured defaults, not the code defaults
     RouteRequestBuilder builder = RouteRequest.of();
     QualifiedModeSet qualifiedModeSet = new QualifiedModeSet(modes.toArray(String[]::new));
-    builder.withJourney(b -> b.setModes(qualifiedModeSet.getRequestModes()));
+    builder.withJourney(b -> b.withModes(qualifiedModeSet.getRequestModes()));
 
     builder.withArriveBy(arriveByCheckBox.isSelected());
     builder.withDateTime(when);

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -112,7 +112,7 @@ public abstract class GtfsTest {
         .withTransferMode(WALK)
         .withEgressMode(WALK);
 
-      journeyBuilder.setModes(requestModesBuilder.build());
+      journeyBuilder.withModes(requestModesBuilder.build());
 
       var filterRequestBuilder = TransitFilterRequest.of();
       if (preferredMode != null) {

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -146,7 +146,7 @@ public abstract class GtfsTest {
       // since this makes interlining _worse_ than alighting and re-boarding the same line.
       // TODO rethink whether it makes sense to weight waiting to board _less_ than 1.
       preferences.withWalk(w -> w.withBoardCost(30));
-      preferences.withTransit(tr -> tr.setOtherThanPreferredRoutesPenalty(0));
+      preferences.withTransit(tr -> tr.withOtherThanPreferredRoutesPenalty(0));
     });
 
     // Route

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -130,7 +130,7 @@ public abstract class GtfsTest {
         filterRequestBuilder.addNot(SelectRequest.of().withRoutes(routeIds).build());
       }
 
-      journeyBuilder.withTransit(b -> b.setFilters(List.of(filterRequestBuilder.build())));
+      journeyBuilder.withTransit(b -> b.withFilters(List.of(filterRequestBuilder.build())));
     });
 
     // Init preferences

--- a/application/src/test/java/org/opentripplanner/astar/AStarTest.java
+++ b/application/src/test/java/org/opentripplanner/astar/AStarTest.java
@@ -94,10 +94,10 @@ public class AStarTest {
     Vertex from = graph.getVertex("56th_24th");
     Vertex to = graph.getVertex("leary_20th");
     ShortestPathTree tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setFrom(from)
-      .setTo(to)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withFrom(from)
+      .withTo(to)
       .getShortestPathTree();
 
     GraphPath path = tree.getPath(to);
@@ -125,10 +125,10 @@ public class AStarTest {
     Vertex from = graph.getVertex("56th_24th");
     Vertex to = graph.getVertex("leary_20th");
     ShortestPathTree tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setFrom(from)
-      .setTo(to)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withFrom(from)
+      .withTo(to)
       .getShortestPathTree();
 
     GraphPath path = tree.getPath(from);
@@ -175,10 +175,10 @@ public class AStarTest {
     TemporaryConcreteEdge.createTemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
 
     ShortestPathTree<State, Edge, Vertex> tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setFrom(from)
-      .setTo(to)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withFrom(from)
+      .withTo(to)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = tree.getPath(to);
@@ -218,10 +218,10 @@ public class AStarTest {
     TemporaryConcreteEdge.createTemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
 
     ShortestPathTree tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setFrom(from)
-      .setTo(to)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withFrom(from)
+      .withTo(to)
       .getShortestPathTree();
 
     GraphPath path = tree.getPath(from);
@@ -258,11 +258,11 @@ public class AStarTest {
     Vertex v1 = graph.getVertex("56th_24th");
     Vertex v2 = graph.getVertex("leary_20th");
     ShortestPathTree tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setTerminationStrategy(strategy)
-      .setRequest(request)
-      .setFrom(v1)
-      .setTo(v2)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withTerminationStrategy(strategy)
+      .withRequest(request)
+      .withFrom(v1)
+      .withTo(v2)
       .getShortestPathTree();
 
     for (Vertex v : targets) {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/TurnRestrictionModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/TurnRestrictionModuleTest.java
@@ -314,10 +314,10 @@ public class TurnRestrictionModuleTest {
     var request = RouteRequest.of().withJourney(j -> j.withDirect(streetRequest)).buildDefault();
 
     ShortestPathTree<State, Edge, Vertex> spt = StreetSearchBuilder.of()
-      .setRequest(request)
-      .setStreetRequest(streetRequest)
-      .setFrom(A)
-      .setTo(F)
+      .withRequest(request)
+      .withStreetRequest(streetRequest)
+      .withFrom(A)
+      .withTo(F)
       .getShortestPathTree();
     GraphPath<State, Edge, Vertex> path = spt.getPath(F);
     List<State> states = path.states;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
@@ -194,7 +194,7 @@ public class TriangleInequalityTest {
           jb.withModes(modes);
         }
         if (!filters.isEmpty()) {
-          jb.withTransit(b -> b.setFilters(filters));
+          jb.withTransit(b -> b.withFilters(filters));
         }
       })
       .buildDefault();

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
@@ -191,7 +191,7 @@ public class TriangleInequalityTest {
       )
       .withJourney(jb -> {
         if (modes != null) {
-          jb.setModes(modes);
+          jb.withModes(modes);
         }
         if (!filters.isEmpty()) {
           jb.withTransit(b -> b.setFilters(filters));

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
@@ -161,12 +161,12 @@ public class TriangleInequalityTest {
     Vertex v
   ) {
     return StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setOriginBackEdge(startBackEdge)
-      .setRequest(options)
-      .setFrom(u)
-      .setTo(v)
-      .setIntersectionTraversalCalculator(calculator)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withOriginBackEdge(startBackEdge)
+      .withRequest(options)
+      .withFrom(u)
+      .withTo(v)
+      .withIntersectionTraversalCalculator(calculator)
       .getShortestPathTree()
       .getPath(v);
   }
@@ -200,12 +200,12 @@ public class TriangleInequalityTest {
       .buildDefault();
 
     ShortestPathTree<State, Edge, Vertex> tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setDominanceFunction(new DominanceFunctions.EarliestArrival())
-      .setRequest(request)
-      .setFrom(start)
-      .setTo(end)
-      .setIntersectionTraversalCalculator(calculator)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withDominanceFunction(new DominanceFunctions.EarliestArrival())
+      .withRequest(request)
+      .withFrom(start)
+      .withTo(end)
+      .withIntersectionTraversalCalculator(calculator)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = tree.getPath(end);

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/UnroutableTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/UnroutableTest.java
@@ -63,11 +63,11 @@ class UnroutableTest {
     Vertex from = graph.getVertex(VertexLabel.osm(2003617278));
     Vertex to = graph.getVertex(VertexLabel.osm(40446276));
     ShortestPathTree<State, Edge, Vertex> spt = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(request.journey().direct())
-      .setFrom(from)
-      .setTo(to)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(request.journey().direct())
+      .withFrom(from)
+      .withTo(to)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = spt.getPath(to);

--- a/application/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/application/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -211,22 +211,22 @@ public class TestHalfEdges {
     var r = RouteRequest.defaultValue();
 
     ShortestPathTree<State, Edge, Vertex> spt1 = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(r)
-      .setStreetRequest(r.journey().direct())
-      .setFrom(br)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(r)
+      .withStreetRequest(r.journey().direct())
+      .withFrom(br)
+      .withTo(end)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> pathBr = spt1.getPath(end);
     assertNotNull(pathBr, "There must be a path from br to end");
 
     ShortestPathTree<State, Edge, Vertex> spt2 = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(r)
-      .setStreetRequest(r.journey().direct())
-      .setFrom(tr)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(r)
+      .withStreetRequest(r.journey().direct())
+      .withFrom(tr)
+      .withTo(end)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> pathTr = spt2.getPath(end);
@@ -237,11 +237,11 @@ public class TestHalfEdges {
     );
 
     ShortestPathTree<State, Edge, Vertex> spt = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(r)
-      .setStreetRequest(r.journey().direct())
-      .setFrom(start)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(r)
+      .withStreetRequest(r.journey().direct())
+      .withFrom(start)
+      .withTo(end)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = spt.getPath(end);
@@ -256,11 +256,11 @@ public class TestHalfEdges {
     r = RouteRequest.of().withArriveBy(true).buildDefault();
 
     spt = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(r)
-      .setStreetRequest(r.journey().direct())
-      .setFrom(start)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(r)
+      .withStreetRequest(r.journey().direct())
+      .withFrom(start)
+      .withTo(end)
       .getShortestPathTree();
 
     path = spt.getPath(start);
@@ -304,11 +304,11 @@ public class TestHalfEdges {
       .buildDefault();
 
     spt = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(r)
-      .setStreetRequest(r.journey().direct())
-      .setFrom(start)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(r)
+      .withStreetRequest(r.journey().direct())
+      .withFrom(start)
+      .withTo(end)
       .getShortestPathTree();
 
     path = spt.getPath(start);
@@ -343,10 +343,10 @@ public class TestHalfEdges {
     );
 
     spt = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(r)
-      .setFrom(start)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(r)
+      .withFrom(start)
+      .withTo(end)
       .getShortestPathTree();
 
     path = spt.getPath(start);
@@ -402,11 +402,11 @@ public class TestHalfEdges {
     var request = RouteRequest.defaultValue();
 
     ShortestPathTree<State, Edge, Vertex> spt = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(request.journey().direct())
-      .setFrom(start)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(request.journey().direct())
+      .withFrom(start)
+      .withTo(end)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = spt.getPath(end);
@@ -453,11 +453,11 @@ public class TestHalfEdges {
     var request = RouteRequest.defaultValue();
 
     ShortestPathTree<State, Edge, Vertex> spt = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(request.journey().direct())
-      .setFrom(start)
-      .setTo(end)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(request.journey().direct())
+      .withFrom(start)
+      .withTo(end)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = spt.getPath(end);
@@ -577,9 +577,9 @@ public class TestHalfEdges {
       assertNotNull(container.getFromVertices());
       assertNotNull(container.getToVertices());
       ShortestPathTree<State, Edge, Vertex> spt = StreetSearchBuilder.of()
-        .setHeuristic(new EuclideanRemainingWeightHeuristic())
-        .setRequest(walking)
-        .setVerticesContainer(container)
+        .withHeuristic(new EuclideanRemainingWeightHeuristic())
+        .withRequest(walking)
+        .withVerticesContainer(container)
         .getShortestPathTree();
       GraphPath<State, Edge, Vertex> path = spt.getPath(
         container.getToVertices().iterator().next()

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
@@ -214,12 +214,12 @@ public class TurnCostTest {
     int expectedDuration
   ) {
     ShortestPathTree<State, Edge, Vertex> tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(new StreetRequest(streetMode))
-      .setFrom(from)
-      .setTo(to)
-      .setIntersectionTraversalCalculator(calculator)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(new StreetRequest(streetMode))
+      .withFrom(from)
+      .withTo(to)
+      .withIntersectionTraversalCalculator(calculator)
       .getShortestPathTree();
     GraphPath<State, Edge, Vertex> path = tree.getPath(bottomLeft);
     assertNotNull(path);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
@@ -60,7 +60,7 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
   public void directBikeRental() {
     RouteRequest request = createTestRequest(2009, 10, 21, 16, 10, 0)
       .withJourney(jb -> {
-        jb.setModes(RequestModes.of().withDirectMode(StreetMode.BIKE_RENTAL).build());
+        jb.withModes(RequestModes.of().withDirectMode(StreetMode.BIKE_RENTAL).build());
         jb.withTransit(b -> b.disable());
       })
       .withFrom(p1)
@@ -83,7 +83,7 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
   @Test
   public void directBikeRentalArrivingAtDestinationWithDepartAt() {
     var builder = createTestRequest(2009, 10, 21, 16, 10, 0).withJourney(jb -> {
-      jb.setModes(RequestModes.of().withDirectMode(StreetMode.BIKE_RENTAL).build());
+      jb.withModes(RequestModes.of().withDirectMode(StreetMode.BIKE_RENTAL).build());
       jb.withTransit(b -> b.disable());
     });
     allowArrivalWithRentalVehicle(builder);
@@ -96,7 +96,7 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
   @Test
   public void directBikeRentalArrivingAtDestinationWithArriveBy() {
     var builder = createTestRequest(2009, 10, 21, 16, 10, 0).withJourney(jb -> {
-      jb.setModes(RequestModes.of().withDirectMode(StreetMode.BIKE_RENTAL).build());
+      jb.withModes(RequestModes.of().withDirectMode(StreetMode.BIKE_RENTAL).build());
       jb.withTransit(b -> b.disable());
     });
     allowArrivalWithRentalVehicle(builder);
@@ -110,7 +110,7 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
   public void accessBikeRental() {
     RouteRequest request = createTestRequest(2009, 10, 21, 16, 14, 0)
       .withJourney(jb ->
-        jb.setModes(
+        jb.withModes(
           RequestModes.of()
             .withAccessMode(StreetMode.BIKE_RENTAL)
             .withEgressMode(StreetMode.WALK)
@@ -135,7 +135,7 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
   public void egressBikeRental() {
     RouteRequest request = createTestRequest(2009, 10, 21, 16, 10, 0)
       .withJourney(jb ->
-        jb.setModes(
+        jb.withModes(
           RequestModes.of()
             .withAccessMode(StreetMode.WALK)
             .withEgressMode(StreetMode.BIKE_RENTAL)

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
@@ -75,7 +75,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
   public void test_trip_planning_with_walk_only_stop() {
     RouteRequest request = createTestRequest(2009, 11, 17, 10, 0, 0)
       .withJourney(jb -> {
-        jb.setAllModes(StreetMode.WALK);
+        jb.withAllModes(StreetMode.WALK);
         jb.withTransit(b -> b.disable());
       })
       .withFrom(ps)
@@ -89,7 +89,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
   public void test_trip_planning_with_walk_only_stop_collection() {
     RouteRequest request = createTestRequest(2009, 11, 17, 10, 0, 0)
       .withJourney(jb -> {
-        jb.setAllModes(StreetMode.WALK);
+        jb.withAllModes(StreetMode.WALK);
         jb.withTransit(b -> b.disable());
       })
       .withFrom(ptc)
@@ -104,7 +104,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
   public void test_trip_planning_with_transit() {
     RouteRequest request = createTestRequest(2009, 11, 17, 10, 0, 0)
       .withJourney(jb -> {
-        jb.setAllModes(StreetMode.WALK);
+        jb.withAllModes(StreetMode.WALK);
       })
       .withFrom(p1)
       .withTo(p2)
@@ -116,7 +116,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
   @Test
   public void test_trip_planning_with_transit_stop() {
     RouteRequest request = createTestRequest(2009, 11, 17, 10, 0, 0)
-      .withJourney(jb -> jb.setAllModes(StreetMode.WALK))
+      .withJourney(jb -> jb.withAllModes(StreetMode.WALK))
       .withFrom(ps)
       .withTo(p3)
       .buildRequest();
@@ -128,7 +128,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
   @Disabled
   public void test_trip_planning_with_transit_stop_collection() {
     RouteRequest request = createTestRequest(2009, 11, 17, 10, 0, 0)
-      .withJourney(jb -> jb.setAllModes(StreetMode.WALK))
+      .withJourney(jb -> jb.withAllModes(StreetMode.WALK))
       .withFrom(ptc)
       .withTo(p3)
       .buildRequest();

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/PatternCostCalculatorTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/PatternCostCalculatorTest.java
@@ -64,7 +64,7 @@ public class PatternCostCalculatorTest {
         })
       )
       .withPreferences(p ->
-        p.withTransit(tr -> tr.setUnpreferredCost(unpreferredCostFunctionOtpDomain))
+        p.withTransit(tr -> tr.withUnpreferredCost(unpreferredCostFunctionOtpDomain))
       )
       .buildDefault();
 
@@ -194,7 +194,7 @@ public class PatternCostCalculatorTest {
       return RouteRequest.of()
         .withPreferences(preferences -> {
           preferences.withTransit(transit ->
-            transit.setUnpreferredCost(
+            transit.withUnpreferredCost(
               CostLinearFunction.of(UNPREFERRED_ROUTE_PENALTY, UNPREFERRED_ROUTE_RELUCTANCE)
             )
           );

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/TransitPreferencesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/TransitPreferencesTest.java
@@ -36,15 +36,15 @@ class TransitPreferencesTest {
   private static final boolean INCLUDE_REALTIME_CANCELLATIONS = true;
 
   private final TransitPreferences subject = TransitPreferences.of()
-    .setReluctanceForMode(RELUCTANCE_FOR_MODE)
-    .setOtherThanPreferredRoutesPenalty(OTHER_THAN_PREFERRED_ROUTES_PENALTY)
-    .setUnpreferredCost(UNPREFERRED_COST)
+    .withReluctanceForMode(RELUCTANCE_FOR_MODE)
+    .withOtherThanPreferredRoutesPenalty(OTHER_THAN_PREFERRED_ROUTES_PENALTY)
+    .withUnpreferredCost(UNPREFERRED_COST)
     .withBoardSlack(b -> b.withDefault(D45s).with(TransitMode.AIRPLANE, D35m))
     .withAlightSlack(b -> b.withDefault(D15s).with(TransitMode.AIRPLANE, D25m))
     .withRelaxTransitGroupPriority(TRANSIT_GROUP_PRIORITY_RELAX)
-    .setIgnoreRealtimeUpdates(IGNORE_REALTIME_UPDATES)
-    .setIncludePlannedCancellations(INCLUDE_PLANNED_CANCELLATIONS)
-    .setIncludeRealtimeCancellations(INCLUDE_REALTIME_CANCELLATIONS)
+    .withIgnoreRealtimeUpdates(IGNORE_REALTIME_UPDATES)
+    .withIncludePlannedCancellations(INCLUDE_PLANNED_CANCELLATIONS)
+    .withIncludeRealtimeCancellations(INCLUDE_REALTIME_CANCELLATIONS)
     .withRaptor(b -> b.withSearchDirection(RAPTOR_SEARCH_DIRECTION))
     .build();
 
@@ -116,8 +116,8 @@ class TransitPreferencesTest {
     assertSame(TransitPreferences.DEFAULT, TransitPreferences.of().build());
 
     // Create a copy, make a change and set it back again to force creating a new object
-    var other = subject.copyOf().setIgnoreRealtimeUpdates(!IGNORE_REALTIME_UPDATES).build();
-    var copy = other.copyOf().setIgnoreRealtimeUpdates(IGNORE_REALTIME_UPDATES).build();
+    var other = subject.copyOf().withIgnoreRealtimeUpdates(!IGNORE_REALTIME_UPDATES).build();
+    var copy = other.copyOf().withIgnoreRealtimeUpdates(IGNORE_REALTIME_UPDATES).build();
     assertEqualsAndHashCode(subject, other, copy);
   }
 

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/JourneyRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/JourneyRequestTest.java
@@ -72,7 +72,7 @@ class JourneyRequestTest {
 
   @Test
   void setAllModes() {
-    var subject = JourneyRequest.of().setAllModes(StreetMode.BIKE).build();
+    var subject = JourneyRequest.of().withAllModes(StreetMode.BIKE).build();
     assertEquals(StreetMode.BIKE, subject.access().mode());
     assertEquals(StreetMode.BIKE, subject.egress().mode());
     assertEquals(StreetMode.BIKE, subject.transfer().mode());
@@ -81,7 +81,7 @@ class JourneyRequestTest {
 
   @Test
   void testMappingInOutOfRequestMode() {
-    var subject = JourneyRequest.of().setModes(REQUEST_MODES).build();
+    var subject = JourneyRequest.of().withModes(REQUEST_MODES).build();
     assertEquals(REQUEST_MODES.accessMode, subject.access().mode());
     assertEquals(REQUEST_MODES.egressMode, subject.egress().mode());
     assertEquals(REQUEST_MODES.transferMode, subject.transfer().mode());

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/TransitRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/TransitRequestTest.java
@@ -37,7 +37,7 @@ class TransitRequestTest {
   );
 
   private final TransitRequest subject = TransitRequest.of()
-    .setFilters(FILTERS)
+    .withFilters(FILTERS)
     .withBannedTrips(BANNED_TRIPS)
     .withPriorityGroupsByAgency(PRIORITY_GROUP_BY_AGENCY)
     .addPriorityGroupsGlobal(PRIORITY_GROUP_GLOBAL)

--- a/application/src/test/java/org/opentripplanner/street/integration/BikeRentalTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BikeRentalTest.java
@@ -668,11 +668,11 @@ public class BikeRentalTest extends GraphRoutingTest {
     StreetMode streetMode
   ) {
     var tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(options)
-      .setStreetRequest(new StreetRequest(streetMode))
-      .setFrom(fromVertex)
-      .setTo(toVertex)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(options)
+      .withStreetRequest(new StreetRequest(streetMode))
+      .withFrom(fromVertex)
+      .withTo(toVertex)
       .getShortestPathTree();
 
     var path = tree.getPath(arriveBy ? fromVertex : toVertex);

--- a/application/src/test/java/org/opentripplanner/street/integration/BikeWalkingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BikeWalkingTest.java
@@ -377,11 +377,11 @@ public class BikeWalkingTest extends GraphRoutingTest {
       .buildDefault();
 
     var tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(new StreetRequest(streetMode))
-      .setFrom(fromVertex)
-      .setTo(toVertex)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(new StreetRequest(streetMode))
+      .withFrom(fromVertex)
+      .withTo(toVertex)
       .getShortestPathTree();
 
     var path = tree.getPath(arriveBy ? fromVertex : toVertex);

--- a/application/src/test/java/org/opentripplanner/street/integration/CarPickupTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/CarPickupTest.java
@@ -179,11 +179,11 @@ public class CarPickupTest extends GraphRoutingTest {
       .buildDefault();
 
     var tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(new StreetRequest(StreetMode.CAR_PICKUP))
-      .setFrom(fromVertex)
-      .setTo(toVertex)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(new StreetRequest(StreetMode.CAR_PICKUP))
+      .withFrom(fromVertex)
+      .withTo(toVertex)
       .getShortestPathTree();
     var path = tree.getPath(arriveBy ? fromVertex : toVertex);
 

--- a/application/src/test/java/org/opentripplanner/street/integration/ParkAndRideTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/ParkAndRideTest.java
@@ -163,11 +163,11 @@ public abstract class ParkAndRideTest extends GraphRoutingTest {
       .buildRequest();
 
     var tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(new StreetRequest(streetMode))
-      .setFrom(fromVertex)
-      .setTo(toVertex)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(new StreetRequest(streetMode))
+      .withFrom(fromVertex)
+      .withTo(toVertex)
       .getShortestPathTree();
 
     var path = tree.getPath(arriveBy ? fromVertex : toVertex);

--- a/application/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
@@ -102,10 +102,10 @@ public class TurnRestrictionTest {
       .buildDefault();
 
     ShortestPathTree<State, Edge, Vertex> tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setFrom(topRight)
-      .setTo(bottomLeft)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withFrom(topRight)
+      .withTo(bottomLeft)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = tree.getPath(bottomLeft);
@@ -132,10 +132,10 @@ public class TurnRestrictionTest {
       .buildDefault();
 
     ShortestPathTree<State, Edge, Vertex> tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setFrom(topRight)
-      .setTo(bottomLeft)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withFrom(topRight)
+      .withTo(bottomLeft)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = tree.getPath(bottomLeft);
@@ -169,11 +169,11 @@ public class TurnRestrictionTest {
     var request = RouteRequest.defaultValue();
 
     ShortestPathTree<State, Edge, Vertex> tree = StreetSearchBuilder.of()
-      .setHeuristic(new EuclideanRemainingWeightHeuristic())
-      .setRequest(request)
-      .setStreetRequest(new StreetRequest(StreetMode.CAR))
-      .setFrom(topRight)
-      .setTo(bottomLeft)
+      .withHeuristic(new EuclideanRemainingWeightHeuristic())
+      .withRequest(request)
+      .withStreetRequest(new StreetRequest(StreetMode.CAR))
+      .withFrom(topRight)
+      .withTo(bottomLeft)
       .getShortestPathTree();
 
     GraphPath<State, Edge, Vertex> path = tree.getPath(bottomLeft);

--- a/application/src/test/java/org/opentripplanner/street/search/request/StreetSearchRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/street/search/request/StreetSearchRequestMapperTest.java
@@ -29,7 +29,7 @@ class StreetSearchRequestMapperTest {
     builder.withJourney(jb ->
       jb
         .withWheelchair(true)
-        .setModes(RequestModes.of().withAllStreetModes(StreetMode.BIKE).build())
+        .withModes(RequestModes.of().withAllStreetModes(StreetMode.BIKE).build())
     );
 
     var request = builder.buildRequest();

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTestRequest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTestRequest.java
@@ -73,7 +73,7 @@ public class SpeedTestRequest {
       } else {
         var fb = TransitFilterRequest.of()
           .addSelect(SelectRequest.of().withTransportModes(tModes).build());
-        journeyBuilder.withTransit(b -> b.setFilters(List.of(fb.build())));
+        journeyBuilder.withTransit(b -> b.withFilters(List.of(fb.build())));
       }
 
       if (profile.raptorProfile().is(MIN_TRAVEL_DURATION)) {

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTestRequest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTestRequest.java
@@ -65,7 +65,7 @@ public class SpeedTestRequest {
       builder.withNumItineraries(opts.numOfItineraries());
     }
     builder.withJourney(journeyBuilder -> {
-      journeyBuilder.setModes(input.modes().getRequestModes());
+      journeyBuilder.withModes(input.modes().getRequestModes());
 
       var tModes = input.modes().getTransitModes().stream().map(MainAndSubMode::new).toList();
       if (tModes.isEmpty()) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/request/DebugRequestBuilder.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/request/DebugRequestBuilder.java
@@ -43,13 +43,13 @@ public class DebugRequestBuilder {
     return stops.stream().sorted().collect(Collectors.toList());
   }
 
-  public DebugRequestBuilder addStops(Collection<Integer> stops) {
+  public DebugRequestBuilder withStops(Collection<Integer> stops) {
     this.stops.addAll(stops);
     return this;
   }
 
-  public DebugRequestBuilder addStops(int... stops) {
-    return addStops(Arrays.stream(stops).boxed().collect(Collectors.toList()));
+  public DebugRequestBuilder withStops(int... stops) {
+    return withStops(Arrays.stream(stops).boxed().collect(Collectors.toList()));
   }
 
   /**
@@ -59,7 +59,7 @@ public class DebugRequestBuilder {
     return path;
   }
 
-  public DebugRequestBuilder setPath(List<Integer> stopsInPath) {
+  public DebugRequestBuilder withPath(List<Integer> stopsInPath) {
     if (!path.isEmpty()) {
       throw new IllegalStateException(
         "The API support only one debug path. " + "Existing: " + path + ", new: " + stopsInPath
@@ -77,7 +77,7 @@ public class DebugRequestBuilder {
    * Select the stop index where the debugging should start. It is the index of the stops in the
    * path list.
    */
-  public DebugRequestBuilder debugPathFromStopIndex(int stopIndex) {
+  public DebugRequestBuilder withDebugPathFromStopIndex(int stopIndex) {
     this.debugPathFromStopIndex = stopIndex;
     return this;
   }
@@ -86,7 +86,9 @@ public class DebugRequestBuilder {
     return stopArrivalListener;
   }
 
-  public DebugRequestBuilder stopArrivalListener(Consumer<DebugEvent<ArrivalView<?>>> listener) {
+  public DebugRequestBuilder withStopArrivalListener(
+    Consumer<DebugEvent<ArrivalView<?>>> listener
+  ) {
     this.stopArrivalListener = listener;
     return this;
   }
@@ -95,7 +97,7 @@ public class DebugRequestBuilder {
     return patternRideDebugListener;
   }
 
-  public DebugRequestBuilder patternRideDebugListener(
+  public DebugRequestBuilder withPatternRideDebugListener(
     Consumer<DebugEvent<PatternRideView<?, ?>>> listener
   ) {
     this.patternRideDebugListener = listener;
@@ -106,7 +108,9 @@ public class DebugRequestBuilder {
     return pathFilteringListener;
   }
 
-  public DebugRequestBuilder pathFilteringListener(Consumer<DebugEvent<RaptorPath<?>>> listener) {
+  public DebugRequestBuilder withPathFilteringListener(
+    Consumer<DebugEvent<RaptorPath<?>>> listener
+  ) {
     this.pathFilteringListener = listener;
     return this;
   }
@@ -115,7 +119,7 @@ public class DebugRequestBuilder {
     return logger;
   }
 
-  public DebugRequestBuilder logger(DebugLogger logger) {
+  public DebugRequestBuilder withLogger(DebugLogger logger) {
     this.logger = logger;
     return this;
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/SystemErrDebugLogger.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/SystemErrDebugLogger.java
@@ -67,8 +67,8 @@ public class SystemErrDebugLogger implements DebugLogger {
   }
 
   /**
-   * This should be passed into the {@link DebugRequestBuilder#stopArrivalListener(Consumer)} using
-   * a lambda to enable debugging stop arrivals.
+   * This should be passed into the {@link DebugRequestBuilder#withStopArrivalListener(Consumer)}
+   * using a lambda to enable debugging stop arrivals.
    */
   public void stopArrivalLister(DebugEvent<ArrivalView<?>> e) {
     printIterationHeader(e.iterationStartTime());
@@ -82,7 +82,7 @@ public class SystemErrDebugLogger implements DebugLogger {
   }
 
   /**
-   * This should be passed into the {@link DebugRequestBuilder#patternRideDebugListener(Consumer)}
+   * This should be passed into the {@link DebugRequestBuilder#withPatternRideDebugListener(Consumer)}
    * using a lambda to enable debugging pattern ride events.
    */
   public void patternRideLister(DebugEvent<PatternRideView<?, ?>> e) {
@@ -97,7 +97,7 @@ public class SystemErrDebugLogger implements DebugLogger {
   }
 
   /**
-   * This should be passed into the {@link DebugRequestBuilder#pathFilteringListener(Consumer)}
+   * This should be passed into the {@link DebugRequestBuilder#withPathFilteringListener(Consumer)}
    * using a lambda to enable debugging paths put in the final result pareto-set.
    */
   public void pathFilteringListener(DebugEvent<RaptorPath<?>> e) {

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
@@ -182,15 +182,15 @@ public class TestTransitData
     var debug = request.debug();
 
     if (debug.stops().isEmpty()) {
-      debug.addStops(stopsVisited());
+      debug.withStops(stopsVisited());
     }
     var logger = new SystemErrDebugLogger(true, dryRun);
 
     debug
-      .stopArrivalListener(logger::stopArrivalLister)
-      .patternRideDebugListener(logger::patternRideLister)
-      .pathFilteringListener(logger::pathFilteringListener)
-      .logger(logger);
+      .withStopArrivalListener(logger::stopArrivalLister)
+      .withPatternRideDebugListener(logger::patternRideLister)
+      .withPathFilteringListener(logger::pathFilteringListener)
+      .withLogger(logger);
   }
 
   public TestTransitData withRoute(TestRoute route) {


### PR DESCRIPTION
### Summary

100% pure refactoring of `Bulder setX` to `Builder withX`. This changes all reminding builders to follow the current naming conventions.

### Issue

This was not done for AStarBuilder in #6888, where this issue where raised as part of the review.

### Unit tests

🟥  The code is not changed, except deleting on unused method and renaming builder methods.



### Documentation

🟥  Not relevant

### Changelog

🟥  Not relevant

### Bumping the serialization version id

🟥  Not needed
