### PR TITLE
fix: build and deploy debug client also when graphql schema changes

### DIFF
--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - 'client/**'
       - 'application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql'
+  workflow_dispatch:
 
 # to avoid conflicts, make sure that only one workflow pushes to Github at the same time
 concurrency:


### PR DESCRIPTION
### Summary

The debug client now also depends on the graphql schema to build certain ui elements dynamically. Parts of this happens runtime but it also has build-time dependencies. We therefore need to rebuild and release a new version of the debug client whenever the graphql schema changes.

This commit updates the path filters in the github workflow trigger to accomplish this.

In addition, I added the workflow_dispatch event to the triggers, so that it is possible to trigger the workflow manually. This is useful if for some other reason it is necessary to release a new build of the ui.

