### PR TITLE
Add Jackson BOM to enforce consistent Jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,15 @@
             </dependency>
 
             <dependency>
+                <!-- This makes sure all Jackson libraries are using compatible versions. -->
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf.version}</version>
@@ -680,7 +689,7 @@
                 </repository>
             </distributionManagement>
         </profile>
-        
+
         <profile>
             <id>integrationTests</id>
             <activation>


### PR DESCRIPTION
### Summary

As detailed in #7322, a recent change (probably the extraction of the street module) causes inconsistencies in Maven version management for the Jackson library.

  ## Problem
  The `street` module's `geojson-jackson:1.14` dependency transitively pulls in `jackson-core:2.10.0`, which lacks `JsonParser.getReadCapabilities()` (added in 2.12). This causes a `NoSuchMethodError` at runtime when
  launching from the IDE.

  The root pom defines `<jackson.version>2.21.0</jackson.version>` and uses it for direct dependencies in `application/pom.xml`, but without a `<dependencyManagement>` entry the version isn't enforced on transitive
  dependencies in other modules.

  ## Solution
  Import the Jackson BOM in `<dependencyManagement>`, following the same pattern already used for the Google Cloud `libraries-bom`. This ensures all `com.fasterxml.jackson.*` artifacts resolve to `${jackson.version}`
  across all modules.

### Issue

Closes #7322

### Unit tests
No

### Documentation

No

### Changelog

skip

### Bumping the serialization version id

No