### PR TITLE
Prevent long routes mistakenly getting grouped across service-date

### DIFF
--- a/application/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -113,9 +113,9 @@ public interface Leg {
   boolean hasSameMode(Leg other);
 
   /**
-   * Return {@code true} if to legs are the same. The mode must match and the time must overlap.
-   * For transit the trip ID must match and board/alight position must overlap. (Two trips with
-   * different service-date can overlap in time, so we use boarding-/alight-position to verify).
+   * Return {@code true} if two legs are the same. The mode must match and the time must overlap.
+   * For transit the service date, trip ID, and board/alight position must all match. (Two trips
+   * with different service-date can overlap in time, so we use boarding-/alight-position to verify)
    */
   default boolean isPartiallySameLeg(Leg other) {
     if (!hasSameMode(other)) {
@@ -133,20 +133,7 @@ public interface Leg {
     }
     // Transit leg
     else {
-      // If NOT the same trip, return false
-      if (!trip().getId().equals(other.trip().getId())) {
-        return false;
-      }
-
-      // Return true if legs overlap in space(have one common stop visit), this is necessary
-      // since the same trip id on two following service dates may overlap in time. For example,
-      // a trip may run in a loop for 48 hours, overlapping with the same trip id of the trip
-      // scheduled for the next service day. They both visit the same stops, with overlapping
-      // times, but the stop positions will be different.
-      return (
-        boardStopPosInPattern() < other.alightStopPosInPattern() &&
-        alightStopPosInPattern() > other.boardStopPosInPattern()
-      );
+      return isPartiallySameTransitLeg(other);
     }
   }
 

--- a/application/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
@@ -26,6 +26,14 @@ public interface PlanTestConstants {
   int D5_m = DurationUtils.durationInSeconds("5m");
   int D10_m = DurationUtils.durationInSeconds("10m");
   int D12_m = DurationUtils.durationInSeconds("12m");
+  int D1_h = DurationUtils.durationInSeconds("1h");
+  int D2_h = DurationUtils.durationInSeconds("2h");
+  int D3_h = DurationUtils.durationInSeconds("3h");
+  int D4_h = DurationUtils.durationInSeconds("4h");
+  int D5_h = DurationUtils.durationInSeconds("5h");
+  int D10_h = DurationUtils.durationInSeconds("10h");
+  int D12_h = DurationUtils.durationInSeconds("12h");
+  int D24_h = DurationUtils.durationInSeconds("24h");
 
   // Time constants, all values are in seconds
   int T11_00 = time("11:00");

--- a/application/src/test/java/org/opentripplanner/model/plan/leg/LegTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/leg/LegTest.java
@@ -156,6 +156,15 @@ public class LegTest implements PlanTestConstants {
       Leg busOther = leg(b -> b.bus(tripId, startTime, endTime, 1, fromStopIndex, B, dayBefore));
       assertFalse(busLeg.isPartiallySameLeg(busOther));
     }
+
+    // Same trip id but on a different service day
+    {
+      Leg leg1 = leg(b -> b.bus(tripId, startTime, endTime, fromStopIndex, toStopIndex, B, day));
+      Leg leg2 = leg(b ->
+        b.bus(tripId, startTime, endTime, fromStopIndex, toStopIndex, B, day.plusDays(1))
+      );
+      assertFalse(leg1.isPartiallySameLeg(leg2));
+    }
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
@@ -13,6 +13,7 @@ import static org.opentripplanner.routing.api.request.preference.ItineraryFilter
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -262,6 +263,38 @@ class ItineraryListFilterChainTest implements PlanTestConstants {
       .withRemoveTimeshiftedItinerariesWithSameRoutesAndStops(true)
       .build();
     assertEquals(toStr(List.of(i4, i1)), toStr(chain.filter(List.of(i1, i2, i3, i4, i5, i6))));
+  }
+
+  @Test
+  void departuresOnDifferentServiceDatesShouldNotBeGroupedTogether() {
+    final int TRIP_ID = 1;
+    final int D50_h = 50 * D1_h;
+    final int COST = 1000;
+
+    LocalDate date1 = TestItineraryBuilder.SERVICE_DAY;
+    LocalDate date2 = TestItineraryBuilder.SERVICE_DAY.plusDays(1);
+
+    // Same trip ID and stop positions, 50h journey, departing 24h apart on consecutive service
+    // dates. The time windows overlap (50h > 24h gap), but the filter chain should still not
+    // group these and flag any of them for deletion, because the 24h difference means they are
+    // different TripOnServiceDate. This situation commonly arises with multi-day ferry routes,
+    // such as the ones along the Norwegian cost.
+    var day1 = newItinerary(A).bus(TRIP_ID, T11_00, T11_00 + D50_h, B, date1).build(COST);
+    var day2 = newItinerary(A)
+      .bus(TRIP_ID, T11_00 + D24_h, T11_00 + D24_h + D50_h, B, date2)
+      .build(COST);
+
+    var chain = new ItineraryListFilterChainBuilder(STREET_AND_ARRIVAL_TIME)
+      .withMaxNumberOfItineraries(3)
+      .addGroupBySimilarity(
+        GroupBySimilarity.createWithMoreThanOneItineraryPerGroup(0.68, 3, true, 0.0)
+      )
+      .build();
+
+    chain.filter(List.of(day2, day1));
+
+    assertFalse(day1.isFlaggedForDeletion(), "Day-1 departure should not be filtered");
+    assertFalse(day2.isFlaggedForDeletion(), "Day-2 departure should not be filtered");
   }
 
   private ItineraryListFilterChainBuilder createBuilder(


### PR DESCRIPTION
### Summary
Long routes that overlap and have the same trip id would get grouped in our itinerary filters, causing some departures to be filtered out when they shouldn't. This PR addresses this by fixing `isPartiallySameLeg` not accounting for service date on transit legs. `isPartiallySameLeg` now returns false for two legs that have different service date. My fix reuses `isPartiallySameTransitLeg` to check transit legs, where this edge case was already handled.

### Issue
This is essentially a resurfacing (or different instance) of #7249, which we previously closed. A ferry route along the Norwegian coast doesn't show up in the trip response when it should.

A reproduction case is the following query against Norway plan data. This isolates the request to a 12-day coastal ferry route that goes along the Norwegian coast. They have several ferries that go with roughly 2 days in between along the same route, and all these have the same trip id. That means there are stop patterns that are identical except that they are some multiple of 24h apart and (and so have non-identical service dates). These would get flagged and filtered out by the group-by-all-same-stations filter.

The issue is that we were not applying a check for service date, which meant that consecutive dated trips would get grouped and then filtered out in the itinerary filter chain.

See example query below. Note that I have turned on the `debug: listAll` setting, which means we get back the results that would normally be filtered out by the filters. You can see the before/after the fix below. Specifically, the HAV:Line:1 departing on 2026-03-26 did not get returned before this fix.

```graphql
{
  trip(
    from: {place: "NSR:StopPlace:60783"}
    to: {place: "NSR:StopPlace:58047"}
    dateTime: "2026-03-26T01:00:00+01:00"
    numTripPatterns: 3
    searchWindow: 2880
    itineraryFilters:  {
       debug: listAll
    }
    filters: [{select: [{
      transportModes: [{ transportMode: water }]
    }]}]
  ) {
    routingErrors {
      description
    }
    tripPatterns {
      generalizedCost
      systemNotices {
        tag
        text
      }
      legs {
        fromPlace { name }
        toPlace { name }
        aimedStartTime
        aimedEndTime
        line { id }
      }
    }
  }
}
```

**Bad response (pre fix):**
```json
{
  "data": {
    "trip": {
      "routingErrors": [],
      "tripPatterns": [
        {
          "generalizedCost": 191400,
          "systemNotices": [
            {
              "tag": "similar-legs-filter-68p-3x-group-by-all-same-stations",
              "text": "This itinerary is marked as deleted by the similar-legs-filter-68p-3x-group-by-all-same-stations filter."
            }
          ],
          "legs": [
            {
              "fromPlace": {
                "name": "Tromsø kystrutekai"
              },
              "toPlace": {
                "name": "Trondheim kystrutekai"
              },
              "aimedStartTime": "2026-03-26T01:30:00+01:00",
              "aimedEndTime": "2026-03-28T06:30:00+01:00",
              "line": {
                "id": "HAV:Line:1"
              }
            }
          ]
        },
        {
          "generalizedCost": 191400,
          "systemNotices": [],
          "legs": [
            {
              "fromPlace": {
                "name": "Tromsø kystrutekai"
              },
              "toPlace": {
                "name": "Trondheim kystrutekai"
              },
              "aimedStartTime": "2026-03-27T01:30:00+01:00",
              "aimedEndTime": "2026-03-29T07:30:00+02:00",
              "line": {
                "id": "HUR:Line:1"
              }
            }
          ]
        },
        {
          "generalizedCost": 191400,
          "systemNotices": [
            {
              "tag": "outside-search-window",
              "text": "This itinerary is marked as deleted by the outside-search-window filter."
            }
          ],
          "legs": [
            {
              "fromPlace": {
                "name": "Tromsø kystrutekai"
              },
              "toPlace": {
                "name": "Trondheim kystrutekai"
              },
              "aimedStartTime": "2026-03-28T01:30:00+01:00",
              "aimedEndTime": "2026-03-30T07:30:00+02:00",
              "line": {
                "id": "HAV:Line:1"
              }
            }
          ]
        }
      ]
    }
  }
}
```

**Good response (after fix):**
```json
{
  "data": {
    "trip": {
      "routingErrors": [],
      "tripPatterns": [
        {
          "generalizedCost": 191400,
          "systemNotices": [],
          "legs": [
            {
              "fromPlace": {
                "name": "Tromsø kystrutekai"
              },
              "toPlace": {
                "name": "Trondheim kystrutekai"
              },
              "aimedStartTime": "2026-03-26T01:30:00+01:00",
              "aimedEndTime": "2026-03-28T06:30:00+01:00",
              "line": {
                "id": "HAV:Line:1"
              }
            }
          ]
        },
        {
          "generalizedCost": 191400,
          "systemNotices": [],
          "legs": [
            {
              "fromPlace": {
                "name": "Tromsø kystrutekai"
              },
              "toPlace": {
                "name": "Trondheim kystrutekai"
              },
              "aimedStartTime": "2026-03-27T01:30:00+01:00",
              "aimedEndTime": "2026-03-29T07:30:00+02:00",
              "line": {
                "id": "HUR:Line:1"
              }
            }
          ]
        },
        {
          "generalizedCost": 191400,
          "systemNotices": [
            {
              "tag": "outside-search-window",
              "text": "This itinerary is marked as deleted by the outside-search-window filter."
            }
          ],
          "legs": [
            {
              "fromPlace": {
                "name": "Tromsø kystrutekai"
              },
              "toPlace": {
                "name": "Trondheim kystrutekai"
              },
              "aimedStartTime": "2026-03-28T01:30:00+01:00",
              "aimedEndTime": "2026-03-30T07:30:00+02:00",
              "line": {
                "id": "HAV:Line:1"
              }
            }
          ]
        }
      ]
    }
  }
}
```

### Unit tests
* LegTest: Added a test case asserting the check on service date. This corresponds to a similar test case for isPartiallySameTransitLeg
* ItineraryListFilterChainTest: Added a higher-level test case that reproduces a similar case to what's described above

### Documentation
Javadoc for isPartiallySameLeg is updated with the additional condition for transit.


<img width="478" height="621" alt="image" src="https://github.com/user-attachments/assets/7c806940-eefd-4f0f-bb68-199404402026" />
