### PR TITLE
Support for ETag and If-Not-Modified in GBFS updater

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/io/OtpHttpResponse.java
+++ b/application/src/main/java/org/opentripplanner/framework/io/OtpHttpResponse.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpStatus;
 
 /**
  * Represents an HTTP response containing the body content, headers and status code.
@@ -96,6 +97,20 @@ public class OtpHttpResponse {
    */
   public int statusCode() {
     return statusCode;
+  }
+
+  /**
+   * Returns true if status code is 304 (Not Modified)
+   */
+  public boolean statusNotModified() {
+    return statusCode == HttpStatus.SC_NOT_MODIFIED;
+  }
+
+  /**
+   * Returns true if status code is 200 (OK)
+   */
+  public boolean statusOk() {
+    return statusCode == HttpStatus.SC_OK;
   }
 
   /**


### PR DESCRIPTION
### Summary

This PR adds support for keeping ETag header values from GBFS datasource responses, and passing them to subsequent requests, in order for the server to respond with 304 Not Modified when the content hasn't changed.

If the responses don't have an ETag header, there is no change in behavior.

### Issue

Closes #6927 

### Unit tests

All existing tests pass. No additional tests added as changes are mostly based around the http client. The ETag/if-not-modified behavior has been manually tested against Entur's gbfs aggregator.
