### PR TITLE
Reorganize Maven project to prevent double execution of prettier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ mvn prettier:check
 
 # Spotless removes unused imports
 # Runs automatically during build (validate phase)
+
+# OpenRewrite for code refactoring and modernization
+# Run with the -Prewrite (or -Drw shortcut):
+mvn validate -Prewrite
 ```
 
 ## Running OTP
@@ -257,3 +261,4 @@ Features not yet part of core OTP can be developed as Sandbox extensions. These 
 - Use feature flags (disabled by default)
 - Have conditional code blocks in core OTP
 - See: http://docs.opentripplanner.org/en/latest/SandboxExtension/
+- Use comments sparingly. Only comment complex code.

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -520,15 +520,12 @@
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
                 <configuration>
-                    <inputGlobs>
-                        <inputGlob>src/main/java/**/*.java</inputGlob>
+                    <inputGlobs combine.children="append">
+                        <!-- Additional patterns specific to the application module -->
                         <inputGlob>src/ext/java/**/*.java</inputGlob>
-                        <inputGlob>src/test/java/**/*.java</inputGlob>
-                        <inputGlob>src/test-fixtures/java/**/*.java</inputGlob>
                         <inputGlob>src/ext-test/java/**/*.java</inputGlob>
                         <inputGlob>src/**/*.json</inputGlob>
                         <inputGlob>src/test/resources/org/opentripplanner/apis/**/*.graphql</inputGlob>
-                        <!-- Ignore patterns. -->
                         <inputGlob>!src/test/resources/org/opentripplanner/apis/vectortiles/style.json</inputGlob>
                     </inputGlobs>
                 </configuration>

--- a/astar/pom.xml
+++ b/astar/pom.xml
@@ -13,7 +13,12 @@
     <name>OpenTripPlanner - A*</name>
 
     <build>
-        <plugins/>
+        <plugins>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,24 @@
                     <groupId>com.hubspot.maven.plugins</groupId>
                     <artifactId>prettier-maven-plugin</artifactId>
                     <version>${plugin.prettier.version}</version>
+                    <configuration>
+                        <skip>${plugin.prettier.skip}</skip>
+                        <prettierJavaVersion>2.6.8</prettierJavaVersion>
+                        <inputGlobs>
+                            <inputGlob>src/main/java/**/*.java</inputGlob>
+                            <inputGlob>src/test/java/**/*.java</inputGlob>
+                            <inputGlob>src/test-fixtures/java/**/*.java</inputGlob>
+                        </inputGlobs>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>prettier-format</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>${plugin.prettier.goal}</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -334,14 +352,6 @@
                         <version>2.22.0</version>
                     </dependency>
                 </dependencies>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -372,28 +382,6 @@
                         <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <configuration>
-                    <skip>${plugin.prettier.skip}</skip>
-                    <prettierJavaVersion>2.6.8</prettierJavaVersion>
-                    <inputGlobs>
-                        <inputGlob>src/main/java/**/*.java</inputGlob>
-                        <inputGlob>src/test/java/**/*.java</inputGlob>
-                        <inputGlob>src/test-fixtures/java/**/*.java</inputGlob>
-                    </inputGlobs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>${plugin.prettier.goal}</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -630,8 +618,8 @@
             <activation>
                 <property>
                     <!--
-                      This works as a short alias to enable this from the command line. To skip
-                      rewrite, set the 'rw' system property with the '-D rw' parameter.
+                      This works as a short alias to enable this from the command line.
+                      To run rewrite, set the 'rw' system property with the '-Drw' parameter.
                     -->
                     <name>rw</name>
                     <value/>
@@ -641,6 +629,23 @@
                 <plugin.rewrite.skip>false</plugin.rewrite.skip>
                 <plugin.checkstyle.skip>true</plugin.checkstyle.skip>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>rewrite-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>rewrite-run</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>clean-test-snapshots</id>

--- a/raptor/pom.xml
+++ b/raptor/pom.xml
@@ -12,6 +12,15 @@
     <artifactId>raptor</artifactId>
     <name>OpenTripPlanner - Raptor</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- project dependencies -->
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -12,6 +12,15 @@
     <artifactId>utils</artifactId>
     <name>OpenTripPlanner - Utils</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- This is the ONLY allowed dependency -->
         <dependency>


### PR DESCRIPTION
### Summary

This PR reorganizes the Maven prettier plugin configuration to eliminate duplicate execution during builds. Previously, the prettier plugin was running twice for each module because the rewrite plugin forks the Maven lifecycle to `process-test-classes`, causing all `validate` phase plugins to re-execute. This change consolidates the configuration into `pluginManagement` and moves the rewrite plugin execution to a dedicated profile, ensuring prettier runs exactly once per module while keeping rewrite available on demand.

### Issue

No issue, this addresses developer experience issue where prettier was executing twice during normal builds, causing unnecessary build time overhead.

### Build Configuration

#### Maven Plugin Management
- Moved prettier plugin configuration from root `<plugins>` to `<pluginManagement>`

#### Module Configuration
- Added prettier plugin declaration to all Java modules:
  - `utils`
  - `raptor`
  - `astar`
- Simplified `application` module configuration to only extend parent with module-specific globs.

#### Rewrite Plugin
- Removed automatic execution from main build configuration
- Added execution to existing `rewrite` profile (activated via `-Drw`)
- Prevents lifecycle forking during normal builds
- Rewrite still available when explicitly needed: `mvn validate -Drw`

### Documentation

- Updated `CLAUDE.md` with instructions for running rewrite manually
- Documented both shortcut (`-Drw`) and explicit profile (`-Prewrite`) methods

### Breaking Changes

None. This is a build configuration change that doesn't affect OTP functionality.

### Testing

Manual Tested

### Documentation

✅  Comments in pom.xml updated

### Changelog

 🟥  Not relevant.

### Bumping the serialization version id

 🟥  Not relevant.
