### PR TITLE
Add Grizzly thread pool queue wait time metric

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilterTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.httpresponsetimemetrics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opentripplanner.ext.httpresponsetimemetrics.HttpResponseTimeMetricsFilter.CLIENT_TAG;
@@ -16,6 +17,7 @@ import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.standalone.server.GrizzlyQueueWaitProbe;
@@ -93,22 +95,35 @@ class HttpResponseTimeMetricsFilterTest {
   }
 
   @Test
-  void recordsQueueWaitTimeWhenPresent() {
+  void totalTimeIncludesQueueWaitWhenPresent() {
     long queueWaitNanos = Duration.ofMillis(50).toNanos();
     recordRequestWithQueueWait("app1", TRANSMODEL_ENDPOINT, queueWaitNanos);
 
-    var queueTimer = findQueueWaitTimer("app1", TRANSMODEL_ENDPOINT);
-    assertNotNull(queueTimer, "Queue wait timer should exist");
-    assertEquals(1, queueTimer.count());
+    var totalTimer = findTotalTimer("app1", TRANSMODEL_ENDPOINT);
+    assertNotNull(totalTimer, "Total timer should exist");
+    assertEquals(1, totalTimer.count());
+
+    var processingTimer = findTimer("app1", TRANSMODEL_ENDPOINT);
+    assertTrue(
+      totalTimer.totalTime(TimeUnit.NANOSECONDS) > processingTimer.totalTime(TimeUnit.NANOSECONDS),
+      "Total time should be greater than processing time when queue wait is present"
+    );
   }
 
   @Test
-  void doesNotRecordQueueWaitTimeWhenAbsent() {
+  void totalTimeEqualsProcessingTimeWhenNoQueueWait() {
     recordRequest("app1", TRANSMODEL_ENDPOINT);
 
-    var queueTimer = findQueueWaitTimer("app1", TRANSMODEL_ENDPOINT);
-    assertNotNull(queueTimer, "Queue wait timer should be pre-created");
-    assertEquals(0, queueTimer.count());
+    var totalTimer = findTotalTimer("app1", TRANSMODEL_ENDPOINT);
+    assertNotNull(totalTimer, "Total timer should be pre-created");
+    assertEquals(1, totalTimer.count());
+
+    var processingTimer = findTimer("app1", TRANSMODEL_ENDPOINT);
+    assertEquals(
+      processingTimer.totalTime(TimeUnit.NANOSECONDS),
+      totalTimer.totalTime(TimeUnit.NANOSECONDS),
+      "Total time should equal processing time when no queue wait"
+    );
   }
 
   @Test
@@ -136,18 +151,18 @@ class HttpResponseTimeMetricsFilterTest {
   }
 
   @Test
-  void queueWaitTimersArePreCreatedAtStartup() {
-    assertNotNull(findQueueWaitTimer("app1", TRANSMODEL_ENDPOINT));
-    assertNotNull(findQueueWaitTimer("other", TRANSMODEL_ENDPOINT));
+  void totalTimersArePreCreatedAtStartup() {
+    assertNotNull(findTotalTimer("app1", TRANSMODEL_ENDPOINT));
+    assertNotNull(findTotalTimer("other", TRANSMODEL_ENDPOINT));
   }
 
   private Timer findTimer(String client, String endpoint) {
     return registry.find(METRIC_NAME).tag(CLIENT_TAG, client).tag(URI_TAG, endpoint).timer();
   }
 
-  private Timer findQueueWaitTimer(String client, String endpoint) {
+  private Timer findTotalTimer(String client, String endpoint) {
     return registry
-      .find(METRIC_NAME + ".queueWait")
+      .find(METRIC_NAME + "_total_time")
       .tag(CLIENT_TAG, client)
       .tag(URI_TAG, endpoint)
       .timer();

--- a/application/src/ext-test/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilterTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.httpresponsetimemetrics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opentripplanner.ext.httpresponsetimemetrics.HttpResponseTimeMetricsFilter.CLIENT_TAG;
@@ -17,6 +18,7 @@ import java.time.Duration;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.standalone.server.GrizzlyQueueWaitProbe;
 
 /**
  * Note: The unit tests relies on mocks to abstract out the micrometer API (request and response objects).
@@ -90,8 +92,65 @@ class HttpResponseTimeMetricsFilterTest {
     assertTimerCount("app1", GTFS_ENDPOINT, 1);
   }
 
+  @Test
+  void recordsQueueWaitTimeWhenPresent() {
+    long queueWaitNanos = Duration.ofMillis(50).toNanos();
+    recordRequestWithQueueWait("app1", TRANSMODEL_ENDPOINT, queueWaitNanos);
+
+    var queueTimer = findQueueWaitTimer("app1", TRANSMODEL_ENDPOINT);
+    assertNotNull(queueTimer, "Queue wait timer should exist");
+    assertEquals(1, queueTimer.count());
+  }
+
+  @Test
+  void doesNotRecordQueueWaitTimeWhenAbsent() {
+    recordRequest("app1", TRANSMODEL_ENDPOINT);
+
+    var queueTimer = findQueueWaitTimer("app1", TRANSMODEL_ENDPOINT);
+    assertNotNull(queueTimer, "Queue wait timer should be pre-created");
+    assertEquals(0, queueTimer.count());
+  }
+
+  @Test
+  void requestToUnmonitoredEndpointConsumesQueueWaitThreadLocal() {
+    // Simulate a queue wait value left by GrizzlyQueueWaitProbe on the current thread
+    var probe = new GrizzlyQueueWaitProbe();
+    Runnable task = () -> {};
+    probe.onTaskQueueEvent(null, task);
+    probe.onTaskDequeueEvent(null, task);
+
+    // Send a request to an unmonitored endpoint — the filter should return early
+    // but still consume the ThreadLocal to prevent it leaking to the next request
+    var requestContext = mock(ContainerRequestContext.class);
+    var uriInfo = mock(UriInfo.class);
+    when(uriInfo.getRequestUri()).thenReturn(URI.create("/unmonitored/path"));
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+    filter.filter(requestContext);
+
+    // The ThreadLocal must be cleared
+    assertNull(
+      GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos(),
+      "Queue wait ThreadLocal should be consumed even for unmonitored endpoints"
+    );
+  }
+
+  @Test
+  void queueWaitTimersArePreCreatedAtStartup() {
+    assertNotNull(findQueueWaitTimer("app1", TRANSMODEL_ENDPOINT));
+    assertNotNull(findQueueWaitTimer("other", TRANSMODEL_ENDPOINT));
+  }
+
   private Timer findTimer(String client, String endpoint) {
     return registry.find(METRIC_NAME).tag(CLIENT_TAG, client).tag(URI_TAG, endpoint).timer();
+  }
+
+  private Timer findQueueWaitTimer(String client, String endpoint) {
+    return registry
+      .find(METRIC_NAME + ".queueWait")
+      .tag(CLIENT_TAG, client)
+      .tag(URI_TAG, endpoint)
+      .timer();
   }
 
   private void assertTimerCount(String client, String endpoint, long expectedCount) {
@@ -104,6 +163,10 @@ class HttpResponseTimeMetricsFilterTest {
   }
 
   private void recordRequest(String clientName, String endpoint) {
+    recordRequestWithQueueWait(clientName, endpoint, null);
+  }
+
+  private void recordRequestWithQueueWait(String clientName, String endpoint, Long queueWaitNanos) {
     var requestContext = mock(ContainerRequestContext.class);
     var responseContext = mock(ContainerResponseContext.class);
     var uriInfo = mock(UriInfo.class);
@@ -115,6 +178,7 @@ class HttpResponseTimeMetricsFilterTest {
 
     when(requestContext.getProperty("metrics.startTime")).thenReturn(System.nanoTime());
     when(requestContext.getProperty("metrics.endpoint")).thenReturn(endpoint);
+    when(requestContext.getProperty("metrics.queueWaitNanos")).thenReturn(queueWaitNanos);
     when(requestContext.getHeaderString(CLIENT_HEADER)).thenReturn(clientName);
 
     filter.filter(requestContext, responseContext);

--- a/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilter.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.opentripplanner.standalone.server.GrizzlyQueueWaitProbe;
 
 /**
  * A Jersey filter that records HTTP request response times with client identification.
@@ -27,6 +28,9 @@ import javax.annotation.Nullable;
  * <p>
  * The metric {@code http.client.requests} is recorded as a Timer with percentile histograms,
  * allowing analysis of response time distribution per client.
+ * <p>
+ * A second set of timers records the time each request spent waiting in the Grizzly thread pool
+ * queue before a worker thread picked it up. This is captured via {@link GrizzlyQueueWaitProbe}.
  * <p>
  * All timers are pre-created at startup for each combination of monitored client and endpoint
  * to ensure predictable metric cardinality.
@@ -39,12 +43,14 @@ public class HttpResponseTimeMetricsFilter
 
   private static final String START_TIME_PROPERTY = "metrics.startTime";
   private static final String ENDPOINT_PROPERTY = "metrics.endpoint";
+  private static final String QUEUE_WAIT_PROPERTY = "metrics.queueWaitNanos";
   private static final String OTHER_CLIENT = "other";
 
   private final String clientHeader;
   private final Set<String> monitoredClients;
   private final Set<String> monitoredEndpoints;
   private final Map<TimerKey, Timer> timers;
+  private final Map<TimerKey, Timer> queueWaitTimers;
 
   private record TimerKey(String client, String endpoint) {}
 
@@ -76,8 +82,16 @@ public class HttpResponseTimeMetricsFilter
     this.monitoredEndpoints = Set.copyOf(monitoredEndpoints);
     this.timers = createTimers(
       metricName,
+      "HTTP request response time by client",
       Objects.requireNonNull(minExpectedResponseTime),
       Objects.requireNonNull(maxExpectedResponseTime),
+      registry
+    );
+    this.queueWaitTimers = createTimers(
+      metricName + ".queueWait",
+      "Time spent waiting in the Grizzly thread pool queue by client",
+      Duration.ofNanos(100),
+      Duration.ofSeconds(5),
       registry
     );
   }
@@ -113,6 +127,7 @@ public class HttpResponseTimeMetricsFilter
 
   private Map<TimerKey, Timer> createTimers(
     String metricName,
+    String description,
     Duration minExpectedResponseTime,
     Duration maxExpectedResponseTime,
     MeterRegistry registry
@@ -124,7 +139,7 @@ public class HttpResponseTimeMetricsFilter
       for (String endpoint : monitoredEndpoints) {
         var key = new TimerKey(client, endpoint);
         var timer = Timer.builder(metricName)
-          .description("HTTP request response time by client")
+          .description(description)
           .tag(CLIENT_TAG, client)
           .tag(URI_TAG, endpoint)
           .publishPercentileHistogram()
@@ -139,6 +154,8 @@ public class HttpResponseTimeMetricsFilter
 
   @Override
   public void filter(ContainerRequestContext requestContext) {
+    Long queueWaitNanos = GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos();
+
     String path = getRequestPath(requestContext);
     String matchedEndpoint = findMatchingEndpoint(path);
     if (matchedEndpoint == null) {
@@ -146,6 +163,10 @@ public class HttpResponseTimeMetricsFilter
     }
     requestContext.setProperty(START_TIME_PROPERTY, System.nanoTime());
     requestContext.setProperty(ENDPOINT_PROPERTY, matchedEndpoint);
+
+    if (queueWaitNanos != null) {
+      requestContext.setProperty(QUEUE_WAIT_PROPERTY, queueWaitNanos);
+    }
   }
 
   @Nullable
@@ -175,11 +196,18 @@ public class HttpResponseTimeMetricsFilter
     String endpoint = (String) requestContext.getProperty(ENDPOINT_PROPERTY);
     String clientName = requestContext.getHeaderString(clientHeader);
     String clientTag = resolveClientTag(clientName);
+    var key = new TimerKey(clientTag, endpoint);
 
     long duration = System.nanoTime() - startTime;
 
-    Timer timer = timers.get(new TimerKey(clientTag, endpoint));
+    Timer timer = timers.get(key);
     timer.record(duration, TimeUnit.NANOSECONDS);
+
+    Long queueWaitNanos = (Long) requestContext.getProperty(QUEUE_WAIT_PROPERTY);
+    if (queueWaitNanos != null) {
+      Timer queueTimer = queueWaitTimers.get(key);
+      queueTimer.record(queueWaitNanos, TimeUnit.NANOSECONDS);
+    }
   }
 
   private String resolveClientTag(@Nullable String clientName) {

--- a/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilter.java
@@ -29,8 +29,9 @@ import org.opentripplanner.standalone.server.GrizzlyQueueWaitProbe;
  * The metric {@code http.client.requests} is recorded as a Timer with percentile histograms,
  * allowing analysis of response time distribution per client.
  * <p>
- * A second set of timers records the time each request spent waiting in the Grizzly thread pool
- * queue before a worker thread picked it up. This is captured via {@link GrizzlyQueueWaitProbe}.
+ * A second set of timers records the total client-perceived time, including any time spent waiting
+ * in the Grizzly thread pool queue before a worker thread picked up the request. The queue wait
+ * time is captured via {@link GrizzlyQueueWaitProbe}.
  * <p>
  * All timers are pre-created at startup for each combination of monitored client and endpoint
  * to ensure predictable metric cardinality.
@@ -50,7 +51,7 @@ public class HttpResponseTimeMetricsFilter
   private final Set<String> monitoredClients;
   private final Set<String> monitoredEndpoints;
   private final Map<TimerKey, Timer> timers;
-  private final Map<TimerKey, Timer> queueWaitTimers;
+  private final Map<TimerKey, Timer> totalTimers;
 
   private record TimerKey(String client, String endpoint) {}
 
@@ -87,11 +88,11 @@ public class HttpResponseTimeMetricsFilter
       Objects.requireNonNull(maxExpectedResponseTime),
       registry
     );
-    this.queueWaitTimers = createTimers(
-      metricName + ".queueWait",
-      "Time spent waiting in the Grizzly thread pool queue by client",
-      Duration.ofNanos(100),
-      Duration.ofSeconds(5),
+    this.totalTimers = createTimers(
+      metricName + "_total_time",
+      "Total client-perceived HTTP request time including thread pool queue wait",
+      Objects.requireNonNull(minExpectedResponseTime),
+      Objects.requireNonNull(maxExpectedResponseTime),
       registry
     );
   }
@@ -204,10 +205,8 @@ public class HttpResponseTimeMetricsFilter
     timer.record(duration, TimeUnit.NANOSECONDS);
 
     Long queueWaitNanos = (Long) requestContext.getProperty(QUEUE_WAIT_PROPERTY);
-    if (queueWaitNanos != null) {
-      Timer queueTimer = queueWaitTimers.get(key);
-      queueTimer.record(queueWaitNanos, TimeUnit.NANOSECONDS);
-    }
+    long totalDuration = duration + (queueWaitNanos != null ? queueWaitNanos : 0);
+    totalTimers.get(key).record(totalDuration, TimeUnit.NANOSECONDS);
   }
 
   private String resolveClientTag(@Nullable String clientName) {

--- a/application/src/main/java/org/opentripplanner/standalone/server/GrizzlyQueueWaitProbe.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/GrizzlyQueueWaitProbe.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.standalone.server;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.glassfish.grizzly.threadpool.AbstractThreadPool;
+import org.glassfish.grizzly.threadpool.ThreadPoolProbe;
+
+/**
+ * A Grizzly {@link ThreadPoolProbe} that measures how long tasks wait in the worker thread pool
+ * queue before being picked up by a worker thread.
+ * <p>
+ * The queue wait time is stored in a {@link ThreadLocal} so that downstream code running in the
+ * same worker thread (e.g., Jersey filters) can retrieve it.
+ * <p>
+ * The probe tracks task submission time in a {@link ConcurrentHashMap} keyed by the task's object
+ * identity. This is safe because Grizzly creates a new {@link Runnable} for each dispatched task
+ * and the entry is short-lived (removed on dequeue or cancel).
+ */
+public class GrizzlyQueueWaitProbe extends ThreadPoolProbe.Adapter {
+
+  static final GrizzlyQueueWaitProbe INSTANCE = new GrizzlyQueueWaitProbe();
+
+  private static final ThreadLocal<Long> QUEUE_WAIT_NANOS = new ThreadLocal<>();
+
+  private final ConcurrentHashMap<Runnable, Long> taskQueueTimes = new ConcurrentHashMap<>();
+
+  public GrizzlyQueueWaitProbe() {}
+
+  @Override
+  public void onTaskQueueEvent(AbstractThreadPool pool, Runnable task) {
+    taskQueueTimes.put(task, System.nanoTime());
+  }
+
+  @Override
+  public void onTaskDequeueEvent(AbstractThreadPool pool, Runnable task) {
+    Long queuedAt = taskQueueTimes.remove(task);
+    if (queuedAt != null) {
+      QUEUE_WAIT_NANOS.set(System.nanoTime() - queuedAt);
+    }
+  }
+
+  @Override
+  public void onTaskCompleteEvent(AbstractThreadPool pool, Runnable task) {
+    QUEUE_WAIT_NANOS.remove();
+  }
+
+  @Override
+  public void onTaskCancelEvent(AbstractThreadPool pool, Runnable task) {
+    taskQueueTimes.remove(task);
+  }
+
+  /**
+   * Returns the queue wait time in nanoseconds for the current task running on this thread,
+   * and clears the stored value. Returns {@code null} if no queue wait was recorded.
+   */
+  public static Long getAndClearQueueWaitNanos() {
+    Long value = QUEUE_WAIT_NANOS.get();
+    QUEUE_WAIT_NANOS.remove();
+    return value;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
@@ -78,6 +78,10 @@ public class GrizzlyServer {
       .setMaxPoolSize(nHandlerThreads)
       .setQueueLimit(-1);
 
+    if (OTPFeature.HttpResponseTimeMetrics.isOn()) {
+      threadPoolConfig.getInitialMonitoringConfig().addProbes(GrizzlyQueueWaitProbe.INSTANCE);
+    }
+
     /* HTTP (non-encrypted) listener */
     NetworkListener httpListener = new NetworkListener(
       "otp_insecure",

--- a/application/src/test/java/org/opentripplanner/standalone/server/GrizzlyQueueWaitProbeTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/server/GrizzlyQueueWaitProbeTest.java
@@ -1,0 +1,81 @@
+package org.opentripplanner.standalone.server;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GrizzlyQueueWaitProbeTest {
+
+  private GrizzlyQueueWaitProbe probe;
+
+  @BeforeEach
+  void setUp() {
+    probe = new GrizzlyQueueWaitProbe();
+  }
+
+  @Test
+  void recordsPositiveQueueWaitTime() throws InterruptedException {
+    Runnable task = () -> {};
+
+    probe.onTaskQueueEvent(null, task);
+    Thread.sleep(5);
+    probe.onTaskDequeueEvent(null, task);
+
+    Long waitNanos = GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos();
+    assertTrue(waitNanos > 0, "Queue wait time should be positive");
+  }
+
+  @Test
+  void getAndClearReturnsNullWhenNoValueRecorded() {
+    assertNull(GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos());
+  }
+
+  @Test
+  void getAndClearConsumesValue() {
+    Runnable task = () -> {};
+
+    probe.onTaskQueueEvent(null, task);
+    probe.onTaskDequeueEvent(null, task);
+
+    // First call returns the value
+    Long first = GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos();
+    assertTrue(first != null && first >= 0);
+
+    // Second call returns null (consumed)
+    assertNull(GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos());
+  }
+
+  @Test
+  void taskCompleteRemovesThreadLocal() {
+    Runnable task = () -> {};
+
+    probe.onTaskQueueEvent(null, task);
+    probe.onTaskDequeueEvent(null, task);
+    probe.onTaskCompleteEvent(null, task);
+
+    assertNull(GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos());
+  }
+
+  @Test
+  void cancelRemovesMapEntryWithoutSettingThreadLocal() {
+    Runnable task = () -> {};
+
+    probe.onTaskQueueEvent(null, task);
+    probe.onTaskCancelEvent(null, task);
+
+    // Dequeue after cancel should not set a value (entry was removed)
+    probe.onTaskDequeueEvent(null, task);
+    assertNull(GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos());
+  }
+
+  @Test
+  void dequeueWithoutPriorEnqueueDoesNotSetValue() {
+    Runnable task = () -> {};
+
+    probe.onTaskDequeueEvent(null, task);
+
+    assertNull(GrizzlyQueueWaitProbe.getAndClearQueueWaitNanos());
+  }
+}


### PR DESCRIPTION
## Summary

The existing `HttpResponseTimeMetricsFilter` only measures processing time inside the Jersey filter chain, missing any time requests spend waiting in the Grizzly worker thread pool queue. Under load, this hidden queue wait can be a significant portion of the total latency experienced by clients.

This PR adds a `ThreadPoolProbe` (`GrizzlyQueueWaitProbe`) that captures the time between task enqueue (selector thread) and dequeue (worker thread), bridging it to the Jersey filter via `ThreadLocal`. A second set of pre-created timers (`otp.http.server.requests_total_time`) records the total client-perceived time — processing time plus queue wait — with the same client/endpoint tags.

### Changes

- **`GrizzlyQueueWaitProbe`** — new `ThreadPoolProbe` that tracks enqueue/dequeue timestamps in a `ConcurrentHashMap` and exposes the delta via `ThreadLocal`
- **`HttpResponseTimeMetricsFilter`** — consumes the queue wait `ThreadLocal` early (before the endpoint check to prevent leaks), stores it as a request property, and records a total time timer (`{metricName}_total_time`) that adds queue wait to processing time
- **`GrizzlyServer`** — registers the probe on the thread pool config when `HttpResponseTimeMetrics` feature is enabled

### Key design decisions

- The `ThreadLocal` is consumed in the request filter *before* the endpoint match check, so unmonitored endpoints don't leave stale values for the next request on the same worker thread
- `onTaskCompleteEvent` clears the `ThreadLocal` as a safety net for edge cases where the filter doesn't run
- Total time timers are pre-created at startup (same as processing time timers) to ensure predictable metric cardinality
- When no queue wait is recorded (e.g. probe not active), total time falls back to processing time only