### PR TITLE
Fix SIRI-SX affects resolver

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/AffectsType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/AffectsType.java
@@ -241,19 +241,22 @@ public class AffectsType {
       .typeResolver(env -> {
         var object = env.getObject();
 
+        // We resolve GraphQLObjectType by name and not by object reference since the GraphQL schema
+        // can be subsequently rebuilt (schema transformation), in which case the GraphQLObjectType
+        // references in this class are deregistered and replaced by other instances.
         if (object instanceof EntitySelector.Stop) {
-          return affectedStopPlace;
+          return env.getSchema().getObjectType("AffectedStopPlace");
         } else if (object instanceof EntitySelector.Route) {
-          return affectedLine;
+          return env.getSchema().getObjectType("AffectedLine");
         } else if (object instanceof EntitySelector.Trip) {
-          return affectedServiceJourney;
+          return env.getSchema().getObjectType("AffectedServiceJourney");
         } else if (object instanceof EntitySelector.StopAndRoute) {
-          return affectedStopPlaceOnLine;
+          return env.getSchema().getObjectType("AffectedStopPlaceOnLine");
         } else if (object instanceof EntitySelector.StopAndTrip) {
-          return affectedStopPlaceOnServiceJourney;
+          return env.getSchema().getObjectType("AffectedStopPlaceOnServiceJourney");
         }
 
-        return affectedUnknown;
+        return env.getSchema().getObjectType("AffectedUnknown");
       })
       .build();
   }


### PR DESCRIPTION
### Summary

As detailed in #7196, the affectedLine type in the Transmodel GraphQL API fails to return the line field when the parameter apiDocumentationProfile is set in router-config.json.
This is due to:
- the Affects data fetcher resolver holds object references to data fetchers.
- these references become stale after the GraphQL documentation is decorated, since this triggers a schema transformation that rebuilds the GraphQL object tree.

As a result, the data fetchers referenced in the resolver are not registered in the GraphQL engine.

The fix consists in resolving the data fetchers by name, not by object reference.

**Note**: the issue occurs only in the affects resolver, in the rest of the code base, fetchers are resolved by name.

### Issue

Closes #7196

### Unit tests

No unit tests, tested manually

### Documentation

No

