### PR TITLE
Replacement filter bugfix

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapper.java
@@ -8,15 +8,14 @@ import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
-import org.opentripplanner.transit.model.basic.MainAndSubMode;
+import org.opentripplanner.transit.model.basic.NarrowedTransitMode;
 import org.opentripplanner.utils.collection.CollectionUtils;
 import org.opentripplanner.utils.collection.ListUtils;
 
 class FilterMapper {
 
   static List<TransitFilter> mapFilters(
-    // TODO(tkalvas) List<NarrowedTransitMode>
-    List<MainAndSubMode> modes,
+    List<NarrowedTransitMode> modes,
     List<GraphQLTypes.GraphQLTransitFilterInput> filters
   ) {
     var filterRequests = new ArrayList<TransitFilter>();
@@ -37,15 +36,13 @@ class FilterMapper {
 
       // in the GTFS API modes can only be included but not excluded.
       if (CollectionUtils.isEmpty(includes)) {
-        // TODO(tkalvas) .withNarrowedTransportModes
-        var modeSelect = SelectRequest.of().withTransportModes(modes).build();
+        var modeSelect = SelectRequest.of().withNarrowedTransportModes(modes).build();
         filterRequestBuilder.addSelect(modeSelect);
       } else {
         // for every inclusion we also need to add the modes, otherwise the filter will not work
         for (var selectInput : ListUtils.nullSafeImmutableList(includes)) {
           var builder = SelectRequestMapper.mapSelectRequest(selectInput, "include");
-          // TODO(tkalvas) .withNarrowedTransportModes
-          builder.withTransportModes(modes);
+          builder.withNarrowedTransportModes(modes);
           filterRequestBuilder.addSelect(builder.build());
         }
       }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapper.java
@@ -15,6 +15,7 @@ import org.opentripplanner.utils.collection.ListUtils;
 class FilterMapper {
 
   static List<TransitFilter> mapFilters(
+    // TODO(tkalvas) List<NarrowedTransitMode>
     List<MainAndSubMode> modes,
     List<GraphQLTypes.GraphQLTransitFilterInput> filters
   ) {
@@ -36,12 +37,14 @@ class FilterMapper {
 
       // in the GTFS API modes can only be included but not excluded.
       if (CollectionUtils.isEmpty(includes)) {
+        // TODO(tkalvas) .withNarrowedTransportModes
         var modeSelect = SelectRequest.of().withTransportModes(modes).build();
         filterRequestBuilder.addSelect(modeSelect);
       } else {
         // for every inclusion we also need to add the modes, otherwise the filter will not work
         for (var selectInput : ListUtils.nullSafeImmutableList(includes)) {
           var builder = SelectRequestMapper.mapSelectRequest(selectInput, "include");
+          // TODO(tkalvas) .withNarrowedTransportModes
           builder.withTransportModes(modes);
           filterRequestBuilder.addSelect(builder.build());
         }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/ModePreferencesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/ModePreferencesMapper.java
@@ -144,6 +144,7 @@ public class ModePreferencesMapper {
         .stream()
         .map(mode -> new MainAndSubMode(mode.getMode()))
         .toList();
+      // TODO(tkalvas) modes, remove var mainModes completely
       var filters = FilterMapper.mapFilters(mainModes, graphQlFilters);
       journey.withTransit(b -> b.withFilters(filters));
     }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/ModePreferencesMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/ModePreferencesMapper.java
@@ -18,7 +18,6 @@ import org.opentripplanner.routing.api.request.request.TransitRequestBuilder;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
 import org.opentripplanner.street.model.StreetMode;
-import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.NarrowedTransitMode;
 import org.opentripplanner.transit.model.basic.ReplacementRequirement;
 import org.opentripplanner.utils.collection.CollectionUtils;
@@ -140,12 +139,7 @@ public class ModePreferencesMapper {
       .map(GraphQLTypes.GraphQLTransitPreferencesInput::getGraphQLFilters)
       .orElse(List.of());
     if (CollectionUtils.hasValue(graphQlFilters)) {
-      var mainModes = modes
-        .stream()
-        .map(mode -> new MainAndSubMode(mode.getMode()))
-        .toList();
-      // TODO(tkalvas) modes, remove var mainModes completely
-      var filters = FilterMapper.mapFilters(mainModes, graphQlFilters);
+      var filters = FilterMapper.mapFilters(modes, graphQlFilters);
       journey.withTransit(b -> b.withFilters(filters));
     }
     // if there isn't a transit filter or a mode set, then we can keep the default which is to include

--- a/application/src/main/java/org/opentripplanner/model/modes/AllowNarrowedTransitModeFilter.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/AllowNarrowedTransitModeFilter.java
@@ -22,7 +22,7 @@ public class AllowNarrowedTransitModeFilter implements AllowTransitModeFilter {
     return true;
   }
 
-  public TransitMode mainMode() {
+  TransitMode mainMode() {
     return this.mode.getMode();
   }
 

--- a/application/src/main/java/org/opentripplanner/model/modes/AllowNarrowedTransitModeFilter.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/AllowNarrowedTransitModeFilter.java
@@ -22,6 +22,10 @@ public class AllowNarrowedTransitModeFilter implements AllowTransitModeFilter {
     return true;
   }
 
+  public TransitMode mainMode() {
+    return this.mode.getMode();
+  }
+
   @Override
   public boolean match(
     TransitMode transitMode,

--- a/application/src/main/java/org/opentripplanner/model/modes/AllowNarrowedTransitModesFilter.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/AllowNarrowedTransitModesFilter.java
@@ -1,0 +1,62 @@
+package org.opentripplanner.model.modes;
+
+import java.util.Collection;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.opentripplanner.transit.model.basic.SubMode;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.utils.tostring.ToStringBuilder;
+
+public class AllowNarrowedTransitModesFilter implements AllowTransitModeFilter {
+
+  private final TransitMode mainMode;
+
+  private final Collection<AllowNarrowedTransitModeFilter> filters;
+
+  AllowNarrowedTransitModesFilter(Collection<AllowNarrowedTransitModeFilter> filters) {
+    this.mainMode = filters.iterator().next().mainMode();
+    this.filters = filters;
+  }
+
+  @Override
+  public boolean isModeSelective() {
+    return true;
+  }
+
+  @Override
+  public boolean match(
+    TransitMode transitMode,
+    SubMode subMode,
+    @Nullable Integer gtfsExtendedType
+  ) {
+    return (
+      mainMode == transitMode &&
+      filters.stream().anyMatch(filter -> filter.match(transitMode, subMode, gtfsExtendedType))
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mainMode, filters);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    AllowNarrowedTransitModesFilter that = (AllowNarrowedTransitModesFilter) obj;
+    return mainMode == that.mainMode && filters.equals(that.filters);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.of(AllowNarrowedTransitModesFilter.class)
+      .addEnum("mainMode", mainMode)
+      .addCol("filters", filters)
+      .toString();
+  }
+}

--- a/application/src/main/java/org/opentripplanner/model/modes/FilterCollection.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/FilterCollection.java
@@ -43,4 +43,10 @@ public class FilterCollection implements AllowTransitModeFilter {
   public boolean isModeSelective() {
     return filters.stream().anyMatch(AllowTransitModeFilter::isModeSelective);
   }
+
+  public String toString() {
+    // must always give the same order so that it works in assertions, so sort
+    var filtersString = filters.stream().map(AllowTransitModeFilter::toString).sorted().toList();
+    return "FilterCollection" + filtersString;
+  }
 }

--- a/application/src/main/java/org/opentripplanner/model/modes/FilterFactory.java
+++ b/application/src/main/java/org/opentripplanner/model/modes/FilterFactory.java
@@ -99,6 +99,24 @@ class FilterFactory {
       // esle ignore empty
     }
 
+    var narrowedModeFiltersByMainMode = stream(map, AllowNarrowedTransitModeFilter.class).collect(
+      Collectors.groupingBy(AllowNarrowedTransitModeFilter::mainMode)
+    );
+
+    for (TransitMode mainMode : narrowedModeFiltersByMainMode.keySet()) {
+      if (mainModes.contains(mainMode)) {
+        continue;
+      }
+
+      var narrowedModeFilters = narrowedModeFiltersByMainMode.get(mainMode);
+
+      if (narrowedModeFilters.size() == 1) {
+        result.addAll(narrowedModeFilters);
+      } else if (narrowedModeFilters.size() > 1) {
+        result.add(new AllowNarrowedTransitModesFilter(narrowedModeFilters));
+      }
+    }
+
     if (result.size() == 1) {
       return result.get(0);
     }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/FilterMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLTransitFilterInput;
 import org.opentripplanner.apis.support.InvalidInputException;
-import org.opentripplanner.transit.model.basic.MainAndSubMode;
+import org.opentripplanner.transit.model.basic.NarrowedTransitMode;
 
 class FilterMapperTest {
 
@@ -25,7 +25,9 @@ class FilterMapperTest {
         List.of(Map.of("agencies", List.of("feed:A")))
       )
     );
-    var result = FilterMapper.mapFilters(MainAndSubMode.all(), List.of(filter)).stream().toList();
+    var result = FilterMapper.mapFilters(NarrowedTransitMode.all(), List.of(filter))
+      .stream()
+      .toList();
     assertEquals(
       "[(select: [(transportModes: ALL, agencies: [feed:A])], not: [(transportModes: EMPTY, routes: [feed:A])])]",
       result.toString()
@@ -73,7 +75,7 @@ class FilterMapperTest {
   void invalidArgument(Map<String, Object> args) {
     var input = new GraphQLTransitFilterInput(args);
     assertThrows(IllegalArgumentException.class, () ->
-      FilterMapper.mapFilters(MainAndSubMode.all(), List.of(input))
+      FilterMapper.mapFilters(NarrowedTransitMode.all(), List.of(input))
     );
   }
 
@@ -82,7 +84,7 @@ class FilterMapperTest {
   void invalidInput(Map<String, Object> args) {
     var input = new GraphQLTransitFilterInput(args);
     assertThrows(InvalidInputException.class, () ->
-      FilterMapper.mapFilters(MainAndSubMode.all(), List.of(input))
+      FilterMapper.mapFilters(NarrowedTransitMode.all(), List.of(input))
     );
   }
 }

--- a/application/src/test/java/org/opentripplanner/model/modes/FilterFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/model/modes/FilterFactoryTest.java
@@ -14,58 +14,42 @@ public class FilterFactoryTest {
   private static final SubMode LOCAL_BUS = SubMode.getOrBuildAndCacheForever("localBus");
   private static final SubMode REGIONAL_BUS = SubMode.getOrBuildAndCacheForever("regionalBus");
 
-  List<NarrowedTransitMode> ONE_MAIN = List.of(
-    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED)
-  );
-  List<NarrowedTransitMode> MULTIPLE_MAINS = List.of(
-    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED),
-    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.IGNORED)
-  );
-  List<NarrowedTransitMode> ONE_SUB = List.of(
-    new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED)
-  );
-  List<NarrowedTransitMode> MULTIPLE_SUBS = List.of(
-    new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED),
-    new NarrowedTransitMode(TransitMode.BUS, REGIONAL_BUS, ReplacementRequirement.IGNORED)
-  );
-  List<NarrowedTransitMode> ONE_MAIN_COVERED_SUB = List.of(
-    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED),
-    new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED)
-  );
-  List<NarrowedTransitMode> ONE_REPLACEMENT = List.of(
-    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.REQUIRED)
-  );
-  List<NarrowedTransitMode> MULTIPLE_REPLACEMENTS = List.of(
-    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.REQUIRED),
-    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.FORBIDDEN)
-  );
-  List<NarrowedTransitMode> ONE_MAIN_COVERED_REPLACEMENT = List.of(
-    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.IGNORED),
-    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.FORBIDDEN)
-  );
-
   @Test
   void oneMain() {
-    var filter = FilterFactory.create(ONE_MAIN);
+    var filter = FilterFactory.create(
+      List.of(new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED))
+    );
     assertEquals(AllowMainModeFilter.class, filter.getClass());
     assertEquals("AllowMainModeFilter{mainMode: BUS}", filter.toString());
   }
 
   @Test
   void multipleMains() {
-    var filter = FilterFactory.create(MULTIPLE_MAINS);
+    var filter = FilterFactory.create(
+      List.of(
+        new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED),
+        new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.IGNORED)
+      )
+    );
     assertEquals("AllowMainModesFilter{mainModes: [RAIL, BUS]}", filter.toString());
   }
 
   @Test
   void oneSub() {
-    var filter = FilterFactory.create(ONE_SUB);
+    var filter = FilterFactory.create(
+      List.of(new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED))
+    );
     assertEquals("AllowMainAndSubModeFilter{mainMode: BUS, subMode: localBus}", filter.toString());
   }
 
   @Test
   void multipleSubs() {
-    var filter = FilterFactory.create(MULTIPLE_SUBS);
+    var filter = FilterFactory.create(
+      List.of(
+        new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED),
+        new NarrowedTransitMode(TransitMode.BUS, REGIONAL_BUS, ReplacementRequirement.IGNORED)
+      )
+    );
     assertEquals(
       "AllowMainAndSubModesFilter{mainMode: BUS, subModes: [localBus, regionalBus]}",
       filter.toString()
@@ -74,13 +58,20 @@ public class FilterFactoryTest {
 
   @Test
   void dropsCoveredSub() {
-    var filter = FilterFactory.create(ONE_MAIN_COVERED_SUB);
+    var filter = FilterFactory.create(
+      List.of(
+        new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED),
+        new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED)
+      )
+    );
     assertEquals("AllowMainModeFilter{mainMode: BUS}", filter.toString());
   }
 
   @Test
   void oneReplacement() {
-    var filter = FilterFactory.create(ONE_REPLACEMENT);
+    var filter = FilterFactory.create(
+      List.of(new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.REQUIRED))
+    );
     assertEquals(
       "AllowNarrowedTransitModeFilter{mode: BUS, isReplacement: REQUIRED}",
       filter.toString()
@@ -89,7 +80,12 @@ public class FilterFactoryTest {
 
   @Test
   void multipleReplacements() {
-    var filter = FilterFactory.create(MULTIPLE_REPLACEMENTS);
+    var filter = FilterFactory.create(
+      List.of(
+        new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.REQUIRED),
+        new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.FORBIDDEN)
+      )
+    );
     assertEquals(
       "FilterCollection[AllowNarrowedTransitModeFilter{mode: BUS, isReplacement: REQUIRED}, AllowNarrowedTransitModeFilter{mode: RAIL, isReplacement: FORBIDDEN}]",
       filter.toString()
@@ -98,7 +94,12 @@ public class FilterFactoryTest {
 
   @Test
   void dropsCoveredReplacement() {
-    var filter = FilterFactory.create(ONE_MAIN_COVERED_REPLACEMENT);
+    var filter = FilterFactory.create(
+      List.of(
+        new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.IGNORED),
+        new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.FORBIDDEN)
+      )
+    );
     assertEquals("AllowMainModeFilter{mainMode: RAIL}", filter.toString());
   }
 }

--- a/application/src/test/java/org/opentripplanner/model/modes/FilterFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/model/modes/FilterFactoryTest.java
@@ -1,0 +1,104 @@
+package org.opentripplanner.model.modes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.basic.NarrowedTransitMode;
+import org.opentripplanner.transit.model.basic.ReplacementRequirement;
+import org.opentripplanner.transit.model.basic.SubMode;
+import org.opentripplanner.transit.model.basic.TransitMode;
+
+public class FilterFactoryTest {
+
+  private static final SubMode LOCAL_BUS = SubMode.getOrBuildAndCacheForever("localBus");
+  private static final SubMode REGIONAL_BUS = SubMode.getOrBuildAndCacheForever("regionalBus");
+
+  List<NarrowedTransitMode> ONE_MAIN = List.of(
+    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED)
+  );
+  List<NarrowedTransitMode> MULTIPLE_MAINS = List.of(
+    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED),
+    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.IGNORED)
+  );
+  List<NarrowedTransitMode> ONE_SUB = List.of(
+    new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED)
+  );
+  List<NarrowedTransitMode> MULTIPLE_SUBS = List.of(
+    new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED),
+    new NarrowedTransitMode(TransitMode.BUS, REGIONAL_BUS, ReplacementRequirement.IGNORED)
+  );
+  List<NarrowedTransitMode> ONE_MAIN_COVERED_SUB = List.of(
+    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.IGNORED),
+    new NarrowedTransitMode(TransitMode.BUS, LOCAL_BUS, ReplacementRequirement.IGNORED)
+  );
+  List<NarrowedTransitMode> ONE_REPLACEMENT = List.of(
+    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.REQUIRED)
+  );
+  List<NarrowedTransitMode> MULTIPLE_REPLACEMENTS = List.of(
+    new NarrowedTransitMode(TransitMode.BUS, null, ReplacementRequirement.REQUIRED),
+    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.FORBIDDEN)
+  );
+  List<NarrowedTransitMode> ONE_MAIN_COVERED_REPLACEMENT = List.of(
+    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.IGNORED),
+    new NarrowedTransitMode(TransitMode.RAIL, null, ReplacementRequirement.FORBIDDEN)
+  );
+
+  @Test
+  void oneMain() {
+    var filter = FilterFactory.create(ONE_MAIN);
+    assertEquals(AllowMainModeFilter.class, filter.getClass());
+    assertEquals("AllowMainModeFilter{mainMode: BUS}", filter.toString());
+  }
+
+  @Test
+  void multipleMains() {
+    var filter = FilterFactory.create(MULTIPLE_MAINS);
+    assertEquals("AllowMainModesFilter{mainModes: [RAIL, BUS]}", filter.toString());
+  }
+
+  @Test
+  void oneSub() {
+    var filter = FilterFactory.create(ONE_SUB);
+    assertEquals("AllowMainAndSubModeFilter{mainMode: BUS, subMode: localBus}", filter.toString());
+  }
+
+  @Test
+  void multipleSubs() {
+    var filter = FilterFactory.create(MULTIPLE_SUBS);
+    assertEquals(
+      "AllowMainAndSubModesFilter{mainMode: BUS, subModes: [localBus, regionalBus]}",
+      filter.toString()
+    );
+  }
+
+  @Test
+  void dropsCoveredSub() {
+    var filter = FilterFactory.create(ONE_MAIN_COVERED_SUB);
+    assertEquals("AllowMainModeFilter{mainMode: BUS}", filter.toString());
+  }
+
+  @Test
+  void oneReplacement() {
+    var filter = FilterFactory.create(ONE_REPLACEMENT);
+    assertEquals(
+      "AllowNarrowedTransitModeFilter{mode: BUS, isReplacement: REQUIRED}",
+      filter.toString()
+    );
+  }
+
+  @Test
+  void multipleReplacements() {
+    var filter = FilterFactory.create(MULTIPLE_REPLACEMENTS);
+    assertEquals(
+      "FilterCollection[AllowNarrowedTransitModeFilter{mode: BUS, isReplacement: REQUIRED}, AllowNarrowedTransitModeFilter{mode: RAIL, isReplacement: FORBIDDEN}]",
+      filter.toString()
+    );
+  }
+
+  @Test
+  void dropsCoveredReplacement() {
+    var filter = FilterFactory.create(ONE_MAIN_COVERED_REPLACEMENT);
+    assertEquals("AllowMainModeFilter{mainMode: RAIL}", filter.toString());
+  }
+}


### PR DESCRIPTION
### Summary

The replacement status addition to trip/route filtering for route queries introduced in #7437 had a missing code path
which led to a bad query result in practice. This PR adds the missing path.

Triggering the bug was only possible with actually using the replacement status feature in specific ways, no queries which were legal earlier were affected.

### Unit tests

A bit of cleanup.

### Documentation

None.

### Changelog

No effect.

### Bumping the serialization version id

No effect.