### PR TITLE
Optimize allocation in SIRI Azure updater

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
@@ -522,8 +522,8 @@ public class SiriAzureUpdater implements GraphUpdater {
     }
 
     try {
-      var siriXmlMessage = message.getBody().toString();
-      var siri = SiriXml.parseXml(siriXmlMessage);
+      var siriXmlMessage = message.getBody();
+      var siri = SiriXml.parseXml(siriXmlMessage.toStream());
       var serviceDelivery = siri.getServiceDelivery();
       if (serviceDelivery == null) {
         if (siri.getHeartbeatNotification() != null) {


### PR DESCRIPTION
### Summary

Pure sandbox code.

This does the same thing as #7353 but for the Siri Azure Updater. By not creating a string we save some memory allocation.

### Unit tests

No

### Documentation

No

### Changelog

skip

### Bumping the serialization version id

No
