### PR TITLE
Add Entur specific link on Emission type in transmodel API

### DIFF
--- a/application/src/ext/resources/org/opentripplanner/ext/apis/transmodel/custom-documentation-entur.properties
+++ b/application/src/ext/resources/org/opentripplanner/ext/apis/transmodel/custom-documentation-entur.properties
@@ -24,5 +24,4 @@ TariffZone.description=A **zone** used to define a zonal fare structure in a zon
   \
   **TariffZone data will not be maintained from 1. MAY 2025 (Entur).**
 
-EmpiricalDelay.description.append=NOTE! This feature is under development and the percentiles used \
-  may change without notice. The percentiles are currently set to min=10 and max=90.
+Emission.description.append=For more information, go to https://data.entur.no/dataset/energy_emissions


### PR DESCRIPTION
### Summary

This PR add Entur specific documentation to the Transmodel API. There is a feature in OTP to enable deployment specific documentation. The documentation added in this PR is only added if the `server.apiDocumentationProfile=ENTUR`.  

### Unit tests

This PR only add documentation.

### Documentation
This is added to the Transmodel API (only visible at runtime, not in the schema):

> <img width="378" height="295" src="https://github.com/user-attachments/assets/f03f8a30-ccc2-4743-a5a4-ea16b1fe795a" />

### Changelog

🟥  Sandbox

### Bumping the serialization version id

🟥  Not needed