### PR TITLE
Revert exception thrown when encountering negative A* weight

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -151,15 +151,21 @@ public class StateEditor {
 
   public void incrementWeight(double weight) {
     if (Double.isInfinite(weight) || Double.isNaN(weight)) {
-      throw new IllegalArgumentException(
-        "A state's weight is being incremented by " + weight + " while traversing edge " + backEdge
+      LOG.warn(
+        "A state's weight is being incremented by {} while traversing edge {}",
+        weight,
+        backEdge
       );
-    }
-    if (weight < 0) {
-      throw new IllegalArgumentException(
-        "A state's weight is being incremented by a negative amount while traversing edge " +
-          backEdge
+      defectiveTraversal = true;
+      return;
+    } else if (weight < 0) {
+      LOG.warn(
+        "A state's weight is being incremented by negative amount {} while traversing edge {}",
+        weight,
+        backEdge
       );
+      defectiveTraversal = true;
+      return;
     }
     this.weight += weight;
   }

--- a/street/src/test/java/org/opentripplanner/street/search/state/StateEditorTest.java
+++ b/street/src/test/java/org/opentripplanner/street/search/state/StateEditorTest.java
@@ -3,7 +3,7 @@ package org.opentripplanner.street.search.state;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Nested;
@@ -45,7 +45,8 @@ public class StateEditorTest {
     StateEditor stateEditor = new StateEditor(vertex, StreetSearchRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
-    assertThrows(IllegalArgumentException.class, () -> stateEditor.incrementWeight(Double.NaN));
+    stateEditor.incrementWeight(Double.NaN);
+    assertNull(stateEditor.makeState());
   }
 
   @Test
@@ -53,9 +54,8 @@ public class StateEditorTest {
     StateEditor stateEditor = new StateEditor(vertex, StreetSearchRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
-    assertThrows(IllegalArgumentException.class, () ->
-      stateEditor.incrementWeight(Double.NEGATIVE_INFINITY)
-    );
+    stateEditor.incrementWeight(Double.NEGATIVE_INFINITY);
+    assertNull(stateEditor.makeState());
   }
 
   @Nested


### PR DESCRIPTION
### Summary

@vpaturet has reported that the Norwegian graph build fails because I made the A* code throw an exception instead of logging a warning in #7519.

This PR reverts to a log message instead of an exception.

I will fix the problem at the root in a follow up.

### Issue

Relates to #7570

### Unit tests

Updated.
