### PR TITLE
Penalty for boarding/alighting area stops in flex routing

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexibleTransitLegTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexibleTransitLegTest.java
@@ -32,7 +32,8 @@ class FlexibleTransitLegTest implements PlanTestConstants {
     1,
     2,
     LocalDate.of(2025, 1, 15),
-    new FlexPath(1000, 600, () -> GeometryUtils.makeLineString(1, 1, 2, 2))
+    new FlexPath(1000, 600, () -> GeometryUtils.makeLineString(1, 1, 2, 2)),
+    FlexParameters.defaultValues()
   );
   private static final TransitAlert ALERT = TransitAlert.of(id("alert"))
     .withHeaderText(I18NString.of("alert 1"))

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdgeTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdgeTest.java
@@ -1,0 +1,109 @@
+package org.opentripplanner.ext.flex.edgetype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.ext.flex.flexpathcalculator.FlexPath;
+import org.opentripplanner.framework.geometry.GeometryUtils;
+import org.opentripplanner.framework.model.Cost;
+import org.opentripplanner.street.model.vertex.SimpleVertex;
+import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.street.search.state.TestStateBuilder;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.site.StopLocation;
+
+class FlexTripEdgeTest {
+
+  private static final FlexPath FLEX_PATH = new FlexPath(1, 0, () ->
+    GeometryUtils.makeLineString(0, 0, 1, 1)
+  );
+  private static final LocalDate SERVICE_DATE = LocalDate.of(2024, 1, 1);
+
+  private static final TimetableRepositoryForTest model = TimetableRepositoryForTest.of();
+  private static final StopLocation AREA_STOP = model.areaStop("1").build();
+  private static final StopLocation REGULAR_STOP = model.stop("2").build();
+
+  public static List<Arguments> cases() {
+    return List.of(
+      Arguments.of(AREA_STOP, AREA_STOP, 0, 0, 600),
+      Arguments.of(AREA_STOP, AREA_STOP, 100, 0, 700),
+      Arguments.of(AREA_STOP, AREA_STOP, 0, 100, 700),
+      Arguments.of(AREA_STOP, AREA_STOP, 100, 100, 800),
+      Arguments.of(AREA_STOP, REGULAR_STOP, 100, 100, 700),
+      Arguments.of(REGULAR_STOP, AREA_STOP, 100, 100, 700),
+      Arguments.of(REGULAR_STOP, REGULAR_STOP, 100, 100, 600),
+      Arguments.of(REGULAR_STOP, REGULAR_STOP, 0, 0, 600)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("cases")
+  void applyCost(
+    StopLocation boardStop,
+    StopLocation alightStop,
+    int boardCost,
+    int alightCost,
+    int expectedWeight
+  ) {
+    State state = TestStateBuilder.ofWalking().build();
+    assertEquals(0, state.getWeight());
+    var edge = new FlexTripEdge(
+      state.getVertex(),
+      new SimpleVertex("v2", 1, 1),
+      boardStop,
+      alightStop,
+      null,
+      0,
+      1,
+      SERVICE_DATE,
+      FLEX_PATH,
+      flexParameters(boardCost, alightCost)
+    );
+    State[] result = edge.traverse(state);
+
+    assertEquals(1, result.length);
+
+    var s = result[0];
+    assertEquals(expectedWeight, s.getWeight());
+  }
+
+  private FlexParameters flexParameters(int boardCost, int alightCost) {
+    return new FlexParameters() {
+      @Override
+      public Duration maxTransferDuration() {
+        return null;
+      }
+
+      @Override
+      public Duration maxFlexTripDuration() {
+        return null;
+      }
+
+      @Override
+      public Duration maxAccessWalkDuration() {
+        return null;
+      }
+
+      @Override
+      public Duration maxEgressWalkDuration() {
+        return null;
+      }
+
+      @Override
+      public Cost areaStopBoardCost() {
+        return Cost.costOfSeconds(boardCost);
+      }
+
+      @Override
+      public Cost areaStopAlightCost() {
+        return Cost.costOfSeconds(alightCost);
+      }
+    };
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/template/FlexTemplateFactoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/template/FlexTemplateFactoryTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.ScheduledFlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.StreetFlexPathCalculator;
@@ -43,7 +44,7 @@ class FlexTemplateFactoryTest {
   /**
    * This is pass-through information
    */
-  private static final Duration MAX_TRANSFER_DURATION = Duration.ofMinutes(10);
+  private static final FlexParameters PARAMS = FlexParameters.defaultValues();
 
   /**
    * Any calculator will do. The only thing we will test here is that a new scheduled calculator
@@ -93,7 +94,7 @@ class FlexTemplateFactoryTest {
       stopTime(2, STOP_B, BOARD_AND_ALIGHT, T_10_10)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with access boarding at stop A
     var subject = factory.createAccessTemplates(closestTrip(flexTrip, STOP_A, 0));
@@ -125,7 +126,7 @@ class FlexTemplateFactoryTest {
       stopTime(2, STOP_B, BOARD_AND_ALIGHT, T_10_10)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with egress alighting at stop B
     var subject = factory.createEgressTemplates(closestTrip(flexTrip, STOP_B, 1));
@@ -159,7 +160,7 @@ class FlexTemplateFactoryTest {
       stopTime(4, STOP_D, ALIGHT_ONLY, T_10_30)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with boarding at stop A
     var subject = factory.createAccessTemplates(closestTrip(flexTrip, STOP_A, 0));
@@ -200,7 +201,7 @@ class FlexTemplateFactoryTest {
       stopTime(4, STOP_D, ALIGHT_ONLY, T_10_30)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with boarding at stop A
     var subject = factory.createEgressTemplates(closestTrip(flexTrip, STOP_D, 3));
@@ -240,7 +241,7 @@ class FlexTemplateFactoryTest {
       stopTime(2, GROUP_STOP_34, ALIGHT_ONLY, T_10_20)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with access boarding at stop A
     var subject = factory.createAccessTemplates(closestTrip(flexTrip, STOP_G1, 0));
@@ -263,7 +264,7 @@ class FlexTemplateFactoryTest {
       stopTime(2, GROUP_STOP_34, ALIGHT_ONLY, T_10_20)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with access boarding at stop A
     var subject = factory.createEgressTemplates(closestTrip(flexTrip, STOP_G4, 1));
@@ -287,7 +288,7 @@ class FlexTemplateFactoryTest {
       stopTime(10, STOP_C, ALIGHT_ONLY, T_10_30)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with access boarding at stop A
     var subject = factory.createAccessTemplates(closestTrip(flexTrip, STOP_B, 1));
@@ -309,7 +310,7 @@ class FlexTemplateFactoryTest {
       stopTime(10, STOP_C, ALIGHT_ONLY, T_10_30)
     );
 
-    var factory = FlexTemplateFactory.of(CALCULATOR, MAX_TRANSFER_DURATION);
+    var factory = FlexTemplateFactory.of(CALCULATOR, PARAMS);
 
     // Create template with access boarding at stop A
     var subject = factory.createEgressTemplates(closestTrip(flexTrip, STOP_B, 1));

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexParameters.java
@@ -27,9 +27,13 @@ public interface FlexParameters {
    * See {@link org.opentripplanner.standalone.config.sandbox.FlexConfig}
    */
   Duration maxEgressWalkDuration();
-
+  /**
+   * See {@link org.opentripplanner.standalone.config.sandbox.FlexConfig}
+   */
   Cost areaStopBoardCost();
-
+  /**
+   * See {@link org.opentripplanner.standalone.config.sandbox.FlexConfig}
+   */
   Cost areaStopAlightCost();
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexParameters.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.flex;
 
 import java.time.Duration;
+import org.opentripplanner.framework.model.Cost;
 
 /**
  * Define parameters used to configure flex. For further documentation on these parameters, look
@@ -27,6 +28,10 @@ public interface FlexParameters {
    */
   Duration maxEgressWalkDuration();
 
+  Cost areaStopBoardCost();
+
+  Cost areaStopAlightCost();
+
   /**
    * This defines the default values. This will be used by the OTP configuration and by tests,
    * avoid using this directly.
@@ -51,6 +56,16 @@ public interface FlexParameters {
       @Override
       public Duration maxEgressWalkDuration() {
         return Duration.ofMinutes(45);
+      }
+
+      @Override
+      public Cost areaStopBoardCost() {
+        return Cost.ZERO;
+      }
+
+      @Override
+      public Cost areaStopAlightCost() {
+        return Cost.ZERO;
       }
     };
   }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -135,7 +135,7 @@ public class FlexRouter {
       callbackService,
       accessFlexPathCalculator,
       egressFlexPathCalculator,
-      flexParameters.maxTransferDuration(),
+      flexParameters,
       matcher
     ).calculateDirectFlexPaths(streetAccesses, streetEgresses, dates, requestedTime, arriveBy);
 
@@ -160,7 +160,7 @@ public class FlexRouter {
     return new FlexAccessFactory(
       callbackService,
       accessFlexPathCalculator,
-      flexParameters.maxTransferDuration(),
+      flexParameters,
       matcher
     ).createFlexAccesses(streetAccesses, dates);
   }
@@ -170,7 +170,7 @@ public class FlexRouter {
     return new FlexEgressFactory(
       callbackService,
       egressFlexPathCalculator,
-      flexParameters.maxTransferDuration(),
+      flexParameters,
       matcher
     ).createFlexEgresses(streetEgresses, dates);
   }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Objects;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPath;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.street.model.edge.Edge;
@@ -12,6 +13,7 @@ import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.StateEditor;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.site.StopType;
 
 /**
  * Flex trips edges are not connected to the graph.
@@ -25,6 +27,7 @@ public class FlexTripEdge extends Edge {
   private final int alightStopPosInPattern;
   private final LocalDate serviceDate;
   private final FlexPath flexPath;
+  private final FlexParameters flexParameters;
 
   public FlexTripEdge(
     Vertex v1,
@@ -35,7 +38,8 @@ public class FlexTripEdge extends Edge {
     int boardStopPosInPattern,
     int alightStopPosInPattern,
     LocalDate serviceDate,
-    FlexPath flexPath
+    FlexPath flexPath,
+    FlexParameters flexParameters
   ) {
     super(v1, v2);
     this.s1 = s1;
@@ -45,6 +49,7 @@ public class FlexTripEdge extends Edge {
     this.alightStopPosInPattern = alightStopPosInPattern;
     this.serviceDate = serviceDate;
     this.flexPath = Objects.requireNonNull(flexPath);
+    this.flexParameters = flexParameters;
   }
 
   public StopLocation s1() {
@@ -100,6 +105,12 @@ public class FlexTripEdge extends Edge {
     editor.incrementTimeInSeconds(timeInSeconds);
     editor.incrementWeight(timeInSeconds);
     editor.resetEnteredNoThroughTrafficArea();
+    if (s1.getStopType() == StopType.FLEXIBLE_AREA) {
+      editor.incrementWeight(flexParameters.areaStopBoardCost().toSeconds());
+    }
+    if (s2.getStopType() == StopType.FLEXIBLE_AREA) {
+      editor.incrementWeight(flexParameters.areaStopAlightCost().toSeconds());
+    }
     return editor.makeStateArray();
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/AbstractFlexTemplate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/AbstractFlexTemplate.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.flex.template;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -9,6 +8,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.flex.FlexAccessEgress;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexPathDurations;
 import org.opentripplanner.ext.flex.edgetype.FlexTripEdge;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
@@ -49,7 +49,7 @@ abstract class AbstractFlexTemplate {
   protected final LocalDate serviceDate;
   protected final int requestedBookingTime;
   protected final FlexPathCalculator calculator;
-  private final Duration maxTransferDuration;
+  protected final FlexParameters flexParameters;
 
   /**
    * @param trip                The FlexTrip used for this template
@@ -61,7 +61,7 @@ abstract class AbstractFlexTemplate {
    * @param alightStopPosition  The stop-alight-position in the trip pattern
    * @param date                The service date of this FlexTrip
    * @param calculator          Calculates the path and duration of the FlexTrip
-   * @param maxTransferDuration The limit for how long a transfer is allowed to be
+   * @param flexParameters      Flex parameters
    */
   AbstractFlexTemplate(
     FlexTrip<?, ?> trip,
@@ -71,7 +71,7 @@ abstract class AbstractFlexTemplate {
     int alightStopPosition,
     FlexServiceDate date,
     FlexPathCalculator calculator,
-    Duration maxTransferDuration
+    FlexParameters flexParameters
   ) {
     this.accessEgress = accessEgress;
     this.trip = trip;
@@ -82,7 +82,7 @@ abstract class AbstractFlexTemplate {
     this.serviceDate = date.serviceDate();
     this.requestedBookingTime = date.requestedBookingTime();
     this.calculator = calculator;
-    this.maxTransferDuration = maxTransferDuration;
+    this.flexParameters = flexParameters;
   }
 
   StopLocation getTransferStop() {
@@ -107,7 +107,8 @@ abstract class AbstractFlexTemplate {
     // transferStop is Location Area/Line
     else {
       double maxDistanceMeters =
-        maxTransferDuration.getSeconds() * accessEgress.state.getRequest().walk().speed();
+        flexParameters.maxTransferDuration().toSeconds() *
+        accessEgress.state.getRequest().walk().speed();
 
       return getTransfersFromTransferStop(callback)
         .stream()
@@ -134,7 +135,7 @@ abstract class AbstractFlexTemplate {
       .addServiceTime("secondsFromStartOfTime", secondsFromStartOfTime)
       .addDate("serviceDate", serviceDate)
       .addObj("calculator", calculator)
-      .addDuration("maxTransferDuration", maxTransferDuration)
+      .addObj("flexParameters", flexParameters)
       .toString();
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessFactory.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.ext.flex.template;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.ext.flex.FlexAccessEgress;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
@@ -18,12 +18,12 @@ public class FlexAccessFactory {
   public FlexAccessFactory(
     FlexAccessEgressCallbackAdapter callbackService,
     FlexPathCalculator pathCalculator,
-    Duration maxTransferDuration,
+    FlexParameters params,
     Matcher<Trip> matcher
   ) {
     this.callbackService = callbackService;
     this.matcher = matcher;
-    this.templateFactory = FlexTemplateFactory.of(pathCalculator, maxTransferDuration);
+    this.templateFactory = FlexTemplateFactory.of(pathCalculator, params);
   }
 
   public List<FlexAccessEgress> createFlexAccesses(

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.ext.flex.template;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexPathDurations;
 import org.opentripplanner.ext.flex.edgetype.FlexTripEdge;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
@@ -25,7 +25,7 @@ class FlexAccessTemplate extends AbstractFlexTemplate {
     int alightStopPosition,
     FlexServiceDate date,
     FlexPathCalculator calculator,
-    Duration maxTransferDuration
+    FlexParameters parameters
   ) {
     super(
       trip,
@@ -35,7 +35,7 @@ class FlexAccessTemplate extends AbstractFlexTemplate {
       alightStopPosition,
       date,
       calculator,
-      maxTransferDuration
+      parameters
     );
   }
 
@@ -90,7 +90,8 @@ class FlexAccessTemplate extends AbstractFlexTemplate {
       boardStopPosition,
       alightStopPosition,
       serviceDate,
-      flexPath
+      flexPath,
+      flexParameters
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexDirectPathFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexDirectPathFactory.java
@@ -4,11 +4,11 @@ import static org.opentripplanner.model.StopTime.MISSING_VALUE;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -24,20 +24,20 @@ public class FlexDirectPathFactory {
   private final FlexAccessEgressCallbackAdapter callbackService;
   private final FlexPathCalculator accessPathCalculator;
   private final FlexPathCalculator egressPathCalculator;
-  private final Duration maxTransferDuration;
   private final Matcher<Trip> matcher;
+  private final FlexParameters flexParameters;
 
   public FlexDirectPathFactory(
     FlexAccessEgressCallbackAdapter callbackService,
     FlexPathCalculator accessPathCalculator,
     FlexPathCalculator egressPathCalculator,
-    Duration maxTransferDuration,
+    FlexParameters flexParameters,
     Matcher<Trip> matcher
   ) {
     this.callbackService = callbackService;
     this.accessPathCalculator = accessPathCalculator;
     this.egressPathCalculator = egressPathCalculator;
-    this.maxTransferDuration = maxTransferDuration;
+    this.flexParameters = flexParameters;
     this.matcher = matcher;
   }
 
@@ -53,14 +53,14 @@ public class FlexDirectPathFactory {
     var flexAccessTemplates = new FlexAccessFactory(
       callbackService,
       accessPathCalculator,
-      maxTransferDuration,
+      flexParameters,
       matcher
     ).calculateFlexAccessTemplates(streetAccesses, dates);
 
     var flexEgressTemplates = new FlexEgressFactory(
       callbackService,
       egressPathCalculator,
-      maxTransferDuration,
+      flexParameters,
       matcher
     ).calculateFlexEgressTemplates(streetEgresses, dates);
 

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressFactory.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.ext.flex.template;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.ext.flex.FlexAccessEgress;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
@@ -18,12 +18,12 @@ public class FlexEgressFactory {
   public FlexEgressFactory(
     FlexAccessEgressCallbackAdapter callbackService,
     FlexPathCalculator pathCalculator,
-    Duration maxTransferDuration,
+    FlexParameters flexParameters,
     Matcher<Trip> matcher
   ) {
     this.callbackService = callbackService;
     this.matcher = matcher;
-    this.templateFactory = FlexTemplateFactory.of(pathCalculator, maxTransferDuration);
+    this.templateFactory = FlexTemplateFactory.of(pathCalculator, flexParameters);
   }
 
   public List<FlexAccessEgress> createFlexEgresses(

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.ext.flex.template;
 
 import com.google.common.collect.Lists;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexPathDurations;
 import org.opentripplanner.ext.flex.edgetype.FlexTripEdge;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
@@ -26,7 +26,7 @@ class FlexEgressTemplate extends AbstractFlexTemplate {
     int alightStopPosition,
     FlexServiceDate date,
     FlexPathCalculator calculator,
-    Duration maxTransferDuration
+    FlexParameters flexParameters
   ) {
     super(
       trip,
@@ -36,7 +36,7 @@ class FlexEgressTemplate extends AbstractFlexTemplate {
       alightStopPosition,
       date,
       calculator,
-      maxTransferDuration
+      flexParameters
     );
   }
 
@@ -91,7 +91,8 @@ class FlexEgressTemplate extends AbstractFlexTemplate {
       boardStopPosition,
       alightStopPosition,
       serviceDate,
-      flexPath
+      flexPath,
+      flexParameters
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexTemplateFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexTemplateFactory.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.ext.flex.template;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -17,19 +17,19 @@ import org.opentripplanner.transit.model.timetable.booking.RoutingBookingInfo;
 class FlexTemplateFactory {
 
   private final FlexPathCalculator calculator;
-  private final Duration maxTransferDuration;
+  private final FlexParameters params;
   private NearbyStop nearbyStop;
   private int stopPos;
   private FlexTrip<?, ?> trip;
   private FlexServiceDate date;
 
-  private FlexTemplateFactory(FlexPathCalculator calculator, Duration maxTransferDuration) {
+  private FlexTemplateFactory(FlexPathCalculator calculator, FlexParameters params) {
     this.calculator = Objects.requireNonNull(calculator);
-    this.maxTransferDuration = Objects.requireNonNull(maxTransferDuration);
+    this.params = Objects.requireNonNull(params);
   }
 
-  static FlexTemplateFactory of(FlexPathCalculator calculator, Duration maxTransferDuration) {
-    return new FlexTemplateFactory(calculator, maxTransferDuration);
+  static FlexTemplateFactory of(FlexPathCalculator calculator, FlexParameters flexParameters) {
+    return new FlexTemplateFactory(calculator, flexParameters);
   }
 
   List<FlexAccessTemplate> createAccessTemplates(ClosestTrip closestTrip) {
@@ -133,7 +133,7 @@ class FlexTemplateFactory {
       alightStopPosition,
       date,
       setupCalculator(flexTrip),
-      maxTransferDuration
+      params
     );
   }
 
@@ -151,7 +151,7 @@ class FlexTemplateFactory {
       alightStopPosition,
       date,
       setupCalculator(flexTrip),
-      maxTransferDuration
+      params
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
@@ -21,8 +21,7 @@ public class FlexConfig implements FlexParameters {
     if you can walk 45 minutes to a flex stop/zone you're unlikely to be the target audience for those
     services.
     """;
-  public static final String AREA_STOP_DESCRIPTION =
-    """
+  public static final String AREA_STOP_DESCRIPTION = """
     Area stops is the internal OTP name. In GTFS they are called "locations" and
     NeTEx FlexibleArea.
     """;

--- a/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2
 
 import java.time.Duration;
 import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.framework.model.Cost;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 public class FlexConfig implements FlexParameters {
@@ -25,13 +26,8 @@ public class FlexConfig implements FlexParameters {
   private final Duration maxFlexTripDuration;
   private final Duration maxAccessWalkDuration;
   private final Duration maxEgressWalkDuration;
-
-  private FlexConfig() {
-    maxTransferDuration = Duration.ofMinutes(5);
-    maxFlexTripDuration = Duration.ofMinutes(45);
-    maxAccessWalkDuration = Duration.ofMinutes(45);
-    maxEgressWalkDuration = Duration.ofMinutes(45);
-  }
+  private final Cost areaStopAlightCost;
+  private final Cost areaStopBoardCost;
 
   public FlexConfig(NodeAdapter root, String parameterName) {
     var json = root
@@ -87,6 +83,19 @@ public class FlexConfig implements FlexParameters {
       )
       .description(ACCESS_EGRESS_DESCRIPTION)
       .asDuration(DEFAULT.maxEgressWalkDuration());
+
+    var areaStop = json
+      .of("areaStops")
+      .summary(
+        "Configuration properties for area stops. These stops are called 'locations' in GTFS and 'flexible stops' in NeTEx."
+      )
+      .asObject();
+    areaStopBoardCost = Cost.costOfSeconds(
+      areaStop.of("boardCost").asInt(DEFAULT.areaStopBoardCost().toSeconds())
+    );
+    areaStopAlightCost = Cost.costOfSeconds(
+      areaStop.of("alightCost").asInt(DEFAULT.areaStopAlightCost().toSeconds())
+    );
   }
 
   public Duration maxFlexTripDuration() {
@@ -103,5 +112,15 @@ public class FlexConfig implements FlexParameters {
 
   public Duration maxEgressWalkDuration() {
     return maxEgressWalkDuration;
+  }
+
+  @Override
+  public Cost areaStopBoardCost() {
+    return areaStopBoardCost;
+  }
+
+  @Override
+  public Cost areaStopAlightCost() {
+    return areaStopAlightCost;
   }
 }

--- a/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
@@ -21,6 +21,11 @@ public class FlexConfig implements FlexParameters {
     if you can walk 45 minutes to a flex stop/zone you're unlikely to be the target audience for those
     services.
     """;
+  public static final String AREA_STOP_DESCRIPTION =
+    """
+    Area stops is the internal OTP name. In GTFS they are called "locations" and
+    NeTEx FlexibleArea.
+    """;
 
   private final Duration maxTransferDuration;
   private final Duration maxFlexTripDuration;
@@ -91,10 +96,18 @@ public class FlexConfig implements FlexParameters {
       )
       .asObject();
     areaStopBoardCost = Cost.costOfSeconds(
-      areaStop.of("boardCost").asInt(DEFAULT.areaStopBoardCost().toSeconds())
+      areaStop
+        .of("boardCost")
+        .summary("Cost to board an area stop, in seconds.")
+        .description(AREA_STOP_DESCRIPTION)
+        .asInt(DEFAULT.areaStopBoardCost().toSeconds())
     );
     areaStopAlightCost = Cost.costOfSeconds(
-      areaStop.of("alightCost").asInt(DEFAULT.areaStopAlightCost().toSeconds())
+      areaStop
+        .of("alightCost")
+        .summary("Cost to alight an area stop, in seconds.")
+        .description(AREA_STOP_DESCRIPTION)
+        .asInt(DEFAULT.areaStopAlightCost().toSeconds())
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -16,6 +16,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexibleTransitLeg;
 import org.opentripplanner.ext.flex.edgetype.FlexTripEdge;
 import org.opentripplanner.ext.flex.flexpathcalculator.DirectFlexPathCalculator;
@@ -251,7 +252,8 @@ public class TestItineraryBuilder implements PlanTestConstants {
       fromStopPos,
       toStopPos,
       serviceDate,
-      flexPath
+      flexPath,
+      FlexParameters.defaultValues()
     );
 
     FlexibleTransitLeg leg = FlexibleTransitLeg.of()

--- a/application/src/test/resources/standalone/config/router-config.json
+++ b/application/src/test/resources/standalone/config/router-config.json
@@ -166,7 +166,11 @@
     "maxTransferDuration": "5m",
     "maxFlexTripDuration": "45m",
     "maxAccessWalkDuration": "15m",
-    "maxEgressWalkDuration": "15m"
+    "maxEgressWalkDuration": "15m",
+    "areaStops": {
+      "boardCost": 60,
+      "alightCost": 60
+    }
   },
   "transit": {
     "maxNumberOfTransfers": 12,

--- a/doc/user/RouterConfiguration.md
+++ b/doc/user/RouterConfiguration.md
@@ -648,7 +648,11 @@ Used to group requests when monitoring OTP.
     "maxTransferDuration" : "5m",
     "maxFlexTripDuration" : "45m",
     "maxAccessWalkDuration" : "15m",
-    "maxEgressWalkDuration" : "15m"
+    "maxEgressWalkDuration" : "15m",
+    "areaStops" : {
+      "boardCost" : 60,
+      "alightCost" : 60
+    }
   },
   "transit" : {
     "maxNumberOfTransfers" : 12,

--- a/doc/user/sandbox/Flex.md
+++ b/doc/user/sandbox/Flex.md
@@ -41,7 +41,11 @@ following to `router-config.json`.
     "maxTransferDuration" : "5m",
     "maxFlexTripDuration" : "45m",
     "maxAccessWalkDuration" : "15m",
-    "maxEgressWalkDuration" : "15m"
+    "maxEgressWalkDuration" : "15m",
+    "areaStops" : {
+      "boardCost" : 60,
+      "alightCost" : 60
+    }
   }
 }
 ```
@@ -53,6 +57,9 @@ following to `router-config.json`.
 | [maxEgressWalkDuration](#flex_maxEgressWalkDuration) | `duration` | The maximum duration the passenger will be allowed to walk after leaving the flex vehicle at the final destination.           | *Optional* | `"PT45M"`     |  2.3  |
 | [maxFlexTripDuration](#flex_maxFlexTripDuration)     | `duration` | How long can a non-scheduled flex trip at maximum be.                                                                         | *Optional* | `"PT45M"`     |  2.3  |
 | [maxTransferDuration](#flex_maxTransferDuration)     | `duration` | How long should a passenger be allowed to walk after getting out of a flex vehicle and transferring to a flex or transit one. | *Optional* | `"PT5M"`      |  2.3  |
+| areaStops                                            |  `object`  | Configuration properties for area stops. These stops are called 'locations' in GTFS and 'flexible stops' in NeTEx.            | *Optional* |               |   na  |
+|    alightCost                                        |  `integer` | TODO: Add short summary.                                                                                                      | *Optional* | `0`           |   na  |
+|    boardCost                                         |  `integer` | TODO: Add short summary.                                                                                                      | *Optional* | `0`           |   na  |
 
 
 ### Details

--- a/doc/user/sandbox/Flex.md
+++ b/doc/user/sandbox/Flex.md
@@ -58,8 +58,8 @@ following to `router-config.json`.
 | [maxFlexTripDuration](#flex_maxFlexTripDuration)     | `duration` | How long can a non-scheduled flex trip at maximum be.                                                                         | *Optional* | `"PT45M"`     |  2.3  |
 | [maxTransferDuration](#flex_maxTransferDuration)     | `duration` | How long should a passenger be allowed to walk after getting out of a flex vehicle and transferring to a flex or transit one. | *Optional* | `"PT5M"`      |  2.3  |
 | areaStops                                            |  `object`  | Configuration properties for area stops. These stops are called 'locations' in GTFS and 'flexible stops' in NeTEx.            | *Optional* |               |   na  |
-|    alightCost                                        |  `integer` | TODO: Add short summary.                                                                                                      | *Optional* | `0`           |   na  |
-|    boardCost                                         |  `integer` | TODO: Add short summary.                                                                                                      | *Optional* | `0`           |   na  |
+|    [alightCost](#flex_areaStops_alightCost)          |  `integer` | Cost to alight an area stop, in seconds.                                                                                      | *Optional* | `0`           |   na  |
+|    [boardCost](#flex_areaStops_boardCost)            |  `integer` | Cost to board an area stop, in seconds.                                                                                       | *Optional* | `0`           |   na  |
 
 
 ### Details
@@ -118,6 +118,28 @@ during the graph build but flex ones are calculated at request time and are more
 sensitive to slowdown.
 
 A lower value means that the routing is faster.
+
+
+<h4 id="flex_areaStops_alightCost">alightCost</h4>
+
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0`   
+**Path:** /flex/areaStops 
+
+Cost to alight an area stop, in seconds.
+
+Area stops is the internal OTP name. In GTFS they are called "locations" and
+NeTEx FlexibleArea.
+
+
+<h4 id="flex_areaStops_boardCost">boardCost</h4>
+
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0`   
+**Path:** /flex/areaStops 
+
+Cost to board an area stop, in seconds.
+
+Area stops is the internal OTP name. In GTFS they are called "locations" and
+NeTEx FlexibleArea.
 
 
 


### PR DESCRIPTION
### Summary

This implements an approximation for the business rules requested in #7187: it introduces costs for boarding and alighting area stops during flex routing, making fixed stops more desirable.

This is useful if there are pick up points near on inside area stops that you would like to see preferred over the zone.

### Issue

Ref #7187

### Unit tests

Added.

### Documentation

Added.

### Changelog

Skip.

### Bumping the serialization version id

Config changes, so yes.