### PR TITLE
Improve SpeedTest warm-up

### DIFF
--- a/application/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
+++ b/application/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
@@ -3,6 +3,7 @@ package org.opentripplanner.api.parameter;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.opentripplanner.routing.api.request.RequestModes;
@@ -163,5 +164,19 @@ public class QualifiedModeSet implements Serializable {
       sb.append(" ");
     }
     return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QualifiedModeSet that = (QualifiedModeSet) o;
+    return Objects.equals(qModes, that.qModes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(qModes);
   }
 }

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -257,7 +257,9 @@ public class SpeedTest {
     // We assume we are debugging and not measuring performance if we only run 1 test-case
     // one time; Hence skip JIT compiler warm-up.
     if (testCases.runJitWarmUp() || opts.profiles().length > 1) {
-      performRouting(testCases.getJitWarmUpCase());
+      for (var tc : testCases.getJitWarmUpCases()) {
+        performRouting(tc);
+      }
     }
 
     ResultPrinter.logSingleTestHeader(profile);

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/TestCases.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/TestCases.java
@@ -1,8 +1,11 @@
 package org.opentripplanner.transit.speed_test.model.testcase;
 
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -35,11 +38,38 @@ public class TestCases {
   }
 
   /**
-   * If we need to warm up the JIT compiler, we run the last test-case. This avoids repeating the
-   * same test case twice if more than one test-case exist.
+   * Select test-cases to use for JIT warm-up.
+   * <p>
+   * If there are three or fewer cases, all cases are returned. Otherwise, a small set of cases
+   * is selected. When there are multiple mode combinations, the first test-case for each mode
+   * combination is selected first. Additional cases are then sampled from across the list until
+   * at least three cases have been selected.
    */
-  public TestCase getJitWarmUpCase() {
-    return cases.get(numberOfTestCases() - 1);
+  public List<TestCase> getJitWarmUpCases() {
+    if (numberOfTestCases() <= 3) {
+      return List.copyOf(cases);
+    }
+    var samples = new HashSet<TestCase>();
+
+    var groupByModes = cases.stream().collect(Collectors.groupingBy(tc -> tc.definition().modes()));
+
+    // If more than 1 mode combination exists, return the first test-case for each
+    // mode combination
+    if (groupByModes.keySet().size() > 1) {
+      for (var it : groupByModes.values()) {
+        samples.add(it.getFirst());
+      }
+    }
+    // There are at least 4 cases, so we split the set in 4 groups and pick the first element in
+    // the 3 last groups.
+    int step = numberOfTestCases() / 4;
+    int index = step;
+
+    while (samples.size() < 3) {
+      samples.add(cases.get(index));
+      index += step;
+    }
+    return samples.stream().sorted(Comparator.comparing(TestCase::id)).toList();
   }
 
   public Iterable<TestCase> iterable() {


### PR DESCRIPTION
### Summary

Make sure to run a warm-up case for each mode combination and at least 3 test-cases if the set is bigger than 3. This is to properly warm up the JIT compiler.

### Documentation

🟥  This is a small improvement to the SpeedTest, no doc added

### Changelog

🟥  Not relevant

### Bumping the serialization version id

🟥  Only test code changed