### PR TITLE
fix: Fix flaky uri and path tests in ListCompositeDataSourceTest

### DIFF
--- a/application/src/test/java/org/opentripplanner/datastore/api/ListCompositeDataSourceTest.java
+++ b/application/src/test/java/org/opentripplanner/datastore/api/ListCompositeDataSourceTest.java
@@ -70,6 +70,6 @@ class ListCompositeDataSourceTest {
   }
 
   private String replaceHash(String name) {
-    return name.replaceAll("\\d{6,}", "NNN");
+    return name.replaceAll("-?\\d+", "NNN");
   }
 }


### PR DESCRIPTION
### Summary
I've noticed that the particular tests `uri` and `path` in `ListCompositeDataSourceTest` would sometimes fail and sometimes not when running the tests locally. Upon inspecting this it seems my JVM environment would sometimes return negative values from System.identityHashCode, which is not caught by the regex in `replaceHash`.

I've made the following two changes:
* Amending the regex with a `-?` allows for negative values.
* Swapping the `{6,}` quantifier for a `+` allows for hashes shorter than 6 digits (which is also possible, though rare).

<img width="918" height="362" alt="image" src="https://github.com/user-attachments/assets/07317ab3-a8fd-4bd9-aec7-76521d6658d4" />

#### Why this doesn't happen in CI
It could be that our CI environment runs a JVM that doesn't produce negative-valued identity hash codes.

### Issue
No issue

### Unit tests
Fixed `uri` and `path` in `ListCompositeDataSourceTest`