### PR TITLE
Upgrade GraphiQL to v5.2.2

### DIFF
--- a/application/src/client/graphiql/index.html
+++ b/application/src/client/graphiql/index.html
@@ -43,9 +43,9 @@
             "react-dom": "https://esm.sh/react-dom@19.1.0",
             "react-dom/": "https://esm.sh/react-dom@19.1.0/",
 
-            "graphiql": "https://esm.sh/graphiql@5.2.1?standalone&external=react,react-dom,@graphiql/react,graphql",
-            "graphiql/": "https://esm.sh/graphiql@5.2.1/",
-            "@graphiql/react": "https://esm.sh/@graphiql/react@0.37.2?standalone&external=react,react-dom,graphql,@emotion/is-prop-valid",
+            "graphiql": "https://esm.sh/graphiql@5.2.2?standalone&external=react,react-dom,@graphiql/react,graphql",
+            "graphiql/": "https://esm.sh/graphiql@5.2.2/",
+            "@graphiql/react": "https://esm.sh/@graphiql/react@0.37.3?standalone&external=react,react-dom,graphql,@emotion/is-prop-valid",
 
             "graphql": "https://esm.sh/graphql@16.11.0",
             "@emotion/is-prop-valid": "data:text/javascript,"


### PR DESCRIPTION
### Summary

Fixes GraphiQL 5's autocomplete, which was reported as broken by @optionsome.

### Issue

Closes https://github.com/graphql/graphiql/issues/4132

cc @daniel-heppner-ibigroup 

