### PR TITLE
Improve OTP warm-up

### DIFF
--- a/application/src/main/java/org/opentripplanner/warmup/GtfsWarmupQueryExecutor.java
+++ b/application/src/main/java/org/opentripplanner/warmup/GtfsWarmupQueryExecutor.java
@@ -35,17 +35,73 @@ class GtfsWarmupQueryExecutor implements WarmupQueryStrategy {
         dateTime: $dateTime
         modes: { transit: { access: [$accessMode], egress: [$egressMode] } }
       ) {
+        searchDateTime
+        pageInfo { startCursor endCursor hasNextPage hasPreviousPage }
+        routingErrors { code description inputField }
         edges {
           node {
             start
             end
+            duration generalizedCost waitingTime walkDistance
+            numberOfTransfers
             legs {
-              mode
-              duration
-              from { name lat lon }
-              to { name lat lon }
-              route { shortName }
-              legGeometry { points }
+              mode duration distance generalizedCost
+              start { scheduledTime estimated { time delay } }
+              end { scheduledTime estimated { time delay } }
+              realTime realtimeState
+              transitLeg walkingBike rentedBike
+              from {
+                name lat lon
+                stop {
+                  gtfsId code name platformCode
+                  parentStation { gtfsId name }
+                }
+              }
+              to {
+                name lat lon
+                stop { gtfsId code name }
+              }
+              intermediatePlaces {
+                name lat lon
+                stop { gtfsId name }
+                arrival { scheduledTime estimated { time delay } }
+                departure { scheduledTime estimated { time delay } }
+              }
+              stopCalls {
+                stopLocation { ... on Stop { gtfsId name } }
+                schedule { time { ... on ArrivalDepartureTime { arrival departure } } }
+                realTime {
+                  arrival { time delay }
+                  departure { time delay }
+                }
+              }
+              route {
+                gtfsId shortName longName mode
+                color textColor
+                agency { gtfsId name }
+              }
+              trip {
+                gtfsId tripHeadsign
+                route { gtfsId }
+              }
+              agency { gtfsId name }
+              alerts {
+                alertHeaderText alertDescriptionText
+                effectiveStartDate effectiveEndDate
+                alertSeverityLevel
+              }
+              pickupBookingInfo {
+                contactInfo { phoneNumber infoUrl bookingUrl }
+                message
+              }
+              dropOffBookingInfo {
+                contactInfo { phoneNumber infoUrl bookingUrl }
+                message
+              }
+              fareProducts {
+                product { name riderCategory { id name } }
+              }
+              legGeometry { points length }
             }
           }
         }

--- a/application/src/main/java/org/opentripplanner/warmup/TransmodelWarmupQueryExecutor.java
+++ b/application/src/main/java/org/opentripplanner/warmup/TransmodelWarmupQueryExecutor.java
@@ -31,15 +31,74 @@ class TransmodelWarmupQueryExecutor implements WarmupQueryStrategy {
         arriveBy: $arriveBy
         modes: { accessMode: $accessMode, egressMode: $egressMode }
       ) {
+        metadata { searchWindowUsed nextDateTime prevDateTime }
+        nextPageCursor
+        previousPageCursor
+        routingErrors { code description inputField }
         tripPatterns {
-          duration
+          aimedStartTime expectedStartTime
+          aimedEndTime expectedEndTime
+          duration distance streetDistance generalizedCost
+          systemNotices { tag text }
           legs {
-            mode
-            duration
-            fromPlace { name }
-            toPlace { name }
-            line { publicCode }
-            pointsOnLink { points }
+            mode transportSubmode
+            duration distance generalizedCost
+            aimedStartTime expectedStartTime
+            aimedEndTime expectedEndTime
+            realtime ride walkingBike
+            fromPlace {
+              name
+              quay {
+                id name publicCode
+                tariffZones { id name }
+                stopPlace { id name parent { id name } }
+              }
+            }
+            toPlace {
+              name
+              quay { id name publicCode }
+            }
+            fromEstimatedCall {
+              aimedDepartureTime expectedDepartureTime realtime cancellation
+              destinationDisplay { frontText }
+              notices { id text publicCode }
+              situations { situationNumber }
+            }
+            toEstimatedCall {
+              aimedArrivalTime expectedArrivalTime
+            }
+            intermediateEstimatedCalls {
+              aimedDepartureTime expectedDepartureTime
+              quay { id name }
+            }
+            line {
+              id publicCode name
+              presentation { colour textColour }
+              authority { id name }
+              operator { id name }
+              notices { id text publicCode }
+            }
+            datedServiceJourney { id operatingDay }
+            serviceJourney {
+              id privateCode
+              journeyPattern { id name notices { id text } }
+              notices { id text }
+            }
+            situations {
+              situationNumber severity priority
+              summary { value language }
+              description { value language }
+              advice { value language }
+              validityPeriod { startTime endTime }
+              infoLinks { uri label }
+            }
+            bookingArrangements {
+              bookingMethods
+              bookingContact { phone email url }
+            }
+            pointsOnLink { points length }
+            interchangeFrom { staySeated guaranteed maximumWaitTime priority }
+            interchangeTo { staySeated guaranteed }
           }
         }
       }

--- a/application/src/main/java/org/opentripplanner/warmup/WarmupWorker.java
+++ b/application/src/main/java/org/opentripplanner/warmup/WarmupWorker.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 class WarmupWorker implements Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(WarmupWorker.class);
-  private static final int MAX_QUERIES = 20;
+  private static final int MAX_QUERIES = 100;
 
   private final WarmupParameters parameters;
   private final WarmupQueryStrategy queryStrategy;


### PR DESCRIPTION
### Summary

Improve OTP application warm-up so the request entry chain is JIT-promoted before traffic arrives. Two changes:

1. **Broader GraphQL selection set in the warm-up queries.** The existing warm-up queries selected only a minimal handful of fields per leg, so most response-building data fetchers were never invoked. The new selection sets request the same fields that production clients ask for (`notices`, `situations`, `estimatedCalls`, `serviceJourney`, `datedServiceJourney`, `bookingArrangements`, `interchangeFrom/To`, `intermediateEstimatedCalls`, …) plus several top-level fields (`metadata`, `routingErrors`, page cursors). Same routing work, broader response building, so the corresponding data-fetcher classes are exercised during warm-up.

2. **Raise `MAX_QUERIES` from 20 to 100.** The warm-up loop polls updater readiness and exits as soon as all updaters are primed; `MAX_QUERIES` is a hard ceiling for the case where updater priming takes too long. With the previous value of 20 the loop was exiting on the cap rather than on updater readiness, so the once-per-query methods on the request entry chain (`RaptorService.route`, `RangeRaptorDynamicSearch.runHeuristics`, `TransitRouter.fetchAccessEgresses`, …) were not invoked enough times to clear the JIT tier-up thresholds before traffic arrived. Raising the ceiling lets warm-up keep going until updater priming completes naturally, at no extra steady-state cost.

### Unit tests

`WarmupQueryValidationTest` covers both Transmodel and GTFS warm-up queries against the live schema; both pass. No new tests added — the change is in the content of the warm-up queries and a single integer constant.

