### PR TITLE
Add `startupRetryPeriod` to GBFS feed configuration

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalParameters.java
@@ -9,8 +9,9 @@ public class VehicleRentalParameters extends VehicleRentalUpdaterParameters {
   public VehicleRentalParameters(
     String configRef,
     Duration frequency,
+    Duration startupRetryPeriod,
     VehicleRentalDataSourceParameters sourceParameters
   ) {
-    super(configRef, frequency, sourceParameters);
+    super(configRef, frequency, startupRetryPeriod, sourceParameters);
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -39,7 +39,7 @@ public class VehicleRentalServiceDirectoryFetcher {
     VehicleRentalServiceDirectoryFetcher.class
   );
   private static final Duration DEFAULT_FREQUENCY = Duration.ofSeconds(15);
-  private static final Duration DEFAULT_STARTUP_RETRY_PERIOD = Duration.ofSeconds(0);
+  private static final Duration DEFAULT_STARTUP_RETRY_PERIOD = Duration.ZERO;
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
     .registerModule(new JavaTimeModule())
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -39,6 +39,7 @@ public class VehicleRentalServiceDirectoryFetcher {
     VehicleRentalServiceDirectoryFetcher.class
   );
   private static final Duration DEFAULT_FREQUENCY = Duration.ofSeconds(15);
+  private static final Duration DEFAULT_STARTUP_RETRY_PERIOD = Duration.ofSeconds(0);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
     .registerModule(new JavaTimeModule())
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -170,6 +171,7 @@ public class VehicleRentalServiceDirectoryFetcher {
     VehicleRentalParameters vehicleRentalParameters = new VehicleRentalParameters(
       "vehicle-rental-service-directory:" + parameters.network(),
       DEFAULT_FREQUENCY,
+      DEFAULT_STARTUP_RETRY_PERIOD,
       parameters
     );
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
@@ -14,7 +14,8 @@ public enum OtpVersion {
   V2_6("2.6"),
   V2_7("2.7"),
   V2_8("2.8"),
-  V2_9("2.9");
+  V2_9("2.9"),
+  V2_10("2.10");
 
   private final String text;
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleRentalUpdaterConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleRentalUpdaterConfig.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.standalone.config.routerconfig.updaters;
 
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V1_5;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_10;
 
 import java.time.Duration;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
@@ -23,6 +24,20 @@ public class VehicleRentalUpdaterConfig {
         .since(V1_5)
         .summary("How often the data should be updated.")
         .asDuration(Duration.ofMinutes(1)),
+      c
+        .of("startupRetryPeriod")
+        .since(V2_10)
+        .summary(
+          "How long to retry loading the vehicle rental data source on startup if it initially fails."
+        )
+        .description(
+          """
+          The first time the data source is loaded, OTP will retry for this duration every
+          5 seconds before giving up. This is useful to handle temporary network failures during
+          OTP startup. Set to `PT0S` to disable retries.
+          """
+        )
+        .asDuration(Duration.ofSeconds(15)),
       VehicleRentalSourceFactory.create(sourceType, c)
     );
   }

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleRentalUpdaterConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/VehicleRentalUpdaterConfig.java
@@ -37,7 +37,7 @@ public class VehicleRentalUpdaterConfig {
           OTP startup. Set to `PT0S` to disable retries.
           """
         )
-        .asDuration(Duration.ofSeconds(15)),
+        .asDuration(Duration.ZERO),
       VehicleRentalSourceFactory.create(sourceType, c)
     );
   }

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.retry.OtpRetry;
 import org.opentripplanner.framework.retry.OtpRetryBuilder;
+import org.opentripplanner.framework.retry.OtpRetryException;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
@@ -99,6 +100,9 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
       // Do any setup if needed
       retry.execute(source::setup);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Updater setup interrupted: {}", nameForLogging, e);
+    } catch (OtpRetryException e) {
       LOG.warn("Unable to setup updater: {}", nameForLogging, e);
     }
 

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -12,6 +12,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.framework.retry.OtpRetry;
+import org.opentripplanner.framework.retry.OtpRetryBuilder;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
@@ -46,6 +48,8 @@ import org.slf4j.LoggerFactory;
 public class VehicleRentalUpdater extends PollingGraphUpdater {
 
   private static final Logger LOG = LoggerFactory.getLogger(VehicleRentalUpdater.class);
+  private static final Duration RETRY_INTERVAL = Duration.ofSeconds(5);
+  private static final int RETRY_BACKOFF_MULTIPLIER = 1;
 
   private final Throttle unlinkedPlaceThrottle;
 
@@ -83,10 +87,18 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
     // Adding a vehicle rental station service needs a graph writer runnable
     this.service = repository;
 
+    OtpRetry retry = new OtpRetryBuilder()
+      .withName("%s updater setup".formatted(nameForLogging))
+      .withMaxAttempts((int) parameters.startupRetryPeriod().dividedBy(RETRY_INTERVAL))
+      .withInitialRetryInterval(RETRY_INTERVAL)
+      .withBackoffMultiplier(RETRY_BACKOFF_MULTIPLIER)
+      .withRetryableException(UpdaterConstructionException.class::isInstance)
+      .build();
+
     try {
       // Do any setup if needed
-      source.setup();
-    } catch (UpdaterConstructionException e) {
+      retry.execute(source::setup);
+    } catch (InterruptedException e) {
       LOG.warn("Unable to setup updater: {}", nameForLogging, e);
     }
 

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterParameters.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterParameters.java
@@ -8,15 +8,18 @@ public class VehicleRentalUpdaterParameters implements PollingGraphUpdaterParame
 
   private final String configRef;
   private final Duration frequency;
+  private final Duration startupRetryPeriod;
   private final VehicleRentalDataSourceParameters source;
 
   public VehicleRentalUpdaterParameters(
     String configRef,
     Duration frequency,
+    Duration startupRetryPeriod,
     VehicleRentalDataSourceParameters source
   ) {
     this.configRef = configRef;
     this.frequency = frequency;
+    this.startupRetryPeriod = startupRetryPeriod;
     this.source = source;
   }
 
@@ -31,6 +34,13 @@ public class VehicleRentalUpdaterParameters implements PollingGraphUpdaterParame
   @Override
   public String configRef() {
     return configRef;
+  }
+
+  /**
+   * How long to retry loading the vehicle rental data source on startup if it initially fails.
+   */
+  public Duration startupRetryPeriod() {
+    return startupRetryPeriod;
   }
 
   public VehicleRentalDataSourceParameters sourceParameters() {

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
@@ -30,7 +30,7 @@ class VehicleRentalUpdaterTest {
   public static final VehicleRentalUpdaterParameters PARAMS = new VehicleRentalUpdaterParameters(
     "A",
     Duration.ofMinutes(1),
-    Duration.ofSeconds(0),
+    Duration.ZERO,
     new FakeParams()
   );
   public static final DefaultVehicleRentalService SERVICE = new DefaultVehicleRentalService();

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
@@ -30,6 +30,7 @@ class VehicleRentalUpdaterTest {
   public static final VehicleRentalUpdaterParameters PARAMS = new VehicleRentalUpdaterParameters(
     "A",
     Duration.ofMinutes(1),
+    Duration.ofSeconds(0),
     new FakeParams()
   );
   public static final DefaultVehicleRentalService SERVICE = new DefaultVehicleRentalService();

--- a/doc/user/GBFS-Config.md
+++ b/doc/user/GBFS-Config.md
@@ -30,6 +30,7 @@ Furthermore, support is limited to the following form factors:
 | [network](#u_1_network)                                                               |     `string`    | The name of the network to override the one derived from the source data.                                                                                      | *Optional* |               |  1.5  |
 | overloadingAllowed                                                                    |    `boolean`    | Allow leaving vehicles at a station even though there are no free slots.                                                                                       | *Optional* | `false`       |  2.2  |
 | [sourceType](#u_1_sourceType)                                                         |      `enum`     | What source of vehicle rental updater to use.                                                                                                                  | *Required* |               |  1.5  |
+| [startupRetryPeriod](#u_1_startupRetryPeriod)                                         |    `duration`   | How long to retry loading the vehicle rental data source on startup if it initially fails.                                                                     | *Optional* | `"PT15S"`     |  2.10 |
 | url                                                                                   |     `string`    | The URL to download the data from.                                                                                                                             | *Required* |               |  1.5  |
 | [headers](#u_1_headers)                                                               | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                                                                                     | *Optional* |               |  1.5  |
 | [rentalPickupTypes](#u_1_rentalPickupTypes)                                           |    `enum set`   | This is temporary and will be removed in a future version of OTP. Use this to specify the type of rental data that is allowed to be read from the data source. | *Optional* |               |  2.7  |
@@ -83,6 +84,18 @@ GBFS feeds must include a system_id which will be used as the default `network`.
 **Enum values:** `gbfs` | `smoove`
 
 What source of vehicle rental updater to use.
+
+<h4 id="u_1_startupRetryPeriod">startupRetryPeriod</h4>
+
+**Since version:** `2.10` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT15S"`   
+**Path:** /updaters/[1] 
+
+How long to retry loading the vehicle rental data source on startup if it initially fails.
+
+The first time the data source is loaded, OTP will retry for this duration every
+5 seconds before giving up. This is useful to handle temporary network failures during
+OTP startup. Set to `PT0S` to disable retries.
+
 
 <h4 id="u_1_headers">headers</h4>
 

--- a/doc/user/GBFS-Config.md
+++ b/doc/user/GBFS-Config.md
@@ -30,7 +30,7 @@ Furthermore, support is limited to the following form factors:
 | [network](#u_1_network)                                                               |     `string`    | The name of the network to override the one derived from the source data.                                                                                      | *Optional* |               |  1.5  |
 | overloadingAllowed                                                                    |    `boolean`    | Allow leaving vehicles at a station even though there are no free slots.                                                                                       | *Optional* | `false`       |  2.2  |
 | [sourceType](#u_1_sourceType)                                                         |      `enum`     | What source of vehicle rental updater to use.                                                                                                                  | *Required* |               |  1.5  |
-| [startupRetryPeriod](#u_1_startupRetryPeriod)                                         |    `duration`   | How long to retry loading the vehicle rental data source on startup if it initially fails.                                                                     | *Optional* | `"PT15S"`     |  2.10 |
+| [startupRetryPeriod](#u_1_startupRetryPeriod)                                         |    `duration`   | How long to retry loading the vehicle rental data source on startup if it initially fails.                                                                     | *Optional* | `"PT0S"`      |  2.10 |
 | url                                                                                   |     `string`    | The URL to download the data from.                                                                                                                             | *Required* |               |  1.5  |
 | [headers](#u_1_headers)                                                               | `map of string` | HTTP headers to add to the request. Any header key, value can be inserted.                                                                                     | *Optional* |               |  1.5  |
 | [rentalPickupTypes](#u_1_rentalPickupTypes)                                           |    `enum set`   | This is temporary and will be removed in a future version of OTP. Use this to specify the type of rental data that is allowed to be read from the data source. | *Optional* |               |  2.7  |
@@ -87,7 +87,7 @@ What source of vehicle rental updater to use.
 
 <h4 id="u_1_startupRetryPeriod">startupRetryPeriod</h4>
 
-**Since version:** `2.10` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT15S"`   
+**Since version:** `2.10` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`   
 **Path:** /updaters/[1] 
 
 How long to retry loading the vehicle rental data source on startup if it initially fails.


### PR DESCRIPTION
### Summary

This PR adds a `startupRetryPeriod` that uses `OtpRetry` for `VehicleRentalUpdater`. The first time the data source is loaded, OTP will retry for this duration every 5 seconds before giving up. The default value is `Duration.ZERO` which is equal to the current logic of trying once.

### Issue

Closes https://github.com/opentripplanner/OpenTripPlanner/issues/7511

### Unit tests

- No unit tests
- Manual testing for these situations:
  - `startupRetryPeriod` with `Duration.ZERO` and `Duration.ofSeconds(15)`
  - Succeeds on first setup try
  - Succeeds after 2 setup tries (with 15s `startupRetryPeriod`)
  - Fails after 3 tries (with 15s `startupRetryPeriod`)
  - Fails after 1 try (with 0s `startupRetryPeriod`)

### Documentation

- Config field added and related documentation
