### PR TITLE
Reduce Raptor on-board optimal set by using strict less-than for tripSortIndex

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRide.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRide.java
@@ -34,13 +34,16 @@ import org.opentripplanner.raptor.util.paretoset.ParetoSet;
  *    calculation.
  *  </li>
  *  <li>
- *    We do NOT allow one trip to exclude the pattern-rides of another trip in the pareto-set.
- *    Two pattern-rides are both optimal, if they have boarded the same pattern, in the same round,
- *    but on different trips/vehicles. This have no measurable impact on performance, compared with
- *    allowing an earlier trip dominating a later one. But, it allows for a trip to be optimal at
- *    some stops, and another trip to be optimal at other stops. This may happen if the
- *    generalized-cost is not <em>increasing</em> with the same amount for each trip between each
- *    stop.
+ *    An earlier-departing trip (lower {@code tripSortIndex}) dominates a later one when its cost
+ *    is equal or better. This reduces the on-board optimal set compared with treating all trips as
+ *    incomparable.
+ *    <p>
+ *    For circular patterns with a "tail" (stops that only appear after the loop completes), a
+ *    passenger heading to a tail stop should board on the second pass through a loop stop, thereby
+ *    skipping the full circle. On the second pass, an earlier-departing trip is typically
+ *    available: the earlier trip's second pass will reach the tail stop no later than the later
+ *    trip's first pass. The earlier-departure dominance therefore remains correct even for
+ *    tail-stop destinations.
  *  </li>
  *  <li>
  *    We do not have to update all elements in the "pattern-bag" for every stop visited. The

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c1/PatternRideC1.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c1/PatternRideC1.java
@@ -50,33 +50,12 @@ public record PatternRideC1<T extends RaptorTripSchedule>(
   }
 
   /**
-   * This is the function used to compare {@link PatternRideC1}s for a given pattern.
-   * <p>
-   * Since Raptor only compare rides for a given pattern and a given Raptor round, only 2 criteria
-   * are needed:
-   * <ul>
-   *   <li>
-   *     {@code tripSortIndex} - different trips should not exclude each other. The id can be
-   *     any board-/alight-time or sequence number that is uniq for all trips within a pattern.
-   *     It is only used to check if two trips are different.
-   *   </li>
-   *   <li>
-   *     {@code relative-cost} of riding a pattern. The cost is used to compare paths that have
-   *      boarded the same trip. Two paths riding different trips are not compared, due to the
-   *      first criteria. There is several ways to compute this cost, but you must include the
-   *      previous-stop-arrival-cost and the additional cost of boarding/riding the pattern.
-   *      We assume the cost increase with the same amount for all rides(same trip) traversing
-   *      down the pattern; Than we can safely ignore the cost added between each stop; Hence
-   *      calculating the "relative" board-cost. Remember to include the cost of transit. You
-   *      need to account for the cost of getting from A to B when comparing two {@link PatternRideC1}s
-   *      boarding at A and B.
-   *   </li>
-   * <p>
+   * See {@link PatternRide} for the pareto comparison strategy used by this comparator.
    */
   public static <T extends RaptorTripSchedule> ParetoComparator<
     PatternRideC1<T>
   > paretoComparatorRelativeCost() {
-    return (l, r) -> l.tripSortIndex != r.tripSortIndex || l.relativeC1 < r.relativeC1;
+    return (l, r) -> l.tripSortIndex < r.tripSortIndex || l.relativeC1 < r.relativeC1;
   }
 
   @Override

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c2/PatternRideC2.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c2/PatternRideC2.java
@@ -22,34 +22,13 @@ public record PatternRideC2<T extends RaptorTripSchedule>(
   T trip
 ) implements PatternRide<T> {
   /**
-   * This is the function used to compare {@link PatternRideC2}s for a given pattern.
-   * <p>
-   * Since Raptor only compare rides for a given pattern and a given Raptor round, only 2 criteria
-   * are needed:
-   * <ul>
-   *   <li>
-   *     {@code tripSortIndex} - different trips should not exclude each other. The id can be
-   *     any board-/alight-time or sequence number that is uniq for all trips within a pattern.
-   *     It is only used to check if two trips are different.
-   *   </li>
-   *   <li>
-   *     {@code relative-cost} of riding a pattern. The cost is used to compare paths that have
-   *      boarded the same trip. Two paths riding different trips are not compared, due to the
-   *      first criteria. There is several ways to compute this cost, but you must include the
-   *      previous-stop-arrival-cost and the additional cost of boarding/riding the pattern.
-   *      We assume the cost increase with the same amount for all rides(same trip) traversing
-   *      down the pattern; Than we can safely ignore the cost added between each stop; Hence
-   *      calculating the "relative" board-cost. Remember to include the cost of transit. You
-   *      need to account for the cost of getting from A to B when comparing two
-   *      {@link PatternRideC2}s boarding at A and B.
-   *   </li>
-   * <p>
+   * See {@link PatternRide} for the pareto comparison strategy used by this comparator.
    */
   public static <T extends RaptorTripSchedule> ParetoComparator<
     PatternRideC2<T>
   > paretoComparatorRelativeCost(DominanceFunction dominanceFunctionC2) {
     return (l, r) ->
-      l.tripSortIndex != r.tripSortIndex ||
+      l.tripSortIndex < r.tripSortIndex ||
       l.relativeC1 < r.relativeC1 ||
       dominanceFunctionC2.leftDominateRight(l.c2, r.c2);
   }

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c1/PatternRideC1Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c1/PatternRideC1Test.java
@@ -34,6 +34,15 @@ public class PatternRideC1Test {
       )
     );
 
+    // Left sort index higher than right: should NOT dominate (tripSortIndex is not a dominance
+    // criterion in this direction — different trips are incomparable, only lower index dominates)
+    assertFalse(
+      comparator.leftDominanceExist(
+        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null),
+        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+      )
+    );
+
     assertTrue(
       comparator.leftDominanceExist(
         new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c2/PatternRideC2Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/c2/PatternRideC2Test.java
@@ -29,6 +29,15 @@ public class PatternRideC2Test {
       )
     );
 
+    // Left sort index higher than right: should NOT dominate (tripSortIndex is not a dominance
+    // criterion in this direction — different trips are incomparable, only lower index dominates)
+    assertFalse(
+      comparator.leftDominanceExist(
+        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null),
+        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+      )
+    );
+
     assertTrue(
       comparator.leftDominanceExist(
         new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),


### PR DESCRIPTION
### Summary

The on-board pareto comparator in multi-criteria Raptor used `!=` to compare `tripSortIndex`
across trips, making the criterion symmetric and therefore preventing any trip from ever
dominating another. This kept all trips alive in the on-board optimal set regardless of cost,
allowing sub-optimal rides to survive and reach the path mapper. The path mapper computes costs from the leg perspective (including alight-slack), and when it reconstructs a path from a
sub-optimal stop-arrival the resulting total cost diverges from what Raptor recorded, triggering
the "Cost mismatch" warning in `DestinationArrivalPaths`. Replacing `!=` with `<` establishes a
proper pareto ordering where an earlier-departing trip dominates a later one when its cost is
equal or better, pruning the on-board set more aggressively and eliminating most of the spurious
mismatches.

### Issue

Part of #3623

The `TODO - Bug: Cost mismatch stop-arrivals and paths #3623` comment in
`DestinationArrivalPaths` tracks this class of warning. This change fixes most of the reported
log events by removing the root cause: non-optimal rides that should have been pruned during the
on-board pareto comparison but were kept because the `!=` comparator was inadvertently symmetric.

### Raptor — on-board pareto comparator

- Replace `l.tripSortIndex != r.tripSortIndex` with `l.tripSortIndex < r.tripSortIndex` in
  `PatternRideC1.paretoComparatorRelativeCost()` and `PatternRideC2.paretoComparatorRelativeCost()`.
- With `<` only the earlier-departing trip can dominate; a later trip is pruned when an earlier
  one with equal or better `relativeC1` (and `c2` for C2) exists.
- For circular patterns with a "tail" (stops that only appear after the loop completes), passengers
  heading to a tail stop should board on the second pass, skipping the full circle. An
  earlier-departing trip's second pass reaches the tail no later than a later trip's first pass, so
  the dominance remains correct for this edge case.

### Documentation

- Consolidated the pareto comparison rationale (including the circular-route / tail reasoning) into
  the `PatternRide` interface JavaDoc, replacing the outdated "We do NOT allow one trip to exclude  another" paragraph.
- `paretoComparatorRelativeCost()` in both `PatternRideC1` and `PatternRideC2` now simply reference `PatternRide` rather than repeating the detail.

### Testing

#### Unit Tests

- ✅ Tests added/updated

#### Manual Testing

Verified against the Entur Oslo dataset (Metro lines 4 and 5, bus lines 62–69) that the
"Cost mismatch" log events described in #3623 are no longer produced for the reported search
(Lille Tøyen → Tosenhagen, line 5, 23:06 28.09.2021).

#### Performance Impact

The SpeedTest was run on the entire Norway data set with cases from performance test. 

*Before*
```
METHOD CALLS DURATION                         |                                    
                                              |  Min   Avg  Max     Count   Total  
Raptor Mc-DP Minute Transfers                 |    0     0    9 ms    11'    0,2 s 
Raptor Mc-DP Minute Transit                   |    0     0  103 ms    11'    3,4 s 
Raptor Mc-DP Route                            |    2   199 2242 ms     31    6,2 s 
Raptor MinTravelDuration-Rev Minute Transfers |    0     3   10 ms    204    0,6 s 
Raptor MinTravelDuration-Rev Minute Transit   |    0    12   41 ms    204    2,4 s 
Raptor MinTravelDuration-Rev Route            |    3    99  217 ms     31    3,1 s 
Routing Raptor                                |    9   301 2394 ms     31    9,4 s 
Routing Total                                 |   25   417 2493 ms     31   12,9 s 

Test case ids       : [1   | 2   | 3   | 4   | 5   | 7   | 9   | 10  | 11  | 12  | 14  | 15  | 16  | 17 | 18  | 19  | 20  | 21  | 22  | 23   | 24  | 25   | 27  | 28  | 29  | 30  | 31  | 33  | 36   | 40  | 41]
Number of paths     : [3   | 1   | 18  | 2   | 1   | 9   | 7   | 7   | 6   | 3   | 6   | 4   | 4   | 4  | 2   | 1   | 14  | 1   | 3   | 13   | 2   | 2    | 2   | 29  | 1   | 12  | 7   | 5   | 7    | 25  | 7 ]
Transit times(ms)   : [217 | 202 | 295 | 230 | 101 | 392 | 163 | 468 | 201 | 113 | 321 | 193 | 130 | 86 | 332 | 207 | 125 | 155 | 309 | 2489 | 289 | 1158 | 437 | 321 | 145 | 316 | 423 | 563 | 1312 | 600 | 22]
Total times(ms)     : [220 | 204 | 395 | 255 | 103 | 602 | 179 | 474 | 211 | 136 | 328 | 221 | 134 | 93 | 334 | 209 | 129 | 157 | 313 | 2493 | 292 | 1166 | 441 | 345 | 147 | 320 | 428 | 572 | 1319 | 683 | 25]
Successful searches : 31 / 31
Sample              : 3 / 3
Time total          : 13 seconds

Worker: 
 ==> multi_criteria_destination : [  311,  303,  301 ] Avg: 305,0  (σ=4,3)

Total:  
 ==> multi_criteria_destination : [  445,  420,  417 ] Avg: 427,3  (σ=12,6)

```

*After*
```
METHOD CALLS DURATION                         |                                    
                                              |  Min   Avg  Max     Count   Total  
Raptor Mc-DP Minute Transfers                 |    0     0    6 ms    11'    0,3 s 
Raptor Mc-DP Minute Transit                   |    0     0   85 ms    11'    3,0 s 
Raptor Mc-DP Route                            |    1   179 1970 ms     31    5,6 s 
Raptor MinTravelDuration-Rev Minute Transfers |    0     2    9 ms    204    0,6 s 
Raptor MinTravelDuration-Rev Minute Transit   |    0    11   40 ms    204    2,3 s 
Raptor MinTravelDuration-Rev Route            |    3    94  214 ms     31    2,9 s 
Routing Raptor                                |    8   276 2119 ms     31    8,6 s 
Routing Total                                 |   25   384 2215 ms     31   11,9 s 

Test case ids       : [1   | 2   | 3   | 4   | 5  | 7   | 9   | 10  | 11  | 12  | 14  | 15  | 16  | 17 | 18  | 19  | 20  | 21  | 22  | 23   | 24  | 25   | 27  | 28  | 29  | 30  | 31  | 33  | 36   | 40  | 41]
Number of paths     : [3   | 1   | 18  | 2   | 1  | 9   | 7   | 7   | 6   | 3   | 6   | 4   | 4   | 4  | 2   | 1   | 14  | 1   | 3   | 13   | 2   | 2    | 2   | 29  | 1   | 12  | 7   | 5   | 7    | 25  | 7 ]
Transit times(ms)   : [209 | 197 | 271 | 210 | 93 | 336 | 148 | 432 | 180 | 104 | 302 | 197 | 113 | 84 | 314 | 192 | 117 | 150 | 300 | 2212 | 271 | 1107 | 388 | 298 | 139 | 307 | 376 | 506 | 1187 | 571 | 21]
Total times(ms)     : [212 | 199 | 368 | 233 | 95 | 530 | 163 | 438 | 189 | 123 | 308 | 224 | 117 | 90 | 316 | 194 | 121 | 152 | 305 | 2215 | 273 | 1116 | 406 | 319 | 141 | 311 | 382 | 515 | 1194 | 653 | 25]
Successful searches : 31 / 31
Sample              : 3 / 3
Time total          : 12 seconds

Worker: 
 ==> multi_criteria_destination : [  291,  274,  276 ] Avg: 280,3  (σ=7,6)

Total:  
 ==> multi_criteria_destination : [  418,  384,  384 ] Avg: 395,3  (σ=16,0)
```

### Documentation checklist

- ✅ Code follows OTP style guidelines (Prettier, JavaDoc)
- ✅ Java Documentation updated — `PatternRide` interface JavaDoc updated with new pareto strategy
  and circular-route rationale; `PatternRideC1`/`PatternRideC2` comparator docs consolidated
- 🟥 All configuration options documented — no configuration changes

### Changelog

- ✅ Should be included — this is a bug fix visible to operators/integrators as a reduction in
  "Cost mismatch" WARN log noise, and may affect which itineraries are returned for patterns where previously sub-optimal rides reached the path mapper.

### Bumping the serialization version id

- 🟥 No serialized classes were changed.
