### PR TITLE
Fix HashGridTest comparing query results against itself

### DIFF
--- a/street/src/test/java/org/opentripplanner/street/geometry/HashGridTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/HashGridTest.java
@@ -53,7 +53,7 @@ public class HashGridTest {
           hashGridObjs2.add(obj);
         }
       }
-      List<DummyObject> strtreeObjs = hashGrid.query(searchEnv);
+      List<DummyObject> strtreeObjs = strTree.query(searchEnv);
       // Need to remove non intersecting
       Set<DummyObject> strtreeObjs2 = new HashSet<>();
       for (DummyObject obj : strtreeObjs) {


### PR DESCRIPTION
### Summary

`HashGridTest#testHashGridRandom` is a non-regression test that is meant to compare results returned by OTP's `HashGridSpatialIndex` against JTS's `STRtree` reference implementation across many random envelopes and queries. However, the second `query()` call also went to `hashGrid` instead of `strTree`, so the assertion was comparing the hash grid's results against itself — a tautology that would pass even if `HashGridSpatialIndex` was completely broken.

This one-line fix points the second query at the STRtree reference as originally intended.

### Unit tests

`HashGridTest` is the only test affected. With the corrected reference comparison, the test still passes (1000 random objects, 1000 random queries, fixed seed `42`), confirming that `HashGridSpatialIndex` and `STRtree` agree on every query in the test set.