### PR TITLE
Add `maxFlexStopCount` to the router config

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/template/FlexTemplateFactoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/template/FlexTemplateFactoryTest.java
@@ -51,7 +51,8 @@ class FlexTemplateFactoryTest {
    */
   private static final FlexPathCalculator CALCULATOR = new StreetFlexPathCalculator(
     false,
-    Duration.ofHours(3)
+    Duration.ofHours(3),
+    100
   );
 
   public static final int SERVICE_TIME_OFFSET = 3600 * 2;

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexParameters.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.flex;
 
 import java.time.Duration;
+import org.opentripplanner.routing.api.request.preference.MaxStopCountLimit;
 
 /**
  * Define parameters used to configure flex. For further documentation on these parameters, look
@@ -26,6 +27,10 @@ public interface FlexParameters {
    * See {@link org.opentripplanner.standalone.config.sandbox.FlexConfig}
    */
   Duration maxEgressWalkDuration();
+  /**
+   * See {@link org.opentripplanner.standalone.config.sandbox.FlexConfig}
+   */
+  MaxStopCountLimit maxFlexStopCountLimit();
 
   /**
    * This defines the default values. This will be used by the OTP configuration and by tests,
@@ -51,6 +56,11 @@ public interface FlexParameters {
       @Override
       public Duration maxEgressWalkDuration() {
         return Duration.ofMinutes(45);
+      }
+
+      @Override
+      public MaxStopCountLimit maxFlexStopCountLimit() {
+        return MaxStopCountLimit.of().withDefaultLimit(200).build();
       }
     };
   }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -100,11 +100,13 @@ public class FlexRouter {
     if (graph.hasStreets) {
       this.accessFlexPathCalculator = new StreetFlexPathCalculator(
         false,
-        flexParameters.maxFlexTripDuration()
+        flexParameters.maxFlexTripDuration(),
+        flexParameters.maxFlexStopCountLimit().defaultLimit()
       );
       this.egressFlexPathCalculator = new StreetFlexPathCalculator(
         true,
-        flexParameters.maxFlexTripDuration()
+        flexParameters.maxFlexTripDuration(),
+        flexParameters.maxFlexStopCountLimit().defaultLimit()
       );
     } else {
       // this is only really useful in tests. in real world scenarios you're unlikely to get useful

--- a/application/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
@@ -6,10 +6,12 @@ import java.util.Map;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
+import org.opentripplanner.astar.strategy.MaxCountTerminationStrategy;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.StreetSearchBuilder;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
@@ -35,10 +37,16 @@ public class StreetFlexPathCalculator implements FlexPathCalculator {
   private final Map<Vertex, ShortestPathTree<State, Edge, Vertex>> cache = new HashMap<>();
   private final boolean reverseDirection;
   private final Duration maxFlexTripDuration;
+  private final int maxStopCount;
 
-  public StreetFlexPathCalculator(boolean reverseDirection, Duration maxFlexTripDuration) {
+  public StreetFlexPathCalculator(
+    boolean reverseDirection,
+    Duration maxFlexTripDuration,
+    int maxStopCount
+  ) {
     this.reverseDirection = reverseDirection;
     this.maxFlexTripDuration = maxFlexTripDuration;
+    this.maxStopCount = maxStopCount;
   }
 
   @Override
@@ -84,13 +92,22 @@ public class StreetFlexPathCalculator implements FlexPathCalculator {
       .withArriveBy(reverseDirection)
       .build();
 
-    return StreetSearchBuilder.of()
+    var streetSearch = StreetSearchBuilder.of()
       .withPreStartHook(OTPRequestTimeoutException::checkForTimeout)
       .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(maxFlexTripDuration))
       .withDominanceFunction(new DominanceFunctions.EarliestArrival())
       .withRequest(streetRequest)
       .withFrom(reverseDirection ? null : vertex)
-      .withTo(reverseDirection ? vertex : null)
-      .getShortestPathTree();
+      .withTo(reverseDirection ? vertex : null);
+
+    if (maxStopCount > 0) {
+      streetSearch.withTerminationStrategy(
+        new MaxCountTerminationStrategy<>(maxStopCount, state ->
+          state.getVertex() instanceof TransitStopVertex
+        )
+      );
+    }
+
+    return streetSearch.getShortestPathTree();
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -320,7 +320,6 @@ public class TransitRouter {
         accessEgressRouter,
         serverContext,
         additionalSearchDays,
-        serverContext.flexParameters(),
         serverContext.listExtensionRequestContexts(accessRequest),
         type,
         linkingContext

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
 import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.ext.flex.FlexAccessEgress;
-import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexRouter;
 import org.opentripplanner.ext.flex.filter.FilterMapper;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
@@ -14,7 +13,6 @@ import org.opentripplanner.routing.linking.LinkingContext;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.ExtensionRequestContext;
-import org.opentripplanner.transit.service.TransitService;
 
 public class FlexAccessEgressRouter {
 
@@ -25,14 +23,11 @@ public class FlexAccessEgressRouter {
     AccessEgressRouter accessEgressRouter,
     OtpServerRequestContext serverContext,
     AdditionalSearchDays searchDays,
-    FlexParameters config,
     Collection<ExtensionRequestContext> extensionRequestContexts,
     AccessEgressType accessOrEgress,
     LinkingContext linkingContext
   ) {
     OTPRequestTimeoutException.checkForTimeout();
-
-    TransitService transitService = serverContext.transitService();
 
     Collection<NearbyStop> accessStops = accessOrEgress.isAccess()
       ? accessEgressRouter.findAccessEgresses(
@@ -60,10 +55,10 @@ public class FlexAccessEgressRouter {
 
     FlexRouter flexRouter = new FlexRouter(
       serverContext.graph(),
-      transitService,
+      serverContext.transitService(),
       serverContext.transferService(),
       serverContext.streetDetailsService(),
-      config,
+      serverContext.flexParameters(),
       FilterMapper.map(request.journey().transit().filters()),
       request.dateTime(),
       request.bookingTime(),

--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
@@ -14,7 +14,8 @@ public enum OtpVersion {
   V2_6("2.6"),
   V2_7("2.7"),
   V2_8("2.8"),
-  V2_9("2.9");
+  V2_9("2.9"),
+  V2_10("2.10");
 
   private final String text;
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
@@ -1,10 +1,12 @@
 package org.opentripplanner.standalone.config.sandbox;
 
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_10;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_3;
 
 import java.time.Duration;
 import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.routing.api.request.preference.MaxStopCountLimit;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 public class FlexConfig implements FlexParameters {
@@ -25,12 +27,14 @@ public class FlexConfig implements FlexParameters {
   private final Duration maxFlexTripDuration;
   private final Duration maxAccessWalkDuration;
   private final Duration maxEgressWalkDuration;
+  private final MaxStopCountLimit maxFlexStopCountLimit;
 
   private FlexConfig() {
-    maxTransferDuration = Duration.ofMinutes(5);
-    maxFlexTripDuration = Duration.ofMinutes(45);
-    maxAccessWalkDuration = Duration.ofMinutes(45);
-    maxEgressWalkDuration = Duration.ofMinutes(45);
+    maxTransferDuration = DEFAULT.maxTransferDuration();
+    maxFlexTripDuration = DEFAULT.maxFlexTripDuration();
+    maxAccessWalkDuration = DEFAULT.maxAccessWalkDuration();
+    maxEgressWalkDuration = DEFAULT.maxEgressWalkDuration();
+    maxFlexStopCountLimit = DEFAULT.maxFlexStopCountLimit();
   }
 
   public FlexConfig(NodeAdapter root, String parameterName) {
@@ -40,7 +44,7 @@ public class FlexConfig implements FlexParameters {
       .summary("Configuration for flex routing.")
       .asObject();
 
-    this.maxTransferDuration = json
+    maxTransferDuration = json
       .of("maxTransferDuration")
       .since(V2_3)
       .summary(
@@ -87,6 +91,23 @@ public class FlexConfig implements FlexParameters {
       )
       .description(ACCESS_EGRESS_DESCRIPTION)
       .asDuration(DEFAULT.maxEgressWalkDuration());
+
+    maxFlexStopCountLimit = MaxStopCountLimit.of()
+      .withDefaultLimit(
+        json
+          .of("maxFlexStopCount")
+          .since(V2_10)
+          .summary(
+            "Maximal number of stops collected in the part of flex routing that is done by car"
+          )
+          .description(
+            """
+            Safety limit to prevent visiting too many stops.
+            """
+          )
+          .asInt(DEFAULT.maxFlexStopCountLimit().defaultLimit())
+      )
+      .build();
   }
 
   public Duration maxFlexTripDuration() {
@@ -103,5 +124,9 @@ public class FlexConfig implements FlexParameters {
 
   public Duration maxEgressWalkDuration() {
     return maxEgressWalkDuration;
+  }
+
+  public MaxStopCountLimit maxFlexStopCountLimit() {
+    return maxFlexStopCountLimit;
   }
 }

--- a/doc/user/sandbox/Flex.md
+++ b/doc/user/sandbox/Flex.md
@@ -51,6 +51,7 @@ following to `router-config.json`.
 |------------------------------------------------------|:----------:|-------------------------------------------------------------------------------------------------------------------------------|:----------:|---------------|:-----:|
 | [maxAccessWalkDuration](#flex_maxAccessWalkDuration) | `duration` | The maximum duration the passenger will be allowed to walk to reach a flex stop or zone.                                      | *Optional* | `"PT45M"`     |  2.3  |
 | [maxEgressWalkDuration](#flex_maxEgressWalkDuration) | `duration` | The maximum duration the passenger will be allowed to walk after leaving the flex vehicle at the final destination.           | *Optional* | `"PT45M"`     |  2.3  |
+| [maxFlexStopCount](#flex_maxFlexStopCount)           |  `integer` | Maximal number of stops collected in the part of flex routing that is done by car                                             | *Optional* | `200`         |  2.10 |
 | [maxFlexTripDuration](#flex_maxFlexTripDuration)     | `duration` | How long can a non-scheduled flex trip at maximum be.                                                                         | *Optional* | `"PT45M"`     |  2.3  |
 | [maxTransferDuration](#flex_maxTransferDuration)     | `duration` | How long should a passenger be allowed to walk after getting out of a flex vehicle and transferring to a flex or transit one. | *Optional* | `"PT5M"`      |  2.3  |
 
@@ -87,6 +88,16 @@ Depending on your service this might be what you want to do anyway: many flex se
 by passengers with mobility problems so offering a long walk might be problematic. In other words,
 if you can walk 45 minutes to a flex stop/zone you're unlikely to be the target audience for those
 services.
+
+
+<h4 id="flex_maxFlexStopCount">maxFlexStopCount</h4>
+
+**Since version:** `2.10` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `200`   
+**Path:** /flex 
+
+Maximal number of stops collected in the part of flex routing that is done by car
+
+Safety limit to prevent visiting too many stops.
 
 
 <h4 id="flex_maxFlexTripDuration">maxFlexTripDuration</h4>


### PR DESCRIPTION
### Summary

This PR adds a `maxFlexStopCount` router config parameter to enable limiting computation used on flex.

```
Maximal number of stops collected in the part of flex routing that is done by car
```
### Issue

N/A

### Unit tests

Should I add them?

### Documentation

- Added documentation in the router config field
