### PR TITLE
Reject real-time updates with inconsistent number of stops

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripUpdate.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripUpdate.java
@@ -34,6 +34,17 @@ public record RealTimeTripUpdate(
     Objects.requireNonNull(pattern);
     Objects.requireNonNull(updatedTripTimes);
     Objects.requireNonNull(serviceDate);
+    if (pattern.numberOfStops() != updatedTripTimes.getNumStops()) {
+      throw new IllegalArgumentException(
+        "The pattern %s has %d stops while the TripTimes for Trip %s on service date %s has %d stops".formatted(
+          pattern.logName(),
+          pattern.numberOfStops(),
+          updatedTripTimes.getTrip(),
+          serviceDate,
+          updatedTripTimes.getNumStops()
+        )
+      );
+    }
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableSnapshotTest.java
@@ -64,19 +64,7 @@ public class TimetableSnapshotTest {
     TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
     Trip trip = pattern.scheduledTripsAsStream().findFirst().orElseThrow();
 
-    TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
-      trip,
-      List.of(new StopTime()),
-      new Deduplicator()
-    );
-    RealTimeTripUpdate realTimeTripUpdate = new RealTimeTripUpdate(
-      pattern,
-      updatedTriptimes,
-      SERVICE_DATE,
-      TripOnServiceDate.of(trip.getId()).withTrip(trip).withServiceDate(SERVICE_DATE).build(),
-      true,
-      true
-    );
+    RealTimeTripUpdate realTimeTripUpdate = createRealTimeTripUpdate(pattern, trip);
 
     snapshot.update(realTimeTripUpdate);
     snapshot.update(realTimeTripUpdate);
@@ -150,19 +138,7 @@ public class TimetableSnapshotTest {
       trip.getId(),
       SERVICE_DATE
     );
-    TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
-      trip,
-      List.of(new StopTime()),
-      new Deduplicator()
-    );
-    RealTimeTripUpdate realTimeTripUpdate = new RealTimeTripUpdate(
-      pattern,
-      updatedTriptimes,
-      SERVICE_DATE,
-      TripOnServiceDate.of(trip.getId()).withTrip(trip).withServiceDate(SERVICE_DATE).build(),
-      true,
-      true
-    );
+    RealTimeTripUpdate realTimeTripUpdate = createRealTimeTripUpdate(pattern, trip);
 
     snapshot.update(realTimeTripUpdate);
 
@@ -191,6 +167,22 @@ public class TimetableSnapshotTest {
     assertNotNull(snapshot.getRealTimeAddedTripOnServiceDateById(trip.getId()));
     assertNotNull(snapshot.getRealTimeAddedTripOnServiceDateForTripAndDay(tripIdAndServiceDate));
     assertNotNull(snapshot.getRealtimeAddedRoute(pattern.getRoute().getId()));
+  }
+
+  private static RealTimeTripUpdate createRealTimeTripUpdate(TripPattern pattern, Trip trip) {
+    TripTimes updatedTriptimes = TripTimesFactory.tripTimes(
+      trip,
+      List.of(new StopTime(), new StopTime(), new StopTime()),
+      new Deduplicator()
+    );
+    return new RealTimeTripUpdate(
+      pattern,
+      updatedTriptimes,
+      SERVICE_DATE,
+      TripOnServiceDate.of(trip.getId()).withTrip(trip).withServiceDate(SERVICE_DATE).build(),
+      true,
+      true
+    );
   }
 
   private static TimetableSnapshot createCommittedSnapshot() {


### PR DESCRIPTION
### Summary

Some time ago we experienced a critical regression  (#6692) due to invalid real-time updates tying together `TripTimes` and `TripPatterns` with different numbers of stops.
This resulted in invalid data being fed into Raptor.

This PR aims at preventing the real-time update sub-system from producing such invalid updates.
This will also reduce the severity of an hypothetical regression caused by #7219

Implementation details:
Both the SIRI-ET and GTFS-RT updaters submit trip updates to the `TimetableSnapshot` in the form of a `RealTimeTripUpdate`.
This PR ensures that a `RealTimeTripUpdate` where the `TripPattern` and the `TripTimes` have inconsistent number of stops, cannot be constructed.



### Issue

Related to #6692

### Unit tests
Updated unit tests so that the new invariant remains true in test data.
### Documentation

No

### Changelog

Skip
