### PR TITLE
Invalidate Flex Transfer Index before re-indexing to fix duplicate entries

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexTransferIndex.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexTransferIndex.java
@@ -18,6 +18,7 @@ public class FlexTransferIndex extends TransferIndex {
   private boolean indexed = false;
 
   public void index(TransferRepository transferRepository) {
+    invalidate();
     super.index(transferRepository);
     // Flex transfers should only use WALK mode transfers.
     for (PathTransfer transfer : transferRepository.findTransfersByMode(StreetMode.WALK)) {


### PR DESCRIPTION
### Summary

Invalidate the flex transfer index before re-indexing. The index is saved in the graph and then re-indexed on startup. The key of the internal map (`StopLocation`) has no equals and hash code method defined, so this leads to duplicate entries. It might be better to not save the index in the first place, but I am not sure how to do that. Implementing an equals and hash code method for the `StopLocation` should also fix this, but this could potentially break stuff some place else.

### Issue

Fixes #7216 

### Unit tests

I am not sure how to test this, since this bug only occurs with a graph build before start up.

### Documentation

### Changelog

### Bumping the serialization version id

