### PR TITLE
Add shortName to test trips

### DIFF
--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -146,9 +146,9 @@ class ApiTransitServiceTest {
     var calls = service.findStopCalls(leg);
     assertEquals(
       "[" +
-        "TripTimeOnDate{trip: Trip{F:TestTrip1 RRoute1}, stopPosition: 0, arrival: 12:00, departure: 12:00, serviceDate: 2024-05-08}, " +
-        "TripTimeOnDate{trip: Trip{F:TestTrip1 RRoute1}, stopPosition: 1, arrival: 12:30, departure: 12:30, serviceDate: 2024-05-08}, " +
-        "TripTimeOnDate{trip: Trip{F:TestTrip1 RRoute1}, stopPosition: 2, arrival: 13:00, departure: 13:00, serviceDate: 2024-05-08}" +
+        "TripTimeOnDate{trip: Trip{F:TestTrip1 TestTrip1}, stopPosition: 0, arrival: 12:00, departure: 12:00, serviceDate: 2024-05-08}, " +
+        "TripTimeOnDate{trip: Trip{F:TestTrip1 TestTrip1}, stopPosition: 1, arrival: 12:30, departure: 12:30, serviceDate: 2024-05-08}, " +
+        "TripTimeOnDate{trip: Trip{F:TestTrip1 TestTrip1}, stopPosition: 2, arrival: 13:00, departure: 13:00, serviceDate: 2024-05-08}" +
         "]",
       calls.toString()
     );

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryTestBuilder.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TimetableRepositoryTestBuilder.java
@@ -179,6 +179,7 @@ public class TimetableRepositoryTestBuilder {
     var route = Optional.ofNullable(tripInput.route()).orElse(defaultRoute);
 
     var tripBuilder = Trip.of(id(tripInput.id()))
+      .withShortName(tripInput.shortName())
       .withRoute(route)
       .withHeadsign(tripInput.headsign())
       .withServiceId(serviceId)

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TripInput.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TripInput.java
@@ -36,6 +36,8 @@ public class TripInput {
   @Nullable
   private List<LocalDate> serviceDates = null;
 
+  private String shortName;
+
   @Nullable
   private I18NString headsign;
 
@@ -56,6 +58,7 @@ public class TripInput {
   private TripInput(String id, boolean isFlex) {
     this.id = id;
     this.isFlex = isFlex;
+    this.shortName = id;
   }
 
   public static TripInput of(String id) {
@@ -68,6 +71,10 @@ public class TripInput {
 
   public String id() {
     return id;
+  }
+
+  public String shortName() {
+    return shortName;
   }
 
   public List<StopTime> stopTimes(Trip trip) {


### PR DESCRIPTION
### Summary

This PR only touches test code.

The trip shortName is sometimes used in logs when calling the `Trip.logName()` method. When shortName is null, the route name is used instead. This PR adds the shortName for test trips and defaults it to have the trip id as shortName which is a good default in tests.

### Issue

No

### Unit tests

One test was updated

### Documentation

No

### Changelog

Skip

### Bumping the serialization version id

No