### PR TITLE
Reduce nearby area stop search allocation pressure

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.application.OTPFeature;
-import org.opentripplanner.graph_builder.module.transfer.filter.MinMap;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
@@ -20,6 +19,7 @@ import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.utils.collection.MinMap;
 
 /**
  * A {@link TraverseVisitor} that collects transit stops and flex area stops during an A* search,

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
@@ -2,14 +2,16 @@ package org.opentripplanner.graph_builder.module.nearbystops;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.graph_builder.module.transfer.filter.MinMap;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
@@ -34,7 +36,9 @@ class NearbyStopFinderVisitor implements TraverseVisitor<State, Edge> {
   private final boolean reverseDirection;
 
   private final List<NearbyStop> transitStopsFound = new ArrayList<>();
-  private final Multimap<FeedScopedId, State> statesForAreaStopIds = ArrayListMultimap.create();
+  private final MinMap<FeedScopedId, State> statesForAreaStopIds = new MinMap<>(
+    Comparator.comparingDouble(State::getWeight)
+  );
 
   NearbyStopFinderVisitor(
     Set<Vertex> originVertices,
@@ -65,7 +69,7 @@ class NearbyStopFinderVisitor implements TraverseVisitor<State, Edge> {
     ) {
       for (FeedScopedId id : streetVertex.areaStops()) {
         if (canBoardFlex(state)) {
-          statesForAreaStopIds.put(id, state);
+          statesForAreaStopIds.putMin(id, state);
         }
       }
     }
@@ -81,8 +85,8 @@ class NearbyStopFinderVisitor implements TraverseVisitor<State, Edge> {
     return transitStopsFound;
   }
 
-  Multimap<FeedScopedId, State> statesForAreaStopIds() {
-    return statesForAreaStopIds;
+  Collection<Map.Entry<FeedScopedId, State>> statesForAreaStopIds() {
+    return statesForAreaStopIds.entries();
   }
 
   private boolean canBoardFlex(State state) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
@@ -6,8 +6,6 @@ import com.google.common.collect.Sets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
@@ -137,14 +135,11 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
     stopsFound.addAll(visitor.transitStopsFound());
 
     if (OTPFeature.FlexRouting.isOn()) {
-      for (var statesForAreaStopIds : visitor.statesForAreaStopIds().asMap().entrySet()) {
+      for (var statesForAreaStopIds : visitor.statesForAreaStopIds()) {
         var areaStopId = statesForAreaStopIds.getKey();
-        var states = statesForAreaStopIds.getValue();
-        // Select the vertex from all vertices that are reachable per AreaStop by taking
-        // the minimum walking distance
-        State min = Collections.min(states, Comparator.comparing(State::getWeight));
+        var min = statesForAreaStopIds.getValue();
 
-        // If the best state for this AreaStop is a SplitterVertex, we want to get the
+        // If the best min for this AreaStop is a SplitterVertex, we want to get the
         // TemporaryStreetLocation instead. This allows us to reach SplitterVertices in both
         // directions when routing later.
         if (min.getBackState().getVertex() instanceof TemporaryStreetLocation) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/StreetNearbyStopFinder.java
@@ -139,7 +139,7 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
         var areaStopId = statesForAreaStopIds.getKey();
         var min = statesForAreaStopIds.getValue();
 
-        // If the best min for this AreaStop is a SplitterVertex, we want to get the
+        // If the best state for this AreaStop is a SplitterVertex, we want to get the
         // TemporaryStreetLocation instead. This allows us to reach SplitterVertices in both
         // directions when routing later.
         if (min.getBackState().getVertex() instanceof TemporaryStreetLocation) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/FlexTripNearbyStopFilter.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/FlexTripNearbyStopFilter.java
@@ -31,7 +31,7 @@ class FlexTripNearbyStopFilter implements NearbyStopFilter {
     Collection<NearbyStop> nearbyStops,
     boolean reverseDirection
   ) {
-    MinMap<FlexTrip<?, ?>, NearbyStop> closestStopForFlexTrip = new MinMap<>();
+    MinMap<FlexTrip<?, ?>, NearbyStop> closestStopForFlexTrip = MinMap.ofNaturalOrder();
     for (var it : nearbyStops) {
       var stopId = it.stopId;
       var flexTrips = transitService.getFlexIndex().getFlexTripsByStopId(stopId);

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/FlexTripNearbyStopFilter.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/FlexTripNearbyStopFilter.java
@@ -5,6 +5,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.utils.collection.MinMap;
 
 /**
  * Filters nearby stops based on flex trip availability.

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMap.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMap.java
@@ -18,6 +18,9 @@ public final class MinMap<K, V> {
     this.comparator = comparator;
   }
 
+  /**
+   * Create a MinMap with natural order for values.
+   */
   public static <K, V extends Comparable<? super V>> MinMap<K, V> ofNaturalOrder() {
     return new MinMap<>(Comparator.<V>naturalOrder());
   }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMap.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMap.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module.transfer.filter;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -8,9 +9,18 @@ import javax.annotation.Nullable;
 /**
  * Decorate a HashMap that to track the smallest value for each key.
  */
-class MinMap<K, V extends Comparable<V>> {
+public final class MinMap<K, V> {
 
   private final Map<K, V> map = new HashMap<>();
+  private final Comparator<V> comparator;
+
+  public MinMap(Comparator<V> comparator) {
+    this.comparator = comparator;
+  }
+
+  public static <K, V extends Comparable<? super V>> MinMap<K, V> ofNaturalOrder() {
+    return new MinMap<>(Comparator.<V>naturalOrder());
+  }
 
   /**
    * Put the given key-value pair in the map if the map does not yet contain the key, or if the
@@ -19,9 +29,9 @@ class MinMap<K, V extends Comparable<V>> {
    * @see Map#put(Object, Object)
    * @return whether the key-value pair was inserted in the map.
    */
-  boolean putMin(K key, V value) {
+  public boolean putMin(K key, V value) {
     V oldValue = map.get(key);
-    if (oldValue == null || value.compareTo(oldValue) < 0) {
+    if (oldValue == null || comparator.compare(value, oldValue) < 0) {
       map.put(key, value);
       return true;
     }
@@ -41,5 +51,9 @@ class MinMap<K, V extends Comparable<V>> {
    */
   public Collection<V> values() {
     return map.values();
+  }
+
+  public Collection<Map.Entry<K, V>> entries() {
+    return map.entrySet();
   }
 }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/PatternNearbyStopFilter.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/PatternNearbyStopFilter.java
@@ -43,7 +43,7 @@ class PatternNearbyStopFilter implements NearbyStopFilter {
     boolean reverseDirection
   ) {
     // Track the closest stop on each pattern passing nearby.
-    MinMap<FeedScopedId, NearbyStop> closestStopForPattern = new MinMap<>();
+    MinMap<FeedScopedId, NearbyStop> closestStopForPattern = MinMap.ofNaturalOrder();
 
     // The end result
     Set<NearbyStop> uniqueStopsResult = new HashSet<>();

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/PatternNearbyStopFilter.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/filter/PatternNearbyStopFilter.java
@@ -11,6 +11,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.utils.collection.MinMap;
 
 /**
  * Filters nearby stops based on trip pattern availability.

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitorTest.java
@@ -82,8 +82,10 @@ class NearbyStopFinderVisitorTest {
       visitor.visitVertex(state);
 
       assertEquals(1, visitor.statesForAreaStopIds().size());
-      assertTrue(visitor.statesForAreaStopIds().containsKey(AREA_STOP_ID));
-      assertEquals(state, visitor.statesForAreaStopIds().get(AREA_STOP_ID).iterator().next());
+      assertEquals(
+        "[A:area-1=State{time: 1970-01-01T00:00:00Z, weight: 0.0, vertex: {10.0_10.0 lat,lng=10.0,10.0}}]",
+        visitor.statesForAreaStopIds().toString()
+      );
     });
   }
 
@@ -117,7 +119,10 @@ class NearbyStopFinderVisitorTest {
       visitor.visitVertex(state);
 
       assertEquals(1, visitor.statesForAreaStopIds().size());
-      assertTrue(visitor.statesForAreaStopIds().containsKey(AREA_STOP_ID));
+      assertEquals(
+        "[A:area-1=State{time: 1970-01-01T00:00:00Z, weight: 0.0, vertex: {30.0_30.0 lat,lng=30.0,30.0}}]",
+        visitor.statesForAreaStopIds().toString()
+      );
     });
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMapTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMapTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class MinMapTest {
 
   private static final String KEY = "key";
-  private final MinMap<String, String> subject = new MinMap<>();
+  private final MinMap<String, String> subject = MinMap.ofNaturalOrder();
 
   @Test
   void putMinAndGet() {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMapTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/transfer/filter/MinMapTest.java
@@ -1,9 +1,10 @@
 package org.opentripplanner.graph_builder.module.transfer.filter;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.google.common.truth.Truth;
+import java.util.Comparator;
 import org.junit.jupiter.api.Test;
 
 class MinMapTest {
@@ -28,12 +29,28 @@ class MinMapTest {
   @Test
   void values() {
     subject.putMin("key1", "orange");
-    Truth.assertThat(subject.values()).containsExactly("orange");
+    assertThat(subject.values()).containsExactly("orange");
 
     subject.putMin("key2", "apple");
-    Truth.assertThat(subject.values()).containsExactly("apple", "orange");
+    assertThat(subject.values()).containsExactly("apple", "orange");
 
     subject.putMin("key3", "banana");
-    Truth.assertThat(subject.values()).containsExactly("apple", "banana", "orange");
+    assertThat(subject.values()).containsExactly("apple", "banana", "orange");
+  }
+
+  @Test
+  void customOrder() {
+    var subject = new MinMap<String, String>(Comparator.<String>naturalOrder().reversed());
+    subject.putMin(KEY, "A");
+    assertEquals("A", subject.get(KEY));
+
+    subject.putMin(KEY, "B");
+    assertEquals("B", subject.get(KEY));
+
+    subject.putMin(KEY, "X");
+    assertEquals("X", subject.get(KEY));
+
+    subject.putMin(KEY, "A");
+    assertEquals("X", subject.get(KEY));
   }
 }

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -40,5 +40,10 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/utils/src/main/java/org/opentripplanner/utils/collection/MinMap.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/MinMap.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.graph_builder.module.transfer.filter;
+package org.opentripplanner.utils.collection;
 
 import java.util.Collection;
 import java.util.Comparator;

--- a/utils/src/test/java/org/opentripplanner/utils/collection/MinMapTest.java
+++ b/utils/src/test/java/org/opentripplanner/utils/collection/MinMapTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.graph_builder.module.transfer.filter;
+package org.opentripplanner.utils.collection;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
### Summary

This reduces allocation pressure when searching for nearby area stops by switching from a `Multimap` to a `MinMap`, leaving only a single winning state per area stop.

This required the following refactorings:

- `MinMap` was moved to `utils`
- A new constructor for using a custom comparator

### Unit tests

Updated and added.