### PR TITLE
Fix negative costs for steep bicycle and walk edges

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/issues/ElevationFlattened.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/issues/ElevationFlattened.java
@@ -2,10 +2,11 @@ package org.opentripplanner.graph_builder.issues;
 
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
+import org.opentripplanner.graph_builder.issue.api.OsmUrlGenerator;
 import org.opentripplanner.street.model.edge.Edge;
 
 public record ElevationFlattened(Edge edge) implements DataImportIssue {
-  private static final String FMT = "Edge %s was steeper than Baldwin Street and was flattened.";
+  private static final String FMT = "Edge %s was steeper than 35 percent and flattened.";
 
   @Override
   public String getMessage() {
@@ -15,5 +16,13 @@ public record ElevationFlattened(Edge edge) implements DataImportIssue {
   @Override
   public Geometry getGeometry() {
     return edge.getGeometry();
+  }
+
+  @Override
+  public String getHTMLMessage() {
+    return "<a href='%s'>Edge %s</a> was steeper than 35 percent and flattened.".formatted(
+      OsmUrlGenerator.fromCoordinate(edge.getFromVertex().getCoordinate()),
+      edge.getName()
+    );
   }
 }

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtension.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtension.java
@@ -3,7 +3,6 @@ package org.opentripplanner.street.model.edge;
 import java.io.Serializable;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.street.geometry.CompactElevationProfile;
-import org.opentripplanner.utils.lang.DoubleUtils;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 public class StreetElevationExtension implements Serializable {

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtension.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtension.java
@@ -3,6 +3,7 @@ package org.opentripplanner.street.model.edge;
 import java.io.Serializable;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.street.geometry.CompactElevationProfile;
+import org.opentripplanner.utils.lang.DoubleUtils;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 public class StreetElevationExtension implements Serializable {

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
@@ -96,8 +96,7 @@ public class StreetElevationExtensionBuilder {
   }
 
   private StreetElevationExtension buildInternal() {
-    boolean slopeLimit = permission.allows(StreetTraversalPermission.CAR);
-    SlopeCosts costs = ElevationUtils.getSlopeCosts(elevationProfile, slopeLimit);
+    SlopeCosts costs = ElevationUtils.getSlopeCosts(elevationProfile, true);
 
     var effectiveBikeDistanceFactor = costs.slopeSpeedFactor;
     var effectiveBikeWorkFactor = costs.slopeWorkFactor;

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
@@ -2,7 +2,6 @@ package org.opentripplanner.street.model.edge;
 
 import java.util.Optional;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
-import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.elevation.ElevationUtils;
 import org.opentripplanner.street.model.elevation.SlopeCosts;
 
@@ -11,7 +10,6 @@ import org.opentripplanner.street.model.elevation.SlopeCosts;
  */
 public class StreetElevationExtensionBuilder {
 
-  private StreetTraversalPermission permission;
   private PackedCoordinateSequence elevationProfile;
 
   private float bicycleSafetyFactor;
@@ -28,8 +26,7 @@ public class StreetElevationExtensionBuilder {
       .withSlopeOverride(streetEdge.isSlopeOverride())
       .withStairs(streetEdge.isStairs())
       .withWalkSafetyFactor(streetEdge.getWalkSafetyFactor())
-      .withBicycleSafetyFactor(streetEdge.getBicycleSafetyFactor())
-      .withPermission(streetEdge.getPermission());
+      .withBicycleSafetyFactor(streetEdge.getBicycleSafetyFactor());
   }
 
   public static StreetElevationExtensionBuilder of(StreetEdgeBuilder<?> seb) {
@@ -38,8 +35,7 @@ public class StreetElevationExtensionBuilder {
       .withSlopeOverride(seb.slopeOverride())
       .withStairs(seb.stairs())
       .withWalkSafetyFactor(seb.walkSafetyFactor())
-      .withBicycleSafetyFactor(seb.bicycleSafetyFactor())
-      .withPermission(seb.permission());
+      .withBicycleSafetyFactor(seb.bicycleSafetyFactor());
   }
 
   public Optional<StreetElevationExtension> build() {
@@ -47,11 +43,6 @@ public class StreetElevationExtensionBuilder {
       return Optional.of(buildInternal());
     }
     return Optional.empty();
-  }
-
-  public StreetElevationExtensionBuilder withPermission(StreetTraversalPermission permission) {
-    this.permission = permission;
-    return this;
   }
 
   public StreetElevationExtensionBuilder withElevationProfile(

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilder.java
@@ -87,7 +87,7 @@ public class StreetElevationExtensionBuilder {
   }
 
   private StreetElevationExtension buildInternal() {
-    SlopeCosts costs = ElevationUtils.getSlopeCosts(elevationProfile, true);
+    SlopeCosts costs = ElevationUtils.getSlopeCosts(elevationProfile);
 
     var effectiveBikeDistanceFactor = costs.slopeSpeedFactor;
     var effectiveBikeWorkFactor = costs.slopeWorkFactor;

--- a/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
@@ -98,7 +98,7 @@ public class ElevationUtils {
   /// steep.
   ///
   /// For this reason we set the slope for an elevation segment to zero if it exceeds the limit
-  /// of +/- 35%.
+  /// of {@link #MAX_UPHILL_SLOPE} uphill or {@link #MAX_DOWNHILL_SLOPE} downhill.
   ///
   /// @param elev The elevation profile, where each (x, y) is (distance along edge, elevation)
   public static SlopeCosts getSlopeCosts(CoordinateSequence elev) {

--- a/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
@@ -89,9 +89,18 @@ public class ElevationUtils {
     5.5464612133430242E-02,
   };
 
-  /**
-   * @param elev The elevation profile, where each (x, y) is (distance along edge, elevation)
-   */
+  /// Compute the slope costs for an elevation profile, taking into account that mixing raster elevation
+  /// with OSM data often leads to glitches that cause very high slopes and in turn to negative costs.
+  ///
+  /// We have [analysed](https://github.com/opentripplanner/OpenTripPlanner/pull/7579#pullrequestreview-4226004340)
+  /// if these glitches more commonly lead to edges that are too sloped when in reality they are
+  /// flat or the other way around: the result is that it's more common for slopes to be artificially
+  /// steep.
+  ///
+  /// For this reason we set the slope for an elevation segment to zero if it exceeds the limit
+  /// of +/- 35%.
+  ///
+  /// @param elev The elevation profile, where each (x, y) is (distance along edge, elevation)
   public static SlopeCosts getSlopeCosts(CoordinateSequence elev) {
     Coordinate[] coordinates = elev.toCoordinateArray();
     boolean flattened = false;

--- a/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
@@ -124,8 +124,6 @@ public class ElevationUtils {
         continue;
       }
       double slope = rise / run;
-      // Baldwin St in Dunedin, NZ, is the steepest street
-      // on earth, and has a grade of 35%. Therefore we set the limit to 35%.
       // We need _some_ sort of limit, because the energy
       // usage approximation breaks down at extreme slopes, and
       // gives negative weights

--- a/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
@@ -39,6 +39,13 @@ public class ElevationUtils {
     5.0000000000000000E+03,
     5.0000000000000000E+03,
   };
+
+  /// Maximum slope of 35% after which elevation data is considered unreliable. It is based
+  /// on the steepest drivable road,
+  /// [Baldwin Street in New Zealand](https://en.wikipedia.org/wiki/Baldwin_Street)
+  private static final double MAX_UPHILL_SLOPE = 0.35;
+  private static final double MAX_DOWNHILL_SLOPE = -MAX_UPHILL_SLOPE;
+
   private static final double[] TY = {
     -3.4999999999999998E-01,
     -3.4999999999999998E-01,
@@ -113,7 +120,7 @@ public class ElevationUtils {
       // We need _some_ sort of limit, because the energy
       // usage approximation breaks down at extreme slopes, and
       // gives negative weights
-      if (slope > 0.35 || slope < -0.35) {
+      if (slope > MAX_UPHILL_SLOPE || slope < MAX_DOWNHILL_SLOPE) {
         slope = 0;
         flattened = true;
       }

--- a/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationUtils.java
@@ -83,11 +83,9 @@ public class ElevationUtils {
   };
 
   /**
-   * @param elev       The elevation profile, where each (x, y) is (distance along edge, elevation)
-   * @param slopeLimit Whether the slope should be limited to 0.35, which is the max slope for
-   *                   streets that take cars.
+   * @param elev The elevation profile, where each (x, y) is (distance along edge, elevation)
    */
-  public static SlopeCosts getSlopeCosts(CoordinateSequence elev, boolean slopeLimit) {
+  public static SlopeCosts getSlopeCosts(CoordinateSequence elev) {
     Coordinate[] coordinates = elev.toCoordinateArray();
     boolean flattened = false;
     double maxSlope = 0;
@@ -111,13 +109,11 @@ public class ElevationUtils {
       }
       double slope = rise / run;
       // Baldwin St in Dunedin, NZ, is the steepest street
-      // on earth, and has a grade of 35%.  So for streets
-      // which allow cars, we set the limit to 35%.  Footpaths
-      // are sometimes steeper, so we turn slopeLimit off for them.
-      // But we still need some sort of limit, because the energy
+      // on earth, and has a grade of 35%. Therefore we set the limit to 35%.
+      // We need _some_ sort of limit, because the energy
       // usage approximation breaks down at extreme slopes, and
       // gives negative weights
-      if ((slopeLimit && (slope > 0.35 || slope < -0.35)) || slope > 1.0 || slope < -1.0) {
+      if (slope > 0.35 || slope < -0.35) {
         slope = 0;
         flattened = true;
       }

--- a/street/src/test-fixtures/java/org/opentripplanner/street/model/elevation/ElevationProfiles.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/model/elevation/ElevationProfiles.java
@@ -1,0 +1,20 @@
+package org.opentripplanner.street.model.elevation;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+
+public class ElevationProfiles {
+
+  /**
+   * An elevation profile that is steep enough to cause negative cost values but
+   * not steep enough to be considered erroneous and won't therefore be discarded.
+   */
+  public static final PackedCoordinateSequence.Double STEEP_ELEVATION_PROFILE =
+    new PackedCoordinateSequence.Double(
+      new Coordinate[] {
+        new Coordinate(0, 6972),
+        new Coordinate(25, 6985),
+        new Coordinate(50, 6967),
+      }
+    );
+}

--- a/street/src/test-fixtures/java/org/opentripplanner/street/model/elevation/ElevationProfiles.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/model/elevation/ElevationProfiles.java
@@ -5,10 +5,7 @@ import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 
 public class ElevationProfiles {
 
-  /**
-   * An elevation profile that is steep enough to cause negative cost values but
-   * not steep enough to be considered erroneous and won't therefore be discarded.
-   */
+  /// An elevation profile that exceeds the maximum uphill slope limit of 35%.
   public static final PackedCoordinateSequence.Double STEEP_ELEVATION_PROFILE =
     new PackedCoordinateSequence.Double(
       new Coordinate[] {
@@ -16,5 +13,10 @@ public class ElevationProfiles {
         new Coordinate(25, 6985),
         new Coordinate(50, 6967),
       }
+    );
+
+  public static final PackedCoordinateSequence.Double STEEP_DOWNHILL_PROFILE =
+    new PackedCoordinateSequence.Double(
+      new Coordinate[] { new Coordinate(0, 1000), new Coordinate(25, 800), new Coordinate(50, 700) }
     );
 }

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeScooterTraversalTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeScooterTraversalTest.java
@@ -184,7 +184,7 @@ public class StreetEdgeScooterTraversalTest {
       .build()
       .ifPresent(testStreet::setElevationExtension);
 
-    SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, true);
+    SlopeCosts costs = ElevationUtils.getSlopeCosts(elev);
     double trueLength = costs.lengthMultiplier * length;
 
     var request = StreetSearchRequest.of().withMode(StreetMode.SCOOTER_RENTAL);

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTest.java
@@ -354,7 +354,7 @@ public class StreetEdgeTest {
       .build()
       .ifPresent(testStreet::setElevationExtension);
 
-    SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, true);
+    SlopeCosts costs = ElevationUtils.getSlopeCosts(elev);
     double trueLength = costs.lengthMultiplier * length;
     double slopeWorkLength = testStreet.getEffectiveBikeDistanceForWorkCost();
     double slopeSpeedLength = testStreet.getEffectiveBikeDistance();

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilderTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilderTest.java
@@ -1,8 +1,11 @@
 package org.opentripplanner.street.model.edge;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
+import static org.opentripplanner.street.model.elevation.ElevationProfiles.STEEP_ELEVATION_PROFILE;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +16,7 @@ import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.StreetModelFactory;
 import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.elevation.ElevationProfiles;
 
 class StreetElevationExtensionBuilderTest {
 
@@ -35,6 +39,7 @@ class StreetElevationExtensionBuilderTest {
       StreetModelFactory.V2.getCoordinate(),
     }
   );
+
   private StreetEdgeBuilder<?> streetEdgeBuilder;
 
   @BeforeEach
@@ -99,5 +104,20 @@ class StreetElevationExtensionBuilderTest {
       streetElevationExtensionFromStreetEdge.get().toString(),
       "Street elevation profiles built from StreetEdge and from StreetEdgeBuilder should be identical"
     );
+  }
+
+  @Test
+  void downhill() {
+    var extension = StreetElevationExtensionBuilder.of(
+      streetEdgeBuilder
+        .withPermission(PEDESTRIAN_AND_BICYCLE)
+        .withBicycleSafetyFactor(3)
+    )
+      .withElevationProfile(STEEP_ELEVATION_PROFILE)
+      .withDistanceInMeters(50)
+      .build()
+      .orElseThrow();
+
+    assertThat(extension.getEffectiveBikeDistance()).isGreaterThan(0);
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilderTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetElevationExtensionBuilderTest.java
@@ -4,19 +4,19 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
 import static org.opentripplanner.street.model.elevation.ElevationProfiles.STEEP_ELEVATION_PROFILE;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.StreetModelFactory;
 import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.street.model.elevation.ElevationProfiles;
 
 class StreetElevationExtensionBuilderTest {
 
@@ -54,7 +54,6 @@ class StreetElevationExtensionBuilderTest {
   @Test
   void testInvalidElevationProfile() {
     StreetElevationExtensionBuilder seeb = new StreetElevationExtensionBuilder()
-      .withPermission(StreetTraversalPermission.ALL)
       .withDistanceInMeters(1)
       .withElevationProfile(ELEVATION_PROFILE_ONE_POINT);
     assertTrue(seeb.build().isEmpty());
@@ -63,7 +62,6 @@ class StreetElevationExtensionBuilderTest {
   @Test
   void testValidElevationProfile() {
     StreetElevationExtensionBuilder seeb = new StreetElevationExtensionBuilder()
-      .withPermission(StreetTraversalPermission.ALL)
       .withDistanceInMeters(1)
       .withElevationProfile(ELEVATION_PROFILE_TWO_POINTS);
     Optional<StreetElevationExtension> streetElevationExtension = seeb.build();
@@ -106,12 +104,15 @@ class StreetElevationExtensionBuilderTest {
     );
   }
 
-  @Test
-  void downhill() {
+  /**
+   * With certain elevation profiles it's possible to create negative costs, so we make sure that
+   * this doesn't happen.
+   */
+  @ParameterizedTest
+  @EnumSource(StreetTraversalPermission.class)
+  void steepProfile(StreetTraversalPermission perm) {
     var extension = StreetElevationExtensionBuilder.of(
-      streetEdgeBuilder
-        .withPermission(PEDESTRIAN_AND_BICYCLE)
-        .withBicycleSafetyFactor(3)
+      streetEdgeBuilder.withPermission(perm).withBicycleSafetyFactor(3)
     )
       .withElevationProfile(STEEP_ELEVATION_PROFILE)
       .withDistanceInMeters(50)

--- a/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
@@ -1,8 +1,10 @@
 package org.opentripplanner.street.model.elevation;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.street.model.elevation.ElevationProfiles.STEEP_ELEVATION_PROFILE;
 
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -30,6 +32,12 @@ public class ElevationUtilsTest {
     );
     costs = ElevationUtils.getSlopeCosts(seq, false);
     assertEquals(1.00992634231424500668, costs.lengthMultiplier);
+  }
+
+  @Test
+  public void bikeCost() {
+    var slopeCosts = ElevationUtils.getSlopeCosts(STEEP_ELEVATION_PROFILE, false);
+    assertThat(slopeCosts.slopeSpeedFactor).isGreaterThan(0);
   }
 
   @Test

--- a/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.street.model.elevation.ElevationProfiles.STEEP_ELEVATION_PROFILE;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
@@ -21,30 +20,23 @@ class ElevationUtilsTest {
     CoordinateSequence seq = factory.create(
       new Coordinate[] { new Coordinate(0, 1), new Coordinate(10, 1) }
     );
-    SlopeCosts costs = ElevationUtils.getSlopeCosts(seq, false);
+    SlopeCosts costs = ElevationUtils.getSlopeCosts(seq);
     assertEquals(1.0, costs.lengthMultiplier);
 
     seq = factory.create(new Coordinate[] { new Coordinate(0, 1), new Coordinate(10, 2) });
-    costs = ElevationUtils.getSlopeCosts(seq, false);
+    costs = ElevationUtils.getSlopeCosts(seq);
     assertEquals(1.00498756211208902702, costs.lengthMultiplier);
 
     seq = factory.create(
       new Coordinate[] { new Coordinate(0, 1), new Coordinate(10, 2), new Coordinate(15, 1) }
     );
-    costs = ElevationUtils.getSlopeCosts(seq, false);
+    costs = ElevationUtils.getSlopeCosts(seq);
     assertEquals(1.00992634231424500668, costs.lengthMultiplier);
   }
 
   @Test
-  @Disabled("This currently fails but it's questionable whether it should even be supported")
-  void slopeSpeedFactorWithoutLimit() {
-    var slopeCosts = ElevationUtils.getSlopeCosts(STEEP_ELEVATION_PROFILE, false);
-    assertThat(slopeCosts.slopeSpeedFactor).isGreaterThan(0);
-  }
-
-  @Test
   void slopeSpeedFactorWithLimit() {
-    var slopeCosts = ElevationUtils.getSlopeCosts(STEEP_ELEVATION_PROFILE, true);
+    var slopeCosts = ElevationUtils.getSlopeCosts(STEEP_ELEVATION_PROFILE);
     assertThat(slopeCosts.slopeSpeedFactor).isGreaterThan(0);
   }
 

--- a/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
@@ -6,16 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.street.model.elevation.ElevationProfiles.STEEP_ELEVATION_PROFILE;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 
-public class ElevationUtilsTest {
+class ElevationUtilsTest {
 
   @Test
-  public void testLengthMultiplier() {
+  void testLengthMultiplier() {
     PackedCoordinateSequenceFactory factory = PackedCoordinateSequenceFactory.DOUBLE_FACTORY;
     CoordinateSequence seq = factory.create(
       new Coordinate[] { new Coordinate(0, 1), new Coordinate(10, 1) }
@@ -35,13 +36,20 @@ public class ElevationUtilsTest {
   }
 
   @Test
-  public void bikeCost() {
+  @Disabled("This currently fails but it's questionable whether it should even be supported")
+  void slopeSpeedFactorWithoutLimit() {
     var slopeCosts = ElevationUtils.getSlopeCosts(STEEP_ELEVATION_PROFILE, false);
     assertThat(slopeCosts.slopeSpeedFactor).isGreaterThan(0);
   }
 
   @Test
-  public void testCalculateSlopeWalkEffectiveLengthFactor() {
+  void slopeSpeedFactorWithLimit() {
+    var slopeCosts = ElevationUtils.getSlopeCosts(STEEP_ELEVATION_PROFILE, true);
+    assertThat(slopeCosts.slopeSpeedFactor).isGreaterThan(0);
+  }
+
+  @Test
+  void testCalculateSlopeWalkEffectiveLengthFactor() {
     // 35% should hit the MAX_SLOPE_WALK_EFFECTIVE_LENGTH_FACTOR=3, hence 300m is expected
     assertEquals(300.0, ElevationUtils.calculateEffectiveWalkLength(100, 35), 0.1);
 
@@ -65,7 +73,7 @@ public class ElevationUtilsTest {
   }
 
   @Test
-  public void testPartialElevationProfile() {
+  void testPartialElevationProfile() {
     double[] two_point = new double[] { 0, 10, 10, 20 };
     double[] four_point = new double[] { 0, 100, 10, 110, 20, 120, 25, 125 };
     double[] small_run = new double[] { 0, 100, 10, 110, 20, 120, 20.5, 120.5 };

--- a/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationUtilsTest.java
@@ -4,9 +4,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.street.model.elevation.ElevationProfiles.STEEP_DOWNHILL_PROFILE;
 import static org.opentripplanner.street.model.elevation.ElevationProfiles.STEEP_ELEVATION_PROFILE;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
@@ -32,12 +36,6 @@ class ElevationUtilsTest {
     );
     costs = ElevationUtils.getSlopeCosts(seq);
     assertEquals(1.00992634231424500668, costs.lengthMultiplier);
-  }
-
-  @Test
-  void slopeSpeedFactorWithLimit() {
-    var slopeCosts = ElevationUtils.getSlopeCosts(STEEP_ELEVATION_PROFILE);
-    assertThat(slopeCosts.slopeSpeedFactor).isGreaterThan(0);
   }
 
   @Test
@@ -107,6 +105,17 @@ class ElevationUtilsTest {
       20.25,
       new double[] { 0, 100.25, 9.75, 110, 19.75, 120, 20, 120.25 }
     );
+  }
+
+  private static List<PackedCoordinateSequence> slopeCases() {
+    return List.of(STEEP_ELEVATION_PROFILE, STEEP_DOWNHILL_PROFILE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("slopeCases")
+  void nonNegativeSlopeSpeedFactorOnSteepProfiles(PackedCoordinateSequence seq) {
+    var slopeCosts = ElevationUtils.getSlopeCosts(seq);
+    assertThat(slopeCosts.slopeSpeedFactor).isGreaterThan(0);
   }
 
   private static void assertPartialElevation(


### PR DESCRIPTION
### Summary

It fixes the costs for edges with a steep elevation profile, which can be negative as uncovered by #7570.

It turns out the very complex cost computation algorithm can return negative costs. There are some provision to make sure this cannot happen, but it's only activated if the edge allows cars on it. It's not clear to me why that should be case, so I extended the check to non-car edges as well.

### Issue

Closes #7570
Closes #7572

### Unit tests

Lots added.

### Documentation

Javadoc and an elevation sample to be used for tests.