### PR TITLE
Replace A* debug log with pluggable callback

### DIFF
--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -17,6 +17,7 @@ import org.opentripplanner.astar.spi.DominanceFunction;
 import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
 import org.opentripplanner.astar.spi.SearchTerminationStrategy;
 import org.opentripplanner.astar.spi.SkipEdgeStrategy;
+import org.opentripplanner.astar.spi.StatisticsCallback;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.utils.time.DateUtils;
 import org.slf4j.Logger;
@@ -34,8 +35,6 @@ public class AStar<
 
   private static final Logger LOG = LoggerFactory.getLogger(AStar.class);
 
-  private static final boolean VERBOSE = LOG.isDebugEnabled();
-
   private final boolean arriveBy;
   private final Set<Vertex> fromVertices;
   private final Set<Vertex> toVertices;
@@ -44,6 +43,7 @@ public class AStar<
   private final SkipEdgeStrategy<State, Edge> skipEdgeStrategy;
   private final SearchTerminationStrategy<State> terminationStrategy;
   private final TraverseVisitor<State, Edge> traverseVisitor;
+  private final StatisticsCallback<Vertex> statistics;
   private final Duration timeout;
 
   private final ShortestPathTree<State, Edge, Vertex> spt;
@@ -64,7 +64,8 @@ public class AStar<
     SearchTerminationStrategy<State> terminationStrategy,
     DominanceFunction<State> dominanceFunction,
     Duration timeout,
-    Collection<State> initialStates
+    Collection<State> initialStates,
+    StatisticsCallback<Vertex> stats
   ) {
     this.heuristic = heuristic;
     this.skipEdgeStrategy = skipEdgeStrategy;
@@ -76,6 +77,8 @@ public class AStar<
     this.timeout = Objects.requireNonNull(timeout);
 
     this.spt = new ShortestPathTree<>(dominanceFunction);
+
+    this.statistics = stats;
     this.preSearchHook = preSearchHook;
 
     // Initialized with a reasonable size, see #4445
@@ -106,12 +109,6 @@ public class AStar<
   }
 
   private boolean iterate() {
-    // print debug info
-    if (VERBOSE) {
-      double w = pq.peek_min_key();
-      LOG.debug("pq min key = {}", w);
-    }
-
     // get the lowest-weight state in the queue
     u = pq.extract_min();
 
@@ -130,10 +127,6 @@ public class AStar<
     nVisited += 1;
 
     Vertex u_vertex = u.getVertex();
-
-    if (VERBOSE) {
-      LOG.debug("   vertex {}", u_vertex);
-    }
 
     Collection<Edge> edges = arriveBy ? u_vertex.getIncoming() : u_vertex.getOutgoing();
     for (Edge edge : edges) {
@@ -158,18 +151,6 @@ public class AStar<
         }
         double estimate = v.getWeight() + remaining_w;
 
-        if (VERBOSE) {
-          LOG.debug("      edge {}", edge);
-          LOG.debug(
-            "      {} -> {}(w) + {}(heur) = {} vert = {}",
-            u.getWeight(),
-            v.getWeight(),
-            remaining_w,
-            estimate,
-            v.getVertex()
-          );
-        }
-
         // spt.add returns true if the state is hopeful; enqueue state if it's hopeful
         if (spt.add(v)) {
           // report to the visitor if there is one
@@ -188,6 +169,7 @@ public class AStar<
     // execute the hook before the search begins so that it can be checked if the request
     // has already timed out.
     preSearchHook.run();
+    statistics.searchStarted();
     long abortTime = DateUtils.absoluteTimeout(timeout);
 
     /* the core of the A* algorithm */
@@ -223,10 +205,11 @@ public class AStar<
         targetAcceptedStates.add(u);
 
         // Break out of the search if we've found the requested number of paths.
-        // Currently,  we can only find one path per search.
-        LOG.debug("total vertices visited {}", nVisited);
+        // Currently, we can only find one path per search.
         break;
       }
     }
+
+    statistics.searchFinished(fromVertices, toVertices, nVisited);
   }
 }

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -43,7 +43,7 @@ public class AStar<
   private final SkipEdgeStrategy<State, Edge> skipEdgeStrategy;
   private final SearchTerminationStrategy<State> terminationStrategy;
   private final TraverseVisitor<State, Edge> traverseVisitor;
-  private final StatisticsCallback<Vertex> statistics;
+  private final StatisticsCallback<Vertex> statisticsCallback;
   private final Duration timeout;
 
   private final ShortestPathTree<State, Edge, Vertex> spt;
@@ -65,7 +65,7 @@ public class AStar<
     DominanceFunction<State> dominanceFunction,
     Duration timeout,
     Collection<State> initialStates,
-    StatisticsCallback<Vertex> stats
+    StatisticsCallback<Vertex> statisticsCallback
   ) {
     this.heuristic = heuristic;
     this.skipEdgeStrategy = skipEdgeStrategy;
@@ -78,7 +78,7 @@ public class AStar<
 
     this.spt = new ShortestPathTree<>(dominanceFunction);
 
-    this.statistics = stats;
+    this.statisticsCallback = statisticsCallback;
     this.preSearchHook = preSearchHook;
 
     // Initialized with a reasonable size, see #4445
@@ -169,7 +169,7 @@ public class AStar<
     // execute the hook before the search begins so that it can be checked if the request
     // has already timed out.
     preSearchHook.run();
-    statistics.searchStarted();
+    statisticsCallback.searchStarted();
     long abortTime = DateUtils.absoluteTimeout(timeout);
 
     /* the core of the A* algorithm */
@@ -210,6 +210,6 @@ public class AStar<
       }
     }
 
-    statistics.searchFinished(fromVertices, toVertices, nVisited);
+    statisticsCallback.searchFinished(fromVertices, toVertices, nVisited);
   }
 }

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -15,6 +15,7 @@ import org.opentripplanner.astar.spi.DominanceFunction;
 import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
 import org.opentripplanner.astar.spi.SearchTerminationStrategy;
 import org.opentripplanner.astar.spi.SkipEdgeStrategy;
+import org.opentripplanner.astar.spi.StatisticsCallback;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,7 @@ public abstract class AStarBuilder<
   private Set<Vertex> toVertices;
   private SearchTerminationStrategy<State> terminationStrategy;
   private DominanceFunction<State> dominanceFunction;
+  private StatisticsCallback<Vertex> statsCallback = StatisticsCallback.NOOP;
 
   protected AStarBuilder() {}
 
@@ -67,6 +69,11 @@ public abstract class AStarBuilder<
 
   public Builder withTraverseVisitor(TraverseVisitor<State, Edge> traverseVisitor) {
     this.traverseVisitor = traverseVisitor;
+    return builder;
+  }
+
+  public Builder withStatisticsCallback(StatisticsCallback<Vertex> printer) {
+    this.statsCallback = printer;
     return builder;
   }
 
@@ -139,7 +146,8 @@ public abstract class AStarBuilder<
       terminationStrategy,
       Optional.ofNullable(dominanceFunction).orElseGet(this::createDefaultDominanceFunction),
       streetRoutingTimeout(),
-      initialStates
+      initialStates,
+      statsCallback
     );
   }
 

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -40,7 +40,7 @@ public abstract class AStarBuilder<
   private Set<Vertex> toVertices;
   private SearchTerminationStrategy<State> terminationStrategy;
   private DominanceFunction<State> dominanceFunction;
-  private StatisticsCallback<Vertex> statsCallback = StatisticsCallback.NOOP;
+  private StatisticsCallback<Vertex> statisticsCallback = StatisticsCallback.NOOP;
 
   protected AStarBuilder() {}
 
@@ -72,8 +72,8 @@ public abstract class AStarBuilder<
     return builder;
   }
 
-  public Builder withStatisticsCallback(StatisticsCallback<Vertex> printer) {
-    this.statsCallback = printer;
+  public Builder withStatisticsCallback(StatisticsCallback<Vertex> statisticsCallback) {
+    this.statisticsCallback = statisticsCallback;
     return builder;
   }
 
@@ -147,7 +147,7 @@ public abstract class AStarBuilder<
       Optional.ofNullable(dominanceFunction).orElseGet(this::createDefaultDominanceFunction),
       streetRoutingTimeout(),
       initialStates,
-      statsCallback
+      statisticsCallback
     );
   }
 

--- a/astar/src/main/java/org/opentripplanner/astar/spi/StatisticsCallback.java
+++ b/astar/src/main/java/org/opentripplanner/astar/spi/StatisticsCallback.java
@@ -3,6 +3,9 @@ package org.opentripplanner.astar.spi;
 import java.util.Set;
 import org.opentripplanner.astar.strategy.NoopStatisticsCallback;
 
+/**
+ * A callback for receiving statistics about A* searches.
+ */
 public interface StatisticsCallback<V extends AStarVertex<?, ?, ?>> {
   StatisticsCallback NOOP = new NoopStatisticsCallback<>();
 

--- a/astar/src/main/java/org/opentripplanner/astar/spi/StatisticsCallback.java
+++ b/astar/src/main/java/org/opentripplanner/astar/spi/StatisticsCallback.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.astar.spi;
+
+import java.util.Set;
+import org.opentripplanner.astar.strategy.NoopStatisticsCallback;
+
+public interface StatisticsCallback<V extends AStarVertex<?, ?, ?>> {
+  StatisticsCallback NOOP = new NoopStatisticsCallback<>();
+
+  void searchStarted();
+
+  void searchFinished(Set<V> fromVertices, Set<V> toVertices, int verticesVisited);
+}

--- a/astar/src/main/java/org/opentripplanner/astar/strategy/LoggingCallback.java
+++ b/astar/src/main/java/org/opentripplanner/astar/strategy/LoggingCallback.java
@@ -1,0 +1,33 @@
+package org.opentripplanner.astar.strategy;
+
+import java.util.Set;
+import org.opentripplanner.astar.spi.AStarVertex;
+import org.opentripplanner.astar.spi.StatisticsCallback;
+import org.opentripplanner.utils.time.DurationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingCallback<V extends AStarVertex<?, ?, ?>> implements StatisticsCallback<V> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingCallback.class);
+
+  private double start_Ms;
+
+  @Override
+  public void searchStarted() {
+    start_Ms = System.currentTimeMillis();
+  }
+
+  @Override
+  public void searchFinished(Set<V> fromVertices, Set<V> toVertices, int verticesVisited) {
+    long millis = (long) (System.currentTimeMillis() - start_Ms);
+    var duration = DurationUtils.durationToStrMillisescond(millis);
+    LOG.info(
+      "Statistics for A* search: fromVertices={}, toVertices={}, verticesVisited={}, duration={}",
+      fromVertices,
+      toVertices,
+      verticesVisited,
+      duration
+    );
+  }
+}

--- a/astar/src/main/java/org/opentripplanner/astar/strategy/LoggingCallback.java
+++ b/astar/src/main/java/org/opentripplanner/astar/strategy/LoggingCallback.java
@@ -7,6 +7,9 @@ import org.opentripplanner.utils.time.DurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A callback that logs statistics for A* searches.
+ */
 public class LoggingCallback<V extends AStarVertex<?, ?, ?>> implements StatisticsCallback<V> {
 
   private static final Logger LOG = LoggerFactory.getLogger(LoggingCallback.class);

--- a/astar/src/main/java/org/opentripplanner/astar/strategy/NoopStatisticsCallback.java
+++ b/astar/src/main/java/org/opentripplanner/astar/strategy/NoopStatisticsCallback.java
@@ -4,6 +4,9 @@ import java.util.Set;
 import org.opentripplanner.astar.spi.AStarVertex;
 import org.opentripplanner.astar.spi.StatisticsCallback;
 
+/**
+ * A statistics callback that does nothing.
+ */
 public class NoopStatisticsCallback<V extends AStarVertex<?, ?, ?>>
   implements StatisticsCallback<V> {
 

--- a/astar/src/main/java/org/opentripplanner/astar/strategy/NoopStatisticsCallback.java
+++ b/astar/src/main/java/org/opentripplanner/astar/strategy/NoopStatisticsCallback.java
@@ -1,0 +1,15 @@
+package org.opentripplanner.astar.strategy;
+
+import java.util.Set;
+import org.opentripplanner.astar.spi.AStarVertex;
+import org.opentripplanner.astar.spi.StatisticsCallback;
+
+public class NoopStatisticsCallback<V extends AStarVertex<?, ?, ?>>
+  implements StatisticsCallback<V> {
+
+  @Override
+  public void searchStarted() {}
+
+  @Override
+  public void searchFinished(Set<V> fromVertices, Set<V> toVertices, int verticesVisited) {}
+}

--- a/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequestBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/search/request/StreetSearchRequestBuilder.java
@@ -163,5 +163,4 @@ public class StreetSearchRequestBuilder {
   public StreetSearchRequest build() {
     return new StreetSearchRequest(this);
   }
-
 }


### PR DESCRIPTION
### Summary

This PR replaces the hugely verbose A* debug logging with a pluggable callback so that callers can add their own debug implementation.

### Issue

Ref #7468