### PR TITLE
Skip leg rebuild when fare/alert decoration would be a no-op

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/FaresFilterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/FaresFilterTest.java
@@ -1,11 +1,16 @@
 package org.opentripplanner.ext.fares;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.ItineraryFare;
@@ -20,15 +25,17 @@ public class FaresFilterTest implements PlanTestConstants {
 
   private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
 
+  private Itinerary buildItinerary() {
+    return newItinerary(A, 0)
+      .walk(20, Place.forStop(testModel.stop("1:stop", 1d, 1d).build()))
+      .bus(1, 0, 50, B)
+      .bus(1, 52, 100, C)
+      .build();
+  }
+
   @Test
   void shouldAddFare() {
-    final int ID = 1;
-
-    Itinerary i1 = newItinerary(A, 0)
-      .walk(20, Place.forStop(testModel.stop("1:stop", 1d, 1d).build()))
-      .bus(ID, 0, 50, B)
-      .bus(ID, 52, 100, C)
-      .build();
+    Itinerary i1 = buildItinerary();
 
     assertEquals(ItineraryFare.empty(), i1.fare());
 
@@ -47,5 +54,22 @@ public class FaresFilterTest implements PlanTestConstants {
     var busLeg = i1.transitLeg(1);
 
     assertEquals(List.of(FareOffer.of(busLeg.startTime(), fp)), busLeg.fareOffers());
+  }
+
+  static Stream<Arguments> emptyOrNullFareCases() {
+    return Stream.of(
+      Arguments.of("empty", (FareService) itinerary -> ItineraryFare.empty()),
+      Arguments.of("null", (FareService) itinerary -> null)
+    );
+  }
+
+  @ParameterizedTest(name = "{0} fare must not trigger an itinerary rebuild")
+  @MethodSource("emptyOrNullFareCases")
+  void shouldSkipDecorationWhenFareProducesNoProducts(String label, FareService fareService) {
+    Itinerary i1 = buildItinerary();
+
+    var decorated = new DecorateWithFare(fareService).decorate(i1);
+
+    assertSame(i1, decorated);
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/DecorateWithFare.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/DecorateWithFare.java
@@ -18,8 +18,9 @@ public class DecorateWithFare implements ItineraryDecorator {
   @Override
   public Itinerary decorate(Itinerary itinerary) {
     var fare = fareService.calculateFares(itinerary);
-    return (fare != null)
-      ? ItineraryFaresDecorator.decorateItineraryWithFare(itinerary, fare)
-      : itinerary;
+    if (fare == null || fare.isEmpty()) {
+      return itinerary;
+    }
+    return ItineraryFaresDecorator.decorateItineraryWithFare(itinerary, fare);
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/ItineraryFaresDecorator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/ItineraryFaresDecorator.java
@@ -39,6 +39,9 @@ public final class ItineraryFaresDecorator {
 
   private TransitLeg decorateTransitLeg(TransitLeg leg) {
     var legOffers = fare.getLegProducts().get(leg);
+    if (fareOffers.isEmpty() && legOffers.isEmpty()) {
+      return leg;
+    }
     var allOfferes = ListUtils.combine(fareOffers, legOffers);
 
     return (leg instanceof FareProductAware<TransitLeg> fpa)

--- a/application/src/ext/java/org/opentripplanner/ext/fares/ItineraryFaresDecorator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/ItineraryFaresDecorator.java
@@ -42,10 +42,10 @@ public final class ItineraryFaresDecorator {
     if (fareOffers.isEmpty() && legOffers.isEmpty()) {
       return leg;
     }
-    var allOfferes = ListUtils.combine(fareOffers, legOffers);
+    var allOffers = ListUtils.combine(fareOffers, legOffers);
 
     return (leg instanceof FareProductAware<TransitLeg> fpa)
-      ? fpa.decorateWithFareOffers(allOfferes)
+      ? fpa.decorateWithFareOffers(allOffers)
       : leg;
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -115,6 +115,9 @@ public class AlertToLegMapper {
       !alert.displayDuring(leg.startTime().toEpochSecond(), leg.endTime().toEpochSecond())
     );
 
+    if (totalAlerts.isEmpty()) {
+      return leg;
+    }
     return leg.decorateWithAlerts(Set.copyOf(totalAlerts));
   }
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/DecorateTransitAlertTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/DecorateTransitAlertTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.algorithm.filterchain.filters.transit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.BUS_ROUTE;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
@@ -56,6 +57,27 @@ class DecorateTransitAlertTest implements PlanTestConstants {
     // Then: expect correct alerts to be added
     assertEquals(1, i1.legs().getFirst().listTransitAlerts().size());
     assertEquals(ID, i1.legs().getFirst().listTransitAlerts().iterator().next().getId());
+  }
+
+  @Test
+  void testSkipsLegRebuildWhenNoAlertsMatch() {
+    // Alert service with no alerts at all — nothing can match.
+    var transitAlertService = new TransitAlertServiceImpl(new TimetableRepository());
+    var decorator = new DecorateTransitAlert(transitAlertService, ignore -> null);
+
+    var i1 = newItinerary(A).bus(31, 0, 30, E).build();
+    var originalLegs = i1.legs();
+
+    var decorated = decorator.decorate(i1);
+
+    // Every leg must be the same reference — the short-circuit avoids the rebuild.
+    for (int i = 0; i < originalLegs.size(); i++) {
+      assertSame(
+        originalLegs.get(i),
+        decorated.legs().get(i),
+        "leg " + i + " should not be rebuilt when no alerts apply"
+      );
+    }
   }
 
   private static TransitAlertServiceImpl buildService(TransitAlertBuilder builder) {


### PR DESCRIPTION
### Summary

Add three short-circuit guards so that filter-chain decorators don't rebuild `ScheduledTransitLeg` via the builder when the decoration would have no content to add. Each rebuild re-runs `GeometryUtils.sumDistances` on the full polyline in the leg constructor, so avoiding no-op rebuilds removes measurable CPU work and allocation pressure — especially for deployments that don't use a given feature.

### How the code works

Three guards, each in the most appropriate place:

- **`DecorateWithFare.decorate()`** — return the itinerary unchanged when the fare is either `null` **or** `isEmpty()`. Handles the common "fare service wired but no fare data" case at the top level, skipping every per-leg call below.
- **`ItineraryFaresDecorator.decorateTransitLeg()`** — return the leg unchanged when both the itinerary-level offer list and the per-leg offer collection are empty. Handles the case where the `ItineraryFare` as a whole is non-empty but a specific leg has nothing applicable.
- **`AlertToLegMapper.decorateWithAlerts(leg, ...)`** — return the leg unchanged when `totalAlerts` is empty after the time-filter step. Catches the common case where no alerts match a particular leg even though the alert service is active.

### Unit tests

- `FaresFilterTest` — existing `shouldAddFare` still passes. Added a parameterized test `shouldSkipDecorationWhenFareProducesNoProducts` driven by `(label, FareService)` cases covering both empty `ItineraryFare` and `null`. Both variants assert `assertSame(original, decorated)` — the rebuild would produce an equal-but-distinct object, so reference identity is a precise signal that the short-circuit fired.
- `DecorateTransitAlertTest` — existing `testRoute`/`testStop` still pass. Added `testSkipsLegRebuildWhenNoAlertsMatch` which configures a `TransitAlertServiceImpl` with no alerts at all and asserts every leg in the decorated itinerary is the same reference as the original.


