### PR TITLE
De-duplicate boardinglocations on areas

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -73,6 +74,8 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
   private final VertexFactory vertexFactory;
   private final VertexLinker linker;
 
+  private final Map<Area, OsmBoardingLocationVertex> existingBoardingLocationsAtAreas;
+
   /**
    * @param timetableRepository This module requires the timetable repository because at the time
    *                            of the instantiation the site repository is empty.
@@ -90,6 +93,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
     this.osmInfoGraphBuildService = osmInfoGraphBuildService;
     this.vertexFactory = new VertexFactory(graph);
     this.linker = linker;
+    this.existingBoardingLocationsAtAreas = new HashMap<>();
   }
 
   @Override
@@ -175,12 +179,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         if (platOpt.isPresent()) {
           var platform = platOpt.get();
           if (matchesReference(stop, platform.references())) {
-            var boardingLocation = makeBoardingLocation(
-              stop,
-              platform.geometry().getCentroid(),
-              platform.references(),
-              area.getName()
-            );
+            var boardingLocation = makeBoardingLocationForArea(stop, area, platform);
             linker.addPermanentAreaVertex(boardingLocation, areaGroup);
             linkBoardingLocationToStop(ts, stop.getCode(), boardingLocation);
             return true;
@@ -270,6 +269,25 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       }
     }
     return false;
+  }
+
+  /*
+   * when two stops reference the same OSM platform area, only one
+   * OsmBoardingLocationVertex centroid is created for that area and both stops are linked to it.
+   */
+  private OsmBoardingLocationVertex makeBoardingLocationForArea(
+    RegularStop stop,
+    Area area,
+    Platform platform
+  ) {
+    return existingBoardingLocationsAtAreas.computeIfAbsent(area, _ ->
+      makeBoardingLocation(
+        stop,
+        platform.geometry().getCentroid(),
+        platform.references(),
+        area.getName()
+      )
+    );
   }
 
   private OsmBoardingLocationVertex makeBoardingLocation(

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -74,7 +74,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
   private final VertexFactory vertexFactory;
   private final VertexLinker linker;
 
-  private final Map<Area, OsmBoardingLocationVertex> existingBoardingLocationsAtAreas;
+  private final Map<Platform, OsmBoardingLocationVertex> existingBoardingLocationsAtAreas;
 
   /**
    * @param timetableRepository This module requires the timetable repository because at the time
@@ -172,7 +172,11 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         if (platOpt.isPresent()) {
           var platform = platOpt.get();
           if (matchesReference(stop, platform.references())) {
-            var boardingLocation = makeBoardingLocationForArea(stop, area, platform);
+            var boardingLocation = getOrMakeBoardingLocationForPlatform(
+              stop,
+              platform,
+              area.getName()
+            );
             linker.addPermanentAreaVertex(boardingLocation, areaGroup);
             linkBoardingLocationToStop(ts, stop.getCode(), boardingLocation);
             return true;
@@ -203,26 +207,32 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         });
     }
 
-    for (var platformEdgeList : nearbyEdges.entrySet()) {
-      Platform platform = platformEdgeList.getKey();
-      var name = platform.name();
-      var boardingLocation = makeBoardingLocation(
-        stop,
-        platform.geometry().getCentroid(),
-        platform.references(),
-        name
-      );
-      for (var vertex : linker.linkToSpecificStreetEdgesPermanently(
-        boardingLocation,
-        new TraverseModeSet(TraverseMode.WALK),
-        LinkingDirection.BIDIRECTIONAL,
-        platformEdgeList.getValue().stream().map(StreetEdge.class::cast).collect(Collectors.toSet())
-      )) {
-        linkBoardingLocationToStop(ts, stop.getCode(), vertex);
-      }
-      return true;
-    }
-    return false;
+    return nearbyEdges
+      .entrySet()
+      .stream()
+      .findFirst()
+      .map(platformEdgeList -> {
+        Platform platform = platformEdgeList.getKey();
+        var boardingLocation = getOrMakeBoardingLocationForPlatform(
+          stop,
+          platform,
+          platform.name()
+        );
+        for (var vertex : linker.linkToSpecificStreetEdgesPermanently(
+          boardingLocation,
+          new TraverseModeSet(TraverseMode.WALK),
+          LinkingDirection.BIDIRECTIONAL,
+          platformEdgeList
+            .getValue()
+            .stream()
+            .map(StreetEdge.class::cast)
+            .collect(Collectors.toSet())
+        )) {
+          linkBoardingLocationToStop(ts, stop.getCode(), vertex);
+        }
+        return true;
+      })
+      .orElse(false);
   }
 
   /**
@@ -259,21 +269,16 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
   }
 
   /*
-   * when two stops reference the same OSM platform area, only one
-   * OsmBoardingLocationVertex centroid is created for that area and both stops are linked to it.
+   * when two or more stops reference the same OSM platform, only one
+   * OsmBoardingLocationVertex is created for that platform and both stops are linked to it.
    */
-  private OsmBoardingLocationVertex makeBoardingLocationForArea(
+  private OsmBoardingLocationVertex getOrMakeBoardingLocationForPlatform(
     RegularStop stop,
-    Area area,
-    Platform platform
+    Platform platform,
+    I18NString name
   ) {
-    return existingBoardingLocationsAtAreas.computeIfAbsent(area, _ ->
-      makeBoardingLocation(
-        stop,
-        platform.geometry().getCentroid(),
-        platform.references(),
-        area.getName()
-      )
+    return existingBoardingLocationsAtAreas.computeIfAbsent(platform, _ ->
+      makeBoardingLocation(stop, platform.geometry().getCentroid(), platform.references(), name)
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -65,7 +65,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
   private static final LocalizedString LOCALIZED_PLATFORM_NAME = new LocalizedString(
     "name.platform"
   );
-  private final double searchRadiusDegrees = SphericalDistanceLibrary.metersToDegrees(250);
+  private static final double SEARCH_RADIUS_DEGREES = SphericalDistanceLibrary.metersToDegrees(250);
 
   private final Graph graph;
 
@@ -105,15 +105,8 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
 
     for (TransitStopVertex ts : graph.getVerticesOfType(TransitStopVertex.class)) {
       // if the street is already linked there is no need to link it again,
-      // could happened if using the prune isolated island
-      boolean alreadyLinked = false;
-      for (Edge e : ts.getOutgoing()) {
-        if (e instanceof StreetTransitStopLink) {
-          alreadyLinked = true;
-          break;
-        }
-      }
-      if (alreadyLinked) {
+      // could happen if using the prune isolated island
+      if (ts.getOutgoing().stream().anyMatch(StreetTransitStopLink.class::isInstance)) {
         continue;
       }
       // only connect transit stops that are not part of a pathway network
@@ -150,7 +143,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
     Envelope envelope = new Envelope(ts.getCoordinate());
 
     double xscale = Math.cos((ts.getCoordinate().y * Math.PI) / 180);
-    envelope.expandBy(searchRadiusDegrees / xscale, searchRadiusDegrees);
+    envelope.expandBy(SEARCH_RADIUS_DEGREES / xscale, SEARCH_RADIUS_DEGREES);
     return envelope;
   }
 
@@ -205,13 +198,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         .findPlatform(edge)
         .ifPresent(platform -> {
           if (matchesReference(stop, platform.references())) {
-            if (!nearbyEdges.containsKey(platform)) {
-              var list = new ArrayList<Edge>();
-              list.add(edge);
-              nearbyEdges.put(platform, list);
-            } else {
-              nearbyEdges.get(platform).add(edge);
-            }
+            nearbyEdges.computeIfAbsent(platform, _ -> new ArrayList<>()).add(edge);
           }
         });
     }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -31,7 +31,6 @@ import org.opentripplanner.street.model.edge.BoardingLocationToStopLink;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
-import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.vertex.OsmBoardingLocationVertex;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
@@ -104,11 +103,6 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
     int successes = 0;
 
     for (TransitStopVertex ts : graph.getVerticesOfType(TransitStopVertex.class)) {
-      // if the street is already linked there is no need to link it again,
-      // could happen if using the prune isolated island
-      if (ts.getOutgoing().stream().anyMatch(StreetTransitStopLink.class::isInstance)) {
-        continue;
-      }
       // only connect transit stops that are not part of a pathway network
       if (!ts.hasPathways()) {
         var stop = stopResolver.getStop(ts.getId());

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
@@ -48,14 +48,14 @@ class OsmBoardingLocationsModuleTest {
       Arguments.of(
         false,
         Stream.of(
-            302563833L,
-            3223067049L,
-            302563836L,
-            3223067680L,
-            302563834L,
-            768590748L,
-            302563839L
-          )
+          302563833L,
+          3223067049L,
+          302563836L,
+          3223067680L,
+          302563834L,
+          768590748L,
+          302563839L
+        )
           .map(VertexLabel::osm)
           .collect(Collectors.toSet())
       ),
@@ -64,8 +64,9 @@ class OsmBoardingLocationsModuleTest {
   }
 
   /**
-   * We test that the platform area at Herrenberg station (https://www.openstreetmap.org/way/27558650)
-   * is correctly linked to the stop even though it is not the closest edge to the stop.
+   * We test that the platform area at Herrenberg station
+   * (https://www.openstreetmap.org/way/27558650) is correctly linked to the stop even though it is
+   * not the closest edge to the stop.
    */
   @ParameterizedTest(
     name = "add boarding locations and link them to platform edges when skipVisibility={0}"
@@ -201,19 +202,20 @@ class OsmBoardingLocationsModuleTest {
   }
 
   /**
-   * We test that the underground platforms at Moorgate station (https://www.openstreetmap.org/way/1328222021)
-   * is correctly linked to the stop even though it is not the closest edge to the stop.
+   * We test that the underground platforms at Moorgate station
+   * (https://www.openstreetmap.org/way/1328222021) is correctly linked to the stop even though it
+   * is not the closest edge to the stop.
    */
   @Test
   void testLinearPlatforms() {
     var graph = new Graph();
     var osmInfoRepository = new DefaultOsmInfoGraphBuildRepository();
     var osmModule = OsmModuleTestFactory.of(
-        new DefaultOsmProvider(
-          ResourceLoader.of(OsmBoardingLocationsModuleTest.class).file("moorgate.osm.pbf"),
-          false
-        )
+      new DefaultOsmProvider(
+        ResourceLoader.of(OsmBoardingLocationsModuleTest.class).file("moorgate.osm.pbf"),
+        false
       )
+    )
       .withGraph(graph)
       .withOsmInfoGraphBuildRepository(osmInfoRepository)
       .builder()
@@ -344,8 +346,8 @@ class OsmBoardingLocationsModuleTest {
    * Test that when two stops reference the same OSM platform area (via ref:IFOPT), only one
    * OsmBoardingLocationVertex centroid is created for that area and both stops are linked to it.
    * <p>
-   * The Herrenberg platform area (way 27558650) has ref:IFOPT=de:08115:4512:4:101;de:08115:4512:4:102,
-   * so both stop IDs match the same area.
+   * The Herrenberg platform area (way 27558650) has
+   * ref:IFOPT=de:08115:4512:4:101;de:08115:4512:4:102, so both stop IDs match the same area.
    */
   @Test
   void testDeduplicationOfAreaBoardinglocations() {
@@ -417,7 +419,7 @@ class OsmBoardingLocationsModuleTest {
       .filter(
         bl ->
           bl.references.contains(platform1.getId().getId()) ||
-            bl.references.contains(platform2.getId().getId())
+          bl.references.contains(platform2.getId().getId())
       )
       .toList();
     assertEquals(
@@ -486,8 +488,8 @@ class OsmBoardingLocationsModuleTest {
   }
 
   /**
-   * Assert that there is a one-way path from the beginning through the given vertex to the end
-   * or vice versa.
+   * Assert that there is a one-way path from the beginning through the given vertex to the end or
+   * vice versa.
    */
   private static void assertConnections(Vertex vertex, Vertex beginning, Vertex end) {
     if (vertex == beginning || vertex == end) {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
@@ -48,14 +48,14 @@ class OsmBoardingLocationsModuleTest {
       Arguments.of(
         false,
         Stream.of(
-          302563833L,
-          3223067049L,
-          302563836L,
-          3223067680L,
-          302563834L,
-          768590748L,
-          302563839L
-        )
+            302563833L,
+            3223067049L,
+            302563836L,
+            3223067680L,
+            302563834L,
+            768590748L,
+            302563839L
+          )
           .map(VertexLabel::osm)
           .collect(Collectors.toSet())
       ),
@@ -209,11 +209,11 @@ class OsmBoardingLocationsModuleTest {
     var graph = new Graph();
     var osmInfoRepository = new DefaultOsmInfoGraphBuildRepository();
     var osmModule = OsmModuleTestFactory.of(
-      new DefaultOsmProvider(
-        ResourceLoader.of(OsmBoardingLocationsModuleTest.class).file("moorgate.osm.pbf"),
-        false
+        new DefaultOsmProvider(
+          ResourceLoader.of(OsmBoardingLocationsModuleTest.class).file("moorgate.osm.pbf"),
+          false
+        )
       )
-    )
       .withGraph(graph)
       .withOsmInfoGraphBuildRepository(osmInfoRepository)
       .builder()
@@ -338,6 +338,113 @@ class OsmBoardingLocationsModuleTest {
         assertSplitVertex(vertex.getToVertex(), centroid, fromVertex, toVertex);
       }
     }
+  }
+
+  /**
+   * Test that when two stops reference the same OSM platform area (via ref:IFOPT), only one
+   * OsmBoardingLocationVertex centroid is created for that area and both stops are linked to it.
+   * <p>
+   * The Herrenberg platform area (way 27558650) has ref:IFOPT=de:08115:4512:4:101;de:08115:4512:4:102,
+   * so both stop IDs match the same area.
+   */
+  @Test
+  void testDeduplicationOfAreaBoardinglocations() {
+    File file = ResourceLoader.of(OsmBoardingLocationsModuleTest.class).file(
+      "herrenberg-minimal.osm.pbf"
+    );
+
+    // Two stops that both match the same platform area via ref:IFOPT
+    RegularStop platform1 = testModel
+      .stop("de:08115:4512:4:101")
+      .withCoordinate(48.59328, 8.86128)
+      .build();
+    RegularStop platform2 = testModel
+      .stop("de:08115:4512:4:102")
+      .withCoordinate(48.59328, 8.86128)
+      .build();
+
+    var siteRepo = testModel
+      .siteRepositoryBuilder()
+      .withRegularStops(List.of(platform1, platform2))
+      .build();
+
+    var graph = new Graph();
+    var timetableRepository = new TimetableRepository(siteRepo);
+    var factory = new VertexFactory(graph);
+
+    var osmInfoRepository = new DefaultOsmInfoGraphBuildRepository();
+    var osmModule = OsmModuleTestFactory.of(new DefaultOsmProvider(file, false))
+      .withGraph(graph)
+      .withOsmInfoGraphBuildRepository(osmInfoRepository)
+      .builder()
+      .withBoardingAreaRefTags(Set.of("ref", "ref:IFOPT"))
+      .withAreaVisibility(true)
+      .build();
+
+    osmModule.buildGraph();
+
+    var platformVertex1 = factory.transitStop(ofStop(platform1));
+    var platformVertex2 = factory.transitStop(ofStop(platform2));
+
+    timetableRepository.index();
+    graph.index();
+
+    // Both vertices should start unlinked
+    assertEquals(0, platformVertex1.getIncoming().size());
+    assertEquals(0, platformVertex1.getOutgoing().size());
+    assertEquals(0, platformVertex2.getIncoming().size());
+    assertEquals(0, platformVertex2.getOutgoing().size());
+
+    var osmService = new DefaultOsmInfoGraphBuildService(osmInfoRepository);
+    new OsmBoardingLocationsModule(
+      graph,
+      timetableRepository,
+      VertexLinkerTestFactory.of(graph),
+      osmService
+    ).buildGraph();
+
+    // Both vertices should now be linked
+    assertEquals(1, platformVertex1.getIncoming().size());
+    assertEquals(1, platformVertex1.getOutgoing().size());
+    assertEquals(1, platformVertex2.getIncoming().size());
+    assertEquals(1, platformVertex2.getOutgoing().size());
+
+    var boardingLocations = graph.getVerticesOfType(OsmBoardingLocationVertex.class);
+
+    // Only one centroid should exist for the shared platform area
+    var areaCentroids = boardingLocations
+      .stream()
+      .filter(
+        bl ->
+          bl.references.contains(platform1.getId().getId()) ||
+            bl.references.contains(platform2.getId().getId())
+      )
+      .toList();
+    assertEquals(
+      1,
+      areaCentroids.size(),
+      "Expected exactly one OsmBoardingLocationVertex for the shared platform area, but found " +
+        areaCentroids.size()
+    );
+
+    // Both transit stop vertices should be connected to the same boarding location vertex
+    var linkedVertex1 = platformVertex1
+      .getOutgoing()
+      .stream()
+      .findFirst()
+      .orElseThrow()
+      .getToVertex();
+    var linkedVertex2 = platformVertex2
+      .getOutgoing()
+      .stream()
+      .findFirst()
+      .orElseThrow()
+      .getToVertex();
+    assertEquals(
+      linkedVertex1,
+      linkedVertex2,
+      "Both stops should be linked to the same deduplicated boarding location vertex"
+    );
   }
 
   /**


### PR DESCRIPTION
### Summary

when two stops reference the same OSM platform area (via ref:IFOPT), only one OsmBoardingLocationVertex centroid is created for that area and both stops are linked to it. This ensures that transfers on the same platform can always be reached (0-min transfers).

### Issue

the issue was previously discussed here: https://github.com/opentripplanner/OpenTripPlanner/issues/7240
this PR implements the "Quick fix" outlined by Jessica

The Sollution uses a simple HashMap to ensure that only one OsmBoardingLocationVertex gets created for each stop connected to an area.

This will have an impact on all transfers using the same OSM Area
Before:
<img width="1893" height="579" alt="image" src="https://github.com/user-attachments/assets/99948849-b6e0-417e-a682-254e795a52c5" />
After:
<img width="1628" height="345" alt="image" src="https://github.com/user-attachments/assets/4eb1bab5-5d44-40bf-aabc-fc3ddf4fa667" />

The main difference being, that there is no longer a footpath in the resulting itinerary (instantaneous transfer).

Some minor refactorings to OsmBoardingLocationsModule were also added in a seperate commit: ([Refactor OsmBoardingLocationsModule for simplicity](https://github.com/HBTGmbH/OpenTripPlanner/pull/3/commits/bd2ed163f458ab83ad207d48d688cf5e1930cfd9))

### Unit tests

One of the existing unit test cases uses an example in Herrenberg, which already included an OSM area with 2 stoppoints, so only a new testcase was added, to verify the de-duplication

### Documentation

- javadoc added on factory method and test
