### PR TITLE
To conserve memory, garbage-collect graph build modules as soon as they are finished

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -7,9 +7,9 @@ import static org.opentripplanner.datastore.api.FileType.OSM;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedList;
 import java.util.Objects;
+import java.util.Queue;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
 import org.opentripplanner.ext.emission.EmissionRepository;
@@ -45,7 +45,7 @@ public class GraphBuilder implements Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(GraphBuilder.class);
 
-  private final List<GraphBuilderModule> graphBuilderModules = new ArrayList<>();
+  private final Queue<GraphBuilderModule> graphBuilderModules = new LinkedList<>();
   private final Graph graph;
   private final TimetableRepository timetableRepository;
   private final DataImportIssueStore issueStore;
@@ -215,8 +215,11 @@ public class GraphBuilder implements Runnable {
         builder.checkInputs();
       }
 
-      for (GraphBuilderModule load : graphBuilderModules) {
-        load.buildGraph();
+      // because we want to garbage-collect the modules as soon as they are finished
+      // we remove them from the queue during the build process
+      while (!graphBuilderModules.isEmpty()) {
+        var builder = graphBuilderModules.poll();
+        builder.buildGraph();
       }
 
       new DataImportIssueSummary(issueStore.listIssues()).logSummary();


### PR DESCRIPTION
### Summary

NeTEx bundles, which is data source and some very large indices of entities stay on the heap until the very end of the build process, consuming a large amount of memory.

This is actually not necessary since they are no longer useful (or used) after the NeTEx import is complete.

For this reason I'm changing the iteration logic in `NetexModule` as follows:

- rather than a list, store the bundle in a `Queue`
- get elements off the queue
- after each bundle has been imported it is ready for garbage collection

### Effect

I ran the code on the Norwegian data set and the result is very visible in the memory graph:

#### Before

<img width="1220" height="1067" alt="Screenshot From 2026-03-19 12-35-49" src="https://github.com/user-attachments/assets/3c0222cd-b249-4cb5-92d5-f77923d2d597" />

#### After

<img width="1220" height="1067" alt="Screenshot From 2026-03-19 12-48-45" src="https://github.com/user-attachments/assets/13617b49-6001-417e-aefb-0e84f100afcc" />

### Issue

https://github.com/noi-techpark/opendatahub-mentor-otp/issues/273

### Unit tests

N/A

@rcavaliere