### PR TITLE
Fix ImageN operations registration

### DIFF
--- a/otp-shaded/pom.xml
+++ b/otp-shaded/pom.xml
@@ -76,7 +76,7 @@
                                 <Extension-Name>com.sun.media.imageio</Extension-Name>
                             </manifestEntries>
                         </transformer>
-                        <!-- Preserve the ImageN/JAI configuration file.
+                        <!-- Combine the various ImageN/JAI configuration files into a single one.
                          Required by GeoTools for reading TIFF image during elevation data processing   -->
                         <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                             <resource>META-INF/registryFile.jai</resource>


### PR DESCRIPTION
### Summary

The latest version of GeoTools (v34) replaces the old JAI library by Eclipse ImageN.
This causes a regression where ImageN operations are not registered properly due to the overriding of a configuration file during the jar shading process.
As a result graph building fails when processing elevation data:

```
An uncaught error occurred inside OTP: ImageRead: No OperationDescriptor is registered in the current operation registry under this name.
java.lang.IllegalArgumentException: ImageRead: No OperationDescriptor is registered in the current operation registry under this name.
	at org.eclipse.imagen.ImageN.createNS([ImageN.java:740](http://imagen.java:740/))
	at org.eclipse.imagen.ImageN.create([ImageN.java:672](http://imagen.java:672/))
	at [org.geotools.gce.geotiff.GeoTiffReader.read](http://org.geotools.gce.geotiff.geotiffreader.read/)([GeoTiffReader.java:760](http://geotiffreader.java:760/))
	at org.opentripplanner.graph_builder.module.ned.GeotiffGridCoverageFactoryImpl.getUninterpolatedGridCoverage([GeotiffGridCoverageFactoryImpl.java:89](http://geotiffgridcoveragefactoryimpl.java:89/))
	at org.opentripplanner.graph_builder.module.ned.GeotiffGridCoverageFactoryImpl.getGridCoverage([GeotiffGridCoverageFactoryImpl.java:48](http://geotiffgridcoveragefactoryimpl.java:48/))
	at org.opentripplanner.graph_builder.module.ned.GeotiffGridCoverageFactoryImpl.getGridCoverage([GeotiffGridCoverageFactoryImpl.java:23](http://geotiffgridcoveragefactoryimpl.java:23/))
	at org.opentripplanner.graph_builder.module.ned.ElevationModule.getThreadSpecificCoverageInterpolator([ElevationModule.java:508](http://elevationmodule.java:508/))
	at org.opentripplanner.graph_builder.module.ned.ElevationModule.processEdge([ElevationModule.java:421](http://elevationmodule.java:421/))
	at org.opentripplanner.graph_builder.module.ned.ElevationModule.processEdgeWithProgress([ElevationModule.java:386](http://elevationmodule.java:386/))
	at org.opentripplanner.graph_builder.module.ned.ElevationModule.lambda$buildGraph$0([ElevationModule.java:226](http://elevationmodule.java:226/))
	at java.base/[java.util.stream](http://java.util.stream/).ForEachOps$ForEachOp$OfRef.accept([ForEachOps.java:184](http://foreachops.java:184/))
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining([Spliterators.java:1024](http://spliterators.java:1024/))
	at java.base/[java.util.stream](http://java.util.stream/).AbstractPipeline.copyInto([AbstractPipeline.java:509](http://abstractpipeline.java:509/))
	at java.base/[java.util.stream](http://java.util.stream/).ForEachOps$ForEachTask.compute([ForEachOps.java:291](http://foreachops.java:291/))
	at java.base/java.util.concurrent.CountedCompleter.exec([CountedCompleter.java:754](http://countedcompleter.java:754/))
	at java.base/java.util.concurrent.ForkJoinTask.doExec([ForkJoinTask.java:387](http://forkjointask.java:387/))
	at java.base/java.util.concurrent.ForkJoinTask.invoke([ForkJoinTask.java:667](http://forkjointask.java:667/))
	at java.base/[java.util.stream](http://java.util.stream/).ForEachOps$ForEachOp.evaluateParallel([ForEachOps.java:160](http://foreachops.java:160/))
	at java.base/[java.util.stream](http://java.util.stream/).ForEachOps$ForEachOp$OfRef.evaluateParallel([ForEachOps.java:174](http://foreachops.java:174/))
	at java.base/[java.util.stream](http://java.util.stream/).AbstractPipeline.evaluate([AbstractPipeline.java:233](http://abstractpipeline.java:233/))
	at java.base/[java.util.stream](http://java.util.stream/).ReferencePipeline.forEach([ReferencePipeline.java:596](http://referencepipeline.java:596/))
	at java.base/[java.util.stream](http://java.util.stream/).ReferencePipeline$Head.forEach([ReferencePipeline.java:765](http://referencepipeline.java:765/))
	at org.opentripplanner.graph_builder.module.ned.ElevationModule.buildGraph([ElevationModule.java:226](http://elevationmodule.java:226/))
	at org.opentripplanner.graph_[builder.GraphBuilder.run](http://builder.graphbuilder.run/)([GraphBuilder.java:211](http://graphbuilder.java:211/))
	at org.opentripplanner.standalone.OTPMain.startOTPServer([OTPMain.java:142](http://otpmain.java:142/))
	at org.opentripplanner.standalone.OTPMain.main([OTPMain.java:55](http://otpmain.java:55/))

```

This affects only the Graph Builder and only when running OTP as a shaded jar.

This PR configures the Maven shade plugin to merge, not overwrite, the ImageN/JAI configuration files.

### Issue

No

### Unit tests

No
### Documentation

No

### Changelog

skip

