### PR TITLE
Fix car routing using stations or multi-modal stations as locations

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/linking/configure/LinkingServiceModule.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/configure/LinkingServiceModule.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.routing.linking.VisibilityMode.COMPUTE_AREA_VI
 
 import dagger.Module;
 import dagger.Provides;
+import java.util.Optional;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.VertexLinker;
@@ -41,7 +42,10 @@ public class LinkingServiceModule {
       graph,
       vertexCreationService,
       transitService::findStopOrChildIds,
-      transitService::findStopLocationsGroupCoordinate
+      id -> {
+        var group = transitService.getStopLocationsGroup(id);
+        return Optional.ofNullable(group).map(locationsGroup -> locationsGroup.getCoordinate());
+      }
     );
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -24,7 +24,6 @@ import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.flex.FlexIndex;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
-import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.model.StopTimesInPattern;
@@ -405,13 +404,6 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public MultiModalStation findMultiModalStation(Station station) {
     return this.timetableRepository.getSiteRepository().getMultiModalStationForStation(station);
-  }
-
-  @Override
-  @Nullable
-  public Optional<WgsCoordinate> findStopLocationsGroupCoordinate(FeedScopedId id) {
-    var locationsGroup = timetableRepository.getSiteRepository().getStopLocationsGroup(id);
-    return Optional.ofNullable(locationsGroup).map(StopLocationsGroup::getCoordinate);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.flex.FlexIndex;
-import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.model.StopTimesInPattern;
@@ -226,13 +225,6 @@ public interface TransitService {
   Collection<TripPattern> findPatterns(Route route);
 
   MultiModalStation findMultiModalStation(Station station);
-
-  /**
-   * Return a representative coordinate (most likely the centroid) of a station,
-   * a multi-modal station or group of stations.
-   */
-  @Nullable
-  Optional<WgsCoordinate> findStopLocationsGroupCoordinate(FeedScopedId id);
 
   /**
    * Fetch upcoming vehicle departures from a stop. It goes though all patterns passing the stop for

--- a/application/src/test/java/org/opentripplanner/TestServerContext.java
+++ b/application/src/test/java/org/opentripplanner/TestServerContext.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.Metrics;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.emission.internal.DefaultEmissionRepository;
 import org.opentripplanner.ext.emission.internal.DefaultEmissionService;
@@ -194,7 +195,10 @@ public class TestServerContext {
       graph,
       new VertexCreationService(vertexLinker),
       transitService::findStopOrChildIds,
-      transitService::findStopLocationsGroupCoordinate
+      id -> {
+        var group = transitService.getStopLocationsGroup(id);
+        return Optional.ofNullable(group).map(locationsGroup -> locationsGroup.getCoordinate());
+      }
     );
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,7 +68,10 @@ class LegacyRouteRequestMapperTest implements PlanTestConstants {
       graph,
       vertexCreationService,
       transitService::findStopOrChildIds,
-      transitService::findStopLocationsGroupCoordinate
+      id -> {
+        var group = transitService.getStopLocationsGroup(id);
+        return Optional.ofNullable(group).map(locationsGroup -> locationsGroup.getCoordinate());
+      }
     );
     context = new GraphQLRequestContext(
       new TestRoutingService(List.of()),

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
@@ -64,7 +65,10 @@ class _RouteRequestTestContext {
       graph,
       vertexCreationService,
       transitService::findStopOrChildIds,
-      transitService::findStopLocationsGroupCoordinate
+      id -> {
+        var group = transitService.getStopLocationsGroup(id);
+        return Optional.ofNullable(group).map(locationsGroup -> locationsGroup.getCoordinate());
+      }
     );
     this.context = new GraphQLRequestContext(
       new TestRoutingService(List.of()),

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouterTest.java
@@ -5,6 +5,7 @@ import static com.google.common.truth.Truth.assertThat;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -263,7 +264,10 @@ class AccessEgressRouterTest extends GraphRoutingTest {
         graph,
         vertexCreationService,
         transitService::findStopOrChildIds,
-        transitService::findStopLocationsGroupCoordinate
+        id -> {
+          var group = transitService.getStopLocationsGroup(id);
+          return Optional.ofNullable(group).map(locationsGroup -> locationsGroup.getCoordinate());
+        }
       );
       var linkingRequest = LinkingContextRequestMapper.map(request);
       var linkingContext = linkingContextFactory.create(verticesContainer, linkingRequest);

--- a/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
@@ -353,13 +353,4 @@ class DefaultTransitServiceTest {
     var res = service.findStopOrChildIds(GO_STATIONS.getId());
     assertThat(res).containsExactly(STOP_A.getId(), STOP_B.getId());
   }
-
-  @Test
-  void findStopLocationsGroupCoordinate() {
-    var stationCoordinate = service.findStopLocationsGroupCoordinate(STATION.getId());
-    assertEquals(STATION.getCoordinate(), stationCoordinate.get());
-    var multiModalStationCoordinate = service.findStopLocationsGroupCoordinate(MM_STATION.getId());
-    assertEquals(MM_STATION.getCoordinate(), multiModalStationCoordinate.get());
-    assertThat(service.findStopLocationsGroupCoordinate(STOP_A.getId())).isEmpty();
-  }
 }


### PR DESCRIPTION
### Summary

Previously we had a coordinate fallback for stops as locations in car searches. This pr adds a similar fallback for stations and multi-modal stations using their coordinate (not child stops').

### Issue

Closes #7150

### Unit tests

Added tests

### Documentation

Not needed

### Changelog

From title
