### PR TITLE
Update Entur-specific emission data docs url in Transmodel custom documentation 

### DIFF
--- a/application/src/ext/resources/org/opentripplanner/ext/apis/transmodel/custom-documentation-entur.properties
+++ b/application/src/ext/resources/org/opentripplanner/ext/apis/transmodel/custom-documentation-entur.properties
@@ -24,4 +24,4 @@ TariffZone.description=A **zone** used to define a zonal fare structure in a zon
   \
   **TariffZone data will not be maintained from 1. MAY 2025 (Entur).**
 
-Emission.description.append=For more information, go to https://data.entur.no/dataset/energy_emissions
+Emission.description.append=For more information, go to https://data.entur.no/public/datasets/energy_emissions


### PR DESCRIPTION
### Summary
This updates the url for emission data in the Entur-specific custom documentation for Transmodel api (`transmodel/custom-documentation-entur.properties`). The url has changed, so the old url is now a dead link.

### Issue
No issue. The old link is broken.

### Documentation
Custom documentation for Transmodel garphql API