### PR TITLE
Remove duplicate GBFS stations

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsFeedMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsFeedMapper.java
@@ -67,11 +67,19 @@ public class GbfsFeedMapper
       GBFSStationStatus stationStatus = loader.getFeed(GBFSStationStatus.class);
       if (stationInformation != null && stationStatus != null) {
         // Index all the station status entries on their station ID.
+        // in case of duplicates entries (stations with identical unique id),
+        // only the first occurrence is kept.
         Map<String, GBFSStation> statusLookup = stationStatus
           .getData()
           .getStations()
           .stream()
-          .collect(Collectors.toMap(GBFSStation::getStationId, Function.identity()));
+          .collect(
+            Collectors.toMap(
+              GBFSStation::getStationId,
+              Function.identity(),
+              (gbfsStation1, gbfsStation2) -> gbfsStation1
+            )
+          );
         GbfsStationStatusMapper stationStatusMapper = new GbfsStationStatusMapper(
           statusLookup,
           vehicleTypes

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsFeedMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsFeedMapper.java
@@ -64,11 +64,19 @@ public class GbfsFeedMapper
       var stationStatus = loader.getFeed(GBFSStationStatus.class);
       if (stationInformation != null && stationStatus != null) {
         // Index all the station status entries on their station ID.
+        // in case of duplicates entries (stations with identical unique id),
+        // only the first occurrence is kept.
         Map<String, GBFSStation> statusLookup = stationStatus
           .getData()
           .getStations()
           .stream()
-          .collect(Collectors.toMap(GBFSStation::getStationId, Function.identity()));
+          .collect(
+            Collectors.toMap(
+              GBFSStation::getStationId,
+              Function.identity(),
+              (gbfsStation1, gbfsStation2) -> gbfsStation1
+            )
+          );
         GbfsStationStatusMapper stationStatusMapper = new GbfsStationStatusMapper(
           statusLookup,
           vehicleTypes

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsFeedMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsFeedMapperTest.java
@@ -242,6 +242,74 @@ class GbfsFeedMapperTest {
     );
   }
 
+  @Test
+  void duplicatedStationsDoNotThrowException() {
+    var params = new GbfsVehicleRentalDataSourceParameters(
+      "file:src/test/resources/gbfs/duplicate-stations-v2/gbfs.json",
+      "en",
+      false,
+      HttpHeaders.empty(),
+      null,
+      false,
+      false,
+      RentalPickupType.ALL
+    );
+    var otpHttpClient = new OtpHttpClientFactory()
+      .create(LoggerFactory.getLogger(GbfsFeedMapperTest.class));
+    var loader = new GbfsFeedLoader(
+      params.url(),
+      params.httpHeaders(),
+      params.language(),
+      otpHttpClient
+    );
+    var mapper = new GbfsFeedMapper(loader, params);
+
+    assertTrue(loader.update());
+
+    assertDoesNotThrow(() -> {
+      mapper.getUpdates();
+    });
+  }
+
+  @Test
+  void duplicatedStationsKeepFirstOccurrence() {
+    var params = new GbfsVehicleRentalDataSourceParameters(
+      "file:src/test/resources/gbfs/duplicate-stations-v2/gbfs.json",
+      "en",
+      false,
+      HttpHeaders.empty(),
+      null,
+      false,
+      false,
+      RentalPickupType.ALL
+    );
+    var otpHttpClient = new OtpHttpClientFactory()
+      .create(LoggerFactory.getLogger(GbfsFeedMapperTest.class));
+    var loader = new GbfsFeedLoader(
+      params.url(),
+      params.httpHeaders(),
+      params.language(),
+      otpHttpClient
+    );
+    var mapper = new GbfsFeedMapper(loader, params);
+
+    assertTrue(loader.update());
+
+    List<VehicleRentalPlace> stations = mapper.getUpdates();
+
+    // Should have 3 stations (station_1, station_duplicate, station_3)
+    // even though station_status has 4 entries (with duplicate station_duplicate)
+    assertEquals(3, stations.size());
+
+    // Verify the duplicate station uses the first occurrence data (10 bikes available)
+    var duplicateStation = stations
+      .stream()
+      .filter(s -> s.id().getId().contains("station_duplicate"))
+      .findFirst()
+      .orElseThrow();
+    assertEquals(10, duplicateStation.vehiclesAvailable());
+  }
+
   private static List<GBFSVehicleType> getDuplicatedGbfsVehicleTypes() {
     GBFSVehicleType gbfsVehicleType1 = new GBFSVehicleType();
     gbfsVehicleType1.setVehicleTypeId("sameId");

--- a/application/src/test/resources/gbfs/duplicate-stations-v2/gbfs.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v2/gbfs.json
@@ -1,0 +1,23 @@
+{
+  "last_updated": 1631258451,
+  "ttl": 15,
+  "version": "2.2",
+  "data": {
+    "en": {
+      "feeds": [
+        {
+          "name": "system_information",
+          "url": "file:src/test/resources/gbfs/duplicate-stations-v2/system_information.json"
+        },
+        {
+          "name": "station_information",
+          "url": "file:src/test/resources/gbfs/duplicate-stations-v2/station_information.json"
+        },
+        {
+          "name": "station_status",
+          "url": "file:src/test/resources/gbfs/duplicate-stations-v2/station_status.json"
+        }
+      ]
+    }
+  }
+}

--- a/application/src/test/resources/gbfs/duplicate-stations-v2/station_information.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v2/station_information.json
@@ -1,0 +1,30 @@
+{
+  "last_updated": 1631258451,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "station_id": "station_1",
+        "name": "Station One",
+        "lat": 59.911491,
+        "lon": 10.757933,
+        "capacity": 20
+      },
+      {
+        "station_id": "station_duplicate",
+        "name": "Station Duplicate First",
+        "lat": 59.912491,
+        "lon": 10.758933,
+        "capacity": 15
+      },
+      {
+        "station_id": "station_3",
+        "name": "Station Three",
+        "lat": 59.913491,
+        "lon": 10.759933,
+        "capacity": 10
+      }
+    ]
+  }
+}

--- a/application/src/test/resources/gbfs/duplicate-stations-v2/station_status.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v2/station_status.json
@@ -1,0 +1,45 @@
+{
+  "last_updated": 1631258631,
+  "ttl": 60,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "station_id": "station_1",
+        "num_bikes_available": 5,
+        "num_docks_available": 15,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": 1631258631
+      },
+      {
+        "station_id": "station_duplicate",
+        "num_bikes_available": 10,
+        "num_docks_available": 5,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": 1631258631
+      },
+      {
+        "station_id": "station_duplicate",
+        "num_bikes_available": 8,
+        "num_docks_available": 7,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": 1631258632
+      },
+      {
+        "station_id": "station_3",
+        "num_bikes_available": 3,
+        "num_docks_available": 7,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": 1631258631
+      }
+    ]
+  }
+}

--- a/application/src/test/resources/gbfs/duplicate-stations-v2/system_information.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v2/system_information.json
@@ -1,0 +1,11 @@
+{
+  "last_updated": 1631258451,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "system_id": "test_duplicate_system",
+    "language": "en",
+    "name": "Test Duplicate System",
+    "timezone": "Europe/Oslo"
+  }
+}

--- a/application/src/test/resources/gbfs/duplicate-stations-v3/gbfs.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v3/gbfs.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "feeds": [
+      {
+        "name": "system_information",
+        "url": "file:src/test/resources/gbfs/duplicate-stations-v3/system_information.json"
+      },
+      {
+        "name": "station_information",
+        "url": "file:src/test/resources/gbfs/duplicate-stations-v3/station_information.json"
+      },
+      {
+        "name": "station_status",
+        "url": "file:src/test/resources/gbfs/duplicate-stations-v3/station_status.json"
+      }
+    ]
+  },
+  "last_updated": "2025-11-05T12:00:00+00:00",
+  "ttl": 600,
+  "version": "3.0"
+}

--- a/application/src/test/resources/gbfs/duplicate-stations-v3/station_information.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v3/station_information.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "stations": [
+      {
+        "station_id": "station_1",
+        "name": [
+          {
+            "text": "Station One",
+            "language": "en"
+          }
+        ],
+        "lat": 59.911491,
+        "lon": 10.757933,
+        "capacity": 20
+      },
+      {
+        "station_id": "station_duplicate",
+        "name": [
+          {
+            "text": "Station Duplicate First",
+            "language": "en"
+          }
+        ],
+        "lat": 59.912491,
+        "lon": 10.758933,
+        "capacity": 15
+      },
+      {
+        "station_id": "station_3",
+        "name": [
+          {
+            "text": "Station Three",
+            "language": "en"
+          }
+        ],
+        "lat": 59.913491,
+        "lon": 10.759933,
+        "capacity": 10
+      }
+    ]
+  },
+  "last_updated": "2025-11-05T12:00:00+00:00",
+  "ttl": 86400,
+  "version": "3.0"
+}

--- a/application/src/test/resources/gbfs/duplicate-stations-v3/station_status.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v3/station_status.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "stations": [
+      {
+        "station_id": "station_1",
+        "num_vehicles_available": 5,
+        "num_docks_available": 15,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2025-11-05T12:00:00+00:00"
+      },
+      {
+        "station_id": "station_duplicate",
+        "num_vehicles_available": 10,
+        "num_docks_available": 5,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2025-11-05T12:00:00+00:00"
+      },
+      {
+        "station_id": "station_duplicate",
+        "num_vehicles_available": 8,
+        "num_docks_available": 7,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2025-11-05T12:00:01+00:00"
+      },
+      {
+        "station_id": "station_3",
+        "num_vehicles_available": 3,
+        "num_docks_available": 7,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2025-11-05T12:00:00+00:00"
+      }
+    ]
+  },
+  "last_updated": "2025-11-05T12:00:00+00:00",
+  "ttl": 60,
+  "version": "3.0"
+}

--- a/application/src/test/resources/gbfs/duplicate-stations-v3/system_information.json
+++ b/application/src/test/resources/gbfs/duplicate-stations-v3/system_information.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "system_id": "test_duplicate_system_v3",
+    "name": [
+      {
+        "text": "Test Duplicate System V3",
+        "language": "en"
+      }
+    ],
+    "timezone": "Europe/Oslo"
+  },
+  "last_updated": "2025-11-05T12:00:00+00:00",
+  "ttl": 86400,
+  "version": "3.0"
+}


### PR DESCRIPTION
### Summary

We experience the following error in the GBFS updater:

```
Error while running polling updater VehicleRentalUpdater{source: org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsVehicleRentalDataSource@c8798da}
java.lang.IllegalStateException: Duplicate key YDT:Station:7ae68280-2287-4326-b86d-512b803523c4 (attempted merging values org.mobilitydata.gbfs.v3_0.station_status.GBFSStation@22b254a5[stationId=YDT:Station:7ae68280-2287-4326-b86d-512b803523c4,numVehiclesAvailable=0,vehicleTypesAvailable=[org.mobilitydata.gbfs.v3_0.station_status.GBFSVehicleTypesAvailable@29bffe65[vehicleTypeId=YDT:VehicleType:dott_scooter,count=15,additionalProperties={}]],numVehiclesDisabled=<null>,numDocksAvailable=<null>,numDocksDisabled=<null>,isInstalled=true,isRenting=true,isReturning=true,lastReported=Sun Nov 02 19:13:31 CET 2025,vehicleDocksAvailable=<null>,additionalProperties={}] and org.mobilitydata.gbfs.v3_0.station_status.GBFSStation@adf9b97[stationId=YDT:Station:7ae68280-2287-4326-b86d-512b803523c4,numVehiclesAvailable=0,vehicleTypesAvailable=[org.mobilitydata.gbfs.v3_0.station_status.GBFSVehicleTypesAvailable@5b10f6c0[vehicleTypeId=YDT:VehicleType:dott_scooter,count=15,additionalProperties={}]],numVehiclesDisabled=<null>,numDocksAvailable=<null>,numDocksDisabled=<null>,isInstalled=true,isRenting=true,isReturning=true,lastReported=Sun Nov 02 19:13:31 CET 2025,vehicleDocksAvailable=<null>,additionalProperties={}])
	at java.base/java.util.stream.Collectors.duplicateKeyException(Collectors.java:135)
	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:182)
	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsFeedMapper.getUpdates(GbfsFeedMapper.java:71)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsFeedLoaderAndMapper.getUpdated(GbfsFeedLoaderAndMapper.java:101)
	at org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsVehicleRentalDataSource.getUpdates(GbfsVehicleRentalDataSource.java:50)
	at org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater.runPolling(VehicleRentalUpdater.java:125)
	at org.opentripplanner.updater.spi.PollingGraphUpdater.run(PollingGraphUpdater.java:74)
	at org.opentripplanner.updater.GraphUpdaterManager.lambda$startUpdaters$0(GraphUpdaterManager.java:100)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

The root cause is a feed that sends GBFS stations with duplicated unique id.

The fix consists in ignoring the duplicated stations, keeping only the first instance received.
The fix is applied to both GBFS v2 and v3.

### Issue

No

### Unit tests

Added tests.
The GbfsFeedMapper and GbfsFeedLoader are difficult to test and need refactoring (not in the scope of this PR). GbfsFeedMapperTest relies on importing GBFS json files rather than testing at the object level.

### Documentation

No

### Changelog

skip

