### PR TITLE
Baseline duration of carpool trip fix

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
@@ -22,14 +22,15 @@ public record InsertionCandidate(
   int pickupPosition,
   int dropoffPosition,
   List<GraphPath<State, Edge, Vertex>> routeSegments,
-  Duration baselineDuration,
+  Duration durationBetweenOriginAndDestination,
   Duration totalDuration
 ) {
   /**
-   * Calculates the additional duration caused by inserting this passenger.
+   * Calculates the difference between the total duration when inserting this passenger,
+   * and the duration when driving directly from the start to the end of the trip.
    */
   public Duration additionalDuration() {
-    return totalDuration.minus(baselineDuration);
+    return totalDuration.minus(durationBetweenOriginAndDestination);
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/GraphPathUtils.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/GraphPathUtils.java
@@ -16,13 +16,20 @@ public class GraphPathUtils {
     cumulativeDurations[0] = Duration.ZERO;
 
     for (int i = 0; i < segments.length; i++) {
-      Duration segmentDuration = Duration.between(
-        segments[i].states.getFirst().getTime(),
-        segments[i].states.getLast().getTime()
-      );
+      Duration segmentDuration = calculateDuration(segments[i]);
       cumulativeDurations[i + 1] = cumulativeDurations[i].plus(segmentDuration);
     }
 
     return cumulativeDurations;
+  }
+
+  /**
+   * Calculates duration for a segment
+   */
+  public static Duration calculateDuration(GraphPath<State, Edge, Vertex> segment) {
+    return Duration.between(
+      segment.states.getFirst().getTime(),
+      segment.states.getLast().getTime()
+    );
   }
 }


### PR DESCRIPTION
### Summary

A carpool trip has a maximum deviation time budget, which for now is set to a constant 15 minutes as a temporary value. This is how much longer the driver accepts that the trip will take with extra passengers, compared to how long it would take if the driver did the trip alone.

To check whether the deviation budget was exceeded, the following calculation was used:

additional duration = total duration - baseline duration.

The problem is that the baseline duration is calculated using all stops in the trip, including stops for any previously inserted passengers. This means that the deviation budget could be exceeded for carpooling trips with multiple passengers. This PR fixes this issue. 


### Unit tests

A test findOptimalInsertion_onDeviationBudgetExceeded_returnsNull is added, in which the deviation budget of a carpooling trip with another passenger is exceeded only after this fix. 

A few other tests of InsertionEvaluatorTest are also refractored into using a deterministic routing function, since the previous design using a function which depended on the order in which it was called caused problems. Some of the tests also had to have their durations changed for the tests to pass. 
