### PR TITLE
Add stop code back to log message about failed boarding location linking

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -116,7 +116,12 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       if (!ts.hasPathways()) {
         var stop = stopResolver.getStop(ts.getId());
         if (!connectVertexToStop(ts, stop, graph)) {
-          LOG.debug("Could not connect {} at {}", ts.getId(), ts.getCoordinate());
+          LOG.debug(
+            "Could not connect {} ({}) at {}",
+            ts.getId(),
+            stop.getCode(),
+            ts.getCoordinate()
+          );
         } else {
           successes++;
         }


### PR DESCRIPTION
### Summary

This PR adds back the stop code of unlinked stops to a debug logging message generated by OSM boarding locations module.  Stop code is used by an integration which monitors HSL GTFS stop linking.


