### PR TITLE
GTFS stop count fares

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/GtfsFaresServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/GtfsFaresServiceTest.java
@@ -44,12 +44,12 @@ class GtfsFaresServiceTest implements FareTestConstants {
     var leg1 = TestTransitLeg.of()
       .withStartTime("10:00")
       .withEndTime("10:30")
-      .withNetwork(NETWORK_A.getId())
+      .withNetwork(NETWORK_A)
       .build();
     var leg2 = TestTransitLeg.of()
       .withStartTime("10:40")
       .withEndTime("11:00")
-      .withNetwork(NETWORK_A.getId())
+      .withNetwork(NETWORK_A)
       .build();
 
     var service = new GtfsFaresService(new DefaultFareService(), V2_SERVICE);
@@ -72,7 +72,7 @@ class GtfsFaresServiceTest implements FareTestConstants {
     var leg1 = TestTransitLeg.of()
       .withStartTime("10:00")
       .withEndTime("10:30")
-      .withNetwork(NETWORK_A.getId())
+      .withNetwork(NETWORK_A)
       .build();
     var service = new GtfsFaresService(new DefaultFareService(), V2_SERVICE);
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountNetworkTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountNetworkTest.java
@@ -49,11 +49,11 @@ class StopCountNetworkTest implements PlanTestConstants, FareTestConstants {
     );
   }
 
-  private static TestTransitLeg leg(GroupOfRoutes networkA) {
+  private static TestTransitLeg leg(GroupOfRoutes network) {
     return TestTransitLeg.of()
       .withStartTime("10:00")
       .withEndTime("11:00")
-      .withNetwork(networkA)
+      .withNetwork(network)
       .withIntermediateStops(id(1))
       .build();
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountNetworkTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountNetworkTest.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.ext.fares.service.gtfs.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.model.FareDistance;
+import org.opentripplanner.ext.fares.model.FareLegRule;
+import org.opentripplanner.ext.fares.model.FareTestConstants;
+import org.opentripplanner.model.fare.FareOffer;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.TestItinerary;
+import org.opentripplanner.model.plan.TestTransitLeg;
+import org.opentripplanner.model.plan.TransitLeg;
+import org.opentripplanner.transit.model.network.GroupOfRoutes;
+
+class StopCountNetworkTest implements PlanTestConstants, FareTestConstants {
+
+  private static final GtfsFaresV2Service SERVICE = GtfsFaresV2Service.of()
+    .withLegRules(
+      FareLegRule.of(id("nA"), FARE_PRODUCT_A)
+        .withLegGroupId(LEG_GROUP_A)
+        .withNetworkId(NETWORK_A.getId())
+        .withFareDistance(new FareDistance.Stops(0, 2))
+        .build(),
+      FareLegRule.of(id("nB"), FARE_PRODUCT_B)
+        .withLegGroupId(LEG_GROUP_A)
+        .withNetworkId(NETWORK_B.getId())
+        .withFareDistance(new FareDistance.Stops(0, 2))
+        .build()
+    )
+    .build();
+  private static final TransitLeg TWO_STOPS_ON_NETWORK_A = leg(NETWORK_A);
+  private static final TransitLeg TWO_STOPS_ON_NETWORK_B = leg(NETWORK_B);
+
+  @Test
+  void networkA() {
+    var result = SERVICE.calculateFares(TestItinerary.of(TWO_STOPS_ON_NETWORK_A).build());
+    assertThat(result.offersForLeg(TWO_STOPS_ON_NETWORK_A)).containsExactly(
+      FareOffer.of(TWO_STOPS_ON_NETWORK_A.startTime(), FARE_PRODUCT_A)
+    );
+  }
+
+  @Test
+  void networkB() {
+    var result = SERVICE.calculateFares(TestItinerary.of(TWO_STOPS_ON_NETWORK_B).build());
+    assertThat(result.offersForLeg(TWO_STOPS_ON_NETWORK_B)).containsExactly(
+      FareOffer.of(TWO_STOPS_ON_NETWORK_B.startTime(), FARE_PRODUCT_B)
+    );
+  }
+
+  private static TestTransitLeg leg(GroupOfRoutes networkA) {
+    return TestTransitLeg.of()
+      .withStartTime("10:00")
+      .withEndTime("11:00")
+      .withNetwork(networkA)
+      .withIntermediateStops(id(1))
+      .build();
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountTest.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.ext.fares.service.gtfs.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.fares.model.FareDistance;
+import org.opentripplanner.ext.fares.model.FareLegRule;
+import org.opentripplanner.ext.fares.model.FareTestConstants;
+import org.opentripplanner.model.fare.FareOffer;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.TestItinerary;
+import org.opentripplanner.model.plan.TestTransitLeg;
+import org.opentripplanner.model.plan.TransitLeg;
+
+class StopCountTest implements PlanTestConstants, FareTestConstants {
+
+  private static final GtfsFaresV2Service SERVICE = GtfsFaresV2Service.of()
+    .withLegRules(
+      FareLegRule.of(id("5-stops-max"), FARE_PRODUCT_A)
+        .withLegGroupId(LEG_GROUP_A)
+        .withFareDistance(new FareDistance.Stops(0, 5))
+        .build(),
+      FareLegRule.of(id("4-stops-max"), FARE_PRODUCT_B)
+        .withLegGroupId(LEG_GROUP_A)
+        .withFareDistance(new FareDistance.Stops(0, 4))
+        .build()
+    )
+    .build();
+  private static final TransitLeg FIVE_STOPS_LEG = intermediateStops(
+    id("i1"),
+    id("i2"),
+    id("i3"),
+    id("i4")
+  );
+  private static final TransitLeg FOUR_STOPS_LEG = intermediateStops(id("i1"), id("i2"), id("i3"));
+
+  private static TestTransitLeg intermediateStops(FeedScopedId... stopIds) {
+    return TestTransitLeg.of()
+      .withStartTime("10:00")
+      .withEndTime("11:00")
+      .withNetwork(NETWORK_A.getId())
+      .withIntermediateStops(stopIds)
+      .build();
+  }
+
+  @Test
+  void fourStops() {
+    var result = SERVICE.calculateFares(TestItinerary.of(FOUR_STOPS_LEG).build());
+    assertThat(result.offersForLeg(FOUR_STOPS_LEG)).containsExactly(
+      FareOffer.of(FOUR_STOPS_LEG.startTime(), FARE_PRODUCT_A),
+      FareOffer.of(FOUR_STOPS_LEG.startTime(), FARE_PRODUCT_B)
+    );
+  }
+
+  @Test
+  void fiveStops() {
+    var result = SERVICE.calculateFares(TestItinerary.of(FIVE_STOPS_LEG).build());
+    assertThat(result.offersForLeg(FIVE_STOPS_LEG)).containsExactly(
+      FareOffer.of(FIVE_STOPS_LEG.startTime(), FARE_PRODUCT_A)
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/StopCountTest.java
@@ -40,7 +40,6 @@ class StopCountTest implements PlanTestConstants, FareTestConstants {
     return TestTransitLeg.of()
       .withStartTime("10:00")
       .withEndTime("11:00")
-      .withNetwork(NETWORK_A.getId())
       .withIntermediateStops(stopIds)
       .build();
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferCountTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferCountTest.java
@@ -38,17 +38,17 @@ class TransferCountTest implements PlanTestConstants, FareTestConstants {
   private static final TransitLeg LEG_1 = TestTransitLeg.of()
     .withStartTime("10:00")
     .withEndTime("10:10")
-    .withNetwork(NETWORK_A.getId())
+    .withNetwork(NETWORK_A)
     .build();
   private static final TransitLeg LEG_2 = TestTransitLeg.of()
     .withStartTime("10:20")
     .withEndTime("10:30")
-    .withNetwork(NETWORK_A.getId())
+    .withNetwork(NETWORK_A)
     .build();
   private static final TransitLeg LEG_3 = TestTransitLeg.of()
     .withStartTime("10:30")
     .withEndTime("10:40")
-    .withNetwork(NETWORK_A.getId())
+    .withNetwork(NETWORK_A)
     .build();
 
   @Test

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferCountWithTimeLimitTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferCountWithTimeLimitTest.java
@@ -41,22 +41,22 @@ class TransferCountWithTimeLimitTest implements PlanTestConstants, FareTestConst
   private static final TransitLeg LEG_1 = TestTransitLeg.of()
     .withStartTime("10:00")
     .withEndTime("10:10")
-    .withNetwork(NETWORK_A.getId())
+    .withNetwork(NETWORK_A)
     .build();
   private static final TransitLeg LEG_2 = TestTransitLeg.of()
     .withStartTime("10:20")
     .withEndTime("10:30")
-    .withNetwork(NETWORK_A.getId())
+    .withNetwork(NETWORK_A)
     .build();
   private static final TransitLeg LEG_3 = TestTransitLeg.of()
     .withStartTime("10:40")
     .withEndTime("10:50")
-    .withNetwork(NETWORK_A.getId())
+    .withNetwork(NETWORK_A)
     .build();
   private static final TransitLeg LEG_4 = TestTransitLeg.of()
     .withStartTime("10:50")
     .withEndTime("10:55")
-    .withNetwork(NETWORK_A.getId())
+    .withNetwork(NETWORK_A)
     .build();
 
   @Test

--- a/application/src/ext/java/org/opentripplanner/ext/fares/model/FareDistance.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/model/FareDistance.java
@@ -1,15 +1,7 @@
 package org.opentripplanner.ext.fares.model;
 
-import org.opentripplanner.core.model.basic.Distance;
-
 /** Represents a distance metric used in distance-based fare computation*/
 public sealed interface FareDistance {
   /** Represents the number of stops as a distance metric in fare computation */
   record Stops(int min, int max) implements FareDistance {}
-
-  /**
-   * Represents the linear distance between the origin and destination points as a distance metric
-   * in fare computation
-   */
-  record LinearDistance(Distance min, Distance max) implements FareDistance {}
 }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRule.java
@@ -22,6 +22,9 @@ public final class FareLegRule implements Serializable {
   private final Collection<FareProduct> fareProducts;
 
   @Nullable
+  private final FareDistance fareDistance;
+
+  @Nullable
   private final FeedScopedId legGroupId;
 
   @Nullable
@@ -53,6 +56,7 @@ public final class FareLegRule implements Serializable {
     this.networkId = builder.networkId;
     this.fromAreaId = builder.fromAreaId;
     this.toAreaId = builder.toAreaId;
+    this.fareDistance = builder.fareDistance;
     this.priority = builder.priority;
     // for serialization purposes, make sure that they are immutable lists
     this.fromTimeframes = List.copyOf(builder.fromTimeframes);
@@ -92,6 +96,11 @@ public final class FareLegRule implements Serializable {
   @Nullable
   public FeedScopedId toAreaId() {
     return toAreaId;
+  }
+
+  @Nullable
+  public FareDistance fareDistance() {
+    return fareDistance;
   }
 
   public OptionalInt priority() {
@@ -138,13 +147,22 @@ public final class FareLegRule implements Serializable {
       Objects.equals(this.networkId, that.networkId) &&
       Objects.equals(this.fromAreaId, that.fromAreaId) &&
       Objects.equals(this.toAreaId, that.toAreaId) &&
+      Objects.equals(this.fareDistance, that.fareDistance) &&
       Objects.equals(this.fareProducts, that.fareProducts)
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, legGroupId, networkId, fromAreaId, toAreaId, fareProducts);
+    return Objects.hash(
+      id,
+      legGroupId,
+      networkId,
+      fromAreaId,
+      toAreaId,
+      fareDistance,
+      fareProducts
+    );
   }
 
   @Override

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/DistanceMatcher.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/DistanceMatcher.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.ext.fares.service.gtfs.v2;
+
+import org.opentripplanner.ext.fares.model.FareDistance;
+import org.opentripplanner.ext.fares.model.FareLegRule;
+import org.opentripplanner.model.plan.TransitLeg;
+
+class DistanceMatcher {
+
+  static boolean matchesDistance(TransitLeg leg, FareLegRule rule) {
+    // If no valid distance type is given, do not consider distances in fare computation
+    FareDistance distance = rule.fareDistance();
+    if (distance instanceof FareDistance.Stops(int min, int max)) {
+      var numStops = leg.listIntermediateStops().size();
+      return numStops >= min && max > numStops;
+    } else {
+      return true;
+    }
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/DistanceMatcher.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/DistanceMatcher.java
@@ -10,8 +10,10 @@ class DistanceMatcher {
     // If no valid distance type is given, do not consider distances in fare computation
     FareDistance distance = rule.fareDistance();
     if (distance instanceof FareDistance.Stops(int min, int max)) {
-      var numStops = leg.listIntermediateStops().size();
-      return numStops >= min && max > numStops;
+      // the board stop does not contribute towards the final count, but the alight stop does
+      // therefore we add 1
+      var numStops = leg.listIntermediateStops().size() + 1;
+      return numStops >= min && max >= numStops;
     } else {
       return true;
     }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -244,6 +244,7 @@ class FareLookupService implements Serializable {
       // covers this area
       areaMatcher.matchesFromArea(leg.from().stop, rule.fromAreaId()) &&
       areaMatcher.matchesToArea(leg.to().stop, rule.toAreaId()) &&
+      DistanceMatcher.matchesDistance(leg, rule) &&
       timeframeMatcher.matchesTimeframes(leg, rule)
     );
   }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.gtfs.mapping;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalInt;
 import javax.annotation.Nullable;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Area;
@@ -83,8 +84,8 @@ class FareLegRuleMapper {
     }
     return switch (distanceType) {
       case 0 -> new FareDistance.Stops(
-        fareLegRule.getMinDistance().intValue(),
-        fareLegRule.getMaxDistance().intValue()
+        optionalInt(fareLegRule.getMinDistance()).orElse(0),
+        optionalInt(fareLegRule.getMaxDistance()).orElse(Integer.MAX_VALUE)
       );
       case 1 -> throw new IllegalArgumentException("Distance type 1 is not supported");
       default -> null;
@@ -97,5 +98,13 @@ class FareLegRuleMapper {
     }
     var groupId = idFactory.createId(id, "fare leg rule's timeframe group id");
     return timeframeMapper.findTimeframes(groupId);
+  }
+
+  private static OptionalInt optionalInt(Double value) {
+    if (value == null) {
+      return OptionalInt.empty();
+    } else {
+      return OptionalInt.of(value.intValue());
+    }
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapper.java
@@ -6,18 +6,13 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Area;
-import org.opentripplanner.core.model.basic.Distance;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareDistance;
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.Timeframe;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class FareLegRuleMapper {
-
-  private static final Logger LOG = LoggerFactory.getLogger(FareLegRuleMapper.class);
 
   private final IdFactory idFactory;
   private final FareProductMapper fareProductMapper;
@@ -91,22 +86,7 @@ class FareLegRuleMapper {
         fareLegRule.getMinDistance().intValue(),
         fareLegRule.getMaxDistance().intValue()
       );
-      case 1 -> new FareDistance.LinearDistance(
-        Distance.ofMetersBoxed(fareLegRule.getMinDistance(), error ->
-          LOG.warn(
-            "Fare leg rule min distance not valid: {} - {}",
-            fareLegRule.getMinDistance(),
-            error
-          )
-        ).orElse(null),
-        Distance.ofMetersBoxed(fareLegRule.getMaxDistance(), error ->
-          LOG.warn(
-            "Fare leg rule max distance not valid: {} - {}",
-            fareLegRule.getMaxDistance(),
-            error
-          )
-        ).orElse(null)
-      );
+      case 1 -> throw new IllegalArgumentException("Distance type 1 is not supported");
       default -> null;
     };
   }

--- a/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLeg.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLeg.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.model.plan;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.NotImplementedException;
@@ -9,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.plan.leg.LegCallTime;
+import org.opentripplanner.model.plan.leg.StopArrival;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
@@ -27,6 +30,7 @@ public class TestTransitLeg implements TransitLeg {
   private final ZonedDateTime startTime;
   private final ZonedDateTime endTime;
   private final Trip trip;
+  private final List<StopLocation> intermediateStops;
 
   public TestTransitLeg(TestTransitLegBuilder builder) {
     this.from = builder.from;
@@ -34,6 +38,7 @@ public class TestTransitLeg implements TransitLeg {
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
     this.trip = builder.trip;
+    this.intermediateStops = builder.intermediateStops;
   }
 
   @Override
@@ -50,6 +55,22 @@ public class TestTransitLeg implements TransitLeg {
   @Override
   public Trip trip() {
     return trip;
+  }
+
+  @Override
+  public List<StopArrival> listIntermediateStops() {
+    // TODO: if required, allow manual setting of intermediate stop times
+    var stops = new ArrayList<StopArrival>(intermediateStops.size());
+    var totalDuration = Duration.between(startTime, endTime);
+    var n = intermediateStops.size() + 1;
+    for (int i = 0; i < intermediateStops.size(); i++) {
+      var fraction = Duration.ofMillis((totalDuration.toMillis() * (i + 1)) / n);
+      var time = LegCallTime.ofStatic(startTime.plus(fraction));
+      stops.add(
+        new StopArrival(Place.forStop(intermediateStops.get(i)), time, time, null, null, null)
+      );
+    }
+    return stops;
   }
 
   @Override

--- a/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLegBuilder.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLegBuilder.java
@@ -5,7 +5,9 @@ import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
@@ -37,6 +39,7 @@ public class TestTransitLegBuilder {
   Trip trip = Trip.of(id("t1")).withRoute(ROUTE).withServiceId(id("s1")).build();
   StopLocation from = new TestStopLocation(id("s1"));
   StopLocation to = new TestStopLocation(id("s2"));
+  List<StopLocation> intermediateStops = List.of();
 
   public TestTransitLegBuilder withStartTime(String startTime) {
     var time = LocalTime.parse(startTime);
@@ -75,6 +78,13 @@ public class TestTransitLegBuilder {
       .withGroupOfRoutes(List.of(GroupOfRoutes.of(id).build()))
       .build();
     return withRoute(route);
+  }
+
+  public TestTransitLegBuilder withIntermediateStops(FeedScopedId... stopIds) {
+    this.intermediateStops = Arrays.stream(stopIds)
+      .map(TestStopLocation::new)
+      .collect(Collectors.toUnmodifiableList());
+    return this;
   }
 
   public TestTransitLeg build() {

--- a/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLegBuilder.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLegBuilder.java
@@ -80,6 +80,10 @@ public class TestTransitLegBuilder {
     return withRoute(route);
   }
 
+  public TestTransitLegBuilder withNetwork(GroupOfRoutes network) {
+    return withNetwork(network.getId());
+  }
+
   public TestTransitLegBuilder withIntermediateStops(FeedScopedId... stopIds) {
     this.intermediateStops = Arrays.stream(stopIds)
       .map(TestStopLocation::new)

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
@@ -59,13 +59,13 @@ class FareLegRuleMapperTest {
     fp.setFareProductId(productId);
     var internalProduct = productMapper.map(fp);
 
-    final var obaRule = baseRule();
-    obaRule.setFareProductId(fp.getFareProductId());
-    obaRule.setDistanceType(tc.distanceType);
-    obaRule.setMinDistance(tc.minDistance);
-    obaRule.setMaxDistance(tc.maxDistance);
+    var rule = baseRule();
+    rule.setFareProductId(fp.getFareProductId());
+    rule.setDistanceType(tc.distanceType);
+    rule.setMinDistance(tc.minDistance);
+    rule.setMaxDistance(tc.maxDistance);
 
-    var mappedRules = List.copyOf(ruleMapper.map(List.of(obaRule)));
+    var mappedRules = List.copyOf(ruleMapper.map(List.of(rule)));
     assertEquals(1, mappedRules.size());
 
     var otpRule = mappedRules.get(0);

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
@@ -35,6 +35,8 @@ class FareLegRuleMapperTest {
   private static List<TestCase> testCases() {
     return List.of(
       new TestCase(0, 1d, 10d, new Stops(1, 10)),
+      new TestCase(0, null, 8d, new Stops(0, 8)),
+      new TestCase(0, 2d, null, new Stops(2, Integer.MAX_VALUE)),
       new TestCase(null, null, null, null)
     );
   }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/FareLegRuleMapperTest.java
@@ -8,11 +8,15 @@ import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.FareLegRule;
 import org.onebusaway.gtfs.model.FareMedium;
 import org.onebusaway.gtfs.model.FareProduct;
 import org.onebusaway.gtfs.model.Timeframe;
+import org.opentripplanner.ext.fares.model.FareDistance;
+import org.opentripplanner.ext.fares.model.FareDistance.Stops;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
@@ -20,6 +24,52 @@ import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueSto
 class FareLegRuleMapperTest {
 
   public static final IdFactory ID_FACTORY = new IdFactory("A");
+
+  private record TestCase(
+    Integer distanceType,
+    Double minDistance,
+    Double maxDistance,
+    FareDistance expectedDistance
+  ) {}
+
+  private static List<TestCase> testCases() {
+    return List.of(
+      new TestCase(0, 1d, 10d, new Stops(1, 10)),
+      new TestCase(null, null, null, null)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void mapDistance(TestCase tc) {
+    var productMapper = new FareProductMapper(ID_FACTORY);
+    var ruleMapper = new FareLegRuleMapper(
+      ID_FACTORY,
+      productMapper,
+      timeframeMapper(),
+      DataImportIssueStore.NOOP
+    );
+    var productId = new AgencyAndId("1", "1");
+    var fp = new FareProduct();
+    fp.setAmount(10);
+    fp.setName("Day pass");
+    fp.setCurrency("EUR");
+    fp.setFareProductId(productId);
+    var internalProduct = productMapper.map(fp);
+
+    final var obaRule = baseRule();
+    obaRule.setFareProductId(fp.getFareProductId());
+    obaRule.setDistanceType(tc.distanceType);
+    obaRule.setMinDistance(tc.minDistance);
+    obaRule.setMaxDistance(tc.maxDistance);
+
+    var mappedRules = List.copyOf(ruleMapper.map(List.of(obaRule)));
+    assertEquals(1, mappedRules.size());
+
+    var otpRule = mappedRules.get(0);
+    assertEquals(otpRule.fareDistance(), tc.expectedDistance);
+    assertThat(otpRule.fareProducts()).containsExactly(internalProduct);
+  }
 
   @Test
   void multipleProducts() {

--- a/doc/user/sandbox/Fares.md
+++ b/doc/user/sandbox/Fares.md
@@ -57,10 +57,8 @@ The classes and their maintainers are as follows:
 | HSLFareServiceImpl                         | HSL ([Viljami Nurminen](mailto:viljami.nurminen@cgi.com))  |
 | OrcaFareService                            | IBI Group ([Daniel Heppner](mailto:daniel.heppner@ibigroup.com))|
 
-For more complex scenarios or to handle vehicle rental fares, it is necessary to manually configure 
-fares using the `fares` section in `build-config.json`. You can combine different fares (for example 
-transit and vehicle-rental) by defining a `combinationStrategy` parameter, and a list of sub-fares 
-to combine (all fields starting with `fare` are considered to be sub-fares).
+For more complex scenarios, it is necessary to manually configure fares using the `fares` section 
+in `build-config.json`. 
 
 ```JSON
 // build-config.json

--- a/doc/user/sandbox/Fares.md
+++ b/doc/user/sandbox/Fares.md
@@ -9,17 +9,28 @@
 The code in this sandbox used to be part of OTP core but to allow more experimentation - in 
 particular regarding GTFS Fares V2 - it was moved into a sandbox.
 
-## Fares V2
+## Fares configuration
 
-In 2022 the GTFS spec was extended to contain a powerful new model, called Fares V2, to describe fares, prices and
-products for public transport tickets. A baseline effort was [merged into the main
-spec](https://github.com/google/transit/pull/286) in May.
+By default OTP will compute no fares.
+
+If you want to compute fares according to the GTFS Fares v1 or v2 specification, you need to set the
+`fares` config to `gtfs`.
+
+```JSON
+// build-config.json
+{
+  "fares": "gtfs"
+}
+```
+
+## Fares V2
 
 OTP experimentally supports the merged baseline plus a few extensions from the [larger, unmerged spec](http://bit.ly/gtfs-fares).
 
 To enable Fares V2 support, add the following to `otp-config.json`:
 
 ```json
+// otp-config.json
 {
   "otpFeatures" : {
     "FaresV2" : true
@@ -46,16 +57,10 @@ The classes and their maintainers are as follows:
 | HSLFareServiceImpl                         | HSL ([Viljami Nurminen](mailto:viljami.nurminen@cgi.com))  |
 | OrcaFareService                            | IBI Group ([Daniel Heppner](mailto:daniel.heppner@ibigroup.com))|
 
-
-
-## Fares configuration
-
-By default OTP will compute fares according to the GTFS specification if fare data is provided in
-your GTFS input. It is possible to turn off this by setting the fare to "off". For more complex
-scenarios or to handle vehicle rental fares, it is necessary to manually configure fares using the
-`fares` section in `build-config.json`. You can combine different fares (for example transit and
-vehicle-rental) by defining a `combinationStrategy` parameter, and a list of sub-fares to combine
-(all fields starting with `fare` are considered to be sub-fares).
+For more complex scenarios or to handle vehicle rental fares, it is necessary to manually configure 
+fares using the `fares` section in `build-config.json`. You can combine different fares (for example 
+transit and vehicle-rental) by defining a `combinationStrategy` parameter, and a list of sub-fares 
+to combine (all fields starting with `fare` are considered to be sub-fares).
 
 ```JSON
 // build-config.json


### PR DESCRIPTION
### Summary

Re-introduces and refines the stop count-based fare rules.

This allows you to define far rules like "this rule only applies to legs hat have 3 or fewer stops", which are are common in Germany.

### Spec conformance

This feature is still being drafted and there are competing proposals. I chose to implement the simplest one, but this may not end up in the final spec: https://docs.google.com/document/d/19j-f-wZ5C_kYXmkLBye1g42U-kvfSVgYLkkG5oyBauY/edit?tab=t.0

**If you use this feature, you must stay flexible as the spec process is not complete yet.**

### Unit tests

Lots added and refactored.

