### PR TITLE
Undeprecate car/bikepark nearest filters which were deprecated by accident

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -116,8 +116,8 @@ public class EnumTypes {
     .value("quay", TransmodelPlaceType.QUAY, "Quay")
     .value("stopPlace", TransmodelPlaceType.STOP_PLACE, "StopPlace")
     .value("bicycleRent", TransmodelPlaceType.BICYCLE_RENT, "Bicycle rent stations")
-    .value("bikePark", TransmodelPlaceType.BIKE_PARK, "Bike parks", "Not supported")
-    .value("carPark", TransmodelPlaceType.CAR_PARK, "Car parks", "Not supported")
+    .value("bikePark", TransmodelPlaceType.BIKE_PARK, "Bike parks")
+    .value("carPark", TransmodelPlaceType.CAR_PARK, "Car parks")
     .build();
 
   public static final GraphQLEnumType INPUT_FIELD = GraphQLEnumType.newEnum()

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -3222,9 +3222,9 @@ enum FilterPlaceType {
   "Old value for VEHICLE_RENT"
   BICYCLE_RENT @deprecated(reason : "Use VEHICLE_RENT instead as it's clearer that it also returns rental scooters, cars...")
   "Parking lots (not rental stations) that contain spaces for bicycles"
-  BIKE_PARK @deprecated(reason : "Not supported.")
+  BIKE_PARK
   "Parking lots that contain spaces for cars"
-  CAR_PARK @deprecated(reason : "Not supported.")
+  CAR_PARK
   "Departure rows"
   DEPARTURE_ROW
   """

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1671,9 +1671,9 @@ enum FilterPlaceType {
   "Bicycle rent stations"
   bicycleRent
   "Bike parks"
-  bikePark @deprecated(reason : "Not supported")
+  bikePark
   "Car parks"
-  carPark @deprecated(reason : "Not supported")
+  carPark
   "Quay"
   quay
   "StopPlace"


### PR DESCRIPTION
### Summary

CarPark and BikePark place type filters in the nearest query were accidentally deprecated in #7020 and this reverts that.

### Issue

No issue

### Unit tests

Not relevant

### Documentation

This is just documentation update.

### Changelog

From title
