### PR TITLE
ORCA fare fixes March 2026

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareServiceTest.java
@@ -185,7 +185,11 @@ public class OrcaFareServiceTest {
     assertEquals(hasXfer, hasTransfer, "Incorrect transfer leg fare product status.");
   }
 
-  private static void assertLegHasFareProductForType(Leg leg, ItineraryFare fares, FareType fareType) {
+  private static void assertLegHasFareProductForType(
+    Leg leg,
+    ItineraryFare fares,
+    FareType fareType
+  ) {
     var expectedCategoryName = getRiderCategoryName(fareType);
     var expectedMediumName = usesOrca(fareType) ? "electronic" : "cash";
     var legFareProducts = fares.getLegProducts().get(leg);
@@ -195,11 +199,12 @@ public class OrcaFareServiceTest {
     var hasMatchingProduct = legFareProducts
       .stream()
       .map(FareOffer::fareProduct)
-      .anyMatch(product ->
-        product.category() != null &&
-        product.medium() != null &&
-        product.category().name().equals(expectedCategoryName) &&
-        product.medium().name().equals(expectedMediumName)
+      .anyMatch(
+        product ->
+          product.category() != null &&
+          product.medium() != null &&
+          product.category().name().equals(expectedCategoryName) &&
+          product.medium().name().equals(expectedMediumName)
       );
 
     assertTrue(

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareService.java
@@ -355,10 +355,20 @@ public class OrcaFareService extends DefaultFareService {
       return defaultFare;
     }
     return switch (rideType) {
-      case COMM_TRANS_LOCAL_SWIFT, KC_METRO, KC_WATER_TAXI_VASHON_ISLAND,
-           KC_WATER_TAXI_WEST_SEATTLE, SOUND_TRANSIT, SOUND_TRANSIT_BUS, SOUND_TRANSIT_LINK,
-           SOUND_TRANSIT_SOUNDER, SOUND_TRANSIT_T_LINK, KITSAP_TRANSIT, EVERETT_TRANSIT,
-           PIERCE_COUNTY_TRANSIT, SEATTLE_STREET_CAR -> optionalUSD(1.00f);
+      case
+        COMM_TRANS_LOCAL_SWIFT,
+        KC_METRO,
+        KC_WATER_TAXI_VASHON_ISLAND,
+        KC_WATER_TAXI_WEST_SEATTLE,
+        SOUND_TRANSIT,
+        SOUND_TRANSIT_BUS,
+        SOUND_TRANSIT_LINK,
+        SOUND_TRANSIT_SOUNDER,
+        SOUND_TRANSIT_T_LINK,
+        KITSAP_TRANSIT,
+        EVERETT_TRANSIT,
+        PIERCE_COUNTY_TRANSIT,
+        SEATTLE_STREET_CAR -> optionalUSD(1.00f);
       case MONORAIL -> Optional.empty();
       case WASHINGTON_STATE_FERRIES -> defaultFare.map(df ->
         getWashingtonStateFerriesFare(route.getLongName(), FareType.electronicSpecial, df)


### PR DESCRIPTION

### Summary

Two changes:
- Don't show youth fares when we don't have any other fares for the agency
- Hide KCM fares when the route has free fares.