### PR TITLE
Add state to ElevatorHopEdge for using realtime elevator status in routing

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.raptor.api.model.RaptorCostConverter;
@@ -11,9 +12,11 @@ import org.opentripplanner.raptor.api.model.RaptorTransfer;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.WalkPreferences;
 import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.ElevatorHopEdge;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.state.EdgeTraverser;
 import org.opentripplanner.street.search.state.StateEditor;
+import org.opentripplanner.transit.model.basic.Accessibility;
 import org.opentripplanner.utils.logging.Throttle;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 import org.slf4j.Logger;
@@ -81,6 +84,12 @@ public class Transfer {
   }
 
   public Optional<RaptorTransfer> asRaptorTransfer(StreetSearchRequest request) {
+    for (Edge edge : edges) {
+      if (Objects.requireNonNull(edge) instanceof ElevatorHopEdge e &&
+        e.getElevatorAccessibility().equals(Accessibility.NOT_POSSIBLE)) {
+        return Optional.empty();
+      }
+    }
     WalkPreferences walkPreferences = request.preferences().walk();
     if (edges == null || edges.isEmpty()) {
       double durationSeconds = distanceMeters / walkPreferences.speed();

--- a/application/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
+++ b/application/src/main/java/org/opentripplanner/street/model/edge/ElevatorHopEdge.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.edge;
 
+import java.util.Objects;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.street.model.StreetTraversalPermission;
@@ -22,6 +23,8 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
   private final StreetTraversalPermission permission;
 
   private final Accessibility wheelchairAccessibility;
+  private Accessibility elevatorAccessibility;
+
 
   private final double levels;
   private final int travelTime;
@@ -102,8 +105,20 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     return travelTime;
   }
 
+  public Accessibility getElevatorAccessibility() {
+    return this.elevatorAccessibility;
+  }
+
+  public void setElevatorAccessibility(Accessibility elevatorAccessibility) {
+    this.elevatorAccessibility = elevatorAccessibility;
+  }
+
   @Override
   public State[] traverse(State s0) {
+    if (elevatorAccessibility == Accessibility.NOT_POSSIBLE) {
+      return State.empty();
+    }
+
     RoutingPreferences preferences = s0.getPreferences();
 
     StateEditor s1 = createEditorForDrivingOrWalking(s0, this);
@@ -111,7 +126,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
     if (s0.getRequest().wheelchair()) {
       if (
         wheelchairAccessibility != Accessibility.POSSIBLE &&
-        preferences.wheelchair().elevator().onlyConsiderAccessible()
+          preferences.wheelchair().elevator().onlyConsiderAccessible()
       ) {
         return State.empty();
       } else if (wheelchairAccessibility == Accessibility.NO_INFORMATION) {
@@ -145,6 +160,11 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
       : (int) (preferences.street().elevator().hopTime() * this.levels);
     s1.incrementTimeInSeconds(seconds);
     return s1.makeStateArray();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fromv, tov, elevatorAccessibility);
   }
 
   @Override


### PR DESCRIPTION
### Summary

We want to use the elevator status (working/out of order) in routing. For this, a new field `elevatorAccessibility` was added, and considered during routing and mapping of transfers to raptor transfers. Updating the field as well as introducing an elevator id during graph building will be done in a separate PR.

### Issue

A first step for closing #6533 

### Unit tests

TBD

### Documentation

TBD

### Changelog

TBD

### Bumping the serialization version id

TBD
