### PR TITLE
Update netex-java-model to v3.0.0-SNAPSHOT

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/FareFrameParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/FareFrameParser.java
@@ -38,7 +38,7 @@ public class FareFrameParser extends NetexParser<FareFrame_VersionFrameStructure
     warnOnMissingMapping(LOG, frame.getGeographicalIntervals());
     warnOnMissingMapping(LOG, frame.getGeographicalStructureFactors());
     warnOnMissingMapping(LOG, frame.getGeographicalUnits());
-    warnOnMissingMapping(LOG, frame.getGroupOfDistributionAssignments());
+    warnOnMissingMapping(LOG, frame.getDistributionAssignments());
     warnOnMissingMapping(LOG, frame.getGroupsOfDistanceMatrixElements());
     warnOnMissingMapping(LOG, frame.getGroupsOfDistributionChannels());
     warnOnMissingMapping(LOG, frame.getGroupsOfSalesOfferPackages());

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/NoticeParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/NoticeParser.java
@@ -36,7 +36,7 @@ class NoticeParser {
       return;
     }
 
-    for (JAXBElement<? extends DataManagedObjectStructure> it : na.getNoticeAssignment_()) {
+    for (JAXBElement<? extends DataManagedObjectStructure> it : na.getNoticeAssignment_Dummy()) {
       NoticeAssignment noticeAssignment = (NoticeAssignment) it.getValue();
       boolean error = false;
 

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/ResourceFrameParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/ResourceFrameParser.java
@@ -58,7 +58,7 @@ class ResourceFrameParser extends NetexParser<ResourceFrame_VersionFrameStructur
 
   private void parseOrganization(OrganisationsInFrame_RelStructure elements) {
     if (elements != null) {
-      for (JAXBElement<?> e : elements.getOrganisation_()) {
+      for (JAXBElement<?> e : elements.getOrganisation_Dummy()) {
         parseOrganization((Organisation_VersionStructure) e.getValue());
       }
     }

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
@@ -73,7 +73,7 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
     if (element == null) {
       return;
     }
-    for (JAXBElement<?> dt : element.getDayType_()) {
+    for (JAXBElement<?> dt : element.getDayType_Dummy()) {
       parseDayType(dt);
     }
   }
@@ -82,7 +82,7 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
     if (dayTypes == null) {
       return;
     }
-    for (JAXBElement<?> dt : dayTypes.getDayTypeRefOrDayType_()) {
+    for (JAXBElement<?> dt : dayTypes.getDayTypeRefOrDayType_Dummy()) {
       parseDayType(dt);
     }
   }

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -181,7 +181,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
       return;
     }
 
-    for (JAXBElement<?> element : routes.getRoute_()) {
+    for (JAXBElement<?> element : routes.getRoute_Dummy()) {
       if (element.getValue() instanceof Route route) {
         this.routes.add(route);
       }
@@ -232,7 +232,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
       return;
     }
 
-    for (JAXBElement<?> element : lines.getLine_()) {
+    for (JAXBElement<?> element : lines.getLine_Dummy()) {
       if (element.getValue() instanceof Line) {
         this.lines.add((Line) element.getValue());
       } else if (element.getValue() instanceof FlexibleLine) {
@@ -248,7 +248,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
       return;
     }
 
-    for (JAXBElement<?> pattern : journeyPatterns.getJourneyPattern_OrJourneyPatternView()) {
+    for (JAXBElement<?> pattern : journeyPatterns.getJourneyPattern_Dummy()) {
       if (pattern.getValue() instanceof JourneyPattern_VersionStructure journeyPattern) {
         this.journeyPatterns.add(journeyPattern);
       } else {

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
@@ -52,7 +52,7 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
   @Override
   public void parse(Site_VersionFrameStructure frame) {
     if (frame.getStopPlaces() != null) {
-      parseStopPlaces(frame.getStopPlaces().getStopPlace_());
+      parseStopPlaces(frame.getStopPlaces().getStopPlace());
     }
     if (frame.getGroupsOfStopPlaces() != null) {
       parseGroupsOfStopPlaces(frame.getGroupsOfStopPlaces().getGroupOfStopPlaces());
@@ -66,7 +66,7 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
     }
 
     if (!ignoredFeatures.contains(PARKING) && frame.getParkings() != null) {
-      parseParkings(frame.getParkings().getParking());
+      parseParkings(frame.getParkings().getParking_Dummy());
     }
     // Keep list sorted alphabetically
     warnOnMissingMapping(LOG, frame.getAccesses());
@@ -106,13 +106,16 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
     groupsOfStopPlaces.addAll(groupsOfStopPlacesList);
   }
 
-  private void parseParkings(List<Parking> parking) {
-    parkings.addAll(parking);
+  private void parseParkings(List<JAXBElement<? extends Site_VersionStructure>> parkingList) {
+    for (JAXBElement<? extends Site_VersionStructure> jaxbParking : parkingList) {
+      if (jaxbParking.getValue() instanceof Parking parking) {
+        parkings.add(parking);
+      }
+    }
   }
 
-  private void parseStopPlaces(List<JAXBElement<? extends Site_VersionStructure>> stopPlaceList) {
-    for (JAXBElement<? extends Site_VersionStructure> jaxBStopPlace : stopPlaceList) {
-      StopPlace stopPlace = (StopPlace) jaxBStopPlace.getValue();
+  private void parseStopPlaces(List<StopPlace> stopPlaceList) {
+    for (StopPlace stopPlace : stopPlaceList) {
       if (isMultiModalStopPlace(stopPlace)) {
         multiModalStopPlaces.add(stopPlace);
       } else {

--- a/application/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
@@ -179,7 +179,7 @@ public class BookingInfoMapper {
       ContactInfo contactInfo = ContactInfo.of()
         .withContactPerson(
           contactStructure.getContactPerson() != null
-            ? contactStructure.getContactPerson().getValue()
+            ? MultilingualStringMapper.getStringValue(contactStructure.getContactPerson())
             : null
         )
         .withPhoneNumber(contactStructure.getPhone())
@@ -188,7 +188,7 @@ public class BookingInfoMapper {
         .withBookingUrl(contactStructure.getUrl())
         .withAdditionalDetails(
           contactStructure.getFurtherDetails() != null
-            ? contactStructure.getFurtherDetails().getValue()
+            ? MultilingualStringMapper.getStringValue(contactStructure.getFurtherDetails())
             : null
         )
         .build();
@@ -220,7 +220,9 @@ public class BookingInfoMapper {
         minimumBookingNotice = minimumBookingPeriod;
       }
 
-      String bookingInfoMessage = bookingNote != null ? bookingNote.getValue() : null;
+      String bookingInfoMessage = bookingNote != null
+        ? MultilingualStringMapper.getStringValue(bookingNote)
+        : null;
       return BookingInfo.of()
         .withContactInfo(contactInfo)
         .withBookingMethods(filteredBookingMethods)

--- a/application/src/main/java/org/opentripplanner/netex/mapping/BrandingMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/BrandingMapper.java
@@ -24,15 +24,15 @@ public class BrandingMapper {
     var builder = Branding.of(idFactory.createId(branding.getId()));
 
     if (branding.getShortName() != null) {
-      builder.withShortName(branding.getShortName().getValue());
+      builder.withShortName(MultilingualStringMapper.getStringValue(branding.getShortName()));
     }
 
     if (branding.getName() != null) {
-      builder.withName(branding.getName().getValue());
+      builder.withName(MultilingualStringMapper.getStringValue(branding.getName()));
     }
 
     if (branding.getDescription() != null) {
-      builder.withDescription(branding.getDescription().getValue());
+      builder.withDescription(MultilingualStringMapper.getStringValue(branding.getDescription()));
     }
 
     builder.withUrl(branding.getUrl());

--- a/application/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -91,7 +91,7 @@ class FlexStopsMapper {
         AreaStop areaStop = mapFlexArea(
           flexibleArea,
           flexibleAreaGeometry,
-          flexibleStopPlace.getName().getValue()
+          MultilingualStringMapper.getStringValue(flexibleStopPlace.getName())
         );
         if (areaStop != null) {
           stops.add(areaStop);
@@ -106,7 +106,11 @@ class FlexStopsMapper {
       // get the ids for the area and stop place correct
       var builder = siteRepositoryBuilder
         .groupStop(idFactory.createId(flexibleStopPlace.getId()))
-        .withName(new NonLocalizedString(flexibleStopPlace.getName().getValue()))
+        .withName(
+          new NonLocalizedString(
+            MultilingualStringMapper.getStringValue(flexibleStopPlace.getName())
+          )
+        )
         .withEncompassingAreaGeometries(areaGeometries);
       stops.forEach(builder::addLocation);
       return builder.build();
@@ -125,7 +129,11 @@ class FlexStopsMapper {
     var areaName = area.getName();
     return siteRepositoryBuilder
       .areaStop(idFactory.createId(area.getId()))
-      .withName(new NonLocalizedString(areaName != null ? areaName.getValue() : backupName))
+      .withName(
+        new NonLocalizedString(
+          areaName != null ? MultilingualStringMapper.getStringValue(areaName) : backupName
+        )
+      )
       .withGeometry(geometry)
       .build();
   }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/GroupOfStationsMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/GroupOfStationsMapper.java
@@ -45,7 +45,9 @@ class GroupOfStationsMapper {
     I18NString name;
 
     if (groupOfStopPlaces.getName() != null) {
-      name = NonLocalizedString.ofNullable(groupOfStopPlaces.getName().getValue());
+      name = NonLocalizedString.ofNullable(
+        MultilingualStringMapper.nullableValueOf(groupOfStopPlaces.getName())
+      );
     } else {
       issueStore.add(
         "GroupOfStopPlacesWithoutName",

--- a/application/src/main/java/org/opentripplanner/netex/mapping/MultiModalStationMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/MultiModalStationMapper.java
@@ -9,7 +9,6 @@ import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.MultiModalStationBuilder;
 import org.opentripplanner.transit.model.site.Station;
-import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.StopPlace;
 
 class MultiModalStationMapper {
@@ -29,7 +28,11 @@ class MultiModalStationMapper {
     )
       .withChildStations(childStations)
       .withName(
-        NonLocalizedString.ofNullable(stopPlace.getName(), MultilingualString::getValue, "N/A")
+        NonLocalizedString.ofNullable(
+          stopPlace.getName(),
+          MultilingualStringMapper::getStringValue,
+          "N/A"
+        )
       );
 
     WgsCoordinate coordinate = WgsCoordinateMapper.mapToDomain(stopPlace.getCentroid());

--- a/application/src/main/java/org/opentripplanner/netex/mapping/MultilingualStringMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/MultilingualStringMapper.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
+import java.io.Serializable;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.utils.lang.StringUtils;
 import org.rutebanken.netex.model.MultilingualString;
@@ -12,11 +14,34 @@ public class MultilingualStringMapper {
       return null;
     }
 
-    String value = multilingualString.getValue();
+    String value = getStringValue(multilingualString);
     if (StringUtils.hasNoValue(value)) {
       return null;
     }
 
     return value;
+  }
+
+  /**
+   * Extract the string value from a MultilingualString.
+   * In NeTEx 2.0, MultilingualString uses a mixed content model where
+   * the text is stored in getContent() as a list of serializable objects.
+   */
+  @Nullable
+  public static String getStringValue(@Nullable MultilingualString multilingualString) {
+    if (multilingualString == null) {
+      return null;
+    }
+    List<Serializable> content = multilingualString.getContent();
+    if (content == null || content.isEmpty()) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Serializable item : content) {
+      if (item instanceof String s) {
+        sb.append(s);
+      }
+    }
+    return sb.length() > 0 ? sb.toString() : null;
   }
 }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NoticeMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NoticeMapper.java
@@ -29,8 +29,10 @@ class NoticeMapper {
 
     if (otpNotice == null) {
       otpNotice = Notice.of(id)
-        .withPublicCode(netexNotice.getPublicCode())
-        .withText(netexNotice.getText().getValue())
+        .withPublicCode(
+          netexNotice.getPublicCode() != null ? netexNotice.getPublicCode().getValue() : null
+        )
+        .withText(MultilingualStringMapper.getStringValue(netexNotice.getText()))
         .build();
 
       cache.add(otpNotice);

--- a/application/src/main/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapper.java
@@ -22,12 +22,13 @@ class OperatorToAgencyMapper {
 
   Operator mapOperator(org.rutebanken.netex.model.Operator source) {
     final String name;
-    if (source.getName() == null || StringUtils.hasNoValue(source.getName().getValue())) {
+    String sourceName = MultilingualStringMapper.getStringValue(source.getName());
+    if (source.getName() == null || StringUtils.hasNoValue(sourceName)) {
       issueStore.add("MissingOperatorName", "Missing name for operator %s", source.getId());
       // fall back to NeTEx id when the operator name is missing
       name = source.getId();
     } else {
-      name = source.getName().getValue();
+      name = sourceName;
     }
     var target = Operator.of(idFactory.createId(source.getId())).withName(name);
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/QuayMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/QuayMapper.java
@@ -16,7 +16,6 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.SiteRepositoryBuilder;
 import org.rutebanken.netex.model.BusSubmodeEnumeration;
-import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Quay;
 
 class QuayMapper {
@@ -95,9 +94,11 @@ class QuayMapper {
       .regularStop(id)
       .withParentStation(parentStation)
       .withName(parentStation.getName())
-      .withPlatformCode(quay.getPublicCode())
+      .withPlatformCode(quay.getPublicCode() != null ? quay.getPublicCode().getValue() : null)
       .withDescription(
-        NonLocalizedString.ofNullable(quay.getDescription(), MultilingualString::getValue)
+        NonLocalizedString.ofNullable(
+          MultilingualStringMapper.nullableValueOf(quay.getDescription())
+        )
       )
       .withCoordinate(WgsCoordinateMapper.mapToDomain(quay.getCentroid()))
       .withWheelchairAccessibility(wheelchair)

--- a/application/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
@@ -20,7 +20,7 @@ import org.opentripplanner.transit.model.network.RouteBuilder;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Branding;
 import org.opentripplanner.transit.model.organization.Operator;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.BrandingRefStructure;
 import org.rutebanken.netex.model.FlexibleLine_VersionStructure;
 import org.rutebanken.netex.model.GroupOfLinesRefStructure;
@@ -79,9 +79,11 @@ class RouteMapper {
     builder.withAgency(findOrCreateAuthority(line));
     builder.withOperator(findOperator(line));
     builder.withBranding(findBranding(line));
-    NonLocalizedString longName = NonLocalizedString.ofNullable(line.getName().getValue());
+    NonLocalizedString longName = NonLocalizedString.ofNullable(
+      MultilingualStringMapper.nullableValueOf(line.getName())
+    );
     builder.withLongName(longName);
-    builder.withShortName(line.getPublicCode());
+    builder.withShortName(line.getPublicCode() != null ? line.getPublicCode().getValue() : null);
 
     NetexMainAndSubMode mode;
     try {
@@ -124,7 +126,7 @@ class RouteMapper {
     // but currently it doesn't look it is being parsed.
     // until there is better information from the operators we assume that all ferries allow
     // bicycles on board.
-    if (line.getTransportMode().equals(AllVehicleModesOfTransportEnumeration.WATER)) {
+    if (line.getTransportMode().equals(AllPublicTransportModesEnumeration.WATER)) {
       if (ferryIdsNotAllowedForBicycle.contains(line.getId())) {
         builder.withBikesAllowed(BikeAccess.NOT_ALLOWED);
       } else {

--- a/application/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -20,7 +20,6 @@ import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.SiteRepositoryBuilder;
 import org.rutebanken.netex.model.LimitedUseTypeEnumeration;
 import org.rutebanken.netex.model.LocaleStructure;
-import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.NameTypeEnumeration;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.StopPlace;
@@ -69,7 +68,9 @@ class StationMapper {
       .withCoordinate(mapCoordinate(stopPlace))
       .withShouldRouteToCentroid(shouldRouteToCentroid(id))
       .withDescription(
-        NonLocalizedString.ofNullable(stopPlace.getDescription(), MultilingualString::getValue)
+        NonLocalizedString.ofNullable(
+          MultilingualStringMapper.nullableValueOf(stopPlace.getDescription())
+        )
       )
       .withPriority(StopTransferPriorityMapper.mapToDomain(stopPlace.getWeighting()))
       .withTimezone(
@@ -112,19 +113,19 @@ class StationMapper {
       name = new NonLocalizedString("N/A");
     } else if (stopPlace.getAlternativeNames() != null) {
       Map<String, String> translations = new HashMap<>();
-      translations.put(null, stopPlace.getName().getValue());
+      translations.put(null, MultilingualStringMapper.getStringValue(stopPlace.getName()));
       for (var translation : stopPlace.getAlternativeNames().getAlternativeName()) {
         if (translation.getNameType() == NameTypeEnumeration.TRANSLATION) {
           String lang = translation.getLang() != null
             ? translation.getLang()
             : translation.getName().getLang();
-          translations.put(lang, translation.getName().getValue());
+          translations.put(lang, MultilingualStringMapper.getStringValue(translation.getName()));
         }
       }
 
       name = TranslatedString.getDeduplicatedI18NString(translations, false);
     } else {
-      name = new NonLocalizedString(stopPlace.getName().getValue());
+      name = new NonLocalizedString(MultilingualStringMapper.getStringValue(stopPlace.getName()));
     }
     return name;
   }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -132,7 +132,7 @@ class StopAndStationMapper {
 
     return stopPlace
       .getTariffZones()
-      .getTariffZoneRef_()
+      .getTariffZoneRef_Dummy()
       .stream()
       .map(ref -> findTariffZone(stopPlace, (TariffZoneRef) ref.getValue()))
       .filter(Objects::nonNull)

--- a/application/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -32,7 +32,6 @@ import org.rutebanken.netex.model.DestinationDisplay_VersionStructure;
 import org.rutebanken.netex.model.FlexibleLine;
 import org.rutebanken.netex.model.JourneyPattern_VersionStructure;
 import org.rutebanken.netex.model.LineRefStructure;
-import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.PointInLinkSequence_VersionedChildStructure;
 import org.rutebanken.netex.model.Route;
 import org.rutebanken.netex.model.ServiceJourney;
@@ -318,7 +317,9 @@ class StopTimesMapper {
         );
 
         if (destinationDisplay != null) {
-          currentHeadSign = new NonLocalizedString(destinationDisplay.getFrontText().getValue());
+          currentHeadSign = new NonLocalizedString(
+            MultilingualStringMapper.getStringValue(destinationDisplay.getFrontText())
+          );
           Vias_RelStructure viaValues = destinationDisplay.getVias();
           if (viaValues != null && viaValues.getVia() != null) {
             currentHeadSignVias = viaValues
@@ -332,7 +333,7 @@ class StopTimesMapper {
               .filter(Objects::nonNull)
               .map(DestinationDisplay_VersionStructure::getFrontText)
               .filter(Objects::nonNull)
-              .map(MultilingualString::getValue)
+              .map(MultilingualStringMapper::getStringValue)
               .filter(Objects::nonNull)
               .collect(Collectors.toList());
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TariffZoneMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TariffZoneMapper.java
@@ -56,7 +56,7 @@ class TariffZoneMapper {
     }
 
     FeedScopedId id = idFactory.createId(tariffZone.getId());
-    String name = tariffZone.getName().getValue();
+    String name = MultilingualStringMapper.getStringValue(tariffZone.getName());
     return deduplicate(FareZone.of(id).withName(name).build());
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
@@ -16,9 +16,9 @@ import org.opentripplanner.transfer.constrained.model.TransferPriority;
 import org.opentripplanner.transfer.constrained.model.TripTransferPoint;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.rutebanken.netex.model.JourneyRefStructure;
 import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
 import org.rutebanken.netex.model.ServiceJourneyInterchange;
-import org.rutebanken.netex.model.VehicleJourneyRefStructure;
 
 public class TransferMapper {
 
@@ -78,7 +78,7 @@ public class TransferMapper {
   private TripTransferPoint mapPoint(
     Label label,
     String interchangeId,
-    VehicleJourneyRefStructure sjRef,
+    JourneyRefStructure sjRef,
     ScheduledStopPointRefStructure pointRef
   ) {
     var sjId = sjRef.getRef();

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
@@ -11,7 +11,7 @@ import org.opentripplanner.netex.mapping.support.NetexMainAndSubMode;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.CarAccess;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.TransportSubmodeStructure;
 
 /**
@@ -30,7 +30,7 @@ class TransportModeMapper {
   );
 
   public NetexMainAndSubMode map(
-    AllVehicleModesOfTransportEnumeration netexMode,
+    AllPublicTransportModesEnumeration netexMode,
     TransportSubmodeStructure submode
   ) throws UnsupportedModeException {
     if (submode == null) {
@@ -40,7 +40,7 @@ class TransportModeMapper {
     }
   }
 
-  public TransitMode mapAllVehicleModesOfTransport(AllVehicleModesOfTransportEnumeration mode)
+  public TransitMode mapAllVehicleModesOfTransport(AllPublicTransportModesEnumeration mode)
     throws UnsupportedModeException {
     if (mode == null) {
       throw new UnsupportedModeException(null);
@@ -113,9 +113,9 @@ class TransportModeMapper {
 
   static class UnsupportedModeException extends Exception {
 
-    final AllVehicleModesOfTransportEnumeration mode;
+    final AllPublicTransportModesEnumeration mode;
 
-    public UnsupportedModeException(AllVehicleModesOfTransportEnumeration mode) {
+    public UnsupportedModeException(AllPublicTransportModesEnumeration mode) {
       this.mode = mode;
     }
   }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -109,7 +109,9 @@ class TripMapper {
       builder.withNetexInternalPlanningCode(serviceJourney.getPrivateCode().getValue());
     }
 
-    builder.withShortName(serviceJourney.getPublicCode());
+    builder.withShortName(
+      serviceJourney.getPublicCode() != null ? serviceJourney.getPublicCode().getValue() : null
+    );
     builder.withOperator(findOperator(serviceJourney));
 
     if (serviceJourney.getTransportMode() != null) {

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TripServiceAlterationMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TripServiceAlterationMapper.java
@@ -10,7 +10,7 @@ public class TripServiceAlterationMapper {
       return TripAlteration.PLANNED;
     }
     return switch (netexValue) {
-      case PLANNED -> TripAlteration.PLANNED;
+      case PLANNED, PROVISIONAL -> TripAlteration.PLANNED;
       case CANCELLATION -> TripAlteration.CANCELLATION;
       case REPLACED -> TripAlteration.REPLACED;
       case EXTRA_JOURNEY -> TripAlteration.EXTRA_JOURNEY;

--- a/application/src/main/java/org/opentripplanner/netex/mapping/VehicleParkingMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/VehicleParkingMapper.java
@@ -45,7 +45,9 @@ class VehicleParkingMapper {
     }
     return VehicleParking.builder()
       .id(idFactory.createId(parking.getId()))
-      .name(NonLocalizedString.ofNullable(parking.getName().getValue()))
+      .name(
+        NonLocalizedString.ofNullable(MultilingualStringMapper.nullableValueOf(parking.getName()))
+      )
       .coordinate(WgsCoordinateMapper.mapToDomain(parking.getCentroid()))
       .capacity(mapCapacity(parking))
       .bicyclePlaces(hasBikes(parking))
@@ -62,7 +64,7 @@ class VehicleParkingMapper {
     if (parking.getId() != null) {
       return parking.getId();
     } else if (parking.getName() != null) {
-      return parking.getName().getValue();
+      return MultilingualStringMapper.getStringValue(parking.getName());
     } else if (parking.getCentroid() != null) {
       return parking.getCentroid().toString();
     } else {

--- a/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
@@ -87,7 +87,7 @@ public class NetexMapperIndexes {
     Multimap<String, DatedServiceJourney> dsjBySJId = ArrayListMultimap.create();
     for (DatedServiceJourney dsj : datedServiceJourneys.localValues()) {
       // The validation step ensure no NPE occurs here
-      String sjId = dsj.getJourneyRef().get(0).getValue().getRef();
+      String sjId = dsj.getJourneyRef().getValue().getRef();
       dsjBySJId.put(sjId, dsj);
     }
     return dsjBySJId;

--- a/application/src/main/java/org/opentripplanner/netex/validation/DSJServiceJourneyNotFound.java
+++ b/application/src/main/java/org/opentripplanner/netex/validation/DSJServiceJourneyNotFound.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.netex.validation;
 
 import jakarta.xml.bind.JAXBElement;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.netex.issues.ObjectNotFound;
@@ -26,12 +25,12 @@ class DSJServiceJourneyNotFound extends AbstractHMapValidationRule<String, Dated
 
   @Nullable
   private String getServiceJourneyRef(DatedServiceJourney dsj) {
-    List<JAXBElement<? extends JourneyRefStructure>> journeyRef = dsj.getJourneyRef();
+    JAXBElement<? extends JourneyRefStructure> journeyRef = dsj.getJourneyRef();
 
-    if (journeyRef == null || journeyRef.isEmpty()) {
+    if (journeyRef == null) {
       return null;
     }
-    JourneyRefStructure ref = journeyRef.get(0).getValue();
+    JourneyRefStructure ref = journeyRef.getValue();
     return ref == null ? null : ref.getRef();
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
+++ b/application/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.xml.namespace.QName;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.DayOfWeekEnumeration;
 import org.rutebanken.netex.model.DayType;
@@ -26,6 +26,7 @@ import org.rutebanken.netex.model.OperatingPeriod;
 import org.rutebanken.netex.model.OperatingPeriodRefStructure;
 import org.rutebanken.netex.model.PropertiesOfDay_RelStructure;
 import org.rutebanken.netex.model.PropertyOfDay;
+import org.rutebanken.netex.model.PublicCodeStructure;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.Quays_RelStructure;
 import org.rutebanken.netex.model.ServiceAlterationEnumeration;
@@ -47,8 +48,8 @@ public final class NetexTestDataSupport {
   public static final String STOP_PLACE_VERSION = "TEST_STOP_PLACE_VERSION";
   public static final double STOP_PLACE_LAT = 0.11;
   public static final double STOP_PLACE_LON = 0.22;
-  public static final AllVehicleModesOfTransportEnumeration STOP_PLACE_TRANSPORT_MODE =
-    AllVehicleModesOfTransportEnumeration.BUS;
+  public static final AllPublicTransportModesEnumeration STOP_PLACE_TRANSPORT_MODE =
+    AllPublicTransportModesEnumeration.BUS;
 
   private static final ObjectFactory OBJECT_FACTORY = new ObjectFactory();
 
@@ -207,7 +208,7 @@ public final class NetexTestDataSupport {
     String version,
     Double lat,
     Double lon,
-    AllVehicleModesOfTransportEnumeration transportMode,
+    AllPublicTransportModesEnumeration transportMode,
     Quay quay
   ) {
     StopPlace stopPlace = new StopPlace()
@@ -234,7 +235,7 @@ public final class NetexTestDataSupport {
     String version,
     Double lat,
     Double lon,
-    AllVehicleModesOfTransportEnumeration transportMode
+    AllPublicTransportModesEnumeration transportMode
   ) {
     return createStopPlace(id, name, version, lat, lon, transportMode, null);
   }
@@ -267,7 +268,7 @@ public final class NetexTestDataSupport {
       .withName(createMLString(name))
       .withId(id)
       .withVersion(version)
-      .withPublicCode(platformCode)
+      .withPublicCode(new PublicCodeStructure().withValue(platformCode))
       .withCentroid(createSimplePoint(lat, lon));
   }
 
@@ -276,7 +277,7 @@ public final class NetexTestDataSupport {
   }
 
   private static MultilingualString createMLString(String name) {
-    return new MultilingualString().withValue(name);
+    return new MultilingualString().withContent(name);
   }
 
   private static SimplePoint_VersionStructure createSimplePoint(Double lat, Double lon) {

--- a/application/src/test/java/org/opentripplanner/netex/loader/parser/ResourceFrameParserTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/loader/parser/ResourceFrameParserTest.java
@@ -32,7 +32,7 @@ class ResourceFrameParserTest {
       new Authority()
     );
     resourceFrame.setOrganisations(objectFactory.createOrganisationsInFrame_RelStructure());
-    resourceFrame.getOrganisations().getOrganisation_().add(organisation);
+    resourceFrame.getOrganisations().getOrganisation_Dummy().add(organisation);
     resourceFrameParser.parse(resourceFrame);
     resourceFrameParser.setResultOnIndex(netexEntityIndex);
     assertEquals(1, netexEntityIndex.authoritiesById.size());

--- a/application/src/test/java/org/opentripplanner/netex/loader/parser/SiteFrameParserTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/loader/parser/SiteFrameParserTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.netex.NetexTestDataSupport.createQuay;
 import static org.opentripplanner.netex.NetexTestDataSupport.createStopPlace;
 
-import jakarta.xml.bind.JAXBElement;
 import java.util.Collection;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -13,7 +12,6 @@ import org.opentripplanner.netex.index.NetexEntityIndex;
 import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.SiteFrame;
-import org.rutebanken.netex.model.Site_VersionStructure;
 import org.rutebanken.netex.model.StopPlace;
 
 class SiteFrameParserTest {
@@ -28,12 +26,9 @@ class SiteFrameParserTest {
 
     Quay quay = createQuay();
     StopPlace stopPlace = createStopPlace(quay);
-    JAXBElement<? extends Site_VersionStructure> jaxbStopPlace = OBJECT_FACTORY.createStopPlace(
-      stopPlace
-    );
 
     siteFrame.setStopPlaces(OBJECT_FACTORY.createStopPlacesInFrame_RelStructure());
-    siteFrame.getStopPlaces().getStopPlace_().add(jaxbStopPlace);
+    siteFrame.getStopPlaces().getStopPlace().add(stopPlace);
 
     siteFrameParser.parse(siteFrame);
     siteFrameParser.setResultOnIndex(netexEntityIndex);

--- a/application/src/test/java/org/opentripplanner/netex/mapping/AuthorityToAgencyMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/AuthorityToAgencyMapperTest.java
@@ -86,8 +86,8 @@ public class AuthorityToAgencyMapperTest {
   ) {
     return new Authority()
       .withId(id)
-      .withShortName(new MultilingualString().withValue(shortName))
-      .withName(new MultilingualString().withValue(name))
+      .withShortName(new MultilingualString().withContent(shortName))
+      .withName(new MultilingualString().withContent(name))
       .withContactDetails(new ContactStructure().withUrl(url).withPhone(phone));
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
@@ -41,7 +41,7 @@ class BookingInfoMapperTest {
     StopPointInJourneyPattern stopPoint = new StopPointInJourneyPattern().withBookingArrangements(
       new BookingArrangementsStructure().withBookingContact(
         new ContactStructure().withContactPerson(
-          new MultilingualString().withValue(STOP_POINT_CONTACT)
+          new MultilingualString().withContent(STOP_POINT_CONTACT)
         )
       )
     );
@@ -49,14 +49,14 @@ class BookingInfoMapperTest {
     ServiceJourney serviceJourney = new ServiceJourney().withFlexibleServiceProperties(
       new FlexibleServiceProperties().withBookingContact(
         new ContactStructure().withContactPerson(
-          new MultilingualString().withValue(SERVICE_JOURNEY_CONTACT)
+          new MultilingualString().withContent(SERVICE_JOURNEY_CONTACT)
         )
       )
     );
 
     FlexibleLine flexibleLine = new FlexibleLine().withBookingContact(
       new ContactStructure().withContactPerson(
-        new MultilingualString().withValue(FLEXIBLE_LINE_CONTACT)
+        new MultilingualString().withContent(FLEXIBLE_LINE_CONTACT)
       )
     );
 
@@ -94,7 +94,7 @@ class BookingInfoMapperTest {
 
     FlexibleLine flexibleLine = new FlexibleLine().withBookingContact(
       new ContactStructure().withContactPerson(
-        new MultilingualString().withValue(FLEXIBLE_LINE_CONTACT)
+        new MultilingualString().withContent(FLEXIBLE_LINE_CONTACT)
       )
     );
 
@@ -106,10 +106,10 @@ class BookingInfoMapperTest {
   @Test
   void testMapBookingInfo() {
     ContactStructure contactStructure = new ContactStructure();
-    contactStructure.setContactPerson(new MultilingualString().withValue(PERSON));
+    contactStructure.setContactPerson(new MultilingualString().withContent(PERSON));
     contactStructure.setPhone(PHONE);
     contactStructure.setEmail(EMAIL);
-    contactStructure.setFurtherDetails(new MultilingualString().withValue(DETAILS));
+    contactStructure.setFurtherDetails(new MultilingualString().withContent(DETAILS));
 
     BookingArrangementsStructure bookingArrangements = new BookingArrangementsStructure();
     bookingArrangements.setBookingContact(contactStructure);
@@ -128,7 +128,7 @@ class BookingInfoMapperTest {
   @Test
   void testMapEarliestLatestBookingTime() {
     ContactStructure contactStructure = new ContactStructure();
-    contactStructure.setContactPerson(new MultilingualString().withValue(PERSON));
+    contactStructure.setContactPerson(new MultilingualString().withContent(PERSON));
 
     BookingArrangementsStructure bookingArrangements = new BookingArrangementsStructure();
     bookingArrangements.setBookingContact(contactStructure);
@@ -177,7 +177,7 @@ class BookingInfoMapperTest {
   @Test
   void testMapMinimumBookingNotice() {
     ContactStructure contactStructure = new ContactStructure();
-    contactStructure.setContactPerson(new MultilingualString().withValue(PERSON));
+    contactStructure.setContactPerson(new MultilingualString().withContent(PERSON));
 
     BookingArrangementsStructure bookingArrangements = new BookingArrangementsStructure();
     bookingArrangements.setBookingContact(contactStructure);

--- a/application/src/test/java/org/opentripplanner/netex/mapping/BrandingMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/BrandingMapperTest.java
@@ -34,9 +34,9 @@ public class BrandingMapperTest {
   public Branding createBranding() {
     return new Branding()
       .withId(ID)
-      .withName(new MultilingualString().withValue(NAME))
-      .withShortName(new MultilingualString().withValue(SHORT_NAME))
-      .withDescription(new MultilingualString().withValue(DESCRIPTION))
+      .withName(new MultilingualString().withContent(NAME))
+      .withShortName(new MultilingualString().withContent(SHORT_NAME))
+      .withDescription(new MultilingualString().withContent(DESCRIPTION))
       .withUrl(URL)
       .withImage(IMAGE);
   }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -23,7 +23,7 @@ import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.SiteRepositoryBuilder;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.FlexibleArea;
 import org.rutebanken.netex.model.FlexibleStopPlace;
 import org.rutebanken.netex.model.FlexibleStopPlace_VersionStructure;
@@ -283,8 +283,8 @@ class FlexStopsMapperTest {
 
     return new FlexibleStopPlace()
       .withId(FLEXIBLE_STOP_PLACE_ID)
-      .withName(new MultilingualString().withValue(FLEXIBLE_STOP_PLACE_NAME))
-      .withTransportMode(AllVehicleModesOfTransportEnumeration.BUS)
+      .withName(new MultilingualString().withContent(FLEXIBLE_STOP_PLACE_NAME))
+      .withTransportMode(AllPublicTransportModesEnumeration.BUS)
       .withAreas(areas);
   }
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/GroupOfRoutesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/GroupOfRoutesMapperTest.java
@@ -34,8 +34,8 @@ public class GroupOfRoutesMapperTest {
     return new GroupOfLines()
       .withId(ID)
       .withPrivateCode(new PrivateCodeStructure().withValue(PRIVATE_CODE))
-      .withName(new MultilingualString().withValue(NAME))
-      .withShortName(new MultilingualString().withValue(SHORT_NAME))
-      .withDescription(new MultilingualString().withValue(DESCRIPTION));
+      .withName(new MultilingualString().withContent(NAME))
+      .withShortName(new MultilingualString().withContent(SHORT_NAME))
+      .withDescription(new MultilingualString().withContent(DESCRIPTION));
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -18,7 +18,7 @@ import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.site.RegularStop;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.DayType;
 import org.rutebanken.netex.model.DayTypeRefStructure;
@@ -60,7 +60,7 @@ public class NetexTestDataSample {
   public static final List<String> OPERATING_DAYS = List.of("2022-02-28", "2022-02-29");
   private static final DayType EVERYDAY = new DayType()
     .withId("EVERYDAY")
-    .withName(new MultilingualString().withValue("everyday"));
+    .withName(new MultilingualString().withContent("everyday"));
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
@@ -89,8 +89,8 @@ public class NetexTestDataSample {
 
     Line line = new Line()
       .withId("RUT:Line:1")
-      .withName(new MultilingualString().withValue("Line 1"))
-      .withTransportMode(AllVehicleModesOfTransportEnumeration.BUS);
+      .withName(new MultilingualString().withContent("Line 1"))
+      .withTransportMode(AllPublicTransportModesEnumeration.BUS);
     JAXBElement<LineRefStructure> lineRef = createWrappedRef(line.getId(), LineRefStructure.class);
 
     // Add OTP Route (correspond to Netex Line)
@@ -116,7 +116,7 @@ public class NetexTestDataSample {
           List.of(this.createViaDestinationDisplayRef(DESTINATION_DISPLAY_ID_2))
         )
       )
-      .withFrontText(new MultilingualString().withValue("Bergen"));
+      .withFrontText(new MultilingualString().withContent("Bergen"));
 
     DestinationDisplay destinationStavanger = new DestinationDisplay()
       .withId(DESTINATION_DISPLAY_ID_2)
@@ -125,7 +125,7 @@ public class NetexTestDataSample {
           List.of(this.createViaDestinationDisplayRef(DESTINATION_DISPLAY_ID_1))
         )
       )
-      .withFrontText(new MultilingualString().withValue("Stavanger"));
+      .withFrontText(new MultilingualString().withContent("Stavanger"));
 
     destinationDisplayById.add(destinationBergen);
     destinationDisplayById.add(destinationStavanger);
@@ -188,9 +188,7 @@ public class NetexTestDataSample {
         DatedServiceJourney datedServiceJourney = new DatedServiceJourney()
           .withId(DATED_SERVICE_JOURNEY_ID.get(i))
           .withJourneyRef(
-            List.of(
-              MappingSupport.createWrappedRef(SERVICE_JOURNEY_ID, ServiceJourneyRefStructure.class)
-            )
+            MappingSupport.createWrappedRef(SERVICE_JOURNEY_ID, ServiceJourneyRefStructure.class)
           )
           .withServiceAlteration(ServiceAlterationEnumeration.PLANNED)
           .withOperatingDayRef(new OperatingDayRefStructure().withRef(operatingDay.getId()));

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapperTest.java
@@ -22,6 +22,7 @@ import org.rutebanken.netex.model.Notice;
 import org.rutebanken.netex.model.NoticeAssignment;
 import org.rutebanken.netex.model.NoticeRefStructure;
 import org.rutebanken.netex.model.PointInJourneyPatternRefStructure;
+import org.rutebanken.netex.model.PublicCodeStructure;
 import org.rutebanken.netex.model.ServiceJourney;
 import org.rutebanken.netex.model.TimetabledPassingTime;
 import org.rutebanken.netex.model.TimetabledPassingTimes_RelStructure;
@@ -37,8 +38,8 @@ public class NoticeAssignmentMapperTest {
 
   private static final Notice NOTICE = new org.rutebanken.netex.model.Notice()
     .withId(NOTICE_ID)
-    .withPublicCode("Notice Code")
-    .withText(new MultilingualString().withValue("Notice text"));
+    .withPublicCode(new PublicCodeStructure().withValue("Notice Code"))
+    .withText(new MultilingualString().withContent("Notice text"));
 
   @Test
   public void mapNoticeAssignment() {

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NoticeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NoticeMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Notice;
+import org.rutebanken.netex.model.PublicCodeStructure;
 
 public class NoticeMapperTest {
 
@@ -22,8 +23,8 @@ public class NoticeMapperTest {
     // And
     Notice netexNotice = new Notice();
     netexNotice.setId(NOTICE_ID);
-    netexNotice.setText(new MultilingualString().withValue(NOTICE_TEXT));
-    netexNotice.setPublicCode(PUBLIC_CODE);
+    netexNotice.setText(new MultilingualString().withContent(NOTICE_TEXT));
+    netexNotice.setPublicCode(new PublicCodeStructure().withValue(PUBLIC_CODE));
 
     // When
     otpNotice = mapper.map(netexNotice);
@@ -38,8 +39,8 @@ public class NoticeMapperTest {
     otpNotice = mapper.map(
       new Notice()
         .withId(NOTICE_ID)
-        .withPublicCode("Albatross")
-        .withText(new MultilingualString().withValue("Different text"))
+        .withPublicCode(new PublicCodeStructure().withValue("Albatross"))
+        .withText(new MultilingualString().withContent("Different text"))
     );
 
     // Then

--- a/application/src/test/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapperTest.java
@@ -23,7 +23,7 @@ public class OperatorToAgencyMapperTest {
     // Given
     Operator operator = new Operator()
       .withId(ID)
-      .withName(new MultilingualString().withValue(NAME))
+      .withName(new MultilingualString().withContent(NAME))
       .withContactDetails(new ContactStructure().withUrl(URL).withPhone(PHONE));
 
     // When mapped
@@ -45,7 +45,7 @@ public class OperatorToAgencyMapperTest {
     // Given
     Operator operator = new Operator()
       .withId(ID)
-      .withName(new MultilingualString().withValue(NAME));
+      .withName(new MultilingualString().withContent(NAME));
 
     // When mapped
     org.opentripplanner.transit.model.organization.Operator o;

--- a/application/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
@@ -23,7 +23,7 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Branding;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.Authority;
 import org.rutebanken.netex.model.BrandingRefStructure;
 import org.rutebanken.netex.model.GroupOfLinesRefStructure;
@@ -31,6 +31,7 @@ import org.rutebanken.netex.model.Line;
 import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Network;
 import org.rutebanken.netex.model.PresentationStructure;
+import org.rutebanken.netex.model.PublicCodeStructure;
 import org.rutebanken.netex.model.TransportOrganisationRefStructure;
 
 class RouteMapperTest {
@@ -262,9 +263,9 @@ class RouteMapperTest {
   private Line createExampleLine() {
     Line line = new Line();
     line.setId(LINE_ID);
-    line.setTransportMode(AllVehicleModesOfTransportEnumeration.METRO);
-    line.setName(new MultilingualString().withValue("Line 1"));
-    line.setPublicCode("L1");
+    line.setTransportMode(AllPublicTransportModesEnumeration.METRO);
+    line.setName(new MultilingualString().withContent("Line 1"));
+    line.setPublicCode(new PublicCodeStructure().withValue("L1"));
     line.setRepresentedByGroupRef(new GroupOfLinesRefStructure().withRef(NETWORK_ID));
     line.setBrandingRef(new BrandingRefStructure().withRef(BRANDING_ID));
     return line;
@@ -273,7 +274,7 @@ class RouteMapperTest {
   private Line createExampleFerry(String id) {
     var ferry = createExampleLine();
     ferry.setId(id);
-    ferry.setTransportMode(AllVehicleModesOfTransportEnumeration.WATER);
+    ferry.setTransportMode(AllPublicTransportModesEnumeration.WATER);
     return ferry;
   }
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.netex.NetexTestDataSupport.createQuay;
 import static org.opentripplanner.netex.NetexTestDataSupport.createStopPlace;
-import static org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration.TRAM;
+import static org.rutebanken.netex.model.AllPublicTransportModesEnumeration.TRAM;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.opentripplanner.transit.service.SiteRepositoryBuilder;
 import org.rutebanken.netex.model.AccessibilityAssessment;
 import org.rutebanken.netex.model.AccessibilityLimitation;
 import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.LimitationStatusEnumeration;
 import org.rutebanken.netex.model.LimitedUseTypeEnumeration;
 import org.rutebanken.netex.model.ObjectFactory;
@@ -49,7 +49,7 @@ class StopAndStationMapperTest {
       "1",
       55.707005,
       13.186816,
-      AllVehicleModesOfTransportEnumeration.BUS
+      AllPublicTransportModesEnumeration.BUS
     );
 
     // Create on quay with access, one without, and one with NULL
@@ -114,7 +114,7 @@ class StopAndStationMapperTest {
       "2",
       59.909584,
       10.755165,
-      AllVehicleModesOfTransportEnumeration.TRAM
+      AllPublicTransportModesEnumeration.TRAM
     );
 
     StopPlace stopPlaceOld = createStopPlace(
@@ -123,7 +123,7 @@ class StopAndStationMapperTest {
       "1",
       59.909584,
       10.755165,
-      AllVehicleModesOfTransportEnumeration.TRAM
+      AllPublicTransportModesEnumeration.TRAM
     );
 
     stopPlaces.add(stopPlaceNew);
@@ -219,7 +219,7 @@ class StopAndStationMapperTest {
       "1",
       59.909584,
       10.755165,
-      AllVehicleModesOfTransportEnumeration.TRAM
+      AllPublicTransportModesEnumeration.TRAM
     );
 
     stopPlace.withLimitedUse(LimitedUseTypeEnumeration.ISOLATED);
@@ -255,7 +255,7 @@ class StopAndStationMapperTest {
       "1",
       55.707005,
       13.186816,
-      AllVehicleModesOfTransportEnumeration.BUS
+      AllPublicTransportModesEnumeration.BUS
     );
 
     // Create on quay with access, one without, and one with NULL

--- a/application/src/test/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/StopPlaceTypeMapperTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.basic.TransitMode;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.BusSubmodeEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
 import org.rutebanken.netex.model.StopPlace;
@@ -24,7 +24,7 @@ class StopPlaceTypeMapperTest {
   @Test
   void mapWithTransportModeOnly() {
     var transitMode = stopPlaceTypeMapper.map(
-      new StopPlace().withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
+      new StopPlace().withTransportMode(AllPublicTransportModesEnumeration.RAIL)
     );
     assertEquals(TransitMode.RAIL, transitMode.mainMode());
     assertNull(transitMode.subMode());
@@ -33,7 +33,7 @@ class StopPlaceTypeMapperTest {
   @Test
   void mapCableway() {
     var transitMode = stopPlaceTypeMapper.map(
-      new StopPlace().withTransportMode(AllVehicleModesOfTransportEnumeration.CABLEWAY)
+      new StopPlace().withTransportMode(AllPublicTransportModesEnumeration.CABLEWAY)
     );
     assertEquals(TransitMode.GONDOLA, transitMode.mainMode());
     assertNull(transitMode.subMode());
@@ -43,7 +43,7 @@ class StopPlaceTypeMapperTest {
   void mapWithSubMode() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace()
-        .withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
+        .withTransportMode(AllPublicTransportModesEnumeration.RAIL)
         .withRailSubmode(RailSubmodeEnumeration.REGIONAL_RAIL)
     );
     assertEquals(TransitMode.RAIL, transitMode.mainMode());
@@ -63,7 +63,7 @@ class StopPlaceTypeMapperTest {
   void checkSubModePrecedenceOverMainMode() {
     var transitMode = stopPlaceTypeMapper.map(
       new StopPlace()
-        .withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL)
+        .withTransportMode(AllPublicTransportModesEnumeration.RAIL)
         .withBusSubmode(BusSubmodeEnumeration.SIGHTSEEING_BUS)
     );
     assertEquals(TransitMode.BUS, transitMode.mainMode());

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
@@ -25,7 +25,7 @@ import org.opentripplanner.netex.mapping.TransportModeMapper.UnsupportedModeExce
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.rutebanken.netex.model.AirSubmodeEnumeration;
-import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
 import org.rutebanken.netex.model.BusSubmodeEnumeration;
 import org.rutebanken.netex.model.CoachSubmodeEnumeration;
 import org.rutebanken.netex.model.FunicularSubmodeEnumeration;
@@ -41,72 +41,73 @@ import org.rutebanken.netex.model.WaterSubmodeEnumeration;
 class TransportModeMapperTest {
 
   private static final Map<
-    AllVehicleModesOfTransportEnumeration,
+    AllPublicTransportModesEnumeration,
     TransportSubmodeStructure
   > VALID_SUBMODE_STRUCTURES = Map.ofEntries(
     entry(
-      AllVehicleModesOfTransportEnumeration.AIR,
+      AllPublicTransportModesEnumeration.AIR,
       new TransportSubmodeStructure().withAirSubmode(AirSubmodeEnumeration.DOMESTIC_FLIGHT)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.BUS,
+      AllPublicTransportModesEnumeration.BUS,
       new TransportSubmodeStructure().withBusSubmode(BusSubmodeEnumeration.LOCAL_BUS)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.CABLEWAY,
+      AllPublicTransportModesEnumeration.CABLEWAY,
       new TransportSubmodeStructure().withTelecabinSubmode(TelecabinSubmodeEnumeration.TELECABIN)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.COACH,
+      AllPublicTransportModesEnumeration.COACH,
       new TransportSubmodeStructure().withCoachSubmode(CoachSubmodeEnumeration.NATIONAL_COACH)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.FUNICULAR,
+      AllPublicTransportModesEnumeration.FUNICULAR,
       new TransportSubmodeStructure().withFunicularSubmode(FunicularSubmodeEnumeration.FUNICULAR)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.METRO,
+      AllPublicTransportModesEnumeration.METRO,
       new TransportSubmodeStructure().withMetroSubmode(MetroSubmodeEnumeration.METRO)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.RAIL,
+      AllPublicTransportModesEnumeration.RAIL,
       new TransportSubmodeStructure().withRailSubmode(RailSubmodeEnumeration.LONG_DISTANCE)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.SNOW_AND_ICE,
+      AllPublicTransportModesEnumeration.SNOW_AND_ICE,
       new TransportSubmodeStructure().withSnowAndIceSubmode(SnowAndIceSubmodeEnumeration.SNOW_COACH)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.TAXI,
+      AllPublicTransportModesEnumeration.TAXI,
       new TransportSubmodeStructure().withTaxiSubmode(TaxiSubmodeEnumeration.COMMUNAL_TAXI)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.TRAM,
+      AllPublicTransportModesEnumeration.TRAM,
       new TransportSubmodeStructure().withTramSubmode(TramSubmodeEnumeration.CITY_TRAM)
     ),
     entry(
-      AllVehicleModesOfTransportEnumeration.WATER,
+      AllPublicTransportModesEnumeration.WATER,
       new TransportSubmodeStructure().withWaterSubmode(
         WaterSubmodeEnumeration.INTERNATIONAL_PASSENGER_FERRY
       )
     )
   );
 
-  private static final EnumSet<AllVehicleModesOfTransportEnumeration> SUPPORTED_MODES =
-    EnumSet.copyOf(VALID_SUBMODE_STRUCTURES.keySet());
+  private static final EnumSet<AllPublicTransportModesEnumeration> SUPPORTED_MODES = EnumSet.copyOf(
+    VALID_SUBMODE_STRUCTURES.keySet()
+  );
 
   private final TransportModeMapper transportModeMapper = new TransportModeMapper();
 
   @Test
   void mapWithTransportModeOnly() throws UnsupportedModeException {
-    var transitMode = transportModeMapper.map(AllVehicleModesOfTransportEnumeration.BUS, null);
+    var transitMode = transportModeMapper.map(AllPublicTransportModesEnumeration.BUS, null);
     assertEquals(TransitMode.BUS, transitMode.mainMode());
     assertNull(transitMode.subMode());
   }
 
   @Test
   void mapCableway() throws UnsupportedModeException {
-    var transitMode = transportModeMapper.map(AllVehicleModesOfTransportEnumeration.CABLEWAY, null);
+    var transitMode = transportModeMapper.map(AllPublicTransportModesEnumeration.CABLEWAY, null);
     assertEquals(TransitMode.GONDOLA, transitMode.mainMode());
     assertNull(transitMode.subMode());
   }
@@ -114,8 +115,8 @@ class TransportModeMapperTest {
   @Test
   void mapWithSubMode() throws UnsupportedModeException {
     var transitMode = transportModeMapper.map(
-      AllVehicleModesOfTransportEnumeration.RAIL,
-      VALID_SUBMODE_STRUCTURES.get(AllVehicleModesOfTransportEnumeration.RAIL)
+      AllPublicTransportModesEnumeration.RAIL,
+      VALID_SUBMODE_STRUCTURES.get(AllPublicTransportModesEnumeration.RAIL)
     );
     assertEquals(TransitMode.RAIL, transitMode.mainMode());
     assertEquals("longDistance", transitMode.subMode());
@@ -124,7 +125,7 @@ class TransportModeMapperTest {
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("createSubModeTestCases")
   void acceptAllValidSubModes(
-    AllVehicleModesOfTransportEnumeration mode,
+    AllPublicTransportModesEnumeration mode,
     TransportSubmodeStructure submodeStructure
   ) throws UnsupportedModeException {
     assertNotNull(transportModeMapper.map(mode, submodeStructure));
@@ -133,7 +134,7 @@ class TransportModeMapperTest {
   @Test
   void checkSubModePrecedenceOverMainMode() throws UnsupportedModeException {
     var transitMode = transportModeMapper.map(
-      AllVehicleModesOfTransportEnumeration.BUS,
+      AllPublicTransportModesEnumeration.BUS,
       new TransportSubmodeStructure().withWaterSubmode(
         WaterSubmodeEnumeration.INTERNATIONAL_PASSENGER_FERRY
       )

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TripCalendarBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TripCalendarBuilderTest.java
@@ -151,9 +151,9 @@ public class TripCalendarBuilderTest {
   private ArrayListMultimap<String, DatedServiceJourney> dsj_2020_11_02(String sjId) {
     var dsj = new DatedServiceJourney();
     dsj.withOperatingDayRef(new OperatingDayRefStructure().withRef(OD_1));
-    dsj
-      .getJourneyRef()
-      .add(jaxbElement(new JourneyRefStructure().withRef(sjId), JourneyRefStructure.class));
+    dsj.withJourneyRef(
+      jaxbElement(new JourneyRefStructure().withRef(sjId), JourneyRefStructure.class)
+    );
     ArrayListMultimap<String, DatedServiceJourney> map = ArrayListMultimap.create();
     map.put(sjId, dsj);
     return map;

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ArrayListMultimap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -22,9 +21,10 @@ import org.opentripplanner.transit.model.timetable.TripAlteration;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.rutebanken.netex.model.DatedServiceJourney;
-import org.rutebanken.netex.model.DatedServiceJourneyRefStructure;
 import org.rutebanken.netex.model.OperatingDay;
+import org.rutebanken.netex.model.ReplacedJourneys_RelStructure;
 import org.rutebanken.netex.model.ServiceAlterationEnumeration;
+import org.rutebanken.netex.model.VehicleJourneyRefStructure;
 
 class TripPatternMapperTest {
 
@@ -128,9 +128,9 @@ class TripPatternMapperTest {
     DatedServiceJourney dsjReplacing = sample.getDatedServiceJourneyById(
       NetexTestDataSample.DATED_SERVICE_JOURNEY_ID_2
     );
-    dsjReplacing.withJourneyRef(
-      List.of(
-        MappingSupport.createWrappedRef(dsjReplaced.getId(), DatedServiceJourneyRefStructure.class)
+    dsjReplacing.withReplacedJourneys(
+      new ReplacedJourneys_RelStructure().withDatedVehicleJourneyRefOrNormalDatedVehicleJourneyRef(
+        MappingSupport.createWrappedRef(dsjReplaced.getId(), VehicleJourneyRefStructure.class)
       )
     );
     Optional<TripPatternMapperResult> res = mapTripPattern(sample);

--- a/application/src/test/java/org/opentripplanner/netex/mapping/VehicleParkingMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/VehicleParkingMapperTest.java
@@ -89,8 +89,7 @@ class VehicleParkingMapperTest {
   }
 
   private static Parking parking(Set<ParkingVehicleEnumeration> vehicleTypes) {
-    var name = new MultilingualString();
-    name.setValue("A name");
+    var name = new MultilingualString().withContent("A name");
     var point = new SimplePoint_VersionStructure();
     var loc = new LocationStructure();
     loc.setLatitude(new BigDecimal(10));

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <logback.version>1.5.27</logback.version>
         <lucene.version>10.3.2</lucene.version>
         <micrometer.version>1.16.3</micrometer.version>
-        <netex-java-model.version>2.0.15.2</netex-java-model.version>
+        <netex-java-model.version>3.0.0-SNAPSHOT</netex-java-model.version>
         <netcdf4.version>5.6.0</netcdf4.version>
         <protobuf.version>4.33.5</protobuf.version>
         <siri-java-model.version>2.0.2</siri-java-model.version>
@@ -459,6 +459,16 @@
             <name>Open Source Geospatial Foundation Repository</name>
             <url>https://repo.osgeo.org/repository/release/</url>
         </repository>
+        <repository>
+            <id>maven-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <dependencyManagement>
@@ -680,7 +690,7 @@
                 </repository>
             </distributionManagement>
         </profile>
-        
+
         <profile>
             <id>integrationTests</id>
             <activation>


### PR DESCRIPTION


### Summary

This update adapts OTP to the breaking changes in netex-java-model 3.0.0-SNAPSHOT based on the NeTEx 2.0 schema. Key changes include:

Breaking API changes addressed:
- MultilingualString: Uses mixed content model - getContent() returns List<Serializable> instead of getValue() returning String. Added MultilingualStringMapper.getStringValue() helper method.
- Enum rename: AllVehicleModesOfTransportEnumeration renamed to AllPublicTransportModesEnumeration.
- Collection getter naming: Some methods renamed with _Dummy suffix (e.g., getLine_Dummy(), getRoute_Dummy()).
- PublicCode/PrivateCode: Now return structure types requiring .getValue() to get String.
- StopPlacesInFrame_RelStructure: Now returns List<StopPlace> directly instead of wrapped JAXBElements.
- DatedServiceJourney: getJourneyRef() returns single element instead of List, uses getReplacedJourneys() for replacements.
- ServiceAlterationEnumeration: New PROVISIONAL value added, mapped to PLANNED.

See: https://github.com/entur/netex-java-model/pull/270

### Issue

No
### Unit tests

Updated

### Documentation

No

