### PR TITLE
Rename ServiceDateInterval to LocalDateInterval

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -26,7 +26,7 @@ import org.opentripplanner.gtfs.graphbuilder.GtfsBundleTestFactory;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModule;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModuleTestFactory;
 import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -197,7 +197,7 @@ public class FlexIntegrationTest {
       gtfsBundles,
       timetableRepository,
       graph,
-      ServiceDateInterval.unbounded()
+      LocalDateInterval.unbounded()
     );
     gtfsModule.buildGraph();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTestData.java
@@ -13,7 +13,7 @@ import org.opentripplanner.gtfs.graphbuilder.GtfsBundle;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundleTestFactory;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModule;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModuleTestFactory;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -51,7 +51,7 @@ public final class FlexIntegrationTestData {
       List.of(gtfsBundle),
       timetableRepository,
       graph,
-      new ServiceDateInterval(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
+      new LocalDateInterval(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
     );
     OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
     module.buildGraph();

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -33,7 +33,7 @@ import org.opentripplanner.gtfs.mapping.GTFSToTransitDataImportMapper;
 import org.opentripplanner.model.TransitDataImport;
 import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.routing.graph.Graph;
@@ -64,7 +64,7 @@ public class GtfsModule implements GraphBuilderModule {
    * @see BuildConfig#transitServiceStart
    * @see BuildConfig#transitServiceEnd
    */
-  private final ServiceDateInterval transitPeriodLimit;
+  private final LocalDateInterval transitPeriodLimit;
   private final List<GtfsBundle> gtfsBundles;
   private final FareServiceFactory fareServiceFactory;
 
@@ -84,7 +84,7 @@ public class GtfsModule implements GraphBuilderModule {
     Graph graph,
     DeduplicatorService deduplicator,
     DataImportIssueStore issueStore,
-    ServiceDateInterval transitPeriodLimit,
+    LocalDateInterval transitPeriodLimit,
     FareServiceFactory fareServiceFactory,
     double maxStopToShapeSnapDistance,
     int subwayAccessTime_s
@@ -108,7 +108,7 @@ public class GtfsModule implements GraphBuilderModule {
     List<GtfsBundle> bundles,
     TimetableRepository timetableRepository,
     Graph graph,
-    ServiceDateInterval transitPeriodLimit
+    LocalDateInterval transitPeriodLimit
   ) {
     return new GtfsModule(
       bundles,

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceDateMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/ServiceDateMapper.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.gtfs.mapping;
 
 import java.time.LocalDate;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 
 /** Responsible for mapping GTFS ServiceDate into the OTP model. */
 class ServiceDateMapper {
@@ -13,10 +13,10 @@ class ServiceDateMapper {
       : LocalDate.of(orginal.getYear(), orginal.getMonth(), orginal.getDay());
   }
 
-  static ServiceDateInterval mapServiceDateInterval(
+  static LocalDateInterval mapServiceDateInterval(
     org.onebusaway.gtfs.model.calendar.ServiceDate start,
     org.onebusaway.gtfs.model.calendar.ServiceDate end
   ) {
-    return new ServiceDateInterval(mapLocalDate(start), mapLocalDate(end));
+    return new LocalDateInterval(mapLocalDate(start), mapLocalDate(end));
   }
 }

--- a/application/src/main/java/org/opentripplanner/model/calendar/LocalDateInterval.java
+++ b/application/src/main/java/org/opentripplanner/model/calendar/LocalDateInterval.java
@@ -17,14 +17,14 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
  * {@code null} is used to represent an unbounded interval. One or both the of the {@code start} and
  * {@code end} can be {@code null} (unbounded).
  */
-public final class ServiceDateInterval {
+public final class LocalDateInterval {
 
-  private static final ServiceDateInterval UNBOUNDED = new ServiceDateInterval(MIN, MAX);
+  private static final LocalDateInterval UNBOUNDED = new LocalDateInterval(MIN, MAX);
 
   private final LocalDate start;
   private final LocalDate end;
 
-  public ServiceDateInterval(LocalDate start, LocalDate end) {
+  public LocalDateInterval(LocalDate start, LocalDate end) {
     this.start = start == null ? MIN : start;
     this.end = end == null ? MAX : end;
 
@@ -39,7 +39,7 @@ public final class ServiceDateInterval {
   /**
    * Return a interval with start or end unbounded ({@code null}).
    */
-  public static ServiceDateInterval unbounded() {
+  public static LocalDateInterval unbounded() {
     return UNBOUNDED;
   }
 
@@ -66,9 +66,9 @@ public final class ServiceDateInterval {
   /**
    * The intervals have at least one day in common.
    *
-   * @see #intersection(ServiceDateInterval)
+   * @see #intersection(LocalDateInterval)
    */
-  public boolean overlap(ServiceDateInterval other) {
+  public boolean overlap(LocalDateInterval other) {
     if (!start.isAfter(other.end)) {
       return !end.isBefore(other.start);
     }
@@ -80,10 +80,10 @@ public final class ServiceDateInterval {
    * periods (intersection of {@code this} and {@code other}).
    *
    * @throws IllegalArgumentException it the to periods do not overlap.
-   * @see #overlap(ServiceDateInterval) for checking an intersection exist.
+   * @see #overlap(LocalDateInterval) for checking an intersection exist.
    */
-  public ServiceDateInterval intersection(ServiceDateInterval other) {
-    return new ServiceDateInterval(
+  public LocalDateInterval intersection(LocalDateInterval other) {
+    return new LocalDateInterval(
       ServiceDateUtils.max(start, other.start),
       ServiceDateUtils.min(end, other.end)
     );
@@ -109,7 +109,7 @@ public final class ServiceDateInterval {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ServiceDateInterval that = (ServiceDateInterval) o;
+    LocalDateInterval that = (LocalDateInterval) o;
     return start.equals(that.start) && end.equals(that.end);
   }
 

--- a/application/src/main/java/org/opentripplanner/model/calendar/ServiceCalendar.java
+++ b/application/src/main/java/org/opentripplanner/model/calendar/ServiceCalendar.java
@@ -29,7 +29,7 @@ public final class ServiceCalendar implements Serializable {
 
   private int sunday;
 
-  private ServiceDateInterval period;
+  private LocalDateInterval period;
 
   public FeedScopedId getServiceId() {
     return serviceId;
@@ -113,11 +113,11 @@ public final class ServiceCalendar implements Serializable {
     setWeekend(value);
   }
 
-  public ServiceDateInterval getPeriod() {
+  public LocalDateInterval getPeriod() {
     return period;
   }
 
-  public void setPeriod(ServiceDateInterval period) {
+  public void setPeriod(LocalDateInterval period) {
     this.period = period;
   }
 

--- a/application/src/main/java/org/opentripplanner/model/calendar/openinghours/OpeningHoursCalendarService.java
+++ b/application/src/main/java/org/opentripplanner/model/calendar/openinghours/OpeningHoursCalendarService.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Objects;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.standalone.config.api.TransitServicePeriod;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 
@@ -18,7 +18,7 @@ public class OpeningHoursCalendarService implements Serializable {
   @Inject
   public OpeningHoursCalendarService(
     Deduplicator deduplicator,
-    @TransitServicePeriod ServiceDateInterval transitServicePeriod
+    @TransitServicePeriod LocalDateInterval transitServicePeriod
   ) {
     this.deduplicator = deduplicator;
     this.startOfPeriod = transitServicePeriod.getStart();
@@ -30,7 +30,7 @@ public class OpeningHoursCalendarService implements Serializable {
     LocalDate startOfPeriod,
     LocalDate endOfPeriod
   ) {
-    this(deduplicator, new ServiceDateInterval(startOfPeriod, endOfPeriod));
+    this(deduplicator, new LocalDateInterval(startOfPeriod, endOfPeriod));
   }
 
   public OHCalendarBuilder newBuilder(ZoneId zoneId) {

--- a/application/src/main/java/org/opentripplanner/model/impl/TransitDataImportBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/TransitDataImportBuilder.java
@@ -19,9 +19,9 @@ import org.opentripplanner.model.ShapePoint;
 import org.opentripplanner.model.TransitDataImport;
 import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.model.calendar.CalendarServiceData;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.calendar.ServiceCalendar;
 import org.opentripplanner.model.calendar.ServiceCalendarDate;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.model.calendar.impl.CalendarServiceDataFactoryImpl;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.model.transfer.TransferPoint;
@@ -281,7 +281,7 @@ public class TransitDataImportBuilder {
    * period. If a service is start before and/or ends after the period then the service is modified
    * to match the period.
    */
-  public void limitServiceDays(ServiceDateInterval periodLimit) {
+  public void limitServiceDays(LocalDateInterval periodLimit) {
     if (periodLimit.isUnbounded()) {
       LOG.info("Limiting transit service is skipped, the period is unbounded.");
       return;

--- a/application/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/application/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -12,7 +12,7 @@ import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesF
 import org.opentripplanner.model.TransitDataImport;
 import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.streetdetails.StreetDetailsRepository;
@@ -43,7 +43,7 @@ public class NetexModule implements GraphBuilderModule {
    * @see BuildConfig#transitServiceStart
    * @see BuildConfig#transitServiceEnd
    */
-  private final ServiceDateInterval transitPeriodLimit;
+  private final LocalDateInterval transitPeriodLimit;
 
   private final List<NetexBundle> netexBundles;
 
@@ -55,7 +55,7 @@ public class NetexModule implements GraphBuilderModule {
     StreetDetailsRepository streetDetailsRepository,
     DataImportIssueStore issueStore,
     int subwayAccessTime,
-    ServiceDateInterval transitPeriodLimit,
+    LocalDateInterval transitPeriodLimit,
     List<NetexBundle> netexBundles
   ) {
     this.graph = graph;

--- a/application/src/main/java/org/opentripplanner/netex/mapping/calendar/CalendarServiceBuilder.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/calendar/CalendarServiceBuilder.java
@@ -9,9 +9,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.calendar.ServiceCalendar;
 import org.opentripplanner.model.calendar.ServiceCalendarDate;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 
 /**
@@ -69,7 +69,7 @@ public class CalendarServiceBuilder {
   public ServiceCalendar createEmptyCalendar() {
     ServiceCalendar emptyCalendar = new ServiceCalendar();
     emptyCalendar.setServiceId(EMPTY_SERVICE_ID);
-    emptyCalendar.setPeriod(ServiceDateInterval.unbounded());
+    emptyCalendar.setPeriod(LocalDateInterval.unbounded());
     return emptyCalendar;
   }
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -38,7 +38,7 @@ import org.opentripplanner.graph_builder.module.osm.parameters.OsmExtractParamet
 import org.opentripplanner.graph_builder.module.osm.parameters.OsmExtractParametersList;
 import org.opentripplanner.graph_builder.services.osm.EdgeNamer;
 import org.opentripplanner.gtfs.config.GtfsDefaultParameters;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.netex.config.NetexFeedParameters;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -718,8 +718,8 @@ public class BuildConfig implements OtpDataStoreConfig {
     return root.isEmpty() ? "" : root.toJson();
   }
 
-  public ServiceDateInterval getTransitServicePeriod() {
-    return new ServiceDateInterval(transitServiceStart, transitServiceEnd);
+  public LocalDateInterval getTransitServicePeriod() {
+    return new LocalDateInterval(transitServiceStart, transitServiceEnd);
   }
 
   public List<FeedScopedId> transitRouteToStationCentroid() {

--- a/application/src/main/java/org/opentripplanner/standalone/config/configure/LoadConfigModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/configure/LoadConfigModule.java
@@ -6,7 +6,7 @@ import jakarta.inject.Singleton;
 import java.io.File;
 import org.opentripplanner.datastore.api.OtpBaseDirectory;
 import org.opentripplanner.datastore.api.OtpDataStoreConfig;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.opentripplanner.standalone.config.ConfigModel;
@@ -46,7 +46,7 @@ public class LoadConfigModule {
 
   @Provides
   @TransitServicePeriod
-  static ServiceDateInterval providesTransitServicePeriod(BuildConfig buildConfig) {
+  static LocalDateInterval providesTransitServicePeriod(BuildConfig buildConfig) {
     return buildConfig.getTransitServicePeriod();
   }
 

--- a/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
@@ -3,7 +3,7 @@ package org.opentripplanner.gtfs.graphbuilder;
 import java.util.List;
 import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.service.streetdetails.internal.DefaultStreetDetailsRepository;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -15,7 +15,7 @@ public class GtfsModuleTestFactory {
     List<GtfsBundle> bundles,
     TimetableRepository timetableRepository,
     Graph graph,
-    ServiceDateInterval transitPeriodLimit
+    LocalDateInterval transitPeriodLimit
   ) {
     return new GtfsModule(
       bundles,

--- a/application/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/application/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -24,7 +24,7 @@ import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.graph_builder.module.transfer.DirectTransferGenerator;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundleTestFactory;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModule;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.netex.NetexBundle;
 import org.opentripplanner.netex.configure.NetexConfigure;
@@ -339,7 +339,7 @@ public class ConstantsForTests {
       graph,
       new Deduplicator(),
       DataImportIssueStore.NOOP,
-      ServiceDateInterval.unbounded(),
+      LocalDateInterval.unbounded(),
       fareServiceFactory,
       150.0,
       DurationUtils.durationInSeconds("2m")

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -27,7 +27,7 @@ import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareService;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundle;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundleTestFactory;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModule;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RealTimeRaptorTransitDataUpdater;
@@ -213,7 +213,7 @@ public abstract class GtfsTest {
       gtfsBundleList,
       timetableRepository,
       graph,
-      ServiceDateInterval.unbounded()
+      LocalDateInterval.unbounded()
     );
 
     gtfsGraphBuilderImpl.buildGraph();

--- a/application/src/test/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.ConstantsForTests;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -30,7 +30,7 @@ class GtfsModuleTest {
       List.of(bundle),
       model.timetableRepository,
       model.graph,
-      ServiceDateInterval.unbounded()
+      LocalDateInterval.unbounded()
     );
 
     module.buildGraph();
@@ -61,7 +61,7 @@ class GtfsModuleTest {
       bundles,
       model.timetableRepository,
       model.graph,
-      ServiceDateInterval.unbounded()
+      LocalDateInterval.unbounded()
     );
     assertThrows(IllegalArgumentException.class, module::buildGraph);
   }
@@ -110,7 +110,7 @@ class GtfsModuleTest {
         bundles,
         model.timetableRepository,
         model.graph,
-        ServiceDateInterval.unbounded()
+        LocalDateInterval.unbounded()
       );
 
       module.buildGraph();

--- a/application/src/test/java/org/opentripplanner/model/calendar/LocalDateIntervalTest.java
+++ b/application/src/test/java/org/opentripplanner/model/calendar/LocalDateIntervalTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
-public class ServiceDateIntervalTest {
+public class LocalDateIntervalTest {
 
   private final LocalDate d0 = LocalDate.of(2020, 1, 1);
   private final LocalDate d1 = LocalDate.of(2020, 1, 7);
@@ -19,66 +19,66 @@ public class ServiceDateIntervalTest {
 
   @Test
   public void constructorFailsIfEndIsBeforeTheStart() {
-    assertThrows(IllegalArgumentException.class, () -> new ServiceDateInterval(d1.plusDays(1), d1));
+    assertThrows(IllegalArgumentException.class, () -> new LocalDateInterval(d1.plusDays(1), d1));
   }
 
   @Test
   public void unlimited() {
-    ServiceDateInterval u = ServiceDateInterval.unbounded();
+    LocalDateInterval u = LocalDateInterval.unbounded();
     assertTrue(u.include(LocalDate.MIN));
     assertTrue(u.include(LocalDate.MAX));
   }
 
   @Test
   public void isUnbounded() {
-    assertTrue(ServiceDateInterval.unbounded().isUnbounded());
-    assertFalse(new ServiceDateInterval(null, d2).isUnbounded());
-    assertFalse(new ServiceDateInterval(d2, null).isUnbounded());
+    assertTrue(LocalDateInterval.unbounded().isUnbounded());
+    assertFalse(new LocalDateInterval(null, d2).isUnbounded());
+    assertFalse(new LocalDateInterval(d2, null).isUnbounded());
   }
 
   @Test
   public void getStart() {
-    assertEquals(d1, new ServiceDateInterval(d1, d2).getStart());
-    assertEquals(LocalDate.MIN, ServiceDateInterval.unbounded().getStart());
+    assertEquals(d1, new LocalDateInterval(d1, d2).getStart());
+    assertEquals(LocalDate.MIN, LocalDateInterval.unbounded().getStart());
   }
 
   @Test
   public void getEnd() {
-    assertEquals(d2, new ServiceDateInterval(d1, d2).getEnd());
-    assertEquals(LocalDate.MAX, ServiceDateInterval.unbounded().getEnd());
+    assertEquals(d2, new LocalDateInterval(d1, d2).getEnd());
+    assertEquals(LocalDate.MAX, LocalDateInterval.unbounded().getEnd());
   }
 
   @Test
   public void overlap() {
-    ServiceDateInterval subject = new ServiceDateInterval(d1, d2);
-    ServiceDateInterval other;
+    LocalDateInterval subject = new LocalDateInterval(d1, d2);
+    LocalDateInterval other;
 
     // First day overlap
-    other = new ServiceDateInterval(d0, d1);
+    other = new LocalDateInterval(d0, d1);
     assertTrue(subject.overlap(other), subject + " should overlap " + other);
 
     // Last day overlap
-    other = new ServiceDateInterval(d2, d3);
+    other = new LocalDateInterval(d2, d3);
     assertTrue(subject.overlap(other), subject + " should overlap " + other);
 
     // Same periods overlap
-    other = new ServiceDateInterval(d1, d2);
+    other = new LocalDateInterval(d1, d2);
     assertTrue(subject.overlap(other), subject + " should overlap " + other);
 
     // Small period overlap part of large
-    other = new ServiceDateInterval(d0, d4);
+    other = new LocalDateInterval(d0, d4);
     assertTrue(subject.overlap(other), subject + " should overlap " + other);
 
     // Period ending day before, do NOT overlap
-    other = new ServiceDateInterval(d0, d1.minusDays(1));
+    other = new LocalDateInterval(d0, d1.minusDays(1));
     assertFalse(subject.overlap(other), subject + " should not overlap " + other);
 
     // Period start day after, do NOT overlap
-    other = new ServiceDateInterval(d2.plusDays(1), d3);
+    other = new LocalDateInterval(d2.plusDays(1), d3);
     assertFalse(subject.overlap(other), subject + " should not overlap " + other);
 
     // Period overlap with unlimited
-    ServiceDateInterval unlimited = ServiceDateInterval.unbounded();
+    LocalDateInterval unlimited = LocalDateInterval.unbounded();
     assertTrue(subject.overlap(unlimited), subject + " should overlap unlimited");
 
     // Unlimited overlap with unlimited
@@ -87,37 +87,37 @@ public class ServiceDateIntervalTest {
 
   @Test
   public void intersection() {
-    ServiceDateInterval subject = new ServiceDateInterval(d1, d2);
+    LocalDateInterval subject = new LocalDateInterval(d1, d2);
 
     // Intersection of subject and subject -> subject
     assertEquals(subject, subject.intersection(subject));
 
     // First day in common
     assertEquals(
-      new ServiceDateInterval(d1, d1),
-      subject.intersection(new ServiceDateInterval(d0, d1))
+      new LocalDateInterval(d1, d1),
+      subject.intersection(new LocalDateInterval(d0, d1))
     );
 
     // Last day in common
     assertEquals(
-      new ServiceDateInterval(d2, d2),
-      subject.intersection(new ServiceDateInterval(d2, d3))
+      new LocalDateInterval(d2, d2),
+      subject.intersection(new LocalDateInterval(d2, d3))
     );
 
     // The intersection of subject and unlimited -> subject
-    assertEquals(subject, subject.intersection(ServiceDateInterval.unbounded()));
+    assertEquals(subject, subject.intersection(LocalDateInterval.unbounded()));
   }
 
   @Test
   public void intersectionFailsIfAUnionDoNotExist() {
     assertThrows(IllegalArgumentException.class, () ->
-      new ServiceDateInterval(d0, d1).intersection(new ServiceDateInterval(d1.plusDays(1), d2))
+      new LocalDateInterval(d0, d1).intersection(new LocalDateInterval(d1.plusDays(1), d2))
     );
   }
 
   @Test
   public void include() {
-    ServiceDateInterval subject = new ServiceDateInterval(d1, d3);
+    LocalDateInterval subject = new LocalDateInterval(d1, d3);
 
     assertFalse(subject.include(d0));
     assertTrue(subject.include(d1));
@@ -128,36 +128,36 @@ public class ServiceDateIntervalTest {
 
   @Test
   public void testHashCodeAndEquals() {
-    ServiceDateInterval subject = new ServiceDateInterval(d1, d3);
-    ServiceDateInterval same = new ServiceDateInterval(d1, d3);
-    ServiceDateInterval i1 = new ServiceDateInterval(d1, d2);
-    ServiceDateInterval i2 = new ServiceDateInterval(d2, d3);
+    LocalDateInterval subject = new LocalDateInterval(d1, d3);
+    LocalDateInterval same = new LocalDateInterval(d1, d3);
+    LocalDateInterval i1 = new LocalDateInterval(d1, d2);
+    LocalDateInterval i2 = new LocalDateInterval(d2, d3);
 
     assertEquals(subject, same);
     assertNotEquals(subject, i1);
     assertNotEquals(subject, i2);
-    assertEquals(new ServiceDateInterval(null, null), ServiceDateInterval.unbounded());
+    assertEquals(new LocalDateInterval(null, null), LocalDateInterval.unbounded());
 
     assertEquals(subject.hashCode(), same.hashCode());
     assertNotEquals(subject.hashCode(), i1.hashCode());
     assertNotEquals(subject.hashCode(), i2.hashCode());
     assertEquals(
-      new ServiceDateInterval(null, null).hashCode(),
-      ServiceDateInterval.unbounded().hashCode()
+      new LocalDateInterval(null, null).hashCode(),
+      LocalDateInterval.unbounded().hashCode()
     );
   }
 
   @Test
   public void testToString() {
-    assertEquals("[2020-01-07, 2020-01-15]", new ServiceDateInterval(d1, d2).toString());
-    assertEquals("[MIN, 2020-01-15]", new ServiceDateInterval(null, d2).toString());
-    assertEquals("[2020-01-07, MAX]", new ServiceDateInterval(d1, null).toString());
-    assertEquals("[MIN, MAX]", new ServiceDateInterval(null, null).toString());
-    assertEquals("[MIN, MAX]", ServiceDateInterval.unbounded().toString());
+    assertEquals("[2020-01-07, 2020-01-15]", new LocalDateInterval(d1, d2).toString());
+    assertEquals("[MIN, 2020-01-15]", new LocalDateInterval(null, d2).toString());
+    assertEquals("[2020-01-07, MAX]", new LocalDateInterval(d1, null).toString());
+    assertEquals("[MIN, MAX]", new LocalDateInterval(null, null).toString());
+    assertEquals("[MIN, MAX]", LocalDateInterval.unbounded().toString());
   }
 
   @Test
   public void daysInPeriod() {
-    assertEquals(7, new ServiceDateInterval(d0, d1).daysInPeriod());
+    assertEquals(7, new LocalDateInterval(d0, d1).daysInPeriod());
   }
 }

--- a/application/src/test/java/org/opentripplanner/model/impl/TransitDataImportBuilderLimitPeriodTest.java
+++ b/application/src/test/java/org/opentripplanner/model/impl/TransitDataImportBuilderLimitPeriodTest.java
@@ -14,9 +14,9 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.calendar.LocalDateInterval;
 import org.opentripplanner.model.calendar.ServiceCalendar;
 import org.opentripplanner.model.calendar.ServiceCalendarDate;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.EntityById;
@@ -117,7 +117,7 @@ public class TransitDataImportBuilderLimitPeriodTest {
     assertEquals(1, patternInT2.getScheduledTimetable().getTripTimes().size());
 
     // Limit service to last half of month
-    subject.limitServiceDays(new ServiceDateInterval(D2, D3));
+    subject.limitServiceDays(new LocalDateInterval(D2, D3));
 
     // Verify calendar
     List<ServiceCalendar> calendars = subject.getCalendars();
@@ -173,7 +173,7 @@ public class TransitDataImportBuilderLimitPeriodTest {
     LocalDate end
   ) {
     ServiceCalendar calendar = new ServiceCalendar();
-    calendar.setPeriod(new ServiceDateInterval(start, end));
+    calendar.setPeriod(new LocalDateInterval(start, end));
     calendar.setAllDays(1);
     calendar.setServiceId(serviceId);
     return calendar;


### PR DESCRIPTION
### Summary

During the review of #7144 @t2gran has requested that I extract several smaller preparation PRs out out of this large PR: this one renames ServiceDateInterval to LocalDateInterval, before it is moved to domain-core.

### Issue

Ref #6881 

### Unit tests

Adjusted.

### Bumping the serialization version id

This class is not serializable, so no.