### PR TITLE
Fix RAPTOR path building for flex patterns with duplicated stops

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
@@ -100,7 +100,7 @@ public interface RaptorTripSchedule {
     RaptorTripPattern p = pattern();
     int i = p.numberOfStopsInPattern() - 1;
 
-    while (isBefore(latestArrivalTime, i)) {
+    while (arrivalIsAfter(latestArrivalTime, i)) {
       --i;
       if (i == -1) {
         return -1;
@@ -169,10 +169,11 @@ public interface RaptorTripSchedule {
     return stops;
   }
 
-  /// Check if the time at stop position i is before the given latestArrivalTime, considering
-  /// that there can also be flex stop visits in this pattern that does not have a time.
-  private boolean isBefore(int latestArrivalTime, int i) {
-    int arrival = arrival(i);
+  /// Check if the arrival time at stop position is after the given latestArrivalTime, considering
+  /// that there can also be flex stop visits in this pattern that use -999 to indicate that they
+  /// use a window, not fixed times.
+  private boolean arrivalIsAfter(int latestArrivalTime, int stopPosInPattern) {
+    int arrival = arrival(stopPosInPattern);
     return arrival > latestArrivalTime || arrival == NOT_SET;
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
@@ -11,6 +11,8 @@ import java.util.List;
  * choose the most efficient underlying representation that suits its needs.
  */
 public interface RaptorTripSchedule {
+  int NOT_SET = -999;
+
   /**
    * An id/index for the trip which can be used to sort trips so they follow each other in time. The
    * id/index must increase with the departure time.
@@ -98,7 +100,7 @@ public interface RaptorTripSchedule {
     RaptorTripPattern p = pattern();
     int i = p.numberOfStopsInPattern() - 1;
 
-    while (arrival(i) > latestArrivalTime || arrival(i) == -999) {
+    while (isBefore(latestArrivalTime, i)) {
       --i;
       if (i == -1) {
         return -1;
@@ -165,5 +167,12 @@ public interface RaptorTripSchedule {
     }
 
     return stops;
+  }
+
+  /// Check if the time at stop position i is before the given latestArrivalTime, considering
+  /// that there can also be flex stop visits in this pattern that does not have a time.
+  private boolean isBefore(int latestArrivalTime, int i) {
+    int arrival = arrival(i);
+    return arrival > latestArrivalTime || arrival == NOT_SET;
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
@@ -11,8 +11,6 @@ import java.util.List;
  * choose the most efficient underlying representation that suits its needs.
  */
 public interface RaptorTripSchedule {
-  int NOT_SET = -999;
-
   /**
    * An id/index for the trip which can be used to sort trips so they follow each other in time. The
    * id/index must increase with the departure time.
@@ -100,7 +98,7 @@ public interface RaptorTripSchedule {
     RaptorTripPattern p = pattern();
     int i = p.numberOfStopsInPattern() - 1;
 
-    while (arrivalIsAfter(latestArrivalTime, i)) {
+    while (!p.alightingPossibleAt(i) || arrival(i) > latestArrivalTime) {
       --i;
       if (i == -1) {
         return -1;
@@ -167,13 +165,5 @@ public interface RaptorTripSchedule {
     }
 
     return stops;
-  }
-
-  /// Check if the arrival time at stop position is after the given latestArrivalTime, considering
-  /// that there can also be flex stop visits in this pattern that use -999 to indicate that they
-  /// use a window, not fixed times.
-  private boolean arrivalIsAfter(int latestArrivalTime, int stopPosInPattern) {
-    int arrival = arrival(stopPosInPattern);
-    return arrival > latestArrivalTime || arrival == NOT_SET;
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
@@ -98,7 +98,7 @@ public interface RaptorTripSchedule {
     RaptorTripPattern p = pattern();
     int i = p.numberOfStopsInPattern() - 1;
 
-    while (arrival(i) > latestArrivalTime) {
+    while (arrival(i) > latestArrivalTime || arrival(i) == -999) {
       --i;
       if (i == -1) {
         return -1;

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
@@ -125,7 +125,7 @@ public interface RaptorTripSchedule {
     final int size = p.numberOfStopsInPattern();
     int i = 0;
 
-    while (departure(i) < earliestDepartureTime) {
+    while (!p.boardingPossibleAt(i) || departure(i) < earliestDepartureTime) {
       ++i;
       if (i == size) {
         return -1;

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -10,12 +10,6 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 
 class RaptorTripScheduleTest {
 
-  /**
-   * Trips that mix fixed and flex schedules use -999 for those stop times that use a flexible
-   * window.
-   */
-  private static final int NOT_SET = -999;
-
   private final TestTripSchedule subject = TestTripSchedule.schedule(
     TestTripPattern.pattern("L23", 1, 1, 2, 3, 5, 8, 1)
   )
@@ -56,8 +50,7 @@ class RaptorTripScheduleTest {
     var subject = TestTripSchedule.schedule(
       TestTripPattern.of("flex-with-repeating-stops", 1, 1, 2, 3).restrictions("* * - *").build()
     )
-      .arrivals(time("09:00"), time("09:10"), NOT_SET, time("09:30"))
-      .departures(time("09:01"), time("09:11"), NOT_SET, time("09:31"))
+      .times(time("09:00"), time("09:10"), RaptorConstants.TIME_NOT_SET, time("09:30"))
       .build();
 
     assertEquals(0, subject.findArrivalStopPosition(time("09:06"), 1));
@@ -68,8 +61,7 @@ class RaptorTripScheduleTest {
     var subject = TestTripSchedule.schedule(
       TestTripPattern.of("restricted-repeating-stops", 1, 1, 1, 3).restrictions("* A * *").build()
     )
-      .arrivals(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
-      .departures(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
+      .times(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
       .build();
 
     assertEquals(2, subject.findDepartureStopPosition(time("09:09"), 1));

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -49,10 +49,10 @@ class RaptorTripScheduleTest {
   }
 
   @Nested
-  class FlexPatternWithDuplicateStop {
+  class RestrictedPatternsWithDuplicateStops {
 
     @Test
-    void flexPatternWithDuplicateStop() {
+    void findArrivalStopPosition() {
       var subject = TestTripSchedule.schedule(
         TestTripPattern.of("flex-with-repeating-stops", 1, 1, 2, 3).restrictions("* * - *").build()
       )
@@ -61,6 +61,18 @@ class RaptorTripScheduleTest {
         .build();
 
       assertEquals(0, subject.findArrivalStopPosition(time("09:06"), 1));
+    }
+
+    @Test
+    void findDepartureStopPosition() {
+      var subject = TestTripSchedule.schedule(
+        TestTripPattern.of("restricted-repeating-stops", 1, 1, 1, 3).restrictions("* A * *").build()
+      )
+        .arrivals(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
+        .departures(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
+        .build();
+
+      assertEquals(2, subject.findDepartureStopPosition(time("09:09"), 1));
     }
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.raptor.spi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.raptor.spi.RaptorTripSchedule.NOT_SET;
 import static org.opentripplanner.utils.time.TimeUtils.time;
 import static org.opentripplanner.utils.time.TimeUtils.timeToStrLong;
 
@@ -10,6 +9,8 @@ import org.opentripplanner.raptor._data.transit.TestTripPattern;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 
 public class RaptorTripScheduleTest {
+
+  private static final int NOT_SET = -999;
 
   private final TestTripSchedule subject = TestTripSchedule.schedule(
     TestTripPattern.pattern("L23", 1, 1, 2, 3, 5, 8, 1)
@@ -49,7 +50,7 @@ public class RaptorTripScheduleTest {
   @Test
   public void flexPatternWithDuplicateStop() {
     var subject = TestTripSchedule.schedule(
-      TestTripPattern.pattern("flex-with-repeating-stops", 1, 1, 2, 3)
+      TestTripPattern.of("flex-with-repeating-stops", 1, 1, 2, 3).restrictions("* * - *").build()
     )
       .arrivals(time("09:00"), time("09:10"), NOT_SET, time("09:30"))
       .departures(time("09:01"), time("09:11"), NOT_SET, time("09:31"))

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.utils.time.TimeUtils.time;
 import static org.opentripplanner.utils.time.TimeUtils.timeToStrLong;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.raptor._data.transit.TestTripPattern;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
@@ -48,31 +47,27 @@ class RaptorTripScheduleTest {
     assertEquals("10:56:00", timeToStrLong(subject.departure(2, 1)));
   }
 
-  @Nested
-  class RestrictedPatternsWithDuplicateStops {
+  @Test
+  void restrictedFindArrivalStopPosition() {
+    var subject = TestTripSchedule.schedule(
+      TestTripPattern.of("flex-with-repeating-stops", 1, 1, 2, 3).restrictions("* * - *").build()
+    )
+      .arrivals(time("09:00"), time("09:10"), NOT_SET, time("09:30"))
+      .departures(time("09:01"), time("09:11"), NOT_SET, time("09:31"))
+      .build();
 
-    @Test
-    void findArrivalStopPosition() {
-      var subject = TestTripSchedule.schedule(
-        TestTripPattern.of("flex-with-repeating-stops", 1, 1, 2, 3).restrictions("* * - *").build()
-      )
-        .arrivals(time("09:00"), time("09:10"), NOT_SET, time("09:30"))
-        .departures(time("09:01"), time("09:11"), NOT_SET, time("09:31"))
-        .build();
+    assertEquals(0, subject.findArrivalStopPosition(time("09:06"), 1));
+  }
 
-      assertEquals(0, subject.findArrivalStopPosition(time("09:06"), 1));
-    }
+  @Test
+  void restrictedFindDepartureStopPosition() {
+    var subject = TestTripSchedule.schedule(
+      TestTripPattern.of("restricted-repeating-stops", 1, 1, 1, 3).restrictions("* A * *").build()
+    )
+      .arrivals(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
+      .departures(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
+      .build();
 
-    @Test
-    void findDepartureStopPosition() {
-      var subject = TestTripSchedule.schedule(
-        TestTripPattern.of("restricted-repeating-stops", 1, 1, 1, 3).restrictions("* A * *").build()
-      )
-        .arrivals(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
-        .departures(time("09:00"), time("09:10"), time("09:15"), time("09:30"))
-        .build();
-
-      assertEquals(2, subject.findDepartureStopPosition(time("09:09"), 1));
-    }
+    assertEquals(2, subject.findDepartureStopPosition(time("09:09"), 1));
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -10,6 +10,10 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 
 class RaptorTripScheduleTest {
 
+  /**
+   * Trips that mix fixed and flex schedules use -999 for those stop times that use a flexible
+   * window.
+   */
   private static final int NOT_SET = -999;
 
   private final TestTripSchedule subject = TestTripSchedule.schedule(

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.raptor.spi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor.spi.RaptorTripSchedule.NOT_SET;
+import static org.opentripplanner.utils.time.TimeUtils.time;
 import static org.opentripplanner.utils.time.TimeUtils.timeToStrLong;
 
 import org.junit.jupiter.api.Test;
@@ -42,5 +44,17 @@ public class RaptorTripScheduleTest {
     assertEquals("10:01:00", timeToStrLong(subject.departure(0, 1)));
     assertEquals("10:46:00", timeToStrLong(subject.departure(0, 8)));
     assertEquals("10:56:00", timeToStrLong(subject.departure(2, 1)));
+  }
+
+  @Test
+  public void flexPatternWithDuplicateStop() {
+    var subject = TestTripSchedule.schedule(
+      TestTripPattern.pattern("flex-with-repeating-stops", 1, 1, 2, 3)
+    )
+      .arrivals(time("09:00"), time("09:10"), NOT_SET, time("09:30"))
+      .departures(time("09:01"), time("09:11"), NOT_SET, time("09:31"))
+      .build();
+
+    assertEquals(0, subject.findArrivalStopPosition(time("09:06"), 1));
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -4,11 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.utils.time.TimeUtils.time;
 import static org.opentripplanner.utils.time.TimeUtils.timeToStrLong;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.raptor._data.transit.TestTripPattern;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 
-public class RaptorTripScheduleTest {
+class RaptorTripScheduleTest {
 
   private static final int NOT_SET = -999;
 
@@ -20,42 +21,46 @@ public class RaptorTripScheduleTest {
     .build();
 
   @Test
-  public void arrival() {
+  void arrival() {
     assertEquals("10:00:00", timeToStrLong(subject.arrival(0)));
     assertEquals("10:05:00", timeToStrLong(subject.arrival(1)));
     assertEquals("10:55:00", timeToStrLong(subject.arrival(6)));
   }
 
   @Test
-  public void departure() {
+  void departure() {
     assertEquals("10:01:00", timeToStrLong(subject.departure(0)));
     assertEquals("10:46:00", timeToStrLong(subject.departure(5)));
     assertEquals("10:56:00", timeToStrLong(subject.departure(6)));
   }
 
   @Test
-  public void findArrivalStopPosition() {
+  void findArrivalStopPosition() {
     assertEquals("10:00:00", timeToStrLong(subject.arrival(0, 1)));
     assertEquals("10:05:00", timeToStrLong(subject.arrival(1, 1)));
     assertEquals("10:55:00", timeToStrLong(subject.arrival(2, 1)));
   }
 
   @Test
-  public void findDepartureStopPosition() {
+  void findDepartureStopPosition() {
     assertEquals("10:01:00", timeToStrLong(subject.departure(0, 1)));
     assertEquals("10:46:00", timeToStrLong(subject.departure(0, 8)));
     assertEquals("10:56:00", timeToStrLong(subject.departure(2, 1)));
   }
 
-  @Test
-  public void flexPatternWithDuplicateStop() {
-    var subject = TestTripSchedule.schedule(
-      TestTripPattern.of("flex-with-repeating-stops", 1, 1, 2, 3).restrictions("* * - *").build()
-    )
-      .arrivals(time("09:00"), time("09:10"), NOT_SET, time("09:30"))
-      .departures(time("09:01"), time("09:11"), NOT_SET, time("09:31"))
-      .build();
+  @Nested
+  class FlexPatternWithDuplicateStop {
 
-    assertEquals(0, subject.findArrivalStopPosition(time("09:06"), 1));
+    @Test
+    void flexPatternWithDuplicateStop() {
+      var subject = TestTripSchedule.schedule(
+        TestTripPattern.of("flex-with-repeating-stops", 1, 1, 2, 3).restrictions("* * - *").build()
+      )
+        .arrivals(time("09:00"), time("09:10"), NOT_SET, time("09:30"))
+        .departures(time("09:01"), time("09:11"), NOT_SET, time("09:31"))
+        .build();
+
+      assertEquals(0, subject.findArrivalStopPosition(time("09:06"), 1));
+    }
   }
 }


### PR DESCRIPTION
### Summary

RAPTOR can fail to build a path when it encounters a flex pattern that uses the following "scheduled-deviated" trip pattern:

- RegularStop A, fixed time
- RegularStop A, fixed time
- AreaStop B, time window
- RegularStop C, fixed time

If the egress departure time falls within the time of the window at stop B, then it stop A's second visit (not the first) is chosen as the time to leave the vehicle. If this doesn't line up with the flex egress' opening hours path building fails as the contraints are no longer satisfied.

The problem is in this method: https://github.com/opentripplanner/OpenTripPlanner/blob/2c6314ae93aa14e7c37d7d936ad7157042af226b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java#L97-L108

In such a case stop B uses -999 as the arrival time to indicate that it doesn't have one, which is currently not taken into account.

### Issue

Closes #7306

### Unit tests

Added.

### Documentation

Javadoc.