### PR TITLE
Set default street routing timeout to 5 seconds again

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
@@ -12,6 +12,7 @@ import org.opentripplanner.routing.api.request.framework.DurationForEnum;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.search.intersection_model.DrivingDirection;
 import org.opentripplanner.street.search.intersection_model.IntersectionTraversalModel;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.utils.lang.DoubleUtils;
 import org.opentripplanner.utils.lang.Units;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -42,7 +43,7 @@ public final class StreetPreferences implements Serializable {
     this.accessEgress = AccessEgressPreferences.DEFAULT;
     this.intersectionTraversalModel = IntersectionTraversalModel.SIMPLE;
     this.maxDirectDuration = durationForStreetModeOf(ofHours(4));
-    this.routingTimeout = Duration.ofSeconds(5);
+    this.routingTimeout = StreetSearchRequest.DEFAULT.timeout();
   }
 
   private StreetPreferences(Builder builder) {

--- a/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequest.java
+++ b/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequest.java
@@ -24,7 +24,7 @@ import org.opentripplanner.utils.time.TimeUtils;
  */
 public class StreetSearchRequest implements AStarRequest {
 
-  private static final StreetSearchRequest DEFAULT = new StreetSearchRequest();
+  public static final StreetSearchRequest DEFAULT = new StreetSearchRequest();
 
   /**
    * How close to do you have to be to the start or end to be considered "close".
@@ -80,7 +80,7 @@ public class StreetSearchRequest implements AStarRequest {
     this.rentalPeriod = null;
     this.intersectionTraversalCalculator = IntersectionTraversalCalculator.DEFAULT;
     this.extensionRequestContexts = List.of();
-    this.timeout = Duration.ofSeconds(30);
+    this.timeout = Duration.ofSeconds(5);
   }
 
   StreetSearchRequest(StreetSearchRequestBuilder builder) {

--- a/street/src/test/java/org/opentripplanner/street/search/request/StreetSearchRequestBuilderTest.java
+++ b/street/src/test/java/org/opentripplanner/street/search/request/StreetSearchRequestBuilderTest.java
@@ -1,11 +1,13 @@
 package org.opentripplanner.street.search.request;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.search.TraverseMode.BICYCLE;
 import static org.opentripplanner.street.search.TraverseMode.CAR;
 import static org.opentripplanner.street.search.TraverseMode.SCOOTER;
 
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.search.TraverseMode;
@@ -25,5 +27,11 @@ class StreetSearchRequestBuilderTest {
         "Use rental availability for %s false, but should be true.".formatted(m)
       )
     );
+  }
+
+  @Test
+  void defaultTimeout() {
+    var orig = StreetSearchRequest.of().build();
+    assertEquals(Duration.ofSeconds(5), orig.timeout());
   }
 }


### PR DESCRIPTION
### Summary

In #7328 I tried to make the street routing timeout more relaxed, because I thought that the application default of 5 seconds is too conservative. Turns out that the nearest query uses the default time out and some queries are not terminated when they were before.

### Issue

Closes #7371

Ref #6881 

### Unit tests

Added.