### PR TITLE
Fix error when submodes is null in transmodel api

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapper.java
@@ -109,10 +109,10 @@ class TransitFilterOldWayMapper {
       if (modeWithSubmodes.containsKey("transportMode")) {
         var mainMode = (TransitMode) modeWithSubmodes.get("transportMode");
 
-        if (modeWithSubmodes.containsKey("transportSubModes")) {
-          var transportSubModes = (List<TransmodelTransportSubmode>) modeWithSubmodes.get(
-            "transportSubModes"
-          );
+        var transportSubModes = (List<TransmodelTransportSubmode>) modeWithSubmodes.get(
+          "transportSubModes"
+        );
+        if (transportSubModes != null) {
           for (TransmodelTransportSubmode submode : transportSubModes) {
             tModes.add(new MainAndSubMode(mainMode, SubMode.of(submode.getValue())));
           }

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TransitFilterOldWayMapperTest.java
@@ -7,6 +7,7 @@ import static org.opentripplanner.apis.transmodel._support.RequestHelper.map;
 
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.api.model.transit.DefaultFeedIdMapper;
@@ -182,6 +183,22 @@ class TransitFilterOldWayMapperTest {
 
     assertEquals(
       "(filters: [(select: [(transportModes: [RAIL::local, RAIL::regionalRail])])])",
+      transitBuilder.build().toString()
+    );
+  }
+
+  @Test
+  void handleNullSubmode() {
+    var transportMode = new HashMap<String, Object>();
+    transportMode.put("transportMode", TransitMode.RAIL);
+    transportMode.put("transportSubModes", null);
+
+    var env = envOf(map(entry("modes", map(entry("transportModes", list(transportMode))))));
+
+    MAPPER.mapFilter(env, new DataFetcherDecorator(env), transitBuilder);
+
+    assertEquals(
+      "(filters: [(select: [(transportModes: [RAIL])])])",
       transitBuilder.build().toString()
     );
   }


### PR DESCRIPTION
### Summary

Setting transportSubModes to null in plan query in transmodel api causes `Cannot invoke "java.util.List.iterator()" because "transportSubModes" is null` exception.

This works:
```
 trip(
   ..
   modes: {
      transportModes: [{
        transportMode: bus
      }]
    }
```

This causes an error:
```
 trip(
   ..
   modes: {
      transportModes: [{
        transportMode: bus
        transportSubModes: null
      }]
    }
```

Generally we should treat null fields the same as not present and the documentation for the field says "If this element is notpresent or null, it will default to all transportSubModes".


### Unit tests

Yes.

### Documentation

No

### Changelog

Skip

### Bumping the serialization version id

No
