### PR TITLE
Fix `+Roadmap` and add `Keep Open` label to exempt issues from closure

### DIFF
--- a/.github/workflows/close_stale_pr_and_issues.yml
+++ b/.github/workflows/close_stale_pr_and_issues.yml
@@ -20,5 +20,5 @@ jobs:
           days-before-stale: 90
           days-before-close: 30
           operations-per-run: 260
-          exempt-issue-labels: 'Roadmap'
+          exempt-issue-labels: '+Roadmap,+Keep Open'
           ascending: true


### PR DESCRIPTION
### Summary

The "Stale" bot will skip `+Keep Open` and `+Roadmap` issues

This is just fixing the CI pipeline - no code or doc changes.

### Issue
No relevant

### Unit tests
No relevant



### Documentation
No relevant

### Changelog
No relevant

### Bumping the serialization version id
No relevant
