### PR TITLE
Remove relaxCostAtDestination feature from code

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/preferences/TransitPreferencesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/preferences/TransitPreferencesMapper.java
@@ -39,8 +39,5 @@ public class TransitPreferencesMapper {
         RelaxCostType.mapToDomain((Map<String, Object>) it, CostLinearFunction.NORMAL)
       )
     );
-    callWith.argument("relaxTransitSearchGeneralizedCostAtDestination", (Double value) ->
-      transit.withRaptor(it -> it.withRelaxGeneralizedCostAtDestination(value))
-    );
   }
 }

--- a/application/src/main/java/org/opentripplanner/framework/model/Units.java
+++ b/application/src/main/java/org/opentripplanner/framework/model/Units.java
@@ -76,14 +76,6 @@ public class Units {
   }
 
   /**
-   * If given input value is {@code null}, then return {@code null}, if not
-   * verify value, see {@link #normalizedFactor(double, double, double)}.
-   */
-  public static Double normalizedOptionalFactor(Double value, double minValue, double maxValue) {
-    return (value == null) ? null : normalizedFactor(value, minValue, maxValue);
-  }
-
-  /**
    * Amount of time/slack/duration in seconds - A constant amount of time.
    */
   public static int duration(int seconds) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
@@ -147,15 +147,10 @@ public class RaptorRequestMapper<T extends RaptorTripSchedule> {
 
     builder.withMultiCriteria(mcBuilder -> {
       var pt = preferences.transit();
-      var r = pt.raptor();
 
       // relax transit group priority can be used with via-visit-stop, but not with pass-through
       if (pt.isRelaxTransitGroupPrioritySet() && !hasPassThroughOnly()) {
         mapRelaxTransitGroupPriority(mcBuilder, pt);
-      } else if (!request.isViaSearch()) {
-        // The deprecated relaxGeneralizedCostAtDestination is only enabled, if there is no
-        // via location and the relaxTransitGroupPriority is not used (Normal).
-        r.relaxGeneralizedCostAtDestination().ifPresent(mcBuilder::withRelaxCostAtDestination);
       }
     });
 
@@ -217,13 +212,6 @@ public class RaptorRequestMapper<T extends RaptorTripSchedule> {
     return (
       request.isViaSearch() &&
       request.listViaLocations().stream().allMatch(ViaLocation::isPassThroughLocation)
-    );
-  }
-
-  private boolean hasViaLocationsOnly() {
-    return (
-      request.isViaSearch() &&
-      request.listViaLocations().stream().noneMatch(ViaLocation::isPassThroughLocation)
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/RaptorPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/RaptorPreferences.java
@@ -6,11 +6,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
-import org.opentripplanner.framework.model.Units;
 import org.opentripplanner.raptor.api.model.SearchDirection;
 import org.opentripplanner.raptor.api.request.Optimization;
 import org.opentripplanner.raptor.api.request.RaptorProfile;
@@ -24,8 +22,6 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 public final class RaptorPreferences implements Serializable {
 
   public static final RaptorPreferences DEFAULT = new RaptorPreferences();
-  private static final double MIN_RELAX_COST_AT_DESTINATION = 1.0;
-  private static final double MAX_RELAX_COST_AT_DESTINATION = 2.0;
 
   private final Set<Optimization> optimizations;
 
@@ -34,14 +30,12 @@ public final class RaptorPreferences implements Serializable {
   private final SearchDirection searchDirection;
 
   private final Instant timeLimit;
-  private final Double relaxGeneralizedCostAtDestination;
 
   private RaptorPreferences() {
     this.optimizations = EnumSet.of(Optimization.PARETO_CHECK_AGAINST_DESTINATION);
     this.profile = RaptorProfile.MULTI_CRITERIA;
     this.searchDirection = SearchDirection.FORWARD;
     this.timeLimit = null;
-    this.relaxGeneralizedCostAtDestination = null;
   }
 
   private RaptorPreferences(RaptorPreferences.Builder builder) {
@@ -49,11 +43,6 @@ public final class RaptorPreferences implements Serializable {
     this.profile = Objects.requireNonNull(builder.profile);
     this.searchDirection = Objects.requireNonNull(builder.searchDirection);
     this.timeLimit = builder.timeLimit;
-    this.relaxGeneralizedCostAtDestination = Units.normalizedOptionalFactor(
-      builder.relaxGeneralizedCostAtDestination,
-      MIN_RELAX_COST_AT_DESTINATION,
-      MAX_RELAX_COST_AT_DESTINATION
-    );
   }
 
   public static Builder of() {
@@ -85,14 +74,6 @@ public final class RaptorPreferences implements Serializable {
     return timeLimit;
   }
 
-  /**
-   * See {@link SearchParams#relaxCostAtDestination()} for documentation.
-   */
-  @Deprecated
-  public Optional<Double> relaxGeneralizedCostAtDestination() {
-    return Optional.ofNullable(relaxGeneralizedCostAtDestination);
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -107,20 +88,13 @@ public final class RaptorPreferences implements Serializable {
       optimizations.equals(that.optimizations) &&
       profile == that.profile &&
       searchDirection == that.searchDirection &&
-      Objects.equals(timeLimit, that.timeLimit) &&
-      Objects.equals(relaxGeneralizedCostAtDestination, that.relaxGeneralizedCostAtDestination)
+      Objects.equals(timeLimit, that.timeLimit)
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-      optimizations,
-      profile,
-      searchDirection,
-      timeLimit,
-      relaxGeneralizedCostAtDestination
-    );
+    return Objects.hash(optimizations, profile, searchDirection, timeLimit);
   }
 
   @Override
@@ -131,11 +105,6 @@ public final class RaptorPreferences implements Serializable {
       .addEnum("searchDirection", searchDirection, DEFAULT.searchDirection)
       // Ignore time limit if null (default value)
       .addDateTime("timeLimit", timeLimit)
-      .addNum(
-        "relaxGeneralizedCostAtDestination",
-        relaxGeneralizedCostAtDestination,
-        DEFAULT.relaxGeneralizedCostAtDestination
-      )
       .toString();
   }
 
@@ -147,7 +116,6 @@ public final class RaptorPreferences implements Serializable {
     private SearchDirection searchDirection;
     private Set<Optimization> optimizations;
     private Instant timeLimit;
-    private Double relaxGeneralizedCostAtDestination;
 
     public Builder(RaptorPreferences original) {
       this.original = original;
@@ -155,7 +123,6 @@ public final class RaptorPreferences implements Serializable {
       this.searchDirection = original.searchDirection;
       this.optimizations = null;
       this.timeLimit = original.timeLimit;
-      this.relaxGeneralizedCostAtDestination = original.relaxGeneralizedCostAtDestination;
     }
 
     public Builder withOptimizations(Collection<Optimization> optimizations) {
@@ -177,13 +144,6 @@ public final class RaptorPreferences implements Serializable {
 
     public Builder withTimeLimit(Instant timeLimit) {
       this.timeLimit = timeLimit;
-      return this;
-    }
-
-    public Builder withRelaxGeneralizedCostAtDestination(
-      @Nullable Double relaxGeneralizedCostAtDestination
-    ) {
-      this.relaxGeneralizedCostAtDestination = relaxGeneralizedCostAtDestination;
       return this;
     }
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -3,7 +3,6 @@ package org.opentripplanner.standalone.config.routerequest;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
-import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_3;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_4;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_5;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_7;
@@ -340,28 +339,6 @@ public class RouteRequestConfig {
     if (relaxTransitGroupPriorityValue != null) {
       builder.withRelaxTransitGroupPriority(CostLinearFunction.of(relaxTransitGroupPriorityValue));
     }
-
-    // TODO REMOVE THIS
-    builder.withRaptor(it ->
-      c
-        .of("relaxTransitSearchGeneralizedCostAtDestination")
-        .since(V2_3)
-        .summary("Whether non-optimal transit paths at the destination should be returned")
-        .description(
-          """
-          Let c be the existing minimum pareto optimal generalized cost to beat. Then a trip
-          with cost c' is accepted if the following is true:
-          `c' < Math.round(c * relaxRaptorCostCriteria)`.
-
-          The parameter is optional. If not set a normal comparison is performed.
-
-          Values equals or less than zero is not allowed. Values greater than 2.0 are not
-          supported, due to performance reasons.
-          """
-        )
-        .asDoubleOptional()
-        .ifPresent(it::withRelaxGeneralizedCostAtDestination)
-    );
   }
 
   private static void mapBikePreferences(NodeAdapter root, BikePreferences.Builder builder) {

--- a/application/src/test/java/org/opentripplanner/framework/model/UnitsTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/model/UnitsTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.framework.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -25,12 +24,6 @@ class UnitsTest {
       Units.normalizedFactor(0.999, 1.0, 8.0)
     );
     assertEquals("The value is not in range[1.0, 8.0]: 1.0", ex.getMessage());
-  }
-
-  @Test
-  void normalizedOptionalFactor() {
-    assertNull(Units.normalizedOptionalFactor(null, 0.0, 8.0));
-    assertEquals(1.0, Units.normalizedOptionalFactor(1.0, 0.0, 8.0));
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RaptorRequestMapperTest.RequestFeature.RELAX_COST_DEST;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RaptorRequestMapperTest.RequestFeature.TRANSIT_GROUP_PRIORITY;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RaptorRequestMapperTest.RequestFeature.VIA_PASS_THROUGH;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RaptorRequestMapperTest.RequestFeature.VIA_VISIT;
@@ -84,7 +83,6 @@ class RaptorRequestMapperTest {
   private static final CostLinearFunction RELAX_TRANSIT_GROUP_PRIORITY = CostLinearFunction.of(
     "30m + 1.2t"
   );
-  private static final double RELAX_GENERALIZED_COST_AT_DESTINATION = 2.0;
 
   static List<Arguments> testCasesRelaxedCost() {
     return List.of(
@@ -184,12 +182,6 @@ class RaptorRequestMapperTest {
         null
       ),
       Arguments.of(
-        "RELAX_COST_DEST only",
-        List.of(RELAX_COST_DEST),
-        List.of(RELAX_COST_DEST),
-        null
-      ),
-      Arguments.of(
         "VIA_VISIT is not allowed together VIA_PASS_THROUGH, an error is expected.",
         List.of(VIA_VISIT, VIA_PASS_THROUGH),
         List.of(),
@@ -200,13 +192,13 @@ class RaptorRequestMapperTest {
         VIA_VISIT is not allowed together VIA_PASS_THROUGH, an error is expected.
         Other features are ignored.
         """,
-        List.of(VIA_VISIT, VIA_PASS_THROUGH, TRANSIT_GROUP_PRIORITY, RELAX_COST_DEST),
+        List.of(VIA_VISIT, VIA_PASS_THROUGH, TRANSIT_GROUP_PRIORITY),
         List.of(),
         "A mix of via-locations and pass-through is not allowed in this version."
       ),
       Arguments.of(
         "VIA_PASS_THROUGH cannot be combined with other features, and other features are dropped",
-        List.of(VIA_PASS_THROUGH, TRANSIT_GROUP_PRIORITY, RELAX_COST_DEST),
+        List.of(VIA_PASS_THROUGH, TRANSIT_GROUP_PRIORITY),
         List.of(VIA_PASS_THROUGH),
         null
       ),
@@ -214,24 +206,6 @@ class RaptorRequestMapperTest {
         "VIA_VISIT can be combined with TRANSIT_GROUP_PRIORITY",
         List.of(VIA_VISIT, TRANSIT_GROUP_PRIORITY),
         List.of(VIA_VISIT, TRANSIT_GROUP_PRIORITY),
-        null
-      ),
-      Arguments.of(
-        """
-        VIA_VISIT can only be combined with TRANSIT_GROUP_PRIORITY, and other features are dropped
-        VIA_PASS_THROUGH override VIA_VISIT (see above)
-        """,
-        List.of(VIA_VISIT, TRANSIT_GROUP_PRIORITY, RELAX_COST_DEST),
-        List.of(VIA_VISIT, TRANSIT_GROUP_PRIORITY),
-        null
-      ),
-      Arguments.of(
-        """
-        TRANSIT_GROUP_PRIORITY cannot be combined with other features, override RELAX_COST_DEST
-        VIA_PASS_THROUGH and VIA_VISIT override VIA_VISIT (see above)
-        """,
-        List.of(TRANSIT_GROUP_PRIORITY, RELAX_COST_DEST),
-        List.of(TRANSIT_GROUP_PRIORITY),
         null
       )
     );
@@ -316,13 +290,6 @@ class RaptorRequestMapperTest {
           assertFalse(result.searchParams().isPassThroughSearch());
         }
         break;
-      case RELAX_COST_DEST:
-        assertEquals(expected, result.multiCriteria().relaxCostAtDestination() != null);
-        if (expected) {
-          assertFalse(result.searchParams().isPassThroughSearch());
-          assertFalse(result.searchParams().isVisitViaSearch());
-        }
-        break;
     }
   }
 
@@ -344,13 +311,6 @@ class RaptorRequestMapperTest {
       case TRANSIT_GROUP_PRIORITY -> req.withPreferences(p ->
         p.withTransit(t -> t.withRelaxTransitGroupPriority(RELAX_TRANSIT_GROUP_PRIORITY))
       );
-      case RELAX_COST_DEST -> req.withPreferences(p ->
-        p.withTransit(t ->
-          t.withRaptor(r ->
-            r.withRelaxGeneralizedCostAtDestination(RELAX_GENERALIZED_COST_AT_DESTINATION)
-          )
-        )
-      );
     };
   }
 
@@ -358,7 +318,6 @@ class RaptorRequestMapperTest {
     VIA_VISIT,
     VIA_PASS_THROUGH,
     TRANSIT_GROUP_PRIORITY,
-    RELAX_COST_DEST,
   }
 
   private static class DummyViaCoordinateTransferFactory implements ViaCoordinateTransferFactory {

--- a/application/src/test/java/org/opentripplanner/routing/api/request/preference/RaptorPreferencesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/request/preference/RaptorPreferencesTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.api.request.preference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.routing.api.request.preference.ImmutablePreferencesAsserts.assertEqualsAndHashCode;
 
 import java.time.Instant;
@@ -27,14 +26,11 @@ class RaptorPreferencesTest {
     .atStartOfDay(ZoneIds.UTC)
     .toInstant();
 
-  private static final double RELAX_GENERALIZED_COST_AT_DESTINATION = 1.2;
-
   private final RaptorPreferences subject = RaptorPreferences.of()
     .withSearchDirection(SEARCH_DIRECTION)
     .withProfile(PROFILE)
     .withOptimizations(OPTIMIZATIONS)
     .withTimeLimit(TIME_LIMIT)
-    .withRelaxGeneralizedCostAtDestination(RELAX_GENERALIZED_COST_AT_DESTINATION)
     .build();
 
   @Test
@@ -82,30 +78,6 @@ class RaptorPreferencesTest {
   }
 
   @Test
-  void relaxGeneralizedCostAtDestination() {
-    // Default is not set (null)
-    assertTrue(RaptorPreferences.of().build().relaxGeneralizedCostAtDestination().isEmpty());
-    assertEquals(
-      RELAX_GENERALIZED_COST_AT_DESTINATION,
-      subject.relaxGeneralizedCostAtDestination().orElseThrow()
-    );
-    assertEquals(
-      1.0,
-      RaptorPreferences.of()
-        .withRelaxGeneralizedCostAtDestination(1.0)
-        .build()
-        .relaxGeneralizedCostAtDestination()
-        .orElseThrow()
-    );
-    assertThrows(IllegalArgumentException.class, () ->
-      RaptorPreferences.of().withRelaxGeneralizedCostAtDestination(0.99).build()
-    );
-    assertThrows(IllegalArgumentException.class, () ->
-      RaptorPreferences.of().withRelaxGeneralizedCostAtDestination(2.01).build()
-    );
-  }
-
-  @Test
   void testEqualsAndHashCode() {
     // Return same object if no value is set
     assertSame(RaptorPreferences.DEFAULT, RaptorPreferences.of().build());
@@ -125,8 +97,7 @@ class RaptorPreferencesTest {
       "optimizations: [PARALLEL], " +
       "profile: STANDARD, " +
       "searchDirection: REVERSE, " +
-      "timeLimit: 2020-06-09T00:00:00Z, " +
-      "relaxGeneralizedCostAtDestination: 1.2" +
+      "timeLimit: 2020-06-09T00:00:00Z" +
       "}",
       subject.toString()
     );

--- a/doc/user/RouteRequest.md
+++ b/doc/user/RouteRequest.md
@@ -34,7 +34,6 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 | numItineraries                                                                                               |        `integer`       | The maximum number of itineraries to return.                                                                                                             | *Optional* | `50`             |  2.0  |
 | [otherThanPreferredRoutesPenalty](#rd_otherThanPreferredRoutesPenalty)                                       |        `integer`       | Penalty added for using every route that is not preferred if user set any route as preferred.                                                            | *Optional* | `300`            |  2.0  |
 | [relaxTransitGroupPriority](#rd_relaxTransitGroupPriority)                                                   |        `string`        | The relax function for transit-group-priority                                                                                                            | *Optional* | `"0s + 1.00 t"`  |  2.5  |
-| [relaxTransitSearchGeneralizedCostAtDestination](#rd_relaxTransitSearchGeneralizedCostAtDestination)         |        `double`        | Whether non-optimal transit paths at the destination should be returned                                                                                  | *Optional* |                  |  2.3  |
 | [searchWindow](#rd_searchWindow)                                                                             |       `duration`       | The duration of the search-window.                                                                                                                       | *Optional* |                  |  2.0  |
 | [streetRoutingTimeout](#rd_streetRoutingTimeout)                                                             |       `duration`       | The maximum time a street routing request is allowed to take before returning the results.                                                               | *Optional* | `"PT5S"`         |  2.2  |
 | [transferPenalty](#rd_transferPenalty)                                                                       |        `integer`       | An additional penalty added to boardings after the first.                                                                                                | *Optional* | `0`              |  2.0  |
@@ -299,23 +298,6 @@ The relax function for transit-group-priority
 A path is considered optimal if the generalized-cost is less than the generalized-cost of
 another path. If this parameter is set, the comparison is relaxed further if they belong
 to different transit groups.
-
-
-<h3 id="rd_relaxTransitSearchGeneralizedCostAtDestination">relaxTransitSearchGeneralizedCostAtDestination</h3>
-
-**Since version:** `2.3` ∙ **Type:** `double` ∙ **Cardinality:** `Optional`   
-**Path:** /routingDefaults 
-
-Whether non-optimal transit paths at the destination should be returned
-
-Let c be the existing minimum pareto optimal generalized cost to beat. Then a trip
-with cost c' is accepted if the following is true:
-`c' < Math.round(c * relaxRaptorCostCriteria)`.
-
-The parameter is optional. If not set a normal comparison is performed.
-
-Values equals or less than zero is not allowed. Values greater than 2.0 are not
-supported, due to performance reasons.
 
 
 <h3 id="rd_searchWindow">searchWindow</h3>

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/request/MultiCriteriaRequest.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/request/MultiCriteriaRequest.java
@@ -19,19 +19,14 @@ public class MultiCriteriaRequest<T extends RaptorTripSchedule> {
   @Nullable
   private final RaptorTransitGroupPriorityCalculator transitPriorityCalculator;
 
-  @Nullable
-  private final Double relaxCostAtDestination;
-
   private MultiCriteriaRequest() {
     this.relaxC1 = RelaxFunction.NORMAL;
     this.transitPriorityCalculator = null;
-    this.relaxCostAtDestination = null;
   }
 
   public MultiCriteriaRequest(Builder<T> builder) {
     this.relaxC1 = Objects.requireNonNull(builder.relaxC1());
     this.transitPriorityCalculator = builder.transitPriorityCalculator();
-    this.relaxCostAtDestination = builder.relaxCostAtDestination();
   }
 
   public static <S extends RaptorTripSchedule> Builder<S> of() {
@@ -62,29 +57,6 @@ public class MultiCriteriaRequest<T extends RaptorTripSchedule> {
     return Optional.ofNullable(transitPriorityCalculator);
   }
 
-  /**
-   * Whether to accept non-optimal trips if they are close enough - if and only if they represent
-   * an optimal path for their given iteration. In other words this slack only relaxes the pareto
-   * comparison at the destination.
-   * <p>
-   * Let {@code c} be the existing minimum pareto optimal cost to beat. Then a trip with cost
-   * {@code c'} is accepted if the following is true:
-   * <pre>
-   * c' < Math.round(c * relaxCostAtDestination)
-   * </pre>
-   * If the value is less than 1.0 a normal '<' comparison is performed.
-   * <p>
-   * The default is not set.
-   * <p>
-   * @deprecated This parameter only relax the cost at the destination, not at each stop. This
-   * is replaced by {@link #relaxC1()}. This parameter is ignored if {@link #relaxC1()} exist.
-   */
-  @Deprecated
-  @Nullable
-  public Double relaxCostAtDestination() {
-    return relaxCostAtDestination;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -96,14 +68,13 @@ public class MultiCriteriaRequest<T extends RaptorTripSchedule> {
     MultiCriteriaRequest<?> that = (MultiCriteriaRequest<?>) o;
     return (
       Objects.equals(relaxC1, that.relaxC1) &&
-      Objects.equals(transitPriorityCalculator, that.transitPriorityCalculator) &&
-      Objects.equals(relaxCostAtDestination, that.relaxCostAtDestination)
+      Objects.equals(transitPriorityCalculator, that.transitPriorityCalculator)
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(relaxC1, transitPriorityCalculator, relaxCostAtDestination);
+    return Objects.hash(relaxC1, transitPriorityCalculator);
   }
 
   @Override
@@ -111,7 +82,6 @@ public class MultiCriteriaRequest<T extends RaptorTripSchedule> {
     return ToStringBuilder.of(MultiCriteriaRequest.class)
       .addObj("relaxC1", relaxC1, RelaxFunction.NORMAL)
       .addObj("transitPriorityCalculator", transitPriorityCalculator)
-      .addNum("relaxCostAtDestination", relaxCostAtDestination)
       .toString();
   }
 
@@ -120,13 +90,11 @@ public class MultiCriteriaRequest<T extends RaptorTripSchedule> {
     private final MultiCriteriaRequest<T> original;
     private RelaxFunction relaxC1;
     private RaptorTransitGroupPriorityCalculator transitPriorityCalculator;
-    private Double relaxCostAtDestination;
 
     public Builder(MultiCriteriaRequest<T> original) {
       this.original = original;
       this.relaxC1 = original.relaxC1;
       this.transitPriorityCalculator = original.transitPriorityCalculator;
-      this.relaxCostAtDestination = original.relaxCostAtDestination;
     }
 
     @Nullable
@@ -149,18 +117,6 @@ public class MultiCriteriaRequest<T extends RaptorTripSchedule> {
       return this;
     }
 
-    @Nullable
-    @Deprecated
-    public Double relaxCostAtDestination() {
-      return relaxCostAtDestination;
-    }
-
-    @Deprecated
-    public Builder<T> withRelaxCostAtDestination(Double value) {
-      relaxCostAtDestination = value;
-      return this;
-    }
-
     public MultiCriteriaRequest<T> build() {
       var newInstance = new MultiCriteriaRequest<T>(this);
       return original.equals(newInstance) ? original : newInstance;
@@ -171,7 +127,6 @@ public class MultiCriteriaRequest<T extends RaptorTripSchedule> {
       return ToStringBuilder.of(MultiCriteriaRequest.Builder.class)
         .addObj("relaxC1", relaxC1)
         .addObj("transitPriorityCalculator", transitPriorityCalculator)
-        .addNum("relaxCostAtDestination", relaxCostAtDestination)
         .toString();
     }
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/internalapi/ParetoSetCost.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/internalapi/ParetoSetCost.java
@@ -15,13 +15,6 @@ public enum ParetoSetCost {
    */
   USE_C1,
   /**
-   * Same as {@link #USE_C1}, but the relax function is used to relax the cost at the destination.
-   * DO not use this! This will be removed as soon as the Vy, Entur, Norway has migrated off
-   * this feature.
-   */
-  @Deprecated
-  USE_C1_RELAX_DESTINATION,
-  /**
    * Use both c1 and c2 in the pareto function. A small value is better than a large one.
    */
   USE_C1_AND_C2,

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
@@ -281,9 +281,6 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
     if (isPassThrough()) {
       return ParetoSetCost.USE_C1_AND_C2;
     }
-    if (context().multiCriteria().relaxCostAtDestination() != null) {
-      return ParetoSetCost.USE_C1_RELAX_DESTINATION;
-    }
     return ParetoSetCost.USE_C1;
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/PathParetoSetComparators.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/PathParetoSetComparators.java
@@ -38,7 +38,7 @@ import org.opentripplanner.raptor.util.paretoset.ParetoComparator;
  * parameters used for each stop-arrival. The {@code travelDuration} is only needed at the
  * destination, because Range Raptor works in iterations backwards in time.
  */
-public class PathParetoSetComparators {
+public final class PathParetoSetComparators {
 
   /** Prevent this utility class from instantiation. */
   private PathParetoSetComparators() {}
@@ -85,11 +85,6 @@ public class PathParetoSetComparators {
           c2Comp
         );
       };
-      case USE_C1_RELAX_DESTINATION -> switch (timeConfig) {
-        case USE_TIMETABLE -> comparatorTimetableAndRelaxedC1(relaxC1);
-        case USE_ARRIVAL_TIME -> comparatorArrivalTimeAndRelaxedC1(relaxC1);
-        case USE_DEPARTURE_TIME -> comparatorDepartureTimeAndRelaxedC1(relaxC1);
-      };
     };
   }
 
@@ -127,17 +122,6 @@ public class PathParetoSetComparators {
 
   private static <T extends RaptorTripSchedule> ParetoComparator<
     RaptorPath<T>
-  > comparatorTimetableAndRelaxedC1(final RelaxFunction relaxCost) {
-    return (l, r) ->
-      compareIterationDepartureTime(l, r) ||
-      compareArrivalTime(l, r) ||
-      compareNumberOfTransfers(l, r) ||
-      compareDurationInclusivePenalty(l, r) ||
-      compareC1(relaxCost, l, r);
-  }
-
-  private static <T extends RaptorTripSchedule> ParetoComparator<
-    RaptorPath<T>
   > comparatorArrivalTimeAndC1() {
     return (l, r) ->
       compareArrivalTime(l, r) ||
@@ -154,26 +138,6 @@ public class PathParetoSetComparators {
       compareNumberOfTransfers(l, r) ||
       compareDurationInclusivePenalty(l, r) ||
       compareC1(l, r);
-  }
-
-  private static <T extends RaptorTripSchedule> ParetoComparator<
-    RaptorPath<T>
-  > comparatorArrivalTimeAndRelaxedC1(RelaxFunction relaxCost) {
-    return (l, r) ->
-      compareArrivalTime(l, r) ||
-      compareNumberOfTransfers(l, r) ||
-      compareDurationInclusivePenalty(l, r) ||
-      compareC1(relaxCost, l, r);
-  }
-
-  private static <T extends RaptorTripSchedule> ParetoComparator<
-    RaptorPath<T>
-  > comparatorDepartureTimeAndRelaxedC1(RelaxFunction relaxCost) {
-    return (l, r) ->
-      compareDepartureTime(l, r) ||
-      compareNumberOfTransfers(l, r) ||
-      compareDurationInclusivePenalty(l, r) ||
-      compareC1(relaxCost, l, r);
   }
 
   private static <T extends RaptorTripSchedule> ParetoComparator<

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/configure/PathConfig.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/configure/PathConfig.java
@@ -3,10 +3,8 @@ package org.opentripplanner.raptor.rangeraptor.path.configure;
 import static org.opentripplanner.raptor.rangeraptor.path.PathParetoSetComparators.paretoComparator;
 
 import org.opentripplanner.raptor.api.model.DominanceFunction;
-import org.opentripplanner.raptor.api.model.GeneralizedCostRelaxFunction;
 import org.opentripplanner.raptor.api.model.RaptorStopNameResolver;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
-import org.opentripplanner.raptor.api.model.RelaxFunction;
 import org.opentripplanner.raptor.api.model.SearchDirection;
 import org.opentripplanner.raptor.api.path.RaptorPath;
 import org.opentripplanner.raptor.api.request.RaptorProfile;
@@ -72,16 +70,7 @@ public class PathConfig<T extends RaptorTripSchedule> {
     ParetoSetCost costConfig,
     DominanceFunction c2Comp
   ) {
-    // This code goes away when the USE_C1_RELAX_DESTINATION is deleted
-    var relaxC1 =
-      switch (costConfig) {
-        case USE_C1_RELAXED_IF_C2_IS_OPTIMAL -> ctx.multiCriteria().relaxC1();
-        case USE_C1_RELAX_DESTINATION -> GeneralizedCostRelaxFunction.of(
-          ctx.multiCriteria().relaxCostAtDestination()
-        );
-        default -> RelaxFunction.NORMAL;
-      };
-
+    var relaxC1 = ctx.multiCriteria().relaxC1();
     return paretoComparator(paretoSetTimeConfig(), costConfig, relaxC1, c2Comp);
   }
 

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/path/PathParetoSetComparatorsTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/path/PathParetoSetComparatorsTest.java
@@ -6,7 +6,6 @@ import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetCost.N
 import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetCost.USE_C1;
 import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetCost.USE_C1_AND_C2;
 import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetCost.USE_C1_RELAXED_IF_C2_IS_OPTIMAL;
-import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetCost.USE_C1_RELAX_DESTINATION;
 import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetTime.USE_ARRIVAL_TIME;
 import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetTime.USE_DEPARTURE_TIME;
 import static org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetTime.USE_TIMETABLE;
@@ -52,19 +51,16 @@ public class PathParetoSetComparatorsTest {
       Arguments.of(USE_ARRIVAL_TIME, USE_C1_AND_C2, NO_RELAX_FN, DOMINANCE_FN),
       // TODO: This is failing, error in implementation
       Arguments.of(USE_ARRIVAL_TIME, USE_C1_RELAXED_IF_C2_IS_OPTIMAL, RELAX_FN, DOMINANCE_FN),
-      Arguments.of(USE_ARRIVAL_TIME, USE_C1_RELAX_DESTINATION, RELAX_FN, NO_COMP),
       // Departure time
       Arguments.of(USE_DEPARTURE_TIME, NONE, NO_RELAX_FN, NO_COMP),
       Arguments.of(USE_DEPARTURE_TIME, USE_C1_AND_C2, NO_RELAX_FN, DOMINANCE_FN),
       // TODO: This is failing, error in implementation
       Arguments.of(USE_DEPARTURE_TIME, USE_C1_RELAXED_IF_C2_IS_OPTIMAL, RELAX_FN, DOMINANCE_FN),
-      Arguments.of(USE_DEPARTURE_TIME, USE_C1_RELAX_DESTINATION, RELAX_FN, NO_COMP),
       // Timetable
       Arguments.of(USE_TIMETABLE, NONE, NO_RELAX_FN, NO_COMP),
       Arguments.of(USE_TIMETABLE, USE_C1_AND_C2, NO_RELAX_FN, DOMINANCE_FN),
       // TODO: This is failing, error in implementation
-      Arguments.of(USE_TIMETABLE, USE_C1_RELAXED_IF_C2_IS_OPTIMAL, RELAX_FN, DOMINANCE_FN),
-      Arguments.of(USE_TIMETABLE, USE_C1_RELAX_DESTINATION, RELAX_FN, NO_COMP)
+      Arguments.of(USE_TIMETABLE, USE_C1_RELAXED_IF_C2_IS_OPTIMAL, RELAX_FN, DOMINANCE_FN)
     );
   }
 
@@ -101,9 +97,6 @@ public class PathParetoSetComparatorsTest {
         break;
       case USE_C1_RELAXED_IF_C2_IS_OPTIMAL:
         verifyRelaxedC1IfC2Optimal(comparator);
-        break;
-      case USE_C1_RELAX_DESTINATION:
-        verifyRelaxedC1Comparator(comparator);
         break;
       case NONE:
       default:
@@ -194,26 +187,6 @@ public class PathParetoSetComparatorsTest {
   }
 
   /**
-   * Verify that lower duration always wins
-   */
-  private void verifyDurationComparator(
-    ParetoComparator<RaptorPath<RaptorTripSchedule>> comparator
-  ) {
-    assertTrue(
-      comparator.leftDominanceExist(
-        new TestRaptorPath(ANY, ANY, ANY, NORMAL, ANY, ANY, ANY),
-        new TestRaptorPath(ANY, ANY, ANY, LARGE, ANY, ANY, ANY)
-      )
-    );
-    assertFalse(
-      comparator.leftDominanceExist(
-        new TestRaptorPath(ANY, ANY, ANY, NORMAL, ANY, ANY, ANY),
-        new TestRaptorPath(ANY, ANY, ANY, SMALL, ANY, ANY, ANY)
-      )
-    );
-  }
-
-  /**
    * Verify that lower c1 always wins
    */
   private void verifyC1Comparator(ParetoComparator<RaptorPath<RaptorTripSchedule>> comparator) {
@@ -227,26 +200,6 @@ public class PathParetoSetComparatorsTest {
       comparator.leftDominanceExist(
         new TestRaptorPath(ANY, ANY, ANY, ANY, ANY, NORMAL, ANY),
         new TestRaptorPath(ANY, ANY, ANY, ANY, ANY, SMALL, ANY)
-      )
-    );
-  }
-
-  /**
-   * Verify that relax function is used in a comparator. This method operates on assumption that ratio is 1.5 and slack is 0
-   */
-  private void verifyRelaxedC1Comparator(
-    ParetoComparator<RaptorPath<RaptorTripSchedule>> comparator
-  ) {
-    assertTrue(
-      comparator.leftDominanceExist(
-        new TestRaptorPath(ANY, ANY, ANY, ANY, ANY, RELAXED, ANY),
-        new TestRaptorPath(ANY, ANY, ANY, ANY, ANY, NORMAL, ANY)
-      )
-    );
-    assertFalse(
-      comparator.leftDominanceExist(
-        new TestRaptorPath(ANY, ANY, ANY, ANY, ANY, LARGE, ANY),
-        new TestRaptorPath(ANY, ANY, ANY, ANY, ANY, NORMAL, ANY)
       )
     );
   }


### PR DESCRIPTION
### Summary

The "Relax Cost At Destination" feature was removed as a supported feature in Match 2025 (#6540). The implementation was not removed because we were unsure if someone used this feature. We have had no complains about it, so we can now safely delete the implementation.

### Issue

This is part of #4887 (Already ticked off)

### Unit tests

Tests are updated.

### Documentation

Doc is removed.

### Changelog

Already in the changelog.

### Bumping the serialization version id

The request is changing so the ser.ver.id must be bumped.
