### PR TITLE
Debug vector tiles: Split geofencing zones into separate vector tile source

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
@@ -129,9 +129,10 @@ public class DebugVectorTilesResource {
       "stops",
       tileJsonUrl(base, List.of(REGULAR_STOPS, AREA_STOPS, GROUP_STOPS))
     );
-    var streetSource = new VectorSource(
-      "street",
-      tileJsonUrl(base, List.of(EDGES, GEOFENCING_ZONES, VERTICES))
+    var streetSource = new VectorSource("street", tileJsonUrl(base, List.of(EDGES, VERTICES)));
+    var geofencingSource = new VectorSource(
+      "geofencing",
+      tileJsonUrl(base, List.of(GEOFENCING_ZONES))
     );
     var rentalSource = new VectorSource("rental", tileJsonUrl(base, List.of(RENTAL)));
 
@@ -141,7 +142,7 @@ public class DebugVectorTilesResource {
       GROUP_STOPS.toVectorSourceLayer(stopsSource),
       EDGES.toVectorSourceLayer(streetSource),
       VERTICES.toVectorSourceLayer(streetSource),
-      GEOFENCING_ZONES.toVectorSourceLayer(streetSource),
+      GEOFENCING_ZONES.toVectorSourceLayer(geofencingSource),
       RENTAL.toVectorSourceLayer(rentalSource),
       serverContext.debugUiConfig().additionalBackgroundLayers()
     );


### PR DESCRIPTION
### Summary

Geofencing zones were grouped with edges and vertices in the "street" source, causing slow tile requests (~20s) because EdgeLayerBuilder has no zoom-level filtering. By moving geofencing zones to their own source, they can be loaded independently without triggering expensive edge queries.

Result: much faster loading of vector tiles (and pbf files are also much smaller).

### Issue

No issue for this, as it is a small fix / improvement to debug ui.

### Unit tests

No tests for this particular code.

### Documentation

No documentation.

### Changelog

Skipping changelog.

### Bumping the serialization version id

No