### PR TITLE
Fix interchange lost when trip visits transfer stop twice (loop pattern)

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/GroupNetexMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/GroupNetexMapper.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
-import org.opentripplanner.transfer.constrained.model.ConstrainedTransfer;
 import org.rutebanken.netex.model.ServiceJourneyInterchange;
 
 /**
@@ -54,10 +53,7 @@ class GroupNetexMapper {
       transitBuilder.getTripsById()
     );
     for (ServiceJourneyInterchange it : interchanges) {
-      ConstrainedTransfer result = mapper.mapToTransfer(it);
-      if (result != null) {
-        transitBuilder.getTransfers().add(result);
-      }
+      transitBuilder.getTransfers().addAll(mapper.mapToTransfers(it));
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -41,61 +42,63 @@ public class TransferMapper {
   }
 
   /**
-   * NeTEx ServiceJourneyInterchange example:
-   * <pre>
-   * ServiceJourneyInterchange {
-   *    id: "VYG:ServiceJourneyInterchange:3"
-   *    priority: 2
-   *    planned: true
-   *    guaranteed: true
-   *    fromPointRef.ref: "VYG:ScheduledStopPoint:VOS-BUS-341"
-   *    toPointRef.ref: "VYG:ScheduledStopPoint:VOS-2"
-   *    fromJourneyRef.ref: "VYG:ServiceJourney:BUS-610-322"
-   *    toJourneyRef.ref: "VYG:ServiceJourney:610-323"
-   * }
-   * </pre>
+   * Map a NeTEx ServiceJourneyInterchange to one or more constrained transfers. When a trip visits
+   * the same ScheduledStopPoint multiple times (loop pattern), a transfer is created for each
+   * occurrence so the interchange is findable at any stop position during routing.
    */
-  @Nullable
-  public ConstrainedTransfer mapToTransfer(ServiceJourneyInterchange it) {
+  public List<ConstrainedTransfer> mapToTransfers(ServiceJourneyInterchange it) {
     var id = it.getId();
-    var from = mapPoint(Label.FROM, id, it.getFromJourneyRef(), it.getFromPointRef());
-    var to = mapPoint(Label.TO, id, it.getToJourneyRef(), it.getToPointRef());
+    var fromPoints = mapPoints(Label.FROM, id, it.getFromJourneyRef(), it.getFromPointRef());
+    var toPoints = mapPoints(Label.TO, id, it.getToJourneyRef(), it.getToPointRef());
 
-    if (from == null || to == null) {
+    if (fromPoints.isEmpty() || toPoints.isEmpty()) {
       issueStore.add(
         "InvalidInterchange",
         "Interchange %s contains invalid from/to refs. from=%s, to=%s",
         it,
-        from,
-        to
+        fromPoints,
+        toPoints
       );
-      return null;
+      return List.of();
     }
 
     var c = mapConstraint(it);
-    var tx = new ConstrainedTransfer(idFactory.createId(it.getId()), from, to, c);
+    var feedScopedId = idFactory.createId(it.getId());
 
-    if (tx.noConstraints()) {
+    // The constraint is the same for all position combinations, so check once
+    if (c.isRegularTransfer()) {
+      var tx = new ConstrainedTransfer(feedScopedId, fromPoints.getFirst(), toPoints.getFirst(), c);
       issueStore.add(new InterchangeWithoutConstraint(tx));
-      return null;
+      return List.of();
     }
-    return tx;
+
+    var result = new ArrayList<ConstrainedTransfer>();
+    for (var from : fromPoints) {
+      for (var to : toPoints) {
+        result.add(new ConstrainedTransfer(feedScopedId, from, to, c));
+      }
+    }
+    return result;
   }
 
-  @Nullable
-  private TripTransferPoint mapPoint(
+  private List<TripTransferPoint> mapPoints(
     Label label,
     String interchangeId,
     VehicleJourneyRefStructure sjRef,
     ScheduledStopPointRefStructure pointRef
   ) {
     if (isInvalid(sjRef)) {
-      return null;
+      return List.of();
     }
     var sjId = sjRef.getRef();
     var trip = findTrip(label, "Journey", interchangeId, sjId);
-    int stopPos = findStopPosition(interchangeId, label, "Point", sjId, pointRef);
-    return (trip == null || stopPos < 0) ? null : new TripTransferPoint(trip, stopPos);
+    if (trip == null) {
+      return List.of();
+    }
+    return findAllStopPositions(interchangeId, label, "Point", sjId, pointRef)
+      .stream()
+      .map(pos -> new TripTransferPoint(trip, pos))
+      .toList();
   }
 
   @Nullable
@@ -143,7 +146,7 @@ public class TransferMapper {
     }
   }
 
-  private int findStopPosition(
+  private List<Integer> findAllStopPositions(
     String interchangeId,
     Label label,
     String fieldName,
@@ -155,12 +158,14 @@ public class TransferMapper {
     String errorMessage;
 
     if (scheduledStopPoints != null) {
-      var index = switch (label) {
-        case Label.TO -> scheduledStopPoints.indexOf(sspId);
-        case Label.FROM -> scheduledStopPoints.lastIndexOf(sspId);
-      };
-      if (index >= 0) {
-        return index;
+      var positions = new ArrayList<Integer>();
+      for (int i = 0; i < scheduledStopPoints.size(); i++) {
+        if (scheduledStopPoints.get(i).equals(sspId)) {
+          positions.add(i);
+        }
+      }
+      if (!positions.isEmpty()) {
+        return positions;
       }
 
       errorMessage = "Scheduled-stop-point-ref not found";
@@ -177,7 +182,7 @@ public class TransferMapper {
         sspId
       )
     );
-    return -1;
+    return List.of();
   }
 
   private FeedScopedId createId(String id) {

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TransferMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TransferMapperTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.netex.mapping.MappingSupport.ID_FACTORY;
 
@@ -17,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
+import org.opentripplanner.transfer.constrained.internal.DefaultConstrainedTransferService;
 import org.opentripplanner.transfer.constrained.model.TripTransferPoint;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
@@ -49,7 +49,9 @@ class TransferMapperTest {
       .withGuaranteed(true)
       .withPriority(BigInteger.valueOf(2));
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfers = mapper.mapToTransfers(interchange);
+    assertEquals(1, transfers.size());
+    var transfer = transfers.getFirst();
 
     assertEquals(ID_FACTORY.createId(INTERCHANGE_ID), transfer.getId());
     assertTrue(transfer.getTransferConstraint().isGuaranteed());
@@ -71,7 +73,7 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withStaySeated(true);
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfer = mapper.mapToTransfers(interchange).getFirst();
 
     assertTrue(transfer.getTransferConstraint().isStaySeated());
   }
@@ -92,7 +94,7 @@ class TransferMapperTest {
       .withGuaranteed(true)
       .withMaximumWaitTime(Duration.ofMinutes(5));
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfer = mapper.mapToTransfers(interchange).getFirst();
 
     assertEquals(300, transfer.getTransferConstraint().getMaxWaitTime());
   }
@@ -112,9 +114,9 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withPriority(BigInteger.valueOf(-1));
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfers = mapper.mapToTransfers(interchange);
 
-    assertNotNull(transfer);
+    assertFalse(transfers.isEmpty());
   }
 
   @Test
@@ -133,9 +135,9 @@ class TransferMapperTest {
       .withPriority(BigInteger.valueOf(0))
       .withGuaranteed(true);
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfers = mapper.mapToTransfers(interchange);
 
-    assertNotNull(transfer);
+    assertFalse(transfers.isEmpty());
   }
 
   @Test
@@ -153,9 +155,9 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withPriority(BigInteger.valueOf(1));
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfers = mapper.mapToTransfers(interchange);
 
-    assertNotNull(transfer);
+    assertFalse(transfers.isEmpty());
   }
 
   @Test
@@ -173,9 +175,9 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withPriority(BigInteger.valueOf(2));
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfers = mapper.mapToTransfers(interchange);
 
-    assertNotNull(transfer);
+    assertFalse(transfers.isEmpty());
   }
 
   @Test
@@ -193,7 +195,7 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withGuaranteed(true);
 
-    assertNull(mapper.mapToTransfer(interchange));
+    assertTrue(mapper.mapToTransfers(interchange).isEmpty());
     assertThat(listTypes(issueStore)).contains("InvalidInterchange");
   }
 
@@ -212,7 +214,7 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withGuaranteed(true);
 
-    assertNull(mapper.mapToTransfer(interchange));
+    assertTrue(mapper.mapToTransfers(interchange).isEmpty());
     assertThat(listTypes(issueStore)).contains("InvalidInterchange");
   }
 
@@ -232,7 +234,7 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withGuaranteed(true);
 
-    assertNull(mapper.mapToTransfer(interchange));
+    assertTrue(mapper.mapToTransfers(interchange).isEmpty());
     assertThat(listTypes(issueStore)).contains("InvalidInterchange");
   }
 
@@ -252,7 +254,7 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withGuaranteed(true);
 
-    assertNull(mapper.mapToTransfer(interchange));
+    assertTrue(mapper.mapToTransfers(interchange).isEmpty());
     assertThat(listTypes(issueStore)).contains("InvalidInterchange");
   }
 
@@ -271,12 +273,12 @@ class TransferMapperTest {
       .withFromPointRef(createStopRef(FROM_STOP_ID))
       .withToPointRef(createStopRef(TO_STOP_ID));
 
-    assertNull(mapper.mapToTransfer(interchange));
+    assertTrue(mapper.mapToTransfers(interchange).isEmpty());
     assertThat(listTypes(issueStore)).contains("InterchangeWithoutConstraint");
   }
 
   @Test
-  void usesLastIndexForFromStop() {
+  void createsTransferForEachOccurrenceOfFromStop() {
     var trips = createTripsIndex();
     var stopPointsIndex = Map.of(
       FROM_JOURNEY_ID,
@@ -295,13 +297,78 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withGuaranteed(true);
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfers = mapper.mapToTransfers(interchange);
 
-    assertEquals(2, ((TripTransferPoint) transfer.getFrom()).getStopPositionInPattern());
+    assertEquals(2, transfers.size());
+    assertEquals(0, ((TripTransferPoint) transfers.get(0).getFrom()).getStopPositionInPattern());
+    assertEquals(2, ((TripTransferPoint) transfers.get(1).getFrom()).getStopPositionInPattern());
+  }
+
+  /**
+   * Verifies that a guaranteed interchange is found at all stop positions when the feeder trip
+   * visits the transfer stop twice (loop pattern). See
+   * <a href="https://github.com/opentripplanner/OpenTripPlanner/issues/7466">#7466</a>.
+   */
+  @Test
+  void interchangeFoundAtAllPositionsWhenFeederTripVisitsTransferStopTwice() {
+    var transferStopId = "TEST:ScheduledStopPoint:TransferStop";
+    int firstVisitPosition = 2;
+    int secondVisitPosition = 5;
+    var stopPointsIndex = Map.of(
+      FROM_JOURNEY_ID,
+      List.of(
+        "TEST:ScheduledStopPoint:Start",
+        "TEST:ScheduledStopPoint:StopA",
+        // Position 2: first visit
+        transferStopId,
+        "TEST:ScheduledStopPoint:StopB",
+        "TEST:ScheduledStopPoint:StopC",
+        // Position 5: second visit (loop returns through same stop)
+        transferStopId,
+        "TEST:ScheduledStopPoint:End"
+      ),
+      TO_JOURNEY_ID,
+      List.of(transferStopId, "TEST:ScheduledStopPoint:Destination")
+    );
+
+    var trips = createTripsIndex();
+    var mapper = new TransferMapper(ID_FACTORY, DataImportIssueStore.NOOP, stopPointsIndex, trips);
+
+    var interchange = new ServiceJourneyInterchange()
+      .withId(INTERCHANGE_ID)
+      .withFromJourneyRef(createJourneyRef(FROM_JOURNEY_ID))
+      .withToJourneyRef(createJourneyRef(TO_JOURNEY_ID))
+      .withFromPointRef(createStopRef(transferStopId))
+      .withToPointRef(createStopRef(transferStopId))
+      .withGuaranteed(true)
+      .withMaximumWaitTime(Duration.ofMinutes(5));
+
+    var transfers = mapper.mapToTransfers(interchange);
+    assertEquals(2, transfers.size(), "One transfer per from-stop occurrence");
+    assertTrue(transfers.getFirst().getTransferConstraint().isGuaranteed());
+
+    // Store the transfers in the ConstrainedTransferService (as the graph builder does)
+    var transferService = new DefaultConstrainedTransferService();
+    transferService.addAll(transfers);
+
+    var fromTrip = trips.get(ID_FACTORY.createId(FROM_JOURNEY_ID));
+    var toTrip = trips.get(ID_FACTORY.createId(TO_JOURNEY_ID));
+    var testModel = TimetableRepositoryForTest.of();
+    var stop = testModel.stop("TransferStop", 59.0, 6.0).build();
+
+    // Lookup succeeds at BOTH stop positions
+    assertNotNull(
+      transferService.findTransfer(fromTrip, firstVisitPosition, stop, toTrip, 0, stop),
+      "Transfer found at first visit position"
+    );
+    assertNotNull(
+      transferService.findTransfer(fromTrip, secondVisitPosition, stop, toTrip, 0, stop),
+      "Transfer found at second visit position"
+    );
   }
 
   @Test
-  void usesFirstIndexForToStop() {
+  void createsTransferForEachOccurrenceOfToStop() {
     var trips = createTripsIndex();
     var stopPointsIndex = Map.of(
       FROM_JOURNEY_ID,
@@ -320,9 +387,11 @@ class TransferMapperTest {
       .withToPointRef(createStopRef(TO_STOP_ID))
       .withGuaranteed(true);
 
-    var transfer = mapper.mapToTransfer(interchange);
+    var transfers = mapper.mapToTransfers(interchange);
 
-    assertEquals(0, ((TripTransferPoint) transfer.getTo()).getStopPositionInPattern());
+    assertEquals(2, transfers.size());
+    assertEquals(0, ((TripTransferPoint) transfers.get(0).getTo()).getStopPositionInPattern());
+    assertEquals(2, ((TripTransferPoint) transfers.get(1).getTo()).getStopPositionInPattern());
   }
 
   private DefaultEntityById<Trip> createTripsIndex() {


### PR DESCRIPTION
## Summary

Fixes guaranteed interchanges being silently lost when the feeder trip visits the transfer stop more than once (loop pattern).

`TransferMapper.findStopPosition()` used `lastIndexOf` for the FROM side (introduced in #4597 to support circular routes where the stop is both first and last). For loop-in-middle patterns — where the stop appears mid-route, not at the endpoints — `lastIndexOf` picks the wrong occurrence. The `ConstrainedTransferService` lookup then fails during routing because the stored position doesn't match.

### Example

A bus line has a 45-stop JourneyPattern that passes through a transfer stop at position 29, continues into a residential loop, and returns through the same stop at position 43:

```
Stavanger → ... → Strand rådhus (29) → loop → Strand rådhus (43) → terminal
```

`lastIndexOf` stored position 43. During routing, Raptor alights at position 29 → lookup miss → interchange info lost from API response.

### Fix

Since we cannot know at import time which visit Raptor will use, `TransferMapper` now creates a `ConstrainedTransfer` for **each occurrence** of the stop. This handles both circular routes (#4597) and loop-in-middle patterns correctly.

In the common case (stop visited once), behavior is identical — a single transfer is created.

### Why not filter the duplicate by timing?

For loop patterns this creates one extra transfer that is temporally impossible (the connecting trip departs before the feeder completes the loop). Filtering it out was considered but not implemented because:

- **Raptor already handles it** — `ConstrainedBoardingSearch` skips transfers where the connecting trip departs before the feeder arrives, so the extra transfer is harmless at runtime.
- **No timing data at import time** — `TransferMapper` only has stop point IDs and trip references; timetable data is not yet available.
- **Validation at index generation time is complex** — `TransferIndexGenerator` has access to `TripTimes`, but a correct check would need to account for `maxWaitTime` on guaranteed transfers, real-time updates that shift times, and frequency-based trips with no fixed schedule.
- **Negligible overhead** — loop patterns are rare, each adds one extra `TransferForPattern` object and one failed time comparison per search.

### Changes

- `TransferMapper`: `findStopPosition` → `findAllStopPositions` returning all indices; `mapPoint` → `mapPoints`; `mapToTransfer` → `mapToTransfers` returning cross-product of from × to positions
- `GroupNetexMapper`: updated call site to handle list result
- `TransferMapperTest`: updated all tests; added regression test that verifies the interchange is found at both stop positions via `ConstrainedTransferService`

Addresses #7466