### PR TITLE
Update Gitter URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **NOTE:** this issue system is intended for reporting bugs and tracking progress in software
 development. For all other usage and software development questions or discussion, please post a
-question in our chat room: https://gitter.im/opentripplanner/OpenTripPlanner.
+question in our chat room: https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im.
 
 
 ## Expected behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please read the guidelines carefully to make sure you follow our contribution pr
 
 - If you have any questions about problems you are encountering with code, deployment,
 documentation, or development coordination, please don't hesitate to post to the
-[OpenTripPlanner Gitter chat](https://gitter.im/opentripplanner/OpenTripPlanner).
+[OpenTripPlanner Gitter chat](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im).
 - There are twice-weekly developer meetings to discuss and coordinate contributions in more detail.
 See the [calendar](https://calendar.google.com/calendar/u/0/embed?src=ormbltvsqb6adl80ejgudt0glc@group.calendar.google.com)
 or [iCal link](https://calendar.google.com/calendar/ical/ormbltvsqb6adl80ejgudt0glc@group.calendar.google.com/public/basic.ics)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-[![Join the chat at https://gitter.im/opentripplanner/OpenTripPLanner](https://badges.gitter.im/opentripplanner/OpenTripPlanner.svg)](https://gitter.im/opentripplanner/OpenTripPlanner)
+[![Join the chat at https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im](https://badges.gitter.im/opentripplanner/OpenTripPlanner.svg)](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im)
 [![Matrix](https://img.shields.io/matrix/opentripplanner%3Amatrix.org?label=Matrix%20chat&?cacheSeconds=172800)](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im)
 [![codecov](https://codecov.io/gh/opentripplanner/OpenTripPlanner/branch/dev-2.x/graph/badge.svg?token=ak4PbIKgZ1)](https://codecov.io/gh/opentripplanner/OpenTripPlanner)
 [![Commit activity](https://img.shields.io/github/commit-activity/y/opentripplanner/OpenTripPlanner)](https://github.com/opentripplanner/OpenTripPlanner/graphs/contributors)
@@ -60,7 +60,7 @@ the [main documentation](http://docs.opentripplanner.org/en/dev-2.x/), including
 
 ## Getting in Touch
 
-The fastest way to get help is to use our [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner) where most of the core developers
+The fastest way to get help is to use our [Gitter chat room](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im) where most of the core developers
 are. Bug reports may be filed via the Github [issue tracker](https://github.com/openplans/OpenTripPlanner/issues). The OpenTripPlanner [mailing list](http://groups.google.com/group/opentripplanner-users)
 is used almost exclusively for project announcements. The mailing list and issue tracker are not
 intended for support questions or discussions. Please use the chat for this purpose. Other details

--- a/doc/user/Developers-Guide.md
+++ b/doc/user/Developers-Guide.md
@@ -53,7 +53,7 @@ like "program arguments".
 OpenTripPlanner is a community based open source project, and we welcome all who wish to contribute.
 There are several ways to get involved:
 
-* Join the [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner) and the 
+* Join the [Gitter chat room](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im) and the 
   [user mailing list](http://groups.google.com/group/opentripplanner-users).
 
 * Fix typos and improve the documentation within the `/doc/user` directory of the project (details
@@ -61,7 +61,7 @@ There are several ways to get involved:
 
 * [File a bug or new feature request](http://github.com/openplans/OpenTripPlanner/issues/new).
   If you want a GitHub issue to be addressed, you should also discuss it in
-  [Gitter](https://gitter.im/opentripplanner/OpenTripPlanner) or in the
+  [Gitter](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im) or in the
   [developer meetings](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/CONTRIBUTING.md#developer-meetings).
 
 * Create pull requests citing the relevant issue.
@@ -93,7 +93,7 @@ implementation discussions (in the comments). The created issue should be refere
 request. For really minor and uncontroversial pull requests, it is ok to not create an issue.
 
 **If you want a GitHub issue to be addressed, you should also discuss it in
-[Gitter](https://gitter.im/opentripplanner/OpenTripPlanner) or in the
+[Gitter](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im) or in the
 [developer meetings](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/CONTRIBUTING.md#developer-meetings).**
 
 ### Unit tests using real OSM data

--- a/doc/user/Product-Overview.md
+++ b/doc/user/Product-Overview.md
@@ -69,7 +69,7 @@ be more appropriate for these purposes.
 
 ## Talk to an expert about OTP
 
-Everyone interested in OTP is welcome to post questions on the [Gitter chat](https://gitter.im/opentripplanner/OpenTripPlanner)
+Everyone interested in OTP is welcome to post questions on the [Gitter chat](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im)
 or [OpenTripPlanner-users group](https://groups.google.com/g/opentripplanner-users).
 
 If you’re looking for a conversation with an individual from a similar organizational type, you can 

--- a/doc/user/index.md
+++ b/doc/user/index.md
@@ -64,7 +64,7 @@ your own OTP instance, the best place to start is the [Basic Tutorial](Basic-Tut
 
 # Getting help
 
-The fastest way to get help is to use our [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner) where most of the core developers are. Bug reports may be filed via the Github [issue tracker](https://github.com/openplans/OpenTripPlanner/issues). The issue tracker is not intended for support questions or discussions. Please use the chat for this purpose. The OpenTripPlanner [mailing list](http://groups.google.com/group/opentripplanner-users) is treated as a legacy communications channel and used almost exclusively for project announcements. Again, please direct development and support discussions to the Gitter chat.
+The fastest way to get help is to use our [Gitter chat room](https://matrix.to/#/#opentripplanner_OpenTripPlanner:gitter.im) where most of the core developers are. Bug reports may be filed via the Github [issue tracker](https://github.com/openplans/OpenTripPlanner/issues). The issue tracker is not intended for support questions or discussions. Please use the chat for this purpose. The OpenTripPlanner [mailing list](http://groups.google.com/group/opentripplanner-users) is treated as a legacy communications channel and used almost exclusively for project announcements. Again, please direct development and support discussions to the Gitter chat.
 
 # Financial and In-Kind Support
 


### PR DESCRIPTION
It seems like the old URL doesn't include the SSO any more, so it gives a very confusing user experience.