### PR TITLE
Disallow empty GenericLocation

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.TestServerContext;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateInterval;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -123,7 +124,7 @@ public class FlexIntegrationTest {
 
   @Test
   void shouldReturnARouteWithTwoTransfers() {
-    var from = GenericLocation.fromStopId("ALEX DR@ALEX WAY", "MARTA", "97266");
+    var from = GenericLocation.fromStopId(new FeedScopedId("MARTA", "97266"), "ALEX DR@ALEX WAY");
     var to = GenericLocation.fromCoordinate(33.86701256815635, -84.61787939071655);
 
     var itin = getItinerary(from, to, 3);

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
@@ -101,11 +101,13 @@ class ScheduledDeviatedTripIntegrationTest {
     );
 
     // from zone 3 to zone 2
-    var from = GenericLocation.fromStopId("Transfer Point for Route 30", feedId, "cujv");
+    var from = GenericLocation.fromStopId(
+      new FeedScopedId(feedId, "cujv"),
+      "Transfer Point for Route 30"
+    );
     var to = GenericLocation.fromStopId(
-      "Zone 1 - PUBLIX Super Market,Zone 1 Collection Point",
-      feedId,
-      "yz85"
+      new FeedScopedId(feedId, "yz85"),
+      "Zone 1 - PUBLIX Super Market,Zone 1 Collection Point"
     );
 
     var itineraries = getItineraries(from, to, serverContext);

--- a/application/src/ext-test/java/org/opentripplanner/ext/ojp/mapping/RouteRequestMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/ojp/mapping/RouteRequestMapperTest.java
@@ -45,10 +45,10 @@ class RouteRequestMapperTest {
 
     var routeRequest = mapper.map(tripRequest);
 
-    assertEquals(47.3769, routeRequest.from().lat);
-    assertEquals(8.5417, routeRequest.from().lng);
-    assertEquals(46.9480, routeRequest.to().lat);
-    assertEquals(7.4474, routeRequest.to().lng);
+    assertEquals(47.3769, routeRequest.from().wgsCoordinate().latitude());
+    assertEquals(8.5417, routeRequest.from().wgsCoordinate().longitude());
+    assertEquals(46.9480, routeRequest.to().wgsCoordinate().latitude());
+    assertEquals(7.4474, routeRequest.to().wgsCoordinate().longitude());
     assertTransitFilters("[ALLOW_ALL]", routeRequest);
 
     assertEquals(StreetMode.WALK, routeRequest.journey().access().mode());
@@ -62,8 +62,8 @@ class RouteRequestMapperTest {
 
     var routeRequest = mapper.map(tripRequest);
 
-    assertEquals(id("stop1"), routeRequest.from().stopId);
-    assertEquals(id("stop2"), routeRequest.to().stopId);
+    assertEquals(id("stop1"), routeRequest.from().stopId());
+    assertEquals(id("stop2"), routeRequest.to().stopId());
   }
 
   @Test
@@ -75,8 +75,8 @@ class RouteRequestMapperTest {
     var routeRequest = mapper.map(tripRequest);
 
     assertNotNull(routeRequest.to());
-    assertEquals(id("stopPoint1"), routeRequest.from().stopId);
-    assertEquals(id("stopPoint2"), routeRequest.to().stopId);
+    assertEquals(id("stopPoint1"), routeRequest.from().stopId());
+    assertEquals(id("stopPoint2"), routeRequest.to().stopId());
   }
 
   @Test
@@ -87,9 +87,9 @@ class RouteRequestMapperTest {
 
     var routeRequest = mapper.map(tripRequest);
 
-    assertEquals(47.3769, routeRequest.from().lat);
-    assertEquals(8.5417, routeRequest.from().lng);
-    assertEquals(id("stop1"), routeRequest.to().stopId);
+    assertEquals(47.3769, routeRequest.from().wgsCoordinate().latitude());
+    assertEquals(8.5417, routeRequest.from().wgsCoordinate().longitude());
+    assertEquals(id("stop1"), routeRequest.to().stopId());
   }
 
   @Test

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -353,10 +353,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
       or the passenger's destination if the request is for egress
      */
     GenericLocation passengerLocation = accessOrEgress.isAccess() ? request.from() : request.to();
-    WgsCoordinate passengerCoordinates = new WgsCoordinate(
-      passengerLocation.lat,
-      passengerLocation.lng
-    );
+    WgsCoordinate passengerCoordinates = passengerLocation.wgsCoordinate();
 
     var passengerDepartureTime = request.dateTime();
 
@@ -514,12 +511,12 @@ public class DefaultCarpoolingService implements CarpoolingService {
   private void validateRequest(RouteRequest request) throws RoutingValidationException {
     Objects.requireNonNull(request.from());
     Objects.requireNonNull(request.to());
-    if (request.from().lat == null || request.from().lng == null) {
+    if (request.from().wgsCoordinate() == null) {
       throw new RoutingValidationException(
         List.of(new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.FROM_PLACE))
       );
     }
-    if (request.to().lat == null || request.to().lng == null) {
+    if (request.to().wgsCoordinate() == null) {
       throw new RoutingValidationException(
         List.of(new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.TO_PLACE))
       );

--- a/application/src/ext/java/org/opentripplanner/ext/sorlandsbanen/SorlandsbanenNorwayService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/sorlandsbanen/SorlandsbanenNorwayService.java
@@ -93,17 +93,18 @@ public class SorlandsbanenNorwayService {
     Collection<? extends RoutingAccessEgress> accessEgress,
     RaptorTransitData raptorTransitData
   ) {
-    if (location.lat != null) {
-      return new WgsCoordinate(location.lat, location.lng);
+    var coord = location.wgsCoordinate();
+    if (coord != null) {
+      return coord;
     }
 
     StopLocation firstStop = null;
     for (RoutingAccessEgress it : accessEgress) {
       StopLocation stop = raptorTransitData.getStopByIndex(it.stop());
-      if (stop.getId().equals(location.stopId)) {
+      if (stop.getId().equals(location.stopId())) {
         return stop.getCoordinate();
       }
-      if (idIsParentStation(stop, location.stopId)) {
+      if (idIsParentStation(stop, location.stopId())) {
         return stop.getParentStation().getCoordinate();
       }
       if (firstStop == null) {

--- a/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
+++ b/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.api.common;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.opentripplanner.core.model.id.FeedScopedId;
@@ -37,7 +38,7 @@ public class LocationStringParser {
    * Creates the GenericLocation by parsing a "name::place" string, where "place" is a geographic
    * coordinate string (latitude,longitude) or a feed scoped ID (feedId:stopId).
    */
-  public static GenericLocation fromOldStyleString(String input) {
+  public static Optional<GenericLocation> fromOldStyleString(String input) {
     String name = null;
     String place = input;
     if (input.contains("::")) {
@@ -53,20 +54,18 @@ public class LocationStringParser {
    * for the location that can pass through to the routing response unchanged. The place contains
    * latitude and longitude or a stop ID.
    */
-  public static GenericLocation getGenericLocation(String label, String place) {
+  public static Optional<GenericLocation> getGenericLocation(String label, String place) {
     if (place == null) {
-      return null;
+      return Optional.empty();
     }
 
     Matcher matcher = LAT_LON_PATTERN.matcher(place);
     if (matcher.find()) {
       var lat = Double.parseDouble(matcher.group(1));
       var lon = Double.parseDouble(matcher.group(4));
-      return GenericLocation.fromCoordinate(lat, lon, label);
+      return Optional.of(GenericLocation.fromCoordinate(lat, lon, label));
     } else {
-      return FeedScopedId.parseOptional(place)
-        .map(id -> GenericLocation.fromStopId(id, label))
-        .orElse(GenericLocation.fromUnspecified(label));
+      return FeedScopedId.parseOptional(place).map(id -> GenericLocation.fromStopId(id, label));
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
+++ b/application/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
@@ -62,9 +62,11 @@ public class LocationStringParser {
     if (matcher.find()) {
       var lat = Double.parseDouble(matcher.group(1));
       var lon = Double.parseDouble(matcher.group(4));
-      return new GenericLocation(label, null, lat, lon);
+      return GenericLocation.fromCoordinate(lat, lon, label);
     } else {
-      return new GenericLocation(label, FeedScopedId.parseOptional(place).orElse(null), null, null);
+      return FeedScopedId.parseOptional(place)
+        .map(id -> GenericLocation.fromStopId(id, label))
+        .orElse(GenericLocation.fromUnspecified(label));
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
@@ -45,10 +45,10 @@ public class LegacyRouteRequestMapper {
     CallerWithEnvironment callWith = new CallerWithEnvironment(environment);
 
     callWith.argument("fromPlace", (String from) ->
-      request.withFrom(LocationStringParser.fromOldStyleString(from))
+      LocationStringParser.fromOldStyleString(from).ifPresent(request::withFrom)
     );
     callWith.argument("toPlace", (String to) ->
-      request.withTo(LocationStringParser.fromOldStyleString(to))
+      LocationStringParser.fromOldStyleString(to).ifPresent(request::withTo)
     );
 
     callWith.argument("from", (Map<String, Object> v) -> request.withFrom(toGenericLocation(v)));

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
@@ -262,7 +262,7 @@ public class LegacyRouteRequestMapper {
     String address = (String) m.get("address");
 
     if (address != null) {
-      return new GenericLocation(address, null, lat, lng);
+      return GenericLocation.fromCoordinate(lat, lng, address);
     }
 
     return GenericLocation.fromCoordinate(lat, lng);

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
@@ -184,7 +184,7 @@ public class RouteRequestMapper {
       var stopId = stopLocation.getGraphQLStopLocationId();
       return FeedScopedId.parseOptional(stopId)
         .map(feedScopedId ->
-          new GenericLocation(locationInput.getGraphQLLabel(), feedScopedId, null, null)
+          GenericLocation.fromStopId(feedScopedId, locationInput.getGraphQLLabel())
         )
         .orElseThrow(() ->
           new IllegalArgumentException("Stop id %s is not of valid format.".formatted(stopId))
@@ -192,11 +192,10 @@ public class RouteRequestMapper {
     }
 
     var coordinate = locationInput.getGraphQLLocation().getGraphQLCoordinate();
-    return new GenericLocation(
-      locationInput.getGraphQLLabel(),
-      null,
+    return GenericLocation.fromCoordinate(
       coordinate.getGraphQLLatitude(),
-      coordinate.getGraphQLLongitude()
+      coordinate.getGraphQLLongitude(),
+      locationInput.getGraphQLLabel()
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/GenericLocationMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/GenericLocationMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.transmodel.mapping;
 
 import java.util.Map;
+import java.util.Optional;
 import org.opentripplanner.api.model.transit.FeedScopedIdMapper;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.GenericLocation;
@@ -13,10 +14,9 @@ class GenericLocationMapper {
     this.idMapper = idMapper;
   }
 
-  /**
-   * Maps a GraphQL Location input type to a GenericLocation
-   */
-  GenericLocation toGenericLocation(Map<String, Object> m) {
+  /// Maps a GraphQL Location input type to a GenericLocation.
+  /// Returns an empty result If the input does not contain a coordinate or an id.
+  Optional<GenericLocation> toGenericLocation(Map<String, Object> m) {
     Map<String, Object> coordinates = (Map<String, Object>) m.get("coordinates");
     Double lat = null;
     Double lon = null;
@@ -31,13 +31,13 @@ class GenericLocationMapper {
     name = name == null ? "" : name;
 
     if (stopId != null && lat != null && lon != null) {
-      return GenericLocation.fromStopIdWithFallback(stopId, lat, lon, name);
+      return Optional.of(GenericLocation.fromStopIdWithFallback(stopId, lat, lon, name));
     } else if (stopId != null) {
-      return GenericLocation.fromStopId(stopId, name);
+      return Optional.of(GenericLocation.fromStopId(stopId, name));
     } else if (lat != null && lon != null) {
-      return GenericLocation.fromCoordinate(lat, lon, name);
+      return Optional.of(GenericLocation.fromCoordinate(lat, lon, name));
     } else {
-      return GenericLocation.fromUnspecified(name);
+      return Optional.empty();
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/GenericLocationMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/GenericLocationMapper.java
@@ -30,6 +30,14 @@ class GenericLocationMapper {
     String name = (String) m.get("name");
     name = name == null ? "" : name;
 
-    return new GenericLocation(name, stopId, lat, lon);
+    if (stopId != null && lat != null && lon != null) {
+      return GenericLocation.fromStopIdWithFallback(stopId, lat, lon, name);
+    } else if (stopId != null) {
+      return GenericLocation.fromStopId(stopId, name);
+    } else if (lat != null && lon != null) {
+      return GenericLocation.fromCoordinate(lat, lon, name);
+    } else {
+      return GenericLocation.fromUnspecified(name);
+    }
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapper.java
@@ -48,10 +48,10 @@ public class TripRequestMapper {
     DataFetcherDecorator callWith = new DataFetcherDecorator(environment);
 
     callWith.argument("from", (Map<String, Object> v) ->
-      requestBuilder.withFrom(genericLocationMapper.toGenericLocation(v))
+      genericLocationMapper.toGenericLocation(v).ifPresent(requestBuilder::withFrom)
     );
     callWith.argument("to", (Map<String, Object> v) ->
-      requestBuilder.withTo(genericLocationMapper.toGenericLocation(v))
+      genericLocationMapper.toGenericLocation(v).ifPresent(requestBuilder::withTo)
     );
     callWith.argument("passThroughPoints", (List<Map<String, Object>> v) -> {
       requestBuilder.withViaLocations(tripViaLocationMapper.toLegacyPassThroughLocations(v));

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaLocationDeprecatedMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaLocationDeprecatedMapper.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.opentripplanner.api.model.transit.FeedScopedIdMapper;
+import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.routing.api.request.ViaLocationDeprecated;
 import org.opentripplanner.routing.api.response.RoutingError;
 import org.opentripplanner.routing.api.response.RoutingErrorCode;
@@ -23,7 +24,9 @@ class ViaLocationDeprecatedMapper {
   ViaLocationDeprecated mapViaLocation(Map<String, Object> viaLocation) {
     try {
       return new ViaLocationDeprecated(
-        genericLocationMapper.toGenericLocation(viaLocation),
+        genericLocationMapper
+          .toGenericLocation(viaLocation)
+          .orElseThrow(() -> new InvalidInputException("Invalid via location")),
         false,
         (Duration) viaLocation.get("minSlack"),
         (Duration) viaLocation.get("maxSlack")

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaRequestMapper.java
@@ -62,15 +62,9 @@ public class ViaRequestMapper {
       )
       .withSearchWindow(environment.getArgumentOrDefault("searchWindow", request.searchWindow()))
       .withFrom(
-        genericLocationMapper
-          .toGenericLocation(environment.getArgument("from"))
-          .orElse(null)
+        genericLocationMapper.toGenericLocation(environment.getArgument("from")).orElse(null)
       )
-      .withTo(
-        genericLocationMapper
-          .toGenericLocation(environment.getArgument("to"))
-          .orElse(null)
-      )
+      .withTo(genericLocationMapper.toGenericLocation(environment.getArgument("to")).orElse(null))
       .withNumItineraries(
         environment.getArgumentOrDefault("numTripPatterns", request.numItineraries())
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/ViaRequestMapper.java
@@ -61,8 +61,16 @@ public class ViaRequestMapper {
         )
       )
       .withSearchWindow(environment.getArgumentOrDefault("searchWindow", request.searchWindow()))
-      .withFrom(genericLocationMapper.toGenericLocation(environment.getArgument("from")))
-      .withTo(genericLocationMapper.toGenericLocation(environment.getArgument("to")))
+      .withFrom(
+        genericLocationMapper
+          .toGenericLocation(environment.getArgument("from"))
+          .orElse(null)
+      )
+      .withTo(
+        genericLocationMapper
+          .toGenericLocation(environment.getArgument("to"))
+          .orElse(null)
+      )
       .withNumItineraries(
         environment.getArgumentOrDefault("numTripPatterns", request.numItineraries())
       )

--- a/application/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/application/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.utils.lang.StringUtils;
 import org.opentripplanner.utils.tostring.ValueObjectToStringBuilder;
 
@@ -16,31 +17,23 @@ public class GenericLocation {
 
   public static final GenericLocation UNKNOWN = new GenericLocation(null, null, null, null);
 
-  /**
-   * A label for the place, if provided. This is pass-through information and does not affect
-   * routing in any way.
-   */
   @Nullable
-  public final String label;
+  private final String label;
 
-  /**
-   * Refers to a specific element in the OTP model. This can currently be a regular stop, area stop,
-   * group stop, station, multi-modal station or group of stations.
-   */
   @Nullable
-  public final FeedScopedId stopId;
+  private final FeedScopedId stopId;
 
   /**
    * Coordinates of the location. These can be used by themselves or as a fallback if placeId is not
    * found.
    */
   @Nullable
-  public final Double lat;
+  private final Double lat;
 
   @Nullable
-  public final Double lng;
+  private final Double lng;
 
-  public GenericLocation(
+  private GenericLocation(
     @Nullable String label,
     @Nullable FeedScopedId stopId,
     @Nullable Double lat,
@@ -56,8 +49,22 @@ public class GenericLocation {
     return new GenericLocation(null, id, null, null);
   }
 
+  public static GenericLocation fromStopId(FeedScopedId id, @Nullable String label) {
+    return new GenericLocation(label, id, null, null);
+  }
+
   public static GenericLocation fromStopId(String name, String feedId, String stopId) {
     return new GenericLocation(name, new FeedScopedId(feedId, stopId), null, null);
+  }
+
+  /// Create a GenericLocation of a stop id with fallback coordinates if the id is not found.
+  public static GenericLocation fromStopIdWithFallback(
+    FeedScopedId id,
+    double lat,
+    double lng,
+    @Nullable String label
+  ) {
+    return new GenericLocation(label, id, lat, lng);
   }
 
   /**
@@ -66,6 +73,14 @@ public class GenericLocation {
    */
   public static GenericLocation fromCoordinate(double lat, double lng) {
     return new GenericLocation(null, null, lat, lng);
+  }
+
+  public static GenericLocation fromCoordinate(double lat, double lng, @Nullable String label) {
+    return new GenericLocation(label, null, lat, lng);
+  }
+
+  public static GenericLocation fromUnspecified(@Nullable String label) {
+    return new GenericLocation(label, null, null, null);
   }
 
   /**
@@ -77,6 +92,32 @@ public class GenericLocation {
       return null;
     }
     return new Coordinate(this.lng, this.lat);
+  }
+
+  @Nullable
+  public WgsCoordinate wgsCoordinate() {
+    if (lat == null || lng == null) {
+      return null;
+    }
+    return new WgsCoordinate(lat, lng);
+  }
+
+  /**
+   * Refers to a specific element in the OTP model. This can currently be a regular stop, area stop,
+   * group stop, station, multi-modal station or group of stations.
+   */
+  @Nullable
+  public FeedScopedId stopId() {
+    return stopId;
+  }
+
+  /**
+   * A label for the place, if provided. This is pass-through information and does not affect
+   * routing in any way.
+   */
+  @Nullable
+  public String label() {
+    return label;
   }
 
   public boolean isSpecified() {

--- a/application/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/application/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -110,10 +110,6 @@ public class GenericLocation {
     return label;
   }
 
-  public boolean isSpecified() {
-    return stopId != null || coordinate != null;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) {

--- a/application/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/application/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -53,10 +53,6 @@ public class GenericLocation {
     return new GenericLocation(label, id, null);
   }
 
-  public static GenericLocation fromStopId(String name, String feedId, String stopId) {
-    return new GenericLocation(name, new FeedScopedId(feedId, stopId), null);
-  }
-
   /// Create a GenericLocation of a stop id with fallback coordinates if the id is not found.
   public static GenericLocation fromStopIdWithFallback(
     FeedScopedId id,

--- a/application/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/application/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -22,7 +22,7 @@ public class GenericLocation {
   private final FeedScopedId stopId;
 
   @Nullable
-  WgsCoordinate coordinate;
+  private final WgsCoordinate coordinate;
 
   private GenericLocation(
     @Nullable String label,

--- a/application/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/application/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -15,8 +15,6 @@ import org.opentripplanner.utils.tostring.ValueObjectToStringBuilder;
  */
 public class GenericLocation {
 
-  public static final GenericLocation UNKNOWN = new GenericLocation(null, null, null);
-
   @Nullable
   private final String label;
 
@@ -35,16 +33,23 @@ public class GenericLocation {
     @Nullable FeedScopedId stopId,
     @Nullable WgsCoordinate coordinate
   ) {
+    if (stopId == null && coordinate == null) {
+      throw new IllegalArgumentException(
+        "GenericLocation requires either a stop id or a coordinate"
+      );
+    }
     this.label = label;
     this.stopId = stopId;
     this.coordinate = coordinate;
   }
 
   public static GenericLocation fromStopId(FeedScopedId id) {
+    Objects.requireNonNull(id);
     return new GenericLocation(null, id, null);
   }
 
   public static GenericLocation fromStopId(FeedScopedId id, @Nullable String label) {
+    Objects.requireNonNull(id);
     return new GenericLocation(label, id, null);
   }
 
@@ -59,6 +64,7 @@ public class GenericLocation {
     double lng,
     @Nullable String label
   ) {
+    Objects.requireNonNull(id);
     return new GenericLocation(label, id, new WgsCoordinate(lat, lng));
   }
 
@@ -72,10 +78,6 @@ public class GenericLocation {
 
   public static GenericLocation fromCoordinate(double lat, double lng, @Nullable String label) {
     return new GenericLocation(label, null, new WgsCoordinate(lat, lng));
-  }
-
-  public static GenericLocation fromUnspecified(@Nullable String label) {
-    return new GenericLocation(label, null, null);
   }
 
   /**
@@ -136,10 +138,6 @@ public class GenericLocation {
 
   @Override
   public String toString() {
-    if (UNKNOWN.equals(this)) {
-      return "Unknown location";
-    }
-
     ValueObjectToStringBuilder buf = ValueObjectToStringBuilder.of().skipNull();
     if (StringUtils.hasValue(label)) {
       buf.addText(label).addText(" ");

--- a/application/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/application/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -21,10 +21,6 @@ public class GenericLocation {
   @Nullable
   private final FeedScopedId stopId;
 
-  /**
-   * Coordinates of the location. These can be used by themselves or as a fallback if placeId is not
-   * found.
-   */
   @Nullable
   WgsCoordinate coordinate;
 
@@ -77,7 +73,8 @@ public class GenericLocation {
   }
 
   /**
-   * Returns this as a Coordinate object.
+   * Coordinates of the location. These can be used by themselves or as a fallback if placeId is not
+   * found.
    */
   @Nullable
   public Coordinate getCoordinate() {
@@ -87,6 +84,10 @@ public class GenericLocation {
     return coordinate.asJtsCoordinate();
   }
 
+  /**
+   * Coordinates of the location. These can be used by themselves or as a fallback if placeId is not
+   * found.
+   */
   @Nullable
   public WgsCoordinate wgsCoordinate() {
     return coordinate;

--- a/application/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/application/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -15,7 +15,7 @@ import org.opentripplanner.utils.tostring.ValueObjectToStringBuilder;
  */
 public class GenericLocation {
 
-  public static final GenericLocation UNKNOWN = new GenericLocation(null, null, null, null);
+  public static final GenericLocation UNKNOWN = new GenericLocation(null, null, null);
 
   @Nullable
   private final String label;
@@ -28,33 +28,28 @@ public class GenericLocation {
    * found.
    */
   @Nullable
-  private final Double lat;
-
-  @Nullable
-  private final Double lng;
+  WgsCoordinate coordinate;
 
   private GenericLocation(
     @Nullable String label,
     @Nullable FeedScopedId stopId,
-    @Nullable Double lat,
-    @Nullable Double lng
+    @Nullable WgsCoordinate coordinate
   ) {
     this.label = label;
     this.stopId = stopId;
-    this.lat = lat;
-    this.lng = lng;
+    this.coordinate = coordinate;
   }
 
   public static GenericLocation fromStopId(FeedScopedId id) {
-    return new GenericLocation(null, id, null, null);
+    return new GenericLocation(null, id, null);
   }
 
   public static GenericLocation fromStopId(FeedScopedId id, @Nullable String label) {
-    return new GenericLocation(label, id, null, null);
+    return new GenericLocation(label, id, null);
   }
 
   public static GenericLocation fromStopId(String name, String feedId, String stopId) {
-    return new GenericLocation(name, new FeedScopedId(feedId, stopId), null, null);
+    return new GenericLocation(name, new FeedScopedId(feedId, stopId), null);
   }
 
   /// Create a GenericLocation of a stop id with fallback coordinates if the id is not found.
@@ -64,7 +59,7 @@ public class GenericLocation {
     double lng,
     @Nullable String label
   ) {
-    return new GenericLocation(label, id, lat, lng);
+    return new GenericLocation(label, id, new WgsCoordinate(lat, lng));
   }
 
   /**
@@ -72,15 +67,15 @@ public class GenericLocation {
    * inserting {@code null} values.
    */
   public static GenericLocation fromCoordinate(double lat, double lng) {
-    return new GenericLocation(null, null, lat, lng);
+    return new GenericLocation(null, null, new WgsCoordinate(lat, lng));
   }
 
   public static GenericLocation fromCoordinate(double lat, double lng, @Nullable String label) {
-    return new GenericLocation(label, null, lat, lng);
+    return new GenericLocation(label, null, new WgsCoordinate(lat, lng));
   }
 
   public static GenericLocation fromUnspecified(@Nullable String label) {
-    return new GenericLocation(label, null, null, null);
+    return new GenericLocation(label, null, null);
   }
 
   /**
@@ -88,18 +83,15 @@ public class GenericLocation {
    */
   @Nullable
   public Coordinate getCoordinate() {
-    if (this.lat == null || this.lng == null) {
+    if (this.coordinate == null) {
       return null;
     }
-    return new Coordinate(this.lng, this.lat);
+    return coordinate.asJtsCoordinate();
   }
 
   @Nullable
   public WgsCoordinate wgsCoordinate() {
-    if (lat == null || lng == null) {
-      return null;
-    }
-    return new WgsCoordinate(lat, lng);
+    return coordinate;
   }
 
   /**
@@ -121,7 +113,7 @@ public class GenericLocation {
   }
 
   public boolean isSpecified() {
-    return stopId != null || (lat != null && lng != null);
+    return stopId != null || coordinate != null;
   }
 
   @Override
@@ -133,14 +125,13 @@ public class GenericLocation {
     return (
       Objects.equals(label, that.label) &&
       Objects.equals(stopId, that.stopId) &&
-      Objects.equals(lat, that.lat) &&
-      Objects.equals(lng, that.lng)
+      Objects.equals(coordinate, that.coordinate)
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(label, stopId, lat, lng);
+    return Objects.hash(label, stopId, coordinate);
   }
 
   @Override
@@ -154,7 +145,9 @@ public class GenericLocation {
       buf.addText(label).addText(" ");
     }
     buf.addObj(stopId);
-    buf.addCoordinate(lat, lng);
+    if (coordinate != null) {
+      buf.addCoordinate(coordinate.latitude(), coordinate.longitude());
+    }
     return buf.toString();
   }
 }

--- a/application/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -82,6 +82,10 @@ public class Place {
     this.viaLocationType = viaLocationType;
   }
 
+  public static Place noCoords(I18NString name) {
+    return new Place(name, null, VertexType.NORMAL, null, null, null, null);
+  }
+
   public static Place normal(Double lat, Double lon, I18NString name) {
     return new Place(
       name,
@@ -92,6 +96,10 @@ public class Place {
       null,
       null
     );
+  }
+
+  public static Place normal(WgsCoordinate coord, I18NString name) {
+    return new Place(name, coord, VertexType.NORMAL, null, null, null, null);
   }
 
   public static Place normal(
@@ -174,14 +182,13 @@ public class Place {
     I18NString defaultName
   ) {
     if (location == null) {
-      return Place.normal(null, null, defaultName);
+      return Place.noCoords(defaultName);
     }
-
-    return Place.normal(
-      location.lat,
-      location.lng,
-      NonLocalizedString.ofNullableOrElse(location.label, defaultName)
-    );
+    var coord = location.wgsCoordinate();
+    if (coord == null) {
+      return Place.noCoords(NonLocalizedString.ofNullableOrElse(location.label(), defaultName));
+    }
+    return Place.normal(coord, NonLocalizedString.ofNullableOrElse(location.label(), defaultName));
   }
 
   public static Place forVehicleRentalPlace(VehicleRentalPlaceVertex vertex) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -474,7 +474,7 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
   }
 
   private Place mapPlace(GenericLocation location) {
-    return Place.normal(location.lat, location.lng, new NonLocalizedString(location.label));
+    return Place.normal(location.wgsCoordinate(), new NonLocalizedString(location.label()));
   }
 
   private ZonedDateTime createZonedDateTime(int timeInSeconds) {

--- a/application/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -234,13 +234,13 @@ public class RouteRequest implements Serializable {
   public void validateOriginAndDestination() {
     List<RoutingError> routingErrors = new ArrayList<>(2);
 
-    if (from == null || !from.isSpecified()) {
+    if (from == null) {
       routingErrors.add(
         new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.FROM_PLACE)
       );
     }
 
-    if (to == null || !to.isSpecified()) {
+    if (to == null) {
       routingErrors.add(new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.TO_PLACE));
     }
 
@@ -521,13 +521,13 @@ public class RouteRequest implements Serializable {
 
     List<RoutingError> routingErrors = new ArrayList<>(2);
 
-    if (from == null || !from.isSpecified()) {
+    if (from == null) {
       routingErrors.add(
         new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.FROM_PLACE)
       );
     }
 
-    if (to == null || !to.isSpecified()) {
+    if (to == null) {
       routingErrors.add(new RoutingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.TO_PLACE));
     }
     return routingErrors;

--- a/application/src/main/java/org/opentripplanner/routing/api/request/ViaLocationDeprecated.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/ViaLocationDeprecated.java
@@ -29,8 +29,5 @@ public record ViaLocationDeprecated(
     Objects.requireNonNull(minSlack);
     Objects.requireNonNull(maxSlack);
     Objects.requireNonNull(point);
-    if (!point.isSpecified()) {
-      throw new IllegalArgumentException("The Via location is not specified");
-    }
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/api/request/via/VisitViaLocation.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/via/VisitViaLocation.java
@@ -58,7 +58,7 @@ public class VisitViaLocation extends AbstractViaLocation {
     if (coordinate == null) {
       return null;
     }
-    return new GenericLocation(label(), null, coordinate.latitude(), coordinate.longitude());
+    return GenericLocation.fromCoordinate(coordinate.latitude(), coordinate.longitude(), label());
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/routing/linking/LinkingContextFactory.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/LinkingContextFactory.java
@@ -126,7 +126,7 @@ public class LinkingContextFactory {
     LinkingContextRequest request
   ) {
     var from = request.from();
-    if (from == null || !from.isSpecified()) {
+    if (from == null) {
       return Set.of();
     }
     var modes = request.accessMode() != StreetMode.NOT_SET
@@ -143,7 +143,7 @@ public class LinkingContextFactory {
     LinkingContextRequest request
   ) {
     var to = request.to();
-    if (to == null || !to.isSpecified()) {
+    if (to == null) {
       return Set.of();
     }
     var modes = request.egressMode() != StreetMode.NOT_SET
@@ -269,10 +269,6 @@ public class LinkingContextFactory {
     EnumSet<StreetMode> streetModes,
     LocationType type
   ) {
-    if (!location.isSpecified()) {
-      return Set.of();
-    }
-
     // Differentiate between driving and non-driving, as driving is not available from transit stops
     List<TraverseMode> modes = streetModes
       .stream()
@@ -388,12 +384,7 @@ public class LinkingContextFactory {
     }
 
     // check that vertices where found if to-location was specified
-    if (
-      to != null &&
-      to.isSpecified() &&
-      toStopVertices.isEmpty() &&
-      isDisconnected(toVertices, LocationType.TO)
-    ) {
+    if (to != null && toStopVertices.isEmpty() && isDisconnected(toVertices, LocationType.TO)) {
       routingErrors.add(
         new RoutingError(getRoutingErrorCodeForDisconnected(to), InputField.TO_PLACE)
       );

--- a/application/src/main/java/org/opentripplanner/routing/linking/LinkingContextFactory.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/LinkingContextFactory.java
@@ -193,8 +193,8 @@ public class LinkingContextFactory {
   }
 
   private Set<TransitStopVertex> getStopVertices(GenericLocation location) {
-    if (location != null && location.stopId != null) {
-      return findStopOrChildStopVertices(location.stopId);
+    if (location != null && location.stopId() != null) {
+      return findStopOrChildStopVertices(location.stopId());
     }
     return Set.of();
   }
@@ -281,7 +281,7 @@ public class LinkingContextFactory {
       .toList();
 
     var results = new HashSet<Vertex>();
-    if (location.stopId != null) {
+    if (location.stopId() != null) {
       if (!modes.stream().allMatch(TraverseMode::isInCar)) {
         results.addAll(getStreetVerticesForStop(location));
       }
@@ -299,7 +299,7 @@ public class LinkingContextFactory {
         vertexCreationService.createVertexFromCoordinate(
           container,
           location.getCoordinate(),
-          location.label,
+          location.label(),
           modes,
           type
         )
@@ -311,19 +311,19 @@ public class LinkingContextFactory {
 
   private Set<Vertex> getStreetVerticesForStop(GenericLocation location) {
     // check if there is a stop by the given id
-    var stopVertex = graph.findStopVertex(location.stopId);
+    var stopVertex = graph.findStopVertex(location.stopId());
     if (stopVertex.isPresent()) {
       return Set.of(stopVertex.get());
     }
 
     // station centroids may be used instead of child stop vertices for stations
-    var centroidVertex = graph.findStationCentroidVertex(location.stopId);
+    var centroidVertex = graph.findStationCentroidVertex(location.stopId());
     if (centroidVertex.isPresent()) {
       return Set.of(centroidVertex.get());
     }
 
     // in the regular case you want to resolve a (multi-modal) station into its child stops
-    var childVertices = findStopOrChildStopVertices(location.stopId);
+    var childVertices = findStopOrChildStopVertices(location.stopId());
     if (!childVertices.isEmpty()) {
       return childVertices.stream().map(Vertex.class::cast).collect(Collectors.toUnmodifiableSet());
     }
@@ -339,43 +339,33 @@ public class LinkingContextFactory {
     GenericLocation location,
     LocationType type
   ) {
+    Coordinate coordinate = location.getCoordinate();
     // Fetch coordinate from stop, if not given in request
-    if (location.getCoordinate() == null) {
-      var stopVertex = graph.getStopVertex(location.stopId);
+    if (coordinate == null) {
+      var stopVertex = graph.getStopVertex(location.stopId());
       if (stopVertex != null) {
-        var c = stopVertex.toWgsCoordinate();
-        location = new GenericLocation(
-          location.label,
-          location.stopId,
-          c.latitude(),
-          c.longitude()
-        );
+        coordinate = stopVertex.getCoordinate();
       } else {
         // For car routing, we use station's coordinate instead of child stops' if stop location is
         // a station.
-        var coordinate = findStopLocationsGroupCentroid.apply(location.stopId);
-        if (coordinate.isPresent()) {
-          var c = coordinate.get();
-          location = new GenericLocation(
-            location.label,
-            location.stopId,
-            c.latitude(),
-            c.longitude()
-          );
-        }
+        coordinate = findStopLocationsGroupCentroid
+          .apply(location.stopId())
+          .map(WgsCoordinate::asJtsCoordinate)
+          .orElse(null);
       }
     }
-    return location.getCoordinate() != null
-      ? Optional.of(
-          vertexCreationService.createVertexFromCoordinate(
-            container,
-            location.getCoordinate(),
-            location.label,
-            List.of(TraverseMode.CAR),
-            type
-          )
-        )
-      : Optional.empty();
+    if (coordinate == null) {
+      return Optional.empty();
+    }
+    return Optional.of(
+      vertexCreationService.createVertexFromCoordinate(
+        container,
+        coordinate,
+        location.label(),
+        List.of(TraverseMode.CAR),
+        type
+      )
+    );
   }
 
   private void checkIfVerticesFound(

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -21,13 +21,13 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.opentripplanner.api.common.LocationStringParser;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateInterval;
 import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareService;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundle;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundleTestFactory;
 import org.opentripplanner.gtfs.graphbuilder.GtfsModule;
+import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RealTimeRaptorTransitDataUpdater;
@@ -97,10 +97,10 @@ public abstract class GtfsTest {
       .withDateTime(Instant.ofEpochSecond(Math.abs(dateTime)));
 
     if (fromVertex != null && !fromVertex.isEmpty()) {
-      builder.withFrom(LocationStringParser.getGenericLocation(null, FEED_ID + ":" + fromVertex));
+      builder.withFrom(GenericLocation.fromStopId(FeedScopedId.of(FEED_ID, fromVertex)));
     }
     if (toVertex != null && !toVertex.isEmpty()) {
-      builder.withTo(LocationStringParser.getGenericLocation(null, FEED_ID + ":" + toVertex));
+      builder.withTo(GenericLocation.fromStopId(FeedScopedId.of(FEED_ID, toVertex)));
     }
     if (onTripId != null && !onTripId.isEmpty()) {
       // TODO VIA - set different on-board request

--- a/application/src/test/java/org/opentripplanner/api/common/LocationStringParserTest.java
+++ b/application/src/test/java/org/opentripplanner/api/common/LocationStringParserTest.java
@@ -26,15 +26,15 @@ public class LocationStringParserTest {
     assertNull(loc.stopId());
     assertEquals(new Coordinate(2.5, 1.0), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("Label Label::-15.0,  200");
+    loc = LocationStringParser.fromOldStyleString("Label Label::-15.0,  170");
     assertEquals("Label Label", loc.label());
     assertNull(loc.stopId());
-    assertEquals(new Coordinate(200, -15), loc.getCoordinate());
+    assertEquals(new Coordinate(170, -15), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("A Label::122,-22.3");
+    loc = LocationStringParser.fromOldStyleString("A Label::89,-22.3");
     assertEquals("A Label", loc.label());
     assertNull(loc.stopId());
-    assertEquals(new Coordinate(-22.3, 122), loc.getCoordinate());
+    assertEquals(new Coordinate(-22.3, 89), loc.getCoordinate());
   }
 
   @Test
@@ -57,15 +57,15 @@ public class LocationStringParserTest {
     assertNull(loc.stopId());
     assertEquals(new Coordinate(2.5, 1.0), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("    -15.0,  200");
+    loc = LocationStringParser.fromOldStyleString("    -15.0,  170");
     assertNull(loc.label());
     assertNull(loc.stopId());
-    assertEquals(new Coordinate(200, -15), loc.getCoordinate());
+    assertEquals(new Coordinate(170, -15), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("122,-22.3   ");
+    loc = LocationStringParser.fromOldStyleString("89,-22.3   ");
     assertNull(loc.label());
     assertNull(loc.stopId());
-    assertEquals(new Coordinate(-22.3, 122), loc.getCoordinate());
+    assertEquals(new Coordinate(-22.3, 89), loc.getCoordinate());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/api/common/LocationStringParserTest.java
+++ b/application/src/test/java/org/opentripplanner/api/common/LocationStringParserTest.java
@@ -13,75 +13,58 @@ public class LocationStringParserTest {
   @Test
   public void testFromOldStyleString() {
     GenericLocation loc = LocationStringParser.fromOldStyleString("name::12345");
-    assertEquals("name", loc.label);
-    assertNull(loc.stopId);
-    assertNull(loc.lat);
-    assertNull(loc.lng);
+    assertEquals("name", loc.label());
+    assertNull(loc.stopId());
+    assertNull(loc.wgsCoordinate());
     assertNull(loc.getCoordinate());
   }
 
   @Test
   public void testWithLabelAndCoord() {
     GenericLocation loc = LocationStringParser.fromOldStyleString("name::1.0,2.5");
-    assertEquals("name", loc.label);
-    assertNull(loc.stopId);
-    assertEquals(Double.valueOf(1.0), loc.lat);
-    assertEquals(Double.valueOf(2.5), loc.lng);
+    assertEquals("name", loc.label());
+    assertNull(loc.stopId());
     assertEquals(new Coordinate(2.5, 1.0), loc.getCoordinate());
 
     loc = LocationStringParser.fromOldStyleString("Label Label::-15.0,  200");
-    assertEquals("Label Label", loc.label);
-    assertNull(loc.stopId);
-    assertEquals(Double.valueOf(-15.0), loc.lat);
-    assertEquals(Double.valueOf(200), loc.lng);
+    assertEquals("Label Label", loc.label());
+    assertNull(loc.stopId());
     assertEquals(new Coordinate(200, -15), loc.getCoordinate());
 
     loc = LocationStringParser.fromOldStyleString("A Label::122,-22.3");
-    assertEquals("A Label", loc.label);
-    assertNull(loc.stopId);
-    assertEquals(Double.valueOf(122), loc.lat);
-    assertEquals(Double.valueOf(-22.3), loc.lng);
+    assertEquals("A Label", loc.label());
+    assertNull(loc.stopId());
     assertEquals(new Coordinate(-22.3, 122), loc.getCoordinate());
   }
 
   @Test
   public void testWithId() {
     GenericLocation loc = LocationStringParser.fromOldStyleString("name::aFeed:A1B2C3");
-    assertEquals("name", loc.label);
-    assertEquals(loc.stopId, new FeedScopedId("aFeed", "A1B2C3"));
-    assertNull(loc.lat);
-    assertNull(loc.lng);
+    assertEquals("name", loc.label());
+    assertEquals(loc.stopId(), new FeedScopedId("aFeed", "A1B2C3"));
     assertNull(loc.getCoordinate());
 
     loc = LocationStringParser.fromOldStyleString("feed:4321");
-    assertNull(loc.label);
-    assertEquals(loc.stopId, new FeedScopedId("feed", "4321"));
-    assertNull(loc.lat);
-    assertNull(loc.lng);
+    assertNull(loc.label());
+    assertEquals(loc.stopId(), new FeedScopedId("feed", "4321"));
     assertNull(loc.getCoordinate());
   }
 
   @Test
   public void testWithCoordOnly() {
     GenericLocation loc = LocationStringParser.fromOldStyleString("1.0,2.5");
-    assertNull(loc.label);
-    assertNull(loc.stopId);
-    assertEquals(Double.valueOf(1.0), loc.lat);
-    assertEquals(Double.valueOf(2.5), loc.lng);
+    assertNull(loc.label());
+    assertNull(loc.stopId());
     assertEquals(new Coordinate(2.5, 1.0), loc.getCoordinate());
 
     loc = LocationStringParser.fromOldStyleString("    -15.0,  200");
-    assertNull(loc.label);
-    assertNull(loc.stopId);
-    assertEquals(Double.valueOf(-15.0), loc.lat);
-    assertEquals(Double.valueOf(200), loc.lng);
+    assertNull(loc.label());
+    assertNull(loc.stopId());
     assertEquals(new Coordinate(200, -15), loc.getCoordinate());
 
     loc = LocationStringParser.fromOldStyleString("122,-22.3   ");
-    assertNull(loc.label);
-    assertNull(loc.stopId);
-    assertEquals(Double.valueOf(122), loc.lat);
-    assertEquals(Double.valueOf(-22.3), loc.lng);
+    assertNull(loc.label());
+    assertNull(loc.stopId());
     assertEquals(new Coordinate(-22.3, 122), loc.getCoordinate());
   }
 
@@ -89,17 +72,17 @@ public class LocationStringParserTest {
   public void testFromOldStyleStringIncomplete() {
     String input = "0::";
     GenericLocation loc = LocationStringParser.fromOldStyleString(input);
-    assertEquals("0", loc.label);
-    assertNull(loc.stopId);
+    assertEquals("0", loc.label());
+    assertNull(loc.stopId());
 
     input = "::1";
     loc = LocationStringParser.fromOldStyleString(input);
-    assertEquals("", loc.label);
-    assertNull(loc.stopId);
+    assertEquals("", loc.label());
+    assertNull(loc.stopId());
 
     input = "::";
     loc = LocationStringParser.fromOldStyleString(input);
-    assertEquals("", loc.label);
-    assertNull(loc.stopId);
+    assertEquals("", loc.label());
+    assertNull(loc.stopId());
   }
 }

--- a/application/src/test/java/org/opentripplanner/api/common/LocationStringParserTest.java
+++ b/application/src/test/java/org/opentripplanner/api/common/LocationStringParserTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.api.common;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.core.model.id.FeedScopedId;
@@ -12,26 +13,23 @@ public class LocationStringParserTest {
 
   @Test
   public void testFromOldStyleString() {
-    GenericLocation loc = LocationStringParser.fromOldStyleString("name::12345");
-    assertEquals("name", loc.label());
-    assertNull(loc.stopId());
-    assertNull(loc.wgsCoordinate());
-    assertNull(loc.getCoordinate());
+    var loc = LocationStringParser.fromOldStyleString("name::12345");
+    assertEquals(Optional.empty(), loc);
   }
 
   @Test
   public void testWithLabelAndCoord() {
-    GenericLocation loc = LocationStringParser.fromOldStyleString("name::1.0,2.5");
+    GenericLocation loc = LocationStringParser.fromOldStyleString("name::1.0,2.5").get();
     assertEquals("name", loc.label());
     assertNull(loc.stopId());
     assertEquals(new Coordinate(2.5, 1.0), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("Label Label::-15.0,  170");
+    loc = LocationStringParser.fromOldStyleString("Label Label::-15.0,  170").get();
     assertEquals("Label Label", loc.label());
     assertNull(loc.stopId());
     assertEquals(new Coordinate(170, -15), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("A Label::89,-22.3");
+    loc = LocationStringParser.fromOldStyleString("A Label::89,-22.3").get();
     assertEquals("A Label", loc.label());
     assertNull(loc.stopId());
     assertEquals(new Coordinate(-22.3, 89), loc.getCoordinate());
@@ -39,12 +37,12 @@ public class LocationStringParserTest {
 
   @Test
   public void testWithId() {
-    GenericLocation loc = LocationStringParser.fromOldStyleString("name::aFeed:A1B2C3");
+    GenericLocation loc = LocationStringParser.fromOldStyleString("name::aFeed:A1B2C3").get();
     assertEquals("name", loc.label());
     assertEquals(loc.stopId(), new FeedScopedId("aFeed", "A1B2C3"));
     assertNull(loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("feed:4321");
+    loc = LocationStringParser.fromOldStyleString("feed:4321").get();
     assertNull(loc.label());
     assertEquals(loc.stopId(), new FeedScopedId("feed", "4321"));
     assertNull(loc.getCoordinate());
@@ -52,17 +50,17 @@ public class LocationStringParserTest {
 
   @Test
   public void testWithCoordOnly() {
-    GenericLocation loc = LocationStringParser.fromOldStyleString("1.0,2.5");
+    GenericLocation loc = LocationStringParser.fromOldStyleString("1.0,2.5").get();
     assertNull(loc.label());
     assertNull(loc.stopId());
     assertEquals(new Coordinate(2.5, 1.0), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("    -15.0,  170");
+    loc = LocationStringParser.fromOldStyleString("    -15.0,  170").get();
     assertNull(loc.label());
     assertNull(loc.stopId());
     assertEquals(new Coordinate(170, -15), loc.getCoordinate());
 
-    loc = LocationStringParser.fromOldStyleString("89,-22.3   ");
+    loc = LocationStringParser.fromOldStyleString("89,-22.3   ").get();
     assertNull(loc.label());
     assertNull(loc.stopId());
     assertEquals(new Coordinate(-22.3, 89), loc.getCoordinate());
@@ -70,19 +68,8 @@ public class LocationStringParserTest {
 
   @Test
   public void testFromOldStyleStringIncomplete() {
-    String input = "0::";
-    GenericLocation loc = LocationStringParser.fromOldStyleString(input);
-    assertEquals("0", loc.label());
-    assertNull(loc.stopId());
-
-    input = "::1";
-    loc = LocationStringParser.fromOldStyleString(input);
-    assertEquals("", loc.label());
-    assertNull(loc.stopId());
-
-    input = "::";
-    loc = LocationStringParser.fromOldStyleString(input);
-    assertEquals("", loc.label());
-    assertNull(loc.stopId());
+    assertEquals(Optional.empty(), LocationStringParser.fromOldStyleString("0::"));
+    assertEquals(Optional.empty(), LocationStringParser.fromOldStyleString("::1"));
+    assertEquals(Optional.empty(), LocationStringParser.fromOldStyleString("::"));
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -32,10 +32,8 @@ class RouteRequestMapperTest {
     var defaultRequest = RouteRequest.defaultValue();
     var routeRequest = RouteRequestMapper.toRouteRequest(env, testCtx.context());
 
-    assertEquals(_RouteRequestTestContext.ORIGIN.x, routeRequest.from().lat);
-    assertEquals(_RouteRequestTestContext.ORIGIN.y, routeRequest.from().lng);
-    assertEquals(_RouteRequestTestContext.DESTINATION.x, routeRequest.to().lat);
-    assertEquals(_RouteRequestTestContext.DESTINATION.y, routeRequest.to().lng);
+    assertEquals(_RouteRequestTestContext.ORIGIN, routeRequest.from().getCoordinate());
+    assertEquals(_RouteRequestTestContext.DESTINATION, routeRequest.to().getCoordinate());
     assertEquals(testCtx.locale(), routeRequest.preferences().locale());
     assertEquals(defaultRequest.journey().wheelchair(), routeRequest.journey().wheelchair());
     assertEquals(defaultRequest.arriveBy(), routeRequest.arriveBy());
@@ -140,10 +138,10 @@ class RouteRequestMapperTest {
     );
     var env = testCtx.executionContext(stopLocationArgs);
     var routeRequest = RouteRequestMapper.toRouteRequest(env, testCtx.context());
-    assertEquals(FeedScopedId.parseStrict(stopA), routeRequest.from().stopId);
-    assertEquals(originLabel, routeRequest.from().label);
-    assertEquals(FeedScopedId.parseStrict(stopB), routeRequest.to().stopId);
-    assertEquals(destinationLabel, routeRequest.to().label);
+    assertEquals(FeedScopedId.parseStrict(stopA), routeRequest.from().stopId());
+    assertEquals(originLabel, routeRequest.from().label());
+    assertEquals(FeedScopedId.parseStrict(stopB), routeRequest.to().stopId());
+    assertEquals(destinationLabel, routeRequest.to().label());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
@@ -39,12 +39,12 @@ class _RouteRequestTestContext {
   static final Map<String, Object> ARGS = Map.ofEntries(
     entry(
       "origin",
-      Map.ofEntries(entry("location", Map.of("coordinate", mapCoordinate(ORIGIN.x, ORIGIN.y))))
+      Map.ofEntries(entry("location", Map.of("coordinate", mapCoordinate(ORIGIN.y, ORIGIN.x))))
     ),
     entry(
       "destination",
       Map.ofEntries(
-        entry("location", Map.of("coordinate", mapCoordinate(DESTINATION.x, DESTINATION.y)))
+        entry("location", Map.of("coordinate", mapCoordinate(DESTINATION.y, DESTINATION.x)))
       )
     )
   );

--- a/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.asserts.AssertEqualsAndHashCode;
@@ -29,6 +30,14 @@ class GenericLocationTest {
   @Test
   void getCoordinate() {
     assertEquals(STOP_ID, subject.stopId());
+  }
+
+  @Test
+  void testInvalid() {
+    assertThrows(NullPointerException.class, () -> GenericLocation.fromStopId(null));
+    assertThrows(NullPointerException.class, () ->
+      GenericLocation.fromStopIdWithFallback(null, 0.0, 0.0, "label")
+    );
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
@@ -1,9 +1,7 @@
 package org.opentripplanner.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.model.GenericLocation.UNKNOWN;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.asserts.AssertEqualsAndHashCode;
@@ -22,6 +20,8 @@ class GenericLocationTest {
     LABEL
   );
 
+  private final GenericLocation other = GenericLocation.fromCoordinate(LATITUDE, LONGITUDE, LABEL);
+
   @Test
   void fromStopId() {
     assertEquals(STOP_ID, subject.stopId());
@@ -35,18 +35,16 @@ class GenericLocationTest {
   @Test
   void isSpecified() {
     assertTrue(subject.isSpecified());
-    assertFalse(UNKNOWN.isSpecified());
   }
 
   @Test
   void testEquals() {
     var copy = GenericLocation.fromStopIdWithFallback(STOP_ID, LATITUDE, LONGITUDE, LABEL);
-    AssertEqualsAndHashCode.verify(subject).sameAs(copy).differentFrom(UNKNOWN);
+    AssertEqualsAndHashCode.verify(subject).sameAs(copy).differentFrom(other);
   }
 
   @Test
   void testToString() {
-    assertEquals("Unknown location", UNKNOWN.toString());
     assertEquals("A place F:Stop:1 (20.0, 30.0)", subject.toString());
   }
 }

--- a/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.asserts.AssertEqualsAndHashCode;
@@ -30,11 +29,6 @@ class GenericLocationTest {
   @Test
   void getCoordinate() {
     assertEquals(STOP_ID, subject.stopId());
-  }
-
-  @Test
-  void isSpecified() {
-    assertTrue(subject.isSpecified());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
@@ -15,16 +15,21 @@ class GenericLocationTest {
   private static final FeedScopedId STOP_ID = new FeedScopedId("F", "Stop:1");
   private static final double LATITUDE = 20.0;
   private static final double LONGITUDE = 30.0;
-  private final GenericLocation subject = new GenericLocation(LABEL, STOP_ID, LATITUDE, LONGITUDE);
+  private final GenericLocation subject = GenericLocation.fromStopIdWithFallback(
+    STOP_ID,
+    LATITUDE,
+    LONGITUDE,
+    LABEL
+  );
 
   @Test
   void fromStopId() {
-    assertEquals(STOP_ID, subject.stopId);
+    assertEquals(STOP_ID, subject.stopId());
   }
 
   @Test
   void getCoordinate() {
-    assertEquals(STOP_ID, subject.stopId);
+    assertEquals(STOP_ID, subject.stopId());
   }
 
   @Test
@@ -35,7 +40,7 @@ class GenericLocationTest {
 
   @Test
   void testEquals() {
-    var copy = new GenericLocation(LABEL, STOP_ID, LATITUDE, LONGITUDE);
+    var copy = GenericLocation.fromStopIdWithFallback(STOP_ID, LATITUDE, LONGITUDE, LABEL);
     AssertEqualsAndHashCode.verify(subject).sameAs(copy).differentFrom(UNKNOWN);
   }
 

--- a/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/model/GenericLocationTest.java
@@ -1,11 +1,13 @@
 package org.opentripplanner.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.asserts.AssertEqualsAndHashCode;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.street.geometry.WgsCoordinate;
 
 class GenericLocationTest {
 
@@ -23,13 +25,27 @@ class GenericLocationTest {
   private final GenericLocation other = GenericLocation.fromCoordinate(LATITUDE, LONGITUDE, LABEL);
 
   @Test
-  void fromStopId() {
-    assertEquals(STOP_ID, subject.stopId());
+  void fromStopIdWithFallback() {
+    var location = GenericLocation.fromStopIdWithFallback(STOP_ID, LATITUDE, LONGITUDE, LABEL);
+    assertEquals(STOP_ID, location.stopId());
+    assertEquals(new WgsCoordinate(LATITUDE, LONGITUDE), location.wgsCoordinate());
+    assertEquals(LABEL, location.label());
   }
 
   @Test
-  void getCoordinate() {
-    assertEquals(STOP_ID, subject.stopId());
+  void fromStopId() {
+    var location = GenericLocation.fromStopId(STOP_ID, LABEL);
+    assertEquals(STOP_ID, location.stopId());
+    assertNull(location.wgsCoordinate());
+    assertEquals(LABEL, location.label());
+  }
+
+  @Test
+  void fromCoordinate() {
+    var location = GenericLocation.fromCoordinate(LATITUDE, LONGITUDE, LABEL);
+    assertNull(location.stopId());
+    assertEquals(new WgsCoordinate(LATITUDE, LONGITUDE), location.wgsCoordinate());
+    assertEquals(LABEL, location.label());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -173,7 +173,10 @@ public class PlaceTest {
 
   @Test
   void forGenericLocation() {
-    GenericLocation location = GenericLocation.fromStopId(PLACE_NAME, "id", "stopId");
+    GenericLocation location = GenericLocation.fromStopId(
+      new FeedScopedId("id", "stopId"),
+      PLACE_NAME
+    );
     Place place = Place.forGenericLocation(location, DEFAULT_PLACE_NAME);
     assertNotNull(place);
     assertEquals(PLACE_NAME, place.name.toString());

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -84,11 +84,10 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
    * A place used as dummy to/from, when testing from/to. It can be anywhere, except
    * the same location as the place under test.
    */
-  private static final GenericLocation ANY_PLACE = new GenericLocation(
-    "Any place - not used",
-    null,
+  private static final GenericLocation ANY_PLACE = GenericLocation.fromCoordinate(
     LATITUDE_START,
-    LONGITUDE_0
+    LONGITUDE_0,
+    "Any place - not used"
   );
 
   private Graph graph;
@@ -138,7 +137,8 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
 
     graph.hasStreets = true;
     TestStreetLinkerModule.link(graph, otpModel.timetableRepository());
-    this.stopLocation = new GenericLocation(stop.getLabelString(), stop.getId(), null, null);
+    String label = stop.getLabelString();
+    this.stopLocation = GenericLocation.fromStopId(stop.getId(), label);
   }
 
   private static List<Arguments> testPedestrianLinkingTestCases() {
@@ -327,7 +327,7 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
      * {@code N, N+1, N-1, N+2, N-2 ... }
      */
     GenericLocation placeCloseToStreet() {
-      return new GenericLocation("On " + name, null, LATITUDE_MIDDLE, longitude + OFFSET);
+      return GenericLocation.fromCoordinate(LATITUDE_MIDDLE, longitude + OFFSET, "On " + name);
     }
 
     StreetEdgeBuilder createStreetEdgeBuilder(GraphRoutingTest.Builder factory) {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
@@ -23,25 +23,22 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
 
   private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
-  static GenericLocation p1 = new GenericLocation(
-    "SW Johnson St. & NW 24th Ave. (P1)",
-    null,
+  static GenericLocation p1 = GenericLocation.fromCoordinate(
     45.52832,
-    -122.70059
+    -122.70059,
+    "SW Johnson St. & NW 24th Ave. (P1)"
   );
 
-  static GenericLocation p2 = new GenericLocation(
-    "NW Hoyt St. & NW 20th Ave. (P2)",
-    null,
+  static GenericLocation p2 = GenericLocation.fromCoordinate(
     45.52704,
-    -122.69240
+    -122.69240,
+    "NW Hoyt St. & NW 20th Ave. (P2)"
   );
 
-  static GenericLocation p3 = new GenericLocation(
-    "NW Everett St. & NW 5th Ave. (P3)",
-    null,
+  static GenericLocation p3 = GenericLocation.fromCoordinate(
     45.52523,
-    -122.67525
+    -122.67525,
+    "NW Everett St. & NW 5th Ave. (P3)"
   );
 
   @BeforeAll

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/CarSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/CarSnapshotTest.java
@@ -20,32 +20,28 @@ public class CarSnapshotTest extends SnapshotTestBase {
 
   private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
-  static GenericLocation p1 = new GenericLocation(
-    "NW Pettygrove Ave. & NW 24th Ave. (P1)",
-    null,
+  static GenericLocation p1 = GenericLocation.fromCoordinate(
     45.53261,
-    -122.70075
+    -122.70075,
+    "NW Pettygrove Ave. & NW 24th Ave. (P1)"
   );
 
-  static GenericLocation p2 = new GenericLocation(
-    "NW Marshall St. & NW 24th Ave. (P2)",
-    null,
+  static GenericLocation p2 = GenericLocation.fromCoordinate(
     45.53046,
-    -122.70067
+    -122.70067,
+    "NW Marshall St. & NW 24th Ave. (P2)"
   );
 
-  static GenericLocation p3 = new GenericLocation(
-    "Chapman Elementary School (P3)",
-    null,
+  static GenericLocation p3 = GenericLocation.fromCoordinate(
     45.53335,
-    -122.70517
+    -122.70517,
+    "Chapman Elementary School (P3)"
   );
 
-  static GenericLocation p4 = new GenericLocation(
-    "Legacy Good Samaritan Medical Center (P4)",
-    null,
+  static GenericLocation p4 = GenericLocation.fromCoordinate(
     45.53060,
-    -122.69771
+    -122.69771,
+    "Legacy Good Samaritan Medical Center (P4)"
   );
 
   @BeforeAll

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
@@ -26,28 +26,29 @@ public class ElevationSnapshotTest extends SnapshotTestBase {
 
   private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
-  static GenericLocation p1 = new GenericLocation(
-    "SW Johnson St. & NW 24th Ave. (P1)",
-    null,
+  static GenericLocation p1 = GenericLocation.fromCoordinate(
     45.52832,
-    -122.70059
+    -122.70059,
+    "SW Johnson St. & NW 24th Ave. (P1)"
   );
 
-  static GenericLocation p2 = new GenericLocation(
-    "NW Hoyt St. & NW 20th Ave. (P2)",
-    null,
+  static GenericLocation p2 = GenericLocation.fromCoordinate(
     45.52704,
-    -122.69240
+    -122.69240,
+    "NW Hoyt St. & NW 20th Ave. (P2)"
   );
 
-  static GenericLocation p3 = new GenericLocation(
-    "NW Everett St. & NW 5th Ave. (P3)",
-    null,
+  static GenericLocation p3 = GenericLocation.fromCoordinate(
     45.52523,
-    -122.67525
+    -122.67525,
+    "NW Everett St. & NW 5th Ave. (P3)"
   );
 
-  static GenericLocation p4 = new GenericLocation("Sulzer Pump (P4)", null, 45.54549, -122.69659);
+  static GenericLocation p4 = GenericLocation.fromCoordinate(
+    45.54549,
+    -122.69659,
+    "Sulzer Pump (P4)"
+  );
 
   @BeforeAll
   public static void beforeClass() {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -295,10 +295,13 @@ public abstract class SnapshotTestBase {
 
   private String formatPlace(GenericLocation location) {
     String formatted;
-    if (location.stopId != null) {
-      formatted = String.format("%s::%s", location.label, location.stopId);
+    if (location.stopId() != null) {
+      formatted = String.format("%s::%s", location.label(), location.stopId());
+    } else if (location.wgsCoordinate() != null) {
+      var coord = location.wgsCoordinate();
+      formatted = String.format("%s::%s,%s", location.label(), coord.latitude(), coord.longitude());
     } else {
-      formatted = String.format("%s::%s,%s", location.label, location.lat, location.lng);
+      formatted = String.format("%s::null", location.label());
     }
     return URLEncoder.encode(formatted, StandardCharsets.UTF_8);
   }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
@@ -20,39 +20,34 @@ public class TransitSnapshotTest extends SnapshotTestBase {
 
   static GenericLocation ps = GenericLocation.fromStopId("NE 12th & Couch", "prt", "6577");
 
-  static GenericLocation p0 = new GenericLocation(
-    "SE Stark    St. & SE 17th Ave. (P0)",
-    null,
+  static GenericLocation p0 = GenericLocation.fromCoordinate(
     45.519320,
-    -122.648567
+    -122.648567,
+    "SE Stark    St. & SE 17th Ave. (P0)"
   );
 
-  static GenericLocation p1 = new GenericLocation(
-    "SE Morrison St. & SE 17th Ave. (P1)",
-    null,
+  static GenericLocation p1 = GenericLocation.fromCoordinate(
     45.51726,
-    -122.64847
+    -122.64847,
+    "SE Morrison St. & SE 17th Ave. (P1)"
   );
 
-  static GenericLocation p2 = new GenericLocation(
-    "NW Northrup St. & NW 22nd Ave. (P2)",
-    null,
+  static GenericLocation p2 = GenericLocation.fromCoordinate(
     45.53122,
-    -122.69659
+    -122.69659,
+    "NW Northrup St. & NW 22nd Ave. (P2)"
   );
 
-  static GenericLocation p3 = new GenericLocation(
-    "NW Northrup St. & NW 24th Ave. (P3)",
-    null,
+  static GenericLocation p3 = GenericLocation.fromCoordinate(
     45.53100,
-    -122.70029
+    -122.70029,
+    "NW Northrup St. & NW 24th Ave. (P3)"
   );
 
-  static GenericLocation p4 = new GenericLocation(
-    "NE Thompson St. & NE 18th Ave. (P4)",
-    null,
+  static GenericLocation p4 = GenericLocation.fromCoordinate(
     45.53896,
-    -122.64699
+    -122.64699,
+    "NE Thompson St. & NE 18th Ave. (P4)"
   );
 
   @BeforeAll

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.street.model.StreetMode;
@@ -13,12 +14,14 @@ import org.opentripplanner.street.model.StreetMode;
 public class TransitSnapshotTest extends SnapshotTestBase {
 
   static GenericLocation ptc = GenericLocation.fromStopId(
-    "Rose Quarter Transit Center",
-    "prt",
-    "79-tc"
+    new FeedScopedId("prt", "79-tc"),
+    "Rose Quarter Transit Center"
   );
 
-  static GenericLocation ps = GenericLocation.fromStopId("NE 12th & Couch", "prt", "6577");
+  static GenericLocation ps = GenericLocation.fromStopId(
+    new FeedScopedId("prt", "6577"),
+    "NE 12th & Couch"
+  );
 
   static GenericLocation p0 = GenericLocation.fromCoordinate(
     45.519320,

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouterTest.java
@@ -214,7 +214,7 @@ class AccessEgressRouterTest extends GraphRoutingTest {
   }
 
   private GenericLocation location(FeedScopedId id) {
-    return new GenericLocation(null, id, null, null);
+    return GenericLocation.fromStopId(id);
   }
 
   private GenericLocation location(String id) {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/via/ViaRoutingWorkerTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/via/ViaRoutingWorkerTest.java
@@ -119,7 +119,7 @@ public class ViaRoutingWorkerTest {
   private RoutingResponse createRoutingResponse(RouteRequest req) {
     // request from A or C?
     var c = fromA.coordinate;
-    var firstOrSecondSearch = req.from().lng == c.longitude() && req.from().lat == c.latitude();
+    var firstOrSecondSearch = req.from().wgsCoordinate().equals(c);
 
     var searchItineraries = firstOrSecondSearch ? firstSearch : secondSearch;
 

--- a/application/src/test/java/org/opentripplanner/routing/core/RouteRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/core/RouteRequestTest.java
@@ -257,7 +257,7 @@ class RouteRequestTest {
   @Test
   void testValidateMissingFrom() {
     expectOneRoutingValidationException(
-      () -> minimal.copyOf().withFrom(GenericLocation.UNKNOWN).buildRequest(),
+      () -> minimal.copyOf().withFrom(null).buildRequest(),
       RoutingErrorCode.LOCATION_NOT_FOUND,
       InputField.FROM_PLACE
     );
@@ -266,7 +266,7 @@ class RouteRequestTest {
   @Test
   void testValidateMissingTo() {
     expectOneRoutingValidationException(
-      () -> minimal.copyOf().withTo(GenericLocation.UNKNOWN).buildRequest(),
+      () -> minimal.copyOf().withTo(null).buildRequest(),
       RoutingErrorCode.LOCATION_NOT_FOUND,
       InputField.TO_PLACE
     );

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
@@ -161,7 +161,10 @@ class LinkingContextFactoryTest {
       id -> Optional.empty()
     );
     var container = new TemporaryVerticesContainer();
-    var from = GenericLocation.fromStopId("station", OMEGA_ID.getFeedId(), OMEGA_ID.getId());
+    var from = GenericLocation.fromStopId(
+      new FeedScopedId(OMEGA_ID.getFeedId(), OMEGA_ID.getId()),
+      "station"
+    );
     var request = LinkingContextRequest.of()
       .withFrom(from)
       .withTo(stopToLocation(stopB))
@@ -192,15 +195,15 @@ class LinkingContextFactoryTest {
       }
     );
     var container = new TemporaryVerticesContainer();
+    String label1 = stationAlpha.getName().toString();
     var from = GenericLocation.fromStopId(
-      stationAlpha.getName().toString(),
-      stationAlpha.getId().getFeedId(),
-      stationAlpha.getId().getId()
+      new FeedScopedId(stationAlpha.getId().getFeedId(), stationAlpha.getId().getId()),
+      label1
     );
+    String label = multiModalStation.getName().toString();
     var to = GenericLocation.fromStopId(
-      multiModalStation.getName().toString(),
-      multiModalStation.getId().getFeedId(),
-      multiModalStation.getId().getId()
+      new FeedScopedId(multiModalStation.getId().getFeedId(), multiModalStation.getId().getId()),
+      label
     );
     var request = LinkingContextRequest.of()
       .withFrom(from)
@@ -224,7 +227,10 @@ class LinkingContextFactoryTest {
   @Test
   void centroid() {
     var container = new TemporaryVerticesContainer();
-    var from = GenericLocation.fromStopId("station", ALPHA_ID.getFeedId(), ALPHA_ID.getId());
+    var from = GenericLocation.fromStopId(
+      new FeedScopedId(ALPHA_ID.getFeedId(), ALPHA_ID.getId()),
+      "station"
+    );
     var request = LinkingContextRequest.of()
       .withFrom(from)
       .withTo(stopToLocation(stopB))
@@ -514,10 +520,10 @@ class LinkingContextFactoryTest {
   }
 
   private GenericLocation stopToLocation(RegularStop s) {
+    String label = s.getName().toString();
     return GenericLocation.fromStopId(
-      s.getName().toString(),
-      s.getId().getFeedId(),
-      s.getId().getId()
+      new FeedScopedId(s.getId().getFeedId(), s.getId().getId()),
+      label
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
@@ -302,9 +302,9 @@ class LinkingContextFactoryTest {
   @Test
   void verticesShouldInheritNamesFromLocations() {
     try (var container = new TemporaryVerticesContainer()) {
-      var from = new GenericLocation("First", null, 0.5, 0.5);
-      var via = new GenericLocation("Second", null, 0.4, 0.6);
-      var to = new GenericLocation("Third", null, 0.6, 0.4);
+      var from = GenericLocation.fromCoordinate(0.5, 0.5, "First");
+      var via = GenericLocation.fromCoordinate(0.4, 0.6, "Second");
+      var to = GenericLocation.fromCoordinate(0.6, 0.4, "Third");
       var request = LinkingContextRequest.of()
         .withFrom(from)
         .withTo(to)
@@ -378,7 +378,7 @@ class LinkingContextFactoryTest {
     var request = LinkingContextRequest.of()
       .withFrom(GenericLocation.fromCoordinate(80, 80))
       .withTo(GenericLocation.fromCoordinate(85, 85))
-      .withViaLocationsWithCoordinates(List.of(new GenericLocation("Via1", null, 87.0, 87.0)))
+      .withViaLocationsWithCoordinates(List.of(GenericLocation.fromCoordinate(87.0, 87.0, "Via1")))
       .withDirectMode(StreetMode.WALK)
       .build();
     var exception = assertThrows(RoutingValidationException.class, () ->
@@ -424,12 +424,17 @@ class LinkingContextFactoryTest {
     var nonExistingStopId = new FeedScopedId("F", "NonExistingStop");
 
     // Create locations with both a non-existing stop ID and valid coordinates
-    var from = new GenericLocation("From", nonExistingStopId, stopA.getLat(), stopA.getLon());
-    var to = new GenericLocation(
-      "To",
+    var from = GenericLocation.fromStopIdWithFallback(
+      nonExistingStopId,
+      stopA.getLat(),
+      stopA.getLon(),
+      "From"
+    );
+    var to = GenericLocation.fromStopIdWithFallback(
       new FeedScopedId("F", "AnotherNonExisting"),
       stopD.getLat(),
-      stopD.getLon()
+      stopD.getLon(),
+      "To"
     );
 
     var request = LinkingContextRequest.of()

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextRequestTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextRequestTest.java
@@ -85,8 +85,6 @@ class LinkingContextRequestTest {
 
   @Test
   void testToString() {
-    var defaultRequest = LinkingContextRequest.of().withFrom(GenericLocation.UNKNOWN).build();
-    assertEquals("LinkingContextRequest{from: Unknown location}", defaultRequest.toString());
     assertEquals(
       "LinkingContextRequest{" +
         "from: (1.0, 2.0), " +

--- a/application/src/test/java/org/opentripplanner/routing/linking/mapping/LinkingContextRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/mapping/LinkingContextRequestMapperTest.java
@@ -15,8 +15,8 @@ import org.opentripplanner.street.model.StreetMode;
 
 class LinkingContextRequestMapperTest {
 
-  private static final GenericLocation FROM = new GenericLocation("from", null, 1.0, 0.0);
-  private static final GenericLocation TO = new GenericLocation("to", null, 0.0, 1.0);
+  private static final GenericLocation FROM = GenericLocation.fromCoordinate(1.0, 0.0, "from");
+  private static final GenericLocation TO = GenericLocation.fromCoordinate(0.0, 1.0, "to");
   private static final List<ViaLocation> VIA = List.of(
     new VisitViaLocation("via", null, List.of(), WgsCoordinate.GREENWICH)
   );

--- a/application/src/test/java/org/opentripplanner/streetadapter/StreetSearchRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/streetadapter/StreetSearchRequestMapperTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opentripplanner.core.model.basic.Cost;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RequestModes;
@@ -62,8 +63,8 @@ class StreetSearchRequestMapperTest {
   void mapFromToStopIds() {
     var builder = builder();
 
-    var from = GenericLocation.fromStopId("S1", "A", "STOP1");
-    var to = GenericLocation.fromStopId("S2", "A", "STOP2");
+    var from = GenericLocation.fromStopId(new FeedScopedId("A", "STOP1"), "S1");
+    var to = GenericLocation.fromStopId(new FeedScopedId("A", "STOP2"), "S2");
 
     var req = builder.withDateTime(INSTANT).withFrom(from).withTo(to).buildRequest();
 

--- a/application/src/test/java/org/opentripplanner/streetadapter/StreetSearchRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/streetadapter/StreetSearchRequestMapperTest.java
@@ -79,7 +79,7 @@ class StreetSearchRequestMapperTest {
 
     Instant dateTime = INSTANT;
     builder.withDateTime(dateTime);
-    var from = new GenericLocation(null, id("STOP"), null, null);
+    var from = GenericLocation.fromStopId(id("STOP"));
     builder.withFrom(from);
     var to = GenericLocation.fromCoordinate(60.0, 20.0);
     builder.withTo(to);
@@ -101,7 +101,7 @@ class StreetSearchRequestMapperTest {
   @ParameterizedTest
   @ValueSource(booleans = { true, false })
   void mapTransferRequest(boolean arriveBy) {
-    var from = new GenericLocation(null, id("STOP"), null, null);
+    var from = GenericLocation.fromStopId(id("STOP"));
     var to = GenericLocation.fromCoordinate(60.0, 20.0);
     var builder = builder()
       .withArriveBy(arriveBy)
@@ -332,7 +332,7 @@ class StreetSearchRequestMapperTest {
     var dateTime = Instant.parse("2022-11-10T10:00:00Z");
     var rentalDuration = Duration.ofHours(2);
     builder.withDateTime(dateTime);
-    var from = new GenericLocation(null, FeedScopedIdForTestFactory.id("STOP"), null, null);
+    var from = GenericLocation.fromStopId(FeedScopedIdForTestFactory.id("STOP"));
     builder.withFrom(from);
     var to = GenericLocation.fromCoordinate(60.0, 20.0);
     builder.withTo(to);

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/TestCaseDefinition.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/TestCaseDefinition.java
@@ -30,9 +30,9 @@ public record TestCaseDefinition(
     return String.format(
       "#%s %s - via:%s - %s, %s - via:%s - %s, %s-%s(%s)",
       id,
-      fromPlace.label,
+      fromPlace.label(),
       viaLocation != null ? viaLocation.label() : null,
-      toPlace.label,
+      toPlace.label(),
       coordinateString(fromPlace),
       viaLocation != null ? coordinateString(viaLocation.coordinateLocation()) : null,
       coordinateString(toPlace),
@@ -59,6 +59,12 @@ public record TestCaseDefinition(
   }
 
   private String coordinateString(GenericLocation location) {
-    return ValueObjectToStringBuilder.of().addCoordinate(location.lat, location.lng).toString();
+    var coord = location.wgsCoordinate();
+    if (coord == null) {
+      return ValueObjectToStringBuilder.of().addCoordinate(null, null).toString();
+    }
+    return ValueObjectToStringBuilder.of()
+      .addCoordinate(coord.latitude(), coord.longitude())
+      .toString();
   }
 }

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/io/TestCaseDefinitionCsvFile.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/io/TestCaseDefinitionCsvFile.java
@@ -33,15 +33,15 @@ public class TestCaseDefinitionCsvFile extends AbstractCsvFile<TestCaseDefinitio
       parseTime("departure"),
       parseTime("arrival"),
       parseDuration("window"),
-      new GenericLocation(
+      genericLocation(
         parseString("origin"),
-        FeedScopedId.ofNullable(feedId, parseString("fromPlace")),
+        parseString("fromPlace"),
         parseDouble("fromLat"),
         parseDouble("fromLon")
       ),
-      new GenericLocation(
+      genericLocation(
         parseString("destination"),
-        FeedScopedId.ofNullable(feedId, parseString("toPlace")),
+        parseString("toPlace"),
         parseDouble("toLat"),
         parseDouble("toLon")
       ),
@@ -49,6 +49,14 @@ public class TestCaseDefinitionCsvFile extends AbstractCsvFile<TestCaseDefinitio
       parseString("category"),
       new QualifiedModeSet(parseCollection("modes").toArray(new String[0]))
     );
+  }
+
+  private GenericLocation genericLocation(String label, String id, double lat, double lon) {
+    var feedScopedId = FeedScopedId.ofNullable(feedId, id);
+    if (feedScopedId == null) {
+      return GenericLocation.fromCoordinate(lat, lon, label);
+    }
+    return GenericLocation.fromStopIdWithFallback(feedScopedId, lat, lon, label);
   }
 
   @Nullable


### PR DESCRIPTION
### Summary

The GenericLocation class is used to represent an input location as used in from/to/via. Because of legacy reasons we allow GenericLocations without any location information in it (neither a coordinate nor a stop id).

This PR refactors the GenericLocation class a bit and enforces that they always contain an id or a coordinate.

I've verified that the behavior in the different plan queries stays the same (transmodel trip query and gtfs plan + planConnection queries).

The refactorings:
- Hide the public fields.
- Hide the public constructor and expose factory methods for the different cases.

### Unit tests

This code already has pretty good coverage. I added a test to validate the new behavior.

### Bumping the serialization version id

No
