### PR TITLE
Harmonize error cases in FeedScopedId parsing

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/ojp/mapping/FilterMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/mapping/FilterMapper.java
@@ -99,7 +99,7 @@ class FilterMapper {
       .map(o -> o.getLine())
       .stream()
       .flatMap(r -> r.stream().map(l -> l.getLineRef().getValue()))
-      .map(idMapper::parse)
+      .flatMap(id -> idMapper.parse(id).stream())
       .collect(Collectors.toSet());
   }
 
@@ -112,7 +112,7 @@ class FilterMapper {
       .map(o -> o.getOperatorRef())
       .stream()
       .flatMap(r -> r.stream().map(ref -> ref.getValue()))
-      .map(idMapper::parse)
+      .flatMap(id -> idMapper.parse(id).stream())
       .collect(Collectors.toSet());
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/mapping/RouteRequestMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/mapping/RouteRequestMapper.java
@@ -120,14 +120,14 @@ public class RouteRequestMapper {
         .map(r -> r.getValue())
         .isPresent()
     ) {
-      var id = idMapper.parse(place.getPlaceRef().getStopPlaceRef().getValue());
+      var id = idMapper.parseStrict(place.getPlaceRef().getStopPlaceRef().getValue());
       return GenericLocation.fromStopId(id);
     } else if (
       Optional.ofNullable(place.getPlaceRef().getStopPointRef())
         .map(r -> r.getValue())
         .isPresent()
     ) {
-      var id = idMapper.parse(place.getPlaceRef().getStopPointRef().getValue());
+      var id = idMapper.parseStrict(place.getPlaceRef().getStopPointRef().getValue());
       return GenericLocation.fromStopId(id);
     } else {
       throw new IllegalArgumentException(

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/service/OjpService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/service/OjpService.java
@@ -77,7 +77,7 @@ public class OjpService {
     return placeRefStructure(ser)
       .map(PlaceRefStructure::getStopPointRef)
       .map(StopPointRefStructure::getValue)
-      .map(idMapper::parse);
+      .flatMap(idMapper::parse);
   }
 
   private Optional<WgsCoordinate> coordinate(OJPStopEventRequestStructure ser) {

--- a/application/src/main/java/org/opentripplanner/api/model/transit/DefaultFeedIdMapper.java
+++ b/application/src/main/java/org/opentripplanner/api/model/transit/DefaultFeedIdMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.api.model.transit;
 
+import java.util.Optional;
 import org.opentripplanner.core.model.id.FeedScopedId;
 
 /**
@@ -8,8 +9,8 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 public class DefaultFeedIdMapper implements FeedScopedIdMapper {
 
   @Override
-  public FeedScopedId parse(String id) {
-    return FeedScopedId.parse(id);
+  public Optional<FeedScopedId> parse(String id) {
+    return FeedScopedId.parseOptional(id);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/api/model/transit/FeedScopedIdMapper.java
+++ b/application/src/main/java/org/opentripplanner/api/model/transit/FeedScopedIdMapper.java
@@ -11,7 +11,16 @@ import org.opentripplanner.core.model.id.FeedScopedId;
  * Handles mapping from external IDs into feed-scoped ones.
  */
 public interface FeedScopedIdMapper {
-  FeedScopedId parse(String id);
+  Optional<FeedScopedId> parse(String id);
+
+  /// Parse an id into a FeedScopedId, throwing an exception on invalid inputs
+  ///
+  /// @throws IllegalArgumentException if the input is not a valid FeedScopedId
+  default FeedScopedId parseStrict(String id) throws IllegalArgumentException {
+    return parse(id).orElseThrow(() ->
+      new IllegalArgumentException("invalid feed-scoped-id: " + id)
+    );
+  }
 
   /**
    * @param id a string representation of the id that should be parsed. May be <code>null</code> or
@@ -20,10 +29,10 @@ public interface FeedScopedIdMapper {
    * <code>FeedScopedId</code> wrapped in an <Optional
    */
   default Optional<FeedScopedId> parseNullSafe(@Nullable String id) {
-    if (id == null || id.isBlank()) {
+    if (id == null) {
       return Optional.empty();
     }
-    return Optional.ofNullable(parse(id));
+    return parse(id);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/api/model/transit/HideFeedIdMapper.java
+++ b/application/src/main/java/org/opentripplanner/api/model/transit/HideFeedIdMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.api.model.transit;
 
 import java.util.Objects;
+import java.util.Optional;
 import org.opentripplanner.core.model.id.FeedScopedId;
 
 /**
@@ -17,8 +18,8 @@ public class HideFeedIdMapper implements FeedScopedIdMapper {
   }
 
   @Override
-  public FeedScopedId parse(String id) {
-    return new FeedScopedId(feedId, id);
+  public Optional<FeedScopedId> parse(String id) {
+    return FeedScopedId.ofOptional(feedId, id);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchemaFactory.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchemaFactory.java
@@ -133,7 +133,6 @@ import org.opentripplanner.transit.api.request.TripRequest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
-import org.opentripplanner.utils.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1574,7 +1573,7 @@ public class TransmodelGraphQLSchemaFactory {
   private Stream<FeedScopedId> resolveIds(DataFetchingEnvironment env) {
     return Optional.ofNullable(env.<Collection<String>>getArgument("ids"))
       .stream()
-      .flatMap(ids -> ids.stream().filter(StringUtils::hasValue).map(idMapper::parse));
+      .flatMap(ids -> ids.stream().flatMap(id -> idMapper.parse(id).stream()));
   }
 
   private @Nullable List<FeedScopedId> toNullableIdList(@Nullable List<String> ids) {

--- a/application/src/test/java/org/opentripplanner/api/model/transit/DefaultFeedIdMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/api/model/transit/DefaultFeedIdMapperTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.api.model.transit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 
@@ -13,12 +14,24 @@ class DefaultFeedIdMapperTest {
   @Test
   void parse() {
     var id = SUBJECT.parse("aaa:bbb");
+    assertEquals(Optional.of(new FeedScopedId("aaa", "bbb")), id);
+  }
+
+  @Test
+  void parseFail() {
+    var id = SUBJECT.parse("aaa");
+    assertEquals(Optional.empty(), id);
+  }
+
+  @Test
+  void parseStrict() {
+    var id = SUBJECT.parseStrict("aaa:bbb");
     assertEquals(new FeedScopedId("aaa", "bbb"), id);
   }
 
   @Test
-  void shouldThrowInvalidArgumentException_whenIdIsInvalid() {
-    var e = assertThrows(IllegalArgumentException.class, () -> SUBJECT.parse("invalid"));
+  void parseStrictFail() {
+    var e = assertThrows(IllegalArgumentException.class, () -> SUBJECT.parseStrict("invalid"));
     assertEquals("invalid feed-scoped-id: invalid", e.getMessage());
   }
 

--- a/application/src/test/java/org/opentripplanner/api/model/transit/FeedScopedIdMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/api/model/transit/FeedScopedIdMapperTest.java
@@ -19,8 +19,8 @@ class FeedScopedIdMapperTest {
   private static class IdMapperTestImpl implements FeedScopedIdMapper {
 
     @Override
-    public FeedScopedId parse(String id) {
-      return new FeedScopedId("FIXED", id);
+    public Optional<FeedScopedId> parse(String id) {
+      return FeedScopedId.ofOptional("FIXED", id);
     }
 
     @Override

--- a/application/src/test/java/org/opentripplanner/api/model/transit/HideFeedIdMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/api/model/transit/HideFeedIdMapperTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.api.model.transit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 
@@ -12,7 +13,7 @@ class HideFeedIdMapperTest {
   @Test
   void parse() {
     var id = MAPPER.parse("bbb");
-    assertEquals(new FeedScopedId("aaa", "bbb"), id);
+    assertEquals(Optional.of(new FeedScopedId("aaa", "bbb")), id);
   }
 
   @Test

--- a/domain-core/src/main/java/org/opentripplanner/core/model/id/FeedScopedId.java
+++ b/domain-core/src/main/java/org/opentripplanner/core/model/id/FeedScopedId.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.utils.lang.StringUtils;
 
@@ -22,9 +23,20 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
 
   private final String id;
 
-  public FeedScopedId(String feedId, String id) {
+  /// @throws IllegalArgumentException if the feedId or id is empty
+  public FeedScopedId(String feedId, String id) throws IllegalArgumentException {
     this.feedId = assertHasValue(feedId, "Missing mandatory feedId on FeedScopeId");
     this.id = assertHasValue(id, "Missing mandatory id on FeedScopeId");
+  }
+
+  /// Create a FeedScopedId
+  ///
+  /// @return Optional.empty if the feedId or id is empty, otherwise a FeedScopedId
+  public static Optional<FeedScopedId> ofOptional(String feedId, String id) {
+    if (feedId.isBlank() || id.isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.of(new FeedScopedId(feedId, id));
   }
 
   /**
@@ -36,13 +48,40 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     return id == null || id.isBlank() ? null : new FeedScopedId(feedId, id);
   }
 
-  /**
-   * Given an id of the form "feedId:entityId", parses into a {@link FeedScopedId} id object.
-   *
-   * @param value id of the form "feedId:entityId"
-   * @return an id object
-   * @throws IllegalArgumentException if the id cannot be parsed
-   */
+  /// Given an id of the form "feedId:entityId", parses into a {@link FeedScopedId} id object.
+  ///
+  /// @param value id of the form "feedId:entityId"
+  /// @return Optional.empty if the value is not a valid FeedScopedId
+  public static Optional<FeedScopedId> parseOptional(String value) {
+    int index = value.indexOf(ID_SEPARATOR);
+    if (index == -1) {
+      return Optional.empty();
+    }
+
+    var feedId = value.substring(0, index);
+    var id = value.substring(index + 1);
+    if (feedId.isBlank() || id.isBlank()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(new FeedScopedId(feedId, id));
+  }
+
+  /// Given an id of the form "feedId:entityId", parses into a {@link FeedScopedId} id object.
+  ///
+  /// @param value id of the form "feedId:entityId"
+  /// @throws IllegalArgumentException if the input is not a valid FeedScopedId
+  public static FeedScopedId parseStrict(String value) throws IllegalArgumentException {
+    return parseOptional(value).orElseThrow(() -> new IllegalArgumentException("Invalid FeedScopedId: " + value));
+  }
+
+  /// Given an id of the form "feedId:entityId", parses into a {@link FeedScopedId} id object.
+  ///
+  /// @param value id of the form "feedId:entityId"
+  /// @return an id object or null if the input is empty or null
+  /// @throws IllegalArgumentException if the id cannot be parsed
+  /// @deprecated Use [FeedScopedId#parseOptional] or [FeedScopedId#parseStrict] instead
+  @Deprecated
   @Nullable
   public static FeedScopedId parse(@Nullable String value) throws IllegalArgumentException {
     if (StringUtils.hasNoValue(value)) {

--- a/domain-core/src/test/java/org/opentripplanner/framework/id/FeedScopedIdTest.java
+++ b/domain-core/src/test/java/org/opentripplanner/framework/id/FeedScopedIdTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,6 +16,28 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 class FeedScopedIdTest {
 
   private static final List<FeedScopedId> TRIMET_123 = List.of(new FeedScopedId("trimet", "123"));
+
+  @Test
+  void parseOptional() {
+    assertEquals(Optional.of(new FeedScopedId("FEED", "ID")), FeedScopedId.parseOptional("FEED:ID"));
+    assertEquals(Optional.empty(), FeedScopedId.parseOptional(""));
+    assertEquals(Optional.empty(), FeedScopedId.parseOptional(" "));
+    assertEquals(Optional.empty(), FeedScopedId.parseOptional("ID"));
+    assertEquals(Optional.empty(), FeedScopedId.parseOptional(":"));
+    assertEquals(Optional.empty(), FeedScopedId.parseOptional(":ID"));
+    assertEquals(Optional.empty(), FeedScopedId.parseOptional("FEED:"));
+  }
+
+  @Test
+  void parseStrict() {
+    assertEquals(new FeedScopedId("FEED", "ID"), FeedScopedId.parseStrict("FEED:ID"));
+    assertThrows(IllegalArgumentException.class, () -> FeedScopedId.parseStrict(""));
+    assertThrows(IllegalArgumentException.class, () -> FeedScopedId.parseStrict(" "));
+    assertThrows(IllegalArgumentException.class, () -> FeedScopedId.parseStrict("ID"));
+    assertThrows(IllegalArgumentException.class, () -> FeedScopedId.parseStrict(":"));
+    assertThrows(IllegalArgumentException.class, () -> FeedScopedId.parseStrict(":ID"));
+    assertThrows(IllegalArgumentException.class, () -> FeedScopedId.parseStrict("FEED:"));
+  }
 
   @Test
   void ofNullable() {


### PR DESCRIPTION
### Summary

I'm putting this PR up for discussion.

The `FeedScopedId.parse(String value)` method is used all over the place for parsing a string into a FeedScopedId. But it is inconsistent in how it handles invalid input.

```
FeedScopedId.parse("")      =>   null
FeedScopedId.parse("   ")   =>   null
FeedScopedId.parse("\n")    =>   null
FeedScopedId.parse(null)    =>   null
FeedScopedId.parse("abc")   =>   IllegalArgumentException(invalid feed-scoped-id: abc)
FeedScopedId.parse(":")     =>   IllegalArgumentException(Missing mandatory feedId on FeedScopeId [Value cannot be null, empty or just whitespace: ''])
FeedScopedId.parse("f:")    =>   IllegalArgumentException(Missing mandatory id on FeedScopeId [Value cannot be null, empty or just whitespace: ''])
FeedScopedId.parse("f:x")   =>   ok
```

This leads to inconsistent behavior in lots of places because even if you handle the null value you can still get an exception.

In this PR I deprecate the `FeedScopedId.parse()` method, it's used in so many places that I'm afraid of changing it's behavior. Instead I add two new factory methods:

```
Optional<FeedScopedId> parseOptional(String value)
```

```
FeedScopedId parseStrict(String value) throws IllegalArgumentException
```

I also change the `FeedScopedIdMapper` class so that one has to choose between the optional and the exception behavior.

The changes to the `FeedScopedIdMapper` does change a lot of API behavior since we now won't throw as many IllegalArgumentExceptions now. For example this query:

```
query TransmodelExampleQuery {
  serviceJourney(id: "555") {
    id
  }
}
```

Would previously return

```
{
  "errors": [
    {
      "message": "Exception while fetching data (/serviceJourney) : invalid feed-scoped-id: 555",
      "locations": [
        {
          "line": 5,
          "column": 3
        }
      ],
      "path": [
        "serviceJourney"
      ],
      "extensions": {
        "classification": "DataFetchingException"
      }
    }
  ],
  "data": {
    "serviceJourney": null
  }
}
```

But will now return:

```
{
  "data": {
    "serviceJourney": null
  }
}
```

### Unit tests

I added test cases for the new methods.

### Documentation

Updated javadoc

### Changelog

Skip

### Bumping the serialization version id

I don't think so.
