### PR TITLE
Fixed test that was broken under windows build env.

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/ojp/trias/OjpToTriasTransformerTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/ojp/trias/OjpToTriasTransformerTest.java
@@ -41,6 +41,9 @@ class OjpToTriasTransformerTest {
     var actual = OjpToTriasTransformer.ojpToTrias(ojp);
     var file = LOADER.extTestResourceFile("error.xml");
     var original = readFile(file);
+
+    // normalize to LF, JAXB_FORMATTED_OUTPUT cannot be overridden with line.separator
+    actual = actual.replace("\r\n", "\n").replace("\r", "\n");
     writeFile(file, actual);
     assertEqualStrings(original, actual);
   }


### PR DESCRIPTION
### Summary

Fixes test broken under windows.

### Issue

Closes #7269 

### Unit tests

Addressed the issue in application/src/ext-test/java/org/opentripplanner/ext/ojp/trias/OjpToTriasTransformerTest.java rather than wrapping writer with a normalizing writer in application/src/ext/java/org/opentripplanner/ext/ojp/trias/OjpToTriasTransformer.java that would have been the other more intrusive potential fix, something along the lines of:

```
class LFNormalizingWriter extends Writer {
  private final Writer delegate;

  LFNormalizingWriter(Writer delegate) {
    this.delegate = delegate;
  }

  @Override
  public void write(char[] cbuf, int off, int len) throws IOException {
    String s = new String(cbuf, off, len)
        .replace("\r\n", "\n")
        .replace("\r", "\n");
    delegate.write(s, 0, s.length());
  }

  @Override public void flush() throws IOException { delegate.flush(); }
  @Override public void close() throws IOException { delegate.close(); }
}
```


and then:

```
static void ojpToTrias(Writer writer, StreamSource xmlSource)
    throws IOException, TransformerException {
  var transformer = OJP_TO_TRIAS_TEMPLATE.newTransformer();
  transformer.setOutputProperty(OutputKeys.INDENT, "yes");
  var lfWriter = new LFNormalizingWriter(writer);
  transformer.transform(xmlSource, new StreamResult(lfWriter));
}
```