### PR TITLE
Remove old real time trip updates from Raptor timetables

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RealTimeRaptorTransitDataUpdater.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RealTimeRaptorTransitDataUpdater.java
@@ -214,7 +214,7 @@ public class RealTimeRaptorTransitDataUpdater implements TimetableSnapshotUpdate
       for (TripPatternForDate tripPatternForDate : previouslyUsedPatterns) {
         if (tripPatternForDate.getServiceDate().equals(date)) {
           TripPattern pattern = tripPatternForDate.getTripPattern().getPattern();
-          if (!pattern.isStopPatternModifiedInRealTime()) {
+          if (!pattern.isRealTimeTripPattern()) {
             continue;
           }
           var oldTimeTable = timetableProvider.apply(pattern.getId());


### PR DESCRIPTION
### Summary

The existing code only remove real time trip updates with modified stop-patterns, not added trips(NeTEx ExtraJourney). If an ExtraJourney is canceled, the first update is not removed.

### Issue

This is a follow up on #7052. We would like to do this in multiple PRs to minimize risk. 


### Unit tests

There is very few unit-tests testing the business rules in play here, none of the existing tests broke when this code was changed. I have not added new test - I want to replace this logic and in that case the test is not possible to reuse.

### Documentation

🟥  No doc added.

### Changelog

🟥  This is a follow up on #7052, it should be enough to mention the main issue/PR in the change log.

### Bumping the serialization version id

🟥  Not needed-