### PR TITLE
Reduce ShortestPathTree allocation pressure

### DIFF
--- a/astar/src/main/java/org/opentripplanner/astar/model/ShortestPathTree.java
+++ b/astar/src/main/java/org/opentripplanner/astar/model/ShortestPathTree.java
@@ -43,7 +43,7 @@ public class ShortestPathTree<
   public ShortestPathTree(DominanceFunction<State> dominanceFunction) {
     this.dominanceFunction = dominanceFunction;
     // Initialized with a reasonable size, see #4445
-    stateSets = new IdentityHashMap<>(10_000);
+    stateSets = new IdentityHashMap<>(25_000);
   }
 
   /** @return a list of GraphPaths, sometimes empty but never null. */
@@ -91,7 +91,7 @@ public class ShortestPathTree<
 
     // if the vertex has no states, add one and return
     if (states == null) {
-      states = new ArrayList<>();
+      states = new ArrayList<>(1);
       stateSets.put(vertex, states);
       states.add(newState);
       return true;
@@ -193,7 +193,7 @@ public class ShortestPathTree<
 
   /** @return every state in this tree */
   public Collection<State> getAllStates() {
-    ArrayList<State> allStates = new ArrayList<>();
+    ArrayList<State> allStates = new ArrayList<>(stateSets.size());
     for (List<State> stateSet : stateSets.values()) {
       allStates.addAll(stateSet);
     }


### PR DESCRIPTION
## Summary

Reduce allocation pressure in `ShortestPathTree` by tuning three collection capacities to match observed production usage patterns. No behavioral or API changes.

## Issue

Production replay analysis (4,664 A* searches from 5,000 requests on full Norway graph) revealed three capacity mismatches:

| Problem | Metric | Fix |
|---|---|---|
| `IdentityHashMap(10_000)` resizes at 10,923 entries | 59% of searches trigger resize (median 7.4k vertices, p99 210k) | `IdentityHashMap(25_000)` — 1 MB table, first resize at 43,691 entries (~6% of searches) |
| Per-vertex `new ArrayList<>()` allocates `Object[10]` | 99.73% of vertices have exactly 1 state, 99.99% have ≤2 | `new ArrayList<>(1)` — saves 72 bytes/vertex |
| `getAllStates()` starts with `new ArrayList<>()` capacity 10 | Grows through ~18 resizes creating intermediate garbage arrays | Pre-size to `stateSets.size()` |

### IdentityHashMap capacity selection

Due to power-of-2 internal table sizing, not all `expectedMaxSize` values are distinct:

| expectedMaxSize | table memory | first resize at |
|-----------------|-------------|-----------------|
| 10,000 (before) | 256 KB | 10,923 entries (59% of searches resize) |
| 20,000 | 512 KB | 21,846 entries |
| **25,000 (after)** | **1 MB** | **43,691 entries (~6% of searches resize)** |
| 30,000–40,000 | 1 MB | 43,691 entries (same tier) |
| 50,000 | 2 MB | 87,382 entries |

25,000 was chosen because it lands at the 1 MB tier boundary — same effective threshold as 30k–40k at half the cost of 50k. Reduces resize rate from 59% to ~6% of searches. Empirically verified on Java 25.

These are three one-line capacity tuning changes in a single file.

## Unit tests

- All 12 existing `astar` module tests pass
- No new tests needed — this is a capacity-only change with identical behavior
- Manual verification via production request replay confirmed the allocation patterns

## Changelog

Add label `+Skip Changelog`.