### PR TITLE
style: add null-safety guards to AccessPathLeg, TransferPathLeg, and EgressPathLeg for consistency

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/api/path/AccessPathLeg.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/path/AccessPathLeg.java
@@ -25,11 +25,11 @@ public final class AccessPathLeg<T extends RaptorTripSchedule> implements PathLe
     int c1,
     PathLeg<T> next
   ) {
-    this.access = access;
+    this.access = Objects.requireNonNull(access);
     this.fromTime = fromTime;
     this.toTime = toTime;
     this.c1 = c1;
-    this.next = next;
+    this.next = Objects.requireNonNull(next);
   }
 
   @Override

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/path/EgressPathLeg.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/path/EgressPathLeg.java
@@ -5,8 +5,8 @@ import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 
 /**
- * Represent a egress leg in a path. The egress leg is the last leg arriving at the destination. The
- * previous leg must be a transit leg - no other legs are allowed.
+ * Represent an egress leg in a path. The egress leg is the last leg arriving at the destination.
+ * The previous leg must be a transit leg - no other legs are allowed.
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
@@ -18,7 +18,7 @@ public final class EgressPathLeg<T extends RaptorTripSchedule> implements PathLe
   private final int c1;
 
   public EgressPathLeg(RaptorAccessEgress egress, int fromTime, int toTime, int c1) {
-    this.egress = egress;
+    this.egress = Objects.requireNonNull(egress);
     this.fromTime = fromTime;
     this.toTime = toTime;
     this.c1 = c1;
@@ -30,7 +30,7 @@ public final class EgressPathLeg<T extends RaptorTripSchedule> implements PathLe
   }
 
   /**
-   * The stop index where the leg start, also called the leg departure stop index.
+   * The stop index where the leg starts, also called the leg departure stop index.
    */
   @Override
   public int fromStop() {
@@ -58,7 +58,7 @@ public final class EgressPathLeg<T extends RaptorTripSchedule> implements PathLe
    */
   @Override
   public TransitPathLeg<T> nextLeg() {
-    throw new java.lang.UnsupportedOperationException(
+    throw new UnsupportedOperationException(
       "The egress leg is the last leg in a path. Use isEgressLeg() to identify last leg."
     );
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/path/TransferPathLeg.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/path/TransferPathLeg.java
@@ -29,11 +29,11 @@ public final class TransferPathLeg<T extends RaptorTripSchedule> implements Path
   ) {
     this.fromStop = fromStop;
     this.fromTime = fromTime;
-    this.toStop = transfer.stop();
+    this.toStop = Objects.requireNonNull(transfer).stop();
     this.toTime = toTime;
     this.c1 = c1;
     this.transfer = transfer;
-    this.next = next;
+    this.next = Objects.requireNonNull(next);
   }
 
   public RaptorTransfer transfer() {


### PR DESCRIPTION
**Summary**
Adds Objects.requireNonNull() to constructors in the three Raptor path leg classes — AccessPathLeg, TransferPathLeg, and EgressPathLeg. These are small internal safety improvements for consistency and clarity across the Raptor path hierarchy.

**Issue**
No issue required, this is a small internal code-quality cleanup.

**Motivation**
- Makes sure critical constructor arguments (access, transfer, egress, next) are never null.
- Aligns style and defensive programming with other OTP/Raptor classes
- No change to logic, behavior, or API.

**Technical approach**
- Added Objects.requireNonNull() for required parameters.
- Verified successful compilation and all tests passing with mvn -DskipITs test.
- No new configuration or serialization changes.

**Unit tests**
- No new unit tests were needed since no functionalities were changed.
- Existing test suite passes in full with >> mvn -DskipITs test

**Documentation**
- Code is self-documenting, change is trivial (null-safety only).
- No changes required to external docs or configuration tables.

**Changelog**

- This is an internal code-quality change and does not affect runtime behavior.
_- Label the PR with +Skip Changelog._

**Final checklist**
- [X]  Builds and tests pass locally
- [X]  No functional or API changes
- [X]  Follows OTP cont. guidelines
- [X]  Includes label +Skip Changelog