### PR TITLE
Add missing SIRI ET module tests for modified trips

### DIFF
--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriEtBuilder.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriEtBuilder.java
@@ -19,6 +19,7 @@ import uk.org.siri.siri21.EstimatedVersionFrameStructure;
 import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
 import uk.org.siri.siri21.LineRef;
 import uk.org.siri.siri21.NaturalLanguageStringStructure;
+import uk.org.siri.siri21.OccupancyEnumeration;
 import uk.org.siri.siri21.OperatorRefStructure;
 import uk.org.siri.siri21.QuayRefStructure;
 import uk.org.siri.siri21.RecordedCall;
@@ -129,6 +130,16 @@ public class SiriEtBuilder {
     var calls = new EstimatedVehicleJourney.EstimatedCalls();
     builder.build().forEach(call -> calls.getEstimatedCalls().add(call));
     evj.setEstimatedCalls(calls);
+    return this;
+  }
+
+  public SiriEtBuilder withOccupancy(OccupancyEnumeration occupancy) {
+    evj.setOccupancy(occupancy);
+    return this;
+  }
+
+  public SiriEtBuilder withPredictionInaccurate(boolean predictionInaccurate) {
+    evj.setPredictionInaccurate(predictionInaccurate);
     return this;
   }
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelAllStopsTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelAllStopsTest.java
@@ -15,6 +15,8 @@ import org.opentripplanner.updater.trip.SiriTestHelper;
 /**
  * Cancelling all individual stops (as opposed to journey-level cancellation) should result in an
  * implicit trip cancellation when all stops are non-routable.
+ * TODO RT_VP: This is a non-regression test that captures the existing behavior.
+ *             We should verify that this behavior is acceptable/correct.
  */
 class CancelAllStopsTest implements RealtimeTestConstants {
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelAllStopsTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancelAllStopsTest.java
@@ -1,0 +1,54 @@
+package org.opentripplanner.updater.trip.siri.moduletests.cancellation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.SiriTestHelper;
+
+/**
+ * Cancelling all individual stops (as opposed to journey-level cancellation) should result in an
+ * implicit trip cancellation when all stops are non-routable.
+ */
+class CancelAllStopsTest implements RealtimeTestConstants {
+
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
+  private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
+  private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
+
+  private final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
+    .withWithTripOnServiceDate(TRIP_1_ID)
+    .addStop(STOP_A, "0:00:10", "0:00:11")
+    .addStop(STOP_B, "0:00:20", "0:00:21");
+
+  @Test
+  void testCancelAllStopsCancelsTrip() {
+    var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:11")
+          .withIsCancellation(true)
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:20")
+          .withIsCancellation(true)
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertSuccess(result);
+    assertEquals(RealTimeState.CANCELED, env.tripData(TRIP_1_ID).realTimeState());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MultiTripPatternTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MultiTripPatternTest.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.updater.trip.siri.moduletests.update;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.SiriTestHelper;
+
+/**
+ * Tests that updating one trip on a pattern does not affect other trips on the same pattern.
+ */
+class MultiTripPatternTest implements RealtimeTestConstants {
+
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
+  private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
+  private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
+
+  private final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
+    .withWithTripOnServiceDate(TRIP_1_ID)
+    .addStop(STOP_A, "0:00:10", "0:00:11")
+    .addStop(STOP_B, "0:00:20", "0:00:21");
+
+  private final TripInput TRIP_2_INPUT = TripInput.of(TRIP_2_ID)
+    .withWithTripOnServiceDate(TRIP_2_ID)
+    .addStop(STOP_A, "0:01:10", "0:01:11")
+    .addStop(STOP_B, "0:01:20", "0:01:21");
+
+  @Test
+  void testUpdateOneTripLeavesOtherUnaffected() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).addTrip(TRIP_2_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:25")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertSuccess(result);
+    assertEquals(
+      "UPDATED | A 0:00:15 0:00:15 | B 0:00:25 0:00:25",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+    assertEquals(RealTimeState.SCHEDULED, env.tripData(TRIP_2_ID).realTimeState());
+    assertEquals(
+      "SCHEDULED | A 0:01:10 0:01:11 | B 0:01:20 0:01:21",
+      env.tripData(TRIP_2_ID).showTimetable()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/UpdatedTimesTest.java
@@ -2,22 +2,26 @@ package org.opentripplanner.updater.trip.siri.moduletests.update;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TransitTestEnvironment;
 import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
 import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.OccupancyStatus;
 import org.opentripplanner.updater.spi.UpdateError;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.SiriTestHelper;
 import org.opentripplanner.updater.trip.siri.SiriEtBuilder;
+import uk.org.siri.siri21.OccupancyEnumeration;
 
 class UpdatedTimesTest implements RealtimeTestConstants {
 
   private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
   private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
   private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
+  private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);
 
   private final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
     .withWithTripOnServiceDate(TRIP_1_ID)
@@ -74,6 +78,153 @@ class UpdatedTimesTest implements RealtimeTestConstants {
     var result = siri.applyEstimatedTimetable(updates);
     assertEquals(0, result.successful());
     assertFailure(UpdateError.UpdateErrorType.TRIP_NOT_FOUND, result);
+  }
+
+  /**
+   * Update a 3-stop trip with a mix of recorded calls (past stops) and estimated calls
+   * (future stops).
+   */
+  @Test
+  void testUpdateJourneyWithRecordedAndEstimatedCalls() {
+    var threeStopTrip = TripInput.of(TRIP_1_ID)
+      .withWithTripOnServiceDate(TRIP_1_ID)
+      .addStop(STOP_A, "0:00:10", "0:00:11")
+      .addStop(STOP_B, "0:00:20", "0:00:21")
+      .addStop(STOP_C, "0:00:30", "0:00:31");
+
+    var env = ENV_BUILDER.addTrip(threeStopTrip).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withRecordedCalls(builder -> builder.call(STOP_A).departAimedActual("00:00:11", "00:00:15"))
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:25")
+          .departAimedExpected("00:00:21", "00:00:26")
+          .call(STOP_C)
+          .arriveAimedExpected("00:00:30", "00:00:35")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertSuccess(result);
+    assertEquals(
+      "UPDATED | A [R] 0:00:15 0:00:15 | B 0:00:25 0:00:26 | C 0:00:35 0:00:35",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * Apply two successive updates to the same trip. The second update should replace the first,
+   * not accumulate delays.
+   */
+  @Test
+  void testUpdateJourneyMultipleTimes() {
+    var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    // First update: small delay
+    var firstUpdate = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:25")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result1 = siri.applyEstimatedTimetable(firstUpdate);
+    assertSuccess(result1);
+    assertEquals(
+      "UPDATED | A 0:00:15 0:00:15 | B 0:00:25 0:00:25",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+
+    // Second update: larger delay replaces the first
+    var secondUpdate = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:20")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:33")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result2 = siri.applyEstimatedTimetable(secondUpdate);
+    assertSuccess(result2);
+    assertEquals(
+      "UPDATED | A 0:00:20 0:00:20 | B 0:00:33 0:00:33",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * Set journey-level occupancy and verify it propagates to all stops.
+   */
+  @Test
+  void testUpdateJourneyWithOccupancy() {
+    var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withOccupancy(OccupancyEnumeration.SEATS_AVAILABLE)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:25")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertSuccess(result);
+    var tripTimes = env.tripData(TRIP_1_ID).tripTimes();
+    assertEquals(OccupancyStatus.MANY_SEATS_AVAILABLE, tripTimes.getOccupancyStatus(0));
+    assertEquals(OccupancyStatus.MANY_SEATS_AVAILABLE, tripTimes.getOccupancyStatus(1));
+  }
+
+  /**
+   * Set prediction inaccurate flag and verify it appears on all stops.
+   */
+  @Test
+  void testUpdateJourneyWithPredictionInaccurate() {
+    var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withPredictionInaccurate(true)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:25")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertSuccess(result);
+    assertEquals(
+      "UPDATED | A [PI] 0:00:15 0:00:15 | B [PI] 0:00:25 0:00:25",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
   }
 
   private SiriEtBuilder updatedJourneyBuilder(SiriTestHelper siri) {


### PR DESCRIPTION
### Summary

Add 8 tests covering  use cases for  SIRI ET modified trips:

- Mixed recorded + estimated calls 
- Successive updates replacing previous delays
- Cancel all stops triggering implicit trip cancellation
- Multi-trip pattern isolation (update one, leave other unaffected)
- Journey-level occupancy propagation
- Prediction inaccurate flag propagation
- Updating times on a previously added (replacement) trip
- Quay change then revert to original stops

Also adds withOccupancy() and withPredictionInaccurate() builder methods to SiriEtBuilder for test support.


### Issue

No

### Unit tests

Added unit tests.

### Documentation

No

### Changelog

skip

