### PR TITLE
Fix NPE with unknown GBFS vehicle types

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/support/UnknownVehicleTypeFilter.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/support/UnknownVehicleTypeFilter.java
@@ -1,0 +1,42 @@
+package org.opentripplanner.updater.vehicle_rental.datasources.gbfs.support;
+
+import java.util.Map;
+import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class to filter out unknown vehicle types from GBFS data.
+ */
+public class UnknownVehicleTypeFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UnknownVehicleTypeFilter.class);
+
+  private final Map<String, RentalVehicleType> vehicleTypes;
+
+  public UnknownVehicleTypeFilter(Map<String, RentalVehicleType> vehicleTypes) {
+    this.vehicleTypes = vehicleTypes;
+  }
+
+  /**
+   * Filter to check if a vehicle type exists in the vehicle types map.
+   * Logs a debug message if the vehicle type is unknown.
+   *
+   * @param vehicleTypeId the vehicle type ID to check
+   * @param stationId the station ID (for logging)
+   * @param field the field name (for logging)
+   * @return true if the vehicle type exists, false otherwise
+   */
+  public boolean filterUnknownVehicleType(String vehicleTypeId, String stationId, String field) {
+    if (!vehicleTypes.containsKey(vehicleTypeId)) {
+      LOG.debug(
+        "Station {} references unknown vehicle type '{}' in {}, skipping",
+        stationId,
+        vehicleTypeId,
+        field
+      );
+      return false;
+    }
+    return true;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsStationInformationMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsStationInformationMapper.java
@@ -10,6 +10,7 @@ import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStationUris;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalSystem;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.updater.vehicle_rental.datasources.gbfs.support.UnknownVehicleTypeFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +22,7 @@ class GbfsStationInformationMapper {
   private final Map<String, RentalVehicleType> vehicleTypes;
   private final boolean allowKeepingRentedVehicleAtDestination;
   private final boolean overloadingAllowed;
+  private final UnknownVehicleTypeFilter vehicleTypeFilter;
 
   public GbfsStationInformationMapper(
     VehicleRentalSystem system,
@@ -32,6 +34,7 @@ class GbfsStationInformationMapper {
     this.vehicleTypes = vehicleTypes;
     this.allowKeepingRentedVehicleAtDestination = allowKeepingRentedVehicleAtDestination;
     this.overloadingAllowed = overloadingAllowed;
+    this.vehicleTypeFilter = new UnknownVehicleTypeFilter(vehicleTypes);
   }
 
   public VehicleRentalStation mapStationInformation(GBFSStation station) {
@@ -69,6 +72,13 @@ class GbfsStationInformationMapper {
           .getAdditionalProperties()
           .entrySet()
           .stream()
+          .filter(e ->
+            vehicleTypeFilter.filterUnknownVehicleType(
+              e.getKey(),
+              station.getStationId(),
+              "vehicle_capacity"
+            )
+          )
           .collect(
             Collectors.toMap(e -> vehicleTypes.get(e.getKey()), e -> e.getValue().intValue())
           )
@@ -82,6 +92,13 @@ class GbfsStationInformationMapper {
           .getAdditionalProperties()
           .entrySet()
           .stream()
+          .filter(e ->
+            vehicleTypeFilter.filterUnknownVehicleType(
+              e.getKey(),
+              station.getStationId(),
+              "vehicle_type_capacity"
+            )
+          )
           .collect(
             Collectors.toMap(e -> vehicleTypes.get(e.getKey()), e -> e.getValue().intValue())
           )

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsStationStatusMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsStationStatusMapper.java
@@ -10,6 +10,7 @@ import org.mobilitydata.gbfs.v2_3.station_status.GBFSVehicleTypesAvailable;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.ReturnPolicy;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
+import org.opentripplanner.updater.vehicle_rental.datasources.gbfs.support.UnknownVehicleTypeFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ class GbfsStationStatusMapper {
 
   private final Map<String, GBFSStation> statusLookup;
   private final Map<String, RentalVehicleType> vehicleTypes;
+  private final UnknownVehicleTypeFilter vehicleTypeFilter;
 
   public GbfsStationStatusMapper(
     Map<String, GBFSStation> statusLookup,
@@ -31,6 +33,7 @@ class GbfsStationStatusMapper {
   ) {
     this.statusLookup = Objects.requireNonNull(statusLookup);
     this.vehicleTypes = Objects.requireNonNull(vehicleTypes);
+    this.vehicleTypeFilter = new UnknownVehicleTypeFilter(vehicleTypes);
   }
 
   VehicleRentalStation mapStationStatus(VehicleRentalStation station) {
@@ -91,6 +94,13 @@ class GbfsStationStatusMapper {
           available
             .getVehicleTypeIds()
             .stream()
+            .filter(t ->
+              vehicleTypeFilter.filterUnknownVehicleType(
+                t,
+                status.getStationId(),
+                "vehicle_docks_available"
+              )
+            )
             .map(t -> new VehicleTypeCount(vehicleTypes.get(t), available.getCount()))
         )
         .collect(TYPE_MAP_COLLECTOR);

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationStatusMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsStationStatusMapper.java
@@ -10,6 +10,7 @@ import org.mobilitydata.gbfs.v3_0.station_status.GBFSVehicleTypesAvailable;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.service.vehiclerental.model.ReturnPolicy;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
+import org.opentripplanner.updater.vehicle_rental.datasources.gbfs.support.UnknownVehicleTypeFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ class GbfsStationStatusMapper {
 
   private final Map<String, GBFSStation> statusLookup;
   private final Map<String, RentalVehicleType> vehicleTypes;
+  private final UnknownVehicleTypeFilter vehicleTypeFilter;
 
   public GbfsStationStatusMapper(
     Map<String, GBFSStation> statusLookup,
@@ -31,6 +33,7 @@ class GbfsStationStatusMapper {
   ) {
     this.statusLookup = Objects.requireNonNull(statusLookup);
     this.vehicleTypes = Objects.requireNonNull(vehicleTypes);
+    this.vehicleTypeFilter = new UnknownVehicleTypeFilter(vehicleTypes);
   }
 
   VehicleRentalStation mapStationStatus(VehicleRentalStation station) {
@@ -93,6 +96,13 @@ class GbfsStationStatusMapper {
           available
             .getVehicleTypeIds()
             .stream()
+            .filter(t ->
+              vehicleTypeFilter.filterUnknownVehicleType(
+                t,
+                status.getStationId(),
+                "vehicle_docks_available"
+              )
+            )
             .map(t -> new VehicleTypeCount(vehicleTypes.get(t), available.getCount()))
         )
         .collect(TYPE_MAP_COLLECTOR);


### PR DESCRIPTION
### Summary

The GBFS updater fails with an NPE when a station reference an unknown type:

```
Error while running polling updater VehicleRentalUpdater{source: org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsVehicleRentalDataSource@1316c7da}
java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:1191)
	at java.base/java.util.Map.ofEntries(Map.java:1680)
	at java.base/java.util.Map.copyOf(Map.java:1748)
	at org.opentripplanner.service.vehiclerental.model.VehicleRentalStation.<init>(VehicleRentalStation.java:85)
	at org.opentripplanner.service.vehiclerental.model.VehicleRentalStationBuilder.build(VehicleRentalStationBuilder.java:270)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsStationInformationMapper.mapStationInformation(GbfsStationInformationMapper.java:103)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsFeedMapper.getUpdates(GbfsFeedMapper.java:92)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsFeedLoaderAndMapper.getUpdated(GbfsFeedLoaderAndMapper.java:101)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsVehicleRentalDataSource.getUpdates(GbfsVehicleRentalDataSource.java:50)
	at org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater.runPolling(VehicleRentalUpdater.java:125)
	at org.opentripplanner.updater.spi.PollingGraphUpdater.run(PollingGraphUpdater.java:74)
	at org.opentripplanner.updater.GraphUpdaterManager.lambda$startUpdaters$0(GraphUpdaterManager.java:100)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

This PR fixes the NPE by ignoring unknown types.
### Issue
No

### Unit tests
Added unit tests

### Documentation

No

### Changelog
skip
