### PR TITLE
Stream SIRI-ET initial data HTTP response directly into XML parser

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/updater/google/GooglePubsubEstimatedTimetableSource.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/updater/google/GooglePubsubEstimatedTimetableSource.java
@@ -265,16 +265,12 @@ public class GooglePubsubEstimatedTimetableSource implements AsyncEstimatedTimet
    */
   private void initializeData() {
     if (dataInitializationUrl != null) {
-      LOG.info("Fetching initial data from {}", dataInitializationUrl);
+      LOG.info("Fetching and parsing initial data from {}", dataInitializationUrl);
       final long t1 = System.currentTimeMillis();
-      ByteString value = fetchInitialData();
+      var serviceDelivery = fetchAndParseInitialData();
       final long t2 = System.currentTimeMillis();
-      LOG.info(
-        "Fetching initial data - finished after {} ms, got {}",
-        (t2 - t1),
-        FileSizeToTextConverter.fileSizeToString(value.size())
-      );
-      serviceDelivery(value)
+      LOG.info("Fetching and parsing initial data - finished after {} ms", (t2 - t1));
+      serviceDelivery
         .map(serviceDeliveryConsumer)
         .ifPresent(future -> {
           try {
@@ -299,17 +295,18 @@ public class GooglePubsubEstimatedTimetableSource implements AsyncEstimatedTimet
   }
 
   /**
-   * Fetch the backlog of messages over HTTP from the configured data initialization URL.
+   * Fetch the backlog of messages over HTTP and parse the XML response.
    */
-  private ByteString fetchInitialData() {
+  private Optional<ServiceDelivery> fetchAndParseInitialData() {
     try (OtpHttpClientFactory otpHttpClientFactory = new OtpHttpClientFactory()) {
       var otpHttpClient = otpHttpClientFactory.create(LOG);
-      return otpHttpClient.getAndMap(
+      var siri = otpHttpClient.getAndMap(
         dataInitializationUrl,
         initialGetDataTimeout,
         HttpHeaders.of(Map.of("Content-Type", "application/xml")),
-        response -> ByteString.readFrom(response.body())
+        response -> SiriXml.parseXml(response.body())
       );
+      return Optional.ofNullable(siri.getServiceDelivery());
     }
   }
 


### PR DESCRIPTION
## Summary

Stream the SIRI-ET PubSub initial data HTTP response directly into the StAX/JAXB XML parser instead of buffering the entire payload into a `ByteString`.

This eliminates a ~325 MB (TST) / ~580 MB (PRD) short-lived allocation that contributes to GC pressure during startup. The `SiriXml.parseXml(InputStream)` parser already supports streaming via `XMLStreamReader`, and this pattern is already used by `SiriAzureUpdater` and `SiriFmDataSource`.

### Before
```
HTTP response → ByteString (full buffer in memory) → SiriXml.parseXml()
```

### After
```
HTTP response → SiriXml.parseXml(response.body())  (streamed directly)
```

## Unit tests

No unit tests, tested manually.

## Documentation

No documentation changes needed — no new configuration options or public API changes.