### PR TITLE
Use A* traversal distance for flex access/egress

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/StateToFlexPathMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/StateToFlexPathMapperTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.flex.flexpathcalculator;
 
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.street.search.state.TestStateBuilder.ofDriving;
 
@@ -8,14 +7,16 @@ import org.junit.jupiter.api.Test;
 
 class StateToFlexPathMapperTest {
 
-  private static final int EPSILON = 100;
+  private static final int EPSILON = 10;
+  private static final int EXPECTED_DISTANCE = 471_509;
+  private static final int EXPECTED_DURATION = 42_100;
 
   @Test
   void departAt() {
     var state = ofDriving().streetEdge().streetEdge().streetEdge().build();
     var flexPath = StateToFlexPathMapper.map(state);
-    assertThat(flexPath.distanceMeters).isWithin(EPSILON).of(471509);
-    assertEquals(42100, flexPath.durationSeconds);
+    assertEquals(EXPECTED_DISTANCE, flexPath.distanceMeters, EPSILON);
+    assertEquals(EXPECTED_DURATION, flexPath.durationSeconds, EPSILON);
     assertEquals("LINESTRING (1 1, 2 2, 3 3, 4 4)", flexPath.getGeometry().toString());
   }
 
@@ -23,8 +24,8 @@ class StateToFlexPathMapperTest {
   void arriveBy() {
     var state = ofDriving().streetEdge().streetEdge().streetEdge().build().reverse();
     var flexPath = StateToFlexPathMapper.map(state);
-    assertThat(flexPath.distanceMeters).isWithin(EPSILON).of(471509);
-    assertEquals(42100, flexPath.durationSeconds);
+    assertEquals(EXPECTED_DISTANCE, flexPath.distanceMeters, EPSILON);
+    assertEquals(EXPECTED_DURATION, flexPath.durationSeconds, EPSILON);
     assertEquals("LINESTRING (1 1, 2 2, 3 3, 4 4)", flexPath.getGeometry().toString());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculatorTest.java
@@ -11,7 +11,8 @@ import org.opentripplanner.street.model.vertex.IntersectionVertex;
 class StreetFlexPathCalculatorTest {
 
   private static final int IGNORED = -99;
-  private static final int EPSILON = 1000;
+  private static final int EPSILON = 10;
+  private static final int EXPECTED_DURATION = 42_112;
   private static final int EXPECTED_DISTANCE = 471_653;
 
   private final IntersectionVertex v0 = intersectionVertex(0, 0);
@@ -34,6 +35,7 @@ class StreetFlexPathCalculatorTest {
     var forwardPath = forwardCalculator.calculateFlexPath(v0, v3, IGNORED, IGNORED);
     assertEquals("LINESTRING (0 0, 1 1, 2 2, 3 3)", forwardPath.getGeometry().toString());
 
+    assertEquals(EXPECTED_DURATION, forwardPath.durationSeconds, EPSILON);
     assertEquals(EXPECTED_DISTANCE, forwardPath.distanceMeters, EPSILON);
   }
 
@@ -43,6 +45,7 @@ class StreetFlexPathCalculatorTest {
     var reversePath = reverseCalculator.calculateFlexPath(v3, v0, IGNORED, IGNORED);
     assertEquals("LINESTRING (3 3, 2 2, 1 1, 0 0)", reversePath.getGeometry().toString());
 
+    assertEquals(EXPECTED_DURATION, reversePath.durationSeconds, EPSILON);
     assertEquals(EXPECTED_DISTANCE, reversePath.distanceMeters, EPSILON);
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StateToFlexPathMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StateToFlexPathMapper.java
@@ -26,17 +26,9 @@ class StateToFlexPathMapper {
    * up the distance along the way.
    */
   static FlexPath map(State state) {
-    double distance_m = 0.0;
-
-    // TODO: compute this during traversal of the edges in a follow up PR
-    for (var backEdge : state.listBackEdges()) {
-      distance_m += backEdge.getDistanceMeters();
-    }
-
     // computing the linestring from the graph path is a surprisingly expensive operation
     // so we delay it until it's actually needed. since most flex paths are never shown to the user
     // this improves performance quite a bit.
-
     Supplier<LineString> geometrySupplier = () -> {
       if (state.getRequest().arriveBy()) {
         var geometries = Iterables.transform(state.listBackEdges(), Edge::getGeometry);
@@ -47,7 +39,11 @@ class StateToFlexPathMapper {
       }
     };
 
-    return new FlexPath((int) distance_m, (int) state.getElapsedTimeSeconds(), geometrySupplier);
+    return new FlexPath(
+      (int) state.getTraversalDistanceMeters(),
+      (int) state.getElapsedTimeSeconds(),
+      geometrySupplier
+    );
   }
 
   private static LineString reverse(Edge e) {


### PR DESCRIPTION
### Summary

It uses the accumulated A* traversal distance to compute the distance of the flex access. This was enabled by #7482 .

This saves an iteration of the state chain because the information is already available, which leads to a speed up of about 3% (or about 100ms in the Washington speed test).


### Issue

Ref #7444 

### Unit tests

I unified the existing tests a little.