### PR TITLE
Extract to and from from the StreetSearchRequestBuilder

### DIFF
--- a/application/src/main/java/org/opentripplanner/streetadapter/StreetSearchRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/streetadapter/StreetSearchRequestMapper.java
@@ -3,7 +3,7 @@ package org.opentripplanner.streetadapter;
 import java.time.Instant;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.AccessibilityPreferences;
@@ -19,6 +19,7 @@ import org.opentripplanner.routing.api.request.preference.WalkPreferences;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
 import org.opentripplanner.routing.api.request.preference.filter.VehicleParkingFilter;
 import org.opentripplanner.routing.api.request.preference.filter.VehicleParkingSelect;
+import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.search.intersection_model.IntersectionTraversalCalculator;
 import org.opentripplanner.street.search.request.AccessibilityRequest;
 import org.opentripplanner.street.search.request.BikeRequest;
@@ -41,6 +42,9 @@ import org.opentripplanner.street.search.request.filter.ParkingSelect.TagsSelect
 
 public class StreetSearchRequestMapper {
 
+  /// How close to do you have to be to the start or end to be considered "close".
+  private static final int MAX_CLOSENESS_METERS = 500;
+
   /// Maps a [RouteRequest] to a [StreetSearchRequestBuilder] transferring all parameters
   /// relevant for street routing.
   public static StreetSearchRequestBuilder map(RouteRequest request) {
@@ -50,8 +54,8 @@ public class StreetSearchRequestMapper {
     var streetSearchRequestBuilder = StreetSearchRequest.of()
       .withStartTime(time)
       .withArriveBy(request.arriveBy())
-      .withFrom(mapGenericLocation(request.from()))
-      .withTo(mapGenericLocation(request.to()))
+      .withFromEnvelope(createEnvelope(request.from()))
+      .withToEnvelope(createEnvelope(request.to()))
       .withWheelchairEnabled(request.journey().wheelchair())
       .withGeoidElevation(preferences.system().geoidElevation())
       .withTurnReluctance(street.turnReluctance())
@@ -88,8 +92,8 @@ public class StreetSearchRequestMapper {
   ///
   public static StreetSearchRequestBuilder mapToTransferRequest(RouteRequest request) {
     return map(request)
-      .withFrom(null)
-      .withTo(null)
+      .withFromEnvelope(null)
+      .withToEnvelope(null)
       // transfer requests are always depart-at
       .withArriveBy(false)
       .withStartTime(Instant.ofEpochSecond(0))
@@ -97,15 +101,6 @@ public class StreetSearchRequestMapper {
   }
 
   // private methods
-
-  @Nullable
-  private static Coordinate mapGenericLocation(@Nullable GenericLocation location) {
-    if (location != null) {
-      return location.getCoordinate();
-    } else {
-      return null;
-    }
-  }
 
   private static void mapWheelchair(WheelchairRequest.Builder b, WheelchairPreferences wheelchair) {
     b
@@ -241,5 +236,24 @@ public class StreetSearchRequestMapper {
       .withHopTime(elevator.hopTime())
       .withReluctance(elevator.reluctance())
       .build();
+  }
+
+  @Nullable
+  private static Envelope createEnvelope(@Nullable GenericLocation location) {
+    if (location == null) {
+      return null;
+    }
+    var coordinate = location.getCoordinate();
+    if (coordinate == null) {
+      return null;
+    }
+
+    double lat = SphericalDistanceLibrary.metersToDegrees(MAX_CLOSENESS_METERS);
+    double lon = SphericalDistanceLibrary.metersToLonDegrees(MAX_CLOSENESS_METERS, coordinate.y);
+
+    Envelope env = new Envelope(coordinate);
+    env.expandBy(lon, lat);
+
+    return env;
   }
 }

--- a/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequest.java
+++ b/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequest.java
@@ -26,14 +26,6 @@ public class StreetSearchRequest implements AStarRequest {
 
   public static final StreetSearchRequest DEFAULT = new StreetSearchRequest();
 
-  /**
-   * How close to do you have to be to the start or end to be considered "close".
-   *
-   * @see StreetSearchRequest#isCloseToStartOrEnd(Vertex)
-   * @see DominanceFunctions#betterOrEqualAndComparable(State, State)
-   */
-  public static final int MAX_CLOSENESS_METERS = 500;
-
   // the time at which the search started
   private final Instant startTime;
   private final StreetMode mode;
@@ -139,10 +131,20 @@ public class StreetSearchRequest implements AStarRequest {
     return mode;
   }
 
+  /**
+   * This is used to determine whether vertices are close to the beginning or end of the search.
+   *
+   * @see StreetSearchRequest#isCloseToStartOrEnd
+   */
   public Envelope fromEnvelope() {
     return fromEnvelope;
   }
 
+  /**
+   * This is used to determine whether vertices are close to the beginning or end of the search.
+   *
+   * @see StreetSearchRequest#isCloseToStartOrEnd
+   */
   public Envelope toEnvelope() {
     return toEnvelope;
   }
@@ -187,7 +189,6 @@ public class StreetSearchRequest implements AStarRequest {
    * <p>
    * If you encounter a case of this, you can adjust this code to take this into account.
    *
-   * @see StreetSearchRequest#MAX_CLOSENESS_METERS
    * @see DominanceFunctions#betterOrEqualAndComparable(State, State)
    */
   public boolean isCloseToStartOrEnd(Vertex vertex) {

--- a/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequestBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequestBuilder.java
@@ -1,15 +1,11 @@
 package org.opentripplanner.street.search.request;
 
-import static org.opentripplanner.street.search.request.StreetSearchRequest.MAX_CLOSENESS_METERS;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
-import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.ExtensionRequestContext;
 import org.opentripplanner.street.search.intersection_model.IntersectionTraversalCalculator;
@@ -84,13 +80,13 @@ public class StreetSearchRequestBuilder {
     return this;
   }
 
-  public StreetSearchRequestBuilder withFrom(@Nullable Coordinate from) {
-    this.fromEnvelope = createEnvelope(from);
+  public StreetSearchRequestBuilder withFromEnvelope(@Nullable Envelope fromEnvelope) {
+    this.fromEnvelope = fromEnvelope;
     return this;
   }
 
-  public StreetSearchRequestBuilder withTo(@Nullable Coordinate to) {
-    this.toEnvelope = createEnvelope(to);
+  public StreetSearchRequestBuilder withToEnvelope(@Nullable Envelope toEnvelope) {
+    this.toEnvelope = toEnvelope;
     return this;
   }
 
@@ -168,18 +164,4 @@ public class StreetSearchRequestBuilder {
     return new StreetSearchRequest(this);
   }
 
-  @Nullable
-  private static Envelope createEnvelope(@Nullable Coordinate coordinate) {
-    if (coordinate == null) {
-      return null;
-    }
-
-    double lat = SphericalDistanceLibrary.metersToDegrees(MAX_CLOSENESS_METERS);
-    double lon = SphericalDistanceLibrary.metersToLonDegrees(MAX_CLOSENESS_METERS, coordinate.y);
-
-    Envelope env = new Envelope(coordinate);
-    env.expandBy(lon, lat);
-
-    return env;
-  }
 }


### PR DESCRIPTION
### Summary

The `StreetSearchRequestBuilder` has `withFrom()` and `withTo()` methods. But these are confusingly not actually used to set the origin and destination of the search. This PR tries to make this a little bit less confusing by changing the methods to `withFromEnvelope()` and `withToEnvelope()`.

### Unit tests

None needed

### Documentation

I added a little bit of docs.

### Changelog

Skip

### Bumping the serialization version id

No
