### PR TITLE
Expose GTFS feed version in the GTFS GraphQL API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
@@ -67,7 +67,7 @@ public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
   }
 
   @Override
-  public DataFetcher<String> feedVersion() {
+  public DataFetcher<String> version() {
     return environment ->
       getTransitService(environment).getFeedInfo(getSource(environment)).getVersion();
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
@@ -67,6 +67,12 @@ public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
   }
 
   @Override
+  public DataFetcher<String> feedVersion() {
+    return environment ->
+      getTransitService(environment).getFeedInfo(getSource(environment)).getVersion();
+  }
+
+  @Override
   public DataFetcher<FeedPublisher> publisher() {
     return environment -> {
       String id = getSource(environment);

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -383,6 +383,8 @@ public class GraphQLDataFetchers {
     public DataFetcher<Iterable<Agency>> agencies();
     public DataFetcher<Iterable<TransitAlert>> alerts();
     public DataFetcher<String> feedId();
+
+    public DataFetcher<String> feedVersion();
     public DataFetcher<FeedPublisher> publisher();
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -384,7 +384,7 @@ public class GraphQLDataFetchers {
     public DataFetcher<Iterable<TransitAlert>> alerts();
     public DataFetcher<String> feedId();
 
-    public DataFetcher<String> feedVersion();
+    public DataFetcher<String> version();
     public DataFetcher<FeedPublisher> publisher();
   }
 

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -653,7 +653,7 @@ type Feed {
   "ID of the feed"
   feedId: String!
   "Version of the Feed"
-  feedVersion: String
+  version: String
   "The publisher of the input transit data."
   publisher: FeedPublisher
 }

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -652,6 +652,8 @@ type Feed {
   ): [Alert]
   "ID of the feed"
   feedId: String!
+  "Version of the Feed"
+  feedVersion: String
   "The publisher of the input transit data."
   publisher: FeedPublisher
 }

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -652,10 +652,10 @@ type Feed {
   ): [Alert]
   "ID of the feed"
   feedId: String!
-  "Version of the Feed"
-  version: String
   "The publisher of the input transit data."
   publisher: FeedPublisher
+  "Version of the Feed"
+  version: String
 }
 
 "Feed publisher information"

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -654,7 +654,7 @@ type Feed {
   feedId: String!
   "The publisher of the input transit data."
   publisher: FeedPublisher
-  "Version of the Feed"
+  "The version of the dataset."
   version: String
 }
 

--- a/application/src/test-fixtures/java/org/opentripplanner/model/FeedInfoTestFactory.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/model/FeedInfoTestFactory.java
@@ -3,6 +3,6 @@ package org.opentripplanner.model;
 public class FeedInfoTestFactory {
 
   public static FeedInfo dummyForTest(String id) {
-    return new FeedInfo(id, "publisher", "www.z.org", "en", null, null, null);
+    return new FeedInfo(id, "publisher", "www.z.org", "en", null, null, "12345");
   }
 }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
@@ -12,7 +12,7 @@
           "name": "publisher",
           "url": "www.z.org"
         },
-        "feedVersion": "12345"
+        "version": "12345"
       }
     ]
   }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/feedinfo.json
@@ -11,7 +11,8 @@
         "publisher": {
           "name": "publisher",
           "url": "www.z.org"
-        }
+        },
+        "feedVersion": "12345"
       }
     ]
   }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
@@ -8,6 +8,6 @@
       name
       url
     }
-    feedVersion
+    version
   }
 }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/feedinfo.graphql
@@ -8,5 +8,6 @@
       name
       url
     }
+    feedVersion
   }
 }


### PR DESCRIPTION
### Summary

Exposes the GTFS Feed Version via the GTFS GraphQl API.
This can be used by clients to determine the Data Version used by a specific OTP instance.
This may be helpful to prevent unnecessary, expensive Data Updates (e.g. list of all routes), when no new feed Version was deployed, between attempted updates.

### Unit tests

- extended FeedInfoTestFactory to include feedversion
- extended feedinfo.json and feedinfo.graphql used by GraphQLIntegrationTest to query for and expect feedversion
- tested manually with local instance

### Documentation

- added short description for the new Field in GraphQl Schema
