### PR TITLE
Pin JTS version to prevent conflict with mapbox-vector-tile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -542,6 +542,13 @@
                 <artifactId>gt-geojson-core</artifactId>
                 <version>${geotools.version}</version>
             </dependency>
+            <!-- JTS is a transitive dependency of GeoTools. We pin the version here to
+                 prevent mapbox-vector-tile from pulling in an older, incompatible version. -->
+            <dependency>
+                <groupId>org.locationtech.jts</groupId>
+                <artifactId>jts-core</artifactId>
+                <version>1.20.0</version>
+            </dependency>
             <dependency>
                 <groupId>de.grundid.opendatalab</groupId>
                 <artifactId>geojson-jackson</artifactId>


### PR DESCRIPTION
## Summary

Due to duplicated versions of JTS in the classpath, running OTP with a shaded jar or with InteractiveMain may produce different, incompatible graphs, even when using the exact same version of the code.

Similar issue: #7323

Solution: Pin `jts-core` to 1.20.0 in `<dependencyManagement>` to prevent `mapbox-vector-tile` from pulling in an older, incompatible version.

## Issue

`mapbox-vector-tile:4.0.7` transitively depends on `jts-core:1.18.2`. GeoTools 34.2 requires `jts-core:1.20.0`. Maven's nearest-wins resolution can pick the older version, risking runtime incompatibilities.

### Approach

Add `jts-core:1.20.0` to the root `<dependencyManagement>` section so the correct version is used everywhere, regardless of transitive dependency mediation.

An alternative considered was importing the GeoTools BOMs (`gt-bom` and `gt-platform-dependencies`), but those manage ~170 third-party dependencies and caused version downgrades for `logback` and `commons-collections4`. The manual pin is the simplest and safest fix.

## Unit tests

No new tests — dependency management only. Verified `jts-core` resolves to 1.20.0 via `mvn dependency:tree`.