### PR TITLE
Improve Secret redaction for config File Logging

### DIFF
--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/file/ConfigFileLoader.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/file/ConfigFileLoader.java
@@ -7,13 +7,11 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.application.OtpAppException;
 import org.slf4j.Logger;
@@ -28,9 +26,6 @@ import org.slf4j.LoggerFactory;
 public class ConfigFileLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigFileLoader.class);
-
-  /** When echoing config files to logs, values for these keys will be hidden. */
-  private static final Set<String> REDACT_KEYS = Set.of("secretKey", "accessKey", "gsCredentials");
 
   private final ObjectMapper mapper = new ObjectMapper();
 
@@ -89,31 +84,6 @@ public class ConfigFileLoader {
   }
 
   /**
-   * Convert the JsonNode to a pretty-printed string with secrets hidden, operating on a protective
-   * copy of the node to avoid losing information.
-   */
-  private static String toRedactedString(JsonNode node) {
-    JsonNode redactedNode = node.deepCopy();
-    redactSecretsRecursive(redactedNode);
-    return redactedNode.toPrettyString();
-  }
-
-  /** Note that this method destructively modifies the node and its children in place. */
-  private static void redactSecretsRecursive(JsonNode node) {
-    if (node.isObject()) {
-      node
-        .fields()
-        .forEachRemaining(entry -> {
-          if (entry.getValue().isObject()) {
-            redactSecretsRecursive(entry.getValue());
-          } else if (REDACT_KEYS.contains(entry.getKey())) {
-            entry.setValue(new TextNode("********"));
-          }
-        });
-    }
-  }
-
-  /**
    * Open and parse the JSON file at the given path into a Jackson JSON tree. Comments and unquoted
    * keys are allowed. Returns an empty node if the file does not exist. Throws an exception if the
    * file contains syntax errors or cannot be parsed for some other reason.
@@ -128,7 +98,7 @@ public class ConfigFileLoader {
       String configString = new String(is.readAllBytes(), StandardCharsets.UTF_8);
       JsonNode node = stringToJsonNode(configString, file.toString());
       LOG.info("Load JSON configuration file '{}'", file.getPath());
-      LOG.info("Summarizing '{}': {}", file.getName(), toRedactedString(node));
+      LOG.info("Summarizing '{}': {}", file.getName(), ConfigFileRedactor.toRedactedString(node));
       return node;
     } catch (FileNotFoundException ex) {
       LOG.info("File '{}' is not present. Using default configuration.", file);

--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/file/ConfigFileRedactor.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/file/ConfigFileRedactor.java
@@ -1,0 +1,51 @@
+package org.opentripplanner.standalone.config.framework.file;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.Set;
+
+/**
+ * Redacts secret values from JSON configuration nodes before they are logged. This prevents
+ * sensitive information like passwords and API keys from appearing in log output.
+ */
+public class ConfigFileRedactor {
+
+  /** When echoing config files to logs, values for these keys will be hidden. */
+  private static final Set<String> REDACT_KEYS = Set.of(
+    "secretKey",
+    "accessKey",
+    "gsCredentials",
+    "password"
+  );
+
+  private ConfigFileRedactor() {}
+
+  /**
+   * Convert the JsonNode to a pretty-printed string with secrets hidden, operating on a protective
+   * copy of the node to avoid losing information.
+   */
+  public static String toRedactedString(JsonNode node) {
+    JsonNode redactedNode = node.deepCopy();
+    redactSecretsRecursive(redactedNode);
+    return redactedNode.toPrettyString();
+  }
+
+  /** Note that this method destructively modifies the node and its children in place. */
+  private static void redactSecretsRecursive(JsonNode node) {
+    if (node.isObject()) {
+      node
+        .properties()
+        .forEach(entry -> {
+          if (entry.getValue().isObject() || entry.getValue().isArray()) {
+            redactSecretsRecursive(entry.getValue());
+          } else if (REDACT_KEYS.contains(entry.getKey())) {
+            entry.setValue(new TextNode("********"));
+          }
+        });
+    } else if (node.isArray()) {
+      for (JsonNode element : node) {
+        redactSecretsRecursive(element);
+      }
+    }
+  }
+}

--- a/application/src/test/java/org/opentripplanner/standalone/config/framework/file/ConfigFileRedactorTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/config/framework/file/ConfigFileRedactorTest.java
@@ -1,0 +1,143 @@
+package org.opentripplanner.standalone.config.framework.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+class ConfigFileRedactorTest {
+
+  private static final String REDACTED = "********";
+
+  @Test
+  void redactSecretsInFlatObject() {
+    JsonNode node = parse(
+      """
+      {
+        "secretKey": "mySecret",
+        "accessKey": "myAccessKey",
+        "gsCredentials": "myCredentials",
+        "password": "myPassword",
+        "normalKey": "visible"
+      }
+      """
+    );
+
+    JsonNode redacted = parseRedacted(node);
+
+    assertEquals(REDACTED, redacted.path("secretKey").asText());
+    assertEquals(REDACTED, redacted.path("accessKey").asText());
+    assertEquals(REDACTED, redacted.path("gsCredentials").asText());
+    assertEquals(REDACTED, redacted.path("password").asText());
+    assertEquals("visible", redacted.path("normalKey").asText());
+  }
+
+  @Test
+  void redactSecretsInNestedObject() {
+    JsonNode node = parse(
+      """
+      {
+        "storage": {
+          "secretKey": "nested-secret",
+          "bucket": "my-bucket"
+        }
+      }
+      """
+    );
+
+    JsonNode redacted = parseRedacted(node);
+
+    assertEquals(REDACTED, redacted.path("storage").path("secretKey").asText());
+    assertEquals("my-bucket", redacted.path("storage").path("bucket").asText());
+  }
+
+  @Test
+  void redactSecretsInArray() {
+    JsonNode node = parse(
+      """
+      {
+        "updaters": [
+          { "type": "siri", "secretKey": "abc123" },
+          { "type": "gtfs-rt", "password": "pass456" }
+        ]
+      }
+      """
+    );
+
+    JsonNode redacted = parseRedacted(node);
+
+    JsonNode updaters = redacted.path("updaters");
+    assertEquals("siri", updaters.get(0).path("type").asText());
+    assertEquals(REDACTED, updaters.get(0).path("secretKey").asText());
+    assertEquals("gtfs-rt", updaters.get(1).path("type").asText());
+    assertEquals(REDACTED, updaters.get(1).path("password").asText());
+  }
+
+  @Test
+  void redactSecretsInDeeplyNestedStructure() {
+    JsonNode node = parse(
+      """
+      {
+        "services": [
+          {
+            "name": "service-a",
+            "endpoints": [
+              { "url": "https://example.com", "accessKey": "deep-secret" }
+            ]
+          }
+        ]
+      }
+      """
+    );
+
+    JsonNode redacted = parseRedacted(node);
+
+    JsonNode endpoint = redacted.path("services").get(0).path("endpoints").get(0);
+    assertEquals("https://example.com", endpoint.path("url").asText());
+    assertEquals(REDACTED, endpoint.path("accessKey").asText());
+  }
+
+  @Test
+  void nonSecretValuesArePreserved() {
+    JsonNode node = parse(
+      """
+      {
+        "name": "test",
+        "count": 42,
+        "enabled": true,
+        "items": ["a", "b"]
+      }
+      """
+    );
+
+    JsonNode redacted = parseRedacted(node);
+
+    assertEquals("test", redacted.path("name").asText());
+    assertEquals(42, redacted.path("count").asInt());
+    assertEquals(true, redacted.path("enabled").asBoolean());
+    assertEquals("a", redacted.path("items").get(0).asText());
+    assertEquals("b", redacted.path("items").get(1).asText());
+  }
+
+  @Test
+  void originalNodeIsNotModified() {
+    JsonNode node = parse(
+      """
+      { "secretKey": "original-value" }
+      """
+    );
+
+    ConfigFileRedactor.toRedactedString(node);
+
+    assertEquals("original-value", node.path("secretKey").asText());
+  }
+
+  private static JsonNode parse(String json) {
+    return ConfigFileLoader.nodeFromString(json, "test");
+  }
+
+  private static JsonNode parseRedacted(JsonNode node) {
+    String redactedString = ConfigFileRedactor.toRedactedString(node);
+    return ConfigFileLoader.nodeFromString(redactedString, "test");
+  }
+}


### PR DESCRIPTION
### Summary

Some Secrets in config files were not redacted during logging, this PR aims to fix this.

### Issue

Some Secrets in config files were not redacted during logging, this had 2 causes:

1. `password` was not included in the REDACT_KEYS List but used in the updaterconfig for SIRI-ET via MQTT
2. `JsonArrays` were completely ignored during the recursive search for redactable keys, but `JsonArrays` are used for configuring the updaters.

I have fixed both issues.

### Unit tests
- extracted the redaction Logic to its own class `ConfigFileRedactor` for better Testability
- wrote some unit tests for this new Class in `ConfigFileRedactorTest`

### Documentation

Not needed for bugfix
