### PR TITLE
Add SIRI module test for `VisitNumber`

### DIFF
--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriEtBuilder.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriEtBuilder.java
@@ -252,6 +252,12 @@ public class SiriEtBuilder {
       return this;
     }
 
+    public RecordedCallsBuilder clearOrder() {
+      var call = calls.getLast();
+      call.setOrder(null);
+      return this;
+    }
+
     public RecordedCallsBuilder addDestinationDisplay(String destinationDisplay) {
       var dd = new NaturalLanguageStringStructure();
       dd.setValue(destinationDisplay);
@@ -356,6 +362,12 @@ public class SiriEtBuilder {
 
       var call = calls.getLast();
       call.getArrivalStopAssignments().add(stopAssignmentStructure);
+      return this;
+    }
+
+    public EstimatedCallsBuilder clearOrder() {
+      var call = calls.getLast();
+      call.setOrder(null);
       return this;
     }
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
@@ -85,10 +85,18 @@ class FuzzyTripMatchingTest implements RealtimeTestConstants {
     var updates = siri
       .etBuilder()
       .withRecordedCalls(builder ->
-        builder.call(STOP_A).withVisitNumber(1).departAimedActual("00:00:11", "00:00:15")
+        builder
+          .call(STOP_A)
+          .clearOrder()
+          .withVisitNumber(1)
+          .departAimedActual("00:00:11", "00:00:15")
       )
       .withEstimatedCalls(builder ->
-        builder.call(STOP_B).withVisitNumber(2).arriveAimedExpected("00:00:20", "00:00:25")
+        builder
+          .call(STOP_B)
+          .clearOrder()
+          .withVisitNumber(2)
+          .arriveAimedExpected("00:00:20", "00:00:25")
       )
       .buildEstimatedTimetableDeliveries();
     var result = siri.applyEstimatedTimetableWithFuzzyMatcher(updates);


### PR DESCRIPTION
### Summary

The Italian SIRI feed I'm working with uses `VisitNumber` instead of `Order`": https://p.ip.fi/oSp5

This PR adds a test to make sure that it keeps on working when we add more validations.

### Unit tests

This is just about tests.

cc @rcavaliere