### PR TITLE
Review pareto set

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
@@ -1,22 +1,32 @@
 package org.opentripplanner.raptor.util.paretoset;
 
-/**
- * Comparator used by the {@link ParetoSet} to compare to elements for dominance. There is 4
- * outcomes of a comparison between a left and right vector:
- * <ul>
- *     <li>Left dominates right - At least one left criteria dominates, and no right dominance exist
- *     <li>Right dominates left - At least one right criteria dominates, and no left dominance exist
- *     <li>Mutual dominance - At least one left criteria dominates right and at least one right criteria dominates left
- *     <li>No dominance - all criteria is equals or no dominance exist
- * </ul>
- * To implement the comparator you only need to implement the comparison in one direction - if dominance exist.
- *
- * @param <T> The pareto set element type
- */
+/// Comparator used by the {@link ParetoSet} to compare to elements for dominance. There is 4
+/// outcomes of a comparison between a left and right vector:
+///
+/// - Left dominates right `<` - At least one left criteria dominates, and no right dominance exist
+/// - Right dominates left `>` - At least one right criteria dominates, and no left dominance exist
+/// - Mutual dominance `||` - At least one left criteria dominates right and at least one right
+///   criteria dominates left
+/// - No dominance `=` - all criteria is equals or no dominance exist.
+///
+/// To implement the comparator you only need to implement the comparison in one direction - if dominance exist.
+///
+/// @param <T> The pareto set element type
+///
 @FunctionalInterface
 public interface ParetoComparator<T> {
   /**
    * At least one of the left criteria dominates one of the corresponding right criteria.
    */
   boolean leftDominanceExist(T left, T right);
+
+  default boolean dominanceExist(T left, T right) {
+    return leftDominanceExist(left, right) || leftDominanceExist(right, left);
+  }
+
+  default ParetoDominance compare(T left, T right) {
+    final boolean l = leftDominanceExist(left, right);
+    final boolean r = leftDominanceExist(right, left);
+    return ParetoDominance.of(l, r);
+  }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
@@ -8,9 +8,9 @@ package org.opentripplanner.raptor.util.paretoset;
 ///   criterion dominates.
 /// - **Right dominates left** `≻`: at least one right criterion dominates and no left
 ///   criterion dominates.
-/// - **Mutual dominance** `∥`: at least one left criteria dominates right and at
-///   least one right criteria dominates left
-/// - **No dominance** `≡`: all criteria are equal, or neither side dominates.
+/// - **Mutual dominance** `∥`: at least one left criterion dominates right and at
+///   least one right criterion dominates left
+/// - **No dominance** `≡`: all criteria are equal.
 ///
 /// Implementations only need to provide one directional check in
 /// {@link #leftDominanceExist(Object, Object)}.

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
@@ -17,8 +17,8 @@ package org.opentripplanner.raptor.util.paretoset;
 @FunctionalInterface
 public interface ParetoComparator<T> {
   /**
-   * Returns {@code true} if at least one criterion in {@code left} dominates the corresponding
-   * criterion in {@code right}.
+   * Returns {@code true} if at least one criterion in {@code left} is better then the
+   * corresponding criterion in {@code right}.
    */
   boolean leftDominanceExist(T left, T right);
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
@@ -2,20 +2,17 @@ package org.opentripplanner.raptor.util.paretoset;
 
 /// Compares two elements in a {@link ParetoSet} for Pareto dominance.
 ///
-/// A comparison between a `left` and `right` element can produce four outcomes:
+/// A comparison between a `left` and `right` element can produce four mutually exclusive outcomes:
 ///
-/// - **Left dominates right** `≺`: at least one left criterion dominates and no right
-///   criterion dominates.
-/// - **Right dominates left** `≻`: at least one right criterion dominates and no left
-///   criterion dominates.
-/// - **Mutual dominance** `∥`: at least one left criterion dominates right and at
-///   least one right criterion dominates left
-/// - **No dominance** `≡`: all criteria are equal.
+/// - {@link ParetoDominance#LEFT}
+/// - {@link ParetoDominance#RIGHT}
+/// - {@link ParetoDominance#MUTUAL}
+/// - {@link ParetoDominance#NONE}
 ///
-/// Implementations only need to provide one directional check in
+/// Implementations only need to provide one directional check by implementing
 /// {@link #leftDominanceExist(Object, Object)}.
 ///
-/// @param <T> the Pareto set element type
+/// @param <T> the Pareto set element type.
 ///
 @FunctionalInterface
 public interface ParetoComparator<T> {

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoComparator.java
@@ -1,29 +1,41 @@
 package org.opentripplanner.raptor.util.paretoset;
 
-/// Comparator used by the {@link ParetoSet} to compare to elements for dominance. There is 4
-/// outcomes of a comparison between a left and right vector:
+/// Compares two elements in a {@link ParetoSet} for Pareto dominance.
 ///
-/// - Left dominates right `<` - At least one left criteria dominates, and no right dominance exist
-/// - Right dominates left `>` - At least one right criteria dominates, and no left dominance exist
-/// - Mutual dominance `||` - At least one left criteria dominates right and at least one right
-///   criteria dominates left
-/// - No dominance `=` - all criteria is equals or no dominance exist.
+/// A comparison between a `left` and `right` element can produce four outcomes:
 ///
-/// To implement the comparator you only need to implement the comparison in one direction - if dominance exist.
+/// - **Left dominates right** `≺`: at least one left criterion dominates and no right
+///   criterion dominates.
+/// - **Right dominates left** `≻`: at least one right criterion dominates and no left
+///   criterion dominates.
+/// - **Mutual dominance** `∥`: at least one left criteria dominates right and at
+///   least one right criteria dominates left
+/// - **No dominance** `≡`: all criteria are equal, or neither side dominates.
 ///
-/// @param <T> The pareto set element type
+/// Implementations only need to provide one directional check in
+/// {@link #leftDominanceExist(Object, Object)}.
+///
+/// @param <T> the Pareto set element type
 ///
 @FunctionalInterface
 public interface ParetoComparator<T> {
   /**
-   * At least one of the left criteria dominates one of the corresponding right criteria.
+   * Returns {@code true} if at least one criterion in {@code left} dominates the corresponding
+   * criterion in {@code right}.
    */
   boolean leftDominanceExist(T left, T right);
 
+  /**
+   * Returns {@code true} if either element dominates the other.
+   */
   default boolean dominanceExist(T left, T right) {
     return leftDominanceExist(left, right) || leftDominanceExist(right, left);
   }
 
+  /**
+   * Compares {@code left} and {@code right} and returns the corresponding {@link ParetoDominance}
+   * outcome.
+   */
   default ParetoDominance compare(T left, T right) {
     final boolean l = leftDominanceExist(left, right);
     final boolean r = leftDominanceExist(right, left);

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
@@ -21,9 +21,9 @@ public enum ParetoDominance {
     this.symbol = symbol;
   }
 
-  /**
-   * Create a dominance value from two directional dominance flags.
-   */
+  /// Create a dominance value from two directional dominance flags. For `x`(left) and `y`(right):
+  /// @param leftDominanceExist `x` has at least one criteria that is better than `y`.
+  /// @param rightDominanceExist `y` has at least one criteria that is better than `x`.
   public static ParetoDominance of(boolean leftDominanceExist, boolean rightDominanceExist) {
     if (leftDominanceExist) {
       return rightDominanceExist ? MUTUAL : LEFT;

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
@@ -1,17 +1,16 @@
 package org.opentripplanner.raptor.util.paretoset;
 
-/// Pareto Dominance can have 4 values when comparing two values `x`, `y`. Remember
-/// x and y can be vectors with one or more criteria.
+/// Pareto Dominance can have 4 values when comparing two values `x`, `y`. The 4 values are
+/// mutually exclusive. Remember x and y can be vectors with one or more criteria.
 public enum ParetoDominance {
-  /// Left-Dominance (`x` ≺ `y`), when `x` is strictly better than`y`.
+  /// Left-Dominance (`x` ≺ `y`), when `x` is strictly better than`y`. `[1, 1, 3]` ≺ `[1, 7, 3]`.
   LEFT('≺'),
-  /// Right-Dominance (`x` ≻ `y`), when `y` is strictly better than`x`.
+  /// Right-Dominance (`x` ≻ `y`), when `y` is strictly better than`x`. `[1, 7, 3]` ≻ `[1, 1, 3]`.
   RIGHT('≻'),
-  /// Both Dominate Each Other (Incomparable/Indifferent)  (`x` ∥ `y`). Neither solution is
-  /// superior to the other. Both solutions are part of the Pareto optimal set (Pareto front). For
-  /// two vectors `v` and `u` this happens when the `v` is better in one criteria, and `u` is
-  /// better in another: `[1, 7, 3]` ≡ `[7, 1, 3]`.
-  BOTH('∥'),
+  /// Mutual-Dominance (Incomparable/Indifferent)  (`x` ∥ `y`). Neither solution is superior to the
+  /// other. Both solutions are part of the Pareto optimal set (Pareto front). This happens when
+  /// the `x` is better in one criteria, and `y` is better in another: `[1, 7, 3]` ∥ `[7, 1, 3]`.
+  MUTUAL('∥'),
   /// No Dominate (Strictly equal)  (`x` ≡ `y`). Neither `x` dominates `y` nor `y` dominates
   /// `x`, AND `x` and `y` are equal in all objective values: `[1, 7, 3]` ≡ `[1, 7, 3]`.
   NONE('≡');
@@ -27,7 +26,7 @@ public enum ParetoDominance {
    */
   public static ParetoDominance of(boolean leftDominanceExist, boolean rightDominanceExist) {
     if (leftDominanceExist) {
-      return rightDominanceExist ? BOTH : LEFT;
+      return rightDominanceExist ? MUTUAL : LEFT;
     } else {
       return rightDominanceExist ? RIGHT : NONE;
     }

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.raptor.util.paretoset;
 
 /// Pareto Dominance can have 4 values when comparing two values `x`, `y`. Remember
-/// x and y can be vectors with one or more criterias.
+/// x and y can be vectors with one or more criteria.
 public enum ParetoDominance {
   /// Left-Dominance (`x` ≺ `y`), when `x` is strictly better than`y`.
   LEFT('≺'),
@@ -12,7 +12,7 @@ public enum ParetoDominance {
   /// two vectors `v` and `u` this happens when the `v` is better in one criteria, and `u` is
   /// better in another: `[1, 7, 3]` ≡ `[7, 1, 3]`.
   BOTH('∥'),
-  /// No Dominate (Pareto Equivalent)  (`x` ≡ `y`). Neither `x` dominates `y` nor `y` dominates
+  /// No Dominate (Strictly equal)  (`x` ≡ `y`). Neither `x` dominates `y` nor `y` dominates
   /// `x`, AND `x` and `y` are equal in all objective values: `[1, 7, 3]` ≡ `[1, 7, 3]`.
   NONE('≡');
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoDominance.java
@@ -1,0 +1,61 @@
+package org.opentripplanner.raptor.util.paretoset;
+
+/// Pareto Dominance can have 4 values when comparing two values `x`, `y`. Remember
+/// x and y can be vectors with one or more criterias.
+public enum ParetoDominance {
+  /// Left-Dominance (`x` ≺ `y`), when `x` is strictly better than`y`.
+  LEFT('≺'),
+  /// Right-Dominance (`x` ≻ `y`), when `y` is strictly better than`x`.
+  RIGHT('≻'),
+  /// Both Dominate Each Other (Incomparable/Indifferent)  (`x` ∥ `y`). Neither solution is
+  /// superior to the other. Both solutions are part of the Pareto optimal set (Pareto front). For
+  /// two vectors `v` and `u` this happens when the `v` is better in one criteria, and `u` is
+  /// better in another: `[1, 7, 3]` ≡ `[7, 1, 3]`.
+  BOTH('∥'),
+  /// No Dominate (Pareto Equivalent)  (`x` ≡ `y`). Neither `x` dominates `y` nor `y` dominates
+  /// `x`, AND `x` and `y` are equal in all objective values: `[1, 7, 3]` ≡ `[1, 7, 3]`.
+  NONE('≡');
+
+  private char symbol;
+
+  ParetoDominance(char symbol) {
+    this.symbol = symbol;
+  }
+
+  /**
+   * Create a dominance value from two directional dominance flags.
+   */
+  public static ParetoDominance of(boolean leftDominanceExist, boolean rightDominanceExist) {
+    if (leftDominanceExist) {
+      return rightDominanceExist ? BOTH : LEFT;
+    } else {
+      return rightDominanceExist ? RIGHT : NONE;
+    }
+  }
+
+  /**
+   * Parse a dominance value from either its symbol or enum name.
+   *
+   * <p>Accepted symbols are `≺`, `≻`, `∥`, and `≡`. If the input is not a single-character symbol,
+   * the value is parsed as an enum name (case-insensitive).
+   */
+  public static ParetoDominance of(String value) {
+    if (value.length() == 1) {
+      char ch = value.charAt(0);
+      for (var it : values()) {
+        if (it.symbol == ch) {
+          return it;
+        }
+      }
+    }
+    return valueOf(value.toUpperCase());
+  }
+
+  /**
+   * Return the symbolic representation of this dominance value.
+   */
+  @Override
+  public String toString() {
+    return Character.toString(symbol);
+  }
+}

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
@@ -97,9 +97,7 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
       return false;
     }
 
-    boolean mutualDominanceExist = false;
-    boolean equivalentVectorExist = false;
-
+    loop:
     for (int i = 0; i < size; ++i) {
       T it = elements[i];
 
@@ -107,28 +105,24 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
       boolean rightDominance = rightDominanceExist(newValue, it);
 
       if (leftDominance && rightDominance) {
-        mutualDominanceExist = true;
+        continue loop;
       } else if (leftDominance) {
         removeDominatedElementsFromRestOfSetAndAddNewElement(newValue, i);
         return true;
       } else if (rightDominance) {
-        goodElement = elements[i];
+        goodElement = it;
         notifyElementRejected(newValue, it);
         return false;
       } else {
-        equivalentVectorExist = true;
+        // newValue is equivalent with an existing value
+        notifyElementRejected(newValue, it);
+        return false;
       }
     }
 
-    if (mutualDominanceExist && !equivalentVectorExist) {
-      assertEnoughSpaceInSet();
-      acceptAndAppendValue(newValue);
-      return true;
-    }
-
-    // No dominance found, newValue is equivalent with all values in the set
-    notifyElementRejected(newValue, elements[0]);
-    return false;
+    assertEnoughSpaceInSet();
+    acceptAndAppendValue(newValue);
+    return true;
   }
 
   public final void clear() {

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
@@ -97,26 +97,23 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
       return false;
     }
 
-    loop:
-    for (int i = 0; i < size; ++i) {
+    loop: for (int i = 0; i < size; ++i) {
       T it = elements[i];
 
-      boolean leftDominance = leftDominanceExist(newValue, it);
-      boolean rightDominance = rightDominanceExist(newValue, it);
-
-      if (leftDominance && rightDominance) {
-        continue loop;
-      } else if (leftDominance) {
-        removeDominatedElementsFromRestOfSetAndAddNewElement(newValue, i);
-        return true;
-      } else if (rightDominance) {
-        goodElement = it;
-        notifyElementRejected(newValue, it);
-        return false;
-      } else {
-        // newValue is equivalent with an existing value
-        notifyElementRejected(newValue, it);
-        return false;
+      switch (comparator.compare(newValue, it)) {
+        case BOTH:
+          continue loop;
+        case LEFT:
+          removeDominatedElementsFromRestOfSetAndAddNewElement(newValue, i);
+          return true;
+        case RIGHT:
+          goodElement = it;
+          notifyElementRejected(newValue, it);
+          return false;
+        case NONE:
+          // newValue is equivalent with an existing value
+          notifyElementRejected(newValue, it);
+          return false;
       }
     }
 
@@ -153,20 +150,19 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
       return false;
     }
 
-    loop:
-    for (int i = size - 1; i >= 0; --i) {
-      boolean leftDominance = leftDominanceExist(newValue, elements[i]);
-      boolean rightDominance = rightDominanceExist(newValue, elements[i]);
+    loop: for (int i = size - 1; i >= 0; --i) {
+      var it = elements[i];
 
-      if (leftDominance && rightDominance) {
-        continue loop;
-      } else if (leftDominance) {
-        return true;
-      } else if (rightDominance) {
-        goodElement = elements[i];
-        return false;
-      } else {
-        return false;
+      switch (comparator.compare(newValue, it)) {
+        case BOTH:
+          continue loop;
+        case LEFT:
+          return true;
+        case RIGHT:
+          goodElement = it;
+          return false;
+        case NONE:
+          return false;
       }
     }
     return true;

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
@@ -153,31 +153,23 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
       return false;
     }
 
-    boolean mutualDominanceExist = false;
-    boolean equivalentVectorExist = false;
-
+    loop:
     for (int i = size - 1; i >= 0; --i) {
       boolean leftDominance = leftDominanceExist(newValue, elements[i]);
       boolean rightDominance = rightDominanceExist(newValue, elements[i]);
 
       if (leftDominance && rightDominance) {
-        if (equivalentVectorExist) {
-          return false;
-        }
-        mutualDominanceExist = true;
+        continue loop;
       } else if (leftDominance) {
         return true;
       } else if (rightDominance) {
         goodElement = elements[i];
         return false;
       } else {
-        if (mutualDominanceExist) {
-          return false;
-        }
-        equivalentVectorExist = true;
+        return false;
       }
     }
-    return mutualDominanceExist;
+    return true;
   }
 
   /**

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
@@ -101,7 +101,7 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
       T it = elements[i];
 
       switch (comparator.compare(newValue, it)) {
-        case BOTH:
+        case MUTUAL:
           continue loop;
         case LEFT:
           removeDominatedElementsFromRestOfSetAndAddNewElement(newValue, i);
@@ -154,7 +154,7 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
       var it = elements[i];
 
       switch (comparator.compare(newValue, it)) {
-        case BOTH:
+        case MUTUAL:
           continue loop;
         case LEFT:
           return true;

--- a/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/util/paretoset/ParetoSet.java
@@ -111,7 +111,7 @@ public sealed class ParetoSet<T> extends AbstractCollection<T> permits ParetoSet
           notifyElementRejected(newValue, it);
           return false;
         case NONE:
-          // newValue is equivalent with an existing value
+          // newValue is strictly equal to an existing value
           notifyElementRejected(newValue, it);
           return false;
       }

--- a/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoComparatorTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoComparatorTest.java
@@ -1,0 +1,41 @@
+package org.opentripplanner.raptor.util.paretoset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.BOTH;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.LEFT;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.NONE;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.RIGHT;
+
+import org.junit.jupiter.api.Test;
+
+public class ParetoComparatorTest {
+
+  private static final ParetoComparator<TestVector> COMPARATOR = (l, r) ->
+    l.v1 < r.v1 || l.v2 < r.v2;
+  private static final TestVector A_5_5 = new TestVector("a", 5, 5);
+  private static final TestVector B_5_5 = new TestVector("b", 5, 5);
+  private static final TestVector C_3_5 = new TestVector("c", 3, 5);
+  private static final TestVector D_5_3 = new TestVector("d", 5, 3);
+
+  @Test
+  public void dominanceExist() {
+    // Vectors are equal - no dominance
+    assertFalse(COMPARATOR.dominanceExist(A_5_5, B_5_5));
+
+    // Dominance exist
+    assertTrue(COMPARATOR.dominanceExist(C_3_5, B_5_5));
+    assertTrue(COMPARATOR.dominanceExist(A_5_5, C_3_5));
+    assertTrue(COMPARATOR.dominanceExist(C_3_5, D_5_3));
+  }
+
+  @Test
+  public void compare() {
+    assertEquals(NONE, COMPARATOR.compare(A_5_5, B_5_5));
+    assertEquals(NONE, COMPARATOR.compare(A_5_5, A_5_5));
+    assertEquals(LEFT, COMPARATOR.compare(C_3_5, B_5_5));
+    assertEquals(RIGHT, COMPARATOR.compare(A_5_5, C_3_5));
+    assertEquals(BOTH, COMPARATOR.compare(C_3_5, D_5_3));
+  }
+}

--- a/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoComparatorTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoComparatorTest.java
@@ -3,8 +3,8 @@ package org.opentripplanner.raptor.util.paretoset;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.BOTH;
 import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.LEFT;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.MUTUAL;
 import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.NONE;
 import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.RIGHT;
 
@@ -36,6 +36,6 @@ public class ParetoComparatorTest {
     assertEquals(NONE, COMPARATOR.compare(A_5_5, A_5_5));
     assertEquals(LEFT, COMPARATOR.compare(C_3_5, B_5_5));
     assertEquals(RIGHT, COMPARATOR.compare(A_5_5, C_3_5));
-    assertEquals(BOTH, COMPARATOR.compare(C_3_5, D_5_3));
+    assertEquals(MUTUAL, COMPARATOR.compare(C_3_5, D_5_3));
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoDominanceTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoDominanceTest.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.raptor.util.paretoset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.BOTH;
 import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.LEFT;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.MUTUAL;
 import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.NONE;
 import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.RIGHT;
 
@@ -12,25 +12,25 @@ class ParetoDominanceTest {
 
   @Test
   void testOf() {
-    assertEquals(BOTH, ParetoDominance.of("both"));
+    assertEquals(MUTUAL, ParetoDominance.of("mutual"));
     assertEquals(LEFT, ParetoDominance.of("left"));
     assertEquals(RIGHT, ParetoDominance.of("right"));
     assertEquals(NONE, ParetoDominance.of("none"));
     assertEquals(LEFT, ParetoDominance.of("≺"));
     assertEquals(RIGHT, ParetoDominance.of("≻"));
     assertEquals(NONE, ParetoDominance.of("≡"));
-    assertEquals(BOTH, ParetoDominance.of("∥"));
+    assertEquals(MUTUAL, ParetoDominance.of("∥"));
 
     // Mixed case
-    assertEquals(BOTH, ParetoDominance.of("BOTH"));
-    assertEquals(BOTH, ParetoDominance.of("bOtH"));
+    assertEquals(LEFT, ParetoDominance.of("LEFT"));
+    assertEquals(LEFT, ParetoDominance.of("lEfT"));
   }
 
   @Test
   void testOfLeftRight() {
     assertEquals(LEFT, ParetoDominance.of(true, false));
     assertEquals(RIGHT, ParetoDominance.of(false, true));
-    assertEquals(BOTH, ParetoDominance.of(true, true));
+    assertEquals(MUTUAL, ParetoDominance.of(true, true));
     assertEquals(NONE, ParetoDominance.of(false, false));
   }
 
@@ -39,6 +39,6 @@ class ParetoDominanceTest {
     assertEquals("≺", LEFT.toString());
     assertEquals("≻", RIGHT.toString());
     assertEquals("≡", NONE.toString());
-    assertEquals("∥", BOTH.toString());
+    assertEquals("∥", MUTUAL.toString());
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoDominanceTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoDominanceTest.java
@@ -1,0 +1,44 @@
+package org.opentripplanner.raptor.util.paretoset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.BOTH;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.LEFT;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.NONE;
+import static org.opentripplanner.raptor.util.paretoset.ParetoDominance.RIGHT;
+
+import org.junit.jupiter.api.Test;
+
+class ParetoDominanceTest {
+
+  @Test
+  void testOf() {
+    assertEquals(BOTH, ParetoDominance.of("both"));
+    assertEquals(LEFT, ParetoDominance.of("left"));
+    assertEquals(RIGHT, ParetoDominance.of("right"));
+    assertEquals(NONE, ParetoDominance.of("none"));
+    assertEquals(LEFT, ParetoDominance.of("≺"));
+    assertEquals(RIGHT, ParetoDominance.of("≻"));
+    assertEquals(NONE, ParetoDominance.of("≡"));
+    assertEquals(BOTH, ParetoDominance.of("∥"));
+
+    // Mixed case
+    assertEquals(BOTH, ParetoDominance.of("BOTH"));
+    assertEquals(BOTH, ParetoDominance.of("bOtH"));
+  }
+
+  @Test
+  void testOfLeftRight() {
+    assertEquals(LEFT, ParetoDominance.of(true, false));
+    assertEquals(RIGHT, ParetoDominance.of(false, true));
+    assertEquals(BOTH, ParetoDominance.of(true, true));
+    assertEquals(NONE, ParetoDominance.of(false, false));
+  }
+
+  @Test
+  void testToSting() {
+    assertEquals("≺", LEFT.toString());
+    assertEquals("≻", RIGHT.toString());
+    assertEquals("≡", NONE.toString());
+    assertEquals("∥", BOTH.toString());
+  }
+}

--- a/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoDominanceTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoDominanceTest.java
@@ -35,7 +35,7 @@ class ParetoDominanceTest {
   }
 
   @Test
-  void testToSting() {
+  void testToString() {
     assertEquals("≺", LEFT.toString());
     assertEquals("≻", RIGHT.toString());
     assertEquals("≡", NONE.toString());


### PR DESCRIPTION
### Summary

I got inspiered by @sigtot to do this today. There is a small optimalisation in this PR as well, but I do not expect
it to show up in the SpeedTest, because I think the JIT compiler deals with it in the old versjon. The tests I did on my local machine showed an improvement, but it is within the standard deviation - so hard to tell.

Refactors the `ParetoSet` dominance comparison logic to be cleaner and more explicit.

Introduces a `ParetoDominance` enum with four values (`LEFT`, `RIGHT`, `BOTH`, `NONE`) representing
the four possible outcomes when comparing two Pareto vectors. Each value carries a unicode symbol
(≺ ≻ ∥ ≡) for compact display. The `ParetoComparator` interface gains two default methods —
`compare(left, right)` returning the enum, and `dominanceExist(left, right)` — so the two-sided
check is no longer duplicated at every call site.

The `ParetoSet#add` and `ParetoSet#qualify` loops are rewritten to switch on the enum result,
replacing the dual `leftDominance`/`rightDominance` boolean flags and associated flag-tracking
variables with a single, readable `switch` expression. The logic is equivalent; the intent is
now immediately clear from the case labels.

New unit tests cover all four dominance outcomes for both `ParetoComparator` and `ParetoDominance`.

### Issue

No upstream issue — pure refactor.

### Unit tests

✅  Unit tests added.

### Documentation

✅  JavaDoc added

### Changelog

🟥  Not functional changes

### Bumping the serialization version id

🟥  Only Raptor changes