### PR TITLE
Add publiccode.yml for OpenTripPlanner

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -24,7 +24,7 @@ fundedBy:
     uri: https://www.hsl.fi/en
   - name: Waltti Solutions
     uri: https://waltti.fi/en/
-    name: Aubin
+  - name: Aubin
     uri: https://aubin.app/
   - name: Skånetrafiken
     uri: https://www.skanetrafiken.se


### PR DESCRIPTION
### Summary

This PR add a **publiccode.yml** file to the project. This is recommended for Open Source projects in used by public agencies in the European Union. See https://interoperable-europe.ec.europa.eu/collection/open-source-observatory-osor/publiccodeyml-standard.

In the listing of deployments, I have listed the most significant European deployments, there is a link to the OTP doc where we list all "known" deployments. 

### Issue

No

### Unit tests

Not relevant

### Documentation

✅  This make OTP searchable for Open-Source search-boots, and can potentially be use to list OTP in Open Source Repositories

### Changelog

✅  Yes

### Bumping the serialization version id

🟥  Not relevant