### PR TITLE
Convert A* walk distance to traversal distance

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
@@ -104,7 +104,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor<State, Edge> 
   @Override
   public void visitVertex(State state) {
     Vertex vertex = state.getVertex();
-    double distance = state.getWalkDistance();
+    double distance = state.getTraversalDistanceMeters();
     if (vertex instanceof TransitStopVertex transitVertex) {
       var stop = Objects.requireNonNull(transitService.getRegularStop(transitVertex.getId()));
       handleStop(stop, distance);
@@ -142,7 +142,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor<State, Edge> 
         }
       }
 
-      return current.getWalkDistance() > furthestDistance;
+      return current.getTraversalDistanceMeters() > furthestDistance;
     };
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/StopFinderTraverseVisitor.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/StopFinderTraverseVisitor.java
@@ -54,6 +54,6 @@ public class StopFinderTraverseVisitor implements TraverseVisitor<State, Edge> {
    * reached.
    */
   public SkipEdgeStrategy<State, Edge> getSkipEdgeStrategy() {
-    return (current, edge) -> current.getWalkDistance() > radiusMeters;
+    return (current, edge) -> current.getTraversalDistanceMeters() > radiusMeters;
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
@@ -107,7 +107,7 @@ public class StreetGraphFinder implements GraphFinder {
         .withPreStartHook(OTPRequestTimeoutException::checkForTimeout)
         .withSkipEdgeStrategy(skipEdgeStrategy)
         .withTraverseVisitor(visitor)
-        .withDominanceFunction(new DominanceFunctions.LeastWalk())
+        .withDominanceFunction(new DominanceFunctions.LowestDistance())
         .withRequest(request)
         .withFrom(linkerContext.findVertices(from))
         .getShortestPathTree();

--- a/application/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
+++ b/application/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
@@ -107,7 +107,7 @@ public class StreetGraphFinder implements GraphFinder {
         .withPreStartHook(OTPRequestTimeoutException::checkForTimeout)
         .withSkipEdgeStrategy(skipEdgeStrategy)
         .withTraverseVisitor(visitor)
-        .withDominanceFunction(new DominanceFunctions.LowestDistance())
+        .withDominanceFunction(new DominanceFunctions.ShortestDistance())
         .withRequest(request)
         .withFrom(linkerContext.findVertices(from))
         .getShortestPathTree();

--- a/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -1444,7 +1444,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
       stateListModel.addElement("weightdelta:" + st.getWeightDelta());
       stateListModel.addElement("rentingVehicle:" + st.isRentingVehicle());
       stateListModel.addElement("vehicleParked:" + st.isVehicleParked());
-      stateListModel.addElement("walkDistance:" + st.getTraversalDistanceMeters());
+      stateListModel.addElement("traversalDistance:" + st.getTraversalDistanceMeters());
       stateListModel.addElement("elapsedTime:" + st.getElapsedTimeSeconds());
       outputList.setModel(stateListModel);
 

--- a/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/application/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -1444,7 +1444,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
       stateListModel.addElement("weightdelta:" + st.getWeightDelta());
       stateListModel.addElement("rentingVehicle:" + st.isRentingVehicle());
       stateListModel.addElement("vehicleParked:" + st.isVehicleParked());
-      stateListModel.addElement("walkDistance:" + st.getWalkDistance());
+      stateListModel.addElement("walkDistance:" + st.getTraversalDistanceMeters());
       stateListModel.addElement("elapsedTime:" + st.getElapsedTimeSeconds());
       outputList.setModel(stateListModel);
 

--- a/street/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/EscalatorEdge.java
@@ -37,7 +37,7 @@ public class EscalatorEdge extends Edge {
       }
       s1.incrementWeight(s0.getRequest().walk().escalator().reluctance() * time);
       s1.incrementTimeInSeconds((long) time);
-      s1.incrementWalkDistance(getDistanceMeters());
+      s1.incrementTraversalDistanceMeters(getDistanceMeters());
       return s1.makeStateArray();
     } else {
       return State.empty();

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1064,17 +1064,11 @@ public class StreetEdge
         case CAR -> request.car().reluctance();
         case FLEX -> 1;
       };
-      if (!traverseMode.isInCar()) {
-        s1.incrementTraversalDistanceMeters(turnDuration / 100); // just a tie-breaker
-      }
-
       time_ms += (long) Math.ceil(1000.0 * turnDuration);
       weight += modeReluctance * request.turnReluctance() * turnDuration;
     }
 
-    if (!traverseMode.isInCar()) {
-      s1.incrementTraversalDistanceMeters(getDistanceWithElevation());
-    }
+    s1.incrementTraversalDistanceMeters(getDistanceWithElevation());
 
     if (costExtension != null) {
       weight += costExtension.calculateExtraCost(s0, length_mm, traverseMode);

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -1064,12 +1064,16 @@ public class StreetEdge
         case CAR -> request.car().reluctance();
         case FLEX -> 1;
       };
+      if (!traverseMode.isInCar()) {
+        s1.incrementTraversalDistanceMeters(turnDuration / 100); // just a tie-breaker
+      }
+
       time_ms += (long) Math.ceil(1000.0 * turnDuration);
       weight += modeReluctance * request.turnReluctance() * turnDuration;
     }
 
     if (!traverseMode.isInCar()) {
-      s1.incrementWalkDistance(getDistanceWithElevation());
+      s1.incrementTraversalDistanceMeters(getDistanceWithElevation());
     }
 
     if (costExtension != null) {

--- a/street/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -371,7 +371,7 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
 
       editor.incrementTimeInMilliseconds(orig.getAbsTimeDeltaMilliseconds());
       editor.incrementWeight(orig.getWeightDelta());
-      editor.incrementTraversalDistanceMeters(orig.getWalkDistanceDeltaMeters());
+      editor.incrementTraversalDistanceMeters(orig.getTraversalDistanceDeltaMeters());
 
       // propagate the modes through to the reversed edge
       editor.setBackMode(orig.getBackMode());
@@ -517,7 +517,7 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
     return Math.abs(getTimeDeltaMilliseconds());
   }
 
-  private double getWalkDistanceDeltaMeters() {
+  private double getTraversalDistanceDeltaMeters() {
     if (backState != null) {
       return Math.abs(this.traversalDistance_m - backState.traversalDistance_m);
     } else {

--- a/street/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -45,10 +45,8 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
   /* StateData contains data which is unlikely to change as often */
   public StateData stateData;
 
-  // how far have we walked
-  // TODO(flamholz): this is a very confusing name as it actually applies to all non-transit modes.
-  // we should DEFINITELY rename this variable and the associated methods.
-  public double walkDistance;
+  // how far have we traversed through the graph
+  public double traversalDistance_m;
 
   /* CONSTRUCTORS */
 
@@ -75,7 +73,7 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
         .rentalRestrictions()
         .noDropOffNetworks();
     }
-    this.walkDistance = 0;
+    this.traversalDistance_m = 0;
     this.time_ms = startTime.toEpochMilli();
   }
 
@@ -269,8 +267,11 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
     return stateData.rentalVehiclePropulsionType;
   }
 
-  public double getWalkDistance() {
-    return walkDistance;
+  /**
+   * Return how far this state has traversed through the graph, in meters.
+   */
+  public double getTraversalDistanceMeters() {
+    return traversalDistance_m;
   }
 
   public Vertex getVertex() {
@@ -370,7 +371,7 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
 
       editor.incrementTimeInMilliseconds(orig.getAbsTimeDeltaMilliseconds());
       editor.incrementWeight(orig.getWeightDelta());
-      editor.incrementWalkDistance(orig.getWalkDistanceDelta());
+      editor.incrementTraversalDistanceMeters(orig.getWalkDistanceDeltaMeters());
 
       // propagate the modes through to the reversed edge
       editor.setBackMode(orig.getBackMode());
@@ -516,9 +517,9 @@ public class State implements AStarState<State, Edge, Vertex>, Cloneable {
     return Math.abs(getTimeDeltaMilliseconds());
   }
 
-  private double getWalkDistanceDelta() {
+  private double getWalkDistanceDeltaMeters() {
     if (backState != null) {
-      return Math.abs(this.walkDistance - backState.walkDistance);
+      return Math.abs(this.traversalDistance_m - backState.traversalDistance_m);
     } else {
       return 0.0;
     }

--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -200,9 +200,7 @@ public class StateEditor {
    */
   public void incrementTraversalDistanceMeters(double length) {
     if (length < 0) {
-      LOG.warn("A state's traversal distance is being incremented by a negative amount.");
-      defectiveTraversal = true;
-      return;
+      throw new IllegalArgumentException("Traversal distance cannot be negative");
     }
     child.traversalDistance_m += length;
   }

--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -195,13 +195,16 @@ public class StateEditor {
     incrementTimeInMilliseconds(1000L * seconds);
   }
 
-  public void incrementWalkDistance(double length) {
+  /**
+   * Increment the distance traversed through the graph in meters.
+   */
+  public void incrementTraversalDistanceMeters(double length) {
     if (length < 0) {
-      LOG.warn("A state's walk distance is being incremented by a negative amount.");
+      LOG.warn("A state's traversal distance is being incremented by a negative amount.");
       defectiveTraversal = true;
       return;
     }
-    child.walkDistance += length;
+    child.traversalDistance_m += length;
   }
 
   /* Basic Setters */

--- a/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
+++ b/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
@@ -153,7 +153,7 @@ public abstract class DominanceFunctions implements Serializable, DominanceFunct
 
     @Override
     protected boolean betterOrEqual(State a, State b) {
-      return a.getWalkDistance() <= b.getWalkDistance();
+      return a.getTraversalDistanceMeters() <= b.getTraversalDistanceMeters();
     }
   }
 

--- a/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
+++ b/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
@@ -143,13 +143,9 @@ public abstract class DominanceFunctions implements Serializable, DominanceFunct
   }
 
   /**
-   * A dominance function that prefers the least walking. This should only be used with walk-only
-   * searches because it does not include any functions of time, and once transit is boarded walk
-   * distance is constant.
-   * <p>
-   * It is used when building stop tree caches for egress from transit stops.
+   * A dominance function that prefers the lowest distance.
    */
-  public static class LeastWalk extends DominanceFunctions {
+  public static class LowestDistance extends DominanceFunctions {
 
     @Override
     protected boolean betterOrEqual(State a, State b) {

--- a/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
+++ b/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
@@ -143,9 +143,9 @@ public abstract class DominanceFunctions implements Serializable, DominanceFunct
   }
 
   /**
-   * A dominance function that prefers the lowest distance.
+   * A dominance function that prefers the shortest distance.
    */
-  public static class LowestDistance extends DominanceFunctions {
+  public static class ShortestDistance extends DominanceFunctions {
 
     @Override
     protected boolean betterOrEqual(State a, State b) {

--- a/street/src/test-fixtures/java/org/locationtech/jts/geom/TestCoordinates.java
+++ b/street/src/test-fixtures/java/org/locationtech/jts/geom/TestCoordinates.java
@@ -1,0 +1,16 @@
+package org.locationtech.jts.geom;
+
+public class TestCoordinates {
+
+  public static final Coordinate BERLIN_TV_TOWER = of(52.5212, 13.4105);
+  public static final Coordinate BERLIN_BRANDENBURG_GATE = of(52.51627, 13.37770);
+
+  /**
+   * Because it is a frequent mistake to swap x/y and longitude/latitude when
+   * constructing JTS Coordinates, this static factory method makes is clear
+   * which is which.
+   */
+  public static Coordinate of(double latitude, double longitude) {
+    return new Coordinate(longitude, latitude);
+  }
+}

--- a/street/src/test-fixtures/java/org/opentripplanner/street/geometry/TestCoordinates.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/geometry/TestCoordinates.java
@@ -1,4 +1,6 @@
-package org.locationtech.jts.geom;
+package org.opentripplanner.street.geometry;
+
+import org.locationtech.jts.geom.Coordinate;
 
 public class TestCoordinates {
 

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.edge;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,6 +11,7 @@ import static org.opentripplanner.street.model.StreetModelFactory.streetEdge;
 import static org.opentripplanner.street.model.StreetModelFactory.streetEdgeBuilder;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
 
+import com.google.common.collect.Range;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+import org.opentripplanner._support.geometry.Coordinates;
 import org.opentripplanner.core.model.basic.Cost;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.street.geometry.GeometryUtils;
@@ -464,4 +467,20 @@ public class StreetEdgeTest {
     assertEquals(mainStreet, edge.getName());
     assertFalse(edge.nameIsDerived());
   }
+
+  /**
+   * We test that length is really in the correct unit.
+   */
+  @Test
+  void lengthIsInMeters() {
+    var v0 = intersectionVertex(Coordinates.BERLIN);
+    var v1 = intersectionVertex(Coordinates.BERLIN_BRANDENBURG_GATE);
+    var edge = StreetModelForTest.streetEdge(v0, v1);
+    var range = Range.closed(2000d, 3000d);
+    assertThat(edge.getDistanceMeters()).isIn(range);
+    State s0 = new State(v1, proto);
+    State s1 = edge.traverse(s0)[0];
+    assertThat(s1.getTraversalDistanceMeters()).isIn(range);
+  }
 }
+

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.street.model.edge;
 
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -11,7 +10,6 @@ import static org.opentripplanner.street.model.StreetModelFactory.streetEdge;
 import static org.opentripplanner.street.model.StreetModelFactory.streetEdgeBuilder;
 import static org.opentripplanner.street.model.StreetTraversalPermission.ALL;
 
-import com.google.common.collect.Range;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +19,6 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
-import org.opentripplanner._support.geometry.Coordinates;
 import org.opentripplanner.core.model.basic.Cost;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.street.geometry.GeometryUtils;
@@ -227,7 +224,7 @@ public class StreetEdgeTest {
     State s1 = e0.traverse(s0)[0];
     State s2 = e1.traverse(s1)[0];
 
-    assertEquals(100.00, s2.getWalkDistance());
+    assertEquals(100.00, s2.getTraversalDistanceMeters());
   }
 
   /**
@@ -467,20 +464,4 @@ public class StreetEdgeTest {
     assertEquals(mainStreet, edge.getName());
     assertFalse(edge.nameIsDerived());
   }
-
-  /**
-   * We test that length is really in the correct unit.
-   */
-  @Test
-  void lengthIsInMeters() {
-    var v0 = intersectionVertex(Coordinates.BERLIN);
-    var v1 = intersectionVertex(Coordinates.BERLIN_BRANDENBURG_GATE);
-    var edge = StreetModelForTest.streetEdge(v0, v1);
-    var range = Range.closed(2000d, 3000d);
-    assertThat(edge.getDistanceMeters()).isIn(range);
-    State s0 = new State(v1, proto);
-    State s1 = edge.traverse(s0)[0];
-    assertThat(s1.getTraversalDistanceMeters()).isIn(range);
-  }
 }
-

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTraversalDistanceTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTraversalDistanceTest.java
@@ -6,7 +6,7 @@ import static org.opentripplanner.street.model.StreetModelFactory.intersectionVe
 import com.google.common.collect.Range;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.locationtech.jts.geom.TestCoordinates;
+import org.opentripplanner.street.geometry.TestCoordinates;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.StreetModelFactory;
 import org.opentripplanner.street.search.request.StreetSearchRequest;

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTraversalDistanceTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTraversalDistanceTest.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.street.model.edge;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
+
+import com.google.common.collect.Range;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.locationtech.jts.geom.TestCoordinates;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetModelFactory;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+import org.opentripplanner.street.search.state.State;
+
+public class StreetEdgeTraversalDistanceTest {
+
+  /**
+   * We test that length is really in the correct unit.
+   */
+  @ParameterizedTest
+  @EnumSource(StreetMode.class)
+  void lengthIsInMeters(StreetMode mode) {
+    var v0 = intersectionVertex(TestCoordinates.BERLIN_TV_TOWER);
+    var v1 = intersectionVertex(TestCoordinates.BERLIN_BRANDENBURG_GATE);
+    var edge = StreetModelFactory.streetEdge(v0, v1);
+    var range = Range.closed(2000d, 3000d);
+    assertThat(edge.getDistanceMeters()).isIn(range);
+    State s0 = new State(v0, StreetSearchRequest.copyOf(StreetSearchRequest.DEFAULT).withMode(mode).build());
+    State s1 = edge.traverse(s0)[0];
+    assertThat(s1.getTraversalDistanceMeters()).isIn(range);
+  }
+}


### PR DESCRIPTION
### Summary

This PR resolves a TODO from 2012 (!) by converting the A* walk distance to a traversal distance, which also includes car modes.

For many years I have wondered why it is the way it is and I have come to the conclusion that it isn't not necessary at all and this change will have no negative consequences.

The background of this changes is that it allows us to skip edge traversal in the flex code, leading to a speed up.

### Issue

Related to #7469

### Unit tests

Added.