### PR TITLE
Extract RequestPreProcessor from RoutingWorker

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RequestPreProcessor.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RequestPreProcessor.java
@@ -1,0 +1,54 @@
+package org.opentripplanner.routing.algorithm;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import org.opentripplanner.raptor.api.request.RaptorTuningParameters;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.utils.time.ServiceDateUtils;
+
+/**
+ * Pre-processes a {@link RouteRequest} into a {@link RoutingWorkerRequest} for usage in
+ * {@link RoutingWorker}. This includes extending the request with a page cursor and amending
+ * its data with additional resolved data, such as additional search days.
+ */
+public final class RequestPreProcessor {
+
+  private final RaptorTuningParameters tuningParameters;
+  private final ZoneId zoneId;
+
+  public RequestPreProcessor(RaptorTuningParameters tuningParameters, ZoneId zoneId) {
+    this.tuningParameters = tuningParameters;
+    this.zoneId = zoneId;
+  }
+
+  /**
+   * Pre-process {@code originalRequest} and return a {@link RoutingWorkerRequest} with all values
+   * needed to initialize a {@link RoutingWorker}.
+   */
+  public RoutingWorkerRequest computeRequest(RouteRequest originalRequest) {
+    var request = originalRequest.withPageCursor();
+    var transitSearchTimeZero = ServiceDateUtils.asStartOfService(request.dateTime(), zoneId);
+    var additionalSearchDays = createAdditionalSearchDays(tuningParameters, zoneId, request);
+    return new RoutingWorkerRequest(request, transitSearchTimeZero, additionalSearchDays);
+  }
+
+  private static AdditionalSearchDays createAdditionalSearchDays(
+    RaptorTuningParameters raptorTuningParameters,
+    ZoneId zoneId,
+    RouteRequest request
+  ) {
+    var dateTime = Objects.requireNonNull(request.dateTime());
+    var searchDateTime = ZonedDateTime.ofInstant(dateTime, zoneId);
+    var maxWindow = raptorTuningParameters.dynamicSearchWindowCoefficients().maxWindow();
+
+    return new AdditionalSearchDays(
+      request.arriveBy(),
+      searchDateTime,
+      request.searchWindow(),
+      maxWindow,
+      request.preferences().system().maxJourneyDuration()
+    );
+  }
+}

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.algorithm;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -15,7 +14,6 @@ import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.grouppriority.TransitGroupPriorityItineraryDecorator;
 import org.opentripplanner.model.plan.paging.cursor.PageCursorInput;
-import org.opentripplanner.raptor.api.request.RaptorTuningParameters;
 import org.opentripplanner.raptor.api.request.SearchParams;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChain;
 import org.opentripplanner.routing.algorithm.mapping.PagingServiceFactory;
@@ -41,7 +39,6 @@ import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.linking.TemporaryVerticesContainer;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.transit.model.network.grouppriority.TransitGroupPriorityService;
-import org.opentripplanner.utils.time.ServiceDateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,15 +56,6 @@ public class RoutingWorker {
 
   private final RouteRequest request;
   private final OtpServerRequestContext serverContext;
-  /**
-   * The transit service time-zero normalized for the current search. All transit times are relative
-   * to a "time-zero". This enables us to use an integer(small memory footprint). The times are
-   * number for seconds past the {@code transitSearchTimeZero}. In the internal model all times are
-   * stored relative to the {@link java.time.LocalDate}, but to be able
-   * to compare trip times for different service days we normalize all times by calculating an
-   * offset. Now all times for the selected trip patterns become relative to the {@code
-   * transitSearchTimeZero}.
-   */
   private final ZonedDateTime transitSearchTimeZero;
   private final AdditionalSearchDays additionalSearchDays;
   private final TransitGroupPriorityService transitGroupPriorityService;
@@ -78,22 +66,14 @@ public class RoutingWorker {
   @Nullable
   private LinkingContext currentLinkingContext = null;
 
-  public RoutingWorker(
-    OtpServerRequestContext serverContext,
-    RouteRequest orginalRequest,
-    ZoneId zoneId
-  ) {
-    this.request = orginalRequest.withPageCursor();
+  public RoutingWorker(OtpServerRequestContext serverContext, RoutingWorkerRequest workerRequest) {
+    this.request = workerRequest.request();
+    this.transitSearchTimeZero = workerRequest.transitSearchTimeZero();
+    this.additionalSearchDays = workerRequest.additionalSearchDays();
     this.serverContext = serverContext;
     this.debugTimingAggregator = new DebugTimingAggregator(
       serverContext.meterRegistry(),
       request.preferences().system().tags()
-    );
-    this.transitSearchTimeZero = ServiceDateUtils.asStartOfService(request.dateTime(), zoneId);
-    this.additionalSearchDays = createAdditionalSearchDays(
-      serverContext.raptorTuningParameters(),
-      zoneId,
-      request
     );
     this.transitGroupPriorityService = TransitGroupPriorityService.of(
       request.preferences().transit().relaxTransitGroupPriority(),
@@ -188,23 +168,6 @@ public class RoutingWorker {
       debugTimingAggregator,
       serverContext.transitService(),
       pagingService
-    );
-  }
-
-  private static AdditionalSearchDays createAdditionalSearchDays(
-    RaptorTuningParameters raptorTuningParameters,
-    ZoneId zoneId,
-    RouteRequest request
-  ) {
-    var searchDateTime = ZonedDateTime.ofInstant(request.dateTime(), zoneId);
-    var maxWindow = raptorTuningParameters.dynamicSearchWindowCoefficients().maxWindow();
-
-    return new AdditionalSearchDays(
-      request.arriveBy(),
-      searchDateTime,
-      request.searchWindow(),
-      maxWindow,
-      request.preferences().system().maxJourneyDuration()
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorkerRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorkerRequest.java
@@ -1,0 +1,52 @@
+package org.opentripplanner.routing.algorithm;
+
+import java.time.ZonedDateTime;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
+import org.opentripplanner.routing.api.request.RouteRequest;
+
+/**
+ * A trip planning request for handling in {@link RoutingWorker}
+ */
+public final class RoutingWorkerRequest {
+
+  private final RouteRequest request;
+  private final ZonedDateTime transitSearchTimeZero;
+  private final AdditionalSearchDays additionalSearchDays;
+
+  /**
+   * @param request the route request ready for routing. It should already be pre-processed to have
+   *                e.g. page cursor applied
+   */
+  public RoutingWorkerRequest(
+    RouteRequest request,
+    ZonedDateTime transitSearchTimeZero,
+    AdditionalSearchDays additionalSearchDays
+  ) {
+    this.request = request;
+    this.transitSearchTimeZero = transitSearchTimeZero;
+    this.additionalSearchDays = additionalSearchDays;
+  }
+
+  /** The route request with the page cursor applied. */
+  public RouteRequest request() {
+    return request;
+  }
+
+  /**
+   * The transit service time-zero normalized for the current search. All transit times are relative
+   * to a "time-zero". This enables us to use an integer(small memory footprint). The times are
+   * number for seconds past the {@code transitSearchTimeZero}. In the internal model all times are
+   * stored relative to the {@link java.time.LocalDate}, but to be able
+   * to compare trip times for different service days we normalize all times by calculating an
+   * offset. Now all times for the selected trip patterns become relative to the {@code
+   * transitSearchTimeZero}.
+   */
+  public ZonedDateTime transitSearchTimeZero() {
+    return transitSearchTimeZero;
+  }
+
+  /** The number of extra calendar days to search before and after the requested date. */
+  public AdditionalSearchDays additionalSearchDays() {
+    return additionalSearchDays;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
+++ b/application/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
@@ -4,7 +4,9 @@ import java.time.ZoneId;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.time.ZoneIdFallback;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.RequestPreProcessor;
 import org.opentripplanner.routing.algorithm.RoutingWorker;
+import org.opentripplanner.routing.algorithm.RoutingWorkerRequest;
 import org.opentripplanner.routing.algorithm.via.ViaRoutingWorker;
 import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -39,7 +41,7 @@ public class DefaultRoutingService implements RoutingService {
     LOG.debug("Request: {}", request);
     OTPRequestTimeoutException.checkForTimeout();
     request.validateOriginAndDestination();
-    var worker = new RoutingWorker(serverContext, request, timeZone);
+    var worker = new RoutingWorker(serverContext, mapRequest(request));
     var response = worker.route();
     logResponse(response);
     return response;
@@ -50,10 +52,16 @@ public class DefaultRoutingService implements RoutingService {
     LOG.debug("Request: {}", request);
     OTPRequestTimeoutException.checkForTimeout();
     var viaRoutingWorker = new ViaRoutingWorker(request, req ->
-      new RoutingWorker(serverContext, req, serverContext.transitService().getTimeZone()).route()
+      new RoutingWorker(serverContext, mapRequest(req)).route()
     );
     // TODO: Add output logging here, see route(..) method
     return viaRoutingWorker.route();
+  }
+
+  private RoutingWorkerRequest mapRequest(RouteRequest request) {
+    return new RequestPreProcessor(serverContext.raptorTuningParameters(), timeZone).computeRequest(
+      request
+    );
   }
 
   private void logResponse(RoutingResponse response) {

--- a/application/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
+++ b/application/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.service;
 
-import java.time.ZoneId;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.time.ZoneIdFallback;
 import org.opentripplanner.model.plan.Itinerary;
@@ -29,11 +28,17 @@ public class DefaultRoutingService implements RoutingService {
 
   private final OtpServerRequestContext serverContext;
 
-  private final ZoneId timeZone;
+  private final RequestPreProcessor requestPreProcessor;
 
   public DefaultRoutingService(OtpServerRequestContext serverContext) {
     this.serverContext = serverContext;
-    this.timeZone = ZoneIdFallback.zoneId(serverContext.transitService().getTimeZone());
+
+    var timeZone = ZoneIdFallback.zoneId(serverContext.transitService().getTimeZone());
+
+    this.requestPreProcessor = new RequestPreProcessor(
+      serverContext.raptorTuningParameters(),
+      timeZone
+    );
   }
 
   @Override
@@ -59,9 +64,7 @@ public class DefaultRoutingService implements RoutingService {
   }
 
   private RoutingWorkerRequest mapRequest(RouteRequest request) {
-    return new RequestPreProcessor(serverContext.raptorTuningParameters(), timeZone).computeRequest(
-      request
-    );
+    return requestPreProcessor.computeRequest(request);
   }
 
   private void logResponse(RoutingResponse response) {


### PR DESCRIPTION
### Summary
The `RoutingWorker` currently has many concerns and one of them is populating the request with additional information as a preprocessing step. This pure refactoring PR extracts this concern out to a new `RequestPreProcessor` class instead. This class creates a special-purpose `RoutingWorkerRequest` object with the information `RoutingWorker` needs. 

### Issue
This is a small pre-requisite to #7266. For implementing the start-on-board API, it is necessary to amend the request with a specific `dateTime` resolved from actual timetable/realtime data. Without first merging this PR, this resolving/amending of the request would have to happen in the RoutingWorker, but now we can instead do it in the RequestPreProcessor. 

Peripherally related to #7530

### Unit tests
Not needed. RequestPreProcessor has pure wiring logic and the internal logic is tested in `ServiceDateUtils` and `AdditionalSearchDays`.

### Documentation
Javadoc added to new pre-processor class and the `RoutingWorkerRequest` class.

