### PR TITLE
Fix collection sizing in TimetableBuilder

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableBuilder.java
@@ -14,15 +14,19 @@ public class TimetableBuilder {
 
   private TripPattern pattern;
   private LocalDate serviceDate;
-  private final Map<FeedScopedId, TripTimes> tripTimes = new HashMap<>();
-  private final List<FrequencyEntry> frequencies = new ArrayList<>();
+  private final Map<FeedScopedId, TripTimes> tripTimes;
+  private final List<FrequencyEntry> frequencies;
 
-  TimetableBuilder() {}
+  TimetableBuilder() {
+    tripTimes = new HashMap<>();
+    frequencies = new ArrayList<>();
+  }
 
   TimetableBuilder(Timetable tt) {
     pattern = tt.getPattern();
     serviceDate = tt.getServiceDate();
-    frequencies.addAll(tt.getFrequencyEntries());
+    frequencies = new ArrayList<>(tt.getFrequencyEntries());
+    tripTimes = HashMap.newHashMap(tt.getTripTimes().size());
     addAllTripTimes(tt.getTripTimes());
   }
 


### PR DESCRIPTION
### Summary

Profiling memory allocation shows that the `tripTimes` hash map in `TimetableBuilder` is not properly sized.
The `tripTimes` and `frequency` collections in TimetableBuilder can be initialized with the right size since the number of elements is known at construction time.

**Note**  `new HashMap<>(n) `does not create  a `HashMap` that can hold n elements, since the parameter n is the capacity and the default load factor is 0.75, which triggers a resizing when the `Hashmap` reaches 75% of its capacity.
Instead and since Java 19, the factory method `HashMap.newHashMap(n)` can be used to create a HashMap that can hold n elements.


### Issue

No

### Unit tests

No


### Documentation

No

### Changelog

Skip

