### PR TITLE
Always generate hop geometries in the GTFS graph builder

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
@@ -68,25 +68,27 @@ public class GeometryProcessor {
   }
 
   /**
-   * Generate the geometry for the trip. Assumes that there are already vertices in the graph for
-   * the stops.
+   * Generate the per-hop geometry for the trip. The returned list is never null and always
+   * contains one entry per hop ({@code stopTimes.size() - 1}). When the trip has no usable
+   * shape data, the hops fall back to straight lines between consecutive stops, mirroring the
+   * NeTEx {@link org.opentripplanner.netex.mapping.ServiceLinkMapper} behaviour. Assumes that
+   * there are already vertices in the graph for the stops.
    * <p>
    * THREAD SAFETY The geometries for the trip patterns are computed in parallel. The collections
    * needed for this are concurrent implementations and therefore threadsafe but the issue store,
    * the graph, the TransitDataImport and others are not.
    */
   public List<LineString> createHopGeometries(Trip trip) {
+    List<StopTime> stopTimes = builder.getStopTimesSortedByTrip().get(trip);
     if (
       trip.getShapeId() == null ||
       trip.getShapeId().getId() == null ||
       trip.getShapeId().getId().isEmpty()
     ) {
-      return null;
+      return Arrays.asList(createStraightLineHopGeometries(stopTimes));
     }
 
-    return Arrays.asList(
-      createGeometry(trip.getShapeId(), builder.getStopTimesSortedByTrip().get(trip))
-    );
+    return Arrays.asList(createGeometry(trip.getShapeId(), stopTimes));
   }
 
   private static boolean equals(LinearLocation startIndex, LinearLocation endIndex) {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessorTest.java
@@ -325,6 +325,27 @@ class GeometryProcessorTest {
   }
 
   @Test
+  void tripWithoutShapeIdFallsBackToStraightLines() {
+    var builder = new TransitDataImportBuilder(REPO, NOOP);
+
+    // Trip with no shape_id at all
+    var trip = TimetableRepositoryForTest.trip("t").build();
+    var stops = List.of(STOP_A, STOP_B, STOP_C);
+    var stopTimes = IntStream.range(0, stops.size())
+      .mapToObj(index -> TEST_MODEL.stopTime(trip, index, stops.get(index)))
+      .toList();
+    builder.getStopTimesSortedByTrip().put(trip, stopTimes);
+
+    var processor = new GeometryProcessor(builder, 150, NOOP);
+    var linestrings = processor.createHopGeometries(trip);
+
+    assertLineStringWithinTolerance(
+      List.of(makeLineString(0, 0, 0, 0.1), makeLineString(0, 0.1, 0, 0.2)),
+      linestrings
+    );
+  }
+
+  @Test
   void ignoreInvalidReference() {
     var issueStore = new DefaultDataImportIssueStore();
     var builder = new TransitDataImportBuilder(REPO, issueStore);


### PR DESCRIPTION
## Summary

Align the GTFS graph builder with the NeTEx `ServiceLinkMapper`: when a trip has no `shape_id`, fall back to a straight line between consecutive stops instead of returning `null` from `GeometryProcessor.createHopGeometries(Trip)`. The two other paths in this method already used this fallback for invalid shape references and shape points too far from the stop sequence; this PR extends it to the "no shape data at all" case so the method's return type is always non-null, one entry per hop.

## Issue

Suggested by @habrahamsson-skanetrafiken in https://github.com/opentripplanner/OpenTripPlanner/pull/7559#discussion_r3160972554. The asymmetry between GTFS (returns `null` when shape data is missing) and NeTEx (always synthesizes a straight line) shows up in `TripPattern`: `getGeometry()` returns `null` for shapeless GTFS patterns while `getHopGeometry(int)` synthesizes a straight line on the fly. After this change, both APIs return a non-null geometry for any GTFS pattern with at least one hop, removing one source of conditional null handling for downstream callers.

The behaviour change is observable in three GraphQL resolvers that expose the full-pattern geometry — `JourneyPatternType.pointsOnLink`, `ServiceJourneyType.pointsOnLink`, `TripImpl.tripGeometry`/`Pattern.geometry`/`Pattern.patternGeometry` — which previously returned `null` for shapeless GTFS feeds and will now return a polyline composed of straight stop-to-stop segments. This matches the NeTEx behaviour.

## Unit tests

New `GeometryProcessorTest.tripWithoutShapeIdFallsBackToStraightLines` pins the new contract: a trip with no `shape_id` produces one straight-line `LineString` per hop, between consecutive stop coordinates. Existing tests in `GeometryProcessorTest` cover the with-shape paths and remain unchanged. Full unit test suite passes locally.

## Documentation

`createHopGeometries` Javadoc updated to document the always-non-null contract and the straight-line fallback.