### PR TITLE
Migrate away from deprecated FeedScopedId.parse()

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
@@ -43,7 +43,7 @@ public class OregonHopFareFactory extends DefaultFareServiceFactory {
   static final FeedScopedId LG_CTRAN_REGIONAL = ctranId("REGIONAL");
   static final FeedScopedId LG_CTRAN_EXPRESS = ctranId("EXPRESS");
   static final FeedScopedId LG_CTRAN_LOCAL = ctranId("LOCAL");
-  static final FeedScopedId LG_CTRAN_FLEX_LOCAL = FeedScopedId.parse("CTRAN_FLEX:LOCAL");
+  static final FeedScopedId LG_CTRAN_FLEX_LOCAL = FeedScopedId.of("CTRAN_FLEX", "LOCAL");
 
   // rider categories
   static final RiderCategory CATEGORY_YOUTH = RiderCategory.of(ctranId("YOUTH"))

--- a/application/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/application/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -153,11 +153,11 @@ public class LuceneIndex implements Serializable {
   }
 
   private StopCluster toStopCluster(Document document) {
-    var primaryId = FeedScopedId.parse(document.get(ID));
+    var primaryId = FeedScopedId.parseStrict(document.get(ID));
     var primary = stopClusterMapper.toLocation(primaryId);
 
     var secondaryIds = Arrays.stream(document.getValues(SECONDARY_IDS))
-      .map(FeedScopedId::parse)
+      .map(FeedScopedId::parseStrict)
       .map(stopClusterMapper::toLocation)
       .toList();
 

--- a/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
+++ b/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
@@ -62,19 +62,9 @@ public class LocationStringParser {
     if (matcher.find()) {
       var lat = Double.parseDouble(matcher.group(1));
       var lon = Double.parseDouble(matcher.group(4));
-      return new GenericLocation(
-        label,
-        null,
-        lat,
-        lon
-      );
+      return new GenericLocation(label, null, lat, lon);
     } else {
-      return new GenericLocation(
-        label,
-        FeedScopedId.parseOptional(place).orElse(null),
-        null,
-        null
-      );
+      return new GenericLocation(label, FeedScopedId.parseOptional(place).orElse(null), null, null);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
+++ b/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
@@ -58,17 +58,23 @@ public class LocationStringParser {
       return null;
     }
 
-    Double lat = null;
-    Double lon = null;
-    FeedScopedId placeId = null;
-
     Matcher matcher = LAT_LON_PATTERN.matcher(place);
     if (matcher.find()) {
-      lat = Double.parseDouble(matcher.group(1));
-      lon = Double.parseDouble(matcher.group(4));
-    } else if (FeedScopedId.isValidString(place)) {
-      placeId = FeedScopedId.parse(place);
+      var lat = Double.parseDouble(matcher.group(1));
+      var lon = Double.parseDouble(matcher.group(4));
+      return new GenericLocation(
+        label,
+        null,
+        lat,
+        lon
+      );
+    } else {
+      return new GenericLocation(
+        label,
+        FeedScopedId.parseOptional(place).orElse(null),
+        null,
+        null
+      );
     }
-    return new GenericLocation(label, placeId, lat, lon);
   }
 }

--- a/application/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -93,13 +93,13 @@ public class LegReferenceSerializer {
   static LegReference readScheduledTransitLegV3(ObjectInputStream objectInputStream)
     throws IOException {
     return new ScheduledTransitLegReference(
-      FeedScopedId.parse(objectInputStream.readUTF()),
+      parseNonRequiredId(objectInputStream.readUTF()),
       LocalDate.parse(objectInputStream.readUTF(), DateTimeFormatter.ISO_LOCAL_DATE),
       objectInputStream.readInt(),
       objectInputStream.readInt(),
-      FeedScopedId.parse(objectInputStream.readUTF()),
-      FeedScopedId.parse(objectInputStream.readUTF()),
-      FeedScopedId.parse(objectInputStream.readUTF())
+      FeedScopedId.parseStrict(objectInputStream.readUTF()),
+      FeedScopedId.parseStrict(objectInputStream.readUTF()),
+      parseNonRequiredId(objectInputStream.readUTF())
     );
   }
 
@@ -113,5 +113,14 @@ public class LegReferenceSerializer {
     throws IOException {
     String value = in.readUTF();
     return Enum.valueOf(enumType, value);
+  }
+
+  /// Parse a string into a FeedScopedId, empty string returns null
+  @Nullable
+  private static FeedScopedId parseNonRequiredId(String id) {
+    if (id.isEmpty()) {
+      return null;
+    }
+    return FeedScopedId.parseStrict(id);
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
@@ -323,7 +323,7 @@ public class RaptorRequestMapper<T extends RaptorTripSchedule> {
       try {
         result.add(Integer.parseInt(stop));
       } catch (NumberFormatException ignore) {
-        var a = lookUpStopIndex.lookupStopLocationIndexes(FeedScopedId.parse(stop)).toArray();
+        var a = lookUpStopIndex.lookupStopLocationIndexes(FeedScopedId.parseStrict(stop)).toArray();
         if (a.length != 1) {
           throw new IllegalArgumentException("Unable to parse the input stop id: '" + stop + "'");
         }

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
@@ -40,10 +40,10 @@ public class PatternAtStop {
   public static PatternAtStop fromId(TransitService transitService, String id) {
     String[] parts = id.split(";", 2);
     Base64.Decoder decoder = Base64.getDecoder();
-    FeedScopedId stopId = FeedScopedId.parse(
+    FeedScopedId stopId = FeedScopedId.parseStrict(
       new String(decoder.decode(parts[0]), StandardCharsets.UTF_8)
     );
-    FeedScopedId patternId = FeedScopedId.parse(
+    FeedScopedId patternId = FeedScopedId.parseStrict(
       new String(decoder.decode(parts[1]), StandardCharsets.UTF_8)
     );
     return new PatternAtStop(

--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/json/ParameterBuilder.java
@@ -442,13 +442,15 @@ public class ParameterBuilder {
   /* Custom OTP types */
 
   public FeedScopedId asFeedScopedId(FeedScopedId defaultValue) {
-    return exist() ? FeedScopedId.parse(ofType(FEED_SCOPED_ID).asText()) : defaultValue;
+    return exist() ? FeedScopedId.parseStrict(ofType(FEED_SCOPED_ID).asText()) : defaultValue;
   }
 
   public List<FeedScopedId> asFeedScopedIds(List<FeedScopedId> defaultValues) {
     setInfoOptional(defaultValues);
     info.withArray(FEED_SCOPED_ID);
-    return buildAndListSimpleArrayElements(defaultValues, it -> FeedScopedId.parse(it.asText()));
+    return buildAndListSimpleArrayElements(defaultValues, it ->
+      FeedScopedId.parseStrict(it.asText())
+    );
   }
 
   public CostLinearFunction asCostLinearFunction(CostLinearFunction defaultValue) {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -140,9 +140,9 @@ class RouteRequestMapperTest {
     );
     var env = testCtx.executionContext(stopLocationArgs);
     var routeRequest = RouteRequestMapper.toRouteRequest(env, testCtx.context());
-    assertEquals(FeedScopedId.parse(stopA), routeRequest.from().stopId);
+    assertEquals(FeedScopedId.parseStrict(stopA), routeRequest.from().stopId);
     assertEquals(originLabel, routeRequest.from().label);
-    assertEquals(FeedScopedId.parse(stopB), routeRequest.to().stopId);
+    assertEquals(FeedScopedId.parseStrict(stopB), routeRequest.to().stopId);
     assertEquals(destinationLabel, routeRequest.to().label);
   }
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/FilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/FilterTest.java
@@ -645,7 +645,7 @@ public class FilterTest {
     var filter = TransitFilterRequest.of()
       .addSelect(
         SelectRequest.of()
-          .withGroupOfRoutes(List.of(FeedScopedId.parse("F:" + GROUP_OF_Routes_ID_1)))
+          .withGroupOfRoutes(List.of(FeedScopedId.of("F", GROUP_OF_Routes_ID_1)))
           .build()
       )
       .build();
@@ -677,7 +677,7 @@ public class FilterTest {
     var filter = TransitFilterRequest.of()
       .addNot(
         SelectRequest.of()
-          .withGroupOfRoutes(List.of(FeedScopedId.parse("F:" + GROUP_OF_Routes_ID_1)))
+          .withGroupOfRoutes(List.of(FeedScopedId.of("F", GROUP_OF_Routes_ID_1)))
           .build()
       )
       .build();

--- a/application/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
@@ -27,11 +27,13 @@ class RouteTest {
   private static final TransitMode TRANSIT_MODE = TransitMode.BUS;
   private static final String NETEX_SUBMODE_NAME = "submode";
   private static final SubMode NETEX_SUBMODE = SubMode.of(NETEX_SUBMODE_NAME);
-  private static final Operator OPERATOR = Operator.of(FeedScopedId.parse("x:operatorId"))
+  private static final Operator OPERATOR = Operator.of(FeedScopedId.of("x", "operatorId"))
     .withName("operator name")
     .build();
 
-  private static final Branding BRANDING = Branding.of(FeedScopedId.parse("x:brandingId")).build();
+  private static final Branding BRANDING = Branding.of(
+    FeedScopedId.of("x", "brandingId")
+  ).build();
   private static final String COLOR = "color";
   private static final String TEXT_COLOR = "text color";
   private static final int GTFS_TYPE = 0;
@@ -105,7 +107,7 @@ class RouteTest {
       SUBJECT.sameAs(
         SUBJECT.copy()
           .withOperator(
-            Operator.of(FeedScopedId.parse("x:otherOperatorId"))
+            Operator.of(FeedScopedId.of("x", "otherOperatorId"))
               .withName("other operator name")
               .build()
           )
@@ -118,7 +120,7 @@ class RouteTest {
     assertFalse(
       SUBJECT.sameAs(
         SUBJECT.copy()
-          .withBranding(Branding.of(FeedScopedId.parse("x:otherBrandingId")).build())
+          .withBranding(Branding.of(FeedScopedId.of("x", "otherBrandingId")).build())
           .build()
       )
     );

--- a/application/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
@@ -31,9 +31,7 @@ class RouteTest {
     .withName("operator name")
     .build();
 
-  private static final Branding BRANDING = Branding.of(
-    FeedScopedId.of("x", "brandingId")
-  ).build();
+  private static final Branding BRANDING = Branding.of(FeedScopedId.of("x", "brandingId")).build();
   private static final String COLOR = "color";
   private static final String TEXT_COLOR = "text color";
   private static final int GTFS_TYPE = 0;

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
@@ -32,11 +32,11 @@ class TripTest {
   private static final String NETEX_SUBMODE_NAME = "submode";
   private static final SubMode NETEX_SUBMODE = SubMode.of(NETEX_SUBMODE_NAME);
   private static final String NETEX_INTERNAL_PLANNING_CODE = "internalPlanningCode";
-  private static final Operator OPERATOR = Operator.of(FeedScopedId.parse("x:operatorId"))
+  private static final Operator OPERATOR = Operator.of(FeedScopedId.of("x", "operatorId"))
     .withName("operator name")
     .build();
-  private static final FeedScopedId SERVICE_ID = FeedScopedId.parse("x:serviceId");
-  private static final FeedScopedId SHAPE_ID = FeedScopedId.parse("x:shapeId");
+  private static final FeedScopedId SERVICE_ID = FeedScopedId.of("x", "serviceId");
+  private static final FeedScopedId SHAPE_ID = FeedScopedId.of("x", "shapeId");
   private static final Trip SUBJECT = Trip.of(TimetableRepositoryForTest.id(ID))
     .withShortName(SHORT_NAME)
     .withRoute(ROUTE)
@@ -123,7 +123,7 @@ class TripTest {
       SUBJECT.sameAs(
         SUBJECT.copy()
           .withOperator(
-            Operator.of(FeedScopedId.parse("x:otherOperatorId"))
+            Operator.of(FeedScopedId.of("x", "otherOperatorId"))
               .withName("other operator name")
               .build()
           )
@@ -131,10 +131,10 @@ class TripTest {
       )
     );
     assertFalse(
-      SUBJECT.sameAs(SUBJECT.copy().withServiceId(FeedScopedId.parse("x:otherServiceId")).build())
+      SUBJECT.sameAs(SUBJECT.copy().withServiceId(FeedScopedId.of("x", "otherServiceId")).build())
     );
     assertFalse(
-      SUBJECT.sameAs(SUBJECT.copy().withShapeId(FeedScopedId.parse("x:otherShapeId")).build())
+      SUBJECT.sameAs(SUBJECT.copy().withShapeId(FeedScopedId.of("x", "otherShapeId")).build())
     );
   }
 }

--- a/domain-core/src/main/java/org/opentripplanner/core/model/id/FeedScopedId.java
+++ b/domain-core/src/main/java/org/opentripplanner/core/model/id/FeedScopedId.java
@@ -83,26 +83,6 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     );
   }
 
-  /// Given an id of the form "feedId:entityId", parses into a {@link FeedScopedId} id object.
-  ///
-  /// @param value id of the form "feedId:entityId"
-  /// @return an id object or null if the input is empty or null
-  /// @throws IllegalArgumentException if the id cannot be parsed
-  /// @deprecated Use [FeedScopedId#parseOptional] or [FeedScopedId#parseStrict] instead
-  @Deprecated
-  @Nullable
-  public static FeedScopedId parse(@Nullable String value) throws IllegalArgumentException {
-    if (StringUtils.hasNoValue(value)) {
-      return null;
-    }
-    int index = value.indexOf(ID_SEPARATOR);
-    if (index == -1) {
-      throw new IllegalArgumentException("invalid feed-scoped-id: " + value);
-    } else {
-      return new FeedScopedId(value.substring(0, index), value.substring(index + 1));
-    }
-  }
-
   /**
    * Given collection of strings in the form "feedId:entityId", parses into a list of {@link FeedScopedId}.
    *
@@ -131,10 +111,6 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
       .filter(i -> !i.isBlank())
       .map(FeedScopedId::parseStrict)
       .toList();
-  }
-
-  public static boolean isValidString(@Nullable String value) throws IllegalArgumentException {
-    return value != null && value.indexOf(ID_SEPARATOR) > -1;
   }
 
   public void requireSameFeedId(FeedScopedId other) {

--- a/domain-core/src/main/java/org/opentripplanner/core/model/id/FeedScopedId.java
+++ b/domain-core/src/main/java/org/opentripplanner/core/model/id/FeedScopedId.java
@@ -29,6 +29,12 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     this.id = assertHasValue(id, "Missing mandatory id on FeedScopeId");
   }
 
+  /// Create a FeedScopedID
+  /// @throws IllegalArgumentException if the feedId or id is empty
+  public static FeedScopedId of(String feedId, String id) throws IllegalArgumentException {
+    return new FeedScopedId(feedId, id);
+  }
+
   /// Create a FeedScopedId
   ///
   /// @return Optional.empty if the feedId or id is empty, otherwise a FeedScopedId
@@ -108,7 +114,7 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
         throw new IllegalArgumentException("Collection of FeedScopedId must not contain null.");
       }
     });
-    return value.stream().map(FeedScopedId::parse).toList();
+    return value.stream().map(FeedScopedId::parseStrict).toList();
   }
 
   /**
@@ -123,7 +129,7 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     return Arrays.stream(s.split(","))
       .map(String::strip)
       .filter(i -> !i.isBlank())
-      .map(FeedScopedId::parse)
+      .map(FeedScopedId::parseStrict)
       .toList();
   }
 


### PR DESCRIPTION
## Summary

This is a follow-up to #7412 and #7456.

This PR migrates the final usages away from using FeedScopedId.parse() method that has been deprecated. The original parse() method was lenient for some invalid input (`""` and `null` returns null) but strict for some other invalid input (`"123"` throws exception).

After #7456 and this PR has been merged we can remove the `parse()` method.

## Unit tests

No new tests.

## Documentation

No
## Changelog

Skip

## Bumping the serialization version id

No