### PR TITLE
Add new VEHICLE_RENT PlaceType in Transmodel API and deprecate BICYCLE_RENT

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/PlaceMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/PlaceMapper.java
@@ -24,7 +24,7 @@ public class PlaceMapper {
 
     return switch (api) {
       case QUAY, STOP_PLACE -> PlaceType.STOP;
-      case BICYCLE_RENT -> PlaceType.VEHICLE_RENT;
+      case BICYCLE_RENT, VEHICLE_RENT -> PlaceType.VEHICLE_RENT;
       case BIKE_PARK -> PlaceType.BIKE_PARK;
       case CAR_PARK -> PlaceType.CAR_PARK;
     };

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -115,7 +115,17 @@ public class EnumTypes {
     .name("FilterPlaceType")
     .value("quay", TransmodelPlaceType.QUAY, "Quay")
     .value("stopPlace", TransmodelPlaceType.STOP_PLACE, "StopPlace")
-    .value("bicycleRent", TransmodelPlaceType.BICYCLE_RENT, "Bicycle rent stations")
+    .value(
+      "bicycleRent",
+      TransmodelPlaceType.BICYCLE_RENT,
+      "Bicycle rent stations",
+      "Use vehicleRent instead"
+    )
+    .value(
+      "vehicleRent",
+      TransmodelPlaceType.VEHICLE_RENT,
+      "Vehicle (bicycles, scooters, cars ...) rental stations and vehicles"
+    )
     .value("bikePark", TransmodelPlaceType.BIKE_PARK, "Bike parks")
     .value("carPark", TransmodelPlaceType.CAR_PARK, "Car parks")
     .build();

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/TransmodelPlaceType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/TransmodelPlaceType.java
@@ -4,6 +4,7 @@ public enum TransmodelPlaceType {
   QUAY,
   STOP_PLACE,
   BICYCLE_RENT,
+  VEHICLE_RENT,
   BIKE_PARK,
   CAR_PARK,
 }

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -732,7 +732,7 @@ type QueryType {
     "Only include places that include this mode. Only checked for places with mode i.e. quays, departures."
     filterByModes: [TransportMode],
     "Only include places of given types if set. Default accepts all types"
-    filterByPlaceTypes: [FilterPlaceType] = [quay, stopPlace, bicycleRent, bikePark, carPark],
+    filterByPlaceTypes: [FilterPlaceType] = [quay, stopPlace, bicycleRent, vehicleRent, bikePark, carPark],
     "fetching only the first certain number of nodes"
     first: Int,
     "fetching only the last certain number of nodes"
@@ -1717,7 +1717,7 @@ enum DirectionType {
 
 enum FilterPlaceType {
   "Bicycle rent stations"
-  bicycleRent
+  bicycleRent @deprecated(reason : "Use vehicleRent instead")
   "Bike parks"
   bikePark
   "Car parks"
@@ -1726,6 +1726,8 @@ enum FilterPlaceType {
   quay
   "StopPlace"
   stopPlace
+  "Vehicle (bicycles, scooters, cars ...) rental stations and vehicles"
+  vehicleRent
 }
 
 enum InputField {


### PR DESCRIPTION
### Summary

This deprecates the BICYCLE_RENT place type in the Transmodel API in favor of the new VEHICLE_RENT type. This is in line with the current GTFS API. This commit is extracted from the larger #7258 PR to simplify it, and because this commit is not subject to change pending the discussion over #7228.
### Issue
Deprecation suggested as part of #7228

### Unit tests
Transmodel graphql.schema updated to make the graphql schema test pass. 

### Documentation
* Graphql docs added in line with GTFS API
* Deprecation description added to BICYCLE_RENT