### PR TITLE
Speed up tag lookup during OSM processing

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -84,8 +84,7 @@ public class GraphBuilderModules {
           osmConfiguredDataSource.dataSource(),
           osmConfiguredDataSource.config().osmTagMapper(),
           osmConfiguredDataSource.config().timeZone(),
-          config.osmCacheDataInMem,
-          issueStore
+          config.osmCacheDataInMem
         )
       );
     }

--- a/application/src/main/java/org/opentripplanner/osm/DefaultOsmProvider.java
+++ b/application/src/main/java/org/opentripplanner/osm/DefaultOsmProvider.java
@@ -3,14 +3,12 @@ package org.opentripplanner.osm;
 import crosby.binary.file.BlockInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.time.ZoneId;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.file.FileDataSource;
 import org.opentripplanner.framework.application.OtpFileNames;
-import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.osm.OsmDatabase;
 import org.opentripplanner.osm.tagmapping.OsmTagMapper;
 import org.opentripplanner.osm.tagmapping.OsmTagMapperSource;
@@ -41,21 +39,14 @@ public class DefaultOsmProvider implements OsmProvider {
 
   /** For tests */
   public DefaultOsmProvider(File file, boolean cacheDataInMem) {
-    this(
-      new FileDataSource(file, FileType.OSM),
-      OsmTagMapperSource.DEFAULT,
-      null,
-      cacheDataInMem,
-      DataImportIssueStore.NOOP
-    );
+    this(new FileDataSource(file, FileType.OSM), OsmTagMapperSource.DEFAULT, null, cacheDataInMem);
   }
 
   public DefaultOsmProvider(
     DataSource dataSource,
     OsmTagMapperSource tagMapperSource,
     ZoneId zoneId,
-    boolean cacheDataInMem,
-    DataImportIssueStore issueStore
+    boolean cacheDataInMem
   ) {
     this.source = dataSource;
     this.zoneId = zoneId;
@@ -102,21 +93,12 @@ public class DefaultOsmProvider implements OsmProvider {
     return ProgressTracker.track("Parse OSM " + phase, 1000, size, inputStream, m -> LOG.info(m));
   }
 
-  private void parsePhase(OsmParser parser, OsmParserPhase phase) throws IOException {
+  private void parsePhase(OsmParser parser, OsmParserPhase phase) {
     parser.setPhase(phase);
-    BlockInputStream in = null;
-    try {
-      in = new BlockInputStream(createInputStream(phase), parser);
+    try (BlockInputStream in = new BlockInputStream(createInputStream(phase), parser)) {
       in.process();
-    } finally {
-      // Close
-      try {
-        if (in != null) {
-          in.close();
-        }
-      } catch (Exception e) {
-        LOG.error(e.getMessage(), e);
-      }
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
@@ -504,7 +504,9 @@ public abstract class OsmEntity {
       return false;
     } else {
       return value.equals(tags.get(tag.toLowerCase()));
-    }
+public boolean isTag(String tag, String value) {
+    return tags != null && value != null && value.equals(tags.get(tag.toLowerCase()));
+}
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
@@ -144,8 +144,9 @@ public abstract class OsmEntity {
     "bicycle",
     "vehicle"
   );
-  public static final Set<String> NO_ACCESS_TAGS = Set.of("no", "license", "dismount");
-  public static final Map<StreetTraversalPermission, String> OSM_TAGS_FOR_TRAVERSAL_PERMISSION =
+  private static final Set<String> WALK_ONLY_HIGHWAYS = Set.of("footway", "step", "corridor");
+  private static final Set<String> NO_ACCESS_TAGS = Set.of("no", "license", "dismount");
+  private static final Map<StreetTraversalPermission, String> OSM_TAGS_FOR_TRAVERSAL_PERMISSION =
     Map.of(
       StreetTraversalPermission.CAR,
       "motorcar",
@@ -341,7 +342,7 @@ public abstract class OsmEntity {
   @Nullable
   public String getTag(String tag) {
     tag = tag.toLowerCase();
-    if (tags != null && tags.containsKey(tag)) {
+    if (tags != null) {
       return tags.get(tag);
     }
     return null;
@@ -516,7 +517,12 @@ public abstract class OsmEntity {
    * Takes a tag key and checks if the value is any of those in {@code oneOfTags}.
    */
   public boolean isOneOfTags(String key, Set<String> oneOfTags) {
-    return oneOfTags.stream().anyMatch(value -> isTag(key, value));
+    var value = getTag(key);
+    if (value == null) {
+      return false;
+    } else {
+      return oneOfTags.contains(value);
+    }
   }
 
   /**
@@ -658,7 +664,7 @@ public abstract class OsmEntity {
       return Optional.empty();
     }
 
-    if ("foot".equals(mode) && !isOneOfTags("highway", Set.of("footway", "step", "corridor"))) {
+    if ("foot".equals(mode) && !isOneOfTags("highway", WALK_ONLY_HIGHWAYS)) {
       return Optional.empty();
     }
 

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
@@ -500,13 +500,7 @@ public abstract class OsmEntity {
    * Checks if a tag contains the specified value.
    */
   public boolean isTag(String tag, String value) {
-    if (tags == null || value == null) {
-      return false;
-    } else {
-      return value.equals(tags.get(tag.toLowerCase()));
-public boolean isTag(String tag, String value) {
     return tags != null && value != null && value.equals(tags.get(tag.toLowerCase()));
-}
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
@@ -225,15 +225,13 @@ public abstract class OsmEntity {
    * Is the tag defined?
    */
   public boolean hasTag(String tag) {
-    tag = tag.toLowerCase();
-    return tags != null && tags.containsKey(tag);
+    return getTag(tag) != null;
   }
 
   /**
    * Determines if a tag contains a false value. 'no', 'false', and '0' are considered false.
    */
   public boolean isTagFalse(String tag) {
-    tag = tag.toLowerCase();
     if (tags == null) {
       return false;
     }
@@ -258,7 +256,6 @@ public abstract class OsmEntity {
    * Determines if a tag contains a true value. 'yes', 'true', and '1' are considered true.
    */
   public boolean isTagTrue(String tag) {
-    tag = tag.toLowerCase();
     if (tags == null) {
       return false;
     }
@@ -325,7 +322,6 @@ public abstract class OsmEntity {
     if (isTagTrue(key)) {
       return true;
     }
-    key = key.toLowerCase();
     String value = getTag(key);
     return (
       "designated".equals(value) ||
@@ -341,9 +337,8 @@ public abstract class OsmEntity {
    */
   @Nullable
   public String getTag(String tag) {
-    tag = tag.toLowerCase();
     if (tags != null) {
-      return tags.get(tag);
+      return tags.get(tag.toLowerCase());
     }
     return null;
   }
@@ -505,12 +500,11 @@ public abstract class OsmEntity {
    * Checks if a tag contains the specified value.
    */
   public boolean isTag(String tag, String value) {
-    tag = tag.toLowerCase();
-    if (tags != null && tags.containsKey(tag) && value != null) {
-      return value.equals(tags.get(tag));
+    if (tags == null || value == null) {
+      return false;
+    } else {
+      return value.equals(tags.get(tag.toLowerCase()));
     }
-
-    return false;
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/osm/model/TraverseDirection.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/TraverseDirection.java
@@ -10,22 +10,24 @@ public enum TraverseDirection {
   /**
    * Traverse in the direction the way is defined, from the beginning node to the end node.
    */
-  FORWARD,
+  FORWARD(":forward"),
   /**
    * Traverse against the direction the way is defined, from the end node to the beginning node.
    */
-  BACKWARD,
+  BACKWARD(":backward"),
   /**
    * Traverse not in a specific direction of the way, for example, across an area or through a node.
    */
-  DIRECTIONLESS;
+  DIRECTIONLESS("");
+
+  private final String tagSuffix;
+
+  TraverseDirection(String tagSuffix) {
+    this.tagSuffix = tagSuffix;
+  }
 
   public String tagSuffix() {
-    if (this == DIRECTIONLESS) {
-      return "";
-    }
-
-    return ":" + name().toLowerCase();
+    return tagSuffix;
   }
 
   public TraverseDirection reverse() {


### PR DESCRIPTION
### Summary

These pretty simple changes speed up the processing of OSM ways on my machine from 22k ways/s to 29k ways/s so around a 25% speed up.

While I was there, I also did some light refactoring of the provider code.