### PR TITLE
Add `stopsWithRegularTransfers` build config parameter

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.StopNotLinkedForTransfers;
@@ -51,6 +52,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
 
   private final Duration defaultMaxTransferDuration;
 
+  private final Set<FeedScopedId> includeStopsWithRegularTransfers;
   private final List<RouteRequest> transferRequests;
   private final Map<StreetMode, TransferParametersForMode> transferParametersForMode;
   private final Graph graph;
@@ -59,7 +61,8 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   private final DataImportIssueStore issueStore;
 
   /**
-   * Constructor used in tests. This initializes transferParametersForMode as an empty map.
+   * Constructor used in tests. This initializes transferParametersForMode as an empty map and
+   * stopsWithRegularTransfers as an empty set.
    */
   public DirectTransferGenerator(
     Graph graph,
@@ -73,6 +76,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     this.timetableRepository = timetableRepository;
     this.issueStore = issueStore;
     this.defaultMaxTransferDuration = defaultMaxTransferDuration;
+    this.includeStopsWithRegularTransfers = Set.of();
     this.transferRequests = transferRequests;
     this.transferRepository = transferRepository;
     this.transferParametersForMode = Map.of();
@@ -89,6 +93,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     this.timetableRepository = timetableRepository;
     this.issueStore = issueStore;
     this.defaultMaxTransferDuration = parameters.maxDuration();
+    this.includeStopsWithRegularTransfers = Set.copyOf(parameters.includeStops());
     this.transferRequests = parameters.requests();
     this.transferParametersForMode = parameters.parametersForMode();
     this.transferRepository = transferRepository;
@@ -250,7 +255,11 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     }
 
     if (OTPFeature.ConsiderPatternsForDirectTransfers.isOn()) {
-      return new PatternConsideringNearbyStopFinder(transitService, finder);
+      return new PatternConsideringNearbyStopFinder(
+        transitService,
+        finder,
+        includeStopsWithRegularTransfers
+      );
     } else {
       return finder;
     }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/api/RegularTransferParameters.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/api/RegularTransferParameters.java
@@ -5,12 +5,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.street.model.StreetMode;
 
 public final class RegularTransferParameters {
 
   private final Duration maxDuration;
+  private final List<FeedScopedId> includeStops;
   private final Map<StreetMode, TransferParametersForMode> parametersForMode;
   private final List<RouteRequest> requests;
 
@@ -18,16 +20,19 @@ public final class RegularTransferParameters {
 
   private RegularTransferParameters() {
     this.maxDuration = Duration.ofMinutes(30);
+    this.includeStops = List.of();
     this.parametersForMode = Map.of();
     this.requests = List.of();
   }
 
   public RegularTransferParameters(
     Duration maxDuration,
+    List<FeedScopedId> includeStops,
     Map<StreetMode, TransferParametersForMode> parametersForMode,
     List<RouteRequest> requests
   ) {
     this.maxDuration = Objects.requireNonNull(maxDuration);
+    this.includeStops = List.copyOf(includeStops);
     this.parametersForMode = Map.copyOf(parametersForMode);
     this.requests = List.copyOf(requests);
   }
@@ -38,6 +43,10 @@ public final class RegularTransferParameters {
 
   public Duration maxDuration() {
     return maxDuration;
+  }
+
+  public List<FeedScopedId> includeStops() {
+    return includeStops;
   }
 
   public Map<StreetMode, TransferParametersForMode> parametersForMode() {
@@ -51,17 +60,24 @@ public final class RegularTransferParameters {
   public static class Builder {
 
     private Duration maxDuration;
+    private List<FeedScopedId> includeStops;
     private Map<StreetMode, TransferParametersForMode> parametersForMode = new HashMap<>();
     private List<RouteRequest> requests;
 
     private Builder(RegularTransferParameters original) {
       this.maxDuration = original.maxDuration;
+      this.includeStops = original.includeStops;
       this.parametersForMode.putAll(original.parametersForMode);
       this.requests = original.requests;
     }
 
     public Builder withMaxDuration(Duration maxDuration) {
       this.maxDuration = maxDuration;
+      return this;
+    }
+
+    public Builder withIncludeStops(List<FeedScopedId> includeStops) {
+      this.includeStops = includeStops;
       return this;
     }
 
@@ -84,7 +100,7 @@ public final class RegularTransferParameters {
     }
 
     public RegularTransferParameters build() {
-      return new RegularTransferParameters(maxDuration, parametersForMode, requests);
+      return new RegularTransferParameters(maxDuration, includeStops, parametersForMode, requests);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/PatternConsideringNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/PatternConsideringNearbyStopFinder.java
@@ -2,7 +2,9 @@ package org.opentripplanner.place.nearbystopfinder;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.place.NearbyStopFinder;
 import org.opentripplanner.place.api.NearbyStop;
@@ -37,10 +39,13 @@ public class PatternConsideringNearbyStopFinder implements NearbyStopFinder {
 
   public PatternConsideringNearbyStopFinder(
     TransitService transitService,
-    NearbyStopFinder delegateNearbyStopFinder
+    NearbyStopFinder delegateNearbyStopFinder,
+    Set<FeedScopedId> stopsWithRegularTransfers
   ) {
     this.transitService = transitService;
-    var builder = CompositeNearbyStopFilter.of().add(new PatternNearbyStopFilter(transitService));
+    var builder = CompositeNearbyStopFilter.of().add(
+      new PatternNearbyStopFilter(transitService, stopsWithRegularTransfers)
+    );
 
     if (OTPFeature.FlexRouting.isOn()) {
       builder.add(new FlexTripNearbyStopFilter(transitService));

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/PatternNearbyStopFilter.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/PatternNearbyStopFilter.java
@@ -21,14 +21,20 @@ import org.opentripplanner.utils.collection.MinMap;
  * or alighting is possible (depending on direction).
  * <p>
  * Stops without patterns may still be included if they are marked as sometimes-used by real-time
- * updates (when the IncludeStopsUsedRealTimeInTransfers feature is enabled).
+ * updates (when the IncludeStopsUsedRealTimeInTransfers feature is enabled), or if they are
+ * explicitly listed in the {@code stopsWithRegularTransfers} build configuration.
  */
 class PatternNearbyStopFilter implements NearbyStopFilter {
 
   private final TransitService transitService;
+  private final Set<FeedScopedId> stopsWithRegularTransfers;
 
-  PatternNearbyStopFilter(TransitService transitService) {
+  PatternNearbyStopFilter(
+    TransitService transitService,
+    Set<FeedScopedId> stopsWithRegularTransfers
+  ) {
     this.transitService = transitService;
+    this.stopsWithRegularTransfers = stopsWithRegularTransfers;
   }
 
   @Override
@@ -83,6 +89,15 @@ class PatternNearbyStopFilter implements NearbyStopFilter {
   }
 
   private boolean includeStopUsedRealtime(RegularStop stop) {
-    return OTPFeature.IncludeStopsUsedRealTimeInTransfers.isOn() && stop.isSometimesUsedRealtime();
+    // Some stops, like railway and bus-replacement stops, are tagged during graph building/data
+    // import. These should allways be included.
+    if (OTPFeature.IncludeStopsUsedRealTimeInTransfers.isOn() && stop.isSometimesUsedRealtime()) {
+      return true;
+    }
+    // Some stops is listed in the build-config, these are regular stops to include.
+    if (stopsWithRegularTransfers.contains(stop.getId())) {
+      return true;
+    }
+    return false;
   }
 }

--- a/application/src/main/java/org/opentripplanner/standalone/config/buildconfig/RegularTransferConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/buildconfig/RegularTransferConfig.java
@@ -30,6 +30,32 @@ public class RegularTransferConfig {
         .asDuration(dft.maxDuration())
     );
 
+    builder.withIncludeStops(
+      root
+        .of("stopsWithRegularTransfers")
+        .since(V2_9)
+        .summary(
+          "Stops that should always have regular transfers computed, even without scheduled trips."
+        )
+        .description(
+          """
+          List of stop IDs for which regular transfers are always pre-computed during graph build,
+          even if the stop has no scheduled trips. Remember to include _feedId_ like this
+          `"RB:NSR:Quay:102541"`.
+
+          This is useful for stops that are unused in static transit data, but may be visited by
+          real-time updates (e.g. a platform that a train can be re-routed to at runtime). Without
+          this configuration, stops with no scheduled trips are excluded from transfer pre-computation
+          and become unreachable islands when a real-time update routes a trip to them.
+
+          Note! This parameter should be replaced with an automatic update to regular transfers
+          based on real-time updates.
+          """
+        )
+        .experimentalFeature()
+        .asFeedScopedIds(List.of())
+    );
+
     builder.withParametersForMode(
       root
         .of("transferParametersForMode")

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -94,6 +94,7 @@ Sections follow that describe particular settings in more depth.
 |    includeOsmStationEntrances                                                               |       `boolean`      | Whether to include station entrances from the OSM data.                                                                                                        | *Optional* | `false`                           |  2.10 |
 |    [osmTagMapping](#od_osmTagMapping)                                                       |        `enum`        | The named set of mapping rules applied when parsing OSM tags.                                                                                                  | *Optional* | `"default"`                       |  2.2  |
 |    timeZone                                                                                 |      `time-zone`     | The timezone used to resolve opening hours in OSM data.                                                                                                        | *Optional* |                                   |  2.2  |
+| [stopsWithRegularTransfers](#stopsWithRegularTransfers)                                     |  `feed-scoped-id[]`  | Stops that should always have regular transfers computed, even without scheduled trips.                                                                        | *Optional* |                                   |  2.9  |
 | [transferParametersForMode](#transferParametersForMode)                                     | `enum map of object` | Configures mode-specific properties for transfer calculations.                                                                                                 | *Optional* |                                   |  2.7  |
 |    BIKE                                                                                     |       `object`       | NA                                                                                                                                                             | *Optional* |                                   |  2.7  |
 |       [bikesAllowedStopMaxTransferDuration](#tpfm_BIKE_bikesAllowedStopMaxTransferDuration) |      `duration`      | This is used for specifying a `maxTransferDuration` value to use with transfers between stops which are visited by trips that allow bikes.                     | *Optional* |                                   |  2.9  |
@@ -967,6 +968,28 @@ The named set of mapping rules applied when parsing OSM tags. Overrides the valu
 **Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `hamburg` | `atlanta` | `houston` | `portland` | `constant-speed-finland`
 
 The named set of mapping rules applied when parsing OSM tags.
+
+<h3 id="stopsWithRegularTransfers">stopsWithRegularTransfers</h3>
+
+**Since version:** `2.9` ∙ **Type:** `feed-scoped-id[]` ∙ **Cardinality:** `Optional`   
+**Path:** / 
+
+Stops that should always have regular transfers computed, even without scheduled trips.
+
+List of stop IDs for which regular transfers are always pre-computed during graph build,
+even if the stop has no scheduled trips. Remember to include _feedId_ like this
+`"RB:NSR:Quay:102541"`.
+
+This is useful for stops that are unused in static transit data, but may be visited by
+real-time updates (e.g. a platform that a train can be re-routed to at runtime). Without
+this configuration, stops with no scheduled trips are excluded from transfer pre-computation
+and become unreachable islands when a real-time update routes a trip to them.
+
+Note! This parameter should be replaced with an automatic update to regular transfers
+based on real-time updates.
+
+
+**THIS IS STILL AN EXPERIMENTAL FEATURE - IT MAY CHANGE WITHOUT ANY NOTICE!**
 
 <h3 id="transferParametersForMode">transferParametersForMode</h3>
 


### PR DESCRIPTION
> **Note:** This PR builds on top of #7425 and should be merged after that PR.

> **Note:** I do not intend to merge this, unless this feature is requested from someone else, we
> will merge this into Enturs CI/DI pipeline. We need this until there is a better fix for this. We intend 
> to work on that soon.

### Summary

Introduces a new (experimental) build configuration parameter `stopsWithRegularTransfers` that
allows operators to explicitly list stop IDs for which regular transfers are always pre-computed
during graph build, even if those stops have no scheduled trips in the static data.

This is a targeted workaround for stops that are unused in static GTFS/NeTEx data but may be
visited at runtime via real-time updates (e.g. a platform a train can be re-routed to). Without
this, such stops are excluded from transfer pre-computation and become unreachable islands when a
real-time update routes a trip to them. The parameter is marked **experimental** and is intended
as a temporary measure until automatic transfer updates driven by real-time data are implemented.

### Configuration

**`build-config.json`**
```json
{
  "stopsWithRegularTransfers": ["RB:NSR:Quay:102541", "RB:NSR:Quay:209876"]
}
```

### Documentation

- `doc/user/BuildConfiguration.md` updated with the new parameter entry, description, and
  experimental warning.

### Breaking Changes

None. The new parameter is optional with an empty-list default; existing behaviour is unchanged.

### Testing

#### Unit Tests

- Additional unit tests for the new `stopsWithRegularTransfers` path not yet added — marked experimental.
- The `PatternNearbyStopFilter` logic change (removing the feature-flag guard on
  `isSometimesUsedRealtime`) is covered by the existing filter tests.


#### Manual Testing

The feature has been tested manually and works. 

### Documentation

- ✅ Code follows OTP style guidelines (Prettier, JavaDoc)
- ✅ Java Documentation updated for new public fields and methods
- ✅ Configuration option documented in `BuildConfiguration.md`

### Changelog

- ✅ Relevant to operators using real-time trip re-routing to platforms not in static data.
  Should be included in the changelog as an experimental build-config addition.

### Bumping the serialization version id

- ✅ The build configuration is changed, so bumping the serialization version is required. 

**Note** The `+Bump Serialization Id` label should be set if this is merged, but due to some limitation in our CI/DI pipeline I will wait with this until we have decided to merge this - hopefully we are not merging this.
