### PR TITLE
fixed arriveBy bug for midnight-crossing trips arriving after lastArrivalTime

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.algorithm.mapping;
 import static org.opentripplanner.raptor.api.model.RaptorCostConverter.toOtpDomainCost;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -171,7 +172,41 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
       builder.withGeneralizedCost2(path.c2());
     }
 
-    return builder.build();
+    Itinerary itinerary = builder.build();
+
+    // WORKAROUND for midnight-crossing trips: Filter out itineraries where the actual
+    // arrival time exceeds the cutoff time in arriveBy searches.
+    // This handles cases where time-shifting in Raptor causes trips crossing midnight
+    // to appear with shifted times (e.g., 03:39 -> 01:46).
+    // We need to check the real arrival time from the last transit leg, not the
+    // itinerary endTime which has been time-shifted.
+    if (request.arriveBy()) {
+      Instant cutoffInstant = request.dateTime();
+
+      Leg lastTransitLeg = null;
+      for (int i = legs.size() - 1; i >= 0; i--) {
+        if (legs.get(i).isScheduledTransitLeg()) {
+          lastTransitLeg = legs.get(i);
+          break;
+        }
+      }
+
+      if (lastTransitLeg != null && lastTransitLeg.isScheduledTransitLeg()) {
+        var lastScheduledTransitLeg = lastTransitLeg.asScheduledTransitLeg();
+        var tripTimes = lastScheduledTransitLeg.tripTimes();
+
+        if (tripTimes != null) {
+          int alightStopPos = lastScheduledTransitLeg.alightStopPosInPattern();
+          int actualArrivalSeconds = tripTimes.getArrivalTime(alightStopPos);
+          Instant serviceDateMidnight = lastScheduledTransitLeg.serviceDateMidnight();
+          Instant actualArrivalInstant = serviceDateMidnight.plusSeconds(actualArrivalSeconds);
+          if (actualArrivalInstant.isAfter(cutoffInstant)) {
+            return null;
+          }
+        }
+      }
+    }
+    return itinerary;
   }
 
   private static <T extends TripSchedule> boolean isPathTransferAtSameStop(

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -191,7 +191,11 @@ public class TransitRouter {
       request
     );
 
-    List<Itinerary> itineraries = paths.stream().map(itineraryMapper::createItinerary).toList();
+    List<Itinerary> itineraries = paths
+      .stream()
+      .map(itineraryMapper::createItinerary)
+      .filter(java.util.Objects::nonNull)
+      .toList();
 
     debugTimingAggregator.finishedItineraryCreation();
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/ArriveByMapperSupport.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/ArriveByMapperSupport.java
@@ -1,0 +1,108 @@
+package org.opentripplanner.routing.algorithm.mapping;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZonedDateTime;
+import org.opentripplanner._support.time.ZoneIds;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitData;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TimetableRepository;
+
+public class ArriveByMapperSupport {
+
+  public static final LocalDate SUNDAY = LocalDate.of(2025, 10, 5);
+  public static final LocalDate MONDAY = LocalDate.of(2025, 10, 6);
+
+  // Midnight crossing times from Sunday service day start 00:00 CEST Sunday, = 22:00 UTC Saturday
+  public static final int AFTER_MIDNIGHT_DEPART = 95700; // 26.58h = Monday 00:35 UTC
+  public static final int AFTER_CUTOFF_ARRIVE = 99540; // 27.65h = Monday 01:39 UTC (filtered out)
+
+  // Normal daytime times
+  public static final int BEFORE_CUTOFF_DEPART = 54000; // 13:00 UTC
+  public static final int BEFORE_CUTOFF_ARRIVE = 55800; // 13:30 UTC (not filtered)
+
+  // Edge case: arrival exactly at cutoff time
+  public static final int AT_CUTOFF_ARRIVE = 57600; // 14:00 UTC (not filtered)
+
+  public static final GenericLocation FROM = GenericLocation.fromCoordinate(60.0, 10.0);
+  public static final GenericLocation TO = GenericLocation.fromCoordinate(59.0, 12.0);
+
+  public static <T extends TripSchedule> RaptorPathToItineraryMapper<
+    T
+  > createMidnightDepartByMapper(Instant departTime, RaptorTransitData transitData) {
+    var serviceDate = LocalDateTime.of(2025, Month.OCTOBER, 5, 0, 0);
+    var transitSearchTimeZero = serviceDate.plusDays(1).atZone(ZoneIds.STOCKHOLM);
+    return createMapper(transitSearchTimeZero, departTime, false, transitData);
+  }
+
+  public static <T extends TripSchedule> RaptorPathToItineraryMapper<
+    T
+  > createMidnightArriveByMapper(Instant cutoffTime, RaptorTransitData transitData) {
+    var serviceDate = LocalDateTime.of(2025, Month.OCTOBER, 5, 0, 0);
+    var transitSearchTimeZero = serviceDate.plusDays(1).atZone(ZoneIds.STOCKHOLM);
+    return createMapper(transitSearchTimeZero, cutoffTime, true, transitData);
+  }
+
+  /**
+   * Creates a mapper configured for the given search direction (arriveBy or departBy) with the specified scenario.
+   */
+  public static <T extends TripSchedule> RaptorPathToItineraryMapper<T> createMapper(
+    ZonedDateTime transitSearchTimeZero,
+    Instant time,
+    boolean arriveBy,
+    RaptorTransitData transitData
+  ) {
+    var request = RouteRequest.of()
+      .withFrom(FROM)
+      .withTo(TO)
+      .withDateTime(time)
+      .withArriveBy(arriveBy)
+      .buildRequest();
+
+    var timeTableRepository = new TimetableRepository();
+    timeTableRepository.initTimeZone(ZoneIds.STOCKHOLM);
+    timeTableRepository.index();
+
+    return new RaptorPathToItineraryMapper<>(
+      new Graph(),
+      new DefaultTransitService(timeTableRepository),
+      transitData,
+      transitSearchTimeZero,
+      request
+    );
+  }
+
+  public static String formatTimeString(int... seconds) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < seconds.length; i++) {
+      if (i > 0) result.append(" ");
+      result.append(
+        String.format(
+          "%02d:%02d:%02d",
+          seconds[i] / 3600,
+          (seconds[i] % 3600) / 60,
+          seconds[i] % 60
+        )
+      );
+    }
+    return result.toString();
+  }
+
+  /**
+   * Creates a mapper configured for arriveBy search with normal daytime scenario.
+   */
+  public static <T extends TripSchedule> RaptorPathToItineraryMapper<T> createDaytimeArriveByMapper(
+    Instant cutoffTime,
+    RaptorTransitData transitData
+  ) {
+    var serviceDate = LocalDateTime.of(2025, Month.OCTOBER, 6, 0, 0);
+    var transitSearchTimeZero = serviceDate.atZone(ZoneIds.STOCKHOLM);
+    return createMapper(transitSearchTimeZero, cutoffTime, true, transitData);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
@@ -4,11 +4,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.raptorlegacy._data.RaptorTestConstants.BOARD_SLACK;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.ArrayList;
@@ -65,6 +67,8 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
+import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.booking.RoutingBookingInfo;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TimetableRepository;
@@ -359,5 +363,252 @@ public class RaptorPathToItineraryMapperTest {
     data.withRoutes(TestRoute.route("TestRoute_1", 1, 2).withTimetable(timetable));
 
     return data.getRoute(0).getTripSchedule(0);
+  }
+
+  /**
+   * Test filtering of midnight crossing service days for trips arriving after the arriveBy cutoff. Verifies that
+   * trips arriving after the cutoff are filtered out, even when Raptor's time-shifting makes them appear to arrive
+   * before the cutoff.
+   */
+  @Test
+  void testNoTripsAfterArriveBy() {
+    // Service date Sunday 2025-10-05 00:00 CEST (Saturday 22:00 UTC)
+    // Trip departs Monday 00:35 UTC - 95700s from service date
+    // Trip arrives Monday 01:39 UTC - 99540s from service date
+    // ArriveBy search Monday 00:01 UTC
+    // Raptor shows arrival at  Sunday 23:46 UTC due to time shifting
+    // Expected: Trip should be filtered out because the actual arrival is 01:39 UTC
+    var cutoffTime = Instant.parse("2025-10-06T00:01:00Z");
+    var schedule = getScheduleArrivingAfterCutoff();
+
+    RaptorPathToItineraryMapper<TestTripSchedule> mapper =
+      ArriveByMapperSupport.createMidnightArriveByMapper(cutoffTime, getRaptorTransitData());
+
+    // Create a path that Raptor would return (with the time-shifted  values)
+    // Raptor's time shifted values appear to arrive at 6360s = 01:46 local time (which is before cutoff)
+    RaptorPath<TestTripSchedule> path = new TestPathBuilder(COST_CALCULATOR)
+      .access(5640, 1)
+      .bus(schedule, 2)
+      .egress(TestAccessEgress.free(2, 0));
+
+    // Map to itinerary which should return null due to filtering
+    var itinerary = mapper.createItinerary(path);
+
+    // Assert that the itinerary is filtered out (null) because actual arrival time 99540s
+    // from service date is 01:39 UTC which is after 00:01 UTC
+    assertNull(itinerary, "Midnight crossing trip arriving after cutoff should be filtered out");
+  }
+
+  /**
+   * Schedule for times after midnight
+   *
+   * @return
+   */
+  private TestTripSchedule getScheduleArrivingAfterCutoff() {
+    TestTransitData data = new TestTransitData();
+    var pattern = TestTripPattern.pattern("NightTrain", 1, 2).withRoute(ROUTE);
+    var timetable = new TestTripSchedule.Builder()
+      .times(
+        // from Sunday 00:00 CEST 95700s = 26:35:00 = Monday 02:35 CEST (00:35 UTC)
+        ArriveByMapperSupport.AFTER_MIDNIGHT_DEPART,
+        // from Sunday 00:00 CEST 99540s = 27:39:00 = Monday 03:39 CEST (01:39 UTC)
+        ArriveByMapperSupport.AFTER_CUTOFF_ARRIVE
+      )
+      .pattern(pattern)
+      .originalPattern(getOriginalPattern(pattern))
+      .build();
+    data.withRoutes(TestRoute.route("NightRoute", 1, 2).withTimetable(timetable));
+    var schedule = data.getRoute(0).getTripSchedule(0);
+
+    return wrapWithTripTimes(
+      schedule,
+      ArriveByMapperSupport.SUNDAY,
+      ArriveByMapperSupport.AFTER_MIDNIGHT_DEPART,
+      ArriveByMapperSupport.AFTER_CUTOFF_ARRIVE
+    );
+  }
+
+  private TestTripSchedule wrapWithTripTimes(
+    TestTripSchedule schedule,
+    LocalDate serviceDate,
+    int... times
+  ) {
+    var trip = TEST_MODEL.trip("TestTrip").withRoute(ROUTE).build();
+    var timeString = ArriveByMapperSupport.formatTimeString(times);
+    var tripTimes = ScheduledTripTimes.of()
+      .withTrip(trip)
+      .withArrivalTimes(timeString)
+      .withDepartureTimes(timeString)
+      .build();
+    return new TestTripScheduleWithTripTimes(schedule, tripTimes, serviceDate);
+  }
+
+  /**
+   * Wrapper class that delegates to TestTripSchedule but provides real TripTimes
+   */
+  private static class TestTripScheduleWithTripTimes extends TestTripSchedule {
+
+    private final TripTimes tripTimes;
+    LocalDate serviceDate;
+
+    TestTripScheduleWithTripTimes(
+      TestTripSchedule delegate,
+      TripTimes tripTimes,
+      LocalDate serviceDate
+    ) {
+      super(
+        (TestTripPattern) delegate.pattern(),
+        extractArrivalTimes(delegate),
+        extractDepartureTimes(delegate),
+        delegate.transitReluctanceFactorIndex(),
+        delegate.wheelchairBoarding(),
+        delegate.getOriginalTripPattern()
+      );
+      this.tripTimes = tripTimes;
+      this.serviceDate = serviceDate;
+    }
+
+    @Override
+    public TripTimes getOriginalTripTimes() {
+      return tripTimes;
+    }
+
+    @Override
+    public LocalDate getServiceDate() {
+      return serviceDate;
+    }
+
+    private static int[] extractArrivalTimes(TestTripSchedule delegate) {
+      int stops = delegate.pattern().numberOfStopsInPattern();
+      int[] times = new int[stops];
+      for (int i = 0; i < stops; i++) {
+        times[i] = delegate.arrival(i);
+      }
+      return times;
+    }
+
+    private static int[] extractDepartureTimes(TestTripSchedule delegate) {
+      int stops = delegate.pattern().numberOfStopsInPattern();
+      int[] times = new int[stops];
+      for (int i = 0; i < stops; i++) {
+        times[i] = delegate.departure(i);
+      }
+      return times;
+    }
+  }
+
+  /**
+   * Test that normal arriveBy searches (not crossing midnight) still work correctly. Trips arriving before the cutoff
+   * should NOT be filtered.
+   */
+  @Test
+  void testAllowsTripsBeforeArriveBy() {
+    // Cutoff: Monday 14:00 UTC
+    var cutoffTime = Instant.parse("2025-10-06T14:00:00Z");
+    var schedule = getNormalDaytimeSchedule();
+    RaptorPathToItineraryMapper<TestTripSchedule> mapper =
+      ArriveByMapperSupport.createDaytimeArriveByMapper(cutoffTime, getRaptorTransitData());
+    RaptorPath<TestTripSchedule> path = new TestPathBuilder(COST_CALCULATOR)
+      .access(ArriveByMapperSupport.BEFORE_CUTOFF_DEPART - BOARD_SLACK, 1)
+      .bus(schedule, 2)
+      .egress(TestAccessEgress.free(2, 0));
+    var itinerary = mapper.createItinerary(path);
+
+    // Assert: Normal trip arriving before cutoff should NOT be filtered
+    assertNotNull(itinerary, "Trip arriving before cutoff should not be filtered");
+    assertEquals(
+      Instant.parse("2025-10-06T13:30:00Z"),
+      itinerary.endTime().toInstant(),
+      "Arrival time should be 13:30 UTC"
+    );
+  }
+
+  private TestTripSchedule getNormalDaytimeSchedule() {
+    TestTransitData data = new TestTransitData();
+    var pattern = TestTripPattern.pattern("DayTrain", 1, 2).withRoute(ROUTE);
+
+    var timetable = new TestTripSchedule.Builder()
+      .times(ArriveByMapperSupport.BEFORE_CUTOFF_DEPART, ArriveByMapperSupport.BEFORE_CUTOFF_ARRIVE)
+      .pattern(pattern)
+      .originalPattern(getOriginalPattern(pattern))
+      .build();
+
+    data.withRoutes(TestRoute.route("DayRoute", 1, 2).withTimetable(timetable));
+    var schedule = data.getRoute(0).getTripSchedule(0);
+
+    return wrapWithTripTimes(
+      schedule,
+      ArriveByMapperSupport.MONDAY,
+      +ArriveByMapperSupport.BEFORE_CUTOFF_DEPART,
+      +ArriveByMapperSupport.BEFORE_CUTOFF_ARRIVE
+    );
+  }
+
+  /**
+   * Test that departBy searches are not affected by the filtering. The filter should only apply to arriveBy
+   * searches.
+   */
+  @Test
+  void testDepartByIsNotAffectedByFiltering() {
+    var departTime = Instant.parse("2025-10-06T00:01:00+02:00");
+    var schedule = getScheduleArrivingAfterCutoff();
+    RaptorPathToItineraryMapper<TestTripSchedule> mapper =
+      ArriveByMapperSupport.createMidnightDepartByMapper(departTime, getRaptorTransitData());
+
+    RaptorPath<TestTripSchedule> path = new TestPathBuilder(COST_CALCULATOR)
+      .access(ArriveByMapperSupport.AFTER_MIDNIGHT_DEPART - BOARD_SLACK, 1)
+      .bus(schedule, 2)
+      .egress(TestAccessEgress.free(2, 0));
+
+    var itinerary = mapper.createItinerary(path);
+
+    // Assert: departBy searches should not filter trips
+    assertNotNull(itinerary, "departBy searches should not filter trips");
+  }
+
+  /**
+   * Test edge case: Trip arriving exactly at cutoff time. Should NOT be filtered (we only filter trips arriving AFTER
+   * cutoff).
+   */
+  @Test
+  void testAllowsTripsAtArriveBy() {
+    var cutoffTime = Instant.parse("2025-10-06T14:00:00Z");
+    var schedule = getExactCutoffSchedule();
+    RaptorPathToItineraryMapper<TestTripSchedule> mapper =
+      ArriveByMapperSupport.createDaytimeArriveByMapper(cutoffTime, getRaptorTransitData());
+
+    RaptorPath<TestTripSchedule> path = new TestPathBuilder(COST_CALCULATOR)
+      .access(ArriveByMapperSupport.BEFORE_CUTOFF_DEPART - BOARD_SLACK, 1)
+      .bus(schedule, 2)
+      .egress(TestAccessEgress.free(2, 0));
+
+    var itinerary = mapper.createItinerary(path);
+
+    // Assert: Trip arriving exactly at cutoff should be allowed
+    assertNotNull(
+      itinerary,
+      "Trip arriving exactly at cutoff should not be filtered (only AFTER cutoff is filtered)"
+    );
+  }
+
+  private TestTripSchedule getExactCutoffSchedule() {
+    TestTransitData data = new TestTransitData();
+    var pattern = TestTripPattern.pattern("ExactTrain", 1, 2).withRoute(ROUTE);
+
+    var timetable = new TestTripSchedule.Builder()
+      .times(ArriveByMapperSupport.BEFORE_CUTOFF_DEPART, ArriveByMapperSupport.AT_CUTOFF_ARRIVE)
+      .pattern(pattern)
+      .originalPattern(getOriginalPattern(pattern))
+      .build();
+
+    data.withRoutes(TestRoute.route("ExactRoute", 1, 2).withTimetable(timetable));
+    var schedule = data.getRoute(0).getTripSchedule(0);
+
+    return wrapWithTripTimes(
+      schedule,
+      ArriveByMapperSupport.MONDAY,
+      ArriveByMapperSupport.BEFORE_CUTOFF_DEPART,
+      ArriveByMapperSupport.AT_CUTOFF_ARRIVE
+    );
   }
 }


### PR DESCRIPTION
This PR fixes a bug where midnight-crossing trips are incorrectly included in arriveBy search results even when they arrive after the specified cutoff time. The issue is that the arrival time used for filtering differs from the actual arrival time calculated from the trip's service date and scheduled arrival seconds.

##  Issue

Closes #6962

In arriveBy searches, midnight-crossing trips (trips with service dates from the previous day but scheduled times > 24 hours) are incorrectly included in results even when they arrive after the user's specified arrival time.

##  Example

  A trip with:
  - Service date: Sunday
  - Scheduled arrival: 27:39:00 from service date start (= Monday 03:39 CEST / 01:39 UTC)
  - User's arriveBy cutoff: Monday 00:01 UTC

  Without this fix, the trip is incorrectly included in results even though it arrives at 01:39 UTC, which is after the 00:01 UTC cutoff.

##  Additions

  - Added filtering logic in RaptorPathToItineraryMapper that calculates actual arrival times using the trip's service date and scheduled arrival seconds, filtering out trips that arrive after the cutoff in arriveBy searches
  - Added unit tests covering the bug scenario, normal trips, departBy searches, and edge cases
  - Added ArriveByMapperSupport test helper class with common test data and factory methods

##  Removals

  None

##  Unit tests

  Added 4 unit tests in RaptorPathToItineraryMapperTest:

  1. testNoTripsAfterArriveBy() - Verifies midnight-crossing trips arriving after cutoff are filtered
  2. testAllowsTripsBeforeArriveBy() - Ensures normal trips before cutoff still work
  3. testDepartByIsNotAffectedByFiltering() - Confirms departBy searches are unaffected
  4. testAllowsTripsAtArriveBy() - Tests edge case of trips arriving exactly at cutoff

  All tests use real TripTimes objects for accurate service date/time calculations.

 ## Documentation

  Code includes detailed inline documentation explaining the workaround and the issue it addresses.

 ## Changelog

  Fixed bug where midnight-crossing trips incorrectly appeared in arriveBy search results when they actually arrived after the specified cutoff time.

##  Performance impact

  Minimal - the fix only adds a simple time comparison for arriveBy searches with transit legs. The loop to find the last transit leg is O(n) where n is a small number of legs.

##  Complexity

  The workaround is straightforward and localized. It calculates the actual arrival time from the trip's original data rather than relying on the potentially incorrect itinerary end time.

##  Reproducibility

   The bug can be reproduced with the following GraphQL query:
```
  {
    trip(
      from: { coordinates: { latitude: 55.609224, longitude: 13.000547 } }
      to: { coordinates: { latitude: 55.708507, longitude: 13.191408 } }
      dateTime: "2025-10-13T00:01:00Z"
      arriveBy: true
      numTripPatterns: 5
    ) {
      tripPatterns {
        legs {
          mode
          aimedEndTime
          serviceDate
          toPlace { name }
          serviceJourney { id }
        }
      }
    }
  }
```
  Without the fix: Returns ServiceJourney ST:SE:276:ServiceJourney:1120000357544809 with:
  - Displayed arrival: 01:46 CEST (23:46 UTC) - appears to be before the cutoff
  - Actual arrival for that stop ID: 03:39 CEST (01:39 UTC) - actually after the 00:01 UTC cutoff
  The trip is incorrectly included because it appears to arrive before the cutoff, when it actually arrives 1h 38min after.

 With the fix: This trip is correctly filtered out.