### PR TITLE
Add test: distinct SSPs per visit disambiguate interchange in loop pa…

### DIFF
--- a/application/src/test/java/org/opentripplanner/netex/mapping/TransferMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TransferMapperTest.java
@@ -300,6 +300,54 @@ class TransferMapperTest {
     assertEquals(2, ((TripTransferPoint) transfer.getFrom()).getStopPositionInPattern());
   }
 
+  /**
+   * When two visits to the same Quay use distinct ScheduledStopPoint IDs, the interchange
+   * reference is unambiguous — the SSP appears only once in the stop list, so both indexOf and
+   * lastIndexOf return the correct position. This is the ideal data modeling for loop patterns.
+   */
+  @Test
+  void distinctSspPerVisitDisambiguatesLoopPattern() {
+    var transferStopVisit1 = "TEST:ScheduledStopPoint:TransferStop_visit1";
+    var transferStopVisit2 = "TEST:ScheduledStopPoint:TransferStop_visit2";
+    var stopPointsIndex = Map.of(
+      FROM_JOURNEY_ID,
+      List.of(
+        "TEST:ScheduledStopPoint:Start",
+        "TEST:ScheduledStopPoint:StopA",
+        // Position 2: first visit (same Quay)
+        transferStopVisit1,
+        "TEST:ScheduledStopPoint:StopB",
+        "TEST:ScheduledStopPoint:StopC",
+        // Position 5: second visit (same Quay, different SSP)
+        transferStopVisit2,
+        "TEST:ScheduledStopPoint:End"
+      ),
+      TO_JOURNEY_ID,
+      List.of(transferStopVisit1, "TEST:ScheduledStopPoint:Destination")
+    );
+
+    var trips = createTripsIndex();
+    var mapper = new TransferMapper(ID_FACTORY, DataImportIssueStore.NOOP, stopPointsIndex, trips);
+
+    // Interchange references the first-visit SSP
+    var interchange = new ServiceJourneyInterchange()
+      .withId(INTERCHANGE_ID)
+      .withFromJourneyRef(createJourneyRef(FROM_JOURNEY_ID))
+      .withToJourneyRef(createJourneyRef(TO_JOURNEY_ID))
+      .withFromPointRef(createStopRef(transferStopVisit1))
+      .withToPointRef(createStopRef(transferStopVisit1))
+      .withGuaranteed(true)
+      .withMaximumWaitTime(Duration.ofMinutes(5));
+
+    var transfer = mapper.mapToTransfer(interchange);
+
+    assertNotNull(transfer);
+    assertTrue(transfer.getTransferConstraint().isGuaranteed());
+    // The SSP is unique, so the position resolves correctly to the first visit
+    assertEquals(2, ((TripTransferPoint) transfer.getFrom()).getStopPositionInPattern());
+    assertEquals(0, ((TripTransferPoint) transfer.getTo()).getStopPositionInPattern());
+  }
+
   @Test
   void usesFirstIndexForToStop() {
     var trips = createTripsIndex();


### PR DESCRIPTION
## Summary

Adds a unit test documenting that distinct `ScheduledStopPoint` IDs per visit disambiguate interchange mapping in loop patterns. Related to #7466.

### Context

When a `ServiceJourneyInterchange` references a `ScheduledStopPoint` that appears multiple times in a trip's stop list (loop pattern), `TransferMapper.findStopPosition()` can pick the wrong occurrence (#7466). However, if each visit to the same Quay uses a **distinct SSP ID**, the reference is unambiguous — `indexOf`/`lastIndexOf` both return the correct position since the SSP appears only once.

### End-to-end verification

Tested locally with the full Norway dataset: modifying the 45-stop JourneyPattern to use `KOL:ScheduledStopPoint:11305094_1` for the second visit to Strand rådhus (instead of reusing `11305094_0`) made all 4 previously broken interchanges visible in the GraphQL API — without any OTP code changes.

| Trip | Original (same SSP) | Modified (distinct SSPs) |
|---|---|---|
| 2021 | interchange lost | interchange found |
| 2032 | interchange lost | interchange found |
| 2038 | interchange lost | interchange found |
| 2041 | interchange lost | interchange found |

### Test

`distinctSspPerVisitDisambiguatesLoopPattern` — sets up a FROM trip with a loop pattern where two visits to the same stop use different SSP IDs, creates an interchange referencing the first-visit SSP, and verifies the stop position resolves to position 2 (the first visit).

