### PR TITLE
Update safety mixins documentation

### DIFF
--- a/doc/templates/OsmMapper.md
+++ b/doc/templates/OsmMapper.md
@@ -23,8 +23,13 @@ Lower safety values make an OSM way more desirable and higher values less desira
 
 ### Safety mixins
 
-Mixins are selectors that have only an effect on the bicycle and walk safety factors but not on the
-permission of an OSM way. Their safety values are multiplied with the base values from the selected
-way properties. Multiple mixins can apply to the same way and their effects compound.
+Mixins are selectors that have an effect on the bicycle and walk safety factors. 
+Their safety values are multiplied with the base values from the selected way properties.
+
+Mixins can also add or remove permissions on an OSM way, which will be further overridden with
+explicitly set permission tags. If two mixins add and remove the same permission on the same way,
+the behavior is unspecified which usually indicates a tagging error on the way.
+
+Multiple mixins can apply to the same way and their effects compound.
 
 <!-- INSERT: mixins -->

--- a/doc/user/osm/Finland.md
+++ b/doc/user/osm/Finland.md
@@ -113,9 +113,14 @@ Lower safety values make an OSM way more desirable and higher values less desira
 
 ### Safety mixins
 
-Mixins are selectors that have only an effect on the bicycle and walk safety factors but not on the
-permission of an OSM way. Their safety values are multiplied with the base values from the selected
-way properties. Multiple mixins can apply to the same way and their effects compound.
+Mixins are selectors that have an effect on the bicycle and walk safety factors. 
+Their safety values are multiplied with the base values from the selected way properties.
+
+Mixins can also add or remove permissions on an OSM way, which will be further overridden with
+explicitly set permission tags. If two mixins add and remove the same permission on the same way,
+the behavior is unspecified which usually indicates a tagging error on the way.
+
+Multiple mixins can apply to the same way and their effects compound.
 
 <!-- mixins BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->

--- a/doc/user/osm/Germany.md
+++ b/doc/user/osm/Germany.md
@@ -76,9 +76,14 @@ Lower safety values make an OSM way more desirable and higher values less desira
 
 ### Safety mixins
 
-Mixins are selectors that have only an effect on the bicycle and walk safety factors but not on the
-permission of an OSM way. Their safety values are multiplied with the base values from the selected
-way properties. Multiple mixins can apply to the same way and their effects compound.
+Mixins are selectors that have an effect on the bicycle and walk safety factors. 
+Their safety values are multiplied with the base values from the selected way properties.
+
+Mixins can also add or remove permissions on an OSM way, which will be further overridden with
+explicitly set permission tags. If two mixins add and remove the same permission on the same way,
+the behavior is unspecified which usually indicates a tagging error on the way.
+
+Multiple mixins can apply to the same way and their effects compound.
 
 <!-- mixins BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->

--- a/doc/user/osm/Norway.md
+++ b/doc/user/osm/Norway.md
@@ -75,9 +75,14 @@ Lower safety values make an OSM way more desirable and higher values less desira
 
 ### Safety mixins
 
-Mixins are selectors that have only an effect on the bicycle and walk safety factors but not on the
-permission of an OSM way. Their safety values are multiplied with the base values from the selected
-way properties. Multiple mixins can apply to the same way and their effects compound.
+Mixins are selectors that have an effect on the bicycle and walk safety factors. 
+Their safety values are multiplied with the base values from the selected way properties.
+
+Mixins can also add or remove permissions on an OSM way, which will be further overridden with
+explicitly set permission tags. If two mixins add and remove the same permission on the same way,
+the behavior is unspecified which usually indicates a tagging error on the way.
+
+Multiple mixins can apply to the same way and their effects compound.
 
 <!-- mixins BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->

--- a/doc/user/osm/OsmTag.md
+++ b/doc/user/osm/OsmTag.md
@@ -68,9 +68,14 @@ Lower safety values make an OSM way more desirable and higher values less desira
 
 ### Safety mixins
 
-Mixins are selectors that have only an effect on the bicycle and walk safety factors but not on the
-permission of an OSM way. Their safety values are multiplied with the base values from the selected
-way properties. Multiple mixins can apply to the same way and their effects compound.
+Mixins are selectors that have an effect on the bicycle and walk safety factors. 
+Their safety values are multiplied with the base values from the selected way properties.
+
+Mixins can also add or remove permissions on an OSM way, which will be further overridden with
+explicitly set permission tags. If two mixins add and remove the same permission on the same way,
+the behavior is unspecified which usually indicates a tagging error on the way.
+
+Multiple mixins can apply to the same way and their effects compound.
 
 <!-- mixins BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->

--- a/doc/user/osm/UK.md
+++ b/doc/user/osm/UK.md
@@ -72,9 +72,14 @@ Lower safety values make an OSM way more desirable and higher values less desira
 
 ### Safety mixins
 
-Mixins are selectors that have only an effect on the bicycle and walk safety factors but not on the
-permission of an OSM way. Their safety values are multiplied with the base values from the selected
-way properties. Multiple mixins can apply to the same way and their effects compound.
+Mixins are selectors that have an effect on the bicycle and walk safety factors. 
+Their safety values are multiplied with the base values from the selected way properties.
+
+Mixins can also add or remove permissions on an OSM way, which will be further overridden with
+explicitly set permission tags. If two mixins add and remove the same permission on the same way,
+the behavior is unspecified which usually indicates a tagging error on the way.
+
+Multiple mixins can apply to the same way and their effects compound.
 
 <!-- mixins BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->


### PR DESCRIPTION
### Summary

This updates the safety mixins documentation to reflect that they can now change way permissions after the change in #6767.

### Issue

N/A

### Unit tests

N/A, purely documentation change

### Documentation

Updated

### Changelog

No need

### Bumping the serialization version id

No need