### PR TITLE
Set default fares to "off"

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
@@ -58,7 +58,7 @@ public class FaresConfiguration {
     }
 
     if (type == null) {
-      type = "default";
+      type = "off";
     }
 
     FareServiceFactory factory = createFactory(type);

--- a/application/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
@@ -2,7 +2,7 @@ package org.opentripplanner.ext.fares;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.ext.fares.service.NoopFareServiceFactory;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.ext.fares.service.gtfs.v1.custom.AtlantaFareServiceFactory;
 import org.opentripplanner.ext.fares.service.gtfs.v1.custom.CombineInterlinedLegsFactory;
 import org.opentripplanner.ext.fares.service.gtfs.v1.custom.HSLFareServiceFactory;
@@ -68,8 +68,8 @@ public class FaresConfiguration {
 
   private static FareServiceFactory createFactory(String type) {
     return switch (type) {
-      case "default" -> new DefaultFareServiceFactory();
       case "off" -> new NoopFareServiceFactory();
+      case "gtfs" -> new GtfsFareServiceFactory();
       case
         "highest-fare-in-free-transfer-window",
         "highestFareInFreeTransferWindow" -> new HighestFareInFreeTransferWindowFareServiceFactory();

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/GtfsFareServiceFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/GtfsFareServiceFactory.java
@@ -30,9 +30,9 @@ import org.slf4j.LoggerFactory;
  * as well as Fares V2.
  *
  */
-public class DefaultFareServiceFactory implements FareServiceFactory {
+public class GtfsFareServiceFactory implements FareServiceFactory {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DefaultFareServiceFactory.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GtfsFareServiceFactory.class);
 
   protected Map<FeedScopedId, FareRuleSet> regularFareRules = new HashMap<>();
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/AtlantaFareServiceFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/AtlantaFareServiceFactory.java
@@ -6,10 +6,10 @@ import java.util.Map;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.fares.model.FareRulesData;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.routing.fares.FareService;
 
-public class AtlantaFareServiceFactory extends DefaultFareServiceFactory {
+public class AtlantaFareServiceFactory extends GtfsFareServiceFactory {
 
   protected Map<FeedScopedId, FareRuleSet> regularFareRules = new HashMap<>();
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/CombineInterlinedLegsFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/CombineInterlinedLegsFactory.java
@@ -1,13 +1,13 @@
 package org.opentripplanner.ext.fares.service.gtfs.v1.custom;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.ext.fares.service.gtfs.v1.custom.CombinedInterlinedLegsFareService.CombinationMode;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-public class CombineInterlinedLegsFactory extends DefaultFareServiceFactory {
+public class CombineInterlinedLegsFactory extends GtfsFareServiceFactory {
 
   private CombinationMode mode = CombinationMode.ALWAYS;
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HSLFareServiceFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HSLFareServiceFactory.java
@@ -6,14 +6,14 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.ext.fares.model.FareRule;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.transit.model.network.Route;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HSLFareServiceFactory extends DefaultFareServiceFactory {
+public class HSLFareServiceFactory extends GtfsFareServiceFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(HSLFareService.class);
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HighestFareInFreeTransferWindowFareServiceFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HighestFareInFreeTransferWindowFareServiceFactory.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.fares.model.FareRulesData;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
@@ -26,7 +26,7 @@ import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
  * <p>
  * This calculator is maintained by IBI Group.
  */
-public class HighestFareInFreeTransferWindowFareServiceFactory extends DefaultFareServiceFactory {
+public class HighestFareInFreeTransferWindowFareServiceFactory extends GtfsFareServiceFactory {
 
   protected Map<FeedScopedId, FareRuleSet> regularFareRules = new HashMap<>();
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareFactory.java
@@ -6,10 +6,10 @@ import java.util.Map;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.fares.model.FareRulesData;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.routing.fares.FareService;
 
-public class OrcaFareFactory extends DefaultFareServiceFactory {
+public class OrcaFareFactory extends GtfsFareServiceFactory {
 
   protected Map<FeedScopedId, FareRuleSet> regularFareRules = new HashMap<>();
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
@@ -11,7 +11,7 @@ import org.opentripplanner.ext.fares.model.FareTransferRuleBuilder;
 import org.opentripplanner.ext.fares.model.TimeLimitType;
 import org.opentripplanner.ext.fares.service.gtfs.GtfsFaresService;
 import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareService;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.ext.fares.service.gtfs.v2.GtfsFaresV2Service;
 import org.opentripplanner.model.fare.FareMedium;
 import org.opentripplanner.model.fare.FareProduct;
@@ -20,7 +20,7 @@ import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.transit.model.basic.Money;
 
-public class OregonHopFareFactory extends DefaultFareServiceFactory {
+public class OregonHopFareFactory extends GtfsFareServiceFactory {
 
   static final FeedScopedId TRIMET_ADULT_SINGLE_RIDE = trimetId("TRIMET_ADULT_SINGLE_RIDE");
   static final FeedScopedId TRIMET_HC_SINGLE_RIDE = trimetId("TRIMET_HC_SINGLE_RIDE");

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -19,7 +19,7 @@ import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateInterval;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.ext.flex.FlexTripsMapper;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -118,7 +118,7 @@ public class GtfsModule implements GraphBuilderModule {
       new Deduplicator(),
       DataImportIssueStore.NOOP,
       transitPeriodLimit,
-      new DefaultFareServiceFactory(),
+      new GtfsFareServiceFactory(),
       150.0,
       120
     );

--- a/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
@@ -2,7 +2,7 @@ package org.opentripplanner.gtfs.graphbuilder;
 
 import java.util.List;
 import org.opentripplanner.core.model.time.LocalDateInterval;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.service.streetdetails.internal.DefaultStreetDetailsRepository;
 import org.opentripplanner.street.graph.Graph;
@@ -25,7 +25,7 @@ public class GtfsModuleTestFactory {
       new Deduplicator(),
       DataImportIssueStore.NOOP,
       transitPeriodLimit,
-      new DefaultFareServiceFactory(),
+      new GtfsFareServiceFactory(),
       150.0,
       120
     );

--- a/application/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/application/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -14,7 +14,7 @@ import org.opentripplanner.core.model.time.LocalDateInterval;
 import org.opentripplanner.datastore.api.CompositeDataSource;
 import org.opentripplanner.datastore.api.FileType;
 import org.opentripplanner.datastore.file.DirectoryDataSource;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.model.ConfiguredCompositeDataSource;
@@ -147,7 +147,7 @@ public class ConstantsForTests {
     try {
       var graph = new Graph();
       var timetableRepository = new TimetableRepository(new SiteRepository());
-      var fareFactory = new DefaultFareServiceFactory();
+      var fareFactory = new GtfsFareServiceFactory();
       // Add street data from OSM
       {
         var osmModule = OsmModuleTestFactory.of(new DefaultOsmProvider(PORTLAND_CENTRAL_OSM, false))
@@ -239,7 +239,7 @@ public class ConstantsForTests {
       otpModel.graph(),
       otpModel.timetableRepository(),
       gtfsPath,
-      new DefaultFareServiceFactory(),
+      new GtfsFareServiceFactory(),
       null
     );
 
@@ -250,7 +250,7 @@ public class ConstantsForTests {
   }
 
   public static TestOtpModel buildGtfsGraph(File gtfsPath) {
-    return buildGtfsGraph(gtfsPath, new DefaultFareServiceFactory());
+    return buildGtfsGraph(gtfsPath, new GtfsFareServiceFactory());
   }
 
   public static TestOtpModel buildGtfsGraph(File gtfsFile, FareServiceFactory fareServiceFactory) {

--- a/application/src/test/java/org/opentripplanner/TestOtpModel.java
+++ b/application/src/test/java/org/opentripplanner/TestOtpModel.java
@@ -1,6 +1,6 @@
 package org.opentripplanner;
 
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
@@ -17,7 +17,7 @@ public record TestOtpModel(
     TimetableRepository timetableRepository,
     TransferRepository transferRepository
   ) {
-    this(graph, timetableRepository, transferRepository, new DefaultFareServiceFactory());
+    this(graph, timetableRepository, transferRepository, new GtfsFareServiceFactory());
   }
 
   public TestOtpModel index() {

--- a/application/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -33,7 +33,7 @@ import org.opentripplanner.ext.empiricaldelay.internal.DefaultEmpiricalDelayRepo
 import org.opentripplanner.ext.empiricaldelay.model.EmpiricalDelay;
 import org.opentripplanner.ext.empiricaldelay.model.TripDelays;
 import org.opentripplanner.ext.empiricaldelay.model.calendar.EmpiricalDelayCalendar;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.framework.model.Gram;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueSummary;
 import org.opentripplanner.model.plan.Emission;
@@ -272,7 +272,7 @@ public class GraphSerializationTest {
       emissionRepository,
       empiricalDelayRepository,
       null,
-      new DefaultFareServiceFactory()
+      new GtfsFareServiceFactory()
     );
     serializedObj.save(new FileDataSource(tempFile, FileType.GRAPH));
     SerializedGraphObject deserializedGraph = SerializedGraphObject.load(tempFile);

--- a/application/src/test/java/org/opentripplanner/transit/service/TimetableRepositoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/TimetableRepositoryTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareServiceFactory;
+import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.graph_builder.module.TimeZoneAdjusterModule;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;
@@ -44,7 +44,7 @@ class TimetableRepositoryTest {
       graph,
       timetableRepository,
       ConstantsForTests.SIMPLE_GTFS,
-      new DefaultFareServiceFactory(),
+      new GtfsFareServiceFactory(),
       FAKE_FEED_ID
     );
 
@@ -66,7 +66,7 @@ class TimetableRepositoryTest {
           graph,
           timetableRepository,
           RESOURCE_LOADER.file("kcm_gtfs.zip"),
-          new DefaultFareServiceFactory(),
+          new GtfsFareServiceFactory(),
           null
         ),
       ("The graph contains agencies with different time zones. " +
@@ -89,7 +89,7 @@ class TimetableRepositoryTest {
       graph,
       timetableRepository,
       ConstantsForTests.SIMPLE_GTFS,
-      new DefaultFareServiceFactory(),
+      new GtfsFareServiceFactory(),
       FAKE_FEED_ID
     );
 
@@ -98,7 +98,7 @@ class TimetableRepositoryTest {
       graph,
       timetableRepository,
       RESOURCE_LOADER.file("kcm_gtfs.zip"),
-      new DefaultFareServiceFactory(),
+      new GtfsFareServiceFactory(),
       null
     );
 


### PR DESCRIPTION
### Summary

Fares are a Sandbox feature and should be default _off_ in GraphBuilder. Deployments uting fares need to set the profile in their config. There is a "default" fares profile, and this should probably be renamed to "Standard" or similar.  I can do this in this PR if we agree on the name.

### Issue

The fares has a significant overhead and slow down the OTP server on each plan request - even for deployments witch does not use fares.


### Unit tests

🟥  Not relevant.

### Documentation

🟥  I assume the doc is updated automatically.


### Changelog

✅  This is important for those who uses the "default" fares today - they need to update their config. 

### Bumping the serialization version id

🟥  Not needed.