### PR TITLE
fix: show head sign from fromEstimatedCall rather than toEstimatedCall

### DIFF
--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -13,7 +13,7 @@ import { Leg } from '../../static/query/tripQueryTypes';
  */
 function legName(leg: Leg): string {
   if (leg.line?.publicCode) {
-    return leg.line.publicCode + ' ' + leg.toEstimatedCall?.destinationDisplay?.frontText;
+    return leg.line.publicCode + ' ' + leg.fromEstimatedCall?.destinationDisplay?.frontText;
   } else {
     return leg.line?.name || 'unknown';
   }

--- a/client/src/static/query/selector.fragment.graphql
+++ b/client/src/static/query/selector.fragment.graphql
@@ -32,7 +32,7 @@
                     id
                 }
             }
-            toEstimatedCall {
+            fromEstimatedCall {
                 destinationDisplay {
                     frontText
                 }


### PR DESCRIPTION
### Summary

@jessicaKoehnke rightly pointed out that the debug ui incorrectly shows the head sign (or destination display) from the `toEstimatedCall` instead of `fromEstimatedCall` which would be the appropriate field to pick this from, since this is what is visible when you *board* the trip.

### Issue

Fixes #6942