### PR TITLE
Encapsulate vehicle rental graph construction in street module

### DIFF
--- a/application/src/main/java/org/opentripplanner/streetadapter/VertexFactory.java
+++ b/application/src/main/java/org/opentripplanner/streetadapter/VertexFactory.java
@@ -8,8 +8,6 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.osm.model.OsmNode;
 import org.opentripplanner.service.vehicleparking.model.VehicleParking;
 import org.opentripplanner.service.vehicleparking.model.VehicleParkingEntrance;
-import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
-import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.vertex.BarrierPassThroughVertex;
@@ -158,10 +156,6 @@ public class VertexFactory {
 
   public VehicleParkingEntranceVertex vehicleParkingEntrance(VehicleParkingEntrance entrance) {
     return addToGraph(new VehicleParkingEntranceVertex(entrance));
-  }
-
-  public VehicleRentalPlaceVertex vehicleRentalPlace(VehicleRentalPlace station) {
-    return addToGraph(new VehicleRentalPlaceVertex(station));
   }
 
   public TransitPathwayNodeVertex transitPathwayNode(PathwayNode node) {

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -15,6 +15,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
+import org.opentripplanner.service.vehiclerental.street.GeofencingZoneApplier;
 import org.opentripplanner.service.vehiclerental.street.StreetVehicleRentalLink;
 import org.opentripplanner.service.vehiclerental.street.VehicleRentalEdge;
 import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex;
@@ -229,8 +230,8 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
         latestModifiedEdges.forEach(StreetEdge::removeRentalExtension);
 
-        var updater = new GeofencingVertexUpdater(context.graph()::findEdges);
-        latestModifiedEdges = updater.applyGeofencingZones(geofencingZones);
+        var applier = new GeofencingZoneApplier(context.graph()::findEdges);
+        latestModifiedEdges = applier.applyGeofencingZones(geofencingZones);
         latestAppliedGeofencingZones = geofencingZones;
 
         var end = System.currentTimeMillis();

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -9,8 +9,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
@@ -22,12 +20,10 @@ import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex
 import org.opentripplanner.street.linking.DisposableEdgeCollection;
 import org.opentripplanner.street.linking.LinkingDirection;
 import org.opentripplanner.street.linking.VertexLinker;
-import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.street.model.RentalRestrictionExtension;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
-import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.RealTimeUpdateContext;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
@@ -150,7 +146,6 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
     public void run(RealTimeUpdateContext context) {
       // Apply stations to graph
       Set<FeedScopedId> stationSet = new HashSet<>();
-      var vertexFactory = new VertexFactory(context.graph());
 
       /* add any new stations and update vehicle counts for existing stations */
       for (VehicleRentalPlace station : stations) {
@@ -159,22 +154,13 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
         VehicleRentalPlaceVertex vehicleRentalVertex = verticesByStation.get(station.id());
 
         if (vehicleRentalVertex == null) {
-          vehicleRentalVertex = vertexFactory.vehicleRentalPlace(station);
+          vehicleRentalVertex = new VehicleRentalPlaceVertex(station);
+          context.graph().addVertex(vehicleRentalVertex);
           DisposableEdgeCollection tempEdges = linker.linkVertexForRealTime(
             vehicleRentalVertex,
             new TraverseModeSet(TraverseMode.WALK),
             LinkingDirection.BIDIRECTIONAL,
-            (vertex, streetVertex) ->
-              List.of(
-                StreetVehicleRentalLink.createStreetVehicleRentalLink(
-                  (VehicleRentalPlaceVertex) vertex,
-                  streetVertex
-                ),
-                StreetVehicleRentalLink.createStreetVehicleRentalLink(
-                  streetVertex,
-                  (VehicleRentalPlaceVertex) vertex
-                )
-              )
+            StreetVehicleRentalLink::createBidirectionalLinks
           );
           if (vehicleRentalVertex.getOutgoing().isEmpty()) {
             // Copy reference to pass into lambda
@@ -189,15 +175,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
               )
             );
           }
-          Set<RentalFormFactor> formFactors = Stream.concat(
-            station.availablePickupFormFactors(false).stream(),
-            station.availableDropoffFormFactors(false).stream()
-          ).collect(Collectors.toSet());
-          for (RentalFormFactor formFactor : formFactors) {
-            tempEdges.addEdge(
-              VehicleRentalEdge.createVehicleRentalEdge(vehicleRentalVertex, formFactor)
-            );
-          }
+          VehicleRentalEdge.createRentalEdgesForStation(vehicleRentalVertex, station, tempEdges);
           verticesByStation.put(station.id(), vehicleRentalVertex);
           tempEdgesByStation.put(station.id(), tempEdges);
         } else {

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/street/GeofencingZoneApplier.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/street/GeofencingZoneApplier.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.updater.vehicle_rental;
+package org.opentripplanner.service.vehiclerental.street;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -14,15 +14,13 @@ import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
-import org.opentripplanner.service.vehiclerental.street.BusinessAreaBorder;
-import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.RentalRestrictionExtension;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 
 /**
- * Even though the data is kept on the vertex this updater operates mostly on edges which then
+ * Even though the data is kept on the vertex this class operates mostly on edges which then
  * delegate to the vertices.
  * <p>
  * This is because we want to drop the vehicle outside the geofencing zone rather than on the first
@@ -32,11 +30,11 @@ import org.opentripplanner.street.model.edge.StreetEdge;
  * Perhaps this logic will be replaced with edge splitting where a new vertex is insert right on
  * the border of the zone.
  */
-class GeofencingVertexUpdater {
+public class GeofencingZoneApplier {
 
   private final Function<Envelope, Collection<Edge>> getEdgesForEnvelope;
 
-  public GeofencingVertexUpdater(Function<Envelope, Collection<Edge>> getEdgesForEnvelope) {
+  public GeofencingZoneApplier(Function<Envelope, Collection<Edge>> getEdgesForEnvelope) {
     this.getEdgesForEnvelope = getEdgesForEnvelope;
   }
 
@@ -44,7 +42,7 @@ class GeofencingVertexUpdater {
    * Applies the restrictions described in the geofencing zones to eges by adding
    * {@link RentalRestrictionExtension} to them.
    */
-  Map<StreetEdge, RentalRestrictionExtension> applyGeofencingZones(
+  public Map<StreetEdge, RentalRestrictionExtension> applyGeofencingZones(
     Collection<GeofencingZone> geofencingZones
   ) {
     var restrictedZones = geofencingZones.stream().filter(GeofencingZone::hasRestriction).toList();

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/street/StreetVehicleRentalLink.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/street/StreetVehicleRentalLink.java
@@ -1,8 +1,10 @@
 package org.opentripplanner.service.vehiclerental.street;
 
+import java.util.List;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.StateEditor;
 
@@ -35,6 +37,20 @@ public class StreetVehicleRentalLink extends Edge {
     StreetVertex tov
   ) {
     return connectToGraph(new StreetVehicleRentalLink(fromv, tov));
+  }
+
+  /**
+   * Creates a bidirectional pair of links between a rental vertex and a street vertex.
+   * Designed to be used as a method reference for {@link org.opentripplanner.street.linking.VertexLinker#linkVertexForRealTime}.
+   */
+  public static List<Edge> createBidirectionalLinks(
+    Vertex rentalVertex,
+    StreetVertex streetVertex
+  ) {
+    return List.of(
+      createStreetVehicleRentalLink((VehicleRentalPlaceVertex) rentalVertex, streetVertex),
+      createStreetVehicleRentalLink(streetVertex, (VehicleRentalPlaceVertex) rentalVertex)
+    );
   }
 
   @Override

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdge.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.service.vehiclerental.street;
 
 import java.time.Instant;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
@@ -8,6 +10,7 @@ import org.opentripplanner.service.vehiclerental.model.RentalVehicleType.Propuls
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalVehicle;
+import org.opentripplanner.street.linking.DisposableEdgeCollection;
 import org.opentripplanner.street.mapping.StreetModeToRentalTraverseModeMapper;
 import org.opentripplanner.street.model.RentalFormFactor;
 import org.opentripplanner.street.model.StreetMode;
@@ -34,6 +37,24 @@ public class VehicleRentalEdge extends Edge {
     RentalFormFactor formFactor
   ) {
     return connectToGraph(new VehicleRentalEdge(vertex, formFactor));
+  }
+
+  /**
+   * Creates rental edges for all form factors available at a station and adds them to the
+   * given disposable edge collection.
+   */
+  public static void createRentalEdgesForStation(
+    VehicleRentalPlaceVertex vertex,
+    VehicleRentalPlace station,
+    DisposableEdgeCollection edges
+  ) {
+    var formFactors = Stream.concat(
+      station.availablePickupFormFactors(false).stream(),
+      station.availableDropoffFormFactors(false).stream()
+    ).collect(Collectors.toSet());
+    for (var formFactor : formFactors) {
+      edges.addEdge(createVehicleRentalEdge(vertex, formFactor));
+    }
   }
 
   @Override

--- a/street/src/test-fixtures/java/org/opentripplanner/street/geometry/Polygons.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/geometry/Polygons.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.street.geometry;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+
+public class Polygons {
+
+  private static final GeometryFactory FAC = GeometryUtils.getGeometryFactory();
+
+  public static final Polygon OSLO = FAC.createPolygon(
+    new Coordinate[] {
+      new Coordinate(10.62535658370308, 59.961055202323195),
+      new Coordinate(10.62535658370308, 59.889009435700416),
+      new Coordinate(10.849791142928694, 59.889009435700416),
+      new Coordinate(10.849791142928694, 59.961055202323195),
+      new Coordinate(10.62535658370308, 59.961055202323195),
+    }
+  );
+
+  public static final Polygon OSLO_FROGNER_PARK = FAC.createPolygon(
+    new Coordinate[] {
+      new Coordinate(10.69770054003061, 59.92939032560119),
+      new Coordinate(10.695210909925208, 59.929138466684975),
+      new Coordinate(10.692696865071184, 59.92745319808358),
+      new Coordinate(10.693774304996225, 59.92709930323093),
+      new Coordinate(10.69495957972947, 59.92745914988427),
+      new Coordinate(10.697664535925895, 59.92736919590291),
+      new Coordinate(10.697927604125255, 59.924837887427856),
+      new Coordinate(10.697448767354985, 59.924447953413335),
+      new Coordinate(10.697819761729818, 59.92378800804022),
+      new Coordinate(10.699196446969069, 59.92329018587293),
+      new Coordinate(10.700285749621997, 59.92347619027632),
+      new Coordinate(10.704714696822037, 59.92272030268688),
+      new Coordinate(10.71001707489603, 59.92597766029715),
+      new Coordinate(10.707838597058043, 59.92676341291536),
+      new Coordinate(10.708389137506913, 59.92790300889098),
+      new Coordinate(10.707060536853078, 59.928376832499424),
+      new Coordinate(10.705803789539402, 59.92831087551576),
+      new Coordinate(10.706641515204467, 59.92953431964068),
+      new Coordinate(10.70484606360543, 59.93046383654274),
+      new Coordinate(10.701817874860211, 59.93008590667682),
+      new Coordinate(10.700525251174469, 59.93028982601595),
+      new Coordinate(10.69770054003061, 59.92939032560119),
+    }
+  );
+}

--- a/street/src/test/java/org/opentripplanner/service/vehiclerental/street/GeofencingZoneApplierTest.java
+++ b/street/src/test/java/org/opentripplanner/service/vehiclerental/street/GeofencingZoneApplierTest.java
@@ -1,26 +1,23 @@
-package org.opentripplanner.updater.vehicle_rental;
+package org.opentripplanner.service.vehiclerental.street;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.opentripplanner.street.model.StreetModelForTest.intersectionVertex;
-import static org.opentripplanner.street.model.StreetModelForTest.streetEdge;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.id;
+import static org.opentripplanner.core.model.id.FeedScopedIdFactory.id;
+import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
+import static org.opentripplanner.street.model.StreetModelFactory.streetEdge;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
-import org.opentripplanner._support.geometry.Polygons;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
-import org.opentripplanner.service.vehiclerental.street.BusinessAreaBorder;
-import org.opentripplanner.service.vehiclerental.street.GeofencingZoneExtension;
-import org.opentripplanner.service.vehiclerental.street.NoRestriction;
 import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.geometry.Polygons;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 
-class GeofencingVertexUpdaterTest {
+class GeofencingZoneApplierTest {
 
   StreetVertex insideFrognerPark1 = intersectionVertex(59.928667, 10.699322);
   StreetVertex insideFrognerPark2 = intersectionVertex(59.9245634, 10.703902);
@@ -32,7 +29,7 @@ class GeofencingVertexUpdaterTest {
   StreetEdge insideFrognerPark = streetEdge(insideFrognerPark1, insideFrognerPark2);
   StreetEdge halfInHalfOutFrognerPark = streetEdge(insideFrognerPark2, outsideFrognerPark1);
   StreetEdge businessBorder = streetEdge(insideBusinessZone, outsideBusinessZone);
-  final GeofencingVertexUpdater updater = new GeofencingVertexUpdater(ignored ->
+  final GeofencingZoneApplier applier = new GeofencingZoneApplier(ignored ->
     List.of(insideFrognerPark, halfInHalfOutFrognerPark, businessBorder)
   );
 
@@ -58,7 +55,7 @@ class GeofencingVertexUpdaterTest {
   void insideZone() {
     assertInstanceOf(NoRestriction.class, insideFrognerPark.getFromVertex().rentalRestrictions());
 
-    updater.applyGeofencingZones(List.of(zone, businessArea));
+    applier.applyGeofencingZones(List.of(zone, businessArea));
 
     var ext = insideFrognerPark.getFromVertex().rentalRestrictions();
 
@@ -73,7 +70,7 @@ class GeofencingVertexUpdaterTest {
   void halfInHalfOutZone() {
     assertInstanceOf(NoRestriction.class, insideFrognerPark.getFromVertex().rentalRestrictions());
 
-    updater.applyGeofencingZones(List.of(zone, businessArea));
+    applier.applyGeofencingZones(List.of(zone, businessArea));
 
     var ext = insideFrognerPark.getFromVertex().rentalRestrictions();
 
@@ -87,7 +84,7 @@ class GeofencingVertexUpdaterTest {
   @Test
   void outsideZone() {
     assertInstanceOf(NoRestriction.class, insideFrognerPark.getFromVertex().rentalRestrictions());
-    updater.applyGeofencingZones(List.of(zone, businessArea));
+    applier.applyGeofencingZones(List.of(zone, businessArea));
     assertInstanceOf(
       GeofencingZoneExtension.class,
       insideFrognerPark.getFromVertex().rentalRestrictions()
@@ -97,7 +94,7 @@ class GeofencingVertexUpdaterTest {
   @Test
   void businessAreaBorder() {
     assertInstanceOf(NoRestriction.class, insideFrognerPark.getFromVertex().rentalRestrictions());
-    var updated = updater.applyGeofencingZones(List.of(zone, businessArea));
+    var updated = applier.applyGeofencingZones(List.of(zone, businessArea));
 
     assertEquals(3, updated.size());
 

--- a/street/src/test/java/org/opentripplanner/service/vehiclerental/street/StreetVehicleRentalLinkTest.java
+++ b/street/src/test/java/org/opentripplanner/service/vehiclerental/street/StreetVehicleRentalLinkTest.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.service.vehiclerental.street;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.street.model.RentalFormFactor;
+import org.opentripplanner.street.model.StreetModelFactory;
+
+class StreetVehicleRentalLinkTest {
+
+  @Test
+  void createBidirectionalLinks() {
+    var rentalVertex = StreetModelFactory.rentalVertex(RentalFormFactor.BICYCLE);
+    var streetVertex = intersectionVertex(59.9, 10.7);
+
+    var links = StreetVehicleRentalLink.createBidirectionalLinks(rentalVertex, streetVertex);
+
+    assertEquals(2, links.size());
+
+    // First link: rental → street
+    var rentalToStreet = links.get(0);
+    assertInstanceOf(StreetVehicleRentalLink.class, rentalToStreet);
+    assertEquals(rentalVertex, rentalToStreet.getFromVertex());
+    assertEquals(streetVertex, rentalToStreet.getToVertex());
+
+    // Second link: street → rental
+    var streetToRental = links.get(1);
+    assertInstanceOf(StreetVehicleRentalLink.class, streetToRental);
+    assertEquals(streetVertex, streetToRental.getFromVertex());
+    assertEquals(rentalVertex, streetToRental.getToVertex());
+  }
+}

--- a/street/src/test/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdgeFactoryTest.java
+++ b/street/src/test/java/org/opentripplanner/service/vehiclerental/street/VehicleRentalEdgeFactoryTest.java
@@ -1,0 +1,97 @@
+package org.opentripplanner.service.vehiclerental.street;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.street.model.RentalFormFactor.BICYCLE;
+import static org.opentripplanner.street.model.RentalFormFactor.SCOOTER;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
+import org.opentripplanner.service.vehiclerental.model.TestVehicleRentalStationBuilder;
+import org.opentripplanner.street.Scope;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.linking.DisposableEdgeCollection;
+import org.opentripplanner.street.model.RentalFormFactor;
+
+class VehicleRentalEdgeFactoryTest {
+
+  @Test
+  void createRentalEdgesForSingleFormFactor() {
+    var station = TestVehicleRentalStationBuilder.of()
+      .withVehicleTypeBicycle(3, 3)
+      .withStationOn(true)
+      .build();
+    var vertex = new VehicleRentalPlaceVertex(station);
+    var graph = new Graph();
+    var edges = new DisposableEdgeCollection(graph, Scope.REALTIME);
+
+    VehicleRentalEdge.createRentalEdgesForStation(vertex, station, edges);
+
+    assertEquals(1, vertex.getOutgoing().size());
+    var edge = (VehicleRentalEdge) vertex.getOutgoing().iterator().next();
+    assertEquals(BICYCLE, edge.formFactor);
+  }
+
+  @Test
+  void createRentalEdgesForMultipleFormFactors() {
+    var station = TestVehicleRentalStationBuilder.of()
+      .withVehicleTypeBicycle(3, 3)
+      .withVehicleType(SCOOTER, RentalVehicleType.PropulsionType.ELECTRIC, 2, 2)
+      .withStationOn(true)
+      .build();
+    var vertex = new VehicleRentalPlaceVertex(station);
+    var graph = new Graph();
+    var edges = new DisposableEdgeCollection(graph, Scope.REALTIME);
+
+    VehicleRentalEdge.createRentalEdgesForStation(vertex, station, edges);
+
+    assertEquals(2, vertex.getOutgoing().size());
+    var formFactors = vertex
+      .getOutgoing()
+      .stream()
+      .map(e -> ((VehicleRentalEdge) e).formFactor)
+      .collect(java.util.stream.Collectors.toSet());
+    assertTrue(formFactors.contains(BICYCLE));
+    assertTrue(formFactors.contains(SCOOTER));
+  }
+
+  @Test
+  void createRentalEdgesDeduplicatesOverlappingFormFactors() {
+    // A station where BICYCLE is both a pickup and dropoff form factor
+    var station = TestVehicleRentalStationBuilder.of()
+      .withVehicleTypeBicycle(3, 3)
+      .withStationOn(true)
+      .build();
+    var vertex = new VehicleRentalPlaceVertex(station);
+    var graph = new Graph();
+    var edges = new DisposableEdgeCollection(graph, Scope.REALTIME);
+
+    VehicleRentalEdge.createRentalEdgesForStation(vertex, station, edges);
+
+    // Should only create one edge per form factor, not duplicate for pickup + dropoff
+    assertEquals(1, vertex.getOutgoing().size());
+  }
+
+  @Test
+  void createRentalEdgesForStationWithNoFormFactors() {
+    // Station with 0 available vehicles and 0 spaces — but still has a default type
+    var station = TestVehicleRentalStationBuilder.of()
+      .withVehicles(0)
+      .withSpaces(0)
+      .withStationOn(true)
+      .build();
+    var vertex = new VehicleRentalPlaceVertex(station);
+    var graph = new Graph();
+    var edges = new DisposableEdgeCollection(graph, Scope.REALTIME);
+
+    VehicleRentalEdge.createRentalEdgesForStation(vertex, station, edges);
+
+    // Default vehicle type is BICYCLE, even with 0 count it's still in the type map
+    var formFactors = vertex
+      .getOutgoing()
+      .stream()
+      .map(e -> ((VehicleRentalEdge) e).formFactor)
+      .collect(java.util.stream.Collectors.toSet());
+    assertTrue(formFactors.contains(RentalFormFactor.BICYCLE));
+  }
+}


### PR DESCRIPTION
### Summary

  - Rename GeofencingVertexUpdater to GeofencingZoneApplier and move it from the updater package to the street module where it belongs
  - Add factory methods to VehicleRentalEdge and StreetVehicleRentalLink to encapsulate graph construction logic                                                                                                                                                                                 
  - Simplify VehicleRentalUpdater by delegating edge/vertex creation to the domain classes                                                                                                                                                                                                       
  - Remove vehicleRentalPlace method from VertexFactory in favor of direct vertex construction    

### Issue

Main motivation is better maintainability for new features, and shared logic with wip sandbox (https://github.com/opentripplanner/OpenTripPlanner/pull/7155).

Related issues https://github.com/opentripplanner/OpenTripPlanner/issues/7349 https://github.com/opentripplanner/OpenTripPlanner/issues/6881

Builds on top of #7366 and #7368 
