### PR TITLE
Add connectionStartupTimeout for resilience against Siri ET MQTT broker unavailability 

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttEstimatedTimetableSource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttEstimatedTimetableSource.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -47,6 +48,12 @@ import uk.org.siri.siri21.Siri;
  * (ready for routing requests), when all retained messages in the connected MQTT are processed.
  * If there are no retained messages, the updater is primed immediately. Live messages (messages
  * without a retained flag) are always processed, even if the updater is not yet primed.
+ * <p>
+ * If the MQTT broker is unavailable at startup, the updater waits up to
+ * {@code connectionStartupTimeout} for a connection. If no connection is established within that
+ * time, the updater marks itself as primed immediately so OTP can start routing without real-time
+ * data. The MQTT client continues retrying in the background; once the broker becomes available
+ * live messages will be processed normally.
  */
 public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSource {
 
@@ -64,6 +71,7 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
   private final ExecutorService liveExecutor;
 
   private volatile boolean primed = false;
+  private final CompletableFuture<Void> connectionFuture = new CompletableFuture<>();
 
   private Instant connectedAt;
   private final AtomicLong liveMessageCounter = new AtomicLong();
@@ -96,9 +104,28 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
   public void start(Function<ServiceDelivery, Future<?>> serviceDeliveryConsumer) {
     this.serviceDeliveryConsumer = serviceDeliveryConsumer;
 
-    client = connectAndSubscribeToClient();
-    connectedAt = Instant.now();
+    client = buildAndConnectClient();
 
+    // Wait up to connectionStartupTimeout for the broker to connect.
+    waitToConnectWithTimeout();
+
+    if (!connectionFuture.isDone()) {
+      // Broker was not reachable within the startup timeout. Allow OTP to route without
+      // real-time data. The HiveMQ client continues reconnecting in the background; live
+      // messages will flow once the broker becomes available (via onConnect -> subscribe).
+      LOG.warn(
+        "MQTT broker at {} was not reachable within {}. " +
+          "OTP will start routing without real-time data. " +
+          "The MQTT client will keep retrying in the background.",
+        parameters.url(),
+        parameters.connectionStartupTimeout()
+      );
+      liveExecutor.submit(new LiveRunner());
+      primed = true;
+      return;
+    }
+
+    // Normal priming path: broker was available, retained messages may have arrived.
     List<CompletableFuture<Void>> primingFutures = new ArrayList<>();
 
     for (int i = 0; i < parameters.numberOfPrimingWorkers(); i++) {
@@ -126,6 +153,18 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
       });
 
     liveExecutor.submit(new LiveRunner());
+  }
+
+  private void waitToConnectWithTimeout() {
+    try {
+      connectionFuture.get(parameters.connectionStartupTimeout().toMillis(), TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      // Broker was not reachable within the startup timeout
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (ExecutionException e) {
+      LOG.warn("Unexpected error while waiting for MQTT connection", e);
+    }
   }
 
   private void waitForGraphUpdates() {
@@ -170,7 +209,12 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
       .register(Metrics.globalRegistry);
   }
 
-  private Mqtt5AsyncClient connectAndSubscribeToClient() {
+  /**
+   * Build the HiveMQ client and initiate a non-blocking connect. The client will automatically
+   * retry the connection (with exponential backoff) if the broker is unavailable. When a
+   * connection is established, {@link #onConnect()} is called which sets up the subscription.
+   */
+  private Mqtt5AsyncClient buildAndConnectClient() {
     Mqtt5SimpleAuth auth;
     if (hasNoValue(parameters.user()) || hasNoValue(parameters.password())) {
       auth = null;
@@ -180,7 +224,7 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
         .password(parameters.password().getBytes(StandardCharsets.UTF_8))
         .build();
     }
-    Mqtt5AsyncClient client = Mqtt5Client.builder()
+    Mqtt5AsyncClient mqttClient = Mqtt5Client.builder()
       .identifier("OpenTripPlanner-" + UUID.randomUUID())
       .serverHost(parameters.host())
       .serverPort(parameters.port())
@@ -190,17 +234,10 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
       .addDisconnectedListener(this::onDisconnect)
       .buildAsync();
 
-    client.connectWith().keepAlive(30).cleanStart(false).send().join();
+    // Non-blocking connect: HiveMQ will retry automatically if the broker is unavailable.
+    mqttClient.connectWith().keepAlive(30).cleanStart(false).send();
 
-    client
-      .subscribeWith()
-      .topicFilter(parameters.topic())
-      .qos(Optional.ofNullable(MqttQos.fromCode(parameters.qos())).orElse(MqttQos.AT_MOST_ONCE))
-      .callback(this::onMessage)
-      .send()
-      .join();
-
-    return client;
+    return mqttClient;
   }
 
   private void onDisconnect(MqttClientDisconnectedContext ctx) {
@@ -208,11 +245,22 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
   }
 
   private void onConnect() {
+    connectedAt = Instant.now();
+    connectionFuture.complete(null);
     LOG.info(
       "Connected client to MQTT broker: {} with qos: {}",
       parameters.url(),
       parameters.qos()
     );
+    // Subscribe on every connect (including reconnects). With cleanStart=false the broker
+    // remembers the subscription across reconnects, but re-subscribing is idempotent in MQTT5
+    // and ensures the callback is always registered correctly.
+    client
+      .subscribeWith()
+      .topicFilter(parameters.topic())
+      .qos(Optional.ofNullable(MqttQos.fromCode(parameters.qos())).orElse(MqttQos.AT_MOST_ONCE))
+      .callback(this::onMessage)
+      .send();
   }
 
   @Override
@@ -224,7 +272,9 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
   public void teardown() {
     liveExecutor.shutdownNow();
     primingExecutor.shutdownNow();
-    client.disconnect();
+    if (client != null) {
+      client.disconnect();
+    }
   }
 
   private Optional<ServiceDelivery> serviceDelivery(byte[] payload) {

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttSiriETUpdaterParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttSiriETUpdaterParameters.java
@@ -16,6 +16,7 @@ public class MqttSiriETUpdaterParameters implements UrlUpdaterParameters {
   private final boolean fuzzyTripMatching;
   private final int numberOfPrimingWorkers;
   private final Duration maxPrimingIdleTime;
+  private final Duration connectionStartupTimeout;
 
   public MqttSiriETUpdaterParameters(
     String configRef,
@@ -28,7 +29,8 @@ public class MqttSiriETUpdaterParameters implements UrlUpdaterParameters {
     int qos,
     boolean fuzzyTripMatching,
     int numberOfPrimingWorkers,
-    Duration maxPrimingIdleTime
+    Duration maxPrimingIdleTime,
+    Duration connectionStartupTimeout
   ) {
     this.configRef = configRef;
     this.feedId = feedId;
@@ -41,6 +43,7 @@ public class MqttSiriETUpdaterParameters implements UrlUpdaterParameters {
     this.fuzzyTripMatching = fuzzyTripMatching;
     this.numberOfPrimingWorkers = numberOfPrimingWorkers;
     this.maxPrimingIdleTime = maxPrimingIdleTime;
+    this.connectionStartupTimeout = connectionStartupTimeout;
   }
 
   @Override
@@ -92,5 +95,9 @@ public class MqttSiriETUpdaterParameters implements UrlUpdaterParameters {
 
   public Duration maxPrimingIdleTime() {
     return maxPrimingIdleTime;
+  }
+
+  public Duration connectionStartupTimeout() {
+    return connectionStartupTimeout;
   }
 }

--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
@@ -14,7 +14,8 @@ public enum OtpVersion {
   V2_6("2.6"),
   V2_7("2.7"),
   V2_8("2.8"),
-  V2_9("2.9");
+  V2_9("2.9"),
+  V2_10("2.10");
 
   private final String text;
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETMqttUpdaterConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETMqttUpdaterConfig.java
@@ -85,6 +85,22 @@ public class SiriETMqttUpdaterConfig {
       )
       .asDuration(Duration.ofSeconds(1));
 
+    Duration connectionStartupTimeout = siriMqttRoot
+      .of("connectionStartupTimeout")
+      .since(OtpVersion.V2_10)
+      .summary("How long to wait for the MQTT broker to be available at startup.")
+      .description(
+        """
+        If the MQTT broker is unavailable when OTP starts, OTP will wait up to this duration for
+        the broker to become available before allowing routing requests. If the broker connects
+        within this time, normal priming occurs: retained messages are processed before routing is
+        enabled. If the broker does not connect within this time, OTP will start routing without
+        real-time data. The MQTT client will continue attempting to reconnect in the background, and
+        live messages will be processed once the broker is available.
+        """
+      )
+      .asDuration(Duration.ofSeconds(30));
+
     return new MqttSiriETUpdaterParameters(
       configRef,
       feedId,
@@ -96,7 +112,8 @@ public class SiriETMqttUpdaterConfig {
       qos,
       fuzzyTripMatching,
       numberOfPrimingWorkers,
-      maxPrimingIdleTime
+      maxPrimingIdleTime,
+      connectionStartupTimeout
     );
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/updater/mqtt/MqttGtfsRealtimeUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/updater/mqtt/MqttGtfsRealtimeUpdater.java
@@ -149,7 +149,9 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
 
   @Override
   public void teardown() {
-    client.disconnect();
+    if (client != null) {
+      client.disconnect();
+    }
   }
 
   @Override

--- a/doc/user/sandbox/siri/SiriMqttUpdater.md
+++ b/doc/user/sandbox/siri/SiriMqttUpdater.md
@@ -27,22 +27,38 @@ of the `router-config.json`.
 <!-- siri-et-mqtt BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
 
-| Config Parameter                                         |    Type    | Summary                                                |  Req./Opt. | Default Value | Since |
-|----------------------------------------------------------|:----------:|--------------------------------------------------------|:----------:|---------------|:-----:|
-| type = "siri-et-mqtt"                                    |   `enum`   | The type of the updater.                               | *Required* |               |  1.5  |
-| feedId                                                   |  `string`  | The feed ID this updater should be applied to          | *Required* |               |  2.9  |
-| fuzzyTripMatching                                        |  `boolean` | Whether or not the fuzzy trip matcher should be used   | *Required* |               |  2.9  |
-| host                                                     |  `string`  | The host of the MQTT broker                            | *Required* |               |  2.9  |
-| [maxPrimingIdleTime](#u__17__maxPrimingIdleTime)         | `duration` | Max idle time until priming is considered complete.    | *Optional* | `"PT1S"`      |  2.9  |
-| [numberOfPrimingWorkers](#u__17__numberOfPrimingWorkers) |  `integer` | Number of priming workers to process retained messages | *Optional* | `1`           |  2.9  |
-| [password](#u__17__password)                             |  `string`  | The password for authorization at the MQTT broker      | *Optional* |               |  2.9  |
-| port                                                     |  `integer` | The port of the MQTT broker                            | *Required* |               |  2.9  |
-| qos                                                      |  `integer` | The qos used for the MQTT subscription                 | *Required* |               |  2.9  |
-| topic                                                    |  `string`  | The topic the updater should subscribe to              | *Required* |               |  2.9  |
-| [user](#u__17__user)                                     |  `string`  | The user for authorization at the MQTT broker          | *Optional* |               |  2.9  |
+| Config Parameter                                             |    Type    | Summary                                                          |  Req./Opt. | Default Value | Since |
+|--------------------------------------------------------------|:----------:|------------------------------------------------------------------|:----------:|---------------|:-----:|
+| type = "siri-et-mqtt"                                        |   `enum`   | The type of the updater.                                         | *Required* |               |  1.5  |
+| [connectionStartupTimeout](#u__17__connectionStartupTimeout) | `duration` | How long to wait for the MQTT broker to be available at startup. | *Optional* | `"PT30S"`     |  2.10 |
+| feedId                                                       |  `string`  | The feed ID this updater should be applied to                    | *Required* |               |  2.9  |
+| fuzzyTripMatching                                            |  `boolean` | Whether or not the fuzzy trip matcher should be used             | *Required* |               |  2.9  |
+| host                                                         |  `string`  | The host of the MQTT broker                                      | *Required* |               |  2.9  |
+| [maxPrimingIdleTime](#u__17__maxPrimingIdleTime)             | `duration` | Max idle time until priming is considered complete.              | *Optional* | `"PT1S"`      |  2.9  |
+| [numberOfPrimingWorkers](#u__17__numberOfPrimingWorkers)     |  `integer` | Number of priming workers to process retained messages           | *Optional* | `1`           |  2.9  |
+| [password](#u__17__password)                                 |  `string`  | The password for authorization at the MQTT broker                | *Optional* |               |  2.9  |
+| port                                                         |  `integer` | The port of the MQTT broker                                      | *Required* |               |  2.9  |
+| qos                                                          |  `integer` | The qos used for the MQTT subscription                           | *Required* |               |  2.9  |
+| topic                                                        |  `string`  | The topic the updater should subscribe to                        | *Required* |               |  2.9  |
+| [user](#u__17__user)                                         |  `string`  | The user for authorization at the MQTT broker                    | *Optional* |               |  2.9  |
 
 
 ##### Parameter details
+
+<h4 id="u__17__connectionStartupTimeout">connectionStartupTimeout</h4>
+
+**Since version:** `2.10` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT30S"`   
+**Path:** /updaters/[17] 
+
+How long to wait for the MQTT broker to be available at startup.
+
+If the MQTT broker is unavailable when OTP starts, OTP will wait up to this duration for
+the broker to become available before allowing routing requests. If the broker connects
+within this time, normal priming occurs: retained messages are processed before routing is
+enabled. If the broker does not connect within this time, OTP will start routing without
+real-time data. The MQTT client will continue attempting to reconnect in the background, and
+live messages will be processed once the broker is available.
+
 
 <h4 id="u__17__maxPrimingIdleTime">maxPrimingIdleTime</h4>
 


### PR DESCRIPTION
### Summary
Adds a connectionStartupTimeout configuration parameter to the SIRI MQTT updater so that OTP can start routing without real-time data when the MQTT broker is unavailable at startup, instead of blocking indefinitely. The MQTT client continues retrying in the background and resumes processing live messages once the broker becomes available.

### Issue
No related issue. 

### Motivation
Previously, if the MQTT broker was unreachable when OTP started, the blocking .join() call in connectAndSubscribeToClient() would hang OTP startup indefinitely with no fallback.

### How the code works
The HiveMQ client connection is now initiated non-blocking. At startup, OTP waits up to connectionStartupTimeout (default: 30s) for the broker to connect. If the broker connects in time, normal priming proceeds (retained messages are processed before routing is enabled). If not, OTP logs a warning and marks the updater as primed immediately, allowing routing to start without real-time data. Subscription setup is moved into the onConnect callback so it is correctly re-established on every reconnect, including after a broker restart.

New optional parameter in `router-config.json`:
```json
{
  "type": "siri-et-mqtt",
  "connectionStartupTimeout": "PT30S"
}
```

### Unit tests
No unit tests were added. The change is primarily a resilience/configuration improvement to the MQTT connection lifecycle. Manual verification was done to confirm OTP starts correctly both when the broker is available and when it is not.

### Documentation
- The connectionStartupTimeout parameter is documented inline in SiriETMqttUpdaterConfig.java using OTP's config framework, and the auto-generated SiriMqttUpdater.md table and parameter details section have been updated accordingly.
- The class-level Javadoc on MqttEstimatedTimetableSource was updated to describe the new startup timeout behavior.
- A new OtpVersion.V2_10 enum entry was added to mark the parameter's introduction version.