### PR TITLE
Reduce allocation in NearbyStop access/egress path

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPath.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPath.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.routing.graphfinder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.search.state.State;
+
+/**
+ * Extracts the traversed edges and effective walk distance from a {@link State} chain produced by
+ * an A* street search. The state chain is a linked list from the final state back to the origin via
+ * {@link State#getBackState()}/{@link State#getBackEdge()}.
+ * <p>
+ * This utility encapsulates the direction-dependent ordering: for depart-after searches the chain
+ * yields edges in reverse chronological order (newest first), while for arriveBy searches the chain
+ * already yields edges in chronological order.
+ * Implementation note: an earlier design relied on {@link org.opentripplanner.astar.model.GraphPath}
+ * to extract the list of edges in chronological order / reverse chronological order.
+ * The current implementation is optimized for reducing memory allocation.
+ */
+class ChronologicalGraphPath {
+
+  private final List<Edge> edges;
+  private final double effectiveWalkDistance;
+
+  private ChronologicalGraphPath(List<Edge> edges, double effectiveWalkDistance) {
+    this.edges = edges;
+    this.effectiveWalkDistance = effectiveWalkDistance;
+  }
+
+  /**
+   * Walk the state chain and collect edges in chronological order (origin → destination), summing
+   * up the effective walk distance along the way.
+   */
+  static ChronologicalGraphPath of(State state) {
+    double walkDistance = 0.0;
+    var edges = new ArrayList<Edge>();
+    for (State cur = state; cur != null; cur = cur.getBackState()) {
+      Edge backEdge = cur.getBackEdge();
+      if (backEdge != null && cur.getBackState() != null) {
+        walkDistance += backEdge.getEffectiveWalkDistance();
+        edges.add(backEdge);
+      }
+    }
+    // For depart-after, edges are in reverse chronological order; reverse to chronological.
+    // For arriveBy, the A* searched backward so edges are already chronological.
+    if (!state.getRequest().arriveBy()) {
+      Collections.reverse(edges);
+    }
+    return new ChronologicalGraphPath(edges, walkDistance);
+  }
+
+  List<Edge> edges() {
+    return edges;
+  }
+
+  double effectiveWalkDistance() {
+    return effectiveWalkDistance;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPath.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPath.java
@@ -47,6 +47,8 @@ class ChronologicalGraphPath {
     // For depart-after, edges are in reverse chronological order; reverse to chronological.
     // For arriveBy, the A* searched backward so edges are already chronological.
     if (!state.getRequest().arriveBy()) {
+      // We considered using `ArrayList.reversed()` (view) here, but there is no significant performance gain
+      // and the graph deserialization would break. See PR #7455.
       Collections.reverse(edges);
     }
     return new ChronologicalGraphPath(edges, walkDistance);

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPath.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPath.java
@@ -14,9 +14,11 @@ import org.opentripplanner.street.search.state.State;
  * This utility encapsulates the direction-dependent ordering: for depart-after searches the chain
  * yields edges in reverse chronological order (newest first), while for arriveBy searches the chain
  * already yields edges in chronological order.
+ * <p>
  * Implementation note: an earlier design relied on {@link org.opentripplanner.astar.model.GraphPath}
- * to extract the list of edges in chronological order / reverse chronological order.
- * The current implementation is optimized for reducing memory allocation.
+ * which allocates a {@code LinkedList<State>} and, for depart-after searches, a full reversed copy
+ * of the state chain via {@code State.reverse()}. This implementation avoids both by collecting
+ * only the edges into a single {@code ArrayList} and reversing it in place.
  */
 class ChronologicalGraphPath {
 

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -1,12 +1,10 @@
 package org.opentripplanner.routing.graphfinder;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -35,14 +33,8 @@ public class NearbyStop implements Comparable<NearbyStop> {
    * away it is and the geometry of the path leading up to the given State.
    */
   public static NearbyStop nearbyStopForState(State state, StopLocation stop) {
-    double effectiveWalkDistance = 0.0;
-    var graphPath = new GraphPath<>(state);
-    var edges = new ArrayList<Edge>();
-    for (Edge edge : graphPath.edges) {
-      effectiveWalkDistance += edge.getEffectiveWalkDistance();
-      edges.add(edge);
-    }
-    return new NearbyStop(stop, effectiveWalkDistance, edges, state);
+    var result = ChronologicalGraphPath.of(state);
+    return new NearbyStop(stop, result.effectiveWalkDistance(), result.edges(), state);
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPathTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graphfinder/ChronologicalGraphPathTest.java
@@ -1,0 +1,131 @@
+package org.opentripplanner.routing.graphfinder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetModelForTest;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+import org.opentripplanner.street.search.state.State;
+
+class ChronologicalGraphPathTest {
+
+  private static final Instant START_TIME = Instant.parse("2024-01-15T12:00:00Z");
+
+  @Test
+  void departAfterEdgesInChronologicalOrder() {
+    var graph = createThreeEdgeGraph();
+    var state = walkForward(graph);
+
+    var result = ChronologicalGraphPath.of(state);
+
+    assertEquals(3, result.edges().size());
+    assertSame(graph.e1, result.edges().get(0));
+    assertSame(graph.e2, result.edges().get(1));
+    assertSame(graph.e3, result.edges().get(2));
+  }
+
+  @Test
+  void arriveByEdgesInChronologicalOrder() {
+    var graph = createThreeEdgeGraph();
+    var state = walkBackward(graph);
+
+    var result = ChronologicalGraphPath.of(state);
+
+    assertEquals(3, result.edges().size());
+    assertSame(graph.e1, result.edges().get(0));
+    assertSame(graph.e2, result.edges().get(1));
+    assertSame(graph.e3, result.edges().get(2));
+  }
+
+  @Test
+  void bothDirectionsProduceIdenticalEdges() {
+    var graph = createThreeEdgeGraph();
+
+    var forward = ChronologicalGraphPath.of(walkForward(graph));
+    var backward = ChronologicalGraphPath.of(walkBackward(graph));
+
+    assertEquals(forward.edges(), backward.edges());
+    assertEquals(forward.effectiveWalkDistance(), backward.effectiveWalkDistance(), 1e-9);
+  }
+
+  @Test
+  void zeroEdgesForInitialState() {
+    var v1 = StreetModelForTest.intersectionVertex(
+      "ChronologicalGraphPathTest_solo",
+      59.910,
+      10.750
+    );
+    var request = StreetSearchRequest.of()
+      .withMode(StreetMode.WALK)
+      .withArriveBy(false)
+      .withStartTime(START_TIME)
+      .build();
+    var state = new State(v1, request);
+
+    var result = ChronologicalGraphPath.of(state);
+
+    assertEquals(0, result.edges().size());
+    assertEquals(0.0, result.effectiveWalkDistance(), 1e-9);
+  }
+
+  @Test
+  void effectiveWalkDistanceIsPositive() {
+    var graph = createThreeEdgeGraph();
+    var state = walkForward(graph);
+
+    var result = ChronologicalGraphPath.of(state);
+
+    assertTrue(result.effectiveWalkDistance() > 0);
+  }
+
+  private State walkForward(ThreeEdgeGraph g) {
+    var request = StreetSearchRequest.of()
+      .withMode(StreetMode.WALK)
+      .withArriveBy(false)
+      .withStartTime(START_TIME)
+      .build();
+    var s0 = new State(g.v1, request);
+    var s1 = g.e1.traverse(s0)[0];
+    var s2 = g.e2.traverse(s1)[0];
+    return g.e3.traverse(s2)[0];
+  }
+
+  private State walkBackward(ThreeEdgeGraph g) {
+    var request = StreetSearchRequest.of()
+      .withMode(StreetMode.WALK)
+      .withArriveBy(true)
+      .withStartTime(START_TIME)
+      .build();
+    var s0 = new State(g.v4, request);
+    var s1 = g.e3.traverse(s0)[0];
+    var s2 = g.e2.traverse(s1)[0];
+    return g.e1.traverse(s2)[0];
+  }
+
+  private static ThreeEdgeGraph createThreeEdgeGraph() {
+    var v1 = StreetModelForTest.intersectionVertex("ChronologicalGraphPathTest_1", 59.910, 10.750);
+    var v2 = StreetModelForTest.intersectionVertex("ChronologicalGraphPathTest_2", 59.911, 10.751);
+    var v3 = StreetModelForTest.intersectionVertex("ChronologicalGraphPathTest_3", 59.912, 10.752);
+    var v4 = StreetModelForTest.intersectionVertex("ChronologicalGraphPathTest_4", 59.913, 10.753);
+    var e1 = StreetModelForTest.streetEdge(v1, v2);
+    var e2 = StreetModelForTest.streetEdge(v2, v3);
+    var e3 = StreetModelForTest.streetEdge(v3, v4);
+    return new ThreeEdgeGraph(v1, v2, v3, v4, e1, e2, e3);
+  }
+
+  private record ThreeEdgeGraph(
+    StreetVertex v1,
+    StreetVertex v2,
+    StreetVertex v3,
+    StreetVertex v4,
+    StreetEdge e1,
+    StreetEdge e2,
+    StreetEdge e3
+  ) {}
+}

--- a/application/src/test/java/org/opentripplanner/routing/graphfinder/NearbyStopTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graphfinder/NearbyStopTest.java
@@ -8,9 +8,7 @@ import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 
 class NearbyStopTest {
 
-  private static TimetableRepositoryForTest MODEL = TimetableRepositoryForTest.of();
-
-  // TODO Add tests for all public methods in NearbyStop here
+  private static final TimetableRepositoryForTest MODEL = TimetableRepositoryForTest.of();
 
   @Test
   void testIsBetter() {


### PR DESCRIPTION
## Summary

Reduce allocation pressure in `NearbyStop.nearbyStopForState()`, which is called for every stop found during access/egress street searches.

- Replace `GraphPath` construction with direct State chain iteration, avoiding two `LinkedList` allocations per call
- Skip `State.reverse()` for arriveBy searches (edges are already chronological), and use `Collections.reverse()` for depart-after instead of cloning the entire state chain
- Extract the State chain walking logic into a dedicated `ChronologicalGraphPath` class for separation of concerns

Combined effect in production-like JFR profiling: `NearbyStop.nearbyStopForState()` allocation dropped from ~404 GB to ~115 GB per 120s recording (~71% reduction).