### PR TITLE
Make area edges switchable in Debug UI

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -69,6 +69,7 @@ public class DebugStyleSpec {
     POSITRON_BACKGROUND
   );
   private static final String MAGENTA = "#f21d52";
+  private static final String LIGHT_MAGENTA = "#f783a0";
   private static final String BRIGHT_GREEN = "#22DD9E";
   private static final String DARK_GREEN = "#136b04";
   private static final String TEAL = "#277eb5";
@@ -103,12 +104,14 @@ public class DebugStyleSpec {
   private static final ZoomDependentNumber LINE_HALF_WIDTH = new ZoomDependentNumber(
     List.of(new ZoomStop(LINE_DETAIL_ZOOM, 0.1f), new ZoomStop(MAX_ZOOM, 6))
   );
+  private static final ZoomDependentNumber LINE_QUARTER_WIDTH = new ZoomDependentNumber(
+    List.of(new ZoomStop(LINE_DETAIL_ZOOM, 0.01f), new ZoomStop(MAX_ZOOM, 3))
+  );
   private static final ZoomDependentNumber CIRCLE_STROKE = new ZoomDependentNumber(
     List.of(new ZoomStop(15, 0.2f), new ZoomStop(MAX_ZOOM, 3))
   );
   private static final Class<Edge>[] EDGES_TO_DISPLAY = new Class[] {
     StreetEdge.class,
-    AreaEdge.class,
     EscalatorEdge.class,
     PathwayEdge.class,
     ElevatorHopEdge.class,
@@ -443,6 +446,18 @@ public class DebugStyleSpec {
 
   private static List<StyleBuilder> edges(VectorSourceLayer edges) {
     return List.of(
+      StyleBuilder.ofId("area-edge")
+        .group(EDGES_GROUP)
+        .typeLine()
+        .vectorSourceLayer(edges)
+        .edgeFilter(AreaEdge.class)
+        .lineColor(LIGHT_MAGENTA)
+        .lineWidth(LINE_QUARTER_WIDTH)
+        .lineOffset(LINE_OFFSET)
+        .lineOpacity(0.5f)
+        .minZoom(15)
+        .maxZoom(MAX_ZOOM)
+        .intiallyHidden(),
       StyleBuilder.ofId("edge")
         .group(EDGES_GROUP)
         .typeLine()

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
@@ -186,6 +186,11 @@ public class StyleBuilder {
     return this;
   }
 
+  public StyleBuilder lineOpacity(float v) {
+    paint.put("line-opacity", v);
+    return this;
+  }
+
   /**
    * Generates the line color based off a numeric property in the feature.
    * <p>

--- a/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -639,7 +639,6 @@
         "in",
         "class",
         "StreetEdge",
-        "AreaEdge",
         "EscalatorEdge",
         "PathwayEdge",
         "ElevatorHopEdge",
@@ -785,7 +784,6 @@
         "in",
         "class",
         "StreetEdge",
-        "AreaEdge",
         "EscalatorEdge",
         "PathwayEdge",
         "ElevatorHopEdge",
@@ -931,7 +929,6 @@
         "in",
         "class",
         "StreetEdge",
-        "AreaEdge",
         "EscalatorEdge",
         "PathwayEdge",
         "ElevatorHopEdge",
@@ -1267,7 +1264,6 @@
         "in",
         "class",
         "StreetEdge",
-        "AreaEdge",
         "EscalatorEdge",
         "PathwayEdge",
         "ElevatorHopEdge",
@@ -1311,6 +1307,56 @@
       }
     },
     {
+      "id" : "area-edge",
+      "type" : "line",
+      "source" : "vectorSource",
+      "source-layer" : "edges",
+      "minzoom" : 15,
+      "maxzoom" : 23,
+      "paint" : {
+        "line-color" : "#f783a0",
+        "line-width" : [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          13,
+          0.01,
+          23,
+          3.0
+        ],
+        "line-offset" : [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          13,
+          0.4,
+          23,
+          7.0
+        ],
+        "line-opacity" : 0.5
+      },
+      "filter" : [
+        "in",
+        "class",
+        "AreaEdge"
+      ],
+      "layout" : {
+        "line-cap" : "round",
+        "visibility" : "none"
+      },
+      "metadata" : {
+        "group" : "Edges"
+      }
+    },
+    {
       "id" : "edge",
       "type" : "line",
       "source" : "vectorSource",
@@ -1350,7 +1396,6 @@
         "in",
         "class",
         "StreetEdge",
-        "AreaEdge",
         "EscalatorEdge",
         "PathwayEdge",
         "ElevatorHopEdge",
@@ -1384,7 +1429,6 @@
         "in",
         "class",
         "StreetEdge",
-        "AreaEdge",
         "EscalatorEdge",
         "PathwayEdge",
         "ElevatorHopEdge",


### PR DESCRIPTION
### Summary

@JohanEntur has requested that the very busy area edge view be made a bit more user friendly.

Therefore I moved the area edges to a different layer, styled them thinner and made it switchable.

It looks like this:


https://github.com/user-attachments/assets/9f445a49-6551-4f96-bc96-6bb82c291477




### Unit tests

Expected style JSON updated.

### Changelog

Skip.

### Bumping the serialization version id

None.