### PR TITLE
Implement GBFS-spec compliant zone precedence

### DIFF
--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/model/GeofencingZone.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/model/GeofencingZone.java
@@ -14,8 +14,23 @@ public record GeofencingZone(
   @Nullable I18NString name,
   Geometry geometry,
   boolean dropOffBanned,
-  boolean traversalBanned
+  boolean traversalBanned,
+  int priority
 ) {
+  /**
+   * Convenience constructor with default priority (0 = highest priority).
+   * Used for backward compatibility with existing code.
+   */
+  public GeofencingZone(
+    FeedScopedId id,
+    @Nullable I18NString name,
+    Geometry geometry,
+    boolean dropOffBanned,
+    boolean traversalBanned
+  ) {
+    this(id, name, geometry, dropOffBanned, traversalBanned, 0);
+  }
+
   /**
    * Are there any restrictions in this zone. (It's possible that the data says there are none.)
    */

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/street/BusinessAreaBorder.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/street/BusinessAreaBorder.java
@@ -57,4 +57,23 @@ public final class BusinessAreaBorder implements RentalRestrictionExtension {
   public List<String> networks() {
     return List.of(network);
   }
+
+  @Override
+  public boolean appliesTo(State state) {
+    if (!state.isRentingVehicle()) {
+      return false;
+    }
+    if (state.getRequest().arriveBy()) {
+      // In arrive-by search we don't know the rental network yet,
+      // so we apply to all networks
+      return true;
+    }
+    return network.equals(state.getVehicleRentalNetwork());
+  }
+
+  @Override
+  public int priority() {
+    // Business area borders have lowest priority - geofencing zones take precedence
+    return Integer.MAX_VALUE;
+  }
 }

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/street/CompositeRentalRestrictionExtension.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/street/CompositeRentalRestrictionExtension.java
@@ -45,8 +45,7 @@ public final class CompositeRentalRestrictionExtension implements RentalRestrict
 
   /**
    * Find the highest-priority restriction that applies to the given state.
-   * When zones overlap, the one with the lowest priority value wins (GBFS spec:
-   * "earlier listed zones take precedence").
+   * When zones overlap, the one with the lowest priority value wins.
    */
   private Optional<RentalRestrictionExtension> getHighestPriorityApplicable(State state) {
     RentalRestrictionExtension best = null;

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/street/GeofencingVertexUpdater.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/street/GeofencingVertexUpdater.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.updater.vehicle_rental;
+package org.opentripplanner.service.vehiclerental.street;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -15,8 +15,6 @@ import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
-import org.opentripplanner.service.vehiclerental.street.BusinessAreaBorder;
-import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;
 import org.opentripplanner.street.model.RentalRestrictionExtension;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
@@ -32,7 +30,7 @@ import org.opentripplanner.street.model.edge.StreetEdge;
  * Perhaps this logic will be replaced with edge splitting where a new vertex is insert right on
  * the border of the zone.
  */
-class GeofencingVertexUpdater {
+public class GeofencingVertexUpdater {
 
   private final Function<Envelope, Collection<Edge>> getEdgesForEnvelope;
 
@@ -44,7 +42,7 @@ class GeofencingVertexUpdater {
    * Applies the restrictions described in the geofencing zones to eges by adding
    * {@link RentalRestrictionExtension} to them.
    */
-  Map<StreetEdge, RentalRestrictionExtension> applyGeofencingZones(
+  public Map<StreetEdge, RentalRestrictionExtension> applyGeofencingZones(
     Collection<GeofencingZone> geofencingZones
   ) {
     var restrictedZones = geofencingZones.stream().filter(GeofencingZone::hasRestriction).toList();

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/street/GeofencingZoneExtension.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/street/GeofencingZoneExtension.java
@@ -90,4 +90,19 @@ public final class GeofencingZoneExtension implements RentalRestrictionExtension
   public String toString() {
     return zone.id().toString();
   }
+
+  @Override
+  public boolean appliesTo(State state) {
+    if (!state.isRentingVehicle()) {
+      return false;
+    }
+    return (
+      state.unknownRentalNetwork() || zone.id().getFeedId().equals(state.getVehicleRentalNetwork())
+    );
+  }
+
+  @Override
+  public int priority() {
+    return zone.priority();
+  }
 }

--- a/application/src/main/java/org/opentripplanner/service/vehiclerental/street/NoRestriction.java
+++ b/application/src/main/java/org/opentripplanner/service/vehiclerental/street/NoRestriction.java
@@ -50,4 +50,10 @@ public final class NoRestriction implements RentalRestrictionExtension {
   public Set<String> noDropOffNetworks() {
     return Set.of();
   }
+
+  @Override
+  public boolean appliesTo(State state) {
+    // No restriction never applies as there is nothing to apply
+    return false;
+  }
 }

--- a/application/src/main/java/org/opentripplanner/street/model/RentalRestrictionExtension.java
+++ b/application/src/main/java/org/opentripplanner/street/model/RentalRestrictionExtension.java
@@ -58,6 +58,23 @@ public interface RentalRestrictionExtension {
 
   Set<String> noDropOffNetworks();
 
+  /**
+   * Check if this restriction applies to the current state (network/vehicle type match).
+   * This is separate from whether the action is banned - used for priority-based selection
+   * when multiple restrictions overlap.
+   */
+  default boolean appliesTo(State state) {
+    return true;
+  }
+
+  /**
+   * Get the priority of this restriction. Lower values indicate higher priority (0 is highest).
+   * Used for selecting which restriction takes precedence when multiple overlap.
+   */
+  default int priority() {
+    return Integer.MAX_VALUE;
+  }
+
   enum RestrictionType {
     NO_TRAVERSAL,
     NO_DROP_OFF,

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -17,6 +17,7 @@ import org.opentripplanner.routing.linking.VertexLinker;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
+import org.opentripplanner.service.vehiclerental.street.GeofencingVertexUpdater;
 import org.opentripplanner.service.vehiclerental.street.StreetVehicleRentalLink;
 import org.opentripplanner.service.vehiclerental.street.VehicleRentalEdge;
 import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/GbfsGeofencingZoneMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/GbfsGeofencingZoneMapper.java
@@ -2,6 +2,9 @@ package org.opentripplanner.updater.vehicle_rental.datasources.gbfs;
 
 import com.google.common.hash.Hashing;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.geojson.MultiPolygon;
 import org.locationtech.jts.geom.Geometry;
@@ -13,9 +16,22 @@ import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class GbfsGeofencingZoneMapper<T> {
+/**
+ * Abstract mapper for GBFS geofencing zones. Subclasses implement version-specific
+ * access to GBFS feature properties and rules.
+ *
+ * @param <F> The GBFS feature type (zone)
+ * @param <R> The GBFS rule type
+ */
+public abstract class GbfsGeofencingZoneMapper<F, R> {
 
   private static final Logger LOG = LoggerFactory.getLogger(GbfsGeofencingZoneMapper.class);
+
+  /**
+   * Priority multiplier for zone index. Each zone's rules get priorities in the range
+   * [zoneIndex * 1000, zoneIndex * 1000 + 999], allowing up to 1000 rules per zone.
+   */
+  private static final int ZONE_PRIORITY_MULTIPLIER = 1000;
 
   private final String systemId;
 
@@ -23,35 +39,62 @@ public abstract class GbfsGeofencingZoneMapper<T> {
     this.systemId = systemId;
   }
 
-  protected abstract boolean featureBansDropOff(T feature);
+  protected abstract MultiPolygon featureGeometry(F feature);
 
-  protected abstract boolean featureBansPassThrough(T feature);
+  protected abstract @Nullable I18NString featureName(F feature);
 
-  protected abstract MultiPolygon featureGeometry(T feature);
+  protected abstract List<R> featureRules(F feature);
 
-  protected abstract @Nullable I18NString featureName(T feature);
+  protected abstract boolean ruleBansDropOff(R rule);
+
+  protected abstract boolean ruleBansPassThrough(R rule);
 
   /**
-   * Convert the GBFS type to the internal model.
+   * Convert a GBFS feature to internal model(s). Each rule in the feature becomes
+   * a separate GeofencingZone with its own priority.
+   *
+   * @param feature The GBFS feature (zone)
+   * @param zoneIndex Position in GBFS feature array (for priority calculation)
+   * @return List of GeofencingZone objects, one per rule
    */
-  @Nullable
-  protected GeofencingZone toInternalModel(T feature) {
-    Geometry g;
+  protected List<GeofencingZone> toInternalModel(F feature, int zoneIndex) {
+    Geometry geometry;
     try {
-      g = GeometryUtils.convertGeoJsonToJtsGeometry(featureGeometry(feature));
+      geometry = GeometryUtils.convertGeoJsonToJtsGeometry(featureGeometry(feature));
     } catch (UnsupportedGeometryException e) {
       LOG.error("Could not convert geofencing zone", e);
-      return null;
+      return Collections.emptyList();
     }
 
-    var id = fallbackId(g);
-    return new GeofencingZone(
-      new FeedScopedId(systemId, id),
-      featureName(feature),
-      g,
-      featureBansDropOff(feature),
-      featureBansPassThrough(feature)
-    );
+    var rules = featureRules(feature);
+    if (rules == null || rules.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    var name = featureName(feature);
+    var baseId = fallbackId(geometry);
+    var zones = new ArrayList<GeofencingZone>(rules.size());
+
+    for (int ruleIndex = 0; ruleIndex < rules.size(); ruleIndex++) {
+      var rule = rules.get(ruleIndex);
+      int priority = zoneIndex * ZONE_PRIORITY_MULTIPLIER + ruleIndex;
+
+      // Create unique ID for each rule within a zone
+      String id = rules.size() > 1 ? baseId + "-rule" + ruleIndex : baseId;
+
+      zones.add(
+        new GeofencingZone(
+          new FeedScopedId(systemId, id),
+          name,
+          geometry,
+          ruleBansDropOff(rule),
+          ruleBansPassThrough(rule),
+          priority
+        )
+      );
+    }
+
+    return zones;
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsGeofencingZoneMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v2/GbfsGeofencingZoneMapper.java
@@ -1,20 +1,23 @@
 package org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v2;
 
 import java.util.List;
-import java.util.Objects;
+import java.util.stream.IntStream;
 import org.geojson.MultiPolygon;
 import org.mobilitydata.gbfs.v2_3.geofencing_zones.GBFSFeature;
 import org.mobilitydata.gbfs.v2_3.geofencing_zones.GBFSGeofencingZones;
+import org.mobilitydata.gbfs.v2_3.geofencing_zones.GBFSRule;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 
 /**
- * A mapper from the raw GBFS type into the internal model of the geofencing zones.
+ * A mapper from the raw GBFS v2 type into the internal model of the geofencing zones.
+ * Each rule within a zone becomes a separate GeofencingZone with its own priority.
  */
 class GbfsGeofencingZoneMapper
   extends org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsGeofencingZoneMapper<
-    GBFSFeature
+    GBFSFeature,
+    GBFSRule
   > {
 
   public GbfsGeofencingZoneMapper(String systemId) {
@@ -22,24 +25,11 @@ class GbfsGeofencingZoneMapper
   }
 
   public List<GeofencingZone> mapGeofencingZone(GBFSGeofencingZones input) {
-    return input
-      .getData()
-      .getGeofencingZones()
-      .getFeatures()
-      .stream()
-      .map(this::toInternalModel)
-      .filter(Objects::nonNull)
+    var features = input.getData().getGeofencingZones().getFeatures();
+    return IntStream.range(0, features.size())
+      .boxed()
+      .flatMap(zoneIndex -> toInternalModel(features.get(zoneIndex), zoneIndex).stream())
       .toList();
-  }
-
-  @Override
-  protected boolean featureBansDropOff(GBFSFeature feature) {
-    return !feature.getProperties().getRules().get(0).getRideAllowed();
-  }
-
-  @Override
-  protected boolean featureBansPassThrough(GBFSFeature feature) {
-    return !feature.getProperties().getRules().get(0).getRideThroughAllowed();
   }
 
   @Override
@@ -50,5 +40,20 @@ class GbfsGeofencingZoneMapper
   @Override
   protected I18NString featureName(GBFSFeature feature) {
     return NonLocalizedString.ofNullable(feature.getProperties().getName());
+  }
+
+  @Override
+  protected List<GBFSRule> featureRules(GBFSFeature feature) {
+    return feature.getProperties().getRules();
+  }
+
+  @Override
+  protected boolean ruleBansDropOff(GBFSRule rule) {
+    return !rule.getRideAllowed();
+  }
+
+  @Override
+  protected boolean ruleBansPassThrough(GBFSRule rule) {
+    return !rule.getRideThroughAllowed();
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsGeofencingZoneMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/v3/GbfsGeofencingZoneMapper.java
@@ -3,21 +3,24 @@ package org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3;
 import static org.opentripplanner.updater.vehicle_rental.datasources.gbfs.v3.GbfsFeedMapper.optionalLocalizedString;
 
 import java.util.List;
-import java.util.Objects;
+import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.geojson.MultiPolygon;
 import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSFeature;
 import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSGeofencingZones;
 import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSName;
+import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSRule;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 
 /**
- * A mapper from the raw GBFS type into the internal model of the geofencing zones.
+ * A mapper from the raw GBFS v3 type into the internal model of the geofencing zones.
+ * Each rule within a zone becomes a separate GeofencingZone with its own priority.
  */
 class GbfsGeofencingZoneMapper
   extends org.opentripplanner.updater.vehicle_rental.datasources.gbfs.GbfsGeofencingZoneMapper<
-    GBFSFeature
+    GBFSFeature,
+    GBFSRule
   > {
 
   public GbfsGeofencingZoneMapper(String systemId) {
@@ -25,25 +28,12 @@ class GbfsGeofencingZoneMapper
   }
 
   public List<GeofencingZone> mapGeofencingZone(GBFSGeofencingZones input) {
-    return input
-      .getData()
-      .getGeofencingZones()
-      .getFeatures()
-      .stream()
-      .filter(f -> f.getGeometry() != null)
-      .map(this::toInternalModel)
-      .filter(Objects::nonNull)
+    var features = input.getData().getGeofencingZones().getFeatures();
+    return IntStream.range(0, features.size())
+      .boxed()
+      .filter(zoneIndex -> features.get(zoneIndex).getGeometry() != null)
+      .flatMap(zoneIndex -> toInternalModel(features.get(zoneIndex), zoneIndex).stream())
       .toList();
-  }
-
-  @Override
-  protected boolean featureBansDropOff(GBFSFeature feature) {
-    return !feature.getProperties().getRules().get(0).getRideEndAllowed();
-  }
-
-  @Override
-  protected boolean featureBansPassThrough(GBFSFeature feature) {
-    return !feature.getProperties().getRules().get(0).getRideThroughAllowed();
   }
 
   @Override
@@ -58,5 +48,20 @@ class GbfsGeofencingZoneMapper
       GBFSName::getLanguage,
       GBFSName::getText
     );
+  }
+
+  @Override
+  protected List<GBFSRule> featureRules(GBFSFeature feature) {
+    return feature.getProperties().getRules();
+  }
+
+  @Override
+  protected boolean ruleBansDropOff(GBFSRule rule) {
+    return !rule.getRideEndAllowed();
+  }
+
+  @Override
+  protected boolean ruleBansPassThrough(GBFSRule rule) {
+    return !rule.getRideThroughAllowed();
   }
 }

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/street/GeofencingVertexUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/street/GeofencingVertexUpdaterTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.updater.vehicle_rental;
+package org.opentripplanner.service.vehiclerental.street;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -14,11 +14,9 @@ import org.locationtech.jts.geom.Polygon;
 import org.opentripplanner._support.geometry.Polygons;
 import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
-import org.opentripplanner.service.vehiclerental.street.BusinessAreaBorder;
-import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;
-import org.opentripplanner.service.vehiclerental.street.NoRestriction;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.service.vehiclerental.street.GeofencingVertexUpdater;
 
 class GeofencingVertexUpdaterTest {
 

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/street/GeofencingVertexUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/street/GeofencingVertexUpdaterTest.java
@@ -16,7 +16,6 @@ import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.vertex.StreetVertex;
-import org.opentripplanner.service.vehiclerental.street.GeofencingVertexUpdater;
 
 class GeofencingVertexUpdaterTest {
 


### PR DESCRIPTION
Refactor geofencing zone handling: move GeofencingVertexUpdater to the service layer and implement priority-based precedence for overlapping zones with support for multiple
  rules per zone.

###  Issue

  This PR addresses three improvements to the geofencing zone implementation:

  1. Module organization: GeofencingVertexUpdater was in the updater package, making it unavailable to the sandbox module. Moving it to the service layer enables clean reuse.
  2. OR-logic problem: When zones overlap, CompositeRentalRestrictionExtension uses OR-logic - if ANY zone bans an action, it's banned. Per GBFS spec, earlier listed zones should
   take precedence.
  3. Only first rule used: GBFS zones can have multiple rules per zone (for different vehicle types), but only rules[0] was being used.

  Technical approach:

  The solution isolates GBFS-specific semantics to the mapper layer while keeping the domain model GBFS-agnostic:

  - Moved GeofencingVertexUpdater from updater to service/vehiclerental/street
  - Added a priority field to GeofencingZone (lower value = higher priority)
  - Added appliesTo(State) and priority() methods to RentalRestrictionExtension interface
  - Replaced OR-logic in CompositeRentalRestrictionExtension with priority-based selection
  - Each GBFS rule becomes a separate GeofencingZone with priority = zoneIndex * 1000 + ruleIndex

  This allows proper precedence: zone at position 0 with rule 0 has priority 0 (highest), zone at position 1 with rule 0 has priority 1000, etc.

###  Unit tests

  - Added tests for priority-based zone precedence (higherPriorityZoneTakesPrecedence, lowerPriorityZoneDoesNotOverride)
  - Added test verifying zone priorities from GBFS data (geofencingZonePriority)
  - All 96 existing vehicle rental and geofencing tests pass
  - Refactoring phases were committed separately with test verification at each step

###  Documentation

  - Added Javadoc to new methods (appliesTo(), priority(), getHighestPriorityApplicable())
  - Added class-level documentation explaining the priority calculation in GbfsGeofencingZoneMapper
  - No new configuration options added

### Bumping the serialization version id

  The GeofencingZone record now has an additional priority field, which affects serialization. The label +Bump Serialization Id should be added to this PR.