### PR TITLE
Avoid assigning values to multiple variables on the same line and initializing multiple class variables on the same line

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/TileRenderer.java
+++ b/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/TileRenderer.java
@@ -38,7 +38,8 @@ public interface TileRenderer {
     public double metersPerPixel;
 
     /** Tile size in pixels */
-    public int tileWidth, tileHeight;
+    public int tileWidth;
+    public int tileHeight;
 
     /** Expand the bounding box to add some margins, in pixel size. */
     public abstract Envelope expandPixels(double marginXPixels, double marginYPixels);

--- a/application/src/main/java/com/jhlabs/awt/ShapeStroke.java
+++ b/application/src/main/java/com/jhlabs/awt/ShapeStroke.java
@@ -41,9 +41,12 @@ public class ShapeStroke implements Stroke {
     GeneralPath result = new GeneralPath();
     PathIterator it = new FlatteningPathIterator(shape.getPathIterator(null), FLATNESS);
     float[] points = new float[6];
-    float moveX = 0, moveY = 0;
-    float lastX = 0, lastY = 0;
-    float thisX = 0, thisY = 0;
+    float moveX = 0;
+    float moveY = 0;
+    float lastX = 0;
+    float lastY = 0;
+    float thisX = 0;
+    float thisY = 0;
     int type = 0;
     float next = phase;
 

--- a/application/src/main/java/com/jhlabs/awt/TextStroke.java
+++ b/application/src/main/java/com/jhlabs/awt/TextStroke.java
@@ -49,9 +49,12 @@ public class TextStroke implements Stroke {
     GeneralPath result = new GeneralPath();
     PathIterator it = new FlatteningPathIterator(shape.getPathIterator(null), FLATNESS);
     float[] points = new float[6];
-    float moveX = 0, moveY = 0;
-    float lastX = 0, lastY = 0;
-    float thisX = 0, thisY = 0;
+    float moveX = 0;
+    float moveY = 0;
+    float lastX = 0;
+    float lastY = 0;
+    float thisX = 0;
+    float thisY = 0;
     int type = 0;
     float next = 0;
     int currentChar = 0;
@@ -123,9 +126,12 @@ public class TextStroke implements Stroke {
   public float measurePathLength(Shape shape) {
     PathIterator it = new FlatteningPathIterator(shape.getPathIterator(null), FLATNESS);
     float[] points = new float[6];
-    float moveX = 0, moveY = 0;
-    float lastX = 0, lastY = 0;
-    float thisX = 0, thisY = 0;
+    float moveX = 0;
+    float moveY = 0;
+    float lastX = 0;
+    float lastY = 0;
+    float thisX = 0;
+    float thisY = 0;
     int type = 0;
     float total = 0;
 

--- a/application/src/main/java/org/opentripplanner/framework/geometry/HashGridSpatialIndex.java
+++ b/application/src/main/java/org/opentripplanner/framework/geometry/HashGridSpatialIndex.java
@@ -46,7 +46,8 @@ public class HashGridSpatialIndex<T> implements SpatialIndex, Serializable {
   private static final double DEFAULT_X_BIN_SIZE = 0.0035; // ~500m
 
   /* Size of bin in X and Y direction, in coordinates units. */
-  private final double xBinSize, yBinSize;
+  private final double xBinSize;
+  private final double yBinSize;
 
   /* The map of all bins. Please see visit() and xKey/yKey for details on the key. */
   private final TLongObjectHashMap<ArrayList<T>> bins;

--- a/application/src/main/java/org/opentripplanner/framework/io/FileUtils.java
+++ b/application/src/main/java/org/opentripplanner/framework/io/FileUtils.java
@@ -46,7 +46,8 @@ public class FileUtils {
     var expectedLines = expectedDoc.split("[\n\r]+");
     var resultLines = resultDoc.split("[\n\r]+");
 
-    int i = 0, j = 0;
+    int i = 0;
+    int j = 0;
 
     while (i < expectedLines.length && j < resultLines.length) {
       while (expectedLines[i].isBlank()) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
@@ -383,7 +383,9 @@ public class PruneIslands implements GraphBuilderModule {
     boolean markIsolated,
     TraverseMode traverseMode
   ) {
-    int nothru = 0, removed = 0, restricted = 0;
+    int nothru = 0;
+    int removed = 0;
+    int restricted = 0;
     //iterate over the street vertex of the subgraph
     for (Iterator<Vertex> vIter = island.streetIterator(); vIter.hasNext();) {
       Vertex v = vIter.next();

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -436,7 +436,10 @@ public class ElevationModule implements GraphBuilderModule {
       double edgeLenM = 0;
       double sampleDistance = distanceBetweenSamplesM;
       double previousDistance = 0;
-      double x1 = coords[0].x, y1 = coords[0].y, x2, y2;
+      double x1 = coords[0].x;
+      double y1 = coords[0].y;
+      double x2;
+      double y2;
       for (int i = 0; i < coords.length - 1; i++) {
         x2 = coords[i + 1].x;
         y2 = coords[i + 1].y;

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmArea.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmArea.java
@@ -128,7 +128,8 @@ class OsmArea {
       return closedRings;
     }
 
-    long firstEndpoint = 0, otherEndpoint = 0;
+    long firstEndpoint = 0;
+    long otherEndpoint = 0;
     OsmWay firstWay = null;
     for (Long endpoint : waysByEndpoint.keySet()) {
       List<OsmWay> list = waysByEndpoint.get(endpoint);

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
@@ -833,7 +833,9 @@ public class OsmDatabase {
    * Store turn restrictions.
    */
   private void processRestriction(OsmRelation relation) {
-    long from = -1, to = -1, via = -1;
+    long from = -1;
+    long to = -1;
+    long via = -1;
     for (OsmRelationMember member : relation.getMembers()) {
       String role = member.getRole();
       if (role.equals("from")) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -347,7 +347,8 @@ public class OsmModule implements GraphBuilderModule {
       // this is a workaround for crappy OSM data quality
       ArrayList<Long> nodes = new ArrayList<>(way.getNodeRefs().size());
       long last = -1;
-      double lastLat = -1, lastLon = -1;
+      double lastLat = -1;
+      double lastLon = -1;
       String lastLevel = null;
       for (TLongIterator iter = way.getNodeRefs().iterator(); iter.hasNext();) {
         long nodeId = iter.next();

--- a/application/src/main/java/org/opentripplanner/osm/OsmParser.java
+++ b/application/src/main/java/org/opentripplanner/osm/OsmParser.java
@@ -105,7 +105,9 @@ class OsmParser extends BinaryParser {
 
   @Override
   protected void parseDense(Osmformat.DenseNodes nodes) {
-    long lastId = 0, lastLat = 0, lastLon = 0;
+    long lastId = 0;
+    long lastLat = 0;
+    long lastLon = 0;
     int j = 0; // Index into the keysvals array.
 
     if (parsePhase != OsmParserPhase.Nodes) {
@@ -121,7 +123,8 @@ class OsmParser extends BinaryParser {
       lastLon = lon;
       long id = nodes.getId(i) + lastId;
       lastId = id;
-      double latf = parseLat(lat), lonf = parseLon(lon);
+      double latf = parseLat(lat);
+      double lonf = parseLon(lon);
 
       tmp.setId(id);
       tmp.setOsmProvider(provider);

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleAlightSearch.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleAlightSearch.java
@@ -206,7 +206,8 @@ public final class TripScheduleAlightSearch<T extends RaptorTripSchedule>
    * @return a better lower bound index (inclusive)
    */
   private int binarySearchForTripIndex() {
-    int lower = 0, upper = nTrips;
+    int lower = 0;
+    int upper = nTrips;
 
     // Do a binary search to find where to start the search.
     // We IGNORE if the trip schedule is in service.

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleBoardSearch.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleBoardSearch.java
@@ -208,7 +208,8 @@ public final class TripScheduleBoardSearch<T extends RaptorTripSchedule>
    * @return a better upper bound index (exclusive)
    */
   private int binarySearchForTripIndex() {
-    int lower = 0, upper = nTrips;
+    int lower = 0;
+    int upper = nTrips;
 
     // Do a binary search to find where to start the search.
     while (upper - lower > binarySearchThreshold) {

--- a/application/src/main/java/org/opentripplanner/visualizer/RouteDialog.java
+++ b/application/src/main/java/org/opentripplanner/visualizer/RouteDialog.java
@@ -19,7 +19,8 @@ public class RouteDialog extends JDialog {
   private final JTextField toField;
   private final JButton goButton;
 
-  public String from, to;
+  public String from;
+  public String to;
 
   public RouteDialog(JFrame owner, String initialFrom) {
     super(owner, true);

--- a/application/src/main/java/org/opentripplanner/visualizer/ShowGraph.java
+++ b/application/src/main/java/org/opentripplanner/visualizer/ShowGraph.java
@@ -111,7 +111,8 @@ public class ShowGraph extends PApplet implements MouseWheelListener {
   protected double mouseModelX;
   protected double mouseModelY;
   private Point startDrag = null;
-  private int dragX, dragY;
+  private int dragX;
+  private int dragY;
   private boolean ctrlPressed = false;
   boolean drawFast = false;
   boolean drawStreetEdges = true;
@@ -382,7 +383,8 @@ public class ShowGraph extends PApplet implements MouseWheelListener {
   }
 
   public void highlightCoordinate(Coordinate c) {
-    double xd = 0, yd = 0;
+    double xd = 0;
+    double yd = 0;
     while (!modelBounds.contains(c)) {
       xd = modelBounds.getWidth() / 100;
       yd = modelBounds.getHeight() / 100;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
@@ -64,8 +64,20 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
     .withJourney(jb -> jb.withTransfer(new StreetRequest(StreetMode.CAR)))
     .buildDefault();
 
-  private TransitStopVertex S0, S11, S12, S13, S21, S22, S23;
-  private StreetVertex V0, V11, V12, V13, V21, V22, V23;
+  private TransitStopVertex S0;
+  private TransitStopVertex S11;
+  private TransitStopVertex S12;
+  private TransitStopVertex S13;
+  private TransitStopVertex S21;
+  private TransitStopVertex S22;
+  private TransitStopVertex S23;
+  private StreetVertex V0;
+  private StreetVertex V11;
+  private StreetVertex V12;
+  private StreetVertex V13;
+  private StreetVertex V21;
+  private StreetVertex V22;
+  private StreetVertex V23;
 
   @Test
   public void testDirectTransfersWithoutPatterns() {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/ned/MissingElevationHandlerTest.java
@@ -24,13 +24,35 @@ class MissingElevationHandlerTest {
 
   private static final DataImportIssueStore issueStore = DefaultDataImportIssueStore.NOOP;
 
-  private StreetEdge AB, BC, CA, AB2, AD, ED, AF, FG, GB, FH, CJ, JI, AI, BJ;
+  private StreetEdge AB;
+  private StreetEdge BC;
+  private StreetEdge CA;
+  private StreetEdge AB2;
+  private StreetEdge AD;
+  private StreetEdge ED;
+  private StreetEdge AF;
+  private StreetEdge FG;
+  private StreetEdge GB;
+  private StreetEdge FH;
+  private StreetEdge CJ;
+  private StreetEdge JI;
+  private StreetEdge AI;
+  private StreetEdge BJ;
 
   private Map<Vertex, Double> elevations;
 
   @BeforeEach
   void setUp() {
-    IntersectionVertex A, B, C, D, E, F, G, H, I, J;
+    IntersectionVertex A;
+    IntersectionVertex B;
+    IntersectionVertex C;
+    IntersectionVertex D;
+    IntersectionVertex E;
+    IntersectionVertex F;
+    IntersectionVertex G;
+    IntersectionVertex H;
+    IntersectionVertex I;
+    IntersectionVertex J;
 
     A = vertex("A");
     B = vertex("B");

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
@@ -96,7 +96,9 @@ public class OsmModuleTest {
     assertNotNull(v3);
     assertNotNull(v4);
 
-    Edge e1 = null, e2 = null, e3 = null;
+    Edge e1 = null;
+    Edge e2 = null;
+    Edge e3 = null;
     for (Edge e : v2.getOutgoing()) {
       if (e.getToVertex() == v1) {
         e1 = e;

--- a/application/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/application/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -57,8 +57,16 @@ public class TestHalfEdges {
   private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
 
   private Graph graph;
-  private StreetEdge top, bottom, left, right, leftBack, rightBack;
-  private IntersectionVertex br, tr, bl, tl;
+  private StreetEdge top;
+  private StreetEdge bottom;
+  private StreetEdge left;
+  private StreetEdge right;
+  private StreetEdge leftBack;
+  private StreetEdge rightBack;
+  private IntersectionVertex br;
+  private IntersectionVertex tr;
+  private IntersectionVertex bl;
+  private IntersectionVertex tl;
   private TransitStopVertex station1;
   private TransitStopVertex station2;
   private TimetableRepository timetableRepository;

--- a/application/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
@@ -15,7 +15,9 @@ class DirectGraphFinderTest extends GraphRoutingTest {
 
   private SiteRepository siteRepository;
 
-  private TransitStopVertex S1, S2, S3;
+  private TransitStopVertex S1;
+  private TransitStopVertex S2;
+  private TransitStopVertex S3;
 
   @BeforeEach
   protected void setUp() throws Exception {

--- a/application/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
@@ -28,15 +28,25 @@ import org.opentripplanner.transit.service.TransitService;
 
 class StreetGraphFinderTest extends GraphRoutingTest {
 
-  private TransitStopVertex S1, S2, S3;
-  private IntersectionVertex A, B, C, D;
-  private VehicleRentalPlaceVertex BR1, BR2;
+  private TransitStopVertex S1;
+  private TransitStopVertex S2;
+  private TransitStopVertex S3;
+  private IntersectionVertex A;
+  private IntersectionVertex B;
+  private IntersectionVertex C;
+  private IntersectionVertex D;
+  private VehicleRentalPlaceVertex BR1;
+  private VehicleRentalPlaceVertex BR2;
 
   private TransitService transitService;
   private StreetGraphFinder graphFinder;
-  private Route R1, R2;
-  private TripPattern TP1, TP2;
-  private VehicleParking BP1, PR1, PR2;
+  private Route R1;
+  private Route R2;
+  private TripPattern TP1;
+  private TripPattern TP2;
+  private VehicleParking BP1;
+  private VehicleParking PR1;
+  private VehicleParking PR2;
 
   @BeforeEach
   protected void setUp() throws Exception {

--- a/application/src/test/java/org/opentripplanner/routing/util/elevation/ToblersHikingFunctionTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/util/elevation/ToblersHikingFunctionTest.java
@@ -43,7 +43,10 @@ public class ToblersHikingFunctionTest {
 
   static class TestCase {
 
-    final double slopeAnglePercentage, dx, dh, expected;
+    final double slopeAnglePercentage;
+    final double dx;
+    final double dh;
+    final double expected;
 
     TestCase(double slopeAnglePercentage, double expected) {
       this.slopeAnglePercentage = slopeAnglePercentage;

--- a/application/src/test/java/org/opentripplanner/service/vehicleparking/VehicleParkingTestGraphData.java
+++ b/application/src/test/java/org/opentripplanner/service/vehicleparking/VehicleParkingTestGraphData.java
@@ -11,7 +11,8 @@ import org.opentripplanner.transit.service.TimetableRepository;
 
 public class VehicleParkingTestGraphData {
 
-  protected IntersectionVertex A, B;
+  protected IntersectionVertex A;
+  protected IntersectionVertex B;
 
   protected Graph graph;
 

--- a/application/src/test/java/org/opentripplanner/street/integration/BicycleParkAndRideTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BicycleParkAndRideTest.java
@@ -14,7 +14,11 @@ public class BicycleParkAndRideTest extends ParkAndRideTest {
    * <-------> B --------> C --------> D ---------> E | Bike Park
    */
 
-  private StreetVertex A, B, C, D, E;
+  private StreetVertex A;
+  private StreetVertex B;
+  private StreetVertex C;
+  private StreetVertex D;
+  private StreetVertex E;
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/application/src/test/java/org/opentripplanner/street/integration/BikeRentalTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BikeRentalTest.java
@@ -39,11 +39,18 @@ public class BikeRentalTest extends GraphRoutingTest {
 
   private final String NON_NETWORK = "non network";
   private TransitStopVertex S1;
-  private TemporaryStreetLocation T1, T2;
+  private TemporaryStreetLocation T1;
+  private TemporaryStreetLocation T2;
   private TransitEntranceVertex E1;
-  private StreetVertex A, B, C, D;
-  private VehicleRentalPlaceVertex B1, B2;
-  private StreetEdge SE1, SE2, SE3;
+  private StreetVertex A;
+  private StreetVertex B;
+  private StreetVertex C;
+  private StreetVertex D;
+  private VehicleRentalPlaceVertex B1;
+  private VehicleRentalPlaceVertex B2;
+  private StreetEdge SE1;
+  private StreetEdge SE2;
+  private StreetEdge SE3;
 
   @BeforeEach
   public void setUp() {

--- a/application/src/test/java/org/opentripplanner/street/integration/BikeWalkingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BikeWalkingTest.java
@@ -26,10 +26,21 @@ import org.opentripplanner.street.search.strategy.EuclideanRemainingWeightHeuris
  */
 public class BikeWalkingTest extends GraphRoutingTest {
 
-  private TransitStopVertex S1, S2;
+  private TransitStopVertex S1;
+  private TransitStopVertex S2;
   private TransitEntranceVertex E1;
-  private StreetVertex A, B, C, D, E, F, Q;
-  private StreetEdge AB, BC, CD, DE, EF;
+  private StreetVertex A;
+  private StreetVertex B;
+  private StreetVertex C;
+  private StreetVertex D;
+  private StreetVertex E;
+  private StreetVertex F;
+  private StreetVertex Q;
+  private StreetEdge AB;
+  private StreetEdge BC;
+  private StreetEdge CD;
+  private StreetEdge DE;
+  private StreetEdge EF;
 
   @Test
   public void testWalkOnly() {

--- a/application/src/test/java/org/opentripplanner/street/integration/CarParkAndRideTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/CarParkAndRideTest.java
@@ -16,7 +16,12 @@ public class CarParkAndRideTest extends ParkAndRideTest {
    * Car Park
    */
 
-  private StreetVertex A, B, C, D, E, F;
+  private StreetVertex A;
+  private StreetVertex B;
+  private StreetVertex C;
+  private StreetVertex D;
+  private StreetVertex E;
+  private StreetVertex F;
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/application/src/test/java/org/opentripplanner/street/integration/CarPickupTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/CarPickupTest.java
@@ -28,7 +28,11 @@ public class CarPickupTest extends GraphRoutingTest {
 
   private TransitStopVertex S1;
   private TransitEntranceVertex E1;
-  private StreetVertex A, B, C, D, E;
+  private StreetVertex A;
+  private StreetVertex B;
+  private StreetVertex C;
+  private StreetVertex D;
+  private StreetVertex E;
 
   @Test
   public void testCarPickupCarOnly() {

--- a/application/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/TurnRestrictionTest.java
@@ -37,7 +37,8 @@ public class TurnRestrictionTest {
 
   private Vertex bottomLeft;
 
-  private StreetEdge maple_main1, broad1_2;
+  private StreetEdge maple_main1;
+  private StreetEdge broad1_2;
 
   @BeforeEach
   public void before() {

--- a/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -41,7 +41,9 @@ public class StreetEdgeTest {
   private static final double DELTA = 0.00001;
   private static final double SPEED = 6.0;
 
-  private IntersectionVertex v0, v1, v2;
+  private IntersectionVertex v0;
+  private IntersectionVertex v1;
+  private IntersectionVertex v2;
   private StreetSearchRequest proto;
 
   @BeforeEach

--- a/application/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeTest.java
+++ b/application/src/test/java/org/opentripplanner/street/model/edge/TemporaryPartialStreetEdgeTest.java
@@ -27,8 +27,14 @@ import org.opentripplanner.street.search.state.State;
 public class TemporaryPartialStreetEdgeTest {
 
   private Graph graph;
-  private IntersectionVertex v1, v2, v3, v4;
-  private StreetEdge e1, e1Reverse, e2, e3;
+  private IntersectionVertex v1;
+  private IntersectionVertex v2;
+  private IntersectionVertex v3;
+  private IntersectionVertex v4;
+  private StreetEdge e1;
+  private StreetEdge e1Reverse;
+  private StreetEdge e2;
+  private StreetEdge e3;
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoSetWithMarkerTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoSetWithMarkerTest.java
@@ -153,7 +153,8 @@ public class ParetoSetWithMarkerTest {
 
   private static class Vector {
 
-    final int u, v;
+    final int u;
+    final int v;
 
     Vector(int u, int v) {
       this.u = u;

--- a/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/TestVector.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/TestVector.java
@@ -10,7 +10,10 @@ class TestVector {
 
   private static final int NOT_SET = -999;
   final String name;
-  final int v1, v2, v3, v4;
+  final int v1;
+  final int v2;
+  final int v3;
+  final int v4;
 
   TestVector(TestVector o) {
     this(o.name, o.v1, o.v2, o.v3, o.v4);

--- a/utils/src/main/java/org/opentripplanner/utils/time/DateUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/time/DateUtils.java
@@ -162,7 +162,9 @@ public class DateUtils {
   public static LocalTime parseTime(String time) {
     boolean amPm = false;
     int addHours = 0;
-    int hour = 0, min = 0, sec = 0;
+    int hour = 0;
+    int min = 0;
+    int sec = 0;
     try {
       String[] hms = time.toUpperCase().split(":");
 

--- a/utils/src/test/java/org/opentripplanner/utils/collection/CompositeComparatorTest.java
+++ b/utils/src/test/java/org/opentripplanner/utils/collection/CompositeComparatorTest.java
@@ -30,7 +30,8 @@ public class CompositeComparatorTest {
 
   private static class A {
 
-    final int a, b;
+    final int a;
+    final int b;
 
     public A(int a, int b) {
       this.a = a;


### PR DESCRIPTION
### Summary

Avoid assigning values to multiple variables on the same line and initializing multiple class variables on the same line.

### Issue

Related to Helsinki's OTP Summit discussions and https://github.com/opentripplanner/OpenTripPlanner/issues/6913.

### Unit tests

No

### Documentation

No

### Changelog

Skipped