### PR TITLE
Don't fail the whole search if direct, flex or transit search generates a routing validation exception

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -247,6 +247,8 @@ public class RoutingWorker {
         DirectStreetRouter.route(serverContext, directBuilder.buildRequest(), linkingContext()),
         emptyDirectModeHandler.removeWalkAllTheWayResults()
       );
+    } catch (RoutingValidationException e) {
+      return RoutingResult.failed(e.getRoutingErrors());
     } finally {
       debugTimingAggregator.finishedDirectStreetRouter();
     }
@@ -261,6 +263,8 @@ public class RoutingWorker {
       return RoutingResult.ok(
         DirectFlexRouter.route(serverContext, request, additionalSearchDays, linkingContext())
       );
+    } catch (RoutingValidationException e) {
+      return RoutingResult.failed(e.getRoutingErrors());
     } finally {
       debugTimingAggregator.finishedDirectFlexRouter();
     }
@@ -280,6 +284,8 @@ public class RoutingWorker {
       );
       raptorSearchParamsUsed = transitResults.getSearchParams();
       return RoutingResult.ok(transitResults.getItineraries());
+    } catch (RoutingValidationException e) {
+      return RoutingResult.failed(e.getRoutingErrors());
     } finally {
       debugTimingAggregator.finishedTransitRouter();
     }


### PR DESCRIPTION
### Summary

Don't fail the whole search if direct, flex or transit search generates a routing error.

### Issue

Fixes #7050

### Unit tests

Can't really add tests for this.

### Documentation

Not needed

### Changelog

From title
