### PR TITLE
Remove some siri azure updater tests

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdaterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdaterTest.java
@@ -402,31 +402,7 @@ class SiriAzureUpdaterTest {
     );
 
     assertEquals("Unexpected null value", thrown.getMessage(), "Exception message should match");
-    verify(updater, never()).sleep(anyInt());
     verify(task, times(1)).run();
-  }
-
-  /**
-   * Verifies that executeWithRetry returns false when startupTimeout is exceeded.
-   */
-  @Test
-  void testExecuteWithRetry_TimeoutAfterStartupTimeout() throws Throwable {
-    SiriAzureUpdater timeoutUpdater = spy(createUpdater(mockConfig));
-
-    doNothing().when(timeoutUpdater).sleep(anyInt());
-
-    // fail with a retryable exception
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY)).when(task).run();
-
-    // Use a very short timeout for this test to avoid waiting
-    long shortTimeout = 100L; // 100ms
-    boolean result = timeoutUpdater.executeWithRetry(task, "Test Task", shortTimeout);
-
-    assertFalse(result, "Expected executeWithRetry to return false due to timeout");
-
-    // Verify that multiple retries were attempted
-    verify(task, atLeast(2)).run();
-    verify(timeoutUpdater, atLeast(1)).sleep(anyInt());
   }
 
   /**
@@ -529,32 +505,6 @@ class SiriAzureUpdaterTest {
       defaultConfig.getStartupTimeout(),
       "Default startup timeout should be 5 minutes"
     );
-  }
-
-  /**
-   * Verifies that custom startup timeout values are properly applied.
-   */
-  @Test
-  void testCustomStartupTimeoutConfiguration() throws Exception {
-    when(mockConfig.getStartupTimeout()).thenReturn(Duration.ofMinutes(1));
-    SiriAzureUpdater customTimeoutUpdater = spy(createUpdater(mockConfig));
-
-    doNothing().when(customTimeoutUpdater).sleep(anyInt());
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY)).when(task).run();
-
-    long testTimeout = 200L;
-    boolean result;
-    try {
-      result = customTimeoutUpdater.executeWithRetry(task, "Test Task", testTimeout);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-
-    assertFalse(result, "executeWithRetry should return false on timeout");
-
-    // Verify retries were attempted
-    verify(task, atLeast(2)).run();
-    verify(customTimeoutUpdater, atLeast(1)).sleep(anyInt());
   }
 
   /**


### PR DESCRIPTION
### Summary

This PR only touches sandbox test code.

There are some bad tests in SiriAzureUpdaterTest that are intermittently failing since they depend on timing. This PR removes them. I'll change the siri azure updaters to use the `OtpRetry` class instead of rolling our own retry mechanism when I get the time.

### Bumping the serialization version id

Nope