### PR TITLE
Fix default boarding/alighting rules for SIRI ET ExtraJourneys (#7506)

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
@@ -6,6 +6,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -43,6 +44,15 @@ class StopTimesMapper {
     stopTime.setStopSequence(stopSequence);
     stopTime.setTrip(trip);
     stopTime.setStop(stop);
+
+    // Set default boarding/alighting rules for first and last stops.
+    // Can't alight at first stop and can't board at last stop.
+    if (isFirstStop) {
+      stopTime.setDropOffType(PickDrop.NONE);
+    }
+    if (isLastStop) {
+      stopTime.setPickupType(PickDrop.NONE);
+    }
 
     // Fallback to other time, if one doesn't exist
     var aimedArrivalTime = call.getAimedArrivalTime() != null

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/AddedTripBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/AddedTripBuilderTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.basic.SubMode;
@@ -181,6 +182,14 @@ class AddedTripBuilderTest {
     assertEquals(STOP_A, stopPattern.getStop(0));
     assertEquals(STOP_B, stopPattern.getStop(1));
     assertEquals(STOP_C, stopPattern.getStop(2));
+
+    // Assert pickup/dropoff defaults: no alighting at first stop, no boarding at last stop
+    assertEquals(PickDrop.SCHEDULED, pattern.getBoardType(0), "Can board at first stop");
+    assertEquals(PickDrop.NONE, pattern.getAlightType(0), "Cannot alight at first stop");
+    assertEquals(PickDrop.SCHEDULED, pattern.getBoardType(1), "Can board at middle stop");
+    assertEquals(PickDrop.SCHEDULED, pattern.getAlightType(1), "Can alight at middle stop");
+    assertEquals(PickDrop.NONE, pattern.getBoardType(2), "Cannot board at last stop");
+    assertEquals(PickDrop.SCHEDULED, pattern.getAlightType(2), "Can alight at last stop");
 
     // Assert scheduled timetable
     var scheduledTimes = pattern.getScheduledTimetable().getTripTimes(trip);

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -9,6 +9,7 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSucce
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.transit.model._data.TransitTestEnvironment;
 import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
 import org.opentripplanner.transit.model._data.TripInput;
@@ -288,6 +289,49 @@ class ExtraJourneyTest implements RealtimeTestConstants {
       "SCHEDULED | A 0:01 0:01 | B 0:03 0:05 | C 0:07 0:07",
       env.tripData(ADDED_TRIP_ID).showScheduledTimetable()
     );
+  }
+
+  /**
+   * When SIRI does not explicitly set boarding/alighting activity, the default rules should
+   * apply: no alighting at the first stop and no boarding at the last stop.
+   */
+  @Test
+  void testExtraJourneyDefaultBoardingAlighting() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
+      .withIsExtraJourney(true)
+      .withOperatorRef(OPERATOR_ID)
+      .withLineRef(ROUTE_ID)
+      .withRecordedCalls(builder -> builder.call(STOP_A).departAimedActual("00:01", "00:02"))
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_B)
+          .arriveAimedExpected("00:03", "00:04")
+          .departAimedExpected("00:05", "00:06")
+          .call(STOP_C)
+          .arriveAimedExpected("00:07", "00:08")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    assertSuccess(siri.applyEstimatedTimetable(updates));
+
+    var pattern = env.tripData(ADDED_TRIP_ID).tripPattern();
+
+    // First stop: can board, cannot alight
+    assertEquals(PickDrop.SCHEDULED, pattern.getBoardType(0));
+    assertEquals(PickDrop.NONE, pattern.getAlightType(0));
+
+    // Middle stop: can board and alight
+    assertEquals(PickDrop.SCHEDULED, pattern.getBoardType(1));
+    assertEquals(PickDrop.SCHEDULED, pattern.getAlightType(1));
+
+    // Last stop: cannot board, can alight
+    assertEquals(PickDrop.NONE, pattern.getBoardType(2));
+    assertEquals(PickDrop.SCHEDULED, pattern.getAlightType(2));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Set correct default boarding/alighting rules on first and last stops for SIRI ET ExtraJourneys and AddedTrips.

## Issue

Addresses #7506

When SIRI does not explicitly set boarding/alighting activity, the `PickDropMapper` returns `Optional.empty()`, leaving both `pickupType` and `dropOffType` at the `StopTime` default of `SCHEDULED`. This is incorrect for the first stop (no alighting possible) and the last stop (no boarding possible), causing departure boards to show arrivals at the last stop as "departing".

The fix sets `dropOffType=NONE` for the first stop and `pickupType=NONE` for the last stop before calling `PickDropMapper`.

## Unit tests

- Added assertions in `testAddedTrip()` verifying correct pickup/dropoff on first, middle, and last stops
