### PR TITLE
Fix wrong context cast in Transmodel QuayAtDistanceType

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayAtDistanceType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayAtDistanceType.java
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import java.util.Optional;
 import org.opentripplanner.api.model.transit.FeedScopedIdMapper;
-import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
+import org.opentripplanner.apis.transmodel.TransmodelRequestContext;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -61,6 +61,6 @@ public class QuayAtDistanceType {
   }
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {
-    return environment.<GraphQLRequestContext>getContext().transitService();
+    return environment.<TransmodelRequestContext>getContext().getTransitService();
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/ApisArchitectureTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/ApisArchitectureTest.java
@@ -1,0 +1,41 @@
+package org.opentripplanner.apis;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner._support.arch.ArchComponent;
+import org.opentripplanner._support.arch.Package;
+
+/**
+ * Enforces that the GraphQL API implementations remain isolated from each other.
+ * Cross-imports lead to runtime ClassCastExceptions because each API installs its
+ * own request-context type into the GraphQL execution context.
+ */
+public class ApisArchitectureTest {
+
+  private static final Package APIS = Package.of("org.opentripplanner.apis");
+  private static final Package GTFS = APIS.subPackage("gtfs..");
+  private static final Package TRANSMODEL = APIS.subPackage("transmodel..");
+
+  @Test
+  void transmodelMustNotDependOnGtfs() {
+    noClasses()
+      .that()
+      .resideInAPackage(TRANSMODEL.packageIdentifier())
+      .should()
+      .dependOnClassesThat()
+      .resideInAPackage(GTFS.packageIdentifier())
+      .check(ArchComponent.OTP_CLASSES);
+  }
+
+  @Test
+  void gtfsMustNotDependOnTransmodel() {
+    noClasses()
+      .that()
+      .resideInAPackage(GTFS.packageIdentifier())
+      .should()
+      .dependOnClassesThat()
+      .resideInAPackage(TRANSMODEL.packageIdentifier())
+      .check(ArchComponent.OTP_CLASSES);
+  }
+}


### PR DESCRIPTION
### Summary

Fixes a `ClassCastException` thrown on every `quaysByRadius { edges { node { quay } } }` query against the Transmodel API. `QuayAtDistanceType` lives in the Transmodel API package but its `getTransitService` helper cast the GraphQL context to the GTFS API's `GraphQLRequestContext`. At runtime the Transmodel endpoint installs a `TransmodelRequestContext`, so the cast failed for every `quay` field resolution under `quaysByRadius`.

Bug introduced in #7463.

### Issue

Closes #7580

### Unit tests

Added `ApisArchitectureTest` with two ArchUnit rules forbidding cross-imports between `apis.transmodel` and `apis.gtfs` in either direction. Both rules pass after the fix and would have caught #7463 in CI.