### PR TITLE
Walk to and from carpooling trips

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
@@ -52,7 +52,6 @@ class CarpoolAccessEgressTest {
     double expectedWeight =
       walkToPickup.getWeight() + walkFromDropoff.getWeight() + rideSeconds * carpoolReluctance;
     assertEquals(RaptorCostConverter.toRaptorCost(expectedWeight), accessEgress.c1());
-    assertEquals(expectedWeight, accessEgress.getTotalWeight());
   }
 
   /** With no walk, the cost reduces to {@code (sharedSegmentSeconds + dwell) * carpoolReluctance}. */

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
@@ -1,0 +1,139 @@
+package org.opentripplanner.ext.carpooling.routing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPath;
+import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
+import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
+import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createSimpleTrip;
+
+import java.time.Duration;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.core.model.basic.Cost;
+import org.opentripplanner.framework.model.TimeAndCost;
+import org.opentripplanner.raptor.spi.RaptorCostConverter;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.state.State;
+
+class CarpoolAccessEgressTest {
+
+  private static final int STOP = 0;
+  private static final Duration STOP_DURATION = Duration.ofMinutes(2);
+  private static final int DWELL_SECONDS = (int) STOP_DURATION.getSeconds();
+  private static final int PICKUP_POSITION = 1;
+  private static final int DROPOFF_POSITION = 2;
+  private static final Duration PICKUP_SEGMENT_DURATION = Duration.ofMinutes(1);
+
+  /**
+   * Walk time must be billed at the walk path's own A* weight (which already encodes walk
+   * reluctance, safety, slope, ...) and the carpool ride at {@code carpoolReluctance}. The ride
+   * includes the boarding dwell at the pickup stop.
+   */
+  @Test
+  void c1AddsWalkPathWeightsAndChargesRideAtCarpoolReluctance() {
+    var walkToPickup = createGraphPath(Duration.ofSeconds(80));
+    var walkFromDropoff = createGraphPath(Duration.ofSeconds(40));
+    double carpoolReluctance = 1.0;
+
+    var accessEgress = newAccessEgress(
+      1_000,
+      walkToPickup,
+      Duration.ofSeconds(60),
+      walkFromDropoff,
+      carpoolReluctance
+    );
+
+    int rideSeconds = 60 + DWELL_SECONDS;
+    double expectedWeight =
+      walkToPickup.getWeight() + walkFromDropoff.getWeight() + rideSeconds * carpoolReluctance;
+    assertEquals(RaptorCostConverter.toRaptorCost(expectedWeight), accessEgress.c1());
+    assertEquals(expectedWeight, accessEgress.getTotalWeight());
+  }
+
+  /** With no walk, the cost reduces to {@code (sharedSegmentSeconds + dwell) * carpoolReluctance}. */
+  @Test
+  void c1WithoutWalkUsesOnlyCarpoolReluctance() {
+    var accessEgress = newAccessEgress(0, null, Duration.ofSeconds(300), null, 1.5);
+
+    int rideSeconds = 300 + DWELL_SECONDS;
+    assertEquals(RaptorCostConverter.toRaptorCost(rideSeconds * 1.5), accessEgress.c1());
+  }
+
+  @Test
+  void durationInSecondsCoversWalksAndRide() {
+    var accessEgress = newAccessEgress(
+      1_000,
+      createGraphPath(Duration.ofSeconds(80)),
+      Duration.ofSeconds(60),
+      createGraphPath(Duration.ofSeconds(40)),
+      1.0
+    );
+
+    int expectedDuration = 80 + 60 + DWELL_SECONDS + 40;
+    assertEquals(expectedDuration, accessEgress.durationInSeconds());
+    assertEquals(1_000, accessEgress.getPassengerDepartureTime());
+    assertEquals(1_000 + expectedDuration, accessEgress.getPassengerArrivalTime());
+  }
+
+  /**
+   * {@code withPenalty} installs the new penalty and preserves everything else. The leg's intrinsic
+   * c1 and duration are computed from walks + ride only — Raptor adds the penalty separately — so
+   * they must stay unchanged across the copy.
+   */
+  @Test
+  void withPenaltyInstallsPenaltyAndPreservesLeg() {
+    var original = newAccessEgress(
+      1_000,
+      createGraphPath(Duration.ofSeconds(80)),
+      Duration.ofSeconds(60),
+      createGraphPath(Duration.ofSeconds(40)),
+      1.0
+    );
+    var newPenalty = new TimeAndCost(Duration.ofSeconds(30), Cost.costOfSeconds(45));
+
+    var withPenalty = (CarpoolAccessEgress) original.withPenalty(newPenalty);
+
+    assertEquals(newPenalty, withPenalty.penalty());
+    assertEquals(original.stop(), withPenalty.stop());
+    assertEquals(original.c1(), withPenalty.c1());
+    assertEquals(original.durationInSeconds(), withPenalty.durationInSeconds());
+    assertEquals(original.getPassengerDepartureTime(), withPenalty.getPassengerDepartureTime());
+    assertEquals(original.getPassengerArrivalTime(), withPenalty.getPassengerArrivalTime());
+  }
+
+  /**
+   * Builds a CarpoolAccessEgress with the passenger picked up mid-trip (pickupPos = 1, dropoffPos
+   * = 2). The route segments list is therefore [pickupSegment, sharedSegment]: the driver runs
+   * the first to reach the passenger and the second is the passenger's shared ride. The
+   * passenger's ride duration is {@code sharedSegmentDuration + STOP_DURATION} — the boarding
+   * dwell at the pickup stop is part of the ride.
+   */
+  private static CarpoolAccessEgress newAccessEgress(
+    int passengerDepartureTime,
+    @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+    Duration sharedSegmentDuration,
+    @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff,
+    double carpoolReluctance
+  ) {
+    var candidate = new InsertionCandidate(
+      createSimpleTrip(OSLO_CENTER, OSLO_NORTH),
+      PICKUP_POSITION,
+      DROPOFF_POSITION,
+      List.of(createGraphPath(PICKUP_SEGMENT_DURATION), createGraphPath(sharedSegmentDuration)),
+      STOP_DURATION,
+      null,
+      walkToPickup,
+      walkFromDropoff
+    );
+    return new CarpoolAccessEgress(
+      STOP,
+      passengerDepartureTime,
+      candidate,
+      TimeAndCost.ZERO,
+      carpoolReluctance
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.carpooling.routing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPath;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.core.model.basic.Cost;
 import org.opentripplanner.framework.model.TimeAndCost;
+import org.opentripplanner.raptor.spi.RaptorConstants;
 import org.opentripplanner.raptor.spi.RaptorCostConverter;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -79,12 +81,15 @@ class CarpoolAccessEgressTest {
   }
 
   /**
-   * {@code withPenalty} installs the new penalty and preserves everything else. The leg's intrinsic
-   * c1 and duration are computed from walks + ride only — Raptor adds the penalty separately — so
-   * they must stay unchanged across the copy.
+   * {@code withPenalty} installs the new penalty and preserves the leg's stop and time anchors.
+   * Mirroring {@code DefaultAccessEgress}, the penalty's cost is folded into {@link
+   * CarpoolAccessEgress#c1()} (Raptor itself does not propagate the time-penalty into c1) and the
+   * penalty's time is exposed via {@link CarpoolAccessEgress#timePenalty()}. The wall-clock
+   * {@code durationInSeconds} is unchanged because the time-penalty is virtual time inside Raptor,
+   * not part of the leg's actual duration.
    */
   @Test
-  void withPenaltyInstallsPenaltyAndPreservesLeg() {
+  void withPenaltyFoldsCostIntoC1AndExposesTimePenalty() {
     var original = newAccessEgress(
       1_000,
       createGraphPath(Duration.ofSeconds(80)),
@@ -98,10 +103,39 @@ class CarpoolAccessEgressTest {
 
     assertEquals(newPenalty, withPenalty.penalty());
     assertEquals(original.stop(), withPenalty.stop());
-    assertEquals(original.c1(), withPenalty.c1());
+    assertEquals(original.c1() + newPenalty.cost().toCentiSeconds(), withPenalty.c1());
+    assertEquals((int) newPenalty.time().toSeconds(), withPenalty.timePenalty());
     assertEquals(original.durationInSeconds(), withPenalty.durationInSeconds());
     assertEquals(original.getPassengerDepartureTime(), withPenalty.getPassengerDepartureTime());
     assertEquals(original.getPassengerArrivalTime(), withPenalty.getPassengerArrivalTime());
+  }
+
+  /** Without a penalty, {@code timePenalty()} returns the Raptor sentinel {@code TIME_NOT_SET}. */
+  @Test
+  void timePenaltyDefaultsToTimeNotSet() {
+    var subject = newAccessEgress(0, null, Duration.ofSeconds(300), null, 1.0);
+
+    assertEquals(RaptorConstants.TIME_NOT_SET, subject.timePenalty());
+  }
+
+  /**
+   * {@code withPenalty} is a one-shot decoration. Calling it on a leg that already has a non-zero
+   * penalty would otherwise re-fold a cost into {@code c1} and silently discard the previous
+   * penalty, so the second application throws — matching {@code DefaultAccessEgress}.
+   */
+  @Test
+  void canNotAddPenaltyTwice() {
+    var subject = newAccessEgress(
+      1_000,
+      createGraphPath(Duration.ofSeconds(80)),
+      Duration.ofSeconds(60),
+      createGraphPath(Duration.ofSeconds(40)),
+      1.0
+    );
+    var penalty = new TimeAndCost(Duration.ofSeconds(30), Cost.costOfSeconds(45));
+    var withPenalty = subject.withPenalty(penalty);
+
+    assertThrows(IllegalStateException.class, () -> withPenalty.withPenalty(penalty));
   }
 
   /**

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidateTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidateTest.java
@@ -11,7 +11,6 @@ import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createSimpl
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
 
 class InsertionCandidateTest {
 
@@ -32,6 +31,8 @@ class InsertionCandidateTest {
       2,
       List.of(originToPickup, pickupToDropoff, dropoffToDestination),
       STOP_DURATION,
+      null,
+      null,
       null
     );
 
@@ -44,7 +45,7 @@ class InsertionCandidateTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(5);
 
-    var candidate = new InsertionCandidate(trip, 2, 4, segments, STOP_DURATION, null);
+    var candidate = new InsertionCandidate(trip, 2, 4, segments, STOP_DURATION, null, null, null);
 
     var pickupSegments = candidate.getPickupSegments();
     assertEquals(2, pickupSegments.size());
@@ -56,7 +57,7 @@ class InsertionCandidateTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(3);
 
-    var candidate = new InsertionCandidate(trip, 0, 2, segments, STOP_DURATION, null);
+    var candidate = new InsertionCandidate(trip, 0, 2, segments, STOP_DURATION, null, null, null);
 
     var pickupSegments = candidate.getPickupSegments();
     assertTrue(pickupSegments.isEmpty());
@@ -67,7 +68,7 @@ class InsertionCandidateTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(5);
 
-    var candidate = new InsertionCandidate(trip, 1, 3, segments, STOP_DURATION, null);
+    var candidate = new InsertionCandidate(trip, 1, 3, segments, STOP_DURATION, null, null, null);
 
     var sharedSegments = candidate.getSharedSegments();
     assertEquals(2, sharedSegments.size());
@@ -79,7 +80,7 @@ class InsertionCandidateTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(3);
 
-    var candidate = new InsertionCandidate(trip, 1, 2, segments, STOP_DURATION, null);
+    var candidate = new InsertionCandidate(trip, 1, 2, segments, STOP_DURATION, null, null, null);
 
     var sharedSegments = candidate.getSharedSegments();
     assertEquals(1, sharedSegments.size());
@@ -90,7 +91,7 @@ class InsertionCandidateTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(5);
 
-    var candidate = new InsertionCandidate(trip, 1, 3, segments, STOP_DURATION, null);
+    var candidate = new InsertionCandidate(trip, 1, 3, segments, STOP_DURATION, null, null, null);
 
     var dropoffSegments = candidate.getDropoffSegments();
     assertEquals(2, dropoffSegments.size());
@@ -102,7 +103,7 @@ class InsertionCandidateTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(3);
 
-    var candidate = new InsertionCandidate(trip, 1, 3, segments, STOP_DURATION, null);
+    var candidate = new InsertionCandidate(trip, 1, 3, segments, STOP_DURATION, null, null, null);
 
     var dropoffSegments = candidate.getDropoffSegments();
     assertTrue(dropoffSegments.isEmpty());
@@ -113,31 +114,13 @@ class InsertionCandidateTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(3);
 
-    var candidate = new InsertionCandidate(trip, 1, 2, segments, STOP_DURATION, null);
+    var candidate = new InsertionCandidate(trip, 1, 2, segments, STOP_DURATION, null, null, null);
 
     var str = candidate.toString();
     assertTrue(str.contains("pickup@1"));
     assertTrue(str.contains("dropoff@2"));
     assertTrue(str.contains("duration="));
     assertTrue(str.contains("segments=3"));
-  }
-
-  /**
-   * No pickup segments → durationUntilPickup is zero and no boarding dwell is added to the ride.
-   * Single shared segment → passengerRideDuration is just the segment duration.
-   */
-  @Test
-  void durations_noPickupSegments_singleSharedSegment() {
-    var stopDuration = Duration.ofMinutes(2);
-    var sharedPath = createGraphPath(Duration.ofMinutes(10));
-    var sharedDuration = GraphPathUtils.calculateDuration(sharedPath);
-
-    var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
-    var candidate = new InsertionCandidate(trip, 0, 1, List.of(sharedPath), stopDuration, null);
-
-    assertEquals(Duration.ofMinutes(10), sharedDuration);
-    assertEquals(Duration.ZERO, candidate.getDurationUntilPickupArrival());
-    assertEquals(sharedDuration, candidate.getPassengerRideDuration());
   }
 
   /**
@@ -150,8 +133,8 @@ class InsertionCandidateTest {
     var pickupPath = createGraphPath(Duration.ofMinutes(8));
     var sharedPath = createGraphPath(Duration.ofMinutes(15));
 
-    var pickupDuration = GraphPathUtils.calculateDuration(pickupPath);
-    var sharedDuration = GraphPathUtils.calculateDuration(sharedPath);
+    var pickupDuration = Duration.ofSeconds(pickupPath.getDuration());
+    var sharedDuration = Duration.ofSeconds(sharedPath.getDuration());
 
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var candidate = new InsertionCandidate(
@@ -160,6 +143,8 @@ class InsertionCandidateTest {
       2,
       List.of(pickupPath, sharedPath),
       stopDuration,
+      null,
+      null,
       null
     );
 
@@ -179,10 +164,10 @@ class InsertionCandidateTest {
     var shared0 = createGraphPath(Duration.ofMinutes(10));
     var shared1 = createGraphPath(Duration.ofMinutes(12));
 
-    var pickup0Duration = GraphPathUtils.calculateDuration(pickup0);
-    var pickup1Duration = GraphPathUtils.calculateDuration(pickup1);
-    var shared0Duration = GraphPathUtils.calculateDuration(shared0);
-    var shared1Duration = GraphPathUtils.calculateDuration(shared1);
+    var pickup0Duration = Duration.ofSeconds(pickup0.getDuration());
+    var pickup1Duration = Duration.ofSeconds(pickup1.getDuration());
+    var shared0Duration = Duration.ofSeconds(shared0.getDuration());
+    var shared1Duration = Duration.ofSeconds(shared1.getDuration());
 
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var candidate = new InsertionCandidate(
@@ -191,6 +176,8 @@ class InsertionCandidateTest {
       4,
       List.of(pickup0, pickup1, shared0, shared1),
       stopDuration,
+      null,
+      null,
       null
     );
 
@@ -208,6 +195,7 @@ class InsertionCandidateTest {
    */
   @Test
   void durations_scaleWithStopDuration() {
+    var pickup = createGraphPath(Duration.ofMinutes(5));
     var shared0 = createGraphPath(Duration.ofMinutes(10));
     var shared1 = createGraphPath(Duration.ofMinutes(10));
 
@@ -215,26 +203,30 @@ class InsertionCandidateTest {
 
     var candidateSmall = new InsertionCandidate(
       trip,
-      0,
-      2,
-      List.of(shared0, shared1),
+      1,
+      3,
+      List.of(pickup, shared0, shared1),
       Duration.ofMinutes(1),
+      null,
+      null,
       null
     );
     var candidateLarge = new InsertionCandidate(
       trip,
-      0,
-      2,
-      List.of(shared0, shared1),
+      1,
+      3,
+      List.of(pickup, shared0, shared1),
       Duration.ofMinutes(5),
+      null,
+      null,
       null
     );
 
-    // Pickup at origin (no pickup segments) → no boarding dwell, so only the 1 intermediate
-    // stop between the 2 shared segments scales: 1x stopDuration difference.
+    // Boarding dwell + 1 intermediate stop between the 2 shared segments scales: 2x stopDuration
+    // difference.
     var difference = candidateLarge
       .getPassengerRideDuration()
       .minus(candidateSmall.getPassengerRideDuration());
-    assertEquals(Duration.ofMinutes(4), difference);
+    assertEquals(Duration.ofMinutes(8), difference);
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidateTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidateTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.carpooling.routing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPath;
 import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPaths;
@@ -52,15 +53,31 @@ class InsertionCandidateTest {
     assertEquals(segments.subList(0, 2), pickupSegments);
   }
 
+  /**
+   * Pickup at position 0 would mean boarding at the driver's origin, which {@code
+   * InsertionPositionFinder} never produces (its loop starts at 1). The constructor enforces this
+   * because {@link InsertionCandidate#getPassengerRideDuration} unconditionally adds the boarding
+   * dwell, which only makes sense when the passenger boards mid-trip.
+   */
   @Test
-  void getPickupSegments_positionZero_returnsEmpty() {
+  void constructor_pickupAtOrigin_throws() {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
     var segments = createGraphPaths(3);
 
-    var candidate = new InsertionCandidate(trip, 0, 2, segments, STOP_DURATION, null, null, null);
+    assertThrows(IllegalArgumentException.class, () ->
+      new InsertionCandidate(trip, 0, 2, segments, STOP_DURATION, null, null, null)
+    );
+  }
 
-    var pickupSegments = candidate.getPickupSegments();
-    assertTrue(pickupSegments.isEmpty());
+  /** Dropoff must be strictly after pickup; equal positions would yield an empty shared ride. */
+  @Test
+  void constructor_dropoffNotAfterPickup_throws() {
+    var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
+    var segments = createGraphPaths(3);
+
+    assertThrows(IllegalArgumentException.class, () ->
+      new InsertionCandidate(trip, 2, 2, segments, STOP_DURATION, null, null, null)
+    );
   }
 
   @Test

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
@@ -23,15 +23,11 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
-import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
-import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.routing.linking.LinkingContext;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.SimpleVertex;
@@ -42,8 +38,6 @@ import org.opentripplanner.utils.collection.Pair;
 class InsertionEvaluatorTest {
 
   private InsertionPositionFinder positionFinder;
-  private LinkingContext linkingContext;
-  private StreetVertexUtils streetVertexUtils;
   private Map<WgsCoordinate, Vertex> vertexMap;
 
   @BeforeEach
@@ -51,7 +45,6 @@ class InsertionEvaluatorTest {
     positionFinder = new InsertionPositionFinder(new BeelineEstimator());
 
     vertexMap = new HashMap<>();
-    Map<GenericLocation, Set<Vertex>> locationVertices = new HashMap<>();
 
     for (WgsCoordinate coord : List.of(
       OSLO_CENTER,
@@ -70,14 +63,7 @@ class InsertionEvaluatorTest {
         coord.longitude()
       );
       vertexMap.put(coord, vertex);
-      locationVertices.put(
-        GenericLocation.fromCoordinate(coord.latitude(), coord.longitude()),
-        Set.of(vertex)
-      );
     }
-
-    linkingContext = new LinkingContext(locationVertices, Set.of(), Set.of());
-    streetVertexUtils = new StreetVertexUtils(null, null);
   }
 
   private CarpoolTripWithVertices createTripWithVertices(CarpoolTrip trip) {
@@ -115,17 +101,11 @@ class InsertionEvaluatorTest {
       return null;
     }
 
-    var evaluator = new InsertionEvaluator(
-      linkingContext,
-      streetVertexUtils,
-      carpoolRouter,
-      Duration.ZERO
-    );
+    var evaluator = new InsertionEvaluator(carpoolRouter, Duration.ZERO);
     return evaluator.findBestInsertion(
       tripWithVertices,
       viablePositions,
-      passengerPickup,
-      passengerDropoff
+      new PassengerSnap(vertexMap.get(passengerPickup), vertexMap.get(passengerDropoff), null, null)
     );
   }
 
@@ -315,17 +295,11 @@ class InsertionEvaluatorTest {
 
     var viablePositions = List.of(new InsertionPosition(1, 2), new InsertionPosition(2, 3));
 
-    var evaluator = new InsertionEvaluator(
-      linkingContext,
-      streetVertexUtils,
-      routingFunction,
-      Duration.ZERO
-    );
+    var evaluator = new InsertionEvaluator(routingFunction, Duration.ZERO);
     var result = evaluator.findBestInsertion(
       tripWithVertices,
       viablePositions,
-      OSLO_EAST,
-      OSLO_WEST
+      new PassengerSnap(vertexMap.get(OSLO_EAST), vertexMap.get(OSLO_WEST), null, null)
     );
 
     assertNotNull(result);

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
@@ -3,13 +3,13 @@ package org.opentripplanner.ext.carpooling.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,15 +27,15 @@ import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessE
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.routing.graphfinder.TransitServiceResolver;
-import org.opentripplanner.routing.linking.LinkingContext;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
-import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitService;
@@ -49,18 +49,22 @@ import org.opentripplanner.transit.service.TransitService;
  * <p>
  * Graph layout (going east):
  * <pre>
- *                     T1     P2      T3
- *                    / \     / \     / \
+ *                     T1     P2      T3       T5 (walk-only spur)
+ *                    / \     / \     / \      :
+ *                    |   |   |   |   |   |    : (PEDESTRIAN only)
  *   P1 ---------- A ----- B ----- C ----- D ---------- P3
  *                    \ /             \ /
  *                    T2              T4
  *
  *   Carpool trip: A -> (B -> C) -> D  (2 or 4 stops)
- *   Transit stops: T1..T4
+ *   Transit stops: T1..T4 connected to the drivable network with all-permission streets;
+ *                  T5 connected to D via a pedestrian-only edge — its link endpoint is
+ *                  reachable from the road network only by walking the final stretch.
  *     T1 = north of A-B midpoint (connected to A and B)
  *     T2 = south of A-B midpoint (connected to A and B)
  *     T3 = north of C-D midpoint (connected to C and D)
  *     T4 = south of C-D midpoint (connected to C and D)
+ *     T5 = north of D, reachable from D only via a walk-only spur
  *   Passenger locations:
  *     P1 = 50km west of A (connected to A)
  *     P2 = between B and C, north (connected to B and C)
@@ -80,12 +84,12 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
   private DefaultCarpoolingService service;
   private CarpoolingRepository repository;
   private TransitServiceResolver transitServiceResolver;
-  private LinkingContext linkingContext;
 
   private TransitStopVertex stopT1;
   private TransitStopVertex stopT2;
   private TransitStopVertex stopT3;
   private TransitStopVertex stopT4;
+  private TransitStopVertex stopT5;
 
   // Carpool trip waypoints
   private WgsCoordinate coordA;
@@ -147,6 +151,21 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
           biLink(iT3, stopT3);
           biLink(iT4, stopT4);
 
+          // T5 sits on a pedestrian-only spur off the drivable network: a car can drive
+          // to D but cannot continue to iT5, so a pure CAR nearby-stop search misses it.
+          // CAR_PICKUP, which models walk -> drive -> walk, can drive to D and walk the
+          // final stretch to reach stopT5.
+          var iT5 = intersection("iT5", ORIGIN.moveEastMeters(2000).moveNorthMeters(200));
+          street(
+            D,
+            iT5,
+            200,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          stopT5 = stop("T5", iT5.toWgsCoordinate());
+          biLink(iT5, stopT5);
+
           // Passenger locations
           var iP1 = intersection("P1", ORIGIN.moveWestMeters(50000));
           biStreet(iP1, A, 50000);
@@ -177,26 +196,10 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
     Graph graph = model.graph();
     var timetableRepository = model.timetableRepository();
     VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
+    var vertexCreationService = new VertexCreationService(vertexLinker);
     TransitService transitService = new DefaultTransitService(timetableRepository);
     transitServiceResolver = new TransitServiceResolver(transitService);
     repository = new DefaultCarpoolingRepository();
-
-    // LinkingContext: P1 -> {iP1}, P2 -> {iP2}, P3 -> {iP3}
-    var p1Location = GenericLocation.fromCoordinate(coordP1.latitude(), coordP1.longitude());
-    var p2Location = GenericLocation.fromCoordinate(coordP2.latitude(), coordP2.longitude());
-    var p3Location = GenericLocation.fromCoordinate(coordP3.latitude(), coordP3.longitude());
-    linkingContext = new LinkingContext(
-      Map.of(
-        p1Location,
-        Set.<Vertex>of(vertexP1),
-        p2Location,
-        Set.<Vertex>of(vertexP2),
-        p3Location,
-        Set.<Vertex>of(vertexP3)
-      ),
-      Collections.emptySet(),
-      Collections.emptySet()
-    );
 
     StreetLimitationParametersService streetLimitationParams =
       new StreetLimitationParametersService() {
@@ -215,7 +218,7 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       repository,
       streetLimitationParams,
       transitService,
-      vertexLinker
+      vertexCreationService
     );
   }
 
@@ -256,7 +259,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.WALK),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -276,7 +278,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.WALK),
       AccessEgressType.EGRESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -292,7 +293,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -312,7 +312,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -333,7 +332,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -343,8 +341,8 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       assertTrue(accessEgress.durationInSeconds() > 0, "Duration should be positive");
       assertTrue(accessEgress.hasOpeningHours(), "Carpool access should have opening hours");
       assertFalse(accessEgress.isWalkOnly(), "Carpool access should not be walk-only");
-      assertNotNull(accessEgress.getSegments(), "Segments should not be null");
-      assertFalse(accessEgress.getSegments().isEmpty(), "Segments should not be empty");
+      assertNotNull(accessEgress.sharedSegments(), "Shared segments should not be null");
+      assertFalse(accessEgress.sharedSegments().isEmpty(), "Shared segments should not be empty");
     }
 
     int stopT3Index = transitServiceResolver.getStop(stopT3.getId()).getIndex();
@@ -373,7 +371,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.EGRESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -381,7 +378,7 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
 
     for (CarpoolAccessEgress accessEgress : results) {
       assertTrue(accessEgress.durationInSeconds() > 0, "Duration should be positive");
-      assertNotNull(accessEgress.getSegments(), "Segments should not be null");
+      assertNotNull(accessEgress.sharedSegments(), "Shared segments should not be null");
     }
 
     int stopT1Index = transitServiceResolver.getStop(stopT1.getId()).getIndex();
@@ -410,15 +407,14 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       transitSearchTimeZero
     );
 
     assertFalse(results.isEmpty(), "Should find access results for a compatible trip");
 
     for (CarpoolAccessEgress accessEgress : results) {
-      int departure = accessEgress.getDepartureTimeOfPassenger();
-      int arrival = accessEgress.getArrivalTimeOfPassenger();
+      int departure = accessEgress.getPassengerDepartureTime();
+      int arrival = accessEgress.getPassengerArrivalTime();
 
       assertTrue(
         departure >= 0,
@@ -465,7 +461,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -520,7 +515,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
@@ -551,12 +545,11 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       SEARCH_TIME
     );
 
     for (CarpoolAccessEgress accessEgress : results) {
-      int depTime = accessEgress.getDepartureTimeOfPassenger();
+      int depTime = accessEgress.getPassengerDepartureTime();
 
       int earliest = accessEgress.earliestDepartureTime(0);
       assertEquals(depTime, earliest, "Earliest departure should be the carpool departure time");
@@ -577,6 +570,104 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
     assertTrue(
       results.stream().anyMatch(r -> r.stop() == stopT4Index),
       "At least one access result should include stopT4"
+    );
+  }
+
+  /**
+   * Regression test: {@code routeAccessEgress} must call {@code findNearbyStops} with
+   * {@link StreetMode#CAR_PICKUP}, not {@link StreetMode#CAR}. CAR_PICKUP allows the search
+   * to leave the drivable network and walk the last stretch to a transit stop whose link
+   * endpoint is reachable only via a pedestrian-only edge (e.g. a pedestrian-plaza stop).
+   * <p>
+   * In this graph stopT5 is exactly such a stop: a walk-only spur off D. A pure CAR search
+   * would never reach it, so it would not appear in any access result. If the implementation
+   * regresses to using CAR here, this assertion will fail.
+   */
+  @Test
+  void accessFindsTransitStopReachableOnlyViaWalkOnlySpurFromDrivableNetwork() {
+    var departureTime = SEARCH_TIME.plusMinutes(30);
+    var trip = CarpoolTripTestData.createSimpleTripWithTime(coordA, coordD, departureTime);
+    repository.upsertCarpoolTrip(trip);
+
+    var request = buildCarpoolRequest(coordP2, coordP3, SEARCH_TIME);
+
+    var results = service.routeAccessEgress(
+      request,
+      new StreetRequest(StreetMode.CARPOOL),
+      AccessEgressType.ACCESS,
+      transitServiceResolver,
+      SEARCH_TIME
+    );
+
+    int stopT5Index = transitServiceResolver.getStop(stopT5.getId()).getIndex();
+    var stopT5Result = results
+      .stream()
+      .filter(r -> r.stop() == stopT5Index)
+      .findFirst()
+      .orElse(null);
+    assertNotNull(
+      stopT5Result,
+      "Access results should include stopT5, which is only reachable from the drivable " +
+        "network by walking. If routeAccessEgress called findNearbyStops with " +
+        "StreetMode.CAR instead of CAR_PICKUP the search could not leave the car network " +
+        "to walk the pedestrian-only spur to stopT5, and the stop would be missing here."
+    );
+
+    // The carpool drops the passenger at D (the only drivable vertex incident to the spur)
+    // and the passenger must walk D -> iT5 -> stopT5. The result must therefore carry a
+    // non-empty walk-from-dropoff segment.
+    var walkFromDropoff = stopT5Result.walkFromDropoff();
+    assertNotNull(
+      walkFromDropoff,
+      "stopT5 access result must include a walk-from-dropoff segment, since the carpool " +
+        "cannot drive past D and the passenger has to walk the pedestrian-only spur to T5"
+    );
+    assertTrue(
+      walkFromDropoff.getDuration() > 0,
+      "Walk from dropoff to stopT5 should have positive duration"
+    );
+  }
+
+  /**
+   * Counterpart to the walk-only-spur test: when both the passenger and the transit stop sit on
+   * the drivable network, the carpool can pick up at the passenger's location and drop off at
+   * the stop's link vertex without any walking. Both {@code walkToPickup} and
+   * {@code walkFromDropoff} must therefore be {@code null} (rather than zero-duration
+   * placeholders) so the itinerary mapper can tell the walking and no-walking cases apart.
+   */
+  @Test
+  void accessResultForStopOnDrivableNetworkHasNullWalkSegments() {
+    var departureTime = SEARCH_TIME.plusMinutes(30);
+    var trip = CarpoolTripTestData.createSimpleTripWithTime(coordA, coordD, departureTime);
+    repository.upsertCarpoolTrip(trip);
+
+    var request = buildCarpoolRequest(coordP2, coordP3, SEARCH_TIME);
+
+    var results = service.routeAccessEgress(
+      request,
+      new StreetRequest(StreetMode.CARPOOL),
+      AccessEgressType.ACCESS,
+      transitServiceResolver,
+      SEARCH_TIME
+    );
+
+    int stopT3Index = transitServiceResolver.getStop(stopT3.getId()).getIndex();
+    var stopT3Result = results
+      .stream()
+      .filter(r -> r.stop() == stopT3Index)
+      .findFirst()
+      .orElse(null);
+    assertNotNull(stopT3Result, "Access results should include stopT3");
+
+    assertNull(
+      stopT3Result.walkToPickup(),
+      "Passenger P2 sits on an all-permission street, so the carpool can pick up directly " +
+        "at the passenger's location; walkToPickup should be null"
+    );
+    assertNull(
+      stopT3Result.walkFromDropoff(),
+      "stopT3 is biLinked to a drivable intersection, so the carpool can drop the " +
+        "passenger off directly at the stop's link vertex; walkFromDropoff should be null"
     );
   }
 
@@ -631,7 +722,6 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       new StreetRequest(StreetMode.CARPOOL),
       AccessEgressType.ACCESS,
       transitServiceResolver,
-      linkingContext,
       transitSearchTimeZero
     );
 
@@ -678,7 +768,7 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
     for (CarpoolAccessEgress accessEgress : filteredResults) {
       assertEquals(
         expectedDeparture,
-        accessEgress.getDepartureTimeOfPassenger(),
+        accessEgress.getPassengerDepartureTime(),
         "Departure time should equal trip start plus driving time from A to P2"
       );
 
@@ -689,7 +779,7 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
         expectedDeparture + (int) pickupTime.getSeconds() + (int) drivingP2ToStop.getSeconds();
       assertEquals(
         expectedArrival,
-        accessEgress.getArrivalTimeOfPassenger(),
+        accessEgress.getPassengerArrivalTime(),
         "Arrival time should equal passenger departure plus boarding dwell plus driving " +
           "time from P2 to stop"
       );

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
@@ -49,7 +49,7 @@ import org.opentripplanner.transit.service.TransitService;
  * <p>
  * Graph layout (going east):
  * <pre>
- *                     T1     P2      T3       T5 (walk-only spur)
+ *                     T1     P2      T3       T5 (walk-only side branch)
  *                    / \     / \     / \      :
  *                    |   |   |   |   |   |    : (PEDESTRIAN only)
  *   P1 ---------- A ----- B ----- C ----- D ---------- P3
@@ -64,7 +64,7 @@ import org.opentripplanner.transit.service.TransitService;
  *     T2 = south of A-B midpoint (connected to A and B)
  *     T3 = north of C-D midpoint (connected to C and D)
  *     T4 = south of C-D midpoint (connected to C and D)
- *     T5 = north of D, reachable from D only via a walk-only spur
+ *     T5 = north of D, reachable from D only via a walk-only side branch
  *   Passenger locations:
  *     P1 = 50km west of A (connected to A)
  *     P2 = between B and C, north (connected to B and C)
@@ -151,7 +151,7 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
           biLink(iT3, stopT3);
           biLink(iT4, stopT4);
 
-          // T5 sits on a pedestrian-only spur off the drivable network: a car can drive
+          // T5 sits on a pedestrian-only side branch off the drivable network: a car can drive
           // to D but cannot continue to iT5, so a pure CAR nearby-stop search misses it.
           // CAR_PICKUP, which models walk -> drive -> walk, can drive to D and walk the
           // final stretch to reach stopT5.
@@ -579,12 +579,12 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
    * to leave the drivable network and walk the last stretch to a transit stop whose link
    * endpoint is reachable only via a pedestrian-only edge (e.g. a pedestrian-plaza stop).
    * <p>
-   * In this graph stopT5 is exactly such a stop: a walk-only spur off D. A pure CAR search
-   * would never reach it, so it would not appear in any access result. If the implementation
-   * regresses to using CAR here, this assertion will fail.
+   * In this graph stopT5 is exactly such a stop: a walk-only side branch off D. A pure CAR
+   * search would never reach it, so it would not appear in any access result. If the
+   * implementation regresses to using CAR here, this assertion will fail.
    */
   @Test
-  void accessFindsTransitStopReachableOnlyViaWalkOnlySpurFromDrivableNetwork() {
+  void accessFindsTransitStopReachableOnlyViaWalkOnlySideBranchFromDrivableNetwork() {
     var departureTime = SEARCH_TIME.plusMinutes(30);
     var trip = CarpoolTripTestData.createSimpleTripWithTime(coordA, coordD, departureTime);
     repository.upsertCarpoolTrip(trip);
@@ -610,17 +610,17 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       "Access results should include stopT5, which is only reachable from the drivable " +
         "network by walking. If routeAccessEgress called findNearbyStops with " +
         "StreetMode.CAR instead of CAR_PICKUP the search could not leave the car network " +
-        "to walk the pedestrian-only spur to stopT5, and the stop would be missing here."
+        "to walk the pedestrian-only side branch to stopT5, and the stop would be missing here."
     );
 
-    // The carpool drops the passenger at D (the only drivable vertex incident to the spur)
+    // The carpool drops the passenger at D (the only drivable vertex incident to the side branch)
     // and the passenger must walk D -> iT5 -> stopT5. The result must therefore carry a
     // non-empty walk-from-dropoff segment.
     var walkFromDropoff = stopT5Result.walkFromDropoff();
     assertNotNull(
       walkFromDropoff,
       "stopT5 access result must include a walk-from-dropoff segment, since the carpool " +
-        "cannot drive past D and the passenger has to walk the pedestrian-only spur to T5"
+        "cannot drive past D and the passenger has to walk the pedestrian-only side branch to T5"
     );
     assertTrue(
       walkFromDropoff.getDuration() > 0,
@@ -629,7 +629,7 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
   }
 
   /**
-   * Counterpart to the walk-only-spur test: when both the passenger and the transit stop sit on
+   * Counterpart to the walk-only-side-branch test: when both the passenger and the transit stop sit on
    * the drivable network, the carpool can pick up at the passenger's location and drop off at
    * the stop's link vertex without any walking. Both {@code walkToPickup} and
    * {@code walkFromDropoff} must therefore be {@code null} (rather than zero-duration

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
@@ -9,10 +9,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
@@ -24,14 +21,13 @@ import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.linking.LinkingContext;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
-import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitService;
@@ -75,7 +71,6 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
 
   private DefaultCarpoolingService service;
   private CarpoolingRepository repository;
-  private LinkingContext linkingContext;
 
   private WgsCoordinate coordB;
   private WgsCoordinate coordC;
@@ -143,33 +138,9 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
     Graph graph = model.graph();
     var timetableRepository = model.timetableRepository();
     VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
+    var vertexCreationService = new VertexCreationService(vertexLinker);
     TransitService transitService = new DefaultTransitService(timetableRepository);
     repository = new DefaultCarpoolingRepository();
-
-    var pickupLocation = GenericLocation.fromCoordinate(
-      passengerPickup.latitude(),
-      passengerPickup.longitude()
-    );
-    var dropoffLocation = GenericLocation.fromCoordinate(
-      passengerDropoff.latitude(),
-      passengerDropoff.longitude()
-    );
-    var farAwayLocation = GenericLocation.fromCoordinate(
-      farAwayDropoff.latitude(),
-      farAwayDropoff.longitude()
-    );
-    linkingContext = new LinkingContext(
-      Map.of(
-        pickupLocation,
-        Set.<Vertex>of(vertexPickup),
-        dropoffLocation,
-        Set.<Vertex>of(vertexDropoff),
-        farAwayLocation,
-        Set.<Vertex>of(vertexFarAway)
-      ),
-      Collections.emptySet(),
-      Collections.emptySet()
-    );
 
     StreetLimitationParametersService streetLimitationParams =
       new StreetLimitationParametersService() {
@@ -188,7 +159,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
       repository,
       streetLimitationParams,
       transitService,
-      vertexLinker
+      vertexCreationService
     );
   }
 
@@ -217,7 +188,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
       .withJourney(j -> j.withDirect(new StreetRequest(StreetMode.WALK)))
       .buildRequest();
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertTrue(results.isEmpty());
   }
@@ -226,7 +197,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
   void returnsEmptyWhenNoCarpoolTripsInRepository() {
     var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertTrue(results.isEmpty());
   }
@@ -239,7 +210,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
 
     var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertTrue(results.isEmpty());
   }
@@ -252,7 +223,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
 
     var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertFalse(results.isEmpty(), "Should find direct results for a compatible trip");
 
@@ -273,7 +244,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
 
     var request = buildDirectCarpoolRequest(passengerPickup, farAwayDropoff, SEARCH_TIME);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertTrue(
       results.isEmpty(),
@@ -294,7 +265,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
 
     var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertEquals(2, results.size(), "Should find exactly 2 results for 2 compatible trips");
   }
@@ -321,7 +292,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
 
     var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertFalse(results.isEmpty(), "Trip with intermediate stops should produce results");
 
@@ -352,7 +323,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
 
     var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertFalse(results.isEmpty(), "Should find results for trip with intermediate stops");
     assertEquals(1, results.size(), "Should find exactly one result");
@@ -436,7 +407,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
     var expectedStartTime = actualPickupArrivalTime;
     var expectedEndTime = expectedStartTime.plus(stopDuration).plus(drivingPickupToDropoff);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertFalse(results.isEmpty(), "Trip within search window should produce a result");
 
@@ -490,7 +461,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
     var expectedStartTime = departureTime.plus(drivingToPickup);
     var expectedEndTime = expectedStartTime.plus(stopDuration).plus(drivingPickupToDropoff);
 
-    var results = service.routeDirect(request, linkingContext);
+    var results = service.routeDirect(request);
 
     assertFalse(results.isEmpty(), "Should find results");
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
@@ -1,0 +1,285 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
+import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
+import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.model.plan.leg.StreetLeg;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.linking.VertexLinker;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.search.TraverseMode;
+import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitService;
+
+/**
+ * Integration tests that exercise the walk-to/from-carpool behavior added to
+ * {@link DefaultCarpoolingService}. The graph places the passenger's origin and destination on
+ * pedestrian-only edges, so the snapper must find a nearby stoppable vertex and the resulting
+ * itinerary must contain leading and trailing WALK {@link StreetLeg}s around the carpool leg.
+ *
+ * <pre>
+ *   A ====== B ============= C ====== D          (=  biStreet: car + ped)
+ *            .               .
+ *            . (ped only)    . (ped only)
+ *            P               Q                   (passenger pickup / dropoff)
+ * </pre>
+ *
+ * <ul>
+ *   <li>{@code A} — carpool trip origin (where the driver starts).
+ *   <li>{@code D} — carpool trip destination (where the driver ends).
+ *   <li>{@code B} — drivable mid-route intersection nearest to the passenger's origin; the snapper
+ *       resolves it as the stoppable pickup vertex because {@code P} sits on a pedestrian-only
+ *       spur the car cannot enter.
+ *   <li>{@code C} — drivable mid-route intersection nearest to the passenger's destination; the
+ *       snapper resolves it as the stoppable dropoff vertex for the same reason.
+ *   <li>{@code P} — passenger origin, off the drivable network on a pedestrian-only spur from B.
+ *   <li>{@code Q} — passenger destination, off the drivable network on a pedestrian-only spur
+ *       from C.
+ * </ul>
+ *
+ * The expected itinerary therefore walks {@code P → B}, drives {@code B → C} as a carpool leg,
+ * and walks {@code C → Q}.
+ */
+class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
+
+  private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
+  private static final WgsCoordinate TRIP_START = ORIGIN;
+  private static final WgsCoordinate B_COORD = ORIGIN.moveEastMeters(500);
+  private static final WgsCoordinate C_COORD = ORIGIN.moveEastMeters(1500);
+  private static final WgsCoordinate TRIP_END = ORIGIN.moveEastMeters(2000);
+  private static final WgsCoordinate PASSENGER_REQUESTED_PICKUP = B_COORD.moveSouthMeters(80);
+  private static final WgsCoordinate PASSENGER_REQUESTED_DROPOFF = C_COORD.moveSouthMeters(80);
+  private static final ZoneId ZONE = ZoneId.of("Europe/Oslo");
+  private static final ZonedDateTime SEARCH_TIME = LocalDateTime.of(2025, 6, 15, 12, 0).atZone(
+    ZONE
+  );
+
+  private DefaultCarpoolingService service;
+  private CarpoolingRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    var model = modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          var A = intersection("A", TRIP_START);
+          var B = intersection("B", B_COORD);
+          var C = intersection("C", C_COORD);
+          var D = intersection("D", TRIP_END);
+
+          var P = intersection("P", PASSENGER_REQUESTED_PICKUP);
+          var Q = intersection("Q", PASSENGER_REQUESTED_DROPOFF);
+
+          biStreet(A, B, 500);
+          biStreet(B, C, 1000);
+          biStreet(C, D, 500);
+          // Passenger pickup and dropoff sit on pedestrian-only spurs off the main road.
+          street(
+            B,
+            P,
+            80,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          street(
+            C,
+            Q,
+            80,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+        }
+      }
+    );
+
+    Graph graph = model.graph();
+    var timetableRepository = model.timetableRepository();
+    VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
+    var vertexCreationService = new VertexCreationService(vertexLinker);
+    TransitService transitService = new DefaultTransitService(timetableRepository);
+    repository = new DefaultCarpoolingRepository();
+
+    StreetLimitationParametersService streetLimitationParams =
+      new StreetLimitationParametersService() {
+        @Override
+        public float maxCarSpeed() {
+          return 40.0f;
+        }
+
+        @Override
+        public int maxAreaNodes() {
+          return 500;
+        }
+      };
+
+    service = new DefaultCarpoolingService(
+      repository,
+      streetLimitationParams,
+      transitService,
+      vertexCreationService
+    );
+  }
+
+  private RouteRequest buildDirectCarpoolRequest(ZonedDateTime dateTime) {
+    return RouteRequest.of()
+      .withFrom(
+        GenericLocation.fromCoordinate(
+          PASSENGER_REQUESTED_PICKUP.latitude(),
+          PASSENGER_REQUESTED_PICKUP.longitude()
+        )
+      )
+      .withTo(
+        GenericLocation.fromCoordinate(
+          PASSENGER_REQUESTED_DROPOFF.latitude(),
+          PASSENGER_REQUESTED_DROPOFF.longitude()
+        )
+      )
+      .withDateTime(dateTime.toInstant())
+      .withJourney(j -> j.withDirect(new StreetRequest(StreetMode.CARPOOL)))
+      .buildRequest();
+  }
+
+  @Test
+  void passengerOnPedestrianOnlyEdge_emitsWalkLegsAroundCarpoolLeg() {
+    var departureTime = SEARCH_TIME.plusMinutes(10);
+    var trip = CarpoolTripTestData.createSimpleTripWithTime(TRIP_START, TRIP_END, departureTime);
+    repository.upsertCarpoolTrip(trip);
+
+    var request = buildDirectCarpoolRequest(SEARCH_TIME);
+    var results = service.routeDirect(request);
+
+    assertFalse(results.isEmpty(), "Expected a direct carpool itinerary when walks are feasible");
+
+    for (var itinerary : results) {
+      var legs = itinerary.legs();
+      assertEquals(
+        3,
+        legs.size(),
+        () -> "Expected WALK + CARPOOL + WALK, got " + legs.size() + " legs: " + legs
+      );
+
+      var walkToPickup = legs.getFirst();
+      var carpoolLeg = legs.get(1);
+      assertTrue(
+        walkToPickup instanceof StreetLeg sl && sl.getMode() == TraverseMode.WALK,
+        "First leg should be a walking StreetLeg"
+      );
+      assertTrue(
+        walkToPickup.duration().toSeconds() > 0,
+        "Walk-to-pickup duration should be positive"
+      );
+      // Time anchoring: the walk to the pickup must end exactly when the carpool boards, and
+      // start exactly walk-duration before that. This pins down both the chaining and the
+      // back-shift performed by CarpoolItineraryMapper.buildItinerary.
+      assertEquals(
+        carpoolLeg.startTime(),
+        walkToPickup.endTime(),
+        "Walk-to-pickup should end exactly when the carpool leg starts"
+      );
+      assertEquals(
+        carpoolLeg.startTime().minus(walkToPickup.duration()),
+        walkToPickup.startTime(),
+        "Walk-to-pickup should start one walk-duration before the carpool leg starts"
+      );
+      assertTrue(
+        walkToPickup.from().coordinate.sameLocation(PASSENGER_REQUESTED_PICKUP),
+        () ->
+          "Walk-to-pickup should start at the passenger origin (P) " +
+          PASSENGER_REQUESTED_PICKUP +
+          " but started at " +
+          walkToPickup.from().coordinate
+      );
+      assertTrue(
+        walkToPickup.to().coordinate.sameLocation(B_COORD),
+        () ->
+          "Walk-to-pickup should end at the snapped pickup vertex B " +
+          B_COORD +
+          " but ended at " +
+          walkToPickup.to().coordinate
+      );
+
+      assertTrue(
+        carpoolLeg instanceof CarpoolLeg,
+        () -> "Middle leg should be a CarpoolLeg representing the driving share, was " + carpoolLeg
+      );
+      assertEquals(
+        TransitMode.CARPOOL,
+        ((CarpoolLeg) carpoolLeg).mode(),
+        "Middle leg mode should be TransitMode.CARPOOL (driving)"
+      );
+      assertTrue(
+        carpoolLeg.from().coordinate.sameLocation(B_COORD),
+        () ->
+          "Carpool leg should board at vertex B " +
+          B_COORD +
+          " but boarded at " +
+          carpoolLeg.from().coordinate
+      );
+      assertTrue(
+        carpoolLeg.to().coordinate.sameLocation(C_COORD),
+        () ->
+          "Carpool leg should alight at vertex C " +
+          C_COORD +
+          " but alighted at " +
+          carpoolLeg.to().coordinate
+      );
+
+      var walkFromDropoff = legs.getLast();
+      assertTrue(
+        walkFromDropoff instanceof StreetLeg sl && sl.getMode() == TraverseMode.WALK,
+        "Last leg should be a walking StreetLeg"
+      );
+      assertTrue(
+        walkFromDropoff.duration().toSeconds() > 0,
+        "Walk-from-dropoff duration should be positive"
+      );
+      assertEquals(
+        carpoolLeg.endTime(),
+        walkFromDropoff.startTime(),
+        "Walk-from-dropoff should start exactly when the carpool leg ends"
+      );
+      assertEquals(
+        carpoolLeg.endTime().plus(walkFromDropoff.duration()),
+        walkFromDropoff.endTime(),
+        "Walk-from-dropoff should end one walk-duration after the carpool leg ends"
+      );
+      assertTrue(
+        walkFromDropoff.from().coordinate.sameLocation(C_COORD),
+        () ->
+          "Walk-from-dropoff should start at the snapped dropoff vertex C " +
+          C_COORD +
+          " but started at " +
+          walkFromDropoff.from().coordinate
+      );
+      assertTrue(
+        walkFromDropoff.to().coordinate.sameLocation(PASSENGER_REQUESTED_DROPOFF),
+        () ->
+          "Walk-from-dropoff should end at the passenger destination (Q) " +
+          PASSENGER_REQUESTED_DROPOFF +
+          " but ended at " +
+          walkFromDropoff.to().coordinate
+      );
+    }
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
@@ -50,12 +50,13 @@ import org.opentripplanner.transit.service.TransitService;
  *   <li>{@code D} — carpool trip destination (where the driver ends).
  *   <li>{@code B} — drivable mid-route intersection nearest to the passenger's origin; the snapper
  *       resolves it as the car-accessible pickup vertex because {@code P} sits on a
- *       pedestrian-only spur the car cannot enter.
+ *       pedestrian-only side branch the car cannot enter.
  *   <li>{@code C} — drivable mid-route intersection nearest to the passenger's destination; the
  *       snapper resolves it as the car-accessible dropoff vertex for the same reason.
- *   <li>{@code P} — passenger origin, off the drivable network on a pedestrian-only spur from B.
- *   <li>{@code Q} — passenger destination, off the drivable network on a pedestrian-only spur
- *       from C.
+ *   <li>{@code P} — passenger origin, off the drivable network on a pedestrian-only side branch
+ *       from B.
+ *   <li>{@code Q} — passenger destination, off the drivable network on a pedestrian-only side
+ *       branch from C.
  * </ul>
  *
  * The expected itinerary therefore walks {@code P → B}, drives {@code B → C} as a carpool leg,
@@ -95,7 +96,7 @@ class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
           biStreet(A, B, 500);
           biStreet(B, C, 1000);
           biStreet(C, D, 500);
-          // Passenger pickup and dropoff sit on pedestrian-only spurs off the main road.
+          // Passenger pickup and dropoff sit on pedestrian-only side branches off the main road.
           street(
             B,
             P,

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
@@ -34,8 +34,9 @@ import org.opentripplanner.transit.service.TransitService;
 /**
  * Integration tests that exercise the walk-to/from-carpool behavior added to
  * {@link DefaultCarpoolingService}. The graph places the passenger's origin and destination on
- * pedestrian-only edges, so the snapper must find a nearby stoppable vertex and the resulting
- * itinerary must contain leading and trailing WALK {@link StreetLeg}s around the carpool leg.
+ * pedestrian-only edges, so the snapper must find a nearby car-accessible vertex and the
+ * resulting itinerary must contain leading and trailing WALK {@link StreetLeg}s around the
+ * carpool leg.
  *
  * <pre>
  *   A ====== B ============= C ====== D          (=  biStreet: car + ped)
@@ -48,10 +49,10 @@ import org.opentripplanner.transit.service.TransitService;
  *   <li>{@code A} — carpool trip origin (where the driver starts).
  *   <li>{@code D} — carpool trip destination (where the driver ends).
  *   <li>{@code B} — drivable mid-route intersection nearest to the passenger's origin; the snapper
- *       resolves it as the stoppable pickup vertex because {@code P} sits on a pedestrian-only
- *       spur the car cannot enter.
+ *       resolves it as the car-accessible pickup vertex because {@code P} sits on a
+ *       pedestrian-only spur the car cannot enter.
  *   <li>{@code C} — drivable mid-route intersection nearest to the passenger's destination; the
- *       snapper resolves it as the stoppable dropoff vertex for the same reason.
+ *       snapper resolves it as the car-accessible dropoff vertex for the same reason.
  *   <li>{@code P} — passenger origin, off the drivable network on a pedestrian-only spur from B.
  *   <li>{@code Q} — passenger destination, off the drivable network on a pedestrian-only spur
  *       from C.

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapperTest.java
@@ -13,7 +13,7 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 
-class StoppableVertexSnapperTest extends GraphRoutingTest {
+class CarAccessibleVertexSnapperTest extends GraphRoutingTest {
 
   private IntersectionVertex A;
   private IntersectionVertex B;
@@ -25,7 +25,7 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
    * <pre>
    *   A --(pedestrian)-- B --(pedestrian)-- C --(all modes)-- D
    * </pre>
-   * C and D are stoppable by a car (C thanks to the CD edge; D also via CD). A and B are on
+   * C and D are car-accessible (C thanks to the CD edge; D also via CD). A and B are on
    * pedestrian-only edges and cannot be reached by a driver.
    */
   @BeforeEach
@@ -60,8 +60,8 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
   }
 
   @Test
-  void alreadyStoppableVertex_returnsSameVertexWithoutWalk() {
-    var result = StoppableVertexSnapper.snapPickup(
+  void alreadyCarAccessibleVertex_returnsSameVertexWithoutWalk() {
+    var result = CarAccessibleVertexSnapper.snapPickup(
       StreetSearchRequest.DEFAULT,
       D,
       Duration.ofMinutes(10)
@@ -72,8 +72,8 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
   }
 
   @Test
-  void pedestrianOnlyVertex_withinBudget_snapsToNearestStoppable() {
-    var result = StoppableVertexSnapper.snapPickup(
+  void pedestrianOnlyVertex_withinBudget_snapsToNearestCarAccessible() {
+    var result = CarAccessibleVertexSnapper.snapPickup(
       StreetSearchRequest.DEFAULT,
       A,
       Duration.ofMinutes(10)
@@ -86,7 +86,7 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
 
   @Test
   void pedestrianOnlyVertex_budgetTooTight_returnsNull() {
-    var result = StoppableVertexSnapper.snapPickup(
+    var result = CarAccessibleVertexSnapper.snapPickup(
       StreetSearchRequest.DEFAULT,
       A,
       Duration.ofSeconds(5)
@@ -96,7 +96,7 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
 
   @Test
   void arriveBySearch_walksBackwardsAlongIncomingEdges() {
-    var result = StoppableVertexSnapper.snapDropoff(
+    var result = CarAccessibleVertexSnapper.snapDropoff(
       StreetSearchRequest.DEFAULT,
       A,
       Duration.ofMinutes(10)
@@ -104,25 +104,25 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
     assertNotNull(result);
     assertEquals(C, result.vertex());
     assertNotNull(result.walkPath());
-    // Walk path must be chronological: starts at C (the stoppable vertex) and ends at A.
+    // Walk path must be chronological: starts at C (the car-accessible vertex) and ends at A.
     assertEquals(C, result.walkPath().states.getFirst().getVertex());
     assertEquals(A, result.walkPath().states.getLast().getVertex());
     assertTrue(result.walkPath().getDuration() > 0);
   }
 
   /**
-   * A vertex with car edges in only one direction is not stoppable: the carpool driver picks up
-   * mid-route and must both arrive at and leave the pickup, so a pedestrian-zone vertex hanging
+   * A vertex with car edges in only one direction is not car-accessible: the carpool driver picks
+   * up mid-route and must both arrive at and leave the pickup, so a pedestrian-zone vertex hanging
    * off a one-way drivable exit (CAR outgoing only, no incoming) and the corresponding terminus
    * (CAR incoming only, no outgoing) both fail the predicate. The snapper must skip them and walk
    * on to a vertex with car edges in both directions.
    * <p>
    * Graph: {@code S --(ped)-- V --(one-way CAR forward)--> W --(ped only)-- X --(two-way CAR)-- Y}.
    * V has outgoing CAR but no incoming; W has incoming CAR but no outgoing; X is the first
-   * fully stoppable vertex (it has the X↔Y bidirectional drivable pair).
+   * fully car-accessible vertex (it has the X↔Y bidirectional drivable pair).
    */
   @Test
-  void halfStoppableVertexIsRejected() {
+  void halfCarAccessibleVertexIsRejected() {
     var holder = new IntersectionVertex[5];
     modelOf(
       new GraphRoutingTest.Builder() {
@@ -157,7 +157,7 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
             StreetTraversalPermission.PEDESTRIAN,
             StreetTraversalPermission.PEDESTRIAN
           );
-          // X↔Y: bidirectional ALL — X gets in-CAR (from Y) and out-CAR (to Y), so X is stoppable.
+          // X↔Y: bidirectional ALL — X gets in-CAR (from Y) and out-CAR (to Y), so X is car-accessible.
           street(
             holder[3],
             holder[4],
@@ -169,30 +169,35 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
       }
     );
 
-    var result = StoppableVertexSnapper.snapPickup(
+    var result = CarAccessibleVertexSnapper.snapPickup(
       StreetSearchRequest.DEFAULT,
       holder[0],
       Duration.ofMinutes(10)
     );
 
     assertNotNull(result);
-    assertEquals(holder[3], result.vertex(), "Should skip half-stoppable V and W and snap to X");
+    assertEquals(
+      holder[3],
+      result.vertex(),
+      "Should skip half-car-accessible V and W and snap to X"
+    );
   }
 
   /**
-   * The snap must minimize <em>generalized walk weight</em> across reachable stoppable vertices,
-   * not raw distance and not graph-traversal order. Two stoppable vertices are reachable from S:
-   * X is geometrically closer (50m) but reached via an edge with {@code walkSafetyFactor=10},
-   * while Y is twice as far (100m) along a normal-safety edge. By weight Y is cheaper (≈100
-   * weight units vs ≈500), so the snapper must return Y. A buggy implementation that returned
-   * the first stoppable vertex encountered by distance — or that paired the dominance function
-   * with a non-trivial heuristic that broke cost-ascending pop order — would land on X.
+   * The snap must minimize <em>generalized walk weight</em> across reachable car-accessible
+   * vertices, not raw distance and not graph-traversal order. Two car-accessible vertices are
+   * reachable from S: X is geometrically closer (50m) but reached via an edge with
+   * {@code walkSafetyFactor=10}, while Y is twice as far (100m) along a normal-safety edge. By
+   * weight Y is cheaper (≈100 weight units vs ≈500), so the snapper must return Y. A buggy
+   * implementation that returned the first car-accessible vertex encountered by distance — or
+   * that paired the dominance function with a non-trivial heuristic that broke cost-ascending
+   * pop order — would land on X.
    * <p>
    * <pre>
    *   S --(walk  50 m, safety x10)--> X &lt;--car--&gt; Xc        weight ~500
    *   S --(walk 100 m, safety  x1)--> Y &lt;--car--&gt; Yc        weight ~100  (cheaper)
    * </pre>
-   * Both X and Y are stoppable: their bidirectional CAR edges to Xc / Yc give them car-in
+   * Both X and Y are car-accessible: their bidirectional CAR edges to Xc / Yc give them car-in
    * <em>and</em> car-out. The S→X edge is half the distance but its safety factor blows the
    * weight up; S→Y wins despite being farther.
    */
@@ -228,7 +233,7 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
             StreetTraversalPermission.PEDESTRIAN
           );
 
-          // X ↔ Xc and Y ↔ Yc give X and Y bidirectional CAR access, making them stoppable.
+          // X ↔ Xc and Y ↔ Yc give X and Y bidirectional CAR access, making them car-accessible.
           street(
             holder[1],
             holder[2],
@@ -247,7 +252,7 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
       }
     );
 
-    var result = StoppableVertexSnapper.snapPickup(
+    var result = CarAccessibleVertexSnapper.snapPickup(
       StreetSearchRequest.DEFAULT,
       holder[0],
       Duration.ofMinutes(10)
@@ -276,8 +281,12 @@ class StoppableVertexSnapperTest extends GraphRoutingTest {
       .withWalk(b -> b.withReluctance(4.0))
       .build();
 
-    var lowResult = StoppableVertexSnapper.snapPickup(lowReluctance, A, Duration.ofMinutes(10));
-    var highResult = StoppableVertexSnapper.snapPickup(highReluctance, A, Duration.ofMinutes(10));
+    var lowResult = CarAccessibleVertexSnapper.snapPickup(lowReluctance, A, Duration.ofMinutes(10));
+    var highResult = CarAccessibleVertexSnapper.snapPickup(
+      highReluctance,
+      A,
+      Duration.ofMinutes(10)
+    );
 
     assertNotNull(lowResult);
     assertNotNull(highResult);

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/StoppableVertexSnapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/StoppableVertexSnapperTest.java
@@ -1,0 +1,295 @@
+package org.opentripplanner.ext.carpooling.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+
+class StoppableVertexSnapperTest extends GraphRoutingTest {
+
+  private IntersectionVertex A;
+  private IntersectionVertex B;
+  private IntersectionVertex C;
+  private IntersectionVertex D;
+
+  /**
+   * Graph layout:
+   * <pre>
+   *   A --(pedestrian)-- B --(pedestrian)-- C --(all modes)-- D
+   * </pre>
+   * C and D are stoppable by a car (C thanks to the CD edge; D also via CD). A and B are on
+   * pedestrian-only edges and cannot be reached by a driver.
+   */
+  @BeforeEach
+  void setUp() {
+    modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          A = intersection("A", 59.9139, 10.7522);
+          B = intersection("B", 59.9139, 10.7530);
+          C = intersection("C", 59.9139, 10.7540);
+          D = intersection("D", 59.9139, 10.7548);
+
+          street(
+            A,
+            B,
+            50,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          street(
+            B,
+            C,
+            70,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          street(C, D, 50, StreetTraversalPermission.ALL, StreetTraversalPermission.ALL);
+        }
+      }
+    );
+  }
+
+  @Test
+  void alreadyStoppableVertex_returnsSameVertexWithoutWalk() {
+    var result = StoppableVertexSnapper.snapPickup(
+      StreetSearchRequest.DEFAULT,
+      D,
+      Duration.ofMinutes(10)
+    );
+    assertNotNull(result);
+    assertEquals(D, result.vertex());
+    assertNull(result.walkPath());
+  }
+
+  @Test
+  void pedestrianOnlyVertex_withinBudget_snapsToNearestStoppable() {
+    var result = StoppableVertexSnapper.snapPickup(
+      StreetSearchRequest.DEFAULT,
+      A,
+      Duration.ofMinutes(10)
+    );
+    assertNotNull(result);
+    assertEquals(C, result.vertex());
+    assertNotNull(result.walkPath());
+    assertTrue(result.walkPath().getDuration() > 0);
+  }
+
+  @Test
+  void pedestrianOnlyVertex_budgetTooTight_returnsNull() {
+    var result = StoppableVertexSnapper.snapPickup(
+      StreetSearchRequest.DEFAULT,
+      A,
+      Duration.ofSeconds(5)
+    );
+    assertNull(result);
+  }
+
+  @Test
+  void arriveBySearch_walksBackwardsAlongIncomingEdges() {
+    var result = StoppableVertexSnapper.snapDropoff(
+      StreetSearchRequest.DEFAULT,
+      A,
+      Duration.ofMinutes(10)
+    );
+    assertNotNull(result);
+    assertEquals(C, result.vertex());
+    assertNotNull(result.walkPath());
+    // Walk path must be chronological: starts at C (the stoppable vertex) and ends at A.
+    assertEquals(C, result.walkPath().states.getFirst().getVertex());
+    assertEquals(A, result.walkPath().states.getLast().getVertex());
+    assertTrue(result.walkPath().getDuration() > 0);
+  }
+
+  /**
+   * A vertex with car edges in only one direction is not stoppable: the carpool driver picks up
+   * mid-route and must both arrive at and leave the pickup, so a pedestrian-zone vertex hanging
+   * off a one-way drivable exit (CAR outgoing only, no incoming) and the corresponding terminus
+   * (CAR incoming only, no outgoing) both fail the predicate. The snapper must skip them and walk
+   * on to a vertex with car edges in both directions.
+   * <p>
+   * Graph: {@code S --(ped)-- V --(one-way CAR forward)--> W --(ped only)-- X --(two-way CAR)-- Y}.
+   * V has outgoing CAR but no incoming; W has incoming CAR but no outgoing; X is the first
+   * fully stoppable vertex (it has the X↔Y bidirectional drivable pair).
+   */
+  @Test
+  void halfStoppableVertexIsRejected() {
+    var holder = new IntersectionVertex[5];
+    modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          holder[0] = intersection("S", 60.0000, 10.0000);
+          holder[1] = intersection("V", 60.0000, 10.0010);
+          holder[2] = intersection("W", 60.0000, 10.0020);
+          holder[3] = intersection("X", 60.0000, 10.0030);
+          holder[4] = intersection("Y", 60.0000, 10.0040);
+
+          street(
+            holder[0],
+            holder[1],
+            50,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          // V→W: forward allows cars, reverse pedestrian only. V has out-CAR only; W has in-CAR only.
+          street(
+            holder[1],
+            holder[2],
+            50,
+            StreetTraversalPermission.ALL,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          // W↔X: pedestrian both ways, so the walker can keep going but neither side gains CAR here.
+          street(
+            holder[2],
+            holder[3],
+            50,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          // X↔Y: bidirectional ALL — X gets in-CAR (from Y) and out-CAR (to Y), so X is stoppable.
+          street(
+            holder[3],
+            holder[4],
+            50,
+            StreetTraversalPermission.ALL,
+            StreetTraversalPermission.ALL
+          );
+        }
+      }
+    );
+
+    var result = StoppableVertexSnapper.snapPickup(
+      StreetSearchRequest.DEFAULT,
+      holder[0],
+      Duration.ofMinutes(10)
+    );
+
+    assertNotNull(result);
+    assertEquals(holder[3], result.vertex(), "Should skip half-stoppable V and W and snap to X");
+  }
+
+  /**
+   * The snap must minimize <em>generalized walk weight</em> across reachable stoppable vertices,
+   * not raw distance and not graph-traversal order. Two stoppable vertices are reachable from S:
+   * X is geometrically closer (50m) but reached via an edge with {@code walkSafetyFactor=10},
+   * while Y is twice as far (100m) along a normal-safety edge. By weight Y is cheaper (≈100
+   * weight units vs ≈500), so the snapper must return Y. A buggy implementation that returned
+   * the first stoppable vertex encountered by distance — or that paired the dominance function
+   * with a non-trivial heuristic that broke cost-ascending pop order — would land on X.
+   * <p>
+   * <pre>
+   *   S --(walk  50 m, safety x10)--> X &lt;--car--&gt; Xc        weight ~500
+   *   S --(walk 100 m, safety  x1)--> Y &lt;--car--&gt; Yc        weight ~100  (cheaper)
+   * </pre>
+   * Both X and Y are stoppable: their bidirectional CAR edges to Xc / Yc give them car-in
+   * <em>and</em> car-out. The S→X edge is half the distance but its safety factor blows the
+   * weight up; S→Y wins despite being farther.
+   */
+  @Test
+  void snapsToMinimumWeightVertex_notNearestByDistance() {
+    var holder = new IntersectionVertex[5];
+    modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          holder[0] = intersection("S", 60.0000, 10.0000);
+          holder[1] = intersection("X", 60.0000, 10.0006);
+          holder[2] = intersection("Xc", 60.0000, 10.0012);
+          holder[3] = intersection("Y", 60.0000, 9.9988);
+          holder[4] = intersection("Yc", 60.0000, 9.9982);
+
+          // S → X: short (50m) but penalized — walkSafetyFactor 10 makes its weight ≈ 500.
+          var sx = street(
+            holder[0],
+            holder[1],
+            50,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+          sx.forEach(e -> e.setWalkSafetyFactor(10.0f));
+
+          // S → Y: longer (100m) but normal safety — weight ≈ 100, the cheaper snap.
+          street(
+            holder[0],
+            holder[3],
+            100,
+            StreetTraversalPermission.PEDESTRIAN,
+            StreetTraversalPermission.PEDESTRIAN
+          );
+
+          // X ↔ Xc and Y ↔ Yc give X and Y bidirectional CAR access, making them stoppable.
+          street(
+            holder[1],
+            holder[2],
+            50,
+            StreetTraversalPermission.ALL,
+            StreetTraversalPermission.ALL
+          );
+          street(
+            holder[3],
+            holder[4],
+            50,
+            StreetTraversalPermission.ALL,
+            StreetTraversalPermission.ALL
+          );
+        }
+      }
+    );
+
+    var result = StoppableVertexSnapper.snapPickup(
+      StreetSearchRequest.DEFAULT,
+      holder[0],
+      Duration.ofMinutes(10)
+    );
+
+    assertNotNull(result);
+    assertNotNull(result.walkPath(), "S is pedestrian-only — a real walk path is expected");
+    assertEquals(
+      holder[3],
+      result.vertex(),
+      "Should pick Y (low-weight, farther) over X (penalized, closer) by minimum generalized weight"
+    );
+  }
+
+  /**
+   * The walk A* must run with the supplied request's preferences, not the library defaults.
+   * Doubling {@code walkReluctance} on otherwise-identical requests should roughly double the
+   * walk path's weight
+   */
+  @Test
+  void walkPathWeightUsesSuppliedWalkReluctance() {
+    var lowReluctance = StreetSearchRequest.copyOf(StreetSearchRequest.DEFAULT)
+      .withWalk(b -> b.withReluctance(1.0))
+      .build();
+    var highReluctance = StreetSearchRequest.copyOf(StreetSearchRequest.DEFAULT)
+      .withWalk(b -> b.withReluctance(4.0))
+      .build();
+
+    var lowResult = StoppableVertexSnapper.snapPickup(lowReluctance, A, Duration.ofMinutes(10));
+    var highResult = StoppableVertexSnapper.snapPickup(highReluctance, A, Duration.ofMinutes(10));
+
+    assertNotNull(lowResult);
+    assertNotNull(highResult);
+    assertNotNull(lowResult.walkPath());
+    assertNotNull(highResult.walkPath());
+    double lowWeight = lowResult.walkPath().getWeight();
+    double highWeight = highResult.walkPath().getWeight();
+    assertTrue(lowWeight > 1, "Expected non-trivial low-reluctance weight, got " + lowWeight);
+    assertTrue(highWeight > 1, "Expected non-trivial high-reluctance weight, got " + highWeight);
+    assertTrue(
+      highWeight > lowWeight * 2,
+      "Weight should scale with walk reluctance: low=" + lowWeight + ", high=" + highWeight
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/StreetVertexUtilsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/StreetVertexUtilsTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.carpooling.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -8,20 +7,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
 
 import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.routing.linking.LinkingContext;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.TemporaryVerticesContainer;
 import org.opentripplanner.street.model.StreetModelForTest;
 import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.TraverseMode;
 
 class StreetVertexUtilsTest {
 
@@ -45,66 +43,74 @@ class StreetVertexUtilsTest {
     var graph = new Graph();
     graph.addVertex(from);
     graph.addVertex(to);
-    StreetModelForTest.streetEdge(from, to, StreetTraversalPermission.CAR);
+    StreetModelForTest.streetEdge(from, to, StreetTraversalPermission.ALL);
     graph.hasStreets = true;
     graph.index();
     graph.calculateConvexHull();
 
     var vertexLinker = VertexLinkerTestFactory.of(graph);
+    var vertexCreationService = new VertexCreationService(vertexLinker);
     var temporaryVerticesContainer = new TemporaryVerticesContainer();
-    streetVertexUtils = new StreetVertexUtils(vertexLinker, temporaryVerticesContainer);
+    streetVertexUtils = new StreetVertexUtils(vertexCreationService, temporaryVerticesContainer);
   }
 
   @Test
-  void returnsExistingVertexFromLinkingContext() {
-    var location = GenericLocation.fromCoordinate(OSLO_CENTER.latitude(), OSLO_CENTER.longitude());
-    var existingVertex = StreetModelForTest.intersectionVertex(
-      OSLO_CENTER.latitude(),
-      OSLO_CENTER.longitude()
-    );
-    var linkingContext = new LinkingContext(
-      Map.of(location, Set.of(existingVertex)),
-      Set.of(),
-      Set.of()
-    );
-
-    var result = streetVertexUtils.getOrCreateVertex(OSLO_CENTER, linkingContext);
-
-    assertEquals(existingVertex, result);
-  }
-
-  @Test
-  void createsTemporaryVertexWhenNotInContext() {
-    var emptyContext = new LinkingContext(Map.of(), Set.of(), Set.of());
-
-    var result = streetVertexUtils.getOrCreateVertex(OSLO_CENTER, emptyContext);
+  void passenger_createsBidirectionallyLinkedVertex() {
+    var result = streetVertexUtils.createPassengerVertex(OSLO_CENTER);
 
     assertNotNull(result);
+
+    // Splitters reached by following the passenger vertex's outgoing connectors.
+    var outgoingSplitters = new HashSet<Vertex>();
+    for (var edge : result.getOutgoing()) {
+      outgoingSplitters.add(edge.getToVertex());
+    }
+    // Splitters that have a connector pointing back to the passenger vertex.
+    var incomingSplitters = new HashSet<Vertex>();
+    for (var edge : result.getIncoming()) {
+      incomingSplitters.add(edge.getFromVertex());
+    }
+
+    // BIDIRECTIONAL linking requires that the same splitter is both reachable from the passenger
+    // vertex AND has a return connector — either direction missing would be a directional-linking
+    // regression. This is the universal contract of createPassengerVertex.
+    //
+    // The car-permitting check below is fixture-dependent: the splitter inherits the underlying
+    // edge's permissions, and this test's road has StreetTraversalPermission.ALL, so the splitter
+    // is car-routable in both directions. On a walk-only edge the splitter would be walk-only —
+    // also correct behavior per the createPassengerVertex Javadoc, just not what this test
+    // exercises.
+    boolean foundBidirectionalCarSplitter = outgoingSplitters
+      .stream()
+      .filter(incomingSplitters::contains)
+      .anyMatch(
+        v ->
+          hasCarPermittingStreetEdge(v.getOutgoing()) && hasCarPermittingStreetEdge(v.getIncoming())
+      );
+    assertTrue(
+      foundBidirectionalCarSplitter,
+      "Passenger must be linked BIDIRECTIONALLY to a car-accessible splitter so carpool CAR " +
+        "routing works in both directions"
+    );
   }
 
   @Test
-  void returnsNullWhenLinkingFails() {
-    var emptyContext = new LinkingContext(Map.of(), Set.of(), Set.of());
-    // Coordinate far from any graph edge
+  void passenger_returnsNullWhenLinkingFails() {
     var farAway = new WgsCoordinate(0.0, 0.0);
 
-    var result = streetVertexUtils.getOrCreateVertex(farAway, emptyContext);
+    var result = streetVertexUtils.createPassengerVertex(farAway);
 
     assertNull(result);
   }
 
   @Test
-  void createdVertexIsLinkedToGraphVertices() {
-    var emptyContext = new LinkingContext(Map.of(), Set.of(), Set.of());
-
-    var result = streetVertexUtils.getOrCreateVertex(OSLO_CENTER, emptyContext);
+  void driverWaypoint_createsVertexLinkedToGraph() {
+    var result = streetVertexUtils.createDriverWaypointVertex(OSLO_CENTER);
 
     assertNotNull(result);
     assertFalse(result.getOutgoing().isEmpty());
     assertFalse(result.getIncoming().isEmpty());
 
-    // The temporary vertex is linked to split points on the street edge between from and to.
-    // Walk two hops to verify the split points connect back to the original graph vertices.
     var twoHopOutgoing = new HashSet<Vertex>();
     for (var edge : result.getOutgoing()) {
       for (var nextEdge : edge.getToVertex().getOutgoing()) {
@@ -120,5 +126,25 @@ class StreetVertexUtilsTest {
       }
     }
     assertTrue(twoHopIncoming.contains(from) || twoHopIncoming.contains(to));
+  }
+
+  @Test
+  void driverWaypoint_returnsNullWhenLinkingFails() {
+    var farAway = new WgsCoordinate(0.0, 0.0);
+
+    var result = streetVertexUtils.createDriverWaypointVertex(farAway);
+
+    assertNull(result);
+  }
+
+  private static boolean hasCarPermittingStreetEdge(
+    Iterable<? extends org.opentripplanner.street.model.edge.Edge> edges
+  ) {
+    for (var e : edges) {
+      if (e instanceof StreetEdge se && se.getPermission().allows(TraverseMode.CAR)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingService.java
@@ -8,7 +8,6 @@ import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessE
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.routing.graphfinder.TransitServiceResolver;
-import org.opentripplanner.routing.linking.LinkingContext;
 
 /**
  * Service for finding carpooling options by matching passenger requests with available driver trips.
@@ -20,21 +19,18 @@ import org.opentripplanner.routing.linking.LinkingContext;
 public interface CarpoolingService {
   /**
    * Finds carpooling itineraries matching the passenger's routing request.
-   * <p>
    *
    * @param request the routing request containing passenger origin, destination, and preferences
-   * @param linkingContext linking context with pre-linked vertices for the request
    * @return list of carpool itineraries, may be empty if no compatible trips found
    * @throws IllegalArgumentException if request is null
    */
-  List<Itinerary> routeDirect(RouteRequest request, LinkingContext linkingContext);
+  List<Itinerary> routeDirect(RouteRequest request);
 
   List<CarpoolAccessEgress> routeAccessEgress(
     RouteRequest request,
     StreetRequest streetRequest,
     AccessEgressType accessOrEgress,
     TransitServiceResolver transitServiceResolver,
-    LinkingContext linkingContext,
     ZonedDateTime transitSearchTimeZero
   );
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/configure/CarpoolingModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/configure/CarpoolingModule.java
@@ -9,7 +9,7 @@ import org.opentripplanner.ext.carpooling.CarpoolingService;
 import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.service.DefaultCarpoolingService;
 import org.opentripplanner.framework.application.OTPFeature;
-import org.opentripplanner.street.linking.VertexLinker;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -32,7 +32,7 @@ public class CarpoolingModule {
     @Nullable CarpoolingRepository repository,
     StreetLimitationParametersService streetLimitationParametersService,
     TransitService transitService,
-    VertexLinker vertexLinker
+    VertexCreationService vertexCreationService
   ) {
     if (OTPFeature.CarPooling.isOff()) {
       return null;
@@ -41,7 +41,7 @@ public class CarpoolingModule {
       repository,
       streetLimitationParametersService,
       transitService,
-      vertexLinker
+      vertexCreationService
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -70,11 +70,13 @@ public class CarpoolItineraryMapper {
    *
    * @param candidate the insertion candidate containing route segments, trip details, and
    *        optional walk paths around the carpool pickup/dropoff
+   * @param carpoolReluctance multiplier applied to ride seconds when computing the carpool leg's
+   *        {@code generalizedCost}.
    * @return an itinerary for the passenger's journey, or {@code null} if the candidate has no
    *         shared segments (a safety check that should not trigger for valid candidates)
    */
   @Nullable
-  public Itinerary toItinerary(InsertionCandidate candidate) {
+  public Itinerary toItinerary(InsertionCandidate candidate, double carpoolReluctance) {
     var sharedSegments = candidate.getSharedSegments();
     if (sharedSegments.isEmpty()) {
       return null;
@@ -86,14 +88,16 @@ public class CarpoolItineraryMapper {
       candidate.walkToPickup(),
       candidate.walkFromDropoff(),
       carpoolStart,
-      carpoolEnd
+      carpoolEnd,
+      candidate.getPassengerRideWeight(carpoolReluctance)
     );
   }
 
   private static CarpoolLeg buildCarpoolLeg(
     List<GraphPath<State, Edge, Vertex>> sharedSegments,
     ZonedDateTime startTime,
-    ZonedDateTime endTime
+    ZonedDateTime endTime,
+    double rideWeight
   ) {
     var firstSegment = sharedSegments.getFirst();
     var lastSegment = sharedSegments.getLast();
@@ -113,7 +117,7 @@ public class CarpoolItineraryMapper {
       .withTo(Place.normal(toVertex, new NonLocalizedString("Carpool alighting")))
       .withGeometry(GeometryUtils.concatenateLineStrings(allEdges, Edge::getGeometry))
       .withDistanceMeters(allEdges.stream().mapToDouble(Edge::getDistanceMeters).sum())
-      .withGeneralizedCost((int) lastSegment.getWeight())
+      .withGeneralizedCost((int) rideWeight)
       .build();
   }
 
@@ -160,7 +164,8 @@ public class CarpoolItineraryMapper {
       accessEgress.walkToPickup(),
       accessEgress.walkFromDropoff(),
       accessEgress.getCarpoolStart(),
-      accessEgress.getCarpoolEnd()
+      accessEgress.getCarpoolEnd(),
+      accessEgress.getPassengerRideWeight()
     );
   }
 
@@ -174,14 +179,15 @@ public class CarpoolItineraryMapper {
     @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
     @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff,
     ZonedDateTime carpoolStart,
-    ZonedDateTime carpoolEnd
+    ZonedDateTime carpoolEnd,
+    double rideWeight
   ) {
     List<Leg> legs = new ArrayList<>(3);
     if (walkToPickup != null) {
       var walkStart = carpoolStart.minusSeconds(walkToPickup.getDuration());
       legs.add(buildWalkLeg(walkToPickup, walkStart, carpoolStart));
     }
-    legs.add(buildCarpoolLeg(sharedSegments, carpoolStart, carpoolEnd));
+    legs.add(buildCarpoolLeg(sharedSegments, carpoolStart, carpoolEnd, rideWeight));
     if (walkFromDropoff != null) {
       var walkEnd = carpoolEnd.plusSeconds(walkFromDropoff.getDuration());
       legs.add(buildWalkLeg(walkFromDropoff, carpoolEnd, walkEnd));

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -1,19 +1,25 @@
 package org.opentripplanner.ext.carpooling.internal;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.core.model.basic.Cost;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.InsertionCandidate;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
+import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.TraverseMode;
+import org.opentripplanner.street.search.state.State;
 
 /**
  * Maps carpooling insertion candidates to OTP itineraries for API responses.
@@ -23,36 +29,27 @@ import org.opentripplanner.street.model.vertex.Vertex;
  * portion from the complete driver route and constructs an itinerary with timing, geometry,
  * and cost information.
  *
- * <h2>Mapping Strategy</h2>
+ * <h2>Itinerary Shape</h2>
  * <p>
- * An {@link InsertionCandidate} contains:
- * <ul>
- *   <li><strong>Pickup segments:</strong> Driver's route from start to passenger pickup</li>
- *   <li><strong>Shared segments:</strong> Passenger's journey from pickup to dropoff</li>
- *   <li><strong>Dropoff segments:</strong> Driver's route from dropoff to end</li>
- * </ul>
- * <p>
- * This mapper focuses on the <strong>shared segments</strong>, which represent the passenger's
- * actual carpool ride. The pickup segments are used only to calculate when the driver arrives
- * at the pickup location.
+ * Both direct-mode and access/egress itineraries have between one and three legs, emitted in
+ * chronological order:
+ * <ol>
+ *   <li>An optional leading {@link StreetLeg} (WALK) from the passenger-side location (origin
+ *       for direct/access, transit stop for egress) to the snapped carpool pickup vertex.</li>
+ *   <li>A {@link CarpoolLeg} covering the shared ride between pickup and dropoff. The
+ *       boarding dwell at the pickup is included in this leg's duration, not added before it.</li>
+ *   <li>An optional trailing {@link StreetLeg} (WALK) from the snapped dropoff vertex to the
+ *       dropoff-side location (destination for direct/egress, transit stop for access).</li>
+ * </ol>
  *
  * <h2>Time Calculation</h2>
  * <p>
- * The passenger's start time is the moment the driver arrives at the pickup location
- * (trip start + pickup travel); the boarding dwell is included in the leg's duration, not
- * added before it. The start time is <em>not</em> shifted to match the passenger's requested
- * departure time: the driver is on a committed schedule and cannot wait. Whether the
- * passenger should show up early, or whether a trip starting before the requested time
- * should be matched at all, is a filtering concern and lives upstream of this mapper.
- *
- * <h2>Geometry and Cost</h2>
- * <p>
- * The itinerary includes:
- * <ul>
- *   <li><strong>Geometry:</strong> Concatenated line strings from all shared route edges</li>
- *   <li><strong>Distance:</strong> Sum of all shared segment edge distances</li>
- *   <li><strong>Generalized cost:</strong> A* path weight from routing (time + penalties)</li>
- * </ul>
+ * The carpool leg's start time is the moment the driver arrives at the pickup
+ * (trip start + pickup travel). If a leading walk leg exists, its start is back-shifted by the
+ * walk's duration; the trailing walk leg's end is forward-shifted similarly. The itinerary is
+ * <em>not</em> shifted to match the passenger's requested departure time — the driver is on a
+ * committed schedule and cannot wait. Whether the passenger should show up early or be matched
+ * at all is a filtering concern upstream of this mapper.
  *
  * <h2>Package Location</h2>
  * <p>
@@ -65,47 +62,16 @@ import org.opentripplanner.street.model.vertex.Vertex;
  */
 public class CarpoolItineraryMapper {
 
-  private final ZonedDateTime transitSearchTimeZero;
-
-  /**
-   * @param transitSearchTimeZero the base time for access egress requests; not used for direct
-   */
-  public CarpoolItineraryMapper(ZonedDateTime transitSearchTimeZero) {
-    this.transitSearchTimeZero = transitSearchTimeZero;
-  }
-
-  public CarpoolItineraryMapper() {
-    this(null);
-  }
-
   /**
    * Converts an insertion candidate into an OTP itinerary representing the passenger's journey.
-   * <p>
-   * Extracts the passenger's portion of the journey (shared segments) and constructs an itinerary
-   * with accurate timing, geometry, and cost information. The resulting itinerary contains a
-   * single {@link CarpoolLeg} representing the ride from pickup to dropoff.
+   * The itinerary contains a {@link CarpoolLeg} for the shared ride, optionally preceded by a
+   * WALK {@link StreetLeg} from the passenger's origin to the snapped pickup vertex and
+   * optionally followed by a WALK leg from the snapped dropoff vertex to the destination.
    *
-   * <h3>Time Calculation Details</h3>
-   * <p>
-   * Start and end times come entirely from the driver's schedule:
-   * <ol>
-   *   <li><strong>Start:</strong> {@code trip.startTime() +}
-   *       {@link InsertionCandidate#getDurationUntilPickupArrival()} — the moment the driver
-   *       arrives at the pickup point.</li>
-   *   <li><strong>End:</strong> {@code start +}
-   *       {@link InsertionCandidate#getPassengerRideDuration()}, which already includes the
-   *       boarding dwell at the pickup and any intermediate stop delays along the shared
-   *       segments.</li>
-   * </ol>
-   *
-   * <h3>Null Return Cases</h3>
-   * <p>
-   * Returns {@code null} if the candidate has no shared segments, which should never happen
-   * for valid insertion candidates but serves as a safety check.
-   *
-   * @param candidate the insertion candidate containing route segments and trip details
-   * @return an itinerary with a single carpool leg, or null if shared segments are empty
-   *         (should not occur for valid candidates)
+   * @param candidate the insertion candidate containing route segments, trip details, and
+   *        optional walk paths around the carpool pickup/dropoff
+   * @return an itinerary for the passenger's journey, or {@code null} if the candidate has no
+   *         shared segments (a safety check that should not trigger for valid candidates)
    */
   @Nullable
   public Itinerary toItinerary(InsertionCandidate candidate) {
@@ -113,11 +79,22 @@ public class CarpoolItineraryMapper {
     if (sharedSegments.isEmpty()) {
       return null;
     }
+    var carpoolStart = candidate.trip().startTime().plus(candidate.getDurationUntilPickupArrival());
+    var carpoolEnd = carpoolStart.plus(candidate.getPassengerRideDuration());
+    return buildItinerary(
+      sharedSegments,
+      candidate.walkToPickup(),
+      candidate.walkFromDropoff(),
+      carpoolStart,
+      carpoolEnd
+    );
+  }
 
-    var startTime = candidate.trip().startTime().plus(candidate.getDurationUntilPickupArrival());
-
-    var endTime = startTime.plus(candidate.getPassengerRideDuration());
-
+  private static CarpoolLeg buildCarpoolLeg(
+    List<GraphPath<State, Edge, Vertex>> sharedSegments,
+    ZonedDateTime startTime,
+    ZonedDateTime endTime
+  ) {
     var firstSegment = sharedSegments.getFirst();
     var lastSegment = sharedSegments.getLast();
 
@@ -129,7 +106,7 @@ public class CarpoolItineraryMapper {
       .flatMap(seg -> seg.edges.stream())
       .toList();
 
-    CarpoolLeg carpoolLeg = CarpoolLeg.of()
+    return CarpoolLeg.of()
       .withStartTime(startTime)
       .withEndTime(endTime)
       .withFrom(Place.normal(fromVertex, new NonLocalizedString("Carpool boarding")))
@@ -138,39 +115,79 @@ public class CarpoolItineraryMapper {
       .withDistanceMeters(allEdges.stream().mapToDouble(Edge::getDistanceMeters).sum())
       .withGeneralizedCost((int) lastSegment.getWeight())
       .build();
+  }
 
-    return Itinerary.ofDirect(List.of(carpoolLeg))
-      .withGeneralizedCost(Cost.costOfSeconds(carpoolLeg.generalizedCost()))
+  private static StreetLeg buildWalkLeg(
+    GraphPath<State, Edge, Vertex> walkPath,
+    ZonedDateTime startTime,
+    ZonedDateTime endTime
+  ) {
+    Vertex fromVertex = walkPath.states.getFirst().getVertex();
+    Vertex toVertex = walkPath.states.getLast().getVertex();
+
+    LineString geometry = GeometryUtils.concatenateLineStrings(walkPath.edges, Edge::getGeometry);
+    double distance = walkPath.edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
+
+    return StreetLeg.of()
+      .withMode(TraverseMode.WALK)
+      .withStartTime(startTime)
+      .withEndTime(endTime)
+      .withFrom(Place.normal(fromVertex, fromVertex.getName()))
+      .withTo(Place.normal(toVertex, toVertex.getName()))
+      .withGeometry(geometry)
+      .withDistanceMeters(distance)
+      .withGeneralizedCost((int) walkPath.getWeight())
       .build();
   }
 
+  /**
+   * Converts a Raptor carpool access/egress leg back into an OTP itinerary for the response. Same
+   * shape as {@link #toItinerary(InsertionCandidate, double)} — an optional WALK leg, the carpool
+   * leg, and an optional WALK leg — but driven from the {@link CarpoolAccessEgress} accessors so
+   * the displayed times and ride cost agree with the values Raptor used during the search.
+   *
+   * @return the itinerary, or {@code null} if the access/egress has no shared segments (a safety
+   *         check that should not trigger for valid legs)
+   */
+  @Nullable
   public Itinerary toItinerary(CarpoolAccessEgress accessEgress) {
-    var segments = accessEgress.getSegments();
-    var allEdges = segments
-      .stream()
-      .flatMap(seg -> seg.edges.stream())
-      .toList();
-    var startTime = transitSearchTimeZero.plusSeconds(accessEgress.getDepartureTimeOfPassenger());
-    var endTime = transitSearchTimeZero.plusSeconds(accessEgress.getArrivalTimeOfPassenger());
-    var fromVertex = segments.getFirst().states.getFirst().getVertex();
-    var toVertex = segments.getLast().states.getLast().getVertex();
-    LineString geometry = GeometryUtils.concatenateLineStrings(allEdges, Edge::getGeometry);
-    var cost = accessEgress.getTotalWeight();
+    var sharedSegments = accessEgress.sharedSegments();
+    if (sharedSegments.isEmpty()) {
+      return null;
+    }
+    return buildItinerary(
+      sharedSegments,
+      accessEgress.walkToPickup(),
+      accessEgress.walkFromDropoff(),
+      accessEgress.getCarpoolStart(),
+      accessEgress.getCarpoolEnd()
+    );
+  }
 
-    var carpoolLeg = CarpoolLeg.of()
-      .withStartTime(startTime)
-      .withEndTime(endTime)
-      .withFrom(Place.normal(fromVertex, new NonLocalizedString("Carpool boarding")))
-      .withTo(Place.normal(toVertex, new NonLocalizedString("Carpool alighting")))
-      .withDistanceMeters(allEdges.stream().mapToDouble(Edge::getDistanceMeters).sum())
-      .withGeneralizedCost((int) cost)
-      .withGeometry(geometry)
-      .build();
+  /**
+   * Assembles a WALK + CARPOOL + WALK itinerary around the shared ride. Walk legs are omitted
+   * when their corresponding path is {@code null}; the walk legs' outer times are derived from
+   * {@code carpoolStart}/{@code carpoolEnd} plus the walk durations.
+   */
+  private static Itinerary buildItinerary(
+    List<GraphPath<State, Edge, Vertex>> sharedSegments,
+    @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+    @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff,
+    ZonedDateTime carpoolStart,
+    ZonedDateTime carpoolEnd
+  ) {
+    List<Leg> legs = new ArrayList<>(3);
+    if (walkToPickup != null) {
+      var walkStart = carpoolStart.minusSeconds(walkToPickup.getDuration());
+      legs.add(buildWalkLeg(walkToPickup, walkStart, carpoolStart));
+    }
+    legs.add(buildCarpoolLeg(sharedSegments, carpoolStart, carpoolEnd));
+    if (walkFromDropoff != null) {
+      var walkEnd = carpoolEnd.plusSeconds(walkFromDropoff.getDuration());
+      legs.add(buildWalkLeg(walkFromDropoff, carpoolEnd, walkEnd));
+    }
 
-    var itinerary = Itinerary.ofDirect(List.of(carpoolLeg))
-      .withGeneralizedCost(Cost.costOfSeconds(carpoolLeg.generalizedCost()))
-      .build();
-
-    return itinerary;
+    int totalCost = legs.stream().mapToInt(Leg::generalizedCost).sum();
+    return Itinerary.ofDirect(legs).withGeneralizedCost(Cost.costOfSeconds(totalCost)).build();
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -217,8 +217,8 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
 
   /**
    * Walk path from the passenger's origin (or transit stop, for egress) to the snapped pickup
-   * vertex. {@code null} when the origin/stop is already on a stoppable vertex and no walk is
-   * needed.
+   * vertex. {@code null} when the origin/stop is already on a car-accessible vertex and no walk
+   * is needed.
    */
   @Nullable
   public GraphPath<State, Edge, Vertex> walkToPickup() {
@@ -236,8 +236,8 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
 
   /**
    * Walk path from the snapped dropoff vertex to the passenger's destination (or transit stop, for
-   * access). {@code null} when the destination/stop is already on a stoppable vertex and no walk
-   * is needed.
+   * access). {@code null} when the destination/stop is already on a car-accessible vertex and no
+   * walk is needed.
    */
   @Nullable
   public GraphPath<State, Edge, Vertex> walkFromDropoff() {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -46,6 +46,7 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
 
   private final int durationInSeconds;
   private final int c1;
+  private final int timePenalty;
   private final double totalWeight;
 
   private final InsertionCandidate insertionCandidate;
@@ -76,6 +77,7 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
     this.insertionCandidate = insertionCandidate;
     this.penalty = penalty;
     this.carpoolReluctance = carpoolReluctance;
+    this.timePenalty = penalty.isZero() ? RaptorConstants.TIME_NOT_SET : penalty.timeInSeconds();
 
     var walkToPickup = insertionCandidate.walkToPickup();
     var walkFromDropoff = insertionCandidate.walkFromDropoff();
@@ -88,7 +90,7 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
     double walkWeight =
       GraphPathUtils.weightOrZero(walkToPickup) + GraphPathUtils.weightOrZero(walkFromDropoff);
     this.totalWeight = walkWeight + rideSeconds * carpoolReluctance;
-    this.c1 = RaptorCostConverter.toRaptorCost(this.totalWeight);
+    this.c1 = RaptorCostConverter.toRaptorCost(this.totalWeight) + penalty.cost().toCentiSeconds();
   }
 
   @Override
@@ -114,6 +116,11 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
   @Override
   public int durationInSeconds() {
     return this.durationInSeconds;
+  }
+
+  @Override
+  public int timePenalty() {
+    return this.timePenalty;
   }
 
   /**
@@ -166,10 +173,14 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
   /**
    * Returns a copy of this leg with the given Raptor penalty applied on top. Used by Raptor's
    * access-egress penalty pass; everything else (stop, time anchor, candidate, reluctance) is
-   * preserved unchanged.
+   * preserved unchanged. The penalty's cost is folded into {@link #c1()} and its time is exposed
+   * via {@link #timePenalty()}, mirroring {@code DefaultAccessEgress}.
    */
   @Override
   public RoutingAccessEgress withPenalty(TimeAndCost penalty) {
+    if (this.penalty != TimeAndCost.ZERO) {
+      throw new IllegalStateException("Can not add penalty twice...");
+    }
     return new CarpoolAccessEgress(
       this.stop,
       this.passengerDepartureTime,

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -1,8 +1,10 @@
 package org.opentripplanner.ext.carpooling.routing;
 
-import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.raptor.spi.RaptorConstants;
 import org.opentripplanner.raptor.spi.RaptorCostConverter;
@@ -11,50 +13,82 @@ import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
 
+/**
+ * Raptor access/egress adapter wrapping an {@link InsertionCandidate}: the candidate carries the
+ * carpool-side data (walks, shared segments, ride duration) and this class adds the Raptor framing
+ * (stop index, departure time anchor, c1, penalty, reluctance).
+ * <p>
+ * The walk paths' A* weights are used as-is for the walk portion of the cost; they already encode
+ * the user's walk preferences (reluctance, safety, slope, ...) from the search that produced them.
+ * The ride portion is billed at {@code carpoolReluctance}.
+ */
 public class CarpoolAccessEgress implements RoutingAccessEgress {
+
+  private final int stop;
 
   /**
    * The Raptor departure time of this access/egress leg, in seconds since
-   * {@code transitSearchTimeZero}. For a carpool leg this is the moment the car arrives at the
-   * pickup: the passenger must be ready by this instant, since the driver is on a committed
-   * schedule and cannot wait. The boarding dwell at the pickup is part of
-   * {@link #durationInSeconds}, not of the time before departure.
+   * {@code transitSearchTimeZero}. This is the moment the passenger leaves the origin side of the
+   * leg: the start of an optional walk to the carpool pickup, or — when no walk is needed — the
+   * moment the carpool itself arrives at the pickup. The driver runs on a committed schedule, so
+   * Raptor cannot delay this time.
    */
-  private final int departureTimeOfPassenger;
+  private final int passengerDepartureTime;
 
   /**
    * The Raptor arrival time of this access/egress leg, in seconds since
-   * {@code transitSearchTimeZero}. For a carpool leg this is the moment the car reaches the
-   * dropoff (the transit stop for access, the passenger's destination for egress), after
-   * boarding dwell and shared travel.
+   * {@code transitSearchTimeZero}. This is the moment the passenger reaches the destination side
+   * of the leg: the end of an optional walk from the carpool dropoff, or — when no walk is needed
+   * — the moment the carpool reaches the dropoff. Equal to {@code passengerDepartureTime +
+   * walkToPickupSeconds + rideSeconds + walkFromDropoffSeconds}.
    */
-  private final int arrivalTimeOfPassenger;
-  private final int stop;
+  private final int passengerArrivalTime;
+
   private final int durationInSeconds;
   private final int c1;
-  private final List<GraphPath<State, Edge, Vertex>> segments;
-  private final TimeAndCost penalty;
   private final double totalWeight;
+
+  private final InsertionCandidate insertionCandidate;
+  private final TimeAndCost penalty;
   private final double carpoolReluctance;
 
+  /**
+   * @param stop Raptor stop index of the transit-side endpoint — the stop the passenger boards
+   *        transit at (for access) or alights from transit at (for egress).
+   * @param passengerDepartureTime see {@link #passengerDepartureTime}.
+   * @param insertionCandidate the carpool-side data: walks bracketing the ride, the shared ride
+   *        itself, the trip and pickup/dropoff positions. Everything except Raptor framing flows
+   *        from here.
+   * @param penalty optional Raptor time/cost penalty added on top of the leg, applied via
+   *        {@link #withPenalty(TimeAndCost)}; pass {@link TimeAndCost#ZERO} for no penalty.
+   * @param carpoolReluctance multiplier on ride seconds when computing {@link #c1()}; the walk
+   *        portions are billed at the walks' own A* weights and are not multiplied by this.
+   */
   public CarpoolAccessEgress(
     int stop,
-    Duration duration,
-    int departureTimeOfPassenger,
-    int arrivalTimeOfPassenger,
-    List<GraphPath<State, Edge, Vertex>> segments,
+    int passengerDepartureTime,
+    InsertionCandidate insertionCandidate,
     TimeAndCost penalty,
-    Double carpoolReluctance
+    double carpoolReluctance
   ) {
-    this.departureTimeOfPassenger = departureTimeOfPassenger;
-    this.arrivalTimeOfPassenger = arrivalTimeOfPassenger;
     this.stop = stop;
-    this.durationInSeconds = (int) duration.getSeconds();
-    this.carpoolReluctance = carpoolReluctance;
-    this.totalWeight = this.durationInSeconds * carpoolReluctance;
-    this.c1 = RaptorCostConverter.toRaptorCost(this.totalWeight);
-    this.segments = segments;
+    this.passengerDepartureTime = passengerDepartureTime;
+    this.insertionCandidate = insertionCandidate;
     this.penalty = penalty;
+    this.carpoolReluctance = carpoolReluctance;
+
+    var walkToPickup = insertionCandidate.walkToPickup();
+    var walkFromDropoff = insertionCandidate.walkFromDropoff();
+    int walkSeconds = (int) (GraphPathUtils.durationOrZero(walkToPickup).getSeconds() +
+      GraphPathUtils.durationOrZero(walkFromDropoff).getSeconds());
+    int rideSeconds = (int) insertionCandidate.getPassengerRideDuration().getSeconds();
+    this.durationInSeconds = walkSeconds + rideSeconds;
+    this.passengerArrivalTime = passengerDepartureTime + this.durationInSeconds;
+
+    double walkWeight =
+      GraphPathUtils.weightOrZero(walkToPickup) + GraphPathUtils.weightOrZero(walkFromDropoff);
+    this.totalWeight = walkWeight + rideSeconds * carpoolReluctance;
+    this.c1 = RaptorCostConverter.toRaptorCost(this.totalWeight);
   }
 
   @Override
@@ -62,61 +96,95 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
     return this.stop;
   }
 
+  /**
+   * The Raptor cost of this leg, equal to {@code walkToPickupWeight + walkFromDropoffWeight +
+   * rideSeconds * carpoolReluctance}, converted to Raptor's centi-second unit. The walk weights
+   * already encode the user's walk preferences (reluctance, safety, slope, ...) — only the ride
+   * portion is multiplied by {@code carpoolReluctance}.
+   */
   @Override
   public int c1() {
     return this.c1;
   }
 
+  /**
+   * Total wall-clock duration of the leg (walk + ride + walk), in seconds. Constant — Raptor
+   * cannot stretch or shrink this since the carpool runs on a fixed schedule.
+   */
   @Override
   public int durationInSeconds() {
     return this.durationInSeconds;
   }
 
+  /**
+   * The carpool's departure time is fixed by the driver's schedule. Returns
+   * {@link #passengerDepartureTime} if the requested time is at or before it, otherwise
+   * {@link RaptorConstants#TIME_NOT_SET} — the passenger can't be picked up later than the
+   * driver passes.
+   */
   @Override
   public int earliestDepartureTime(int requestedDepartureTime) {
-    if (requestedDepartureTime > departureTimeOfPassenger) {
+    if (requestedDepartureTime > passengerDepartureTime) {
       return RaptorConstants.TIME_NOT_SET;
     }
-    return departureTimeOfPassenger;
+    return passengerDepartureTime;
   }
 
+  /**
+   * Symmetric to {@link #earliestDepartureTime(int)}: the carpool's arrival time is fixed.
+   * Returns {@link #passengerArrivalTime} if the requested time is at or after it, otherwise
+   * {@link RaptorConstants#TIME_NOT_SET}.
+   */
   @Override
   public int latestArrivalTime(int requestedArrivalTime) {
-    if (requestedArrivalTime < arrivalTimeOfPassenger) {
+    if (requestedArrivalTime < passengerArrivalTime) {
       return RaptorConstants.TIME_NOT_SET;
     }
-    return arrivalTimeOfPassenger;
+    return passengerArrivalTime;
   }
 
+  /**
+   * Always {@code true}: a carpool leg has a fixed time window because the driver runs on a
+   * committed schedule, so Raptor must respect the leg's departure/arrival times rather than
+   * shifting the leg to fit the request.
+   */
   @Override
   public boolean hasOpeningHours() {
     return true;
   }
 
-  public int getDepartureTimeOfPassenger() {
-    return departureTimeOfPassenger;
+  /** See {@link #passengerDepartureTime} for semantics. */
+  public int getPassengerDepartureTime() {
+    return passengerDepartureTime;
   }
 
-  public int getArrivalTimeOfPassenger() {
-    return arrivalTimeOfPassenger;
+  /** See {@link #passengerArrivalTime} for semantics. */
+  public int getPassengerArrivalTime() {
+    return passengerArrivalTime;
   }
 
+  /**
+   * Returns a copy of this leg with the given Raptor penalty applied on top. Used by Raptor's
+   * access-egress penalty pass; everything else (stop, time anchor, candidate, reluctance) is
+   * preserved unchanged.
+   */
   @Override
   public RoutingAccessEgress withPenalty(TimeAndCost penalty) {
     return new CarpoolAccessEgress(
       this.stop,
-      Duration.ofSeconds(this.durationInSeconds),
-      this.departureTimeOfPassenger,
-      this.arrivalTimeOfPassenger,
-      this.segments,
+      this.passengerDepartureTime,
+      this.insertionCandidate,
       penalty,
       this.carpoolReluctance
     );
   }
 
-  /*
-    TODO: Implement this function.
-    It is never used for instances of CarpoolAccessEgress, but this might change in the future.
+  /**
+   * Not implemented — Raptor never fetches the final State of a carpool access/egress leg.
+   * Itinerary mapping reads the leg's segments and times via the public accessors instead. May be
+   * implemented later if a caller starts requiring it.
+   *
+   * @throws UnsupportedOperationException always.
    */
   @Override
   public State getFinalState() {
@@ -125,20 +193,70 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
     );
   }
 
+  /** Always {@code false}: a carpool leg, by definition, contains a vehicle ride. */
   @Override
   public boolean isWalkOnly() {
     return false;
   }
 
+  /** {@inheritDoc} */
   @Override
   public TimeAndCost penalty() {
     return this.penalty;
   }
 
-  public List<GraphPath<State, Edge, Vertex>> getSegments() {
-    return this.segments;
+  /**
+   * Walk path from the passenger's origin (or transit stop, for egress) to the snapped pickup
+   * vertex. {@code null} when the origin/stop is already on a stoppable vertex and no walk is
+   * needed.
+   */
+  @Nullable
+  public GraphPath<State, Edge, Vertex> walkToPickup() {
+    return insertionCandidate.walkToPickup();
   }
 
+  /**
+   * The carpool route segments traversed by the passenger between pickup and dropoff (inclusive of
+   * intermediate stops the driver makes along the way for other passengers). Never empty for a
+   * valid leg.
+   */
+  public List<GraphPath<State, Edge, Vertex>> sharedSegments() {
+    return insertionCandidate.getSharedSegments();
+  }
+
+  /**
+   * Walk path from the snapped dropoff vertex to the passenger's destination (or transit stop, for
+   * access). {@code null} when the destination/stop is already on a stoppable vertex and no walk
+   * is needed.
+   */
+  @Nullable
+  public GraphPath<State, Edge, Vertex> walkFromDropoff() {
+    return insertionCandidate.walkFromDropoff();
+  }
+
+  /**
+   * Absolute wall-clock time at which the carpool arrives at the pickup vertex — i.e. the start
+   * of the shared ride. Computed from the driver's trip start time plus the duration of all
+   * segments preceding the passenger's pickup; independent of {@code transitSearchTimeZero}.
+   */
+  public ZonedDateTime getCarpoolStart() {
+    return insertionCandidate
+      .trip()
+      .startTime()
+      .plus(insertionCandidate.getDurationUntilPickupArrival());
+  }
+
+  /** Absolute wall-clock time at which the carpool arrives at the dropoff vertex. */
+  public ZonedDateTime getCarpoolEnd() {
+    return getCarpoolStart().plus(insertionCandidate.getPassengerRideDuration());
+  }
+
+  /**
+   * The pre-Raptor generalized cost of this leg in seconds-equivalent (walk weights + reluctance-
+   * weighted ride seconds), before conversion to Raptor's centi-second unit. Useful for tests and
+   * debug logging that want to see the cost in user-preference units rather than Raptor's int
+   * encoding.
+   */
   public double getTotalWeight() {
     return this.totalWeight;
   }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -20,7 +20,7 @@ import org.opentripplanner.street.search.state.State;
  * <p>
  * The walk paths' A* weights are used as-is for the walk portion of the cost; they already encode
  * the user's walk preferences (reluctance, safety, slope, ...) from the search that produced them.
- * The ride portion is billed at {@code carpoolReluctance}.
+ * The ride portion is weighted by {@code carpoolReluctance}.
  */
 public class CarpoolAccessEgress implements RoutingAccessEgress {
 
@@ -62,7 +62,7 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
    * @param penalty optional Raptor time/cost penalty added on top of the leg, applied via
    *        {@link #withPenalty(TimeAndCost)}; pass {@link TimeAndCost#ZERO} for no penalty.
    * @param carpoolReluctance multiplier on ride seconds when computing {@link #c1()}; the walk
-   *        portions are billed at the walks' own A* weights and are not multiplied by this.
+   *        portions use the walks' own A* weights and are not multiplied by this.
    */
   public CarpoolAccessEgress(
     int stop,

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -47,7 +47,6 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
   private final int durationInSeconds;
   private final int c1;
   private final int timePenalty;
-  private final double totalWeight;
 
   private final InsertionCandidate insertionCandidate;
   private final TimeAndCost penalty;
@@ -89,8 +88,8 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
 
     double walkWeight =
       GraphPathUtils.weightOrZero(walkToPickup) + GraphPathUtils.weightOrZero(walkFromDropoff);
-    this.totalWeight = walkWeight + rideSeconds * carpoolReluctance;
-    this.c1 = RaptorCostConverter.toRaptorCost(this.totalWeight) + penalty.cost().toCentiSeconds();
+    double totalWeight = walkWeight + insertionCandidate.getPassengerRideWeight(carpoolReluctance);
+    this.c1 = RaptorCostConverter.toRaptorCost(totalWeight) + penalty.cost().toCentiSeconds();
   }
 
   @Override
@@ -263,12 +262,11 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
   }
 
   /**
-   * The pre-Raptor generalized cost of this leg in seconds-equivalent (walk weights + reluctance-
-   * weighted ride seconds), before conversion to Raptor's centi-second unit. Useful for tests and
-   * debug logging that want to see the cost in user-preference units rather than Raptor's int
-   * encoding.
+   * Cost of the carpool ride portion only (excluding walks and penalty), in raw weight units. The
+   * itinerary mapper uses this for {@code CarpoolLeg.generalizedCost} so the displayed cost agrees
+   * with the ride contribution to {@link #c1()}.
    */
-  public double getTotalWeight() {
-    return this.totalWeight;
+  public double getPassengerRideWeight() {
+    return insertionCandidate.getPassengerRideWeight(carpoolReluctance);
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTripWithVertices.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTripWithVertices.java
@@ -5,7 +5,6 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
-import org.opentripplanner.routing.linking.LinkingContext;
 import org.opentripplanner.street.model.vertex.Vertex;
 
 /**
@@ -36,20 +35,20 @@ public class CarpoolTripWithVertices {
   }
 
   /**
-   * Resolves vertices for the trip's route points using the given utilities.
+   * Resolves vertices for the trip's route points using the given utilities. Driver route
+   * points are always linked in CAR mode since the driver traverses the entire trip.
    *
    * @return the trip with vertices, or null if any route point could not be linked to the graph
    */
   @Nullable
   public static CarpoolTripWithVertices create(
     CarpoolTrip trip,
-    StreetVertexUtils streetVertexUtils,
-    LinkingContext linkingContext
+    StreetVertexUtils streetVertexUtils
   ) {
     var vertices = trip
       .routePoints()
       .stream()
-      .map(coordinate -> streetVertexUtils.getOrCreateVertex(coordinate, linkingContext))
+      .map(streetVertexUtils::createDriverWaypointVertex)
       .toList();
     if (vertices.stream().anyMatch(Objects::isNull)) {
       return null;

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
@@ -123,6 +123,14 @@ public record InsertionCandidate(
     return totalSegmentDuration(getSharedSegments(), stopDuration).plus(stopDuration);
   }
 
+  /**
+   * Generalized cost of the passenger's ride in raw weight units (seconds-equivalent), equal to
+   * {@link #getPassengerRideDuration()} multiplied by {@code carpoolReluctance}.
+   */
+  public double getPassengerRideWeight(double carpoolReluctance) {
+    return getPassengerRideDuration().getSeconds() * carpoolReluctance;
+  }
+
   private static Duration totalSegmentDuration(
     List<GraphPath<State, Edge, Vertex>> segments,
     Duration stopDuration

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.carpooling.routing;
 
 import java.time.Duration;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
@@ -30,15 +31,23 @@ public record InsertionCandidate(
   List<GraphPath<State, Edge, Vertex>> routeSegments,
   Duration stopDuration,
   NearbyStop transitStop,
-  Duration totalTripDuration
+  Duration totalTripDuration,
+  @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+  @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff
 ) {
+  /**
+   * Convenience constructor that derives {@code totalTripDuration} from the route segments and
+   * stop duration.
+   */
   public InsertionCandidate(
     CarpoolTrip trip,
     int pickupPosition,
     int dropoffPosition,
     List<GraphPath<State, Edge, Vertex>> routeSegments,
     Duration stopDuration,
-    NearbyStop transitStop
+    NearbyStop transitStop,
+    @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+    @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff
   ) {
     this(
       trip,
@@ -47,7 +56,9 @@ public record InsertionCandidate(
       routeSegments,
       stopDuration,
       transitStop,
-      computeTotalTripDuration(routeSegments, stopDuration)
+      computeTotalTripDuration(routeSegments, stopDuration),
+      walkToPickup,
+      walkFromDropoff
     );
   }
 
@@ -104,27 +115,22 @@ public record InsertionCandidate(
   }
 
   /**
-   * Calculates the duration of the passenger's ride from pickup arrival to dropoff.
-   * Includes the boarding dwell at the pickup (when there are pickup segments preceding it),
-   * travel time through shared segments, and stop delays at intermediate stops between shared
-   * segments. The no-pickup-segments case (passenger boarding at the trip origin) cannot occur
-   * today — the search never places {@code pickupPosition == 0} — but the branch guards against
-   * it by omitting the boarding dwell.
+   * Calculates the duration of the passenger's ride from pickup arrival to dropoff. Includes the
+   * boarding dwell at the pickup, travel time through shared segments, and stop delays between
+   * shared segments.
    */
   public Duration getPassengerRideDuration() {
-    Duration boardingDwell = pickupPosition == 0 ? Duration.ZERO : stopDuration;
-    return totalSegmentDuration(getSharedSegments(), stopDuration).plus(boardingDwell);
+    return totalSegmentDuration(getSharedSegments(), stopDuration).plus(stopDuration);
   }
 
   private static Duration totalSegmentDuration(
     List<GraphPath<State, Edge, Vertex>> segments,
     Duration stopDuration
   ) {
-    return segments
-      .stream()
-      .map(GraphPathUtils::calculateDuration)
-      .reduce(Duration.ZERO, Duration::plus)
-      .plus(stopDuration.multipliedBy(Math.max(0, segments.size() - 1)));
+    long segmentSeconds = segments.stream().mapToLong(GraphPath::getDuration).sum();
+    return Duration.ofSeconds(segmentSeconds).plus(
+      stopDuration.multipliedBy(Math.max(0, segments.size() - 1))
+    );
   }
 
   @Override

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionCandidate.java
@@ -36,6 +36,31 @@ public record InsertionCandidate(
   @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff
 ) {
   /**
+   * {@link InsertionPositionFinder} guarantees {@code 1 <= pickupPosition < dropoffPosition}
+   * (pickup is never at the driver's origin, and dropoff is always strictly after pickup).
+   * {@link #getPassengerRideDuration()} relies on the lower bound — it unconditionally adds a
+   * boarding dwell, which only makes sense when the passenger boards mid-trip rather than at
+   * the trip's start. Enforce both invariants here so a regression upstream fails loud at
+   * construction instead of silently producing inconsistent durations.
+   */
+  public InsertionCandidate {
+    if (pickupPosition < 1) {
+      throw new IllegalArgumentException(
+        "pickupPosition must be >= 1 (pickup at trip origin is invalid); got " + pickupPosition
+      );
+    }
+    if (dropoffPosition <= pickupPosition) {
+      throw new IllegalArgumentException(
+        "dropoffPosition (" +
+          dropoffPosition +
+          ") must be > pickupPosition (" +
+          pickupPosition +
+          ")"
+      );
+    }
+  }
+
+  /**
    * Convenience constructor that derives {@code totalTripDuration} from the route segments and
    * stop duration.
    */

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -9,11 +9,8 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.ext.carpooling.constraints.PassengerDelayConstraints;
-import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
-import org.opentripplanner.routing.linking.LinkingContext;
-import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
@@ -35,25 +32,18 @@ public class InsertionEvaluator {
 
   private static final Logger LOG = LoggerFactory.getLogger(InsertionEvaluator.class);
 
-  private final LinkingContext linkingContext;
-  private final StreetVertexUtils streetVertexUtils;
   private final CarpoolRouter carpoolRouter;
   private final Duration stopDuration;
 
   /**
-   * Creates an evaluator with the specified routing function and linking context.
-   *
-   * @param linkingContext Linking context with pre-linked vertices for routing
-   * @param stopDuration Duration added at each intermediate stop (from car pickupTime preference)
+   * @param carpoolRouter routes a single street segment between two vertices in the candidate
+   *        carpool route — used both to build the baseline route and to re-route only the
+   *        segments that change when a passenger pickup/dropoff is inserted.
+   * @param stopDuration duration added at each intermediate stop (from the car {@code pickupTime}
+   *        preference); applied between consecutive segments when computing total trip and
+   *        passenger-ride durations.
    */
-  public InsertionEvaluator(
-    LinkingContext linkingContext,
-    StreetVertexUtils streetVertexUtils,
-    CarpoolRouter carpoolRouter,
-    Duration stopDuration
-  ) {
-    this.linkingContext = linkingContext;
-    this.streetVertexUtils = streetVertexUtils;
+  public InsertionEvaluator(CarpoolRouter carpoolRouter, Duration stopDuration) {
     this.carpoolRouter = carpoolRouter;
     this.stopDuration = stopDuration;
   }
@@ -105,18 +95,11 @@ public class InsertionEvaluator {
       .viableAccessEgress()
       .stream()
       .map(viableAccessEgress -> {
-        var pickUpVertex = viableAccessEgress.accessEgress() == AccessEgressType.ACCESS
-          ? viableAccessEgress.passengerVertex()
-          : viableAccessEgress.transitVertex();
-        var dropOffVertex = viableAccessEgress.accessEgress() == AccessEgressType.ACCESS
-          ? viableAccessEgress.transitVertex()
-          : viableAccessEgress.passengerVertex();
-
+        var snap = toPassengerSnap(viableAccessEgress);
         return findBestInsertion(
           tripWithVertices,
           viableAccessEgress.insertionPositions(),
-          pickUpVertex,
-          dropOffVertex,
+          snap,
           baselineSegments,
           cumulativeDurations,
           viableAccessEgress.transitStop()
@@ -124,6 +107,22 @@ public class InsertionEvaluator {
       })
       .filter(Objects::nonNull)
       .toList();
+  }
+
+  private static PassengerSnap toPassengerSnap(ViableAccessEgress viableAccessEgress) {
+    boolean isAccess = viableAccessEgress.accessEgress() == AccessEgressType.ACCESS;
+    var pickup = isAccess
+      ? viableAccessEgress.passengerVertex()
+      : viableAccessEgress.transitVertex();
+    var dropoff = isAccess
+      ? viableAccessEgress.transitVertex()
+      : viableAccessEgress.passengerVertex();
+    return new PassengerSnap(
+      pickup,
+      dropoff,
+      viableAccessEgress.walkToPickup(),
+      viableAccessEgress.walkFromDropoff()
+    );
   }
 
   /**
@@ -136,16 +135,15 @@ public class InsertionEvaluator {
    *
    * @param tripWithVertices The carpool trip with resolved vertices
    * @param viablePositions Positions that passed heuristic checks (from InsertionPositionFinder)
-   * @param passengerPickup Passenger's pickup location
-   * @param passengerDropoff Passenger's dropoff location
+   * @param snap Pickup/dropoff vertices (already snapped to stoppable edges by the caller) and
+   *        the optional walk paths bracketing the carpool ride
    * @return The best insertion candidate, or null if none are viable after routing
    */
   @Nullable
   public InsertionCandidate findBestInsertion(
     CarpoolTripWithVertices tripWithVertices,
     List<InsertionPosition> viablePositions,
-    WgsCoordinate passengerPickup,
-    WgsCoordinate passengerDropoff
+    PassengerSnap snap
   ) {
     GraphPath<State, Edge, Vertex>[] baselineSegments = routeSegments(tripWithVertices.vertices());
     if (baselineSegments == null) {
@@ -153,22 +151,12 @@ public class InsertionEvaluator {
       return null;
     }
 
-    var passengerPickupVertex = streetVertexUtils.getOrCreateVertex(
-      passengerPickup,
-      linkingContext
-    );
-    var passengerDropoffVertex = streetVertexUtils.getOrCreateVertex(
-      passengerDropoff,
-      linkingContext
-    );
-
     Duration[] cumulativeDurations = calculateCumulativeDurations(baselineSegments, stopDuration);
 
     return findBestInsertion(
       tripWithVertices,
       viablePositions,
-      passengerPickupVertex,
-      passengerDropoffVertex,
+      snap,
       baselineSegments,
       cumulativeDurations,
       null
@@ -179,8 +167,7 @@ public class InsertionEvaluator {
   private InsertionCandidate findBestInsertion(
     CarpoolTripWithVertices tripWithVertices,
     List<InsertionPosition> viablePositions,
-    Vertex passengerPickup,
-    Vertex passengerDropoff,
+    PassengerSnap snap,
     GraphPath<State, Edge, Vertex>[] baselineSegments,
     Duration[] cumulativeDurations,
     NearbyStop transitStop
@@ -192,8 +179,7 @@ public class InsertionEvaluator {
         tripWithVertices,
         position.pickupPos(),
         position.dropoffPos(),
-        passengerPickup,
-        passengerDropoff,
+        snap,
         baselineSegments,
         cumulativeDurations,
         transitStop
@@ -228,8 +214,7 @@ public class InsertionEvaluator {
     CarpoolTripWithVertices tripWithVertices,
     int pickupPos,
     int dropoffPos,
-    Vertex passengerPickup,
-    Vertex passengerDropoff,
+    PassengerSnap snap,
     GraphPath<State, Edge, Vertex>[] baselineSegments,
     Duration[] originalCumulativeDurations,
     NearbyStop transitStop
@@ -239,15 +224,14 @@ public class InsertionEvaluator {
       baselineSegments,
       pickupPos,
       dropoffPos,
-      passengerPickup,
-      passengerDropoff
+      snap.pickupVertex(),
+      snap.dropoffVertex()
     );
 
     if (modifiedSegments == null) {
       return null;
     }
 
-    // Check passenger delay constraints
     Duration[] modifiedCumulativeDurations = calculateCumulativeDurations(
       modifiedSegments.toArray(new GraphPath[modifiedSegments.size()]),
       stopDuration
@@ -275,7 +259,9 @@ public class InsertionEvaluator {
       dropoffPos,
       modifiedSegments,
       stopDuration,
-      transitStop
+      transitStop,
+      snap.walkToPickup(),
+      snap.walkFromDropoff()
     );
   }
 
@@ -289,25 +275,18 @@ public class InsertionEvaluator {
   ) {
     List<GraphPath<State, Edge, Vertex>> segments = new ArrayList<>();
 
-    // Build modified point list
     List<Vertex> modifiedPoints = new ArrayList<>(originalPoints);
     modifiedPoints.add(pickupPos, passengerPickup);
     modifiedPoints.add(dropoffPos, passengerDropoff);
 
-    // For each segment in the modified route:
-    // - Reuse baseline segment if it didn't change
-    // - Route new segment if it involves passenger stops
     for (int i = 0; i < modifiedPoints.size() - 1; i++) {
       GraphPath<State, Edge, Vertex> segment;
 
-      // Check if this segment can be reused from baseline
-      int baselineIndex = getBaselineSegmentIndex(i, originalPoints, modifiedPoints);
+      int baselineIndex = baselineSegmentIndex(i, pickupPos, dropoffPos);
       if (baselineIndex >= 0 && baselineIndex < baselineSegments.length) {
-        // This segment is unchanged - reuse it!
         segment = baselineSegments[baselineIndex];
         LOG.trace("Reusing baseline segment {} for modified position {}", baselineIndex, i);
       } else {
-        // This segment involves passenger - route it
         var fromVertex = modifiedPoints.get(i);
         var toVertex = modifiedPoints.get(i + 1);
 
@@ -326,47 +305,27 @@ public class InsertionEvaluator {
   }
 
   /**
-   * Maps a modified route segment index to the corresponding baseline segment index.
-   * Returns -1 if the segment cannot be reused (endpoints don't match).
-   *
-   * <p>A baseline segment can only be reused if BOTH endpoints match exactly between
-   * the baseline and modified routes. This ensures we don't reuse a segment whose
-   * endpoints have changed due to passenger insertion.
-   *
-   * @param modifiedIndex Index in modified route (with passenger inserted)
-   * @param originalPoints Original route points (before passenger insertion)
-   * @param modifiedPoints Modified route points (after passenger insertion)
-   * @return Baseline segment index if endpoints match, or -1 if segment must be routed
+   * Maps a modified-route segment index to the corresponding baseline segment index, or
+   * {@code -1} if the modified segment touches the inserted pickup or dropoff and so cannot be
+   * reused.
+   * <p>
+   * The modified route is the original route with two insertions: pickup at {@code pickupPos}
+   * and dropoff at {@code dropoffPos} (List.add semantics, dropoffPos interpreted after the
+   * pickup insertion). A modified segment {@code [i, i+1)} either reuses an original segment
+   * (when both endpoints fall in original points) or is one of the four newly created segments
+   * around the inserted points.
    */
-  private int getBaselineSegmentIndex(
-    int modifiedIndex,
-    List<Vertex> originalPoints,
-    List<Vertex> modifiedPoints
-  ) {
-    // Get the start and end coordinates of this modified segment
-    Vertex modifiedStart = modifiedPoints.get(modifiedIndex);
-    Vertex modifiedEnd = modifiedPoints.get(modifiedIndex + 1);
-
-    // Search through baseline segments to find one with matching endpoints
-    for (int baselineIndex = 0; baselineIndex < originalPoints.size() - 1; baselineIndex++) {
-      Vertex baselineStart = originalPoints.get(baselineIndex);
-      Vertex baselineEnd = originalPoints.get(baselineIndex + 1);
-
-      // Check if both endpoints match (using Vertex's built-in equality)
-      if (modifiedStart.equals(baselineStart) && modifiedEnd.equals(baselineEnd)) {
-        LOG.trace(
-          "Modified segment {} matches baseline segment {} (endpoints match)",
-          modifiedIndex,
-          baselineIndex
-        );
-        return baselineIndex;
-      }
+  private static int baselineSegmentIndex(int modifiedIndex, int pickupPos, int dropoffPos) {
+    int i = modifiedIndex;
+    if (i == pickupPos - 1 || i == pickupPos || i == dropoffPos - 1 || i == dropoffPos) {
+      return -1;
     }
-
-    LOG.trace(
-      "Modified segment {} has no matching baseline segment (endpoints changed)",
-      modifiedIndex
-    );
-    return -1;
+    if (i < pickupPos) {
+      return i;
+    }
+    if (i < dropoffPos) {
+      return i - 1;
+    }
+    return i - 2;
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -135,8 +135,8 @@ public class InsertionEvaluator {
    *
    * @param tripWithVertices The carpool trip with resolved vertices
    * @param viablePositions Positions that passed heuristic checks (from InsertionPositionFinder)
-   * @param snap Pickup/dropoff vertices (already snapped to stoppable edges by the caller) and
-   *        the optional walk paths bracketing the carpool ride
+   * @param snap Pickup/dropoff vertices (already snapped to car-accessible vertices by the
+   *        caller) and the optional walk paths bracketing the carpool ride
    * @return The best insertion candidate, or null if none are viable after routing
    */
   @Nullable

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -314,8 +314,19 @@ public class InsertionEvaluator {
    * pickup insertion). A modified segment {@code [i, i+1)} either reuses an original segment
    * (when both endpoints fall in original points) or is one of the four newly created segments
    * around the inserted points.
+   * <p>
+   * The shift arithmetic below relies on {@code pickupPos < dropoffPos}: the pickup must be
+   * inserted strictly before the dropoff in the modified route. Upstream
+   * {@link InsertionPositionFinder} enforces this when generating positions; the guard here
+   * fails loud if a regression ever lets {@code pickupPos == dropoffPos} through, which would
+   * otherwise silently produce a route with the dropoff before the pickup.
    */
   private static int baselineSegmentIndex(int modifiedIndex, int pickupPos, int dropoffPos) {
+    if (pickupPos >= dropoffPos) {
+      throw new IllegalArgumentException(
+        "pickupPos (" + pickupPos + ") must be < dropoffPos (" + dropoffPos + ")"
+      );
+    }
     int i = modifiedIndex;
     if (i == pickupPos - 1 || i == pickupPos || i == dropoffPos - 1 || i == dropoffPos) {
       return -1;

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -315,11 +315,10 @@ public class InsertionEvaluator {
    * (when both endpoints fall in original points) or is one of the four newly created segments
    * around the inserted points.
    * <p>
-   * The shift arithmetic below relies on {@code pickupPos < dropoffPos}: the pickup must be
-   * inserted strictly before the dropoff in the modified route. Upstream
-   * {@link InsertionPositionFinder} enforces this when generating positions; the guard here
-   * fails loud if a regression ever lets {@code pickupPos == dropoffPos} through, which would
-   * otherwise silently produce a route with the dropoff before the pickup.
+   * Requires {@code pickupPos < dropoffPos} — the shift arithmetic depends on the pickup being
+   * strictly before the dropoff, otherwise the result would silently describe a route with the
+   * dropoff before the pickup. Throws {@link IllegalArgumentException} if the precondition is
+   * violated.
    */
   private static int baselineSegmentIndex(int modifiedIndex, int pickupPos, int dropoffPos) {
     if (pickupPos >= dropoffPos) {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/PassengerSnap.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/PassengerSnap.java
@@ -1,0 +1,24 @@
+package org.opentripplanner.ext.carpooling.routing;
+
+import javax.annotation.Nullable;
+import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.state.State;
+
+/**
+ * Both ends of a passenger's carpool leg, already snapped to vertices the driver can stop at.
+ *
+ * @param pickupVertex   where the driver picks up
+ * @param dropoffVertex  where the driver drops off
+ * @param walkToPickup   walk from the passenger-side origin to {@code pickupVertex}, or
+ *                       {@code null} if the passenger boards at the snapped vertex itself
+ * @param walkFromDropoff walk from {@code dropoffVertex} to the passenger-side destination, or
+ *                        {@code null} if the passenger alights at the snapped vertex itself
+ */
+public record PassengerSnap(
+  Vertex pickupVertex,
+  Vertex dropoffVertex,
+  @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+  @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff
+) {}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/ViableAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/ViableAccessEgress.java
@@ -1,9 +1,13 @@
 package org.opentripplanner.ext.carpooling.routing;
 
 import java.util.List;
+import javax.annotation.Nullable;
+import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.state.State;
 
 /**
  * A transit stop that has been determined viable for carpooling access or egress,
@@ -11,15 +15,23 @@ import org.opentripplanner.street.model.vertex.Vertex;
  * picked up and dropped off on the carpool trip's route.
  *
  * @param transitStop the nearby transit stop
- * @param transitVertex the street graph vertex for the transit stop
- * @param passengerVertex the street graph vertex for the passenger's origin if access, and the passenger's destination if egress
+ * @param transitVertex the street graph vertex where the driver stops to pick up or drop off the
+ *        passenger at the transit-stop side (already snapped to a stoppable edge)
+ * @param passengerVertex the street graph vertex where the driver stops at the passenger side
+ *        — origin for access, destination for egress — already snapped to a stoppable edge
  * @param accessEgress whether this represents access (origin to transit) or egress (transit to destination)
  * @param insertionPositions the viable pickup/dropoff positions on the carpool route
+ * @param walkToPickup walk path from the passenger-side (or transit-stop-side) location to the
+ *        snapped pickup vertex. Null if no walking is needed at the pickup end.
+ * @param walkFromDropoff walk path from the snapped dropoff vertex to the final location. Null if
+ *        no walking is needed at the dropoff end.
  */
 public record ViableAccessEgress(
   NearbyStop transitStop,
   Vertex transitVertex,
   Vertex passengerVertex,
   AccessEgressType accessEgress,
-  List<InsertionPosition> insertionPositions
+  List<InsertionPosition> insertionPositions,
+  @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+  @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff
 ) {}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/ViableAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/ViableAccessEgress.java
@@ -16,9 +16,9 @@ import org.opentripplanner.street.search.state.State;
  *
  * @param transitStop the nearby transit stop
  * @param transitVertex the street graph vertex where the driver stops to pick up or drop off the
- *        passenger at the transit-stop side (already snapped to a stoppable edge)
+ *        passenger at the transit-stop side (already snapped to a car-accessible vertex)
  * @param passengerVertex the street graph vertex where the driver stops at the passenger side
- *        — origin for access, destination for egress — already snapped to a stoppable edge
+ *        — origin for access, destination for egress — already snapped to a car-accessible vertex
  * @param accessEgress whether this represents access (origin to transit) or egress (transit to destination)
  * @param insertionPositions the viable pickup/dropoff positions on the carpool route
  * @param walkToPickup walk path from the passenger-side (or transit-stop-side) location to the

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -4,9 +4,11 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
 import org.opentripplanner.ext.carpooling.filter.FilterChain;
@@ -19,9 +21,12 @@ import org.opentripplanner.ext.carpooling.routing.InsertionCandidate;
 import org.opentripplanner.ext.carpooling.routing.InsertionEvaluator;
 import org.opentripplanner.ext.carpooling.routing.InsertionPosition;
 import org.opentripplanner.ext.carpooling.routing.InsertionPositionFinder;
+import org.opentripplanner.ext.carpooling.routing.PassengerSnap;
 import org.opentripplanner.ext.carpooling.routing.TripWithViableAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.ViableAccessEgress;
 import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
+import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
+import org.opentripplanner.ext.carpooling.util.StoppableVertexSnapper;
 import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.graph_builder.module.nearbystops.StreetNearbyStopFinder;
@@ -36,13 +41,13 @@ import org.opentripplanner.routing.api.response.RoutingErrorCode;
 import org.opentripplanner.routing.error.RoutingValidationException;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.graphfinder.TransitServiceResolver;
-import org.opentripplanner.routing.linking.LinkingContext;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.linking.TemporaryVerticesContainer;
-import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.streetadapter.StreetSearchRequestMapper;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.utils.time.TimeUtils;
@@ -74,7 +79,7 @@ import org.slf4j.LoggerFactory;
  * <h2>Component Dependencies</h2>
  * <ul>
  *   <li><strong>{@link CarpoolingRepository}:</strong> Source of available driver trips</li>
- *   <li><strong>{@link VertexLinker}:</strong> Links coordinates to graph vertices</li>
+ *   <li><strong>{@link VertexCreationService}:</strong> Links coordinates to graph vertices</li>
  *   <li><strong>{@link StreetLimitationParametersService}:</strong> Street routing configuration</li>
  *   <li><strong>{@link FilterChain}:</strong> Pre-screening filters</li>
  *   <li><strong>{@link InsertionPositionFinder}:</strong> Heuristic position filtering</li>
@@ -104,7 +109,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
   private final FilterChain preFilters;
   private final CarpoolItineraryMapper itineraryMapper;
   private final InsertionPositionFinder positionFinder;
-  private final VertexLinker vertexLinker;
+  private final VertexCreationService vertexCreationService;
 
   /**
    * Creates a new carpooling service with the specified dependencies.
@@ -116,21 +121,22 @@ public class DefaultCarpoolingService implements CarpoolingService {
    * @param streetLimitationParametersService provides street routing configuration including
    *        speed limits, must not be null
    * @param transitService provides timezone from GTFS agency data for time conversions, must not be null
-   * @param vertexLinker links coordinates to graph vertices, must not be null
+   * @param vertexCreationService creates request-scoped, bidirectionally-linked temporary vertices
+   *        from coordinates, must not be null
    * @throws NullPointerException if any parameter is null
    */
   public DefaultCarpoolingService(
     CarpoolingRepository repository,
     StreetLimitationParametersService streetLimitationParametersService,
     TransitService transitService,
-    VertexLinker vertexLinker
+    VertexCreationService vertexCreationService
   ) {
     this.repository = repository;
     this.streetLimitationParametersService = streetLimitationParametersService;
     this.preFilters = FilterChain.standard();
     this.itineraryMapper = new CarpoolItineraryMapper();
     this.positionFinder = new InsertionPositionFinder(new BeelineEstimator());
-    this.vertexLinker = vertexLinker;
+    this.vertexCreationService = vertexCreationService;
   }
 
   /**
@@ -148,14 +154,12 @@ public class DefaultCarpoolingService implements CarpoolingService {
    * </ol>
    *
    * @param request the routing request. Must have {@link StreetMode#CARPOOL} as the direct mode.
-   * @param linkingContext pre-linked vertices for the passenger's origin and destination
    * @return a list of carpool itineraries, or an empty list if no viable matches are found
    *         or the direct mode is not CARPOOL
    * @throws RoutingValidationException if origin or destination coordinates are missing
    */
   @Override
-  public List<Itinerary> routeDirect(RouteRequest request, LinkingContext linkingContext)
-    throws RoutingValidationException {
+  public List<Itinerary> routeDirect(RouteRequest request) throws RoutingValidationException {
     if (!StreetMode.CARPOOL.equals(request.journey().direct().mode())) {
       return Collections.emptyList();
     }
@@ -206,25 +210,57 @@ public class DefaultCarpoolingService implements CarpoolingService {
     try (var temporaryVerticesContainer = new TemporaryVerticesContainer()) {
       var router = new CarpoolStreetRouter(streetLimitationParametersService, request);
 
-      var streetVertexUtils = new StreetVertexUtils(this.vertexLinker, temporaryVerticesContainer);
-
-      var stopDuration = request.preferences().car().pickupTime();
-
-      var insertionEvaluator = new InsertionEvaluator(
-        linkingContext,
-        streetVertexUtils,
-        router,
-        stopDuration
+      var streetVertexUtils = new StreetVertexUtils(
+        this.vertexCreationService,
+        temporaryVerticesContainer
       );
 
-      // Find optimal insertions for remaining trips
+      var stopDuration = request.preferences().car().pickupTime();
+      var maxWalkToCarpool = request
+        .preferences()
+        .street()
+        .accessEgress()
+        .maxDuration()
+        .valueOf(StreetMode.WALK);
+      var streetSearchRequest = StreetSearchRequestMapper.map(request).build();
+
+      var passengerPickupVertex = streetVertexUtils.createPassengerVertex(passengerPickup);
+      var passengerDropoffVertex = streetVertexUtils.createPassengerVertex(passengerDropoff);
+      if (passengerPickupVertex == null || passengerDropoffVertex == null) {
+        LOG.warn("Could not link passenger origin/destination to graph");
+        return List.of();
+      }
+
+      var pickupSnap = StoppableVertexSnapper.snapPickup(
+        streetSearchRequest,
+        passengerPickupVertex,
+        maxWalkToCarpool
+      );
+      var dropoffSnap = StoppableVertexSnapper.snapDropoff(
+        streetSearchRequest,
+        passengerDropoffVertex,
+        maxWalkToCarpool
+      );
+      if (pickupSnap == null || dropoffSnap == null) {
+        LOG.debug(
+          "No stoppable pickup/dropoff reachable within {} from passenger origin/destination",
+          maxWalkToCarpool
+        );
+        return List.of();
+      }
+
+      var insertionEvaluator = new InsertionEvaluator(router, stopDuration);
+
+      var snappedPickup = new WgsCoordinate(pickupSnap.vertex().getCoordinate());
+      var snappedDropoff = new WgsCoordinate(dropoffSnap.vertex().getCoordinate());
+
       var insertionCandidates = candidateTrips
         .stream()
         .map(trip -> {
           List<InsertionPosition> viablePositions = positionFinder.findViablePositions(
             trip,
-            passengerPickup,
-            passengerDropoff,
+            snappedPickup,
+            snappedDropoff,
             stopDuration
           );
 
@@ -239,23 +275,22 @@ public class DefaultCarpoolingService implements CarpoolingService {
             trip.getId()
           );
 
-          var tripWithVertices = CarpoolTripWithVertices.create(
-            trip,
-            streetVertexUtils,
-            linkingContext
-          );
+          var tripWithVertices = CarpoolTripWithVertices.create(trip, streetVertexUtils);
 
           if (tripWithVertices == null) {
             LOG.error("Could not resolve vertices for trip {}", trip.getId());
             return null;
           }
 
-          // Evaluate only viable positions with expensive routing
           return insertionEvaluator.findBestInsertion(
             tripWithVertices,
             viablePositions,
-            passengerPickup,
-            passengerDropoff
+            new PassengerSnap(
+              pickupSnap.vertex(),
+              dropoffSnap.vertex(),
+              pickupSnap.walkPath(),
+              dropoffSnap.walkPath()
+            )
           );
         })
         .filter(Objects::nonNull)
@@ -297,8 +332,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
    * @param streetRequest
    * @param accessOrEgress whether this is an access leg (origin to transit) or egress leg
    *        (transit to destination)
-   * @param transitServiceResolver used for nearby stop search
-   * @param linkingContext pre-linked vertices for the passenger's origin and destination
+   * @param transitServiceResolver used for resolving stop locations and nearby stop search
    * @param transitSearchTimeZero the reference time for computing relative start/end times
    *        used by Raptor
    * @return a list of {@link CarpoolAccessEgress} results for Raptor, or an empty list if the
@@ -311,7 +345,6 @@ public class DefaultCarpoolingService implements CarpoolingService {
     StreetRequest streetRequest,
     AccessEgressType accessOrEgress,
     TransitServiceResolver transitServiceResolver,
-    LinkingContext linkingContext,
     ZonedDateTime transitSearchTimeZero
   ) throws RoutingValidationException {
     if (
@@ -331,10 +364,6 @@ public class DefaultCarpoolingService implements CarpoolingService {
     var allTrips = repository.getCarpoolTrips();
     LOG.debug("Repository contains {} carpool trips", allTrips.size());
 
-    /*
-      The passenger's origin if the request is for access,
-      or the passenger's destination if the request is for egress
-     */
     GenericLocation passengerLocation = accessOrEgress.isAccess() ? request.from() : request.to();
     WgsCoordinate passengerCoordinates = passengerLocation.wgsCoordinate();
 
@@ -357,16 +386,45 @@ public class DefaultCarpoolingService implements CarpoolingService {
     }
 
     try (var temporaryVerticesContainer = new TemporaryVerticesContainer()) {
-      var streetVertexUtils = new StreetVertexUtils(this.vertexLinker, temporaryVerticesContainer);
+      var streetVertexUtils = new StreetVertexUtils(
+        this.vertexCreationService,
+        temporaryVerticesContainer
+      );
 
       var carpoolTreeVertexRouter = new CarpoolTreeStreetRouter();
-      Vertex passengerAccessEgressVertex = streetVertexUtils.getOrCreateVertex(
-        passengerCoordinates,
-        linkingContext
+      var streetSearchRequest = StreetSearchRequestMapper.map(request).build();
+      var maxWalkToCarpool = request
+        .preferences()
+        .street()
+        .accessEgress()
+        .maxDuration()
+        .valueOf(StreetMode.WALK);
+      Vertex passengerAccessEgressVertex = streetVertexUtils.createPassengerVertex(
+        passengerCoordinates
       );
 
       if (passengerAccessEgressVertex == null) {
         LOG.error("Could not link passenger coordinates {} to graph", passengerCoordinates);
+        return List.of();
+      }
+
+      var passengerSnap = accessOrEgress.isEgress()
+        ? StoppableVertexSnapper.snapDropoff(
+            streetSearchRequest,
+            passengerAccessEgressVertex,
+            maxWalkToCarpool
+          )
+        : StoppableVertexSnapper.snapPickup(
+            streetSearchRequest,
+            passengerAccessEgressVertex,
+            maxWalkToCarpool
+          );
+      if (passengerSnap == null) {
+        LOG.debug(
+          "No stoppable vertex reachable within {} from passenger coords {}",
+          maxWalkToCarpool,
+          passengerCoordinates
+        );
         return List.of();
       }
 
@@ -375,33 +433,58 @@ public class DefaultCarpoolingService implements CarpoolingService {
         0
       );
 
-      var nearbyStops = streetNearbyStopFinder
+      // CAR_PICKUP models a walk → drive → walk chain inside a single A*. Using it here (instead
+      // of plain CAR) lets the search find transit stops whose link endpoint is only walk-reachable
+      // from the drivable network — typically pedestrian-plaza stops, platforms reached via walk-
+      // only tunnels, etc. — which a pure CAR search misses because it cannot leave the car
+      // network to walk the final stretch.
+      //
+      // CAR_PICKUP can return several NearbyStop records per stopId (different paths to the same
+      // stop link vertex). They all share the same vertex and stopId — which is everything we read
+      // downstream — so any representative works; we don't rank them.
+      var foundStops = streetNearbyStopFinder
         .build()
         .findNearbyStops(
-          Set.of(passengerAccessEgressVertex),
+          Set.of(passengerSnap.vertex()),
           request,
-          StreetMode.CAR,
+          StreetMode.CAR_PICKUP,
           accessOrEgress.isEgress()
-        )
-        .stream()
-        .filter(stop -> !(transitServiceResolver.getStopLocation(stop.stopId) instanceof AreaStop))
-        .toList();
-
-      var nearbyStopsWithVertices = new HashMap<NearbyStop, Vertex>();
-      for (var stop : nearbyStops) {
-        nearbyStopsWithVertices.put(stop, stop.state.getVertex());
+        );
+      // AreaStops are GTFS Flex zones — their linked vertex is a synthetic point inside the zone,
+      // not a real curb/platform a carpool driver could drop the passenger at, so skip them.
+      var byStopId = new LinkedHashMap<FeedScopedId, NearbyStop>();
+      for (var stop : foundStops) {
+        if (transitServiceResolver.getStopLocation(stop.stopId) instanceof AreaStop) {
+          continue;
+        }
+        byStopId.putIfAbsent(stop.stopId, stop);
+      }
+      var stopSnaps = new HashMap<NearbyStop, StoppableVertexSnapper.SnapResult>();
+      for (var stop : byStopId.values()) {
+        var snap = accessOrEgress.isAccess()
+          ? StoppableVertexSnapper.snapDropoff(
+              streetSearchRequest,
+              stop.state.getVertex(),
+              maxWalkToCarpool
+            )
+          : StoppableVertexSnapper.snapPickup(
+              streetSearchRequest,
+              stop.state.getVertex(),
+              maxWalkToCarpool
+            );
+        if (snap != null) {
+          stopSnaps.put(stop, snap);
+        }
       }
 
       var candidateTripsWithVertices = candidateTrips
         .stream()
-        .map(carpoolTrip ->
-          CarpoolTripWithVertices.create(carpoolTrip, streetVertexUtils, linkingContext)
-        )
+        .map(carpoolTrip -> CarpoolTripWithVertices.create(carpoolTrip, streetVertexUtils))
         .filter(Objects::nonNull)
         .toList();
 
       carpoolTreeVertexRouter.addVertex(
-        passengerAccessEgressVertex,
+        passengerSnap.vertex(),
         CarpoolTreeStreetRouter.Direction.BOTH,
         MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
       );
@@ -430,40 +513,34 @@ public class DefaultCarpoolingService implements CarpoolingService {
 
       var stopDuration = request.preferences().car().pickupTime();
 
-      var insertionEvaluator = new InsertionEvaluator(
-        linkingContext,
-        streetVertexUtils,
-        carpoolTreeVertexRouter,
-        stopDuration
-      );
+      var insertionEvaluator = new InsertionEvaluator(carpoolTreeVertexRouter, stopDuration);
 
       var candidateTripsWithViableStopsAndPositions = candidateTripsWithVertices
         .stream()
         .map(tripWithVertices -> {
-          var viableSegmentInsertions = nearbyStopsWithVertices
-            .keySet()
+          var viableSegmentInsertions = stopSnaps
+            .entrySet()
             .stream()
-            .map(nearbyStop -> {
-              var stop = transitServiceResolver.getStopLocation(nearbyStop.stopId);
-              var pickUpCoord = accessOrEgress.isAccess()
-                ? passengerCoordinates
-                : stop.getCoordinate();
-              var dropOffCoord = accessOrEgress.isAccess()
-                ? stop.getCoordinate()
-                : passengerCoordinates;
+            .map(entry -> {
+              var nearbyStop = entry.getKey();
+              var stopSnap = entry.getValue();
+              var pickupSide = accessOrEgress.isAccess() ? passengerSnap : stopSnap;
+              var dropoffSide = accessOrEgress.isAccess() ? stopSnap : passengerSnap;
 
               var viablePositions = positionFinder.findViablePositions(
                 tripWithVertices.trip(),
-                pickUpCoord,
-                dropOffCoord,
+                new WgsCoordinate(pickupSide.vertex().getCoordinate()),
+                new WgsCoordinate(dropoffSide.vertex().getCoordinate()),
                 stopDuration
               );
               return new ViableAccessEgress(
                 nearbyStop,
-                nearbyStopsWithVertices.get(nearbyStop),
-                passengerAccessEgressVertex,
+                stopSnap.vertex(),
+                passengerSnap.vertex(),
                 accessOrEgress,
-                viablePositions
+                viablePositions,
+                pickupSide.walkPath(),
+                dropoffSide.walkPath()
               );
             })
             .filter(it -> !it.insertionPositions().isEmpty())
@@ -514,30 +591,25 @@ public class DefaultCarpoolingService implements CarpoolingService {
     TransitServiceResolver transitServiceResolver,
     InsertionCandidate insertionCandidate,
     ZonedDateTime transitSearchTimeZero,
-    Double carpoolReluctance
+    double carpoolReluctance
   ) {
-    var sharedSegments = insertionCandidate.getSharedSegments();
-    var durationUntilPickup = insertionCandidate.getDurationUntilPickupArrival();
-    var passengerRideDuration = insertionCandidate.getPassengerRideDuration();
-
-    var startTimeOfSegment = insertionCandidate.trip().startTime().plus(durationUntilPickup);
-    var endTimeOfSegment = startTimeOfSegment.plus(passengerRideDuration);
-
-    var relativeStartTime = TimeUtils.toTransitTimeSeconds(
-      transitSearchTimeZero,
-      startTimeOfSegment.toInstant()
+    var carpoolPickupTime = insertionCandidate
+      .trip()
+      .startTime()
+      .plus(insertionCandidate.getDurationUntilPickupArrival());
+    var passengerStartTime = carpoolPickupTime.minus(
+      GraphPathUtils.durationOrZero(insertionCandidate.walkToPickup())
     );
-    var relativeEndTime = TimeUtils.toTransitTimeSeconds(
+
+    var passengerDepartureTime = TimeUtils.toTransitTimeSeconds(
       transitSearchTimeZero,
-      endTimeOfSegment.toInstant()
+      passengerStartTime.toInstant()
     );
 
     return new CarpoolAccessEgress(
       transitServiceResolver.getStopLocation(insertionCandidate.transitStop().stopId).getIndex(),
-      passengerRideDuration,
-      relativeStartTime,
-      relativeEndTime,
-      sharedSegments,
+      passengerDepartureTime,
+      insertionCandidate,
       TimeAndCost.ZERO,
       carpoolReluctance
     );

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -298,9 +298,10 @@ public class DefaultCarpoolingService implements CarpoolingService {
 
       LOG.debug("Found {} viable insertion candidates", insertionCandidates.size());
 
+      var carpoolReluctance = request.preferences().car().reluctance();
       itineraries = insertionCandidates
         .stream()
-        .map(itineraryMapper::toItinerary)
+        .map(candidate -> itineraryMapper.toItinerary(candidate, carpoolReluctance))
         .filter(Objects::nonNull)
         .toList();
     }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -25,8 +25,8 @@ import org.opentripplanner.ext.carpooling.routing.PassengerSnap;
 import org.opentripplanner.ext.carpooling.routing.TripWithViableAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.ViableAccessEgress;
 import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
+import org.opentripplanner.ext.carpooling.util.CarAccessibleVertexSnapper;
 import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
-import org.opentripplanner.ext.carpooling.util.StoppableVertexSnapper;
 import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.graph_builder.module.nearbystops.StreetNearbyStopFinder;
@@ -231,19 +231,19 @@ public class DefaultCarpoolingService implements CarpoolingService {
         return List.of();
       }
 
-      var pickupSnap = StoppableVertexSnapper.snapPickup(
+      var pickupSnap = CarAccessibleVertexSnapper.snapPickup(
         streetSearchRequest,
         passengerPickupVertex,
         maxWalkToCarpool
       );
-      var dropoffSnap = StoppableVertexSnapper.snapDropoff(
+      var dropoffSnap = CarAccessibleVertexSnapper.snapDropoff(
         streetSearchRequest,
         passengerDropoffVertex,
         maxWalkToCarpool
       );
       if (pickupSnap == null || dropoffSnap == null) {
         LOG.debug(
-          "No stoppable pickup/dropoff reachable within {} from passenger origin/destination",
+          "No car-accessible pickup/dropoff reachable within {} from passenger origin/destination",
           maxWalkToCarpool
         );
         return List.of();
@@ -410,19 +410,19 @@ public class DefaultCarpoolingService implements CarpoolingService {
       }
 
       var passengerSnap = accessOrEgress.isEgress()
-        ? StoppableVertexSnapper.snapDropoff(
+        ? CarAccessibleVertexSnapper.snapDropoff(
             streetSearchRequest,
             passengerAccessEgressVertex,
             maxWalkToCarpool
           )
-        : StoppableVertexSnapper.snapPickup(
+        : CarAccessibleVertexSnapper.snapPickup(
             streetSearchRequest,
             passengerAccessEgressVertex,
             maxWalkToCarpool
           );
       if (passengerSnap == null) {
         LOG.debug(
-          "No stoppable vertex reachable within {} from passenger coords {}",
+          "No car-accessible vertex reachable within {} from passenger coords {}",
           maxWalkToCarpool,
           passengerCoordinates
         );
@@ -460,15 +460,15 @@ public class DefaultCarpoolingService implements CarpoolingService {
         }
         byStopId.putIfAbsent(stop.stopId, stop);
       }
-      var stopSnaps = new HashMap<NearbyStop, StoppableVertexSnapper.SnapResult>();
+      var stopSnaps = new HashMap<NearbyStop, CarAccessibleVertexSnapper.SnapResult>();
       for (var stop : byStopId.values()) {
         var snap = accessOrEgress.isAccess()
-          ? StoppableVertexSnapper.snapDropoff(
+          ? CarAccessibleVertexSnapper.snapDropoff(
               streetSearchRequest,
               stop.state.getVertex(),
               maxWalkToCarpool
             )
-          : StoppableVertexSnapper.snapPickup(
+          : CarAccessibleVertexSnapper.snapPickup(
               streetSearchRequest,
               stop.state.getVertex(),
               maxWalkToCarpool

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
@@ -17,18 +17,26 @@ import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.strategy.DominanceFunctions;
 
 /**
- * Resolves a pickup/dropoff point that a carpool driver can actually stop at.
+ * Resolves a vertex a car can route through near a target location — used to pick a pickup or
+ * dropoff point for a carpool when the passenger's origin/destination (or a transit stop's
+ * street-linked vertex) sits on a pedestrian-only edge that the carpool driver cannot reach.
  * <p>
  * The input is one end of a leg the carpool participates in: the passenger's origin/destination
  * for a direct carpool, or a transit stop's street-linked vertex for an access/egress leg. This
- * returns the input vertex unchanged when it is already drivable in both directions, otherwise
- * runs a bounded WALK A* to find the cheapest such vertex by generalized walk weight (i.e. walk
- * time scaled by the request's reluctance, safety factor, and other preferences — not raw
- * distance). If the input is already stoppable the result contains no walk path; otherwise the
- * result carries the walk path the passenger uses to bridge the pedestrian-only stretch.
+ * returns the input vertex unchanged when it already has both an incoming and outgoing
+ * car-permitting street edge, otherwise runs a bounded WALK A* to find the cheapest such vertex
+ * by generalized walk weight (i.e. walk time scaled by the request's reluctance, safety factor,
+ * and other preferences — not raw distance). If the input is already car-accessible the result
+ * contains no walk path; otherwise the result carries the walk path the passenger uses to bridge
+ * the pedestrian-only stretch.
  * <p>
- * The bounded walk A* is capped by {@code maxWalk}; if no stoppable vertex is reachable within
- * that budget — or no walk-traversable edge exists out of the input vertex in the search
+ * The "car-accessible" check is intentionally minimal — bidirectional car-permitting street
+ * edges, nothing more. Speed limits, road class, and OSM stopping/parking restrictions are not
+ * consulted; OTP does not model explicit no-stopping zones today, and this matches the
+ * precedent set by {@code CAR_PICKUP}, which similarly transitions on any car-permitting edge.
+ * <p>
+ * The bounded walk A* is capped by {@code maxWalk}; if no car-accessible vertex is reachable
+ * within that budget — or no walk-traversable edge exists out of the input vertex in the search
  * direction — {@code null} is returned and the caller should reject the carpool match.
  * <p>
  * Use {@link #snapPickup} when the walker departs from {@code vertexToSnap} (forward search,
@@ -36,17 +44,17 @@ import org.opentripplanner.street.search.strategy.DominanceFunctions;
  * incoming edges). The returned walk path is always in chronological order, from the walk's
  * start vertex to its end vertex.
  */
-public final class StoppableVertexSnapper {
+public final class CarAccessibleVertexSnapper {
 
-  private StoppableVertexSnapper() {}
+  private CarAccessibleVertexSnapper() {}
 
   /**
-   * Outcome of a snap: a stoppable {@code vertex} the carpool driver can pick up or drop off at,
-   * paired with the {@code walkPath} the passenger uses to bridge the pedestrian-only stretch
+   * Outcome of a snap: a car-accessible {@code vertex} the carpool driver can pick up or drop off
+   * at, paired with the {@code walkPath} the passenger uses to bridge the pedestrian-only stretch
    * between that vertex and the original input.
    * <p>
-   * {@code walkPath} is {@code null} in two cases: the input vertex was already stoppable (no walk
-   * needed), or the snap landed on a zero-duration neighbour reached only through the
+   * {@code walkPath} is {@code null} in two cases: the input vertex was already car-accessible (no
+   * walk needed), or the snap landed on a zero-duration neighbour reached only through the
    * passenger-side {@code TemporaryStreetLocation}'s zero-cost {@code TemporaryFreeEdge}s — i.e.
    * the same physical point, just a different graph node, with no real walking to render.
    * <p>
@@ -58,8 +66,8 @@ public final class StoppableVertexSnapper {
 
   /**
    * Snaps a pickup point: searches forward from {@code vertexToSnap} along outgoing edges to find
-   * the lowest-weight stoppable vertex within {@code maxWalk}. The returned walk path runs from
-   * {@code vertexToSnap} to the snapped vertex.
+   * the lowest-weight car-accessible vertex within {@code maxWalk}. The returned walk path runs
+   * from {@code vertexToSnap} to the snapped vertex.
    *
    * @see #snap for the parameter contract.
    */
@@ -74,8 +82,8 @@ public final class StoppableVertexSnapper {
 
   /**
    * Snaps a dropoff point: searches backward to {@code vertexToSnap} along incoming edges to find
-   * the lowest-weight stoppable vertex within {@code maxWalk}. The returned walk path runs from
-   * the snapped vertex to {@code vertexToSnap}.
+   * the lowest-weight car-accessible vertex within {@code maxWalk}. The returned walk path runs
+   * from the snapped vertex to {@code vertexToSnap}.
    *
    * @see #snap for the parameter contract.
    */
@@ -98,12 +106,12 @@ public final class StoppableVertexSnapper {
    * @param vertexToSnap one end of the leg the carpool participates in: a passenger
    *        origin/destination for a direct carpool, or a transit stop's street-linked vertex for
    *        an access/egress leg. The function returns this vertex unchanged when it is already
-   *        stoppable, otherwise searches outward (or inward, when {@code arriveBy}) for the
-   *        lowest-weight stoppable vertex.
-   * @param maxWalk walking-time budget for reaching a stoppable vertex.
+   *        car-accessible, otherwise searches outward (or inward, when {@code arriveBy}) for the
+   *        lowest-weight car-accessible vertex.
+   * @param maxWalk walking-time budget for reaching a car-accessible vertex.
    * @param arriveBy {@code false} for a pickup (walker departs from {@code vertexToSnap}),
    *        {@code true} for a dropoff (walker arrives at it).
-   * @return the snap result, or {@code null} if no stoppable vertex is reachable within
+   * @return the snap result, or {@code null} if no car-accessible vertex is reachable within
    *         {@code maxWalk}.
    */
   @Nullable
@@ -113,23 +121,23 @@ public final class StoppableVertexSnapper {
     Duration maxWalk,
     boolean arriveBy
   ) {
-    if (isStoppable(vertexToSnap)) {
+    if (isCarAccessible(vertexToSnap)) {
       return new SnapResult(vertexToSnap, null);
     }
 
-    // We want the cheapest stoppable vertex within maxWalk of the input. A* isn't built for
-    // "first vertex matching a predicate" — it normally stops at a fixed target or once it has
+    // We want the cheapest car-accessible vertex within maxWalk of the input. A* isn't built for
+    // "first vertex matching a predicate" — it normally terminates at a fixed target or once it has
     // explored the full walk shed. So we repurpose its termination strategy as our predicate:
     // the strategy is called once per expanded state in cost-ascending order (this ordering
     // depends on the dominance function and heuristic configured below — see the package
-    // discussion for why), so the first state we see at a stoppable vertex is guaranteed to be
-    // the cheapest one reachable. The strategy only returns a boolean, so we stash the winning
+    // discussion for why), so the first state we see at a car-accessible vertex is guaranteed to
+    // be the cheapest one reachable. The strategy only returns a boolean, so we stash the winning
     // state in foundRef on the side and read it back after the search returns. The one-element
     // array is the standard Java escape hatch for mutating a captured local from a lambda — the
     // search runs single-threaded so no synchronization is needed.
     State[] foundRef = new State[1];
     SearchTerminationStrategy<State> terminator = state -> {
-      if (isStoppable(state.getVertex())) {
+      if (isCarAccessible(state.getVertex())) {
         foundRef[0] = state;
         return true;
       }
@@ -172,16 +180,17 @@ public final class StoppableVertexSnapper {
   }
 
   /**
-   * A vertex is stoppable when the carpool driver can both <em>arrive</em> at it and
-   * <em>leave</em> it by car — i.e. there is at least one incoming car-permitting street edge
-   * <em>and</em> at least one outgoing car-permitting street edge. Both directions are required
-   * because carpool pickups and dropoffs are mid-route insertions; a vertex with only one (e.g.
-   * the pedestrian-side end of a one-way drivable exit) is unrouteable for the carpool A*.
+   * A vertex is "car-accessible" for the purposes of this snapper when there is at least one
+   * incoming car-permitting street edge <em>and</em> at least one outgoing car-permitting street
+   * edge — i.e. a car can both arrive at it and leave it. Both directions are required because
+   * carpool pickups and dropoffs are mid-route insertions; a vertex with only one (e.g. the
+   * pedestrian-side end of a one-way drivable exit) is unrouteable for the carpool A*.
    * <p>
-   * Motorway interiors are excluded naturally — the bounded WALK A* never reaches them, since
-   * pedestrians can't walk onto a motorway in the first place.
+   * No further restriction is consulted — speed limit, road class, OSM stopping/parking tags are
+   * not considered. This is consistent with how OTP's {@code CAR_PICKUP} mode chooses transition
+   * points.
    */
-  private static boolean isStoppable(Vertex vertex) {
+  private static boolean isCarAccessible(Vertex vertex) {
     return (
       anyStreetEdgeAllowsCar(vertex.getIncoming()) && anyStreetEdgeAllowsCar(vertex.getOutgoing())
     );

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
@@ -148,12 +148,13 @@ public final class CarAccessibleVertexSnapper {
       .withMode(StreetMode.WALK)
       .withArriveBy(arriveBy)
       .build();
-    // Pin the heuristic explicitly: the termination strategy fires per state in cost-ascending
-    // order only when expansion is by g (actual weight), not by f = g + h. The trivial heuristic
-    // returns 0 so f == g; any other heuristic would let a state with smaller g be expanded after
-    // a state with larger g but smaller h, breaking the "first match is cheapest" guarantee.
-    // AStarBuilder defaults to TRIVIAL today, but we don't want a future default flip to silently
-    // break this snapper.
+    // Pin the heuristic explicitly: A* expands states in order of f = g + h, where g is the
+    // actual cost from the start, h is the heuristic's estimate of the remaining cost to the
+    // goal, and f is the resulting priority used to pick the next state. The termination
+    // strategy fires per state in cost-ascending order only when expansion is by g alone —
+    // i.e. when h = 0 and so f == g. The trivial heuristic returns 0 for every state, which
+    // satisfies that. Any other heuristic would let a state with smaller g be expanded after a
+    // state with larger g but smaller h, breaking the "first match is cheapest" guarantee.
     var builder = StreetSearchBuilder.of()
       .withRequest(request)
       .withHeuristic(RemainingWeightHeuristic.TRIVIAL)
@@ -163,7 +164,12 @@ public final class CarAccessibleVertexSnapper {
     // AStarBuilder picks the initial-state vertex set based on arriveBy: toVertices for a reverse
     // search, fromVertices for a forward one. Route vertexToSnap to the matching side or
     // createInitialStates receives null.
-    (arriveBy ? builder.withTo(vertexToSnap) : builder.withFrom(vertexToSnap)).run();
+    if (arriveBy) {
+      builder = builder.withTo(vertexToSnap);
+    } else {
+      builder = builder.withFrom(vertexToSnap);
+    }
+    builder.run();
 
     State best = foundRef[0];
     if (best == null) {
@@ -185,10 +191,6 @@ public final class CarAccessibleVertexSnapper {
    * edge — i.e. a car can both arrive at it and leave it. Both directions are required because
    * carpool pickups and dropoffs are mid-route insertions; a vertex with only one (e.g. the
    * pedestrian-side end of a one-way drivable exit) is unrouteable for the carpool A*.
-   * <p>
-   * No further restriction is consulted — speed limit, road class, OSM stopping/parking tags are
-   * not considered. This is consistent with how OTP's {@code CAR_PICKUP} mode chooses transition
-   * points.
    */
   private static boolean isCarAccessible(Vertex vertex) {
     return (

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/GraphPathUtils.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/GraphPathUtils.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.carpooling.util;
 
 import java.time.Duration;
+import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -9,6 +10,22 @@ import org.opentripplanner.street.search.state.State;
 public final class GraphPathUtils {
 
   private GraphPathUtils() {}
+
+  /**
+   * Returns the duration of the given path, or {@link Duration#ZERO} if the path is {@code null}.
+   */
+  public static Duration durationOrZero(@Nullable GraphPath<State, Edge, Vertex> path) {
+    return path == null ? Duration.ZERO : Duration.ofSeconds(path.getDuration());
+  }
+
+  /**
+   * Returns the A* weight of the given path, or {@code 0} if the path is {@code null}. The weight
+   * already accounts for the user's walk preferences (reluctance, safety factor, slope cost,
+   * etc.) since it comes from the search that produced the path.
+   */
+  public static double weightOrZero(@Nullable GraphPath<State, Edge, Vertex> path) {
+    return path == null ? 0 : path.getWeight();
+  }
 
   /**
    * Calculates cumulative durations from pre-routed segments, including stop duration
@@ -23,7 +40,7 @@ public final class GraphPathUtils {
   ) {
     Duration[] segmentDurations = new Duration[segments.length];
     for (int i = 0; i < segments.length; i++) {
-      segmentDurations[i] = calculateDuration(segments[i]);
+      segmentDurations[i] = Duration.ofSeconds(segments[i].getDuration());
     }
     return calculateCumulativeDurations(segmentDurations, stopDuration);
   }
@@ -62,15 +79,5 @@ public final class GraphPathUtils {
     }
 
     return cumulativeDurations;
-  }
-
-  /**
-   * Calculates duration for a segment
-   */
-  public static Duration calculateDuration(GraphPath<State, Edge, Vertex> segment) {
-    return Duration.between(
-      segment.states.getFirst().getTime(),
-      segment.states.getLast().getTime()
-    );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/StoppableVertexSnapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/StoppableVertexSnapper.java
@@ -1,0 +1,198 @@
+package org.opentripplanner.ext.carpooling.util;
+
+import java.time.Duration;
+import javax.annotation.Nullable;
+import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
+import org.opentripplanner.astar.spi.SearchTerminationStrategy;
+import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.StreetSearchBuilder;
+import org.opentripplanner.street.search.TraverseMode;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.street.search.strategy.DominanceFunctions;
+
+/**
+ * Resolves a pickup/dropoff point that a carpool driver can actually stop at.
+ * <p>
+ * The input is one end of a leg the carpool participates in: the passenger's origin/destination
+ * for a direct carpool, or a transit stop's street-linked vertex for an access/egress leg. This
+ * returns the input vertex unchanged when it is already drivable in both directions, otherwise
+ * runs a bounded WALK A* to find the cheapest such vertex by generalized walk weight (i.e. walk
+ * time scaled by the request's reluctance, safety factor, and other preferences — not raw
+ * distance). If the input is already stoppable the result contains no walk path; otherwise the
+ * result carries the walk path the passenger uses to bridge the pedestrian-only stretch.
+ * <p>
+ * The bounded walk A* is capped by {@code maxWalk}; if no stoppable vertex is reachable within
+ * that budget — or no walk-traversable edge exists out of the input vertex in the search
+ * direction — {@code null} is returned and the caller should reject the carpool match.
+ * <p>
+ * Use {@link #snapPickup} when the walker departs from {@code vertexToSnap} (forward search,
+ * outgoing edges) and {@link #snapDropoff} when the walker arrives at it (reverse search,
+ * incoming edges). The returned walk path is always in chronological order, from the walk's
+ * start vertex to its end vertex.
+ */
+public final class StoppableVertexSnapper {
+
+  private StoppableVertexSnapper() {}
+
+  /**
+   * Outcome of a snap: a stoppable {@code vertex} the carpool driver can pick up or drop off at,
+   * paired with the {@code walkPath} the passenger uses to bridge the pedestrian-only stretch
+   * between that vertex and the original input.
+   * <p>
+   * {@code walkPath} is {@code null} in two cases: the input vertex was already stoppable (no walk
+   * needed), or the snap landed on a zero-duration neighbour reached only through the
+   * passenger-side {@code TemporaryStreetLocation}'s zero-cost {@code TemporaryFreeEdge}s — i.e.
+   * the same physical point, just a different graph node, with no real walking to render.
+   * <p>
+   * When non-null, the path is always in chronological order: from {@code vertexToSnap} to
+   * {@code vertex} for a pickup, and from {@code vertex} to {@code vertexToSnap} for a dropoff
+   * (see {@link #snapPickup} / {@link #snapDropoff}).
+   */
+  public record SnapResult(Vertex vertex, @Nullable GraphPath<State, Edge, Vertex> walkPath) {}
+
+  /**
+   * Snaps a pickup point: searches forward from {@code vertexToSnap} along outgoing edges to find
+   * the lowest-weight stoppable vertex within {@code maxWalk}. The returned walk path runs from
+   * {@code vertexToSnap} to the snapped vertex.
+   *
+   * @see #snap for the parameter contract.
+   */
+  @Nullable
+  public static SnapResult snapPickup(
+    StreetSearchRequest baseRequest,
+    Vertex vertexToSnap,
+    Duration maxWalk
+  ) {
+    return snap(baseRequest, vertexToSnap, maxWalk, false);
+  }
+
+  /**
+   * Snaps a dropoff point: searches backward to {@code vertexToSnap} along incoming edges to find
+   * the lowest-weight stoppable vertex within {@code maxWalk}. The returned walk path runs from
+   * the snapped vertex to {@code vertexToSnap}.
+   *
+   * @see #snap for the parameter contract.
+   */
+  @Nullable
+  public static SnapResult snapDropoff(
+    StreetSearchRequest baseRequest,
+    Vertex vertexToSnap,
+    Duration maxWalk
+  ) {
+    return snap(baseRequest, vertexToSnap, maxWalk, true);
+  }
+
+  /**
+   * @param baseRequest a {@link StreetSearchRequest} carrying the user's walk preferences (speed,
+   *        reluctance, safety factor, …). The walk A* runs with these values; mode is forced to
+   *        {@link StreetMode#WALK} and {@code arriveBy} is overridden by the {@code arriveBy}
+   *        parameter, so callers can hand in any request shape (typically the result of mapping
+   *        their {@code RouteRequest}). Pass {@link StreetSearchRequest#DEFAULT} only when
+   *        defaults are truly intended.
+   * @param vertexToSnap one end of the leg the carpool participates in: a passenger
+   *        origin/destination for a direct carpool, or a transit stop's street-linked vertex for
+   *        an access/egress leg. The function returns this vertex unchanged when it is already
+   *        stoppable, otherwise searches outward (or inward, when {@code arriveBy}) for the
+   *        lowest-weight stoppable vertex.
+   * @param maxWalk walking-time budget for reaching a stoppable vertex.
+   * @param arriveBy {@code false} for a pickup (walker departs from {@code vertexToSnap}),
+   *        {@code true} for a dropoff (walker arrives at it).
+   * @return the snap result, or {@code null} if no stoppable vertex is reachable within
+   *         {@code maxWalk}.
+   */
+  @Nullable
+  private static SnapResult snap(
+    StreetSearchRequest baseRequest,
+    Vertex vertexToSnap,
+    Duration maxWalk,
+    boolean arriveBy
+  ) {
+    if (isStoppable(vertexToSnap)) {
+      return new SnapResult(vertexToSnap, null);
+    }
+
+    // We want the cheapest stoppable vertex within maxWalk of the input. A* isn't built for
+    // "first vertex matching a predicate" — it normally stops at a fixed target or once it has
+    // explored the full walk shed. So we repurpose its termination strategy as our predicate:
+    // the strategy is called once per expanded state in cost-ascending order (this ordering
+    // depends on the dominance function and heuristic configured below — see the package
+    // discussion for why), so the first state we see at a stoppable vertex is guaranteed to be
+    // the cheapest one reachable. The strategy only returns a boolean, so we stash the winning
+    // state in foundRef on the side and read it back after the search returns. The one-element
+    // array is the standard Java escape hatch for mutating a captured local from a lambda — the
+    // search runs single-threaded so no synchronization is needed.
+    State[] foundRef = new State[1];
+    SearchTerminationStrategy<State> terminator = state -> {
+      if (isStoppable(state.getVertex())) {
+        foundRef[0] = state;
+        return true;
+      }
+      return false;
+    };
+
+    var request = StreetSearchRequest.copyOf(baseRequest)
+      .withMode(StreetMode.WALK)
+      .withArriveBy(arriveBy)
+      .build();
+    // Pin the heuristic explicitly: the termination strategy fires per state in cost-ascending
+    // order only when expansion is by g (actual weight), not by f = g + h. The trivial heuristic
+    // returns 0 so f == g; any other heuristic would let a state with smaller g be expanded after
+    // a state with larger g but smaller h, breaking the "first match is cheapest" guarantee.
+    // AStarBuilder defaults to TRIVIAL today, but we don't want a future default flip to silently
+    // break this snapper.
+    var builder = StreetSearchBuilder.of()
+      .withRequest(request)
+      .withHeuristic(RemainingWeightHeuristic.TRIVIAL)
+      .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(maxWalk))
+      .withDominanceFunction(new DominanceFunctions.MinimumWeight())
+      .withTerminationStrategy(terminator);
+    // AStarBuilder picks the initial-state vertex set based on arriveBy: toVertices for a reverse
+    // search, fromVertices for a forward one. Route vertexToSnap to the matching side or
+    // createInitialStates receives null.
+    (arriveBy ? builder.withTo(vertexToSnap) : builder.withFrom(vertexToSnap)).run();
+
+    State best = foundRef[0];
+    if (best == null) {
+      return null;
+    }
+
+    var path = new GraphPath<>(best);
+    // The passenger-side TemporaryStreetLocation links to its split vertices via zero-cost
+    // TemporaryFreeEdges; if the snap landed on one of those, there's no real walk to render.
+    if (path.getDuration() == 0) {
+      return new SnapResult(best.getVertex(), null);
+    }
+    return new SnapResult(best.getVertex(), path);
+  }
+
+  /**
+   * A vertex is stoppable when the carpool driver can both <em>arrive</em> at it and
+   * <em>leave</em> it by car — i.e. there is at least one incoming car-permitting street edge
+   * <em>and</em> at least one outgoing car-permitting street edge. Both directions are required
+   * because carpool pickups and dropoffs are mid-route insertions; a vertex with only one (e.g.
+   * the pedestrian-side end of a one-way drivable exit) is unrouteable for the carpool A*.
+   * <p>
+   * Motorway interiors are excluded naturally — the bounded WALK A* never reaches them, since
+   * pedestrians can't walk onto a motorway in the first place.
+   */
+  private static boolean isStoppable(Vertex vertex) {
+    return (
+      anyStreetEdgeAllowsCar(vertex.getIncoming()) && anyStreetEdgeAllowsCar(vertex.getOutgoing())
+    );
+  }
+
+  private static boolean anyStreetEdgeAllowsCar(Iterable<Edge> edges) {
+    for (Edge e : edges) {
+      if (e instanceof StreetEdge se && se.getPermission().allows(TraverseMode.CAR)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/StreetVertexUtils.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/StreetVertexUtils.java
@@ -2,102 +2,110 @@ package org.opentripplanner.ext.carpooling.util;
 
 import java.util.List;
 import javax.annotation.Nullable;
-import org.opentripplanner.core.model.i18n.NonLocalizedString;
-import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.routing.linking.LinkingContext;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
+import org.opentripplanner.routing.linking.internal.VertexCreationService.LocationType;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.linking.LinkingDirection;
 import org.opentripplanner.street.linking.TemporaryVerticesContainer;
-import org.opentripplanner.street.linking.VertexLinker;
-import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
-import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
-import org.opentripplanner.street.model.vertex.TemporaryVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.street.search.TraverseModeSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Utility for resolving street graph vertices from geographic locations within the carpooling
- * routing context.
- * <p>
- * This class provides a two-step vertex resolution strategy:
+ * Creates temporary, request-scoped graph vertices for carpooling — one flavor for the
+ * passenger's pickup/dropoff and one for each point along the driver's trip. Both flavors
+ * always link {@code BIDIRECTIONAL} (as a {@link LocationType#VISIT_VIA_LOCATION}), because
+ * carpool routing passes <em>through</em> these points rather than starting or ending at them.
+ *
+ * <h2>Why not reuse {@code LinkingContext}?</h2>
+ *
+ * OTP's request pipeline already links the passenger's origin and destination through
+ * {@code LinkingContext}, so it's tempting to reach into that and reuse those vertices. We
+ * don't, for three reasons:
+ *
  * <ol>
- *   <li>Check the {@link LinkingContext} for pre-linked vertices (e.g., the passenger's origin
- *       and destination, which are linked as part of the standard OTP request lifecycle).</li>
- *   <li>If not found, create a temporary vertex on-demand using {@link VertexLinker} and register
- *       it with a {@link TemporaryVerticesContainer} for automatic cleanup after the search.</li>
+ *   <li><b>Directionality breaks driver routing.</b> {@code LinkingContext} links the request
+ *       {@code from} as {@code INCOMING} and the {@code to} as {@code OUTGOING} (see
+ *       {@link VertexCreationService#mapDirection}). That makes each vertex a one-way boundary:
+ *       the origin has only outgoing edges, the destination has only incoming. This is the
+ *       right shape for a normal A* that starts at the origin and ends at the destination.
+ *       <br><br>
+ *       Carpooling is different — the driver <em>passes through</em> both the pickup and the
+ *       dropoff. The driver's CAR search must arrive at AND depart from the pickup (to continue
+ *       toward the dropoff), and arrive at AND depart from the dropoff (to continue toward the
+ *       driver's own trip end). When the pickup/dropoff happens to land on a splitter created
+ *       by the request's own linking — the common "passenger is already on a drivable road"
+ *       case — only the half-edges created by that splitter exist at the splitter, and a
+ *       directional linking gives you only one direction of them. The driver's CAR A* then
+ *       cannot pass through. {@code BIDIRECTIONAL} linking creates both half-edges per split
+ *       and fixes this unconditionally.</li>
+ *
+ *   <li><b>Driver waypoints aren't in {@code LinkingContext} at all.</b> The driver's trip
+ *       has a list of route points that come from the carpooling repository, not from the
+ *       passenger's routing request. {@code LinkingContext} has never seen them, so they have
+ *       to be linked on demand regardless. Consolidating passenger-vertex creation into the
+ *       same facade is the obvious follow-through.</li>
  * </ol>
- * <p>
- * The on-demand creation path is needed for driver trip waypoints, which are not part of the
- * original routing request and therefore have no pre-linked vertices.
+ *
+ * <h2>Cleanup</h2>
+ *
+ * All vertices and their temporary edges are registered with the caller's
+ * {@link TemporaryVerticesContainer} via {@link VertexCreationService}; when the container
+ * is closed at the end of the request, everything added here is yanked from the graph.
  */
 public class StreetVertexUtils {
 
-  private static final Logger LOG = LoggerFactory.getLogger(StreetVertexUtils.class);
-
-  private final VertexLinker vertexLinker;
+  private final VertexCreationService vertexCreationService;
   private final TemporaryVerticesContainer temporaryVerticesContainer;
 
   /**
-   * @param vertexLinker links coordinates to graph vertices
-   * @param temporaryVerticesContainer container for temporary vertices and edges
+   * @param vertexCreationService creates and links the temporary graph vertices.
+   * @param temporaryVerticesContainer collects every vertex and edge created here so the request's
+   *        {@code try-with-resources} cleanup yanks them all from the graph at the end of the
+   *        search.
    */
   public StreetVertexUtils(
-    VertexLinker vertexLinker,
+    VertexCreationService vertexCreationService,
     TemporaryVerticesContainer temporaryVerticesContainer
   ) {
-    this.vertexLinker = vertexLinker;
+    this.vertexCreationService = vertexCreationService;
     this.temporaryVerticesContainer = temporaryVerticesContainer;
   }
 
   /**
-   * Gets a vertex for a coordinate, either from the LinkingContext or by creating
-   * a temporary vertex on-demand.
-   * <p>
-   * This method first checks if vertices already exist in the LinkingContext (which
-   * contains pre-linked vertices for the passenger's origin and destination). If not
-   * found (e.g., for driver trip waypoints), it creates a temporary vertex on-demand
-   * using VertexLinker and adds it to the TemporaryVerticesContainer for automatic cleanup.
-   * <p>
-   * @param coord the coordinate to get a vertex for
-   * @param linkingContext linking context to check for existing vertices
-   * @return vertex for the coordinate, or null if it could not be linked to the graph
+   * Creates a bidirectionally-linked, walk-mode-linked passenger vertex. The passenger is a
+   * pedestrian reaching the curb, so {@code WALK} is the correct linking mode: the splitter it
+   * produces inherits the parent edge's permissions, so a walk-only edge yields a pedestrian
+   * splitter (the snap's walk A* will expand past it) and a walk+car edge yields a car-capable
+   * splitter the driver can pass through in either direction.
    */
   @Nullable
-  public Vertex getOrCreateVertex(WgsCoordinate coord, LinkingContext linkingContext) {
-    var location = GenericLocation.fromCoordinate(coord.latitude(), coord.longitude());
-    var vertices = linkingContext.findVertices(location);
-    if (!vertices.isEmpty()) {
-      return vertices.stream().findFirst().get();
-    }
+  public Vertex createPassengerVertex(WgsCoordinate coord) {
+    return linkCoordinate(coord, TraverseMode.WALK, "Carpooling Passenger Waypoint");
+  }
 
-    var tempVertex = new TemporaryStreetLocation(
+  /**
+   * Creates a fresh, car-linked vertex for a driver trip waypoint. Driver trips do not pass
+   * through OTP's request-linking pipeline, so their intermediate stops are always linked
+   * on-demand — and they must be linked in {@link TraverseMode#CAR} because only the driver
+   * traverses those vertices.
+   */
+  @Nullable
+  public Vertex createDriverWaypointVertex(WgsCoordinate coord) {
+    return linkCoordinate(coord, TraverseMode.CAR, "Carpooling Driver Waypoint");
+  }
+
+  @Nullable
+  private Vertex linkCoordinate(WgsCoordinate coord, TraverseMode mode, String label) {
+    var vertex = vertexCreationService.createVertexFromCoordinate(
+      temporaryVerticesContainer,
       coord.asJtsCoordinate(),
-      new NonLocalizedString("Carpooling Waypoint")
+      label,
+      List.of(mode),
+      LocationType.VISIT_VIA_LOCATION
     );
-
-    var disposableEdges = vertexLinker.linkVertexForRequest(
-      tempVertex,
-      new TraverseModeSet(TraverseMode.CAR),
-      LinkingDirection.BIDIRECTIONAL,
-      (vertex, streetVertex) ->
-        List.of(
-          TemporaryFreeEdge.createTemporaryFreeEdge((TemporaryVertex) vertex, streetVertex),
-          TemporaryFreeEdge.createTemporaryFreeEdge(streetVertex, (TemporaryVertex) vertex)
-        )
-    );
-
-    // Add to container for automatic cleanup
-    temporaryVerticesContainer.addEdgeCollection(disposableEdges);
-
-    if (tempVertex.getIncoming().isEmpty() && tempVertex.getOutgoing().isEmpty()) {
-      LOG.error("Couldn't link coordinate {} to graph", coord);
+    // VertexCreationService logs the link failure; here we just lift it to a null return.
+    if (vertex.getIncoming().isEmpty() && vertex.getOutgoing().isEmpty()) {
       return null;
     }
-
-    LOG.debug("Created temporary vertex for coordinate {} (not in LinkingContext)", coord);
-    return tempVertex;
+    return vertex;
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -260,9 +260,7 @@ public class RoutingWorker {
     }
     debugTimingAggregator.startedDirectCarpoolRouter();
     try {
-      return RoutingResult.ok(
-        serverContext.carpoolingService().routeDirect(request, linkingContext())
-      );
+      return RoutingResult.ok(serverContext.carpoolingService().routeDirect(request));
     } catch (RoutingValidationException e) {
       return RoutingResult.failed(e.getRoutingErrors());
     } finally {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -102,7 +102,7 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
       graph.ellipsoidToGeoidDifference
     );
     this.transitService = transitService;
-    this.carpoolItineraryMapper = new CarpoolItineraryMapper(transitSearchTimeZero);
+    this.carpoolItineraryMapper = new CarpoolItineraryMapper();
   }
 
   public Itinerary createItinerary(RaptorPath<T> path) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/AccessEgressFetcher.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/AccessEgressFetcher.java
@@ -133,7 +133,6 @@ class AccessEgressFetcher {
         streetRequest,
         type,
         transitServiceResolver,
-        linkingContext,
         transitSearchTimeZero
       );
       results.addAll(carpoolAccessEgressList);


### PR DESCRIPTION
### Summary

This change adds walking to and from carpooling trips. This has the effect that we get results if the requested origin/destination is at a location which is not car accessible we get results. This also has the effect that more transit stops are found for access/egress requests because some stops are not accessible by car. 

The second commit sneaks in a fix for penalty of CarpoolAccessEgress, which now has the same behaviour as DefaultAccessEgress. 

### Unit tests

There are added substantial testing to the new/changed features. 

- A new class StoppableVertexSnapper which find paths to car accesible vertices has many unit tests. 
- There are new integration tests for both direct routing and access/egress routing with walk paths to/from carpooling 
trips.
- StreetVertexUtils is substantially changed, and tests updated. 
- There are added unit tests for CarpoolAccessEgress, which tests both walking to/from transit stops and the fix including penalty as part of the cost. 

### Documentation

- Have you added documentation in code covering design and rationale behind the code?
Yes 
- Were all non-trivial public classes and methods documented with Javadoc?
Yes