### PR TITLE
Simplify A* interface to return a singular path to target

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
@@ -6,6 +6,7 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.path.StreetPath;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.EuclideanRemainingWeightHeuristic;
 import org.opentripplanner.street.search.StreetSearchBuilder;
@@ -105,12 +106,6 @@ public class CarpoolStreetRouter implements CarpoolRouter {
       .withFrom(fromVertex)
       .withTo(toVertex);
 
-    var paths = streetSearch.getPathsToTarget();
-
-    if (paths.isEmpty()) {
-      return null;
-    }
-
-    return paths.getFirst().toGraphPath();
+    return streetSearch.getPathToTarget().map(StreetPath::toGraphPath).orElse(null);
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -262,7 +262,9 @@ public class RoutingWorker {
     debugTimingAggregator.startedDirectStreetRouter();
     try {
       return RoutingResult.ok(
-        DirectStreetRouter.route(serverContext, directBuilder.buildRequest(), linkingContext()),
+        DirectStreetRouter.route(serverContext, directBuilder.buildRequest(), linkingContext())
+          .stream()
+          .toList(),
         emptyDirectModeHandler.removeWalkAllTheWayResults()
       );
     } catch (RoutingValidationException e) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.astar.model.GraphPath;
@@ -97,19 +98,15 @@ public class GraphPathToItineraryMapper {
   }
 
   /**
-   * Generates a TripPlan from a set of paths
+   * Generates a TripPlan from a path
    */
-  public List<Itinerary> mapItineraries(List<StreetPath> paths, RouteRequest request) {
-    List<Itinerary> itineraries = new LinkedList<>();
-    for (var path : paths) {
-      Itinerary itinerary = generateItinerary(path, request);
-      if (itinerary.legs().isEmpty()) {
-        continue;
-      }
-      itineraries.add(itinerary);
+  public Optional<Itinerary> mapToItinerary(StreetPath path, RouteRequest request) {
+    Itinerary itinerary = generateItinerary(path, request);
+    if (itinerary.legs().isEmpty()) {
+      return Optional.empty();
     }
 
-    return itineraries;
+    return Optional.of(itinerary);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/ItinerariesHelper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/ItinerariesHelper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.algorithm.mapping;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalDouble;
 import org.opentripplanner.model.plan.Itinerary;
@@ -11,31 +10,25 @@ import org.opentripplanner.street.model.edge.StreetEdge;
 
 public class ItinerariesHelper {
 
-  public static List<Itinerary> decorateItinerariesWithRequestData(
-    List<Itinerary> itineraries,
+  public static Itinerary decorateItineraryWithRequestData(
+    Itinerary itinerary,
     boolean wheelchairEnabled,
     WheelchairPreferences wheelchairPreferences
   ) {
     if (!wheelchairEnabled) {
-      return itineraries;
+      return itinerary;
     }
-    var result = new ArrayList<Itinerary>();
-    boolean dirty = false;
 
-    for (Itinerary it : itineraries) {
-      // Communicate the fact that the only way we were able to get a response
-      // was by removing a slope limit.
-      OptionalDouble maxSlope = getMaxSlope(it);
-      if (maxSlope.isPresent()) {
-        dirty = true;
-        itineraries.add(
-          it.copyOf().withMaxSlope(wheelchairPreferences.maxSlope(), maxSlope.getAsDouble()).build()
-        );
-      } else {
-        result.add(it);
-      }
+    // Communicate the fact that the only way we were able to get a response
+    // was by removing a slope limit.
+    OptionalDouble maxSlope = getMaxSlope(itinerary);
+    if (maxSlope.isPresent()) {
+      return itinerary
+        .copyOf()
+        .withMaxSlope(wheelchairPreferences.maxSlope(), maxSlope.getAsDouble())
+        .build();
     }
-    return dirty ? result : itineraries;
+    return itinerary;
   }
 
   private static OptionalDouble getMaxSlope(Itinerary it) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Optional;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -23,19 +22,22 @@ import org.opentripplanner.street.model.StreetMode;
  */
 public class DirectStreetRouter {
 
-  public static List<Itinerary> route(
+  /**
+   * @return a direct street itinerary.
+   */
+  public static Optional<Itinerary> route(
     OtpServerRequestContext serverContext,
     RouteRequest request,
     LinkingContext linkingContext
   ) {
     if (request.journey().direct().mode() == StreetMode.NOT_SET) {
-      return Collections.emptyList();
+      return Optional.empty();
     }
     OTPRequestTimeoutException.checkForTimeout();
     try {
       var maxCarSpeed = serverContext.streetLimitationParametersService().maxCarSpeed();
       if (!straightLineDistanceIsWithinLimit(request, maxCarSpeed, linkingContext)) {
-        return Collections.emptyList();
+        return Optional.empty();
       }
 
       // we could also get a persistent router-scoped GraphPathFinder but there's no setup cost here
@@ -53,15 +55,16 @@ public class DirectStreetRouter {
         serverContext.streetDetailsService(),
         serverContext.graph().ellipsoidToGeoidDifference
       );
-      List<Itinerary> response = graphPathToItineraryMapper.mapItineraries(paths, request);
-      response = ItinerariesHelper.decorateItinerariesWithRequestData(
-        response,
-        request.journey().wheelchair(),
-        request.preferences().wheelchair()
+      var response = graphPathToItineraryMapper.mapToItinerary(paths, request);
+      return response.map(itinerary ->
+        ItinerariesHelper.decorateItineraryWithRequestData(
+          itinerary,
+          request.journey().wheelchair(),
+          request.preferences().wheelchair()
+        )
       );
-      return response;
     } catch (PathNotFoundException e) {
-      return Collections.emptyList();
+      return Optional.empty();
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.impl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
@@ -67,7 +68,7 @@ public class GraphPathFinder {
    * This no longer does "trip banning" to find multiple itineraries. It just searches once trying
    * to find a non-transit path.
    */
-  public List<StreetPath> getPaths(RouteRequest request, Set<Vertex> from, Set<Vertex> to) {
+  public Optional<StreetPath> getPath(RouteRequest request, Set<Vertex> from, Set<Vertex> to) {
     StreetPreferences preferences = request.preferences().street();
 
     StreetSearchBuilder streetSearch = StreetSearchBuilder.of()
@@ -94,20 +95,21 @@ public class GraphPathFinder {
     long searchBeginTime = System.currentTimeMillis();
     LOG.debug("BEGIN SEARCH");
 
-    var paths = streetSearch.getPathsToTarget();
+    var path = streetSearch.getPathToTarget();
 
-    LOG.debug("we have {} paths", paths.size());
+    if (path.isPresent()) {
+      LOG.debug("Found a path");
+    } else {
+      LOG.debug("Found no paths");
+    }
     LOG.debug("END SEARCH ({} msec)", System.currentTimeMillis() - searchBeginTime);
-    return paths;
+    return path;
   }
 
   /**
-   * Try to find N paths through the Graph
+   * Try to find a path through the Graph
    */
-  public List<StreetPath> graphPathFinderEntryPoint(
-    RouteRequest request,
-    LinkingContext linkingContext
-  ) {
+  public StreetPath graphPathFinderEntryPoint(RouteRequest request, LinkingContext linkingContext) {
     return graphPathFinderEntryPoint(
       request,
       linkingContext.findVertices(request.from()),
@@ -115,7 +117,7 @@ public class GraphPathFinder {
     );
   }
 
-  public List<StreetPath> graphPathFinderEntryPoint(
+  public StreetPath graphPathFinderEntryPoint(
     RouteRequest request,
     Set<Vertex> from,
     Set<Vertex> to
@@ -123,40 +125,42 @@ public class GraphPathFinder {
     OTPRequestTimeoutException.checkForTimeout();
     var reqTime = request.dateTime() == null ? RouteRequest.normalizeNow() : request.dateTime();
 
-    var paths = getPaths(request, from, to);
+    var path = getPath(request, from, to).orElseThrow(() -> {
+      logNoPathsFound(request);
+      return new PathNotFoundException();
+    });
 
     // Detect and report that most obnoxious of bugs: path reversal asymmetry.
-    // Removing paths might result in an empty list, so do this check before the empty list check.
-    var gpi = paths.iterator();
-    while (gpi.hasNext()) {
-      var graphPath = gpi.next();
-      // TODO check, is it possible that arriveBy and time are modifed in-place by the search?
-      if (request.arriveBy()) {
-        if (graphPath.endTimeAccurate().isAfter(reqTime)) {
-          LOG.error(
-            "A graph path arrives {} after the requested time {}. This implies a bug.",
-            graphPath.endTimeAccurate(),
-            reqTime
-          );
-          gpi.remove();
-        }
-      } else {
-        if (graphPath.startTimeAccurate().isBefore(reqTime)) {
-          LOG.error(
-            "A graph path leaves {} before the requested time {}. This implies a bug.",
-            graphPath.startTimeAccurate(),
-            reqTime
-          );
-          gpi.remove();
-        }
+    // TODO check, is it possible that arriveBy and time are modifed in-place by the search?
+    if (request.arriveBy()) {
+      if (path.endTimeAccurate().isAfter(reqTime)) {
+        LOG.error(
+          "A street path arrives {} after the requested time {}. This implies a bug.",
+          path.endTimeAccurate(),
+          reqTime
+        );
+        logAndThrowNoPathsFound(request);
+      }
+    } else {
+      if (path.startTimeAccurate().isBefore(reqTime)) {
+        LOG.error(
+          "A street path leaves {} before the requested time {}. This implies a bug.",
+          path.startTimeAccurate(),
+          reqTime
+        );
+        logAndThrowNoPathsFound(request);
       }
     }
 
-    if (paths.isEmpty()) {
-      LOG.debug("Path not found: {} : {}", request.from(), request.to());
-      throw new PathNotFoundException();
-    }
+    return path;
+  }
 
-    return paths;
+  private void logNoPathsFound(RouteRequest request) {
+    LOG.debug("Path not found: {} : {}", request.from(), request.to());
+  }
+
+  private void logAndThrowNoPathsFound(RouteRequest request) {
+    logNoPathsFound(request);
+    throw new PathNotFoundException();
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
@@ -278,14 +278,9 @@ public class OsmModuleTest {
     Vertex topV = graph.getVertex(VertexLabel.osm(559271124));
 
     GraphPathFinder graphPathFinder = new GraphPathFinder();
-    var pathList = graphPathFinder.graphPathFinderEntryPoint(
-      request,
-      Set.of(bottomV),
-      Set.of(topV)
-    );
+    var path = graphPathFinder.graphPathFinderEntryPoint(request, Set.of(bottomV), Set.of(topV));
 
-    assertNotNull(pathList);
-    assertFalse(pathList.isEmpty());
+    assertNotNull(path);
   }
 
   private record VertexPair(Vertex v0, Vertex v1) {}

--- a/application/src/test/java/org/opentripplanner/street/integration/BarrierRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BarrierRoutingTest.java
@@ -79,26 +79,22 @@ public class BarrierRoutingTest {
         rr.withPreferences(p ->
           p.withBike(it -> it.withWalking(walking -> walking.withReluctance(1d)))
         ),
-      itineraries ->
-        itineraries
-          .stream()
-          .flatMap(i ->
-            Stream.of(
-              () -> assertEquals(1, i.legs().size()),
-              () -> assertEquals(TraverseMode.BICYCLE, i.streetLeg(0).getMode()),
-              () ->
-                assertEquals(
-                  List.of(false, true, false, true, false),
-                  i
-                    .legs()
-                    .get(0)
-                    .listWalkSteps()
-                    .stream()
-                    .map(WalkStep::isWalkingBike)
-                    .collect(Collectors.toList())
-                )
+      itinerary ->
+        Stream.of(
+          () -> assertEquals(1, itinerary.legs().size()),
+          () -> assertEquals(TraverseMode.BICYCLE, itinerary.streetLeg(0).getMode()),
+          () ->
+            assertEquals(
+              List.of(false, true, false, true, false),
+              itinerary
+                .legs()
+                .get(0)
+                .listWalkSteps()
+                .stream()
+                .map(WalkStep::isWalkingBike)
+                .collect(Collectors.toList())
             )
-          )
+        )
     );
     assertThatPolylinesAreEqual(polyline2, "o~qgH_ccu@Bi@Bk@Bi@Bg@NaA@_@Dm@Dq@a@KJy@@I@M@E??");
   }
@@ -148,10 +144,10 @@ public class BarrierRoutingTest {
       to,
       streetMode,
       ignored -> {},
-      itineraries ->
-        itineraries
+      itinerary ->
+        itinerary
+          .legs()
           .stream()
-          .flatMap(i -> i.legs().stream())
           .map(
             l ->
               () ->
@@ -179,7 +175,7 @@ public class BarrierRoutingTest {
     GenericLocation to,
     StreetMode streetMode,
     Consumer<RouteRequestBuilder> options,
-    Function<List<Itinerary>, Stream<Executable>> assertions
+    Function<Itinerary, Stream<Executable>> assertions
   ) {
     var builder = RouteRequest.of()
       .withDateTime(DATE_TIME)
@@ -197,7 +193,7 @@ public class BarrierRoutingTest {
     var linkingRequest = LinkingContextRequestMapper.map(request);
     var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
     var gpf = new GraphPathFinder();
-    var paths = gpf.graphPathFinderEntryPoint(request, linkingContext);
+    var path = gpf.graphPathFinderEntryPoint(request, linkingContext);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       new NoopSiteResolver(),
@@ -207,11 +203,11 @@ public class BarrierRoutingTest {
       graph.ellipsoidToGeoidDifference
     );
 
-    var itineraries = graphPathToItineraryMapper.mapItineraries(paths, request);
+    var itinerary = graphPathToItineraryMapper.mapToItinerary(path, request).get();
 
-    assertAll(assertions.apply(itineraries));
+    assertAll(assertions.apply(itinerary));
 
-    Geometry legGeometry = itineraries.get(0).legs().get(0).legGeometry();
+    Geometry legGeometry = itinerary.legs().getFirst().legGeometry();
     temporaryVerticesContainer.close();
 
     return EncodedPolyline.of(legGeometry).points();

--- a/application/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
@@ -98,7 +98,7 @@ public class BicycleRoutingTest {
     var linkingRequest = LinkingContextRequestMapper.map(request);
     var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
     var gpf = new GraphPathFinder();
-    var paths = gpf.graphPathFinderEntryPoint(request, linkingContext);
+    var path = gpf.graphPathFinderEntryPoint(request, linkingContext);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       new NoopSiteResolver(),
@@ -108,22 +108,20 @@ public class BicycleRoutingTest {
       graph.ellipsoidToGeoidDifference
     );
 
-    var itineraries = graphPathToItineraryMapper.mapItineraries(paths, request);
+    var itinerary = graphPathToItineraryMapper.mapToItinerary(path, request).get();
     temporaryVerticesContainer.close();
 
     // make sure that we only get BICYCLE legs
-    itineraries.forEach(i ->
-      i
-        .legs()
-        .forEach(l -> {
-          if (l instanceof StreetLeg stLeg) {
-            assertEquals(TraverseMode.BICYCLE, stLeg.getMode());
-          } else {
-            fail("Expected StreetLeg (BICYCLE): " + l);
-          }
-        })
-    );
-    Geometry legGeometry = itineraries.get(0).legs().get(0).legGeometry();
+    itinerary
+      .legs()
+      .forEach(l -> {
+        if (l instanceof StreetLeg stLeg) {
+          assertEquals(TraverseMode.BICYCLE, stLeg.getMode());
+        } else {
+          fail("Expected StreetLeg (BICYCLE): " + l);
+        }
+      });
+    Geometry legGeometry = itinerary.legs().getFirst().legGeometry();
     return EncodedPolyline.of(legGeometry).points();
   }
 }

--- a/application/src/test/java/org/opentripplanner/street/integration/CarRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/CarRoutingTest.java
@@ -147,7 +147,7 @@ public class CarRoutingTest {
     var linkingRequest = LinkingContextRequestMapper.map(request);
     var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
     var gpf = new GraphPathFinder();
-    var paths = gpf.graphPathFinderEntryPoint(request, linkingContext);
+    var path = gpf.graphPathFinderEntryPoint(request, linkingContext);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       new NoopSiteResolver(),
@@ -157,22 +157,20 @@ public class CarRoutingTest {
       graph.ellipsoidToGeoidDifference
     );
 
-    var itineraries = graphPathToItineraryMapper.mapItineraries(paths, request);
+    var itinerary = graphPathToItineraryMapper.mapToItinerary(path, request).get();
     temporaryVerticesContainer.close();
 
     // make sure that we only get CAR legs
-    itineraries.forEach(i ->
-      i
-        .legs()
-        .forEach(l -> {
-          if (l instanceof StreetLeg stLeg) {
-            assertEquals(TraverseMode.CAR, stLeg.getMode());
-          } else {
-            fail("Expected StreetLeg (CAR): " + l);
-          }
-        })
-    );
-    Geometry legGeometry = itineraries.get(0).legs().get(0).legGeometry();
+    itinerary
+      .legs()
+      .forEach(l -> {
+        if (l instanceof StreetLeg stLeg) {
+          assertEquals(TraverseMode.CAR, stLeg.getMode());
+        } else {
+          fail("Expected StreetLeg (CAR): " + l);
+        }
+      });
+    Geometry legGeometry = itinerary.legs().getFirst().legGeometry();
     return EncodedPolyline.of(legGeometry).points();
   }
 }

--- a/application/src/test/java/org/opentripplanner/street/integration/SplitEdgeTurnRestrictionsTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/SplitEdgeTurnRestrictionsTest.java
@@ -179,7 +179,7 @@ public class SplitEdgeTurnRestrictionsTest {
       var linkingRequest = LinkingContextRequestMapper.map(request);
       var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
       var gpf = new GraphPathFinder();
-      var paths = gpf.graphPathFinderEntryPoint(request, linkingContext);
+      var path = gpf.graphPathFinderEntryPoint(request, linkingContext);
 
       GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
         new NoopSiteResolver(),
@@ -189,21 +189,19 @@ public class SplitEdgeTurnRestrictionsTest {
         graph.ellipsoidToGeoidDifference
       );
 
-      var itineraries = graphPathToItineraryMapper.mapItineraries(paths, request);
+      var itinerary = graphPathToItineraryMapper.mapToItinerary(path, request).get();
 
       // make sure that we only get CAR legs
-      itineraries.forEach(i ->
-        i
-          .legs()
-          .forEach(l -> {
-            if (l instanceof StreetLeg stLeg) {
-              assertEquals(TraverseMode.CAR, stLeg.getMode());
-            } else {
-              fail("Expected StreetLeg (CAR): " + l);
-            }
-          })
-      );
-      Geometry geometry = itineraries.get(0).legs().get(0).legGeometry();
+      itinerary
+        .legs()
+        .forEach(l -> {
+          if (l instanceof StreetLeg stLeg) {
+            assertEquals(TraverseMode.CAR, stLeg.getMode());
+          } else {
+            fail("Expected StreetLeg (CAR): " + l);
+          }
+        });
+      Geometry geometry = itinerary.legs().getFirst().legGeometry();
       return EncodedPolyline.of(geometry).points();
     }
   }

--- a/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
@@ -2,10 +2,10 @@ package org.opentripplanner.street.integration;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -60,16 +60,16 @@ class WalkRoutingTest {
     var end = GenericLocation.fromCoordinate(59.94641, 10.77522);
     var base = DATE_TIME.truncatedTo(ChronoUnit.SECONDS);
     var time = base.plusMillis(offset);
-    var forwardResults = route(roundabout, start, end, time, false);
-    assertEquals(1, forwardResults.size());
-    var forwardStates = forwardResults.getFirst().states();
+    var forwardResult = route(roundabout, start, end, time, false);
+    assertNotNull(forwardResult);
+    var forwardStates = forwardResult.states();
     var forwardDiff = ChronoUnit.MILLIS.between(
       forwardStates.getFirst().getTimeAccurate(),
       forwardStates.getLast().getTimeAccurate()
     );
-    var backwardResults = route(roundabout, start, end, time, true);
-    assertEquals(1, backwardResults.size());
-    var backwardStates = forwardResults.getFirst().states();
+    var backwardResult = route(roundabout, start, end, time, true);
+    assertNotNull(backwardResult);
+    var backwardStates = backwardResult.states();
     var backwardDiff = ChronoUnit.MILLIS.between(
       backwardStates.getFirst().getTimeAccurate(),
       backwardStates.getLast().getTimeAccurate()
@@ -80,7 +80,7 @@ class WalkRoutingTest {
     assertEquals(expected, backwardDiff);
   }
 
-  private static List<StreetPath> route(
+  private static StreetPath route(
     Graph graph,
     GenericLocation from,
     GenericLocation to,

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.opentripplanner.astar.model.BinHeap;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
@@ -19,6 +19,7 @@ import org.opentripplanner.astar.spi.SearchTerminationStrategy;
 import org.opentripplanner.astar.spi.SkipEdgeStrategy;
 import org.opentripplanner.astar.spi.StatisticsCallback;
 import org.opentripplanner.astar.spi.TraverseVisitor;
+import org.opentripplanner.astar.strategy.PathComparator;
 import org.opentripplanner.utils.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,14 +99,14 @@ public class AStar<
     return spt;
   }
 
-  public List<GraphPath<State, Edge, Vertex>> getPathsToTarget() {
+  public Optional<GraphPath<State, Edge, Vertex>> getPathToTarget() {
     runSearch();
 
-    return targetAcceptedStates
-      .stream()
-      .filter(State::isFinal)
-      .map(GraphPath::new)
-      .collect(Collectors.toList());
+    var finalStates = targetAcceptedStates.stream().filter(State::isFinal).toList();
+    if (finalStates.size() > 1) {
+      LOG.warn("Found multiple paths when one was expected.");
+    }
+    return finalStates.stream().map(GraphPath::new).min(new PathComparator(arriveBy));
   }
 
   private boolean iterate() {

--- a/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
+++ b/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
@@ -2,7 +2,7 @@ package org.opentripplanner.astar;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
@@ -48,7 +48,7 @@ public class TestAStarBuilder
     return build().getShortestPathTree();
   }
 
-  public List<GraphPath<TestState, TestEdge, TestVertex>> getPathsToTarget() {
-    return build().getPathsToTarget();
+  public Optional<GraphPath<TestState, TestEdge, TestVertex>> getPathToTarget() {
+    return build().getPathToTarget();
   }
 }

--- a/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
@@ -2,13 +2,12 @@ package org.opentripplanner.street.search;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.opentripplanner.astar.AStarBuilder;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.spi.DominanceFunction;
 import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
-import org.opentripplanner.astar.strategy.PathComparator;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.path.StreetPath;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -80,13 +79,8 @@ public class StreetSearchBuilder extends AStarBuilder<State, Edge, Vertex, Stree
     return build().getShortestPathTree();
   }
 
-  /// Run the street search, returning all paths found
-  public List<StreetPath> getPathsToTarget() {
-    return build()
-      .getPathsToTarget()
-      .stream()
-      .sorted(new PathComparator(arriveBy()))
-      .map(StreetPath::new)
-      .toList();
+  /// Run the street search, returning a found path
+  public Optional<StreetPath> getPathToTarget() {
+    return build().getPathToTarget().map(StreetPath::new);
   }
 }


### PR DESCRIPTION
### Summary

As far as I know, it's not ever intended currently that we return multiple paths and if it does happen, it should be really rare. This pr refactors the A* interface to return a singular path. This is in preparation of future refactoring to allow building itineraries from multiple paths originating from a via point search.

### Issue

Relates to https://github.com/opentripplanner/OpenTripPlanner/issues/4887

### Unit tests

Updated tests

### Documentation

No

### Changelog

Skipped
