### PR TITLE
Add support for via access/egress in Raptor API (API only)

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorAccessEgress.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorAccessEgress.java
@@ -128,6 +128,9 @@ public interface RaptorAccessEgress {
    * ore more via-locations. If so Raptor needs to know how many via-locations are included
    * so it can skip these.
    * <p>
+   * If the access/egress {@code stop} is a via-location then this method should include
+   * it in the count.
+   * <p>
    * The default is zero via-lcations visited.
    */
   default int numberOfViaLocationsVisited() {


### PR DESCRIPTION
### Summary

This is just the Raptor API change needed to implement VIA in access/egress. I will provide the implementation in several steps. 

If via-locations is included in the access/egress then all Raptor need to know is the number of via-location it should skip. The `numberOfViaPoints()` in access/egress can differ, e.g. one access can have none,   another 1 and then 2 and so on.

### Issue

Part of #4887

### Unit tests

There is no functional code in this pr.


### Documentation

So, fare only JavaDoc.


### Changelog

Not compleate/too small.

### Bumping the serialization version id

Not needed.