### PR TITLE
Set correct name on StationCentroidVertex

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/AddTransitEntitiesToGraph.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/AddTransitEntitiesToGraph.java
@@ -128,7 +128,7 @@ public class AddTransitEntitiesToGraph {
   private void addStationCentroidsToGraph() {
     for (Station station : otpTransitService.siteRepository().listStations()) {
       if (station.shouldRouteToCentroid()) {
-        vertexFactory.stationCentroid(station.getId(), station.getCoordinate());
+        vertexFactory.stationCentroid(station);
       }
     }
   }

--- a/application/src/main/java/org/opentripplanner/street/model/vertex/StationCentroidVertex.java
+++ b/application/src/main/java/org/opentripplanner/street/model/vertex/StationCentroidVertex.java
@@ -10,10 +10,12 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 public class StationCentroidVertex extends Vertex {
 
   private final FeedScopedId id;
+  private final I18NString name;
 
-  public StationCentroidVertex(FeedScopedId id, WgsCoordinate coordinate) {
+  public StationCentroidVertex(FeedScopedId id, I18NString name, WgsCoordinate coordinate) {
     super(coordinate.longitude(), coordinate.latitude());
     this.id = id;
+    this.name = name;
   }
 
   public FeedScopedId getId() {
@@ -22,7 +24,7 @@ public class StationCentroidVertex extends Vertex {
 
   @Override
   public I18NString getName() {
-    return I18NString.of(id.getId());
+    return name;
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/street/model/vertex/VertexFactory.java
+++ b/application/src/main/java/org/opentripplanner/street/model/vertex/VertexFactory.java
@@ -3,7 +3,6 @@ package org.opentripplanner.street.model.vertex;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
-import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.osm.model.OsmNode;
 import org.opentripplanner.routing.graph.Graph;
@@ -13,10 +12,10 @@ import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.transit.model.basic.Accessibility;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.BoardingArea;
 import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.PathwayNode;
+import org.opentripplanner.transit.model.site.Station;
 
 /**
  * This class is the central point where all vertices that are supposed to be permanently part
@@ -119,8 +118,10 @@ public class VertexFactory {
     return addToGraph(v);
   }
 
-  public StationCentroidVertex stationCentroid(FeedScopedId id, WgsCoordinate coordinate) {
-    return addToGraph(new StationCentroidVertex(id, coordinate));
+  public StationCentroidVertex stationCentroid(Station station) {
+    return addToGraph(
+      new StationCentroidVertex(station.getId(), station.getName(), station.getCoordinate())
+    );
   }
 
   public VehicleParkingEntranceVertex vehicleParkingEntrance(VehicleParking vehicleParking) {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -312,7 +312,7 @@ public abstract class GraphRoutingTest {
 
     public StationCentroidVertex stationCentroid(Station station) {
       assertTrue(station.shouldRouteToCentroid());
-      return vertexFactory.stationCentroid(station.getId(), station.getCoordinate());
+      return vertexFactory.stationCentroid(station);
     }
 
     public StreetTransitEntranceLink link(StreetVertex from, TransitEntranceVertex to) {

--- a/application/src/test/java/org/opentripplanner/routing/graph/StreetIndexTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graph/StreetIndexTest.java
@@ -24,6 +24,7 @@ class StreetIndexTest {
     .build();
   private final StationCentroidVertex centroidVertex = new StationCentroidVertex(
     station.getId(),
+    station.getName(),
     station.getCoordinate()
   );
 

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
@@ -305,7 +305,11 @@ class LinkingContextFactoryTest {
     graph.addVertex(right);
     graph.addVertex(top);
     graph.addVertex(distant);
-    var centroidVertex = new StationCentroidVertex(station.getId(), station.getCoordinate());
+    var centroidVertex = new StationCentroidVertex(
+      station.getId(),
+      station.getName(),
+      station.getCoordinate()
+    );
     graph.addVertex(centroidVertex);
     StreetStationCentroidLink.createStreetStationLink(centroidVertex, left);
     Arrays.stream(stops).forEach(s -> {


### PR DESCRIPTION
### Summary

This is a minor fix to use the station name instead of the id for `StationCentroidVertex` name.

### Issue

Minor change, no issue needed.

### Bumping the serialization version id

Yes, StationCentroidVertex is part of the serialized graph.
