### PR TITLE
Add FeedScopedId-keyed index to Timetable for O(1) TripTimes lookup

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableBuilder.java
@@ -111,6 +111,10 @@ public class TimetableBuilder {
     return tripTimes.values().stream().sorted().toList();
   }
 
+  Map<FeedScopedId, TripTimes> createImmutableTripTimesIndex() {
+    return Map.copyOf(tripTimes);
+  }
+
   TripPattern getPattern() {
     return pattern;
   }

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableTest.java
@@ -1,22 +1,23 @@
 package org.opentripplanner.transit.model.timetable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.opentripplanner.transit.model._data.FeedScopedIdForTestFactory.id;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
-import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 class TimetableTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
-
-  private static final Route ROUTE = TimetableRepositoryForTest.route("routeId").build();
-  public static final RegularStop STOP_A = TEST_MODEL.stop("A").build();
-  public static final RegularStop STOP_C = TEST_MODEL.stop("C").build();
+  private final TransitTestEnvironmentBuilder envBuilder = TransitTestEnvironment.of();
+  private final RegularStop stopA = envBuilder.stop("A");
+  private final RegularStop stopC = envBuilder.stop("C");
 
   @ParameterizedTest
   @CsvSource(
@@ -32,20 +33,72 @@ class TimetableTest {
     useHeadersInDisplayName = true
   )
   void maxTripSpanDays(String testCaseName, String schedule, int expectedNumberOfDays) {
-    var timetable = TripPattern.of(id(testCaseName))
-      .withRoute(ROUTE)
-      .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A, STOP_C))
-      .withScheduledTimeTableBuilder(builder ->
-        builder.addTripTimes(
-          ScheduledTripTimes.of()
-            .withTrip(TimetableRepositoryForTest.trip("t1").build())
-            .withDepartureTimes(schedule)
-            .build()
-        )
-      )
-      .build()
-      .getScheduledTimetable();
+    var times = schedule.trim().split("\\s+");
+    var env = envBuilder
+      .addTrip(TripInput.of("t1").addStop(stopA, times[0]).addStop(stopC, times[1]))
+      .build();
 
+    var timetable = env.tripData("t1").tripPattern().getScheduledTimetable();
     assertEquals(expectedNumberOfDays, timetable.getMaxTripSpanDays());
+  }
+
+  @Test
+  void getTripTimesByTrip() {
+    var env = envBuilder
+      .addTrip(TripInput.of("trip1").addStop(stopA, "08:00").addStop(stopC, "09:00"))
+      .addTrip(TripInput.of("trip2").addStop(stopA, "10:00").addStop(stopC, "11:00"))
+      .build();
+
+    var timetable = env.tripData("trip1").tripPattern().getScheduledTimetable();
+    var trip1 = env.tripData("trip1").trip();
+    var trip2 = env.tripData("trip2").trip();
+
+    assertSame(timetable.getTripTimes(trip1).getTrip(), trip1);
+    assertSame(timetable.getTripTimes(trip2).getTrip(), trip2);
+  }
+
+  @Test
+  void getTripTimesByFeedScopedId() {
+    var env = envBuilder
+      .addTrip(TripInput.of("trip1").addStop(stopA, "08:00").addStop(stopC, "09:00"))
+      .addTrip(TripInput.of("trip2").addStop(stopA, "10:00").addStop(stopC, "11:00"))
+      .build();
+
+    var timetable = env.tripData("trip1").tripPattern().getScheduledTimetable();
+    var trip1 = env.tripData("trip1").trip();
+    var trip2 = env.tripData("trip2").trip();
+
+    assertSame(timetable.getTripTimes(trip1.getId()).getTrip(), trip1);
+    assertSame(timetable.getTripTimes(trip2.getId()).getTrip(), trip2);
+  }
+
+  @Test
+  void getTripTimesUsesEqualsNotIdentity() {
+    var env = envBuilder
+      .addTrip(TripInput.of("sameId").addStop(stopA, "08:00").addStop(stopC, "09:00"))
+      .build();
+
+    var timetable = env.tripData("sameId").tripPattern().getScheduledTimetable();
+    var trip1 = env.tripData("sameId").trip();
+
+    // Create a different Trip instance with the same ID
+    var trip2 = Trip.of(id("sameId")).withRoute(envBuilder.route("lookupRoute")).build();
+    assertEquals(trip1.getId(), trip2.getId());
+
+    // Lookup using the second instance should find the TripTimes stored with the first
+    assertSame(trip1, timetable.getTripTimes(trip2).getTrip());
+  }
+
+  @Test
+  void getTripTimesReturnsNullForUnknownTrip() {
+    var env = envBuilder
+      .addTrip(TripInput.of("trip1").addStop(stopA, "08:00").addStop(stopC, "09:00"))
+      .build();
+
+    var timetable = env.tripData("trip1").tripPattern().getScheduledTimetable();
+
+    var unknownTrip = Trip.of(id("unknown")).withRoute(envBuilder.route("lookupRoute2")).build();
+    assertNull(timetable.getTripTimes(unknownTrip));
+    assertNull(timetable.getTripTimes(id("unknown")));
   }
 }


### PR DESCRIPTION
## Summary
- `Timetable.getTripTimes(Trip)` used `==` identity comparison and O(n) linear scan over the
  `tripTimes` list. The identity check silently returns `null` when two different `Trip` instances
  share the same `FeedScopedId`.
  Replace both `getTripTimes` overloads with an O(1) `Map<FeedScopedId, TripTimes>` index lookup,
  reusing the `HashMap` already maintained by `TimetableBuilder`.
- Memory impact is limited: ~48 bytes per entry (two object references + HashMap.Node overhead).
  For a dataset like Norway (~3,000 patterns, ~30 trips/pattern ≈ 90,000 entries) this adds ~4 MB,
  negligible compared to OTP's 2–4 GB heap.
- Migrate `TimetableTest` from deprecated `TimetableRepositoryForTest` to `TransitTestEnvironment`.

## Details
- **`TimetableBuilder`**: Add `createImmutableTripTimesIndex()` that wraps the existing internal
  `HashMap<FeedScopedId, TripTimes>` with `Map.copyOf()`.
- **`Timetable`**: Add `tripTimesIndex` field, populate in constructor, use in both `getTripTimes`
  overloads. Rebuild the index in `setServiceCodes()` after remapping TripTimes (this happens only once during graph building).
- **`TimetableTest`**: Rewrite using `TransitTestEnvironment`. Add 4 new tests covering lookup by
  Trip, by FeedScopedId, equals-vs-identity semantics, and null for unknown trips.

**Performance**: Tested with the performance test suite, response time is roughly the same.
https://otp-performance.leonard.io/d/9sXJ43gVk/otp-performance?orgId=1&from=now-7d&to=now&timezone=browser&var-category=transit&var-location=norway&var-branch=add-triptimes-index-to-timetable_perf_test

### Issue

No

### Unit tests

Added unit tests

### Documentation

No

### Changelog
skip

### Bumping the serialization version id

bump