### PR TITLE
Add support for the snow and ice NeTEx transport mode

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/trias/mapping/PtModeMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/trias/mapping/PtModeMapper.java
@@ -18,6 +18,7 @@ public class PtModeMapper {
       case FUNICULAR -> VehicleModesOfTransportEnumeration.FUNICULAR;
       case TROLLEYBUS -> VehicleModesOfTransportEnumeration.TROLLEY_BUS;
       case CARPOOL, TAXI -> VehicleModesOfTransportEnumeration.TAXI;
+      case SNOW_AND_ICE -> VehicleModesOfTransportEnumeration.SNOW_AND_ICE;
     };
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -5262,6 +5262,7 @@ public class GraphQLTypes {
     GONDOLA,
     MONORAIL,
     RAIL,
+    SNOW_AND_ICE,
     SUBWAY,
     TAXI,
     TRAM,

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/TransitModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/TransitModeMapper.java
@@ -18,6 +18,7 @@ public class TransitModeMapper {
       case FUNICULAR -> TransitMode.FUNICULAR;
       case GONDOLA -> TransitMode.GONDOLA;
       case RAIL -> TransitMode.RAIL;
+      case SNOW_AND_ICE -> TransitMode.SNOW_AND_ICE;
       case SUBWAY -> TransitMode.SUBWAY;
       case TRAM -> TransitMode.TRAM;
       case CARPOOL -> TransitMode.CARPOOL;
@@ -43,6 +44,7 @@ public class TransitModeMapper {
       case TAXI -> GraphQLTypes.GraphQLTransitMode.TAXI;
       case TROLLEYBUS -> GraphQLTypes.GraphQLTransitMode.TROLLEYBUS;
       case MONORAIL -> GraphQLTypes.GraphQLTransitMode.MONORAIL;
+      case SNOW_AND_ICE -> GraphQLTypes.GraphQLTransitMode.SNOW_AND_ICE;
     };
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -177,6 +177,7 @@ public class EnumTypes {
     .value("funicular", TransitMode.FUNICULAR)
     .value("lift", TransitMode.GONDOLA)
     .value("rail", TransitMode.RAIL)
+    .value("snowAndIce", TransitMode.SNOW_AND_ICE)
     .value("metro", TransitMode.SUBWAY)
     .value("taxi", TransitMode.TAXI)
     .value("tram", TransitMode.TRAM)

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
@@ -53,6 +53,7 @@ class TransportModeMapper {
       case FUNICULAR -> TransitMode.FUNICULAR;
       case METRO -> TransitMode.SUBWAY;
       case RAIL -> TransitMode.RAIL;
+      case SNOW_AND_ICE -> TransitMode.SNOW_AND_ICE;
       case TAXI -> TransitMode.TAXI;
       case TRAM -> TransitMode.TRAM;
       case WATER -> TransitMode.FERRY;
@@ -101,6 +102,11 @@ class TransportModeMapper {
       return new NetexMainAndSubMode(TransitMode.FERRY, submode.getWaterSubmode().value());
     } else if (submode.getTaxiSubmode() != null) {
       return new NetexMainAndSubMode(TransitMode.TAXI, submode.getTaxiSubmode().value());
+    } else if (submode.getSnowAndIceSubmode() != null) {
+      return new NetexMainAndSubMode(
+        TransitMode.SNOW_AND_ICE,
+        submode.getSnowAndIceSubmode().value()
+      );
     }
     throw new IllegalArgumentException();
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/basic/TransitMode.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/basic/TransitMode.java
@@ -21,7 +21,8 @@ public enum TransitMode implements DocumentedEnum<TransitMode> {
   TROLLEYBUS,
   MONORAIL,
   CARPOOL,
-  TAXI;
+  TAXI,
+  SNOW_AND_ICE;
 
   private static final Set<TransitMode> ON_STREET_MODES = EnumSet.of(
     COACH,
@@ -84,6 +85,7 @@ public enum TransitMode implements DocumentedEnum<TransitMode> {
       If your data source for the carpool trips is SIRI use the `CARPOOL` street mode instead.
       """;
       case TAXI -> "Using a taxi service";
+      case SNOW_AND_ICE -> "Used for off-road snow and ice vehicles";
     };
   }
 }

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -3863,6 +3863,8 @@ enum TransitMode {
   MONORAIL
   "This includes long or short distance trains."
   RAIL
+  "Used for off-road snow and ice vehicles"
+  SNOW_AND_ICE
   "Subway or metro, depending on the local terminology."
   SUBWAY
   "A taxi, possibly operated by a public transport agency."

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1743,6 +1743,7 @@ enum Mode {
   monorail
   rail
   scooter
+  snowAndIce
   taxi
   tram
   trolleybus

--- a/application/src/test/java/org/opentripplanner/api/parameter/QualifiedModeSetTest.java
+++ b/application/src/test/java/org/opentripplanner/api/parameter/QualifiedModeSetTest.java
@@ -204,12 +204,13 @@ class QualifiedModeSetTest {
       FUNICULAR,
       TROLLEYBUS,
       MONORAIL,
-      TransitMode.TAXI
+      TransitMode.TAXI,
+      TransitMode.SNOW_AND_ICE
     );
 
     var mainModes = Set.copyOf(modeSet.getTransitModes());
 
-    assertEquals(mainModes, expected);
+    assertEquals(expected, mainModes);
   }
 
   @Test
@@ -230,12 +231,13 @@ class QualifiedModeSetTest {
       TROLLEYBUS,
       CARPOOL,
       MONORAIL,
-      TransitMode.TAXI
+      TransitMode.TAXI,
+      TransitMode.SNOW_AND_ICE
     );
 
     var mainModes = Set.copyOf(modeSet.getTransitModes());
 
-    assertEquals(mainModes, expected);
+    assertEquals(expected, mainModes);
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
+import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -30,6 +31,7 @@ import org.rutebanken.netex.model.CoachSubmodeEnumeration;
 import org.rutebanken.netex.model.FunicularSubmodeEnumeration;
 import org.rutebanken.netex.model.MetroSubmodeEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
+import org.rutebanken.netex.model.SnowAndIceSubmodeEnumeration;
 import org.rutebanken.netex.model.TaxiSubmodeEnumeration;
 import org.rutebanken.netex.model.TelecabinSubmodeEnumeration;
 import org.rutebanken.netex.model.TramSubmodeEnumeration;
@@ -41,28 +43,52 @@ class TransportModeMapperTest {
   private static final Map<
     AllVehicleModesOfTransportEnumeration,
     TransportSubmodeStructure
-  > VALID_SUBMODE_STRUCTURES = Map.of(
-    AllVehicleModesOfTransportEnumeration.AIR,
-    new TransportSubmodeStructure().withAirSubmode(AirSubmodeEnumeration.DOMESTIC_FLIGHT),
-    AllVehicleModesOfTransportEnumeration.BUS,
-    new TransportSubmodeStructure().withBusSubmode(BusSubmodeEnumeration.LOCAL_BUS),
-    AllVehicleModesOfTransportEnumeration.CABLEWAY,
-    new TransportSubmodeStructure().withTelecabinSubmode(TelecabinSubmodeEnumeration.TELECABIN),
-    AllVehicleModesOfTransportEnumeration.COACH,
-    new TransportSubmodeStructure().withCoachSubmode(CoachSubmodeEnumeration.NATIONAL_COACH),
-    AllVehicleModesOfTransportEnumeration.FUNICULAR,
-    new TransportSubmodeStructure().withFunicularSubmode(FunicularSubmodeEnumeration.FUNICULAR),
-    AllVehicleModesOfTransportEnumeration.METRO,
-    new TransportSubmodeStructure().withMetroSubmode(MetroSubmodeEnumeration.METRO),
-    AllVehicleModesOfTransportEnumeration.RAIL,
-    new TransportSubmodeStructure().withRailSubmode(RailSubmodeEnumeration.LONG_DISTANCE),
-    AllVehicleModesOfTransportEnumeration.TAXI,
-    new TransportSubmodeStructure().withTaxiSubmode(TaxiSubmodeEnumeration.COMMUNAL_TAXI),
-    AllVehicleModesOfTransportEnumeration.TRAM,
-    new TransportSubmodeStructure().withTramSubmode(TramSubmodeEnumeration.CITY_TRAM),
-    AllVehicleModesOfTransportEnumeration.WATER,
-    new TransportSubmodeStructure()
-      .withWaterSubmode(WaterSubmodeEnumeration.INTERNATIONAL_PASSENGER_FERRY)
+  > VALID_SUBMODE_STRUCTURES = Map.ofEntries(
+    entry(
+      AllVehicleModesOfTransportEnumeration.AIR,
+      new TransportSubmodeStructure().withAirSubmode(AirSubmodeEnumeration.DOMESTIC_FLIGHT)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.BUS,
+      new TransportSubmodeStructure().withBusSubmode(BusSubmodeEnumeration.LOCAL_BUS)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.CABLEWAY,
+      new TransportSubmodeStructure().withTelecabinSubmode(TelecabinSubmodeEnumeration.TELECABIN)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.COACH,
+      new TransportSubmodeStructure().withCoachSubmode(CoachSubmodeEnumeration.NATIONAL_COACH)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.FUNICULAR,
+      new TransportSubmodeStructure().withFunicularSubmode(FunicularSubmodeEnumeration.FUNICULAR)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.METRO,
+      new TransportSubmodeStructure().withMetroSubmode(MetroSubmodeEnumeration.METRO)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.RAIL,
+      new TransportSubmodeStructure().withRailSubmode(RailSubmodeEnumeration.LONG_DISTANCE)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.SNOW_AND_ICE,
+      new TransportSubmodeStructure().withSnowAndIceSubmode(SnowAndIceSubmodeEnumeration.SNOW_COACH)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.TAXI,
+      new TransportSubmodeStructure().withTaxiSubmode(TaxiSubmodeEnumeration.COMMUNAL_TAXI)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.TRAM,
+      new TransportSubmodeStructure().withTramSubmode(TramSubmodeEnumeration.CITY_TRAM)
+    ),
+    entry(
+      AllVehicleModesOfTransportEnumeration.WATER,
+      new TransportSubmodeStructure()
+        .withWaterSubmode(WaterSubmodeEnumeration.INTERNATIONAL_PASSENGER_FERRY)
+    )
   );
 
   private static final EnumSet<AllVehicleModesOfTransportEnumeration> SUPPORTED_MODES =

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/_support/mapping/ModeMapper.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/_support/mapping/ModeMapper.java
@@ -40,6 +40,7 @@ class ModeMapper {
       case MONORAIL -> "MONORAIL";
       case CARPOOL -> "CARPOOL";
       case TAXI -> "TAXI";
+      case SNOW_AND_ICE -> "SNOW_AND_ICE";
     };
   }
 }

--- a/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/SelectRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/request/filter/SelectRequestTest.java
@@ -43,7 +43,7 @@ class SelectRequestTest {
       notModesSelect(TC_BUS, TC_TRAM, TC_FERRY).toString()
     );
     assertEquals(
-      "(transportModes: [AIRPLANE, CABLE_CAR, CARPOOL, COACH, FUNICULAR, GONDOLA, MONORAIL, SUBWAY, TAXI, TROLLEYBUS])",
+      "(transportModes: [AIRPLANE, CABLE_CAR, CARPOOL, COACH, FUNICULAR, GONDOLA, MONORAIL, SNOW_AND_ICE, SUBWAY, TAXI, TROLLEYBUS])",
       notModesSelect(TC_BUS, TC_FERRY, TC_TRAM, TC_RAIL).toString()
     );
     var list = new ArrayList<>(
@@ -51,7 +51,7 @@ class SelectRequestTest {
     );
     list.add(TC_LOCAL_BUS);
     assertEquals(
-      "(transportModes: [AIRPLANE, BUS::LOCAL, CABLE_CAR, CARPOOL, COACH, FERRY, FUNICULAR, GONDOLA, MONORAIL, RAIL, SUBWAY, TAXI, TROLLEYBUS])",
+      "(transportModes: [AIRPLANE, BUS::LOCAL, CABLE_CAR, CARPOOL, COACH, FERRY, FUNICULAR, GONDOLA, MONORAIL, RAIL, SNOW_AND_ICE, SUBWAY, TAXI, TROLLEYBUS])",
       SelectRequest.of().withTransportModes(list).build().toString()
     );
   }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/routes-extended.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/routes-extended.json
@@ -132,6 +132,19 @@
         "patterns": []
       },
       {
+        "longName": "Long name for SNOW_AND_ICE",
+        "shortName": "RSNOW_AND_ICE",
+        "gtfsId": "F:SNOW_AND_ICE",
+        "agency": {
+          "gtfsId": "F:A1",
+          "name": "Agency Test"
+        },
+        "mode": "SNOW_AND_ICE",
+        "sortOrder": 14,
+        "bikesAllowed": "NO_INFORMATION",
+        "patterns": []
+      },
+      {
         "longName": "Long name for SUBWAY",
         "shortName": "RSUBWAY",
         "gtfsId": "F:SUBWAY",

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/routes-tutorial.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/routes-tutorial.json
@@ -102,6 +102,16 @@
         "mode": "RAIL"
       },
       {
+        "longName": "Long name for SNOW_AND_ICE",
+        "shortName": "RSNOW_AND_ICE",
+        "gtfsId": "F:SNOW_AND_ICE",
+        "agency": {
+          "gtfsId": "F:A1",
+          "name": "Agency Test"
+        },
+        "mode": "SNOW_AND_ICE"
+      },
+      {
         "longName": "Long name for SUBWAY",
         "shortName": "RSUBWAY",
         "gtfsId": "F:SUBWAY",

--- a/doc/user/RouteRequest.md
+++ b/doc/user/RouteRequest.md
@@ -486,7 +486,7 @@ extra cost, while 1.0 will add the same amount to both time and cost.
 
 **Since version:** `2.0` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults   
-**Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi`
+**Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi` | `snow-and-ice`
 
 How much extra time should be given when alighting a vehicle for each given mode.
 
@@ -610,7 +610,7 @@ for controlling the duration of those events.
 
 **Since version:** `2.0` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults   
-**Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi`
+**Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi` | `snow-and-ice`
 
 How much extra time should be given when boarding a vehicle for each given mode.
 
@@ -1060,7 +1060,7 @@ Unmatched patterns are put in the BASE priority-group.
 
 **Since version:** `2.1` ∙ **Type:** `enum map of double` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults   
-**Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi`
+**Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi` | `snow-and-ice`
 
 Transit reluctance for a given transport mode
 

--- a/doc/user/RoutingModes.md
+++ b/doc/user/RoutingModes.md
@@ -150,6 +150,10 @@ Used for any rail system that runs on a single rail.
 
 Used for intercity or long-distance travel.
 
+<h4 id="SNOW_AND_ICE">SNOW_AND_ICE</h4>
+
+Used for off-road snow and ice vehicles
+
 <h4 id="SUBWAY">SUBWAY</h4>
 
 Subway or Metro, used for any underground rail system within a metropolitan area.


### PR DESCRIPTION
### Summary

This PR adds support for the NeTEx transport mode "snow and ice".
It is used in Norway to model snow coaches.

### Issue
No
### Unit tests

Updated unit tests

### Documentation

Updated API documentation
