### PR TITLE
refactor: Extract NearbyStopFinderVisitor from StreetNearbyStopFinder

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
@@ -1,0 +1,104 @@
+package org.opentripplanner.graph_builder.module.nearbystops;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.opentripplanner.astar.spi.TraverseVisitor;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.TraverseMode;
+import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.transit.model.site.AreaStop;
+
+/**
+ * A {@link TraverseVisitor} that collects transit stops and flex area stops during an A* search,
+ * replacing the post-search scan of all SPT states in {@link StreetNearbyStopFinder}.
+ * <p>
+ * With {@code MinimumWeight} dominance and a trivial heuristic (Dijkstra), {@code visitVertex} is
+ * called exactly once per vertex with the optimal state, producing the same result set as
+ * post-scan filtering of {@code getAllStates()}.
+ */
+class NearbyStopFinderVisitor implements TraverseVisitor<State, Edge> {
+
+  private final StopResolver stopResolver;
+  private final Set<Vertex> originVertices;
+  private final Set<Vertex> ignoreVertices;
+  private final boolean reverseDirection;
+
+  private final List<NearbyStop> transitStopsFound = new ArrayList<>();
+  private final Multimap<AreaStop, State> areaStopStates = ArrayListMultimap.create();
+
+  NearbyStopFinderVisitor(
+    StopResolver stopResolver,
+    Set<Vertex> originVertices,
+    Set<Vertex> ignoreVertices,
+    boolean reverseDirection
+  ) {
+    this.stopResolver = requireNonNull(stopResolver);
+    this.originVertices = requireNonNull(originVertices);
+    this.ignoreVertices = requireNonNull(ignoreVertices);
+    this.reverseDirection = reverseDirection;
+  }
+
+  @Override
+  public void visitVertex(State state) {
+    Vertex vertex = state.getVertex();
+
+    if (originVertices.contains(vertex) || ignoreVertices.contains(vertex)) {
+      return;
+    }
+
+    if (vertex instanceof TransitStopVertex tsv && state.isFinal()) {
+      var stop = requireNonNull(stopResolver.getRegularStop(tsv.getId()));
+      transitStopsFound.add(NearbyStop.nearbyStopForState(state, stop));
+    }
+
+    if (
+      OTPFeature.FlexRouting.isOn() &&
+      vertex instanceof StreetVertex streetVertex &&
+      !streetVertex.areaStops().isEmpty()
+    ) {
+      for (FeedScopedId id : streetVertex.areaStops()) {
+        AreaStop areaStop = Objects.requireNonNull(stopResolver.getAreaStop(id));
+        if (canBoardFlex(state)) {
+          areaStopStates.put(areaStop, state);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void visitEdge(Edge edge) {}
+
+  @Override
+  public void visitEnqueue() {}
+
+  List<NearbyStop> transitStopsFound() {
+    return transitStopsFound;
+  }
+
+  Multimap<AreaStop, State> areaStopStates() {
+    return areaStopStates;
+  }
+
+  private boolean canBoardFlex(State state) {
+    var edges = reverseDirection
+      ? state.getVertex().getIncoming()
+      : state.getVertex().getOutgoing();
+
+    return edges
+      .stream()
+      .anyMatch(e -> e instanceof StreetEdge se && se.getPermission().allows(TraverseMode.CAR));
+  }
+}

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
@@ -2,8 +2,6 @@ package org.opentripplanner.graph_builder.module.nearbystops;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -11,31 +9,23 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
-import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
 import org.opentripplanner.astar.strategy.MaxCountTerminationStrategy;
-import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.graphfinder.NearbyStopFactory;
 import org.opentripplanner.street.model.StreetMode;
-import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.ExtensionRequestContext;
-import org.opentripplanner.street.model.edge.StreetEdge;
-import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.StreetSearchBuilder;
-import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.strategy.DominanceFunctions;
 import org.opentripplanner.streetadapter.StreetSearchRequestMapper;
-import org.opentripplanner.transit.model.site.AreaStop;
 
 public class StreetNearbyStopFinder implements NearbyStopFinder {
 
@@ -124,10 +114,18 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
     }
     stopsFound = new ArrayList<>(stopsFound);
 
+    var visitor = new NearbyStopFinderVisitor(
+      stopResolver,
+      originVertices,
+      ignoreVertices,
+      reverseDirection
+    );
+
     var streetSearch = StreetSearchBuilder.of()
       .withPreStartHook(OTPRequestTimeoutException::checkForTimeout)
       .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(durationLimit))
       .withDominanceFunction(new DominanceFunctions.MinimumWeight())
+      .withTraverseVisitor(visitor)
       .withRequest(
         StreetSearchRequestMapper.map(request)
           .withMode(streetMode)
@@ -144,44 +142,14 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
       );
     }
 
-    ShortestPathTree<State, Edge, Vertex> spt = streetSearch.getShortestPathTree();
+    streetSearch.getShortestPathTree();
 
-    // Only used if OTPFeature.FlexRouting.isOn()
-    Multimap<AreaStop, State> locationsMap = ArrayListMultimap.create();
-
-    if (spt != null) {
-      // TODO use GenericAStar and a traverseVisitor? Add an earliestArrival switch to genericAStar?
-      for (State state : spt.getAllStates()) {
-        Vertex targetVertex = state.getVertex();
-        if (originVertices.contains(targetVertex) || ignoreVertices.contains(targetVertex)) {
-          continue;
-        }
-        if (targetVertex instanceof TransitStopVertex tsv && state.isFinal()) {
-          var stop = requireNonNull(stopResolver.getRegularStop(tsv.getId()));
-          stopsFound.add(NearbyStop.nearbyStopForState(state, stop));
-        }
-        if (
-          OTPFeature.FlexRouting.isOn() &&
-          targetVertex instanceof StreetVertex streetVertex &&
-          !streetVertex.areaStops().isEmpty()
-        ) {
-          for (FeedScopedId id : targetVertex.areaStops()) {
-            AreaStop areaStop = Objects.requireNonNull(stopResolver.getAreaStop(id));
-            // This is for a simplification, so that we only return one vertex from each
-            // stop location. All vertices are added to the multimap, which is filtered
-            // below, so that only the closest vertex is added to stopsFound
-            if (canBoardFlex(state, reverseDirection)) {
-              locationsMap.put(areaStop, state);
-            }
-          }
-        }
-      }
-    }
+    stopsFound.addAll(visitor.transitStopsFound());
 
     if (OTPFeature.FlexRouting.isOn()) {
-      for (var locationStates : locationsMap.asMap().entrySet()) {
-        AreaStop areaStop = locationStates.getKey();
-        Collection<State> states = locationStates.getValue();
+      for (var locationStates : visitor.areaStopStates().asMap().entrySet()) {
+        var areaStop = locationStates.getKey();
+        var states = locationStates.getValue();
         // Select the vertex from all vertices that are reachable per AreaStop by taking
         // the minimum walking distance
         State min = Collections.min(states, Comparator.comparing(State::getWeight));
@@ -198,16 +166,6 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
     }
 
     return stopsFound;
-  }
-
-  private boolean canBoardFlex(State state, boolean reverse) {
-    Collection<Edge> edges = reverse
-      ? state.getVertex().getIncoming()
-      : state.getVertex().getOutgoing();
-
-    return edges
-      .stream()
-      .anyMatch(e -> e instanceof StreetEdge se && se.getPermission().allows(TraverseMode.CAR));
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitorTest.java
@@ -1,0 +1,143 @@
+package org.opentripplanner.graph_builder.module.nearbystops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.street.model.StreetModelForTest;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.street.search.state.TestStateBuilder;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.model.site.RegularStop;
+
+class NearbyStopFinderVisitorTest {
+
+  private static final TransitTestEnvironmentBuilder ENV = TransitTestEnvironment.of();
+  static final RegularStop STOP = ENV.stop("stop-1");
+  static final AreaStop AREA_STOP = ENV.areaStop("area-1");
+
+  private static final StopResolver STOP_RESOLVER = new StopResolver() {
+    @Override
+    public RegularStop getRegularStop(FeedScopedId id) {
+      return STOP;
+    }
+
+    @Override
+    public AreaStop getAreaStop(FeedScopedId id) {
+      return AREA_STOP;
+    }
+  };
+
+  @BeforeAll
+  static void setup() {
+    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
+  }
+
+  @AfterAll
+  static void teardown() {
+    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
+  }
+
+  @Test
+  void collectsTransitStops() {
+    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
+
+    var state = TestStateBuilder.ofWalking().streetEdge().stop(STOP).build();
+    visitor.visitVertex(state);
+
+    var expected = NearbyStop.nearbyStopForState(state, STOP);
+    assertEquals(List.of(expected), visitor.transitStopsFound());
+  }
+
+  @Test
+  void skipsOriginVertices() {
+    var state = TestStateBuilder.ofWalking().streetEdge().stop(STOP).build();
+    var originVertices = Set.of(state.getVertex());
+    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, originVertices, Set.of(), false);
+
+    visitor.visitVertex(state);
+
+    assertTrue(visitor.transitStopsFound().isEmpty());
+  }
+
+  @Test
+  void skipsIgnoreVertices() {
+    var state = TestStateBuilder.ofWalking().streetEdge().stop(STOP).build();
+    var ignoreVertices = Set.of(state.getVertex());
+    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), ignoreVertices, false);
+
+    visitor.visitVertex(state);
+
+    assertTrue(visitor.transitStopsFound().isEmpty());
+  }
+
+  @Test
+  void skipsNonTransitVertices() {
+    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
+
+    // State at a regular intersection, not a transit stop
+    var state = TestStateBuilder.ofWalking().streetEdge().build();
+    visitor.visitVertex(state);
+
+    assertTrue(visitor.transitStopsFound().isEmpty());
+  }
+
+  @Test
+  void collectsAreaStopsWhenFlexEnabled() {
+    var vertex = StreetModelForTest.intersectionVertex(10, 10);
+    var other = StreetModelForTest.intersectionVertex(10.1, 10.1);
+    StreetModelForTest.streetEdge(vertex, other, StreetTraversalPermission.CAR);
+    vertex.addAreaStops(Set.of(AREA_STOP.getId()));
+
+    var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
+    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
+    visitor.visitVertex(state);
+
+    assertEquals(1, visitor.areaStopStates().size());
+    assertTrue(visitor.areaStopStates().containsKey(AREA_STOP));
+    assertEquals(state, visitor.areaStopStates().get(AREA_STOP).iterator().next());
+  }
+
+  @Test
+  void doesNotCollectAreaStopsWithoutCarPermission() {
+    var vertex = StreetModelForTest.intersectionVertex(20, 20);
+    var other = StreetModelForTest.intersectionVertex(20.1, 20.1);
+    StreetModelForTest.streetEdge(vertex, other, StreetTraversalPermission.PEDESTRIAN);
+    vertex.addAreaStops(Set.of(AREA_STOP.getId()));
+
+    var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
+    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
+    visitor.visitVertex(state);
+
+    assertTrue(visitor.areaStopStates().isEmpty());
+  }
+
+  @Test
+  void collectsAreaStopsInReverseDirection() {
+    var vertex = StreetModelForTest.intersectionVertex(30, 30);
+    var other = StreetModelForTest.intersectionVertex(30.1, 30.1);
+    // Create incoming CAR edge: other -> vertex
+    StreetModelForTest.streetEdge(other, vertex, StreetTraversalPermission.CAR);
+    vertex.addAreaStops(Set.of(AREA_STOP.getId()));
+
+    var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
+    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), true);
+    visitor.visitVertex(state);
+
+    assertEquals(1, visitor.areaStopStates().size());
+    assertTrue(visitor.areaStopStates().containsKey(AREA_STOP));
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitorTest.java
@@ -5,10 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.application.OTPFeature;
@@ -40,16 +37,6 @@ class NearbyStopFinderVisitorTest {
       return AREA_STOP;
     }
   };
-
-  @BeforeAll
-  static void setup() {
-    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
-  }
-
-  @AfterAll
-  static void teardown() {
-    OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
-  }
 
   @Test
   void collectsTransitStops() {
@@ -97,47 +84,53 @@ class NearbyStopFinderVisitorTest {
 
   @Test
   void collectsAreaStopsWhenFlexEnabled() {
-    var vertex = StreetModelForTest.intersectionVertex(10, 10);
-    var other = StreetModelForTest.intersectionVertex(10.1, 10.1);
-    StreetModelForTest.streetEdge(vertex, other, StreetTraversalPermission.CAR);
-    vertex.addAreaStops(Set.of(AREA_STOP.getId()));
+    OTPFeature.FlexRouting.testOn(() -> {
+      var vertex = StreetModelForTest.intersectionVertex(10, 10);
+      var other = StreetModelForTest.intersectionVertex(10.1, 10.1);
+      StreetModelForTest.streetEdge(vertex, other, StreetTraversalPermission.CAR);
+      vertex.addAreaStops(Set.of(AREA_STOP.getId()));
 
-    var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
-    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
-    visitor.visitVertex(state);
+      var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
+      var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
+      visitor.visitVertex(state);
 
-    assertEquals(1, visitor.areaStopStates().size());
-    assertTrue(visitor.areaStopStates().containsKey(AREA_STOP));
-    assertEquals(state, visitor.areaStopStates().get(AREA_STOP).iterator().next());
+      assertEquals(1, visitor.areaStopStates().size());
+      assertTrue(visitor.areaStopStates().containsKey(AREA_STOP));
+      assertEquals(state, visitor.areaStopStates().get(AREA_STOP).iterator().next());
+    });
   }
 
   @Test
   void doesNotCollectAreaStopsWithoutCarPermission() {
-    var vertex = StreetModelForTest.intersectionVertex(20, 20);
-    var other = StreetModelForTest.intersectionVertex(20.1, 20.1);
-    StreetModelForTest.streetEdge(vertex, other, StreetTraversalPermission.PEDESTRIAN);
-    vertex.addAreaStops(Set.of(AREA_STOP.getId()));
+    OTPFeature.FlexRouting.testOn(() -> {
+      var vertex = StreetModelForTest.intersectionVertex(20, 20);
+      var other = StreetModelForTest.intersectionVertex(20.1, 20.1);
+      StreetModelForTest.streetEdge(vertex, other, StreetTraversalPermission.PEDESTRIAN);
+      vertex.addAreaStops(Set.of(AREA_STOP.getId()));
 
-    var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
-    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
-    visitor.visitVertex(state);
+      var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
+      var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), false);
+      visitor.visitVertex(state);
 
-    assertTrue(visitor.areaStopStates().isEmpty());
+      assertTrue(visitor.areaStopStates().isEmpty());
+    });
   }
 
   @Test
   void collectsAreaStopsInReverseDirection() {
-    var vertex = StreetModelForTest.intersectionVertex(30, 30);
-    var other = StreetModelForTest.intersectionVertex(30.1, 30.1);
-    // Create incoming CAR edge: other -> vertex
-    StreetModelForTest.streetEdge(other, vertex, StreetTraversalPermission.CAR);
-    vertex.addAreaStops(Set.of(AREA_STOP.getId()));
+    OTPFeature.FlexRouting.testOn(() -> {
+      var vertex = StreetModelForTest.intersectionVertex(30, 30);
+      var other = StreetModelForTest.intersectionVertex(30.1, 30.1);
+      // Create incoming CAR edge: other -> vertex
+      StreetModelForTest.streetEdge(other, vertex, StreetTraversalPermission.CAR);
+      vertex.addAreaStops(Set.of(AREA_STOP.getId()));
 
-    var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
-    var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), true);
-    visitor.visitVertex(state);
+      var state = new State(vertex, StreetSearchRequest.of().withStartTime(Instant.EPOCH).build());
+      var visitor = new NearbyStopFinderVisitor(STOP_RESOLVER, Set.of(), Set.of(), true);
+      visitor.visitVertex(state);
 
-    assertEquals(1, visitor.areaStopStates().size());
-    assertTrue(visitor.areaStopStates().containsKey(AREA_STOP));
+      assertEquals(1, visitor.areaStopStates().size());
+      assertTrue(visitor.areaStopStates().containsKey(AREA_STOP));
+    });
   }
 }


### PR DESCRIPTION
## Summary

Extract stop collection logic from `StreetNearbyStopFinder` into a dedicated `NearbyStopFinderVisitor` that collects transit stops and flex area stops inline during the A* search, replacing the post-search scan of `spt.getAllStates()`.

This resolves the existing TODO (`// TODO use GenericAStar and a traverseVisitor?`) and follows the established `TraverseVisitor` pattern used by `StopFinderTraverseVisitor` and `PlaceFinderTraverseVisitor`.

### How it works

Under `MinimumWeight` dominance with Dijkstra (trivial heuristic), `visitVertex` is called exactly once per vertex with the optimal state — producing the same result set as the old post-scan filtering. The visitor is wired into the search via `StreetSearchBuilder.withTraverseVisitor()` and its results are consumed immediately after the search completes.

### Changes

- **New:** `NearbyStopFinderVisitor` — package-private `TraverseVisitor<State, Edge>` that collects transit stops and flex area stop states during traversal
- **Modified:** `StreetNearbyStopFinder` — wires the visitor into the search builder, removes the `getAllStates()` post-scan loop and the `canBoardFlex` helper
- **New:** `NearbyStopFinderVisitorTest` — unit tests for the visitor

### Performance improvement

The old code called `spt.getAllStates()` after the search completed, which:

1. **Allocated a short-lived ArrayList** sized to the number of explored vertices (typically 10K–25K entries, ~80–200 KB of object references) that became garbage immediately after the loop.
2. **Scanned the full `SegmentedIdentityMap` hash table** via `forEachValue()`, iterating every slot including empty ones (~33% empty at 2/3 load factor), causing cache-unfriendly access.
3. **Iterated all states a second time** — the A* search already visited every state once to relax edges; the post-scan re-iterated the entire set just to find the ~50–200 transit stops among ~10K–25K explored vertices.

With the visitor, stop collection happens inline as each vertex is settled during the search. This eliminates:
- The `ArrayList` allocation (×2 per routing request: access + egress)
- The full hash-table scan of the `SegmentedIdentityMap`
- The redundant second pass over all explored states

The per-vertex filtering work (`instanceof TransitStopVertex`, `isFinal()`, area stop checks) is identical in both approaches — the improvement is purely from avoiding the allocation and redundant iteration in the hot path.

## Unit tests

Added 7 unit tests covering:
- Transit stop collection (happy path)
- Origin and ignore vertex filtering
- Non-transit vertex skipping
- Flex area stop collection when `FlexRouting` is enabled with CAR-permission edges
- Flex area stop rejection when edges lack CAR permission (`canBoardFlex` returns false)
- Reverse direction flex collection (checks incoming edges instead of outgoing)

Existing integration tests in `StreetNearbyStopFinderTest` and `StreetNearbyStopFinderMultipleLinksTest` cover the end-to-end flow.