### PR TITLE
Make URL of NED datum configurable

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -382,7 +382,11 @@ public class GraphBuilderModules {
     awsTileSource.awsSecretKey = config.elevationBucket.secretKey;
     awsTileSource.awsBucketName = config.elevationBucket.bucketName;
 
-    return new NEDGridCoverageFactoryImpl(nedCacheDirectory, awsTileSource);
+    return new NEDGridCoverageFactoryImpl(
+      nedCacheDirectory,
+      config.elevationBucket.datumUrl,
+      awsTileSource
+    );
   }
 
   private static List<ElevationGridCoverageFactory> createDemGeotiffGridCoverageFactories(

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -6,6 +6,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,18 +36,19 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
     "g2012u00.gtx",
   };
   private final File cacheDirectory;
-  public final NEDTileSource tileSource;
+  private final NEDTileSource tileSource;
   private final List<GridCoverage2D> regionCoverages = new ArrayList<>();
+  private final URL datumUrl;
   private List<VerticalDatum> datums;
 
-  public NEDGridCoverageFactoryImpl(File cacheDirectory) {
-    this.cacheDirectory = cacheDirectory;
-    this.tileSource = new DegreeGridNEDTileSource();
-  }
-
-  public NEDGridCoverageFactoryImpl(File cacheDirectory, NEDTileSource tileSource) {
+  public NEDGridCoverageFactoryImpl(File cacheDirectory, URI datumUrl, NEDTileSource tileSource) {
     this.cacheDirectory = cacheDirectory;
     this.tileSource = tileSource;
+    try {
+      this.datumUrl = datumUrl.toURL();
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -182,7 +185,6 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
    */
   private void fetchDatum() throws Exception {
     LOG.info("Attempting to fetch datum files from OTP project web server...");
-    URL datumUrl = new URL("https://otp-repo.ibi-transit.com/elevation.zip");
     ZipInputStream zis = new ZipInputStream(datumUrl.openStream());
     /* Silly boilerplate because Java has no simple unzip-to-directory function. */
     for (ZipEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {

--- a/application/src/main/java/org/opentripplanner/standalone/config/buildconfig/S3BucketConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/buildconfig/S3BucketConfig.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.standalone.config.buildconfig;
 
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.NA;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_9;
 
+import java.net.URI;
 import org.opentripplanner.framework.application.OtpAppException;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.slf4j.Logger;
@@ -18,6 +20,7 @@ public class S3BucketConfig {
   public String accessKey;
   public String secretKey;
   public String bucketName;
+  public URI datumUrl;
 
   public static S3BucketConfig fromConfig(NodeAdapter root, String elevationBucketName) {
     return fromConfig(
@@ -73,6 +76,24 @@ public class S3BucketConfig {
         .since(NA)
         .summary("The bucket from which you want to download.")
         .asString();
+      bucketConfig.datumUrl = config
+        .of("datumUrl")
+        .since(V2_9)
+        .summary("HTTP URL of the vertical datum zip file.")
+        .summary(
+          """
+          URL of the vertical datum zip file which is necessary to convert the
+          [USGS elevation data](https://www.usgs.gov/programs/national-geospatial-program/national-map)
+          from North American Vertical Datum of 1988 (NAVD88) to WGS84 format that OpenStreetMap
+          (and GPS) uses.
+
+          The OTP project used to host these files and hard-code the URL. In 2026 we made the decision
+          to require users to host this file themselves.
+
+          If you would like to get a copy of the file, please ask in our chat room.
+          """
+        )
+        .asUri();
     } catch (OtpAppException ex) {
       LOG.error(
         "You must specify an accessKey, a secretKey, and a bucketName when " +

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -31,7 +33,7 @@ public class ElevationModuleTest {
    */
   @Test
   @Disabled
-  public void testSetElevationOnEdgesUsingS3BucketTiles() {
+  public void testSetElevationOnEdgesUsingS3BucketTiles() throws URISyntaxException {
     // create a graph with a StreetWithElevationEdge
     var graph = new Graph();
     OsmVertex from = new OsmVertex(-122.6932051, 45.5122964, 40513757);
@@ -92,7 +94,12 @@ public class ElevationModuleTest {
     // create the elevation module
     File cacheDirectory = new File(ElevationModuleTest.class.getResource("ned").getFile());
     DegreeGridNEDTileSource awsTileSource = new DegreeGridNEDTileSource();
-    NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory, awsTileSource);
+    var datumUrl = new URI("https://example.com");
+    NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(
+      cacheDirectory,
+      datumUrl,
+      awsTileSource
+    );
     ElevationModule elevationModule = new ElevationModule(gcf, graph);
 
     // build to graph to execute the elevation module


### PR DESCRIPTION
### Summary

@abyrd has requested that the NED elevation data that were hosted on dev.opentripplanner.org be moved to another location since he would like to delete the bucket.

Arcadis uses this data and is re-hosting the files on their infrastructure.