### PR TITLE
Reduce Micrometer Timer overhead in Raptor inner loops

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/performance/PerformanceTimersForRaptor.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/performance/PerformanceTimersForRaptor.java
@@ -3,18 +3,27 @@ package org.opentripplanner.routing.algorithm.raptoradapter.router.performance;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import org.opentripplanner.raptor.api.debug.RaptorTimers;
 import org.opentripplanner.routing.api.request.RoutingTag;
 import org.opentripplanner.routing.framework.MicrometerUtils;
 
 public class PerformanceTimersForRaptor implements RaptorTimers {
 
-  // Variables to track time spent
   private final Timer timerRoute;
   private final Timer routeTransitTimer;
   private final Timer applyTransfersTimer;
   private final MeterRegistry registry;
   private final Collection<RoutingTag> routingTags;
+
+  /**
+   * Accumulators for sub-timings within a single route() call. Instead of calling
+   * Timer.record(Runnable) on every round (~480 calls per search), we accumulate nanos
+   * and report once at the end of route(). This is safe because Raptor search is
+   * single-threaded and each PerformanceTimersForRaptor instance is per-request.
+   */
+  private long routeTransitNanos;
+  private long applyTransfersNanos;
 
   public PerformanceTimersForRaptor(
     String namePrefix,
@@ -35,17 +44,25 @@ public class PerformanceTimersForRaptor implements RaptorTimers {
 
   @Override
   public void route(Runnable body) {
+    routeTransitNanos = 0;
+    applyTransfersNanos = 0;
     timerRoute.record(body);
+    routeTransitTimer.record(routeTransitNanos, TimeUnit.NANOSECONDS);
+    applyTransfersTimer.record(applyTransfersNanos, TimeUnit.NANOSECONDS);
   }
 
   @Override
   public void routeTransit(Runnable body) {
-    routeTransitTimer.record(body);
+    long start = System.nanoTime();
+    body.run();
+    routeTransitNanos += System.nanoTime() - start;
   }
 
   @Override
   public void applyTransfers(Runnable body) {
-    applyTransfersTimer.record(body);
+    long start = System.nanoTime();
+    body.run();
+    applyTransfersNanos += System.nanoTime() - start;
   }
 
   @Override


### PR DESCRIPTION
### Summary

JFR profiling shows `CompositeTimer.record()` as the **second CPU hotspot at 4.7%** with total Micrometer overhead at **17.8% CPU** and **121 GB allocation**. The root cause: `Timer.record(Runnable)` is called ~480 times per search phase (once per round per iteration for both `routeTransit()` and `applyTransfers()`). Each call goes through Micrometer's `CompositeMeterRegistry` chain, which is expensive.

This PR replaces per-round `Timer.record(Runnable)` calls in `PerformanceTimersForRaptor` with lightweight `System.nanoTime()` accumulation. The accumulated durations are reported to Micrometer **once** at the end of `route()` using `Timer.record(long, TimeUnit)`. This reduces `Timer.record()` calls from **~480 per search** to **3 per search** (once each for route, routeTransit, applyTransfers), while preserving all three metrics.

#### Profiling results (before → after)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Micrometer CPU (subsystem) | 17.8% | **0.4%** | -97.8% |
| `CompositeTimer.record()` top-of-stack | 4.7%  | **0%** | eliminated |
| Micrometer allocation | 121 GB (7.2%) | 0.7 GB (0.2%) | -99.5% |
| `System.nanoTime()` overhead (new) | — | 1.6% | expected |

#### Why this is safe

- Each `PerformanceTimersForRaptor` is created per request
- `withNamePrefix()` creates a new instance per search phase
- Raptor search is single-threaded within a request — no concurrent access to accumulators
- `Timer.record(long, TimeUnit)` is equivalent to `Timer.record(Runnable)` for metrics output

### Issue

No

### Unit tests

No — this is a pure implementation change in `PerformanceTimersForRaptor`. The `RaptorTimers` interface is unchanged. All existing raptor adapter tests pass (246 tests).

### Documentation

No

### Changelog

skip