### PR TITLE
Fix expected arrival and departure time documentation in TransModel API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
@@ -79,7 +79,7 @@ public class EstimatedCallType {
           .name("expectedArrivalTime")
           .type(new GraphQLNonNull(dateTimeScalar))
           .description(
-            "Expected time of arrival at quay. Updated with real time information if available. Will be null if an actualArrivalTime exists"
+            "Expected time of arrival at quay. Updated with real time information if available."
           )
           .dataFetcher(environment -> {
             TripTimeOnDate tripTimeOnDate = environment.getSource();
@@ -125,7 +125,7 @@ public class EstimatedCallType {
           .name("expectedDepartureTime")
           .type(new GraphQLNonNull(dateTimeScalar))
           .description(
-            "Expected time of departure from quay. Updated with real time information if available. Will be null if an actualDepartureTime exists"
+            "Expected time of departure from quay. Updated with real time information if available."
           )
           .dataFetcher(environment -> {
             TripTimeOnDate tripTimeOnDate = environment.getSource();

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -244,9 +244,9 @@ type EstimatedCall {
   destinationDisplay: DestinationDisplay
   "The typical delay for this trip on this day for this stop based on historical data."
   empiricalDelay: EmpiricalDelay
-  "Expected time of arrival at quay. Updated with real time information if available. Will be null if an actualArrivalTime exists"
+  "Expected time of arrival at quay. Updated with real time information if available."
   expectedArrivalTime: DateTime!
-  "Expected time of departure from quay. Updated with real time information if available. Will be null if an actualDepartureTime exists"
+  "Expected time of departure from quay. Updated with real time information if available."
   expectedDepartureTime: DateTime!
   "Whether vehicle may be alighted at quay."
   forAlighting: Boolean!


### PR DESCRIPTION
### Summary

The documentation for the `EstimatedCall` fields `expectedArrivalTime` and `expectedDepartureTime` is incorrect: both fields are not nullable.

### Issue

No

### Unit tests
No

### Documentation

Updated documentation

### Changelog

skip