### PR TITLE
 Early Pruning optimization for RAPTOR transfer relaxation

### DIFF
--- a/application/src/main/java/org/opentripplanner/transfer/regular/index/OnDemandRaptorTransferIndex.java
+++ b/application/src/main/java/org/opentripplanner/transfer/regular/index/OnDemandRaptorTransferIndex.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import org.opentripplanner.raptor.spi.RaptorTransfer;
@@ -60,10 +61,11 @@ class OnDemandRaptorTransferIndex implements RaptorTransferIndex {
     // We don't think that the overhead of locking is worthwhile for the occasional chance of two
     // threads generating the transfers at the same time.
     if (forwardRaptorTransfers[stopIndex] == null) {
-      forwardRaptorTransfers[stopIndex] = RaptorTransferIndex.getRaptorTransfers(
-        request,
-        forwardTransfers.get(stopIndex)
+      var transfers = new ArrayList<>(
+        RaptorTransferIndex.getRaptorTransfers(request, forwardTransfers.get(stopIndex))
       );
+      transfers.sort(Comparator.comparingInt(RaptorTransfer::durationInSeconds));
+      forwardRaptorTransfers[stopIndex] = transfers;
     }
 
     return forwardRaptorTransfers[stopIndex];
@@ -74,9 +76,11 @@ class OnDemandRaptorTransferIndex implements RaptorTransferIndex {
     initializeReversedTransfers();
 
     if (reversedRaptorTransfers[stopIndex] == null) {
-      reversedRaptorTransfers[stopIndex] = getReversedRaptorTransfers(
-        reversedTransfers.get(stopIndex)
+      var transfers = new ArrayList<>(
+        getReversedRaptorTransfers(reversedTransfers.get(stopIndex))
       );
+      transfers.sort(Comparator.comparingInt(RaptorTransfer::durationInSeconds));
+      reversedRaptorTransfers[stopIndex] = transfers;
     }
 
     return reversedRaptorTransfers[stopIndex];

--- a/application/src/main/java/org/opentripplanner/transfer/regular/index/PreCachedRaptorTransferIndex.java
+++ b/application/src/main/java/org/opentripplanner/transfer/regular/index/PreCachedRaptorTransferIndex.java
@@ -2,8 +2,10 @@ package org.opentripplanner.transfer.regular.index;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.opentripplanner.raptor.api.model.RaptorTransfer;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.transfer.regular.model.DefaultRaptorTransfer;
 import org.opentripplanner.transfer.regular.model.Transfer;
@@ -45,6 +47,16 @@ class PreCachedRaptorTransferIndex implements RaptorTransferIndex {
         reversedTransfers.get(forwardTransfer.stop()).add(forwardTransfer.reverseOf(fromStop));
       }
     }
+
+    // Sort transfers by duration (Early Pruning optimization: enables breaking the transfer
+    // loop early when arrival time exceeds the best known time, since all subsequent transfers
+    // are guaranteed to be at least as long). See: Rohovyi et al., "Early Pruning for Public
+    // Transport Routing", 2026.
+    Comparator<DefaultRaptorTransfer> byDuration = Comparator.comparingInt(
+      RaptorTransfer::durationInSeconds
+    );
+    forwardTransfers.forEach(list -> list.sort(byDuration));
+    reversedTransfers.forEach(list -> list.sort(byDuration));
 
     // Create immutable copies of the lists for each stop to make them immutable and faster to iterate
     //noinspection unchecked

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -33,9 +33,6 @@ import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   implements RaptorWorkerState<T> {
 
-  private static final boolean EARLY_PRUNING_ENABLED =
-    !"false".equals(System.getProperty("otp.raptor.earlyPruning", "true"));
-
   private final McStopArrivals<T> arrivals;
   private final DestinationArrivalPaths<T> paths;
   private final HeuristicsProvider<T> heuristics;
@@ -44,17 +41,6 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   private final RaptorCostCalculator<T> calculatorGeneralizedCost;
   private final RaptorTransitCalculator<T> transitCalculator;
   private final Collection<McStopArrival<T>> onBoardAccessStopArrivals;
-
-  /**
-   * Early Pruning: best known destination arrival time. Used to prune transfers whose earliest
-   * possible arrival already exceeds this bound. Only arrival time is used as the pruning
-   * criterion — cost and round are not considered, so Pareto-optimal paths with worse arrival
-   * time but better cost may be pruned.
-   * See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
-   */
-  private int bestDestinationArrivalTime;
-  private final int[] egressStopIndices;
-  private final int[] egressMinDurations;
 
   /**
    * create a RaptorState for a network with a particular number of stops, and a given maximum
@@ -67,9 +53,7 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
     McStopArrivalFactory<T> stopArrivalFactory,
     RaptorCostCalculator<T> calculatorGeneralizedCost,
     RaptorTransitCalculator<T> transitCalculator,
-    WorkerLifeCycle lifeCycle,
-    int[] egressStopIndices,
-    int[] egressMinDurations
+    WorkerLifeCycle lifeCycle
   ) {
     this.arrivals = arrivals;
     this.paths = paths;
@@ -78,9 +62,6 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
     this.calculatorGeneralizedCost = calculatorGeneralizedCost;
     this.transitCalculator = transitCalculator;
     this.onBoardAccessStopArrivals = new ArrayList<>();
-    this.egressStopIndices = egressStopIndices;
-    this.egressMinDurations = egressMinDurations;
-    this.bestDestinationArrivalTime = transitCalculator.unreachedTime();
 
     // Attach to the RR life cycle
     lifeCycle.onSetupIteration(ignore -> setupIteration());
@@ -122,39 +103,13 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
 
   /**
    * Set the time at a transit stops iff it is optimal.
-   * Transfers are expected to be sorted by duration (non-decreasing). This enables Early Pruning:
-   * once the earliest possible arrival plus transfer duration exceeds the best known destination
-   * arrival time, all subsequent (longer) transfers will too.
-   * See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
    */
   @Override
   public void transferToStops(int fromStop, Iterator<? extends RaptorTransfer> transfers) {
     var fromArrivals = arrivals.listArrivalsAfterMarker(fromStop);
 
-    if (EARLY_PRUNING_ENABLED) {
-      // Find the earliest arrival time among all Pareto-optimal arrivals at this stop.
-      int earliestArrivalTime = Integer.MAX_VALUE;
-      for (McStopArrival<T> arrival : fromArrivals) {
-        if (arrival.arrivalTime() < earliestArrivalTime) {
-          earliestArrivalTime = arrival.arrivalTime();
-        }
-      }
-
-      while (transfers.hasNext()) {
-        var transfer = transfers.next();
-        int bestPossibleArrival = earliestArrivalTime + transfer.durationInSeconds();
-        if (
-          exceedsTimeLimit(bestPossibleArrival) ||
-          !transitCalculator.isBefore(bestPossibleArrival, bestDestinationArrivalTime)
-        ) {
-          break;
-        }
-        transferToStop(fromArrivals, transfer);
-      }
-    } else {
-      while (transfers.hasNext()) {
-        transferToStop(fromArrivals, transfers.next());
-      }
+    while (transfers.hasNext()) {
+      transferToStop(fromArrivals, transfers.next());
     }
   }
 
@@ -253,20 +208,6 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
       return;
     }
     arrivals.addStopArrival(arrival);
-    // Early Pruning: update best destination arrival time if this is an egress stop.
-    if (EARLY_PRUNING_ENABLED) {
-      int stop = arrival.stop();
-      int arrivalTime = arrival.arrivalTime();
-      for (int i = 0; i < egressStopIndices.length; i++) {
-        if (egressStopIndices[i] == stop) {
-          int destArrival = arrivalTime + egressMinDurations[i];
-          if (transitCalculator.isBefore(destArrival, bestDestinationArrivalTime)) {
-            bestDestinationArrivalTime = destArrival;
-          }
-          break;
-        }
-      }
-    }
   }
 
   private int calculateC1(PatternRide<T> ride, int alightStop, int alightTime, int alightSlack) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -46,15 +46,13 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   private final Collection<McStopArrival<T>> onBoardAccessStopArrivals;
 
   /**
-   * Early Pruning: best known destination arrival time (egress stop time + egress walk duration).
-   * Used as the upper bound for pruning transfers.
+   * Early Pruning: best known destination arrival time. Used to prune transfers whose earliest
+   * possible arrival already exceeds this bound. Only arrival time is used as the pruning
+   * criterion — cost and round are not considered, so Pareto-optimal paths with worse arrival
+   * time but better cost may be pruned.
    * See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
    */
   private int bestDestinationArrivalTime;
-
-  /**
-   * Early Pruning: egress stop indices and their minimum egress durations.
-   */
   private final int[] egressStopIndices;
   private final int[] egressMinDurations;
 
@@ -125,41 +123,38 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   /**
    * Set the time at a transit stops iff it is optimal.
    * Transfers are expected to be sorted by duration (non-decreasing). This enables Early Pruning:
-   * once the earliest possible arrival plus transfer duration exceeds the time limit, all
-   * subsequent (longer) transfers will too. See: Rohovyi et al., "Early Pruning for Public
-   * Transport Routing".
+   * once the earliest possible arrival plus transfer duration exceeds the best known destination
+   * arrival time, all subsequent (longer) transfers will too.
+   * See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
    */
   @Override
   public void transferToStops(int fromStop, Iterator<? extends RaptorTransfer> transfers) {
     var fromArrivals = arrivals.listArrivalsAfterMarker(fromStop);
 
-    // Early Pruning: find the earliest arrival time among all Pareto-optimal arrivals at
-    // this stop. Since transfers are sorted by duration, once earliest + duration exceeds
-    // the best known egress stop arrival time, all remaining transfers will too.
-    // See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
-    int earliestArrivalTime = Integer.MAX_VALUE;
     if (EARLY_PRUNING_ENABLED) {
+      // Find the earliest arrival time among all Pareto-optimal arrivals at this stop.
+      int earliestArrivalTime = Integer.MAX_VALUE;
       for (McStopArrival<T> arrival : fromArrivals) {
         if (arrival.arrivalTime() < earliestArrivalTime) {
           earliestArrivalTime = arrival.arrivalTime();
         }
       }
-    }
 
-    while (transfers.hasNext()) {
-      var transfer = transfers.next();
-      if (EARLY_PRUNING_ENABLED) {
+      while (transfers.hasNext()) {
+        var transfer = transfers.next();
         int bestPossibleArrival = earliestArrivalTime + transfer.durationInSeconds();
-        // Early Pruning: if the best possible arrival via this transfer exceeds the best
-        // known destination arrival time, all subsequent longer transfers will too - break.
         if (
           exceedsTimeLimit(bestPossibleArrival) ||
           !transitCalculator.isBefore(bestPossibleArrival, bestDestinationArrivalTime)
         ) {
           break;
         }
+        transferToStop(fromArrivals, transfer);
       }
-      transferToStop(fromArrivals, transfer);
+    } else {
+      while (transfers.hasNext()) {
+        transferToStop(fromArrivals, transfers.next());
+      }
     }
   }
 
@@ -259,17 +254,17 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
     }
     arrivals.addStopArrival(arrival);
     // Early Pruning: update best destination arrival time if this is an egress stop.
-    updateBestDestinationArrivalTime(arrival.stop(), arrival.arrivalTime());
-  }
-
-  private void updateBestDestinationArrivalTime(int stop, int arrivalTime) {
-    for (int i = 0; i < egressStopIndices.length; i++) {
-      if (egressStopIndices[i] == stop) {
-        int destArrival = arrivalTime + egressMinDurations[i];
-        if (transitCalculator.isBefore(destArrival, bestDestinationArrivalTime)) {
-          bestDestinationArrivalTime = destArrival;
+    if (EARLY_PRUNING_ENABLED) {
+      int stop = arrival.stop();
+      int arrivalTime = arrival.arrivalTime();
+      for (int i = 0; i < egressStopIndices.length; i++) {
+        if (egressStopIndices[i] == stop) {
+          int destArrival = arrivalTime + egressMinDurations[i];
+          if (transitCalculator.isBefore(destArrival, bestDestinationArrivalTime)) {
+            bestDestinationArrivalTime = destArrival;
+          }
+          break;
         }
-        return;
       }
     }
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -33,6 +33,9 @@ import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   implements RaptorWorkerState<T> {
 
+  private static final boolean EARLY_PRUNING_ENABLED =
+    !"false".equals(System.getProperty("otp.raptor.earlyPruning", "true"));
+
   private final McStopArrivals<T> arrivals;
   private final DestinationArrivalPaths<T> paths;
   private final HeuristicsProvider<T> heuristics;
@@ -41,6 +44,19 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   private final RaptorCostCalculator<T> calculatorGeneralizedCost;
   private final RaptorTransitCalculator<T> transitCalculator;
   private final Collection<McStopArrival<T>> onBoardAccessStopArrivals;
+
+  /**
+   * Early Pruning: best known destination arrival time (egress stop time + egress walk duration).
+   * Used as the upper bound for pruning transfers.
+   * See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
+   */
+  private int bestDestinationArrivalTime;
+
+  /**
+   * Early Pruning: egress stop indices and their minimum egress durations.
+   */
+  private final int[] egressStopIndices;
+  private final int[] egressMinDurations;
 
   /**
    * create a RaptorState for a network with a particular number of stops, and a given maximum
@@ -53,7 +69,9 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
     McStopArrivalFactory<T> stopArrivalFactory,
     RaptorCostCalculator<T> calculatorGeneralizedCost,
     RaptorTransitCalculator<T> transitCalculator,
-    WorkerLifeCycle lifeCycle
+    WorkerLifeCycle lifeCycle,
+    int[] egressStopIndices,
+    int[] egressMinDurations
   ) {
     this.arrivals = arrivals;
     this.paths = paths;
@@ -62,6 +80,9 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
     this.calculatorGeneralizedCost = calculatorGeneralizedCost;
     this.transitCalculator = transitCalculator;
     this.onBoardAccessStopArrivals = new ArrayList<>();
+    this.egressStopIndices = egressStopIndices;
+    this.egressMinDurations = egressMinDurations;
+    this.bestDestinationArrivalTime = transitCalculator.unreachedTime();
 
     // Attach to the RR life cycle
     lifeCycle.onSetupIteration(ignore -> setupIteration());
@@ -103,13 +124,42 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
 
   /**
    * Set the time at a transit stops iff it is optimal.
+   * Transfers are expected to be sorted by duration (non-decreasing). This enables Early Pruning:
+   * once the earliest possible arrival plus transfer duration exceeds the time limit, all
+   * subsequent (longer) transfers will too. See: Rohovyi et al., "Early Pruning for Public
+   * Transport Routing".
    */
   @Override
   public void transferToStops(int fromStop, Iterator<? extends RaptorTransfer> transfers) {
     var fromArrivals = arrivals.listArrivalsAfterMarker(fromStop);
 
+    // Early Pruning: find the earliest arrival time among all Pareto-optimal arrivals at
+    // this stop. Since transfers are sorted by duration, once earliest + duration exceeds
+    // the best known egress stop arrival time, all remaining transfers will too.
+    // See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
+    int earliestArrivalTime = Integer.MAX_VALUE;
+    if (EARLY_PRUNING_ENABLED) {
+      for (McStopArrival<T> arrival : fromArrivals) {
+        if (arrival.arrivalTime() < earliestArrivalTime) {
+          earliestArrivalTime = arrival.arrivalTime();
+        }
+      }
+    }
+
     while (transfers.hasNext()) {
-      transferToStop(fromArrivals, transfers.next());
+      var transfer = transfers.next();
+      if (EARLY_PRUNING_ENABLED) {
+        int bestPossibleArrival = earliestArrivalTime + transfer.durationInSeconds();
+        // Early Pruning: if the best possible arrival via this transfer exceeds the best
+        // known destination arrival time, all subsequent longer transfers will too - break.
+        if (
+          exceedsTimeLimit(bestPossibleArrival) ||
+          !transitCalculator.isBefore(bestPossibleArrival, bestDestinationArrivalTime)
+        ) {
+          break;
+        }
+      }
+      transferToStop(fromArrivals, transfer);
     }
   }
 
@@ -208,6 +258,20 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
       return;
     }
     arrivals.addStopArrival(arrival);
+    // Early Pruning: update best destination arrival time if this is an egress stop.
+    updateBestDestinationArrivalTime(arrival.stop(), arrival.arrivalTime());
+  }
+
+  private void updateBestDestinationArrivalTime(int stop, int arrivalTime) {
+    for (int i = 0; i < egressStopIndices.length; i++) {
+      if (egressStopIndices[i] == stop) {
+        int destArrival = arrivalTime + egressMinDurations[i];
+        if (transitCalculator.isBefore(destArrival, bestDestinationArrivalTime)) {
+          bestDestinationArrivalTime = destArrival;
+        }
+        return;
+      }
+    }
   }
 
   private int calculateC1(PatternRide<T> ride, int alightStop, int alightTime, int alightSlack) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
@@ -188,6 +188,7 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
 
   private McRangeRaptorWorkerState<T> createState(Heuristics heuristics) {
     if (state == null) {
+      var egressData = computeEgressStopData();
       state = new McRangeRaptorWorkerState<>(
         stopArrivals(),
         createDestinationArrivalPaths(),
@@ -195,7 +196,9 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
         createStopArrivalFactory(),
         context().costCalculator(),
         context().calculator(),
-        context().lifeCycle()
+        context().lifeCycle(),
+        egressData[0],
+        egressData[1]
       );
     }
     return state;
@@ -310,5 +313,30 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
       return ParetoSetCost.USE_C1_AND_C2;
     }
     return ParetoSetCost.USE_C1;
+  }
+
+  /**
+   * Compute egress stop data for Early Pruning: returns [stopIndices, minDurations].
+   */
+  private int[][] computeEgressStopData() {
+    var egressPaths = contextSegment.egressPaths();
+    if (egressPaths == null) {
+      return new int[][] { new int[0], new int[0] };
+    }
+    var minDurationByStop = new java.util.LinkedHashMap<Integer, Integer>();
+    for (var egress : egressPaths.listAll()) {
+      int stop = egress.stop();
+      int dur = egress.durationInSeconds();
+      minDurationByStop.merge(stop, dur, Math::min);
+    }
+    int[] stops = new int[minDurationByStop.size()];
+    int[] durations = new int[minDurationByStop.size()];
+    int i = 0;
+    for (var entry : minDurationByStop.entrySet()) {
+      stops[i] = entry.getKey();
+      durations[i] = entry.getValue();
+      i++;
+    }
+    return new int[][] { stops, durations };
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
@@ -188,7 +188,6 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
 
   private McRangeRaptorWorkerState<T> createState(Heuristics heuristics) {
     if (state == null) {
-      var egressData = computeEgressStopData();
       state = new McRangeRaptorWorkerState<>(
         stopArrivals(),
         createDestinationArrivalPaths(),
@@ -196,9 +195,7 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
         createStopArrivalFactory(),
         context().costCalculator(),
         context().calculator(),
-        context().lifeCycle(),
-        egressData[0],
-        egressData[1]
+        context().lifeCycle()
       );
     }
     return state;
@@ -315,28 +312,4 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
     return ParetoSetCost.USE_C1;
   }
 
-  /**
-   * Compute egress stop data for Early Pruning: returns [stopIndices, minDurations].
-   */
-  private int[][] computeEgressStopData() {
-    var egressPaths = contextSegment.egressPaths();
-    if (egressPaths == null) {
-      return new int[][] { new int[0], new int[0] };
-    }
-    var minDurationByStop = new java.util.LinkedHashMap<Integer, Integer>();
-    for (var egress : egressPaths.listAll()) {
-      int stop = egress.stop();
-      int dur = egress.durationInSeconds();
-      minDurationByStop.merge(stop, dur, Math::min);
-    }
-    int[] stops = new int[minDurationByStop.size()];
-    int[] durations = new int[minDurationByStop.size()];
-    int i = 0;
-    for (var entry : minDurationByStop.entrySet()) {
-      stops[i] = entry.getKey();
-      durations[i] = entry.getValue();
-      i++;
-    }
-    return new int[][] { stops, durations };
-  }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -31,6 +31,9 @@ import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
   implements StdWorkerState<T> {
 
+  private static final boolean EARLY_PRUNING_ENABLED =
+    !"false".equals(System.getProperty("otp.raptor.earlyPruning", "true"));
+
   /**
    * The best times to reach each stop, whether via a transfer or via transit directly. This is the
    * bare minimum to execute the algorithm.
@@ -59,6 +62,22 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
   private final RaptorTransitCalculator<T> calculator;
 
   /**
+   * Early Pruning: egress stop indices and their minimum egress durations. For each egress stop,
+   * we track the minimum duration of all egress paths from that stop. The best destination arrival
+   * time = min(arrivalTimeAtEgressStop + minEgressDuration).
+   * See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
+   */
+  private final int[] egressStopIndices;
+  private final int[] egressMinDurations;
+
+  /**
+   * Early Pruning: best known destination arrival time (egress stop arrival + egress walk).
+   * If a transfer arrival time is not before this, neither this transfer nor any subsequent
+   * (longer) transfer can improve the solution.
+   */
+  private int bestDestinationArrivalTime;
+
+  /**
    * create a BestTimes Range Raptor State for given context.
    */
   public StdRangeRaptorWorkerState(
@@ -66,13 +85,18 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
     BestTimes bestTimes,
     StopArrivalsState<T> stopArrivalsState,
     BestNumberOfTransfers bestNumberOfTransfers,
-    ArrivedAtDestinationCheck arrivedAtDestinationCheck
+    ArrivedAtDestinationCheck arrivedAtDestinationCheck,
+    int[] egressStopIndices,
+    int[] egressMinDurations
   ) {
     this.calculator = calculator;
     this.bestTimes = bestTimes;
     this.stopArrivalsState = stopArrivalsState;
     this.bestNumberOfTransfers = bestNumberOfTransfers;
     this.arrivedAtDestinationCheck = arrivedAtDestinationCheck;
+    this.egressStopIndices = egressStopIndices;
+    this.egressMinDurations = egressMinDurations;
+    this.bestDestinationArrivalTime = calculator.unreachedTime();
   }
 
   @Override
@@ -121,12 +145,23 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
 
   /**
    * Set the arrival time at all transit stop if time is optimal for the given list of transfers.
+   * Transfers are expected to be sorted by duration (non-decreasing). This enables Early Pruning:
+   * once a transfer exceeds the time limit, all subsequent (longer) transfers will too, so the
+   * loop can terminate early. See: Rohovyi et al., "Early Pruning for Public Transport Routing".
    */
   @Override
   public void transferToStops(int fromStop, Iterator<? extends RaptorTransfer> transfers) {
     int arrivalTimeTransit = bestTimes.transitArrivalTime(fromStop);
-    while (transfers.hasNext()) {
-      transferToStop(arrivalTimeTransit, fromStop, transfers.next());
+    if (EARLY_PRUNING_ENABLED) {
+      while (transfers.hasNext()) {
+        if (transferToStopWithEarlyPruning(arrivalTimeTransit, fromStop, transfers.next())) {
+          break;
+        }
+      }
+    } else {
+      while (transfers.hasNext()) {
+        transferToStopWithEarlyPruning(arrivalTimeTransit, fromStop, transfers.next());
+      }
     }
   }
 
@@ -187,7 +222,15 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
     return stopArrivalsState.previousTransit(boardStopIndex);
   }
 
-  private void transferToStop(int arrivalTimeTransit, int fromStop, RaptorTransfer transfer) {
+  /**
+   * @return true if the time limit was exceeded, signaling that Early Pruning should terminate
+   *     the transfer loop (all subsequent sorted transfers will also exceed the limit).
+   */
+  private boolean transferToStopWithEarlyPruning(
+    int arrivalTimeTransit,
+    int fromStop,
+    RaptorTransfer transfer
+  ) {
     // Use the calculator to make sure the calculation is done correct for a normal
     // forward search and a reverse search.
     final int arrivalTime = calculator.plusDuration(
@@ -196,7 +239,17 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
     );
 
     if (exceedsTimeLimit(arrivalTime)) {
-      return;
+      return true;
+    }
+
+    // Early Pruning: if arrival time at the transfer target is not before the best known
+    // destination arrival time, this transfer (and all subsequent longer transfers) cannot
+    // improve the solution. See: Rohovyi et al., "Early Pruning for Public Transport Routing".
+    if (
+      EARLY_PRUNING_ENABLED &&
+      !calculator.isBefore(arrivalTime, bestDestinationArrivalTime)
+    ) {
+      return true;
     }
 
     final int toStop = transfer.stop();
@@ -206,6 +259,7 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
     } else {
       stopArrivalsState.rejectNewBestTransferTime(fromStop, arrivalTime, transfer);
     }
+    return false;
   }
 
   @Override
@@ -220,7 +274,21 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
   /* private methods */
 
   private boolean newOverallBestTime(int stop, int alightTime) {
-    return bestTimes.updateNewBestTime(stop, alightTime);
+    boolean updated = bestTimes.updateNewBestTime(stop, alightTime);
+    if (updated) {
+      // Early Pruning: update best destination arrival time if this is an egress stop.
+      // Destination arrival = egress stop arrival + minimum egress duration.
+      for (int i = 0; i < egressStopIndices.length; i++) {
+        if (egressStopIndices[i] == stop) {
+          int destArrival = calculator.plusDuration(alightTime, egressMinDurations[i]);
+          if (calculator.isBefore(destArrival, bestDestinationArrivalTime)) {
+            bestDestinationArrivalTime = destArrival;
+          }
+          break;
+        }
+      }
+    }
+    return updated;
   }
 
   private boolean newBestTransitArrivalTime(int stop, int alightTime) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.api.view.TransitArrival;
 import org.opentripplanner.raptor.rangeraptor.internalapi.RaptorRouterResult;
+import org.opentripplanner.raptor.rangeraptor.internalapi.WorkerLifeCycle;
 import org.opentripplanner.raptor.rangeraptor.standard.besttimes.BestTimes;
 import org.opentripplanner.raptor.rangeraptor.standard.internalapi.ArrivedAtDestinationCheck;
 import org.opentripplanner.raptor.rangeraptor.standard.internalapi.BestNumberOfTransfers;
@@ -71,11 +72,22 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
   private final int[] egressMinDurations;
 
   /**
-   * Early Pruning: best known destination arrival time (egress stop arrival + egress walk).
-   * If a transfer arrival time is not before this, neither this transfer nor any subsequent
-   * (longer) transfer can improve the solution.
+   * Early Pruning: best known destination arrival time per round (across all iterations).
+   * Each round only prunes against its own best, so a fast multi-transfer path from a previous
+   * iteration does not block a slower few-transfer path in the current iteration.
+   * This ensures correctness for Range Raptor's [departureTime, arrivalTime, numTransfers] Pareto.
    */
-  private int bestDestinationArrivalTime;
+  private final int[] bestDestArrivalByRound;
+
+  /**
+   * Early Pruning: best known destination arrival time within the current RAPTOR iteration.
+   * Within a single iteration (fixed departure time), rounds proceed sequentially, so this
+   * value only reflects earlier rounds. It is reset at the start of each iteration.
+   */
+  private int bestDestCurrentIteration;
+
+  /** Current round, updated via lifecycle. */
+  private int currentRound;
 
   /**
    * create a BestTimes Range Raptor State for given context.
@@ -87,7 +99,9 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
     BestNumberOfTransfers bestNumberOfTransfers,
     ArrivedAtDestinationCheck arrivedAtDestinationCheck,
     int[] egressStopIndices,
-    int[] egressMinDurations
+    int[] egressMinDurations,
+    int nRounds,
+    WorkerLifeCycle lifeCycle
   ) {
     this.calculator = calculator;
     this.bestTimes = bestTimes;
@@ -96,7 +110,12 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
     this.arrivedAtDestinationCheck = arrivedAtDestinationCheck;
     this.egressStopIndices = egressStopIndices;
     this.egressMinDurations = egressMinDurations;
-    this.bestDestinationArrivalTime = calculator.unreachedTime();
+    this.bestDestArrivalByRound = new int[nRounds + 1];
+    java.util.Arrays.fill(this.bestDestArrivalByRound, calculator.unreachedTime());
+    this.bestDestCurrentIteration = calculator.unreachedTime();
+    this.currentRound = 0;
+    lifeCycle.onPrepareForNextRound(round -> this.currentRound = round);
+    lifeCycle.onSetupIteration(ignore -> this.bestDestCurrentIteration = calculator.unreachedTime());
   }
 
   @Override
@@ -242,14 +261,23 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
       return true;
     }
 
-    // Early Pruning: if arrival time at the transfer target is not before the best known
-    // destination arrival time, this transfer (and all subsequent longer transfers) cannot
-    // improve the solution. See: Rohovyi et al., "Early Pruning for Public Transport Routing".
-    if (
-      EARLY_PRUNING_ENABLED &&
-      !calculator.isBefore(arrivalTime, bestDestinationArrivalTime)
-    ) {
-      return true;
+    // Early Pruning: use the tighter of two valid bounds:
+    // 1. bestDestArrivalByRound[currentRound] — per-round best across all Range Raptor iterations
+    // 2. bestDestCurrentIteration — best within current iteration (from earlier rounds)
+    // Both are valid: (1) ensures cross-iteration correctness for Pareto [dept, arr, transfers],
+    // (2) provides within-iteration pruning as in single-departure RAPTOR (paper's EP).
+    // See: Rohovyi et al., "Early Pruning for Public Transport Routing", 2026.
+    if (EARLY_PRUNING_ENABLED) {
+      int epBound = bestDestCurrentIteration;
+      if (
+        currentRound < bestDestArrivalByRound.length &&
+        calculator.isBefore(bestDestArrivalByRound[currentRound], epBound)
+      ) {
+        epBound = bestDestArrivalByRound[currentRound];
+      }
+      if (!calculator.isBefore(arrivalTime, epBound)) {
+        return true;
+      }
     }
 
     final int toStop = transfer.stop();
@@ -276,13 +304,20 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
   private boolean newOverallBestTime(int stop, int alightTime) {
     boolean updated = bestTimes.updateNewBestTime(stop, alightTime);
     if (updated) {
-      // Early Pruning: update best destination arrival time if this is an egress stop.
-      // Destination arrival = egress stop arrival + minimum egress duration.
+      // Early Pruning: update destination arrival times if this is an egress stop.
       for (int i = 0; i < egressStopIndices.length; i++) {
         if (egressStopIndices[i] == stop) {
           int destArrival = calculator.plusDuration(alightTime, egressMinDurations[i]);
-          if (calculator.isBefore(destArrival, bestDestinationArrivalTime)) {
-            bestDestinationArrivalTime = destArrival;
+          // Update per-round bound (for cross-iteration correctness)
+          if (
+            currentRound < bestDestArrivalByRound.length &&
+            calculator.isBefore(destArrival, bestDestArrivalByRound[currentRound])
+          ) {
+            bestDestArrivalByRound[currentRound] = destArrival;
+          }
+          // Update within-iteration bound (for within-iteration pruning)
+          if (calculator.isBefore(destArrival, bestDestCurrentIteration)) {
+            bestDestCurrentIteration = destArrival;
           }
           break;
         }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
@@ -106,13 +106,16 @@ public class StdRangeRaptorConfig<T extends RaptorTripSchedule> {
 
   private StdRangeRaptorWorkerState<T> resolveState() {
     if (state == null) {
+      var egressData = computeEgressStopData();
       this.state = oneOf(
         new StdRangeRaptorWorkerState<>(
           ctx.calculator(),
           resolveBestTimes(),
           createStopArrivals(),
           resolveBestNumberOfTransfers(),
-          resolveArrivedAtDestinationCheck()
+          resolveArrivedAtDestinationCheck(),
+          egressData[0],
+          egressData[1]
         ),
         StdWorkerState.class
       );
@@ -269,6 +272,28 @@ public class StdRangeRaptorConfig<T extends RaptorTripSchedule> {
       ctx.segments().getLast().egressPaths(),
       "Last leg must have non-null egressPaths"
     );
+  }
+
+  /**
+   * Compute egress stop data for Early Pruning: returns [stopIndices, minDurations] where
+   * minDurations[i] is the minimum egress duration from stopIndices[i] to the destination.
+   */
+  private int[][] computeEgressStopData() {
+    var minDurationByStop = new java.util.LinkedHashMap<Integer, Integer>();
+    for (var egress : egressPaths().listAll()) {
+      int stop = egress.stop();
+      int dur = egress.durationInSeconds();
+      minDurationByStop.merge(stop, dur, Math::min);
+    }
+    int[] stops = new int[minDurationByStop.size()];
+    int[] durations = new int[minDurationByStop.size()];
+    int i = 0;
+    for (var entry : minDurationByStop.entrySet()) {
+      stops[i] = entry.getKey();
+      durations[i] = entry.getValue();
+      i++;
+    }
+    return new int[][] { stops, durations };
   }
 
   private <S extends BestNumberOfTransfers> S withBestNumberOfTransfers(S value) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
@@ -115,7 +115,9 @@ public class StdRangeRaptorConfig<T extends RaptorTripSchedule> {
           resolveBestNumberOfTransfers(),
           resolveArrivedAtDestinationCheck(),
           egressData[0],
-          egressData[1]
+          egressData[1],
+          ctx.nRounds(),
+          ctx.lifeCycle()
         ),
         StdWorkerState.class
       );


### PR DESCRIPTION
### Summary
                                                                                                                                                                       
  Implement the Early Pruning optimization that reduces RAPTOR query time by breaking out of transfer iteration early when remaining (sorted) transfers cannot improve the solution. Following the discussion with @t2gran during the OTP meeting on April 7, 2026, this PR is submitted for review. 
                                                                                                                                                                       
  ### Issue       

  Closes #7470                                                                                                                                                         
   
  ### Unit tests                                                                                                                                                       
                  
  - All existing OTP unit tests pass with the change.
  - No new unit tests were added — the optimization is a performance improvement that preserves identical routing results.
  - Manual verification: benchmarked on 1,000 random queries in the Norway (Oslo region) graph across 30/60/90 min max transfer durations. Results are 100% identical to baseline (0 differences in paths found).                                                                                                                          
  - Performance improvement: +8.5% at 30 min, +8.2% at 60 min, +10.4% at 90 min transfer duration.                                                                     
  - No regression on the standard OTP Norway SpeedTest (45 test cases, identical path counts).                                                                         
                                                                                                                                                                       
  ### Documentation                                                                                                                                                    
                                                                                                                                                                       
  - Design and rationale documented in code comments, referencing the paper: Rohovyi, Abuaisha, Walsh — "Early Pruning for Public Transport Routing", accepted at WCTR 2026 (https://arxiv.org/abs/2603.12592).
  - The optimization can be toggled via system property `otp.raptor.earlyPruning` (enabled by default, set to `"false"` to disable).                                   
  - No new user-facing configuration options were added.                                                                                                               
                                                                                                                                                                       
  