### PR TITLE
Add otp-config to entur performance test

### DIFF
--- a/test/performance/norway/otp-config.json
+++ b/test/performance/norway/otp-config.json
@@ -1,0 +1,13 @@
+{
+  "otpFeatures" : {
+    "FlexRouting" : true,
+    "FloatingBike" : true,
+    "IncludeEmptyRailStopsInTransfers" : true,
+    "MultiCriteriaGroupMaxFilter" : true,
+    "OptimizeTransfers" : true,
+    "ParallelRouting" : false,
+    "ReportApi" : true,
+    "Sorlandsbanen" : true,
+    "TransferConstraints" : true
+  }
+}


### PR DESCRIPTION
### Summary

Adds an _otp-config.json_ configuration file to the Entur performance test setup in test/performance/norway/. This configuration file enables various OTP features that are used in Entur's production environment, ensuring that
  performance tests accurately reflect real-world usage.


### Issue

No issue.

### Unit tests

This will affect the perormance-tests.

### Documentation

No

### Changelog

No

### Bumping the serialization version id

No