### PR TITLE
add Aubin and remove OTP Android from independent productions in the documentation

### DIFF
--- a/doc/user/Deployments.md
+++ b/doc/user/Deployments.md
@@ -86,7 +86,7 @@ The following OTP-based services are presented as production-quality deployments
 by an official transportation authority or government. OTP is also known to be used on the back end
 of several popular multi-city mobile trip planning applications.
 
-* [OTP Android](https://play.google.com/store/apps/details?id=edu.usf.cutr.opentripplanner.android)
-  by CUTR-USF and Vreixo González can find itineraries on many different OTP servers via a service
-  discovery mechanism.
 * [**ViviBus Bologna**](http://www.vivibus.it/) Bologna, Italy.
+* [Aubin](https://aubin.app/) is a country-wide journey planner in Great Britain, with a mobile
+  application which focuses on personalized, need-based travel planning using the capability offered
+  by OpenTripPlanner.


### PR DESCRIPTION
### Summary

Add Aubin and remove OTP Android from independent productions in the documentation.

Aubin is now a production-level deployment in Great Britain which has contributed to OTP and standards development, in a country where official adoption is still lacking.

OTP Android is a dead project which is no longer in development, and the Play Store listing no longer exists.

### Issue

None

### Unit tests

None, documentation changes only

### Documentation

Updated

### Changelog

Not needed

### Bumping the serialization version id

Not needed