### PR TITLE
Improve GBFS v3 station validation

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapperTest.java
@@ -1,0 +1,76 @@
+package org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mobilitydata.gbfs.v3_0.station_information.GBFSName;
+import org.mobilitydata.gbfs.v3_0.station_information.GBFSStation;
+
+class GbfsStationInformationMapperTest {
+
+  private static final String TEST_STATION_ID = "TEST_STATION_ID";
+  private static final String TEST_STATION_NAME = "TEST_STATION_NAME";
+
+  @Test
+  void acceptValidStation() {
+    assertTrue(GbfsStationInformationMapper.isValid(validStation()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidStations")
+  void invalidStationsShouldFail(GBFSStation station, String reason) {
+    assertFalse(GbfsStationInformationMapper.isValid(station), reason);
+  }
+
+  private static GBFSStation validStation() {
+    return new GBFSStation()
+      .withLat(0d)
+      .withLon(0d)
+      .withStationId(TEST_STATION_ID)
+      .withName(List.of(new GBFSName().withText(TEST_STATION_NAME).withLanguage("EN")));
+  }
+
+  private static Stream<Arguments> provideInvalidStations() {
+    return Stream.of(
+      Arguments.of(validStation().withStationId(null), "Missing station ID"),
+      Arguments.of(validStation().withLat(null), "Missing latitude"),
+      Arguments.of(validStation().withLon(null), "Missing longitude"),
+      Arguments.of(validStation().withName(null), "Missing station name list"),
+      Arguments.of(validStation().withName(List.of()), "Empty station name list"),
+      Arguments.of(
+        validStation()
+          .withName(
+            List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withText(null))
+          ),
+        "Station name list contains null name"
+      ),
+      Arguments.of(
+        validStation()
+          .withName(
+            List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withText(""))
+          ),
+        "Station name list contains empty name"
+      ),
+      Arguments.of(
+        validStation()
+          .withName(
+            List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withLanguage(null))
+          ),
+        "Station name list contains null language"
+      ),
+      Arguments.of(
+        validStation()
+          .withName(
+            List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withLanguage(""))
+          ),
+        "Station name list contains empty language"
+      )
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapperTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -24,8 +25,8 @@ class GbfsStationInformationMapperTest {
 
   @ParameterizedTest
   @MethodSource("provideInvalidStations")
-  void invalidStationsShouldFail(GBFSStation station, String reason) {
-    assertFalse(GbfsStationInformationMapper.isValid(station), reason);
+  void invalidStationsShouldFail(GBFSStation station) {
+    assertFalse(GbfsStationInformationMapper.isValid(station));
   }
 
   private static GBFSStation validStation() {
@@ -38,38 +39,38 @@ class GbfsStationInformationMapperTest {
 
   private static Stream<Arguments> provideInvalidStations() {
     return Stream.of(
-      Arguments.of(validStation().withStationId(null), "Missing station ID"),
-      Arguments.of(validStation().withLat(null), "Missing latitude"),
-      Arguments.of(validStation().withLon(null), "Missing longitude"),
-      Arguments.of(validStation().withName(null), "Missing station name list"),
-      Arguments.of(validStation().withName(List.of()), "Empty station name list"),
-      Arguments.of(
+      argumentSet("Missing station ID", validStation().withStationId(null)),
+      argumentSet("Missing latitude", validStation().withLat(null)),
+      argumentSet("Missing longitude", validStation().withLon(null)),
+      argumentSet("Missing station name list", validStation().withName(null)),
+      argumentSet("Empty station name list", validStation().withName(List.of())),
+      argumentSet(
+        "Station name list contains null name",
         validStation()
           .withName(
             List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withText(null))
-          ),
-        "Station name list contains null name"
+          )
       ),
-      Arguments.of(
+      argumentSet(
+        "Station name list contains empty name",
         validStation()
           .withName(
             List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withText(""))
-          ),
-        "Station name list contains empty name"
+          )
       ),
-      Arguments.of(
+      argumentSet(
+        "Station name list contains null language",
         validStation()
           .withName(
             List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withLanguage(null))
-          ),
-        "Station name list contains null language"
+          )
       ),
-      Arguments.of(
+      argumentSet(
+        "Station name list contains empty language",
         validStation()
           .withName(
             List.of(new GBFSName().withText(TEST_STATION_NAME), new GBFSName().withLanguage(""))
-          ),
-        "Station name list contains empty language"
+          )
       )
     );
   }

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationInformationMapper.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.Gbf
 import static org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsFeedMapper.optionalLocalizedString;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.mobilitydata.gbfs.v3_0.station_information.*;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -11,6 +12,7 @@ import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStationUris;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalSystem;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.utils.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,14 +38,7 @@ class GbfsStationInformationMapper {
   }
 
   public VehicleRentalStation mapStationInformation(GBFSStation station) {
-    if (
-      station.getStationId() == null ||
-      station.getStationId().isBlank() ||
-      station.getName() == null ||
-      station.getName().isEmpty() ||
-      station.getLon() == null ||
-      station.getLat() == null
-    ) {
+    if (!isValid(station)) {
       LOG.debug(
         "GBFS station for {} system has issues with required fields: \n{}",
         system.systemId(),
@@ -103,5 +98,25 @@ class GbfsStationInformationMapper {
     }
 
     return builder.build();
+  }
+
+  /**
+   * Return true if the station is valid.
+   */
+  static boolean isValid(GBFSStation station) {
+    return (
+      station.getStationId() != null &&
+      !station.getStationId().isBlank() &&
+      station.getName() != null &&
+      !station.getName().isEmpty() &&
+      station.getName().stream().allMatch(Objects::nonNull) &&
+      station.getName().stream().allMatch(gbfsName -> StringUtils.hasValue(gbfsName.getText())) &&
+      station
+        .getName()
+        .stream()
+        .allMatch(gbfsName -> StringUtils.hasValue(gbfsName.getLanguage())) &&
+      station.getLon() != null &&
+      station.getLat() != null
+    );
   }
 }


### PR DESCRIPTION
### Summary

We experience exceptions when parsing GBFS v3 stations:

```
Error while running polling updater VehicleRentalUpdater{source: org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsVehicleRentalDataSource@64912c72}
java.lang.IllegalArgumentException: Empty localized field
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsFeedMapper.localizedString(GbfsFeedMapper.java:185)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsStationInformationMapper.mapStationInformation(GbfsStationInformationMapper.java:59)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsFeedMapper.getUpdates(GbfsFeedMapper.java:92)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsFeedLoaderAndMapper.getUpdated(GbfsFeedLoaderAndMapper.java:107)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsVehicleRentalDataSource.getUpdates(GbfsVehicleRentalDataSource.java:47)
	at org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater.runPolling(VehicleRentalUpdater.java:125)
	at org.opentripplanner.updater.spi.PollingGraphUpdater.run(PollingGraphUpdater.java:74)
	at org.opentripplanner.updater.GraphUpdaterManager.lambda$startUpdaters$0(GraphUpdaterManager.java:100)
```

The root cause is a lack of validation of the list of names for a given station. These names should be neither null nor blank.

This PR improves the validation of GBFS v3 stations.

### Issue

No

### Unit tests

Added unit tests

### Documentation

No

### Changelog

skip changelog
