### PR TITLE
Remove relation route name application

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
@@ -805,19 +805,6 @@ public class OsmDatabase {
     }
   }
 
-  /**
-   * Handle route=bicycle relations. Copies their network type to all way members.
-   *
-   * @see "https://wiki.openstreetmap.org/wiki/Tag:route%3Dbicycle"
-   */
-  private void processBicycleRoute(OsmRelation relation) {
-    if (relation.isBicycleRoute()) {
-      // we treat networks without known network type like local networks
-      var network = relation.getTagOpt("network").orElse("lcn");
-      setNetworkForAllMembers(relation, network);
-    }
-  }
-
   private void setNetworkForAllMembers(OsmRelation relation, String key) {
     relation
       .getMembers()
@@ -935,7 +922,11 @@ public class OsmDatabase {
    * Handle route=road and route=bicycle relations.
    */
   private void processRoute(OsmRelation relation) {
-    processBicycleRoute(relation);
+    if (relation.isBicycleRoute()) {
+      // we treat networks without known network type like local networks
+      var network = relation.getTagOpt("network").orElse("lcn");
+      setNetworkForAllMembers(relation, network);
+    }
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
@@ -35,7 +35,6 @@ import org.opentripplanner.osm.model.OsmLevelFactory;
 import org.opentripplanner.osm.model.OsmNode;
 import org.opentripplanner.osm.model.OsmRelation;
 import org.opentripplanner.osm.model.OsmRelationMember;
-import org.opentripplanner.osm.model.OsmTag;
 import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.geometry.HashGridSpatialIndex;
@@ -936,37 +935,6 @@ public class OsmDatabase {
    * Handle route=road and route=bicycle relations.
    */
   private void processRoute(OsmRelation relation) {
-    for (OsmRelationMember member : relation.getMembers()) {
-      if (!(member.hasTypeWay() && waysById.containsKey(member.getRef()))) {
-        continue;
-      }
-
-      OsmWay way = waysById.get(member.getRef());
-      if (way == null) {
-        continue;
-      }
-
-      if (relation.hasTag("name")) {
-        if (way.hasTag("otp:route_name")) {
-          way.addTag(
-            "otp:route_name",
-            addUniqueName(way.getTag("otp:route_name"), relation.getTag("name"))
-          );
-        } else {
-          way.addTag(new OsmTag("otp:route_name", relation.getTag("name")));
-        }
-      }
-      if (relation.hasTag("ref")) {
-        if (way.hasTag("otp:route_ref")) {
-          way.addTag(
-            "otp:route_ref",
-            addUniqueName(way.getTag("otp:route_ref"), relation.getTag("ref"))
-          );
-        } else {
-          way.addTag(new OsmTag("otp:route_ref", relation.getTag("ref")));
-        }
-      }
-    }
     processBicycleRoute(relation);
   }
 

--- a/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
+++ b/application/src/main/java/org/opentripplanner/osm/model/OsmEntity.java
@@ -534,14 +534,8 @@ public abstract class OsmEntity {
         false
       );
     }
-    if (tags.containsKey("otp:route_name")) {
-      return new NonLocalizedString(tags.get("otp:route_name"));
-    }
     if (this.creativeName != null) {
       return this.creativeName;
-    }
-    if (tags.containsKey("otp:route_ref")) {
-      return new NonLocalizedString(tags.get("otp:route_ref"));
     }
     if (tags.containsKey("ref")) {
       return new NonLocalizedString(tags.get("ref"));

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapper.java
@@ -404,7 +404,6 @@ public class OsmTagMapper {
     props.createNames("indoor=area", "name.indoor_area");
 
     // Platforms
-    props.createNames("otp:route_ref=*", "name.otp_route_ref");
     props.createNames("highway=platform;ref=*", "name.platform_ref");
     props.createNames("railway=platform;ref=*", "name.platform_ref");
     props.createNames("railway=platform;highway=footway;footway=sidewalk", "name.platform");

--- a/domain-core/src/main/resources/WayProperties.properties
+++ b/domain-core/src/main/resources/WayProperties.properties
@@ -11,7 +11,6 @@ name.bridleway=bridleway
 name.corridor=corridor
 name.indoor_area=indoor area
 
-name.otp_route_ref=Route {otp:route_ref}
 name.platform_ref=Platform {ref}
 name.platform=platform
 

--- a/domain-core/src/main/resources/WayProperties_de.properties
+++ b/domain-core/src/main/resources/WayProperties_de.properties
@@ -12,7 +12,6 @@ name.bridleway=Reitweg
 name.corridor=Korridor
 name.indoor_area=Innenbereich
 
-name.otp_route_ref=Route {otp:route_ref}
 name.platform_ref=Plattform {ref}
 name.platform=Plattform
 

--- a/domain-core/src/main/resources/WayProperties_fi.properties
+++ b/domain-core/src/main/resources/WayProperties_fi.properties
@@ -11,7 +11,6 @@ name.bridleway=ratsupolku
 name.corridor=käytävä
 name.indoor_area=sisätila
 
-name.otp_route_ref=linja {otp:route_ref}
 name.platform_ref=laituri {ref}
 name.platform=laituri
 

--- a/domain-core/src/main/resources/WayProperties_fr.properties
+++ b/domain-core/src/main/resources/WayProperties_fr.properties
@@ -12,7 +12,6 @@ name.bridleway=sentier \u00e9questre
 name.corridor=couloir
 name.indoor_area=zone int\u00e9rieure
 
-name.otp_route_ref=Ligne {otp:route_ref}
 name.platform_ref=Plate-forme {ref}
 name.platform=plate-forme
 

--- a/domain-core/src/main/resources/WayProperties_hu.properties
+++ b/domain-core/src/main/resources/WayProperties_hu.properties
@@ -11,7 +11,6 @@ name.bridleway=nyomvonal
 name.corridor=folyoso
 name.indoor_area=belteri terulet
 
-name.otp_route_ref={otp:route_ref}
 name.platform_ref={ref}
 name.platform=kocsi\u00E1ll\u00E1s / v\u00E1g\u00E1ny
 

--- a/domain-core/src/main/resources/WayProperties_nl.properties
+++ b/domain-core/src/main/resources/WayProperties_nl.properties
@@ -12,7 +12,6 @@ name.bridleway=ruiterpad
 name.corridor=gang
 name.indoor_area=binnenruimte
 
-name.otp_route_ref=Lijn {otp:route_ref}
 name.platform_ref=Spoor {ref}
 name.platform=spoor
 

--- a/domain-core/src/main/resources/WayProperties_no.properties
+++ b/domain-core/src/main/resources/WayProperties_no.properties
@@ -11,7 +11,6 @@ name.bridleway=bridleway
 name.corridor=korridor
 name.indoor_area=innendors omrade
 
-name.otp_route_ref=Rute {otp:route_ref}
 name.platform_ref=Plattform {ref}
 name.platform=plattform
 

--- a/domain-core/src/main/resources/WayProperties_sv.properties
+++ b/domain-core/src/main/resources/WayProperties_sv.properties
@@ -11,7 +11,6 @@ name.bridleway=ridvägem
 name.corridor=korridor
 name.indoor_area=inomhusomrade
 
-name.otp_route_ref=linje {otp:route_ref}
 name.platform_ref=plattform {ref}
 name.platform=plattformen
 


### PR DESCRIPTION
### Summary

Removes the feature where OSM relation route names are applied to edges.

<img width="592" height="854" alt="image" src="https://github.com/user-attachments/assets/120043bb-5139-47ce-9e99-e4d772cc1643" />

This might have been useful many years ago but nowadays the OSM data is better and we can remove.

If someone wants to bring it back, we can do that but with a better design.

### Unit tests

No unit tests fail after removing this.