### PR TITLE
Use zero-copy InputStream for SIRI XML parsing in PubSub updater

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/updater/google/GooglePubsubEstimatedTimetableSource.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/updater/google/GooglePubsubEstimatedTimetableSource.java
@@ -251,7 +251,7 @@ public class GooglePubsubEstimatedTimetableSource implements AsyncEstimatedTimet
   private Optional<ServiceDelivery> serviceDelivery(ByteString data) {
     Siri siri;
     try {
-      siri = SiriXml.parseXml(data.toStringUtf8());
+      siri = SiriXml.parseXml(data.newInput());
     } catch (XMLStreamException | JAXBException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Summary

Use `ByteString.newInput()` instead of `ByteString.toStringUtf8()` when passing
PubSub message data to `SiriXml.parseXml()`, avoiding a full String copy of each
XML message before parsing.

### Detail

`ByteString.toStringUtf8()` allocates ~3x the message size (raw bytes + char[] +
String object) as a transient copy that is immediately discarded after the XML
stream parser reads it. `ByteString.newInput()` returns a zero-copy `InputStream`
backed by the existing byte buffer, which the XML parser can consume directly.

Additionally, passing an `InputStream` instead of a `String` changes how character
encoding is handled. With `toStringUtf8()`, the bytes are eagerly decoded to a Java
`String` (UTF-16) assuming UTF-8 encoding, and the XML parser receives pre-decoded
characters via a `StringReader` — bypassing XML encoding detection entirely. With
`newInput()`, the XML parser receives the raw byte stream and detects the encoding
itself from the XML declaration (`<?xml encoding="..."?>`), which is the correct
behavior per the XML specification. In practice both paths produce the same result
since SIRI XML is always UTF-8, but the `InputStream` path is both more correct and
more efficient.

The `SiriXml.parseXml(InputStream)` overload already exists in `siri-java-model`
and accepts the stream without any additional changes.

### Issue



### Unit tests

No

### Documentation
No

### Changelog
skip