### PR TITLE
Update leg identifier documentation for clarity and usage recommendations

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/LegType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/LegType.java
@@ -67,7 +67,11 @@ public class LegType {
         GraphQLFieldDefinition.newFieldDefinition()
           .name("id")
           .description(
-            "An identifier for the leg, which can be used to re-fetch transit leg information."
+            """
+            An identifier for the leg, which can be used to re-fetch transit leg information. The
+            identifier is valid for a maximum of 2 years, but sometimes it will fail after a few hours.
+            We do not recommend storing IDs for a long time.
+            """
           )
           .type(Scalars.GraphQLID)
           .dataFetcher(env -> LegReferenceSerializer.encode(leg(env).legReference()))

--- a/application/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
@@ -6,9 +6,15 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Optional;
 
-/**
- * Enum for different types of LegReferences
- */
+///
+/// Enum for different types and versions of LegReferences.
+///
+/// **NOTE!** Keep each [LegReferenceType] for at least 2 years after replacing it with a new
+/// version. Customers can store leg references in tickets, and we want tickets to remain valid for
+/// a year. If a customer buys the ticket 6 months before travel, this adds up to 18 months. We do
+/// _not_ recommend using leg references in tickets. Instead, use actual entity IDs like TripOnDate
+/// or (Trip + service-date), from and to stop IDs, and position.
+///
 enum LegReferenceType {
   SCHEDULED_TRANSIT_LEG_V3(
     3,

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -784,6 +784,9 @@ type Leg {
   Re-fetching fails when the underlying transit data no longer exists.
   **Note:** when both id and fare products are queried with [Relay](https://relay.dev/), id should be queried using a suitable GraphQL alias
   such as `legId: id`. Relay does not accept different fare product ids in otherwise identical legs.
+  
+  The identifier is valid for a maximum of 2 years, but sometimes it will fail after a few hours.
+  We do not recommend storing IDs for a long time.
   """
   id: String
   """

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -356,7 +356,11 @@ type Leg {
   fromPlace: Place!
   "Generalized cost or weight of the leg. Used for debugging."
   generalizedCost: Int
-  "An identifier for the leg, which can be used to re-fetch transit leg information."
+  """
+  An identifier for the leg, which can be used to re-fetch transit leg information. The
+  identifier is valid for a maximum of 2 years, but sometimes it will fail after a few hours.
+  We do not recommend storing IDs for a long time.
+  """
   id: ID
   interchangeFrom: Interchange
   interchangeTo: Interchange


### PR DESCRIPTION
### Summary

Improves documentation for leg identifiers (leg references) across both GraphQL APIs and internal code to clarify their lifecycle and usage recommendations.

**Important**
- Documents internal policy to keep LegReferenceType versions for at least 2 years after replacement.
  

### Issue

🟥 No issue for this. This is just updating the documentation.


### Unit tests

🟥  No code changed.


### Documentation

✅ Improved

### Changelog

🟥  Not relevant

### Bumping the serialization version id

🟥  No code changed