### PR TITLE
Update docs for transitServiceStart/End to suggest large period instead of empty string

### DIFF
--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -414,7 +414,7 @@ public class BuildConfig implements OtpDataStoreConfig {
           will not be part of the graph. Use an absolute date or a period relative to the date the graph is
           build(BUILD_DAY).
 
-          Use an empty string to make unbounded.
+          To get an effectively unbounded value, use a very large period like `"-P100Y"`.
           """
         )
         .asDateOrRelativePeriod("-P1Y", confZone);
@@ -430,7 +430,7 @@ public class BuildConfig implements OtpDataStoreConfig {
           will not be part of the graph. Use an absolute date or a period relative to the date the graph is
           build(BUILD_DAY).
 
-          Use an empty string to make it unbounded.
+          To get an effectively unbounded value, use a very large period like `"P100Y"`.
           """
         )
         .asDateOrRelativePeriod("P3Y", confZone);

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -593,7 +593,7 @@ The date is inclusive. If set, any transit service on a day AFTER the given date
 will not be part of the graph. Use an absolute date or a period relative to the date the graph is
 build(BUILD_DAY).
 
-Use an empty string to make it unbounded.
+To get an effectively unbounded value, use a very large period like `"P100Y"`.
 
 
 <h3 id="transitServiceStart">transitServiceStart</h3>
@@ -609,7 +609,7 @@ The date is inclusive. If set, any transit service on a day BEFORE the given dat
 will not be part of the graph. Use an absolute date or a period relative to the date the graph is
 build(BUILD_DAY).
 
-Use an empty string to make unbounded.
+To get an effectively unbounded value, use a very large period like `"-P100Y"`.
 
 
 <h3 id="writeCachedElevations">writeCachedElevations</h3>


### PR DESCRIPTION
## Summary
- The docs for `transitServiceStart` and `transitServiceEnd` previously suggested using an empty string `""` for an unbounded value, but this didn't actually work
- Instead of adding code to handle empty strings, update the documentation to recommend using a very large period like `"-P100Y"` or `"P100Y"`

Addresses #7161