### PR TITLE
To fix arriveBy searches always set arriveBy property to false in transfer requests

### DIFF
--- a/application/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequestMapper.java
@@ -46,6 +46,8 @@ public class StreetSearchRequestMapper {
     return mapInternal(request)
       .withFrom(null)
       .withTo(null)
+      // transfer requests are always depart-at
+      .withArriveBy(false)
       .withStartTime(Instant.ofEpochSecond(0))
       .withMode(request.journey().transfer().mode());
   }


### PR DESCRIPTION
### Summary

In a previous PR (#7027) I missed a requirement of the transfer requests: they are always set to arriveBy=false. These transfer requests are also used in itinerary mapping there and even for arriveBy=true requests they must be set to arriveBy=false because the transfers are not traversed in reverse order.

### Issue

Fixes #7088

### Unit tests

Added.

### Documentation

Some Javadoc added.