### PR TITLE
Fix NeTEx graph builder crash on duplicate StopPointInJourneyPattern

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/validation/JourneyPatternDuplicateStopPoints.java
+++ b/application/src/main/java/org/opentripplanner/netex/validation/JourneyPatternDuplicateStopPoints.java
@@ -1,0 +1,55 @@
+package org.opentripplanner.netex.validation;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
+import org.opentripplanner.graph_builder.issue.api.Issue;
+import org.rutebanken.netex.model.EntityStructure;
+import org.rutebanken.netex.model.JourneyPattern_VersionStructure;
+import org.rutebanken.netex.model.ServiceJourney;
+
+/**
+ * Validates that a JourneyPattern does not contain duplicate StopPointInJourneyPattern IDs.
+ * Duplicate stop point IDs in a journey pattern indicate invalid NeTEx data and will cause
+ * failures when creating lookup maps.
+ */
+class JourneyPatternDuplicateStopPoints extends AbstractHMapValidationRule<String, ServiceJourney> {
+
+  private String duplicateStopPointId;
+  private String journeyPatternId;
+
+  @Override
+  public Status validate(ServiceJourney sj) {
+    journeyPatternId = sj.getJourneyPatternRef().getValue().getRef();
+    JourneyPattern_VersionStructure journeyPattern = index
+      .getJourneyPatternsById()
+      .lookup(journeyPatternId);
+
+    Set<String> seenIds = new HashSet<>();
+
+    for (var point : journeyPattern
+      .getPointsInSequence()
+      .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern()) {
+      String pointId = ((EntityStructure) point).getId();
+      if (!seenIds.add(pointId)) {
+        duplicateStopPointId = pointId;
+        return Status.DISCARD;
+      }
+    }
+
+    return Status.OK;
+  }
+
+  @Override
+  public DataImportIssue logMessage(String key, ServiceJourney sj) {
+    return Issue.issue(
+      "JourneyPatternDuplicateStopPoints",
+      "JourneyPattern contains duplicate StopPointInJourneyPattern. " +
+      "ServiceJourney will be skipped. " +
+      "ServiceJourney=%s, JourneyPattern=%s, Duplicate StopPointInJourneyPattern=%s",
+      sj.getId(),
+      journeyPatternId,
+      duplicateStopPointId
+    );
+  }
+}

--- a/application/src/main/java/org/opentripplanner/netex/validation/Validator.java
+++ b/application/src/main/java/org/opentripplanner/netex/validation/Validator.java
@@ -33,6 +33,7 @@ public class Validator {
     validate(index.quayIdByStopPointRef, new PassengerStopAssignmentQuayNotFound());
     validate(index.serviceJourneyById, new JourneyPatternNotFoundInSJ());
     validate(index.serviceJourneyById, new JourneyPatternSJMismatch());
+    validate(index.serviceJourneyById, new JourneyPatternDuplicateStopPoints());
     validate(index.serviceJourneyById, ServiceJourneyNonIncreasingPassingTime::new);
     validate(index.datedServiceJourneys, new DSJOperatingDayNotFound());
     validate(index.datedServiceJourneys, new DSJServiceJourneyNotFound());

--- a/application/src/test/java/org/opentripplanner/netex/validation/JourneyPatternDuplicateStopPointsTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/validation/JourneyPatternDuplicateStopPointsTest.java
@@ -1,0 +1,93 @@
+package org.opentripplanner.netex.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.netex.index.api.HMapValidationRule.Status.DISCARD;
+import static org.opentripplanner.netex.index.api.HMapValidationRule.Status.OK;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.netex.index.NetexEntityIndex;
+import org.opentripplanner.netex.mapping.MappingSupport;
+import org.rutebanken.netex.model.JourneyPatternRefStructure;
+import org.rutebanken.netex.model.PointsInJourneyPattern_RelStructure;
+import org.rutebanken.netex.model.ServiceJourney;
+import org.rutebanken.netex.model.ServiceJourneyPattern;
+import org.rutebanken.netex.model.StopPointInJourneyPattern;
+
+class JourneyPatternDuplicateStopPointsTest {
+
+  private static final String PATTERN_ID = "pattern";
+  private static final String JOURNEY_ID = "journey";
+
+  @Test
+  void noDuplicates() {
+    var pattern = createPattern("P-1", "P-2", "P-3");
+
+    var index = new NetexEntityIndex();
+    index.journeyPatternsById.add(pattern);
+
+    var journey = createJourney(PATTERN_ID);
+
+    var rule = new JourneyPatternDuplicateStopPoints();
+    rule.setup(index.readOnlyView());
+
+    assertEquals(OK, rule.validate(journey));
+  }
+
+  @Test
+  void duplicateStopPoints() {
+    var pattern = createPattern("P-1", "P-2", "P-2");
+
+    var index = new NetexEntityIndex();
+    index.journeyPatternsById.add(pattern);
+
+    var journey = createJourney(PATTERN_ID);
+
+    var rule = new JourneyPatternDuplicateStopPoints();
+    rule.setup(index.readOnlyView());
+
+    assertEquals(DISCARD, rule.validate(journey));
+  }
+
+  @Test
+  void duplicateStopPointsAtDifferentPositions() {
+    var pattern = createPattern("P-1", "P-2", "P-3", "P-1");
+
+    var index = new NetexEntityIndex();
+    index.journeyPatternsById.add(pattern);
+
+    var journey = createJourney(PATTERN_ID);
+
+    var rule = new JourneyPatternDuplicateStopPoints();
+    rule.setup(index.readOnlyView());
+
+    assertEquals(DISCARD, rule.validate(journey));
+  }
+
+  private ServiceJourneyPattern createPattern(String... pointIds) {
+    var pattern = new ServiceJourneyPattern();
+    pattern.setId(PATTERN_ID);
+
+    var points = new PointsInJourneyPattern_RelStructure();
+    int order = 1;
+    for (String pointId : pointIds) {
+      var point = new StopPointInJourneyPattern();
+      point.setId(pointId);
+      point.setOrder(BigInteger.valueOf(order++));
+      points
+        .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern()
+        .add(point);
+    }
+
+    pattern.setPointsInSequence(points);
+    return pattern;
+  }
+
+  private ServiceJourney createJourney(String patternId) {
+    var journey = new ServiceJourney();
+    journey.setId(JOURNEY_ID);
+    var ref = MappingSupport.createWrappedRef(patternId, JourneyPatternRefStructure.class);
+    journey.withJourneyPatternRef(ref);
+    return journey;
+  }
+}


### PR DESCRIPTION
### Summary

 This PR fixes a graph builder crash that occurs when processing NeTEx data containing JourneyPatterns with duplicate StopPointInJourneyPattern IDs.
    
Add validation to reject ServiceJourneys that reference JourneyPatterns containing duplicate StopPointInJourneyPattern IDs. This prevents IllegalStateException crashes when building lookup maps.

These duplicates are not caught during XSD validation since the unique key in the schema is (id,version,order).

The validator runs early in the validation pipeline to catch invalid data before it causes failures in downstream validators like ServiceJourneyNonIncreasingPassingTime.

Fixes crash with error:
java.lang.IllegalStateException: Duplicate key SKY:StopPointInJourneyPattern:...
  at ServiceJourneyInfo.scheduledStopPointIdByStopPointId()
### Issue

Closes #7091

### Unit tests

Added unit test

### Documentation

No
