### PR TITLE
Eliminate lambda closures in TripSearchTimetable trip time lookups

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.function.IntUnaryOperator;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.raptor.api.model.RaptorTripPattern;
 import org.opentripplanner.raptor.api.model.SearchDirection;
@@ -209,25 +208,13 @@ public class TripPatternForDates
   }
 
   @Override
-  public IntUnaryOperator getArrivalTimes(int stopPositionInPattern) {
-    final int base = stopPositionInPattern * numberOfTripSchedules;
-    return (int tripIndex) -> arrivalTimes[base + tripIndex];
+  public int arrivalTime(int stopPositionInPattern, int tripIndex) {
+    return arrivalTimes[stopPositionInPattern * numberOfTripSchedules + tripIndex];
   }
 
   @Override
-  public IntUnaryOperator getDepartureTimes(int stopPositionInPattern) {
-    final int base = stopPositionInPattern * numberOfTripSchedules;
-    return (int tripIndex) -> departureTimes[base + tripIndex];
-  }
-
-  public IntUnaryOperator getArrivalTimesForTrip(int tripIndex) {
-    return (int stopPositionInPattern) ->
-      arrivalTimes[stopPositionInPattern * numberOfTripSchedules + tripIndex];
-  }
-
-  public IntUnaryOperator getDepartureTimesForTrip(int tripIndex) {
-    return (int stopPositionInPattern) ->
-      departureTimes[stopPositionInPattern * numberOfTripSchedules + tripIndex];
+  public int departureTime(int stopPositionInPattern, int tripIndex) {
+    return departureTimes[stopPositionInPattern * numberOfTripSchedules + tripIndex];
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleAlightSearch.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleAlightSearch.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
-import java.util.function.IntUnaryOperator;
 import javax.annotation.Nullable;
 import org.opentripplanner.raptor.api.model.RaptorConstants;
 import org.opentripplanner.raptor.api.model.RaptorTransferConstraint;
@@ -32,7 +31,6 @@ public final class TripScheduleAlightSearch<T extends RaptorTripSchedule>
 
   private int latestAlightTime;
   private int stopPositionInPattern;
-  private IntUnaryOperator arrivalTimes;
 
   private T candidateTrip;
   private int candidateTripIndex = RaptorConstants.NOT_FOUND;
@@ -102,7 +100,6 @@ public final class TripScheduleAlightSearch<T extends RaptorTripSchedule>
   ) {
     this.latestAlightTime = latestAlightTime;
     this.stopPositionInPattern = stopPositionInPattern;
-    this.arrivalTimes = timetable.getArrivalTimes(stopPositionInPattern);
     this.candidateTrip = null;
     this.candidateTripIndex = RaptorConstants.NOT_FOUND;
 
@@ -162,7 +159,7 @@ public final class TripScheduleAlightSearch<T extends RaptorTripSchedule>
   @Nullable
   private RaptorBoardOrAlightEvent<T> findBoardingSearchForwardInTime(int tripIndexLowerBound) {
     for (int i = tripIndexLowerBound; i < nTrips; ++i) {
-      if (arrivalTimes.applyAsInt(i) <= latestAlightTime) {
+      if (timetable.arrivalTime(stopPositionInPattern, i) <= latestAlightTime) {
         candidateTripIndex = i;
       } else {
         // this trip arrives too late. We can break out of the loop since
@@ -187,7 +184,7 @@ public final class TripScheduleAlightSearch<T extends RaptorTripSchedule>
     final int tripIndexUpperBound
   ) {
     for (int i = tripIndexUpperBound - 1; i >= 0; --i) {
-      if (arrivalTimes.applyAsInt(i) <= latestAlightTime) {
+      if (timetable.arrivalTime(stopPositionInPattern, i) <= latestAlightTime) {
         candidateTrip = timetable.getTripSchedule(i);
         candidateTripIndex = i;
         return this;
@@ -214,7 +211,7 @@ public final class TripScheduleAlightSearch<T extends RaptorTripSchedule>
     while (upper - lower > binarySearchThreshold) {
       int m = (lower + upper) / 2;
 
-      if (arrivalTimes.applyAsInt(m) <= latestAlightTime) {
+      if (timetable.arrivalTime(stopPositionInPattern, m) <= latestAlightTime) {
         lower = m;
       } else {
         upper = m;

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleBoardSearch.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleBoardSearch.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
-import java.util.function.IntUnaryOperator;
 import org.opentripplanner.raptor.api.model.RaptorConstants;
 import org.opentripplanner.raptor.api.model.RaptorTransferConstraint;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
@@ -30,7 +29,6 @@ public final class TripScheduleBoardSearch<T extends RaptorTripSchedule>
 
   private int earliestBoardTime;
   private int stopPositionInPattern;
-  private IntUnaryOperator departureTimes;
 
   private T candidateTrip;
   private int candidateTripIndex = RaptorConstants.NOT_FOUND;
@@ -102,7 +100,6 @@ public final class TripScheduleBoardSearch<T extends RaptorTripSchedule>
   ) {
     this.earliestBoardTime = earliestTime;
     this.stopPositionInPattern = stopPositionInPattern;
-    this.departureTimes = timetable.getDepartureTimes(stopPositionInPattern);
     this.candidateTrip = null;
     this.candidateTripIndex = RaptorConstants.NOT_FOUND;
 
@@ -165,7 +162,7 @@ public final class TripScheduleBoardSearch<T extends RaptorTripSchedule>
     int tripIndexUpperBound
   ) {
     for (int i = tripIndexUpperBound - 1; i >= 0; --i) {
-      if (departureTimes.applyAsInt(i) >= earliestBoardTime) {
+      if (timetable.departureTime(stopPositionInPattern, i) >= earliestBoardTime) {
         candidateTripIndex = i;
       } else {
         // this trip arrives too early. We can break out of the loop since
@@ -190,7 +187,7 @@ public final class TripScheduleBoardSearch<T extends RaptorTripSchedule>
     final int tripIndexLowerBound
   ) {
     for (int i = tripIndexLowerBound; i < nTrips; ++i) {
-      if (departureTimes.applyAsInt(i) >= earliestBoardTime) {
+      if (timetable.departureTime(stopPositionInPattern, i) >= earliestBoardTime) {
         candidateTrip = timetable.getTripSchedule(i);
         candidateTripIndex = i;
         return this;
@@ -215,7 +212,7 @@ public final class TripScheduleBoardSearch<T extends RaptorTripSchedule>
     while (upper - lower > binarySearchThreshold) {
       int m = (lower + upper) / 2;
 
-      if (departureTimes.applyAsInt(m) >= earliestBoardTime) {
+      if (timetable.departureTime(stopPositionInPattern, m) >= earliestBoardTime) {
         upper = m;
       } else {
         lower = m;

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import java.time.LocalDate;
-import java.util.function.IntUnaryOperator;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.raptor.api.model.RaptorTripPattern;
 import org.opentripplanner.raptor.spi.IntIterator;
@@ -22,8 +21,6 @@ public final class TripScheduleWithOffset implements TripSchedule {
   private final TripPatternForDates pattern;
   private final int sortIndex;
   private final int tripIndexForDates;
-  private final IntUnaryOperator arrivalTimes;
-  private final IntUnaryOperator departureTimes;
 
   // Computed when needed later for RaptorPathToItineraryMapper
   private TripTimes tripTimes = null;
@@ -34,12 +31,8 @@ public final class TripScheduleWithOffset implements TripSchedule {
     this.tripIndexForDates = tripIndexForDates;
     this.pattern = pattern;
 
-    // get arrival/departures lambda
-    this.arrivalTimes = pattern.getArrivalTimesForTrip(tripIndexForDates);
-    this.departureTimes = pattern.getDepartureTimesForTrip(tripIndexForDates);
-
     // Trip times are sorted based on the arrival times at stop 0,
-    this.sortIndex = arrivalTimes.applyAsInt(0);
+    this.sortIndex = pattern.arrivalTime(0, tripIndexForDates);
   }
 
   @Override
@@ -49,12 +42,12 @@ public final class TripScheduleWithOffset implements TripSchedule {
 
   @Override
   public int arrival(int stopPosInPattern) {
-    return this.arrivalTimes.applyAsInt(stopPosInPattern);
+    return pattern.arrivalTime(stopPosInPattern, tripIndexForDates);
   }
 
   @Override
   public int departure(int stopPosInPattern) {
-    return this.departureTimes.applyAsInt(stopPosInPattern);
+    return pattern.departureTime(stopPosInPattern, tripIndexForDates);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripSearchTimetable.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripSearchTimetable.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
-import java.util.function.IntUnaryOperator;
 import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
 import org.opentripplanner.raptor.spi.RaptorTimeTable;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
@@ -14,16 +13,14 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
  */
 public interface TripSearchTimetable<T extends RaptorTripSchedule> extends RaptorTimeTable<T> {
   /**
-   * Get the arrival times of all trips at a specific stop index, sorted by time. The returned
-   * function takes the trip index in the TimeTable as input and returns the arrival time as
-   * seconds from midnight on the search date.
+   * Get the arrival time of a specific trip at a specific stop, in seconds from midnight on the
+   * search date.
    */
-  IntUnaryOperator getArrivalTimes(int stopPositionInPattern);
+  int arrivalTime(int stopPositionInPattern, int tripIndex);
 
   /**
-   * Get the departure times of all trips at a specific stop index, sorted by time. The returned
-   * function takes the trip index in the TimeTable as input and returns the departure time as
-   * seconds from midnight on the search date.
+   * Get the departure time of a specific trip at a specific stop, in seconds from midnight on the
+   * search date.
    */
-  IntUnaryOperator getDepartureTimes(int stopPositionInPattern);
+  int departureTime(int stopPositionInPattern, int tripIndex);
 }

--- a/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTripSearchTimetable.java
+++ b/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTripSearchTimetable.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.raptorlegacy._data.transit;
 
-import java.util.function.IntUnaryOperator;
 import org.opentripplanner.raptor.api.model.SearchDirection;
 import org.opentripplanner.raptor.spi.RaptorTripScheduleSearch;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripScheduleSearchFactory;
@@ -36,13 +35,13 @@ public class TestTripSearchTimetable implements TripSearchTimetable<TestTripSche
   }
 
   @Override
-  public IntUnaryOperator getArrivalTimes(int stopPositionInPattern) {
-    return (int tripIndex) -> trips[tripIndex].arrival(stopPositionInPattern);
+  public int arrivalTime(int stopPositionInPattern, int tripIndex) {
+    return trips[tripIndex].arrival(stopPositionInPattern);
   }
 
   @Override
-  public IntUnaryOperator getDepartureTimes(int stopPositionInPattern) {
-    return (int tripIndex) -> trips[tripIndex].departure(stopPositionInPattern);
+  public int departureTime(int stopPositionInPattern, int tripIndex) {
+    return trips[tripIndex].departure(stopPositionInPattern);
   }
 
   @Override


### PR DESCRIPTION
### Summary

Replace `IntUnaryOperator` lambda closures in `TripSearchTimetable` with direct method calls, eliminating per-call heap allocation of capturing lambda objects in Raptor's innermost trip search loops.

The previous API returned lambda closures that captured an array base offset:

```java
public IntUnaryOperator getArrivalTimes(int stopPositionInPattern) {
  final int base = stopPositionInPattern * numberOfTripSchedules;
  return (int tripIndex) -> arrivalTimes[base + tripIndex];
}
```

Each call to `getArrivalTimes()` / `getDepartureTimes()` allocated a new `IntUnaryOperator` lambda on the heap. These lambdas were not eliminated by escape analysis because they were stored into fields of heap-allocated objects (`TripScheduleBoardSearch.departureTimes`, `TripScheduleAlightSearch.arrivalTimes`, `TripScheduleWithOffset.arrivalTimes`/`.departureTimes`), causing them to escape.

JFR allocation profiling showed `TripPatternForDates$$Lambda` objects accounted for **109 GB (6.5%)** of total sampled allocation under a realistic mixed workload (Raptor routing + SIRI-ET real-time updates), making this the easiest high-impact allocation target.

The fix replaces the lambda-returning methods with direct two-argument lookups:

```java
public int arrivalTime(int stopPositionInPattern, int tripIndex) {
  return arrivalTimes[stopPositionInPattern * numberOfTripSchedules + tripIndex];
}
```

This compiles to a single array index computation with zero object allocation.

**Changes:**
- `TripSearchTimetable`: replace `IntUnaryOperator getArrivalTimes(stop)` / `getDepartureTimes(stop)` with `int arrivalTime(stop, trip)` / `int departureTime(stop, trip)`
- `TripPatternForDates`: implement the new interface methods; remove `getArrivalTimesForTrip()` / `getDepartureTimesForTrip()`
- `TripScheduleBoardSearch` / `TripScheduleAlightSearch`: remove cached `IntUnaryOperator` fields; call `timetable.departureTime(stop, i)` / `timetable.arrivalTime(stop, i)` directly in the binary search and linear scan loops
- `TripScheduleWithOffset`: remove `IntUnaryOperator` fields; delegate `arrival()` / `departure()` directly to `pattern.arrivalTime()` / `pattern.departureTime()`

### Speed Test Results

Tested with the Norway speed test dataset (`multi_criteria_destination`, 87 test cases, 4 iterations with warmup):

| Metric | Baseline (`0cc7699cbe`) | This PR (`c41bb82ae6`) | Delta |
|---|---|---|---|
| **Raptor Worker avg** | 252.0 ms (σ=11.0) | 242.0 ms (σ=10.4) | **-10.0 ms (-4.0%)** |
| **Total Routing avg** | 128.8 ms (σ=7.7) | 126.5 ms (σ=9.2) | **-2.3 ms (-1.8%)** |

Last iteration detail:

| Metric | Baseline | This PR | Delta |
|---|---|---|---|
| Routing Raptor avg | 246 ms | 224 ms | **-22 ms (-8.9%)** |
| Raptor Mc-DP Route avg | 148 ms | 121 ms | **-27 ms (-18.2%)** |
| MinTravelDuration-Rev Route avg | 86 ms | 91 ms | +5 ms |
| Routing Total avg | 116 ms | 114 ms | -2 ms |

The Raptor worker time improves ~4% on average, with the multi-criteria destination search (Mc-DP Route) showing the largest gain at -18% in the final warmed-up iteration.

The purpose of this PR is to reduce significantly memory allocation. Speed improvement is expected to be small.

### Issue

No

### Unit tests

Existing tests in `TestTripSearchTimetable` updated to match the new interface. No behavioral change — the time lookup results are identical.

### Documentation

No documentation changes needed.

### Changelog

No changelog entry — internal optimization with no API or behavioral change.