### PR TITLE
Change renovate to rebase only when there are conflicts

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,7 +7,7 @@
   "labels": [
     "+Skip Changelog"
   ],
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "enabledManagers": [
     "npm",
     "maven",


### PR DESCRIPTION
### Summary

Change renovate to rebase only when there are conflicts. We now have a merge queue that should fail if there are issues.

### Issue

No issue

