### PR TITLE
Accept integer values in Transmodel Cost scalar

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/graphql/scalar/CostScalarFactory.java
+++ b/application/src/main/java/org/opentripplanner/framework/graphql/scalar/CostScalarFactory.java
@@ -2,6 +2,7 @@ package org.opentripplanner.framework.graphql.scalar;
 
 import graphql.GraphQLContext;
 import graphql.execution.CoercedVariables;
+import graphql.language.IntValue;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -59,6 +60,9 @@ public class CostScalarFactory {
       @Override
       public Cost parseValue(Object input, GraphQLContext c, Locale l)
         throws CoercingParseValueException {
+        if (input instanceof Integer intValue) {
+          return Cost.costOfSeconds(intValue);
+        }
         return parseCost((String) input);
       }
 
@@ -67,6 +71,9 @@ public class CostScalarFactory {
         throws CoercingParseLiteralException {
         if (input instanceof StringValue stringValue) {
           return parseCost(stringValue.getValue());
+        }
+        if (input instanceof IntValue intValue) {
+          return Cost.costOfSeconds(intValue.getValue().intValue());
         }
         return null;
       }

--- a/application/src/test/java/org/opentripplanner/framework/graphql/scalar/CostScalarFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/graphql/scalar/CostScalarFactoryTest.java
@@ -1,0 +1,57 @@
+package org.opentripplanner.framework.graphql.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import graphql.GraphQLContext;
+import graphql.execution.CoercedVariables;
+import graphql.language.IntValue;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import java.math.BigInteger;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.basic.Cost;
+
+class CostScalarFactoryTest {
+
+  private static final Coercing<?, ?> COERCING = CostScalarFactory.costScalar().getCoercing();
+  private static final Cost COST_ONE_HOUR = Cost.costOfSeconds(3600);
+  private static final GraphQLContext CONTEXT = GraphQLContext.getDefault();
+  private static final Locale LOCALE = Locale.ENGLISH;
+  private static final CoercedVariables VARIABLES = CoercedVariables.emptyVariables();
+
+  @Test
+  void parseValueWithString() {
+    var result = COERCING.parseValue("1h0m0s", CONTEXT, LOCALE);
+    assertEquals(COST_ONE_HOUR, result);
+  }
+
+  @Test
+  void parseValueWithInteger() {
+    var result = COERCING.parseValue(3600, CONTEXT, LOCALE);
+    assertEquals(COST_ONE_HOUR, result);
+  }
+
+  @Test
+  void parseLiteralWithStringValue() {
+    var result = COERCING.parseLiteral(StringValue.of("1h0m0s"), VARIABLES, CONTEXT, LOCALE);
+    assertEquals(COST_ONE_HOUR, result);
+  }
+
+  @Test
+  void parseLiteralWithIntValue() {
+    var result = COERCING.parseLiteral(
+      new IntValue(BigInteger.valueOf(3600)),
+      VARIABLES,
+      CONTEXT,
+      LOCALE
+    );
+    assertEquals(COST_ONE_HOUR, result);
+  }
+
+  @Test
+  void serialize() {
+    var result = COERCING.serialize(COST_ONE_HOUR, CONTEXT, LOCALE);
+    assertEquals("PT1H", result);
+  }
+}


### PR DESCRIPTION
### Summary

Accept integer values (e.g. `constant:3600`) in the Transmodel GraphQL `Cost` scalar, in addition to duration strings (e.g. `constant:"1h0m0s"`). Previously, passing an integer literal caused a `NullPointerException`.

### Issue

Closes #7314

### Unit tests

- Added unit tests to `CostScalarFactoryTest` covering integer parsing in both `parseLiteral` (inline query values) and `parseValue` (variable values)
- Verified manually against a live OTP server using the Portland test dataset — integer `constant:3600` no longer causes an NPE
- No performance impact; this is a simple type-check addition in the scalar coercing logic