### PR TITLE
Update NeTEx Java Model to v2.0.16

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -35,7 +35,6 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.rutebanken.netex.model.DatedServiceJourney;
-import org.rutebanken.netex.model.DatedServiceJourneyRefStructure;
 import org.rutebanken.netex.model.DestinationDisplay;
 import org.rutebanken.netex.model.FlexibleLine;
 import org.rutebanken.netex.model.JourneyPattern_VersionStructure;
@@ -44,6 +43,7 @@ import org.rutebanken.netex.model.Route;
 import org.rutebanken.netex.model.RouteView;
 import org.rutebanken.netex.model.ServiceJourney;
 import org.rutebanken.netex.model.ServiceLink;
+import org.rutebanken.netex.model.VehicleJourneyRefStructure;
 
 /**
  * Maps NeTEx JourneyPattern to OTP TripPattern. All ServiceJourneys in the same JourneyPattern
@@ -301,43 +301,47 @@ class TripPatternMapper {
       datedServiceJourney.getServiceAlteration()
     );
 
-    var replacementFor = datedServiceJourney
-      .getJourneyRef()
-      .stream()
-      .map(JAXBElement::getValue)
-      .filter(DatedServiceJourneyRefStructure.class::isInstance)
-      .map(DatedServiceJourneyRefStructure.class::cast)
-      .map(DatedServiceJourneyRefStructure::getRef)
-      .map(datedServiceJourneyById::lookup)
-      .filter(Objects::nonNull)
-      .map(replacement -> {
-        if (datedServiceJourney.equals(replacement)) {
-          issueStore.add(
-            "InvalidDatedServiceJourneyRef",
-            "DatedServiceJourney %s has reference to itself, skipping",
-            datedServiceJourney.getId()
+    List<TripOnServiceDate> replacementFor;
+    if (datedServiceJourney.getReplacedJourneys() != null) {
+      replacementFor = datedServiceJourney
+        .getReplacedJourneys()
+        .getDatedVehicleJourneyRefOrNormalDatedVehicleJourneyRef()
+        .stream()
+        .map(JAXBElement::getValue)
+        .map(VehicleJourneyRefStructure::getRef)
+        .map(datedServiceJourneyById::lookup)
+        .filter(Objects::nonNull)
+        .map(replacement -> {
+          if (datedServiceJourney.equals(replacement)) {
+            issueStore.add(
+              "InvalidDatedServiceJourneyRef",
+              "DatedServiceJourney %s has reference to itself, skipping",
+              datedServiceJourney.getId()
+            );
+            return null;
+          }
+          String serviceJourneyRef = replacement.getJourneyRef().getValue().getRef();
+          ServiceJourney serviceJourney = serviceJourneyById.lookup(serviceJourneyRef);
+          if (serviceJourney == null) {
+            issueStore.add(
+              "InvalidDatedServiceJourneyRef",
+              "DatedServiceJourney %s has reference to %s, which is not found, skipping",
+              datedServiceJourney.getId(),
+              serviceJourneyRef
+            );
+            return null;
+          }
+          return mapDatedServiceJourney(
+            journeyPattern,
+            mapTrip(journeyPattern, serviceJourney),
+            replacement
           );
-          return null;
-        }
-        String serviceJourneyRef = replacement.getJourneyRef().get(0).getValue().getRef();
-        ServiceJourney serviceJourney = serviceJourneyById.lookup(serviceJourneyRef);
-        if (serviceJourney == null) {
-          issueStore.add(
-            "InvalidDatedServiceJourneyRef",
-            "DatedServiceJourney %s has reference to %s, which is not found, skipping",
-            datedServiceJourney.getId(),
-            serviceJourneyRef
-          );
-          return null;
-        }
-        return mapDatedServiceJourney(
-          journeyPattern,
-          mapTrip(journeyPattern, serviceJourney),
-          replacement
-        );
-      })
-      .filter(Objects::nonNull)
-      .toList();
+        })
+        .filter(Objects::nonNull)
+        .toList();
+    } else {
+      replacementFor = List.of();
+    }
 
     return TripOnServiceDate.of(id)
       .withTrip(trip)

--- a/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
@@ -87,7 +87,7 @@ public class NetexMapperIndexes {
     Multimap<String, DatedServiceJourney> dsjBySJId = ArrayListMultimap.create();
     for (DatedServiceJourney dsj : datedServiceJourneys.localValues()) {
       // The validation step ensure no NPE occurs here
-      String sjId = dsj.getJourneyRef().get(0).getValue().getRef();
+      String sjId = dsj.getJourneyRef().getValue().getRef();
       dsjBySJId.put(sjId, dsj);
     }
     return dsjBySJId;

--- a/application/src/main/java/org/opentripplanner/netex/validation/DSJServiceJourneyNotFound.java
+++ b/application/src/main/java/org/opentripplanner/netex/validation/DSJServiceJourneyNotFound.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.netex.validation;
 
 import jakarta.xml.bind.JAXBElement;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.netex.issues.ObjectNotFound;
@@ -26,12 +25,12 @@ class DSJServiceJourneyNotFound extends AbstractHMapValidationRule<String, Dated
 
   @Nullable
   private String getServiceJourneyRef(DatedServiceJourney dsj) {
-    List<JAXBElement<? extends JourneyRefStructure>> journeyRef = dsj.getJourneyRef();
+    JAXBElement<? extends JourneyRefStructure> journeyRef = dsj.getJourneyRef();
 
-    if (journeyRef == null || journeyRef.isEmpty()) {
+    if (journeyRef == null) {
       return null;
     }
-    JourneyRefStructure ref = journeyRef.get(0).getValue();
+    JourneyRefStructure ref = journeyRef.getValue();
     return ref == null ? null : ref.getRef();
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -188,9 +188,7 @@ public class NetexTestDataSample {
         DatedServiceJourney datedServiceJourney = new DatedServiceJourney()
           .withId(DATED_SERVICE_JOURNEY_ID.get(i))
           .withJourneyRef(
-            List.of(
-              MappingSupport.createWrappedRef(SERVICE_JOURNEY_ID, ServiceJourneyRefStructure.class)
-            )
+            MappingSupport.createWrappedRef(SERVICE_JOURNEY_ID, ServiceJourneyRefStructure.class)
           )
           .withServiceAlteration(ServiceAlterationEnumeration.PLANNED)
           .withOperatingDayRef(new OperatingDayRefStructure().withRef(operatingDay.getId()));

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TripCalendarBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TripCalendarBuilderTest.java
@@ -151,9 +151,9 @@ public class TripCalendarBuilderTest {
   private ArrayListMultimap<String, DatedServiceJourney> dsj_2020_11_02(String sjId) {
     var dsj = new DatedServiceJourney();
     dsj.withOperatingDayRef(new OperatingDayRefStructure().withRef(OD_1));
-    dsj
-      .getJourneyRef()
-      .add(jaxbElement(new JourneyRefStructure().withRef(sjId), JourneyRefStructure.class));
+    dsj.setJourneyRef(
+      jaxbElement(new JourneyRefStructure().withRef(sjId), JourneyRefStructure.class)
+    );
     ArrayListMultimap<String, DatedServiceJourney> map = ArrayListMultimap.create();
     map.put(sjId, dsj);
     return map;

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ArrayListMultimap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -22,8 +21,8 @@ import org.opentripplanner.transit.model.timetable.TripAlteration;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.rutebanken.netex.model.DatedServiceJourney;
-import org.rutebanken.netex.model.DatedServiceJourneyRefStructure;
 import org.rutebanken.netex.model.OperatingDay;
+import org.rutebanken.netex.model.ReplacedJourneys_RelStructure;
 import org.rutebanken.netex.model.ServiceAlterationEnumeration;
 
 class TripPatternMapperTest {
@@ -128,11 +127,16 @@ class TripPatternMapperTest {
     DatedServiceJourney dsjReplacing = sample.getDatedServiceJourneyById(
       NetexTestDataSample.DATED_SERVICE_JOURNEY_ID_2
     );
-    dsjReplacing.withJourneyRef(
-      List.of(
-        MappingSupport.createWrappedRef(dsjReplaced.getId(), DatedServiceJourneyRefStructure.class)
-      )
-    );
+    ReplacedJourneys_RelStructure replacedJourneys = new ReplacedJourneys_RelStructure();
+    replacedJourneys
+      .getDatedVehicleJourneyRefOrNormalDatedVehicleJourneyRef()
+      .add(
+        MappingSupport.createWrappedRef(
+          dsjReplaced.getId(),
+          org.rutebanken.netex.model.VehicleJourneyRefStructure.class
+        )
+      );
+    dsjReplacing.withReplacedJourneys(replacedJourneys);
     Optional<TripPatternMapperResult> res = mapTripPattern(sample);
 
     assertTrue(res.isPresent());

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <logback.version>1.5.32</logback.version>
         <lucene.version>10.4.0</lucene.version>
         <micrometer.version>1.16.5</micrometer.version>
-        <netex-java-model.version>2.0.15.2</netex-java-model.version>
+        <netex-java-model.version>2.0.16</netex-java-model.version>
         <netcdf4.version>5.6.0</netcdf4.version>
         <protobuf.version>4.34.1</protobuf.version>
         <siri-java-model.version>2.0.6</siri-java-model.version>


### PR DESCRIPTION
### Summary
Update the NeTEx Java model to version 2.0.16  ( based on the Entur fork).
This release introduces a breaking change in the way DatedServiceJourneys are modeled. 

See https://github.com/entur/netex-java-model/releases/tag/v2.0.16


### Issue

No

### Unit tests

Updated unit tests

### Documentation

No

