### PR TITLE
Add more complex example for fare product uses

### DIFF
--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -635,6 +635,40 @@ type FareProductUse {
           id: "single-ticket"  // product id
           name: "Single Ticket"
   ```
+  
+  ### Example: Combination of single tickets and day passes
+  
+  If you have two legs and it's possible to either buy singles or use a day pass, you will
+  have a combination of identical and different `FareProduct.id`s.
+  
+  **Illustration**
+  ```yaml
+  itinerary:
+    leg1:
+      fareProducts:
+        # fare product use for day pass
+        id: "AAA" // id of a FareProductUse instance, not product id
+          product:
+            id: "single-ticket" // product id
+            name: "Single Ticket"
+  
+        # fare product use for single ticket
+        id: "CCC" // identical to leg2. the passenger needs to buy ONE pass, not two.
+          product:
+            id: "day-pass"  // product id
+            name: "Day Pass"
+    leg2:
+      fareProducts:
+        id: "BBB" // different to leg1. the passenger needs to buy two single tickets.
+          product:
+            id: "single-ticket"  // product id
+            name: "Single Ticket"
+  
+        id: "CCC" // identical to leg1. the passenger needs to buy ONE pass, not two.
+          product:
+            id: "day-pass"  // product id
+            name: "Day Pass"
+  ```
   """
   id: String!
   "The purchasable fare product"

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -653,7 +653,7 @@ type FareProductUse {
             name: "Single Ticket"
   
         # fare product use for single ticket
-        id: "CCC" // identical to leg2. the passenger needs to buy ONE pass, not two.
+        id: "CCC" // identical to leg2. the passenger needs to buy ONE day pass, not two.
           product:
             id: "day-pass"  // product id
             name: "Day Pass"
@@ -664,11 +664,13 @@ type FareProductUse {
             id: "single-ticket"  // product id
             name: "Single Ticket"
   
-        id: "CCC" // identical to leg1. the passenger needs to buy ONE pass, not two.
+        id: "CCC" // identical to leg1. the passenger needs to buy ONE day pass, not two.
           product:
             id: "day-pass"  // product id
             name: "Day Pass"
   ```
+  **It is the responsibility of the API consumers to display the day pass as a product for the
+  entire itinerary rather than two day passes!**
   """
   id: String!
   "The purchasable fare product"


### PR DESCRIPTION
### Summary

I was requested to improve the documentation of `FareProductUse` and add more complex examples, namely for combining day passes and single tickets.

cc @laurentg 