### PR TITLE
Make elevation tile cache size configurable

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -420,7 +420,8 @@ public class GraphBuilderModules {
       config.distanceBetweenElevationSamples,
       config.maxElevationPropagationMeters,
       config.includeEllipsoidToGeoidDifference,
-      config.multiThreadElevationCalculations
+      config.multiThreadElevationCalculations,
+      config.elevationTileCacheSizeMB
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -64,6 +64,9 @@ import org.slf4j.LoggerFactory;
 public class ElevationModule implements GraphBuilderModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElevationModule.class);
+
+  private static final long ONE_MEGABYTE = 1024L * 1024L;
+
   /**
    * The WGS84 CRS with longitude-first axis order. The first time a CRS lookup is
    * performed is surprisingly expensive (around 500ms), apparently due to  initializing
@@ -342,7 +345,7 @@ public class ElevationModule implements GraphBuilderModule {
    * DEMs and causes the elevation pass to spend most of its time re-decompressing TIFF tiles.
    */
   private void configureTileCache() {
-    long bytes = (long) elevationTileCacheSizeMB * 1024L * 1024L;
+    long bytes = elevationTileCacheSizeMB * ONE_MEGABYTE;
     TileCache cache = ImageN.getDefaultInstance().getTileCache();
     long previousBytes = cache.getMemoryCapacity();
     if (previousBytes == bytes) {
@@ -352,7 +355,7 @@ public class ElevationModule implements GraphBuilderModule {
     LOG.info(
       "Imagen tile cache memory capacity set to {} MB (was {} MB)",
       elevationTileCacheSizeMB,
-      previousBytes / (1024 * 1024)
+      previousBytes / ONE_MEGABYTE
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.imagen.ImageN;
+import org.eclipse.imagen.TileCache;
 import org.geotools.api.coverage.Coverage;
 import org.geotools.api.coverage.PointOutsideCoverageException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -99,6 +101,11 @@ public class ElevationModule implements GraphBuilderModule {
    * data and machine settings, it might be faster to use a single processor.
    */
   private final boolean multiThreadElevationCalculations;
+  /**
+   * Memory budget (in megabytes) for the Imagen tile cache. Applied to
+   * {@link org.eclipse.imagen.ImageN#getDefaultInstance()} before any tile is fetched.
+   */
+  private final int elevationTileCacheSizeMB;
   // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings. AtomicInteger is
   // used to provide thread-safe updating capabilities.
   private final AtomicInteger nPointsEvaluated = new AtomicInteger(0);
@@ -138,7 +145,8 @@ public class ElevationModule implements GraphBuilderModule {
       10,
       2000,
       true,
-      false
+      false,
+      100
     );
   }
 
@@ -153,7 +161,8 @@ public class ElevationModule implements GraphBuilderModule {
     double distanceBetweenSamplesM,
     double maxElevationPropagationMeters,
     boolean includeEllipsoidToGeoidDifference,
-    boolean multiThreadElevationCalculations
+    boolean multiThreadElevationCalculations,
+    int elevationTileCacheSizeMB
   ) {
     gridCoverageFactory = factory;
     this.graph = graph;
@@ -165,12 +174,14 @@ public class ElevationModule implements GraphBuilderModule {
     this.maxElevationPropagationMeters = maxElevationPropagationMeters;
     this.includeEllipsoidToGeoidDifference = includeEllipsoidToGeoidDifference;
     this.multiThreadElevationCalculations = multiThreadElevationCalculations;
+    this.elevationTileCacheSizeMB = elevationTileCacheSizeMB;
     this.distanceBetweenSamplesM = distanceBetweenSamplesM;
   }
 
   @Override
   public void buildGraph() {
     Instant start = Instant.now();
+    configureTileCache();
     gridCoverageFactory.fetchData(graph);
 
     graph.setDistanceBetweenElevationSamples(this.distanceBetweenSamplesM);
@@ -321,6 +332,28 @@ public class ElevationModule implements GraphBuilderModule {
     } else {
       LOG.warn("Not using cached elevations! This could take a while...");
     }
+  }
+
+  /**
+   * Resize the Imagen default tile cache to the configured budget. Run once before any DEM tile
+   * is fetched, so subsequent {@code getTile} calls hit the cache instead of re-decompressing.
+   * <p>
+   * Imagen's default cache is 16 MB, which is too small to hold the hot working set on regional
+   * DEMs and causes the elevation pass to spend most of its time re-decompressing TIFF tiles.
+   */
+  private void configureTileCache() {
+    long bytes = (long) elevationTileCacheSizeMB * 1024L * 1024L;
+    TileCache cache = ImageN.getDefaultInstance().getTileCache();
+    long previousBytes = cache.getMemoryCapacity();
+    if (previousBytes == bytes) {
+      return;
+    }
+    cache.setMemoryCapacity(bytes);
+    LOG.info(
+      "Imagen tile cache memory capacity set to {} MB (was {} MB)",
+      elevationTileCacheSizeMB,
+      previousBytes / (1024 * 1024)
+    );
   }
 
   private void updateElevationMetadata(Graph graph) {

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.framework.application.OtpFileNames.BUILD_CONFI
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V1_5;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_10;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_5;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_7;
@@ -180,6 +181,7 @@ public class BuildConfig implements OtpDataStoreConfig {
   public final boolean writeCachedElevations;
   public final boolean includeEllipsoidToGeoidDifference;
   public final boolean multiThreadElevationCalculations;
+  public final int elevationTileCacheSizeMB;
   public final LocalDate transitServiceStart;
   public final LocalDate transitServiceEnd;
   public final ZoneId transitModelTimeZone;
@@ -304,6 +306,17 @@ public class BuildConfig implements OtpDataStoreConfig {
         """
       )
       .asBoolean(false);
+    elevationTileCacheSizeMB = root
+      .of("elevationTileCacheSizeMB")
+      .since(V2_10)
+      .summary("Memory budget in megabytes for the tile cache used during elevation processing.")
+      .description(
+        """
+          Elevation sampling reads pixels from a tiled DEM through a tile cache.
+          Increase the cache size for large DEMs, lower for memory-constrained environments.
+        """
+      )
+      .asInt(100);
     osmCacheDataInMem = root
       .of("osmCacheDataInMem")
       .since(V2_0)

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -309,11 +309,15 @@ public class BuildConfig implements OtpDataStoreConfig {
     elevationTileCacheSizeMB = root
       .of("elevationTileCacheSizeMB")
       .since(V2_10)
-      .summary("Memory budget in megabytes for the tile cache used during elevation processing.")
+      .summary(
+        "Memory budget in megabytes for the Imagen tile cache used during elevation processing."
+      )
       .description(
         """
-          Elevation sampling reads pixels from a tiled DEM through a tile cache.
-          Increase the cache size for large DEMs, lower for memory-constrained environments.
+        Elevation sampling reads pixels from a tiled DEM through Imagen's tile cache. Sizing the
+        cache to fit the DEM working set turns repeated tile decompressions into cache hits.
+        Increase for large DEMs, lower for memory-constrained environments. The cache lives
+        inside the JVM heap and must fit inside `-Xmx`.
         """
       )
       .asInt(100);

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -24,6 +24,7 @@ Sections follow that describe particular settings in more depth.
 | [configVersion](#configVersion)                                                             |       `string`       | Deployment version of the *build-config.json*.                                                                                                                 | *Optional* |                                   |  2.1  |
 | [dataImportReport](#dataImportReport)                                                       |       `boolean`      | Generate nice HTML report of Graph errors/warnings                                                                                                             | *Optional* | `false`                           |  2.0  |
 | [distanceBetweenElevationSamples](#distanceBetweenElevationSamples)                         |       `double`       | The distance between elevation samples in meters.                                                                                                              | *Optional* | `10.0`                            |  2.0  |
+| [elevationTileCacheSizeMB](#elevationTileCacheSizeMB)                                       |       `integer`      | Memory budget in megabytes for the tile cache used during elevation processing.                                                                                | *Optional* | `100`                             |  2.10 |
 | embedRouterConfig                                                                           |       `boolean`      | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire.                                                   | *Optional* | `true`                            |  2.0  |
 | [graph](#graph)                                                                             |         `uri`        | URI to the graph object file for reading and writing.                                                                                                          | *Optional* |                                   |  2.0  |
 | [includeEllipsoidToGeoidDifference](#includeEllipsoidToGeoidDifference)                     |       `boolean`      | Include the Ellipsoid to Geoid difference in the calculations of every point along every StreetWithElevationEdge.                                              | *Optional* | `false`                           |  2.0  |
@@ -445,6 +446,17 @@ The reports are stored in the same location as the graph.
 The distance between elevation samples in meters.
 
 The default is the approximate resolution of 1/3 arc-second NED data. This should not be smaller than the horizontal resolution of the height data used.
+
+<h3 id="elevationTileCacheSizeMB">elevationTileCacheSizeMB</h3>
+
+**Since version:** `2.10` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `100`   
+**Path:** / 
+
+Memory budget in megabytes for the tile cache used during elevation processing.
+
+  Elevation sampling reads pixels from a tiled DEM through a tile cache.
+  Increase the cache size for large DEMs, lower for memory-constrained environments.
+
 
 <h3 id="graph">graph</h3>
 

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -24,7 +24,7 @@ Sections follow that describe particular settings in more depth.
 | [configVersion](#configVersion)                                                             |       `string`       | Deployment version of the *build-config.json*.                                                                                                                 | *Optional* |                                   |  2.1  |
 | [dataImportReport](#dataImportReport)                                                       |       `boolean`      | Generate nice HTML report of Graph errors/warnings                                                                                                             | *Optional* | `false`                           |  2.0  |
 | [distanceBetweenElevationSamples](#distanceBetweenElevationSamples)                         |       `double`       | The distance between elevation samples in meters.                                                                                                              | *Optional* | `10.0`                            |  2.0  |
-| [elevationTileCacheSizeMB](#elevationTileCacheSizeMB)                                       |       `integer`      | Memory budget in megabytes for the tile cache used during elevation processing.                                                                                | *Optional* | `100`                             |  2.10 |
+| [elevationTileCacheSizeMB](#elevationTileCacheSizeMB)                                       |       `integer`      | Memory budget in megabytes for the Imagen tile cache used during elevation processing.                                                                         | *Optional* | `100`                             |  2.10 |
 | embedRouterConfig                                                                           |       `boolean`      | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire.                                                   | *Optional* | `true`                            |  2.0  |
 | [graph](#graph)                                                                             |         `uri`        | URI to the graph object file for reading and writing.                                                                                                          | *Optional* |                                   |  2.0  |
 | [includeEllipsoidToGeoidDifference](#includeEllipsoidToGeoidDifference)                     |       `boolean`      | Include the Ellipsoid to Geoid difference in the calculations of every point along every StreetWithElevationEdge.                                              | *Optional* | `false`                           |  2.0  |
@@ -452,10 +452,12 @@ The default is the approximate resolution of 1/3 arc-second NED data. This shoul
 **Since version:** `2.10` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `100`   
 **Path:** / 
 
-Memory budget in megabytes for the tile cache used during elevation processing.
+Memory budget in megabytes for the Imagen tile cache used during elevation processing.
 
-  Elevation sampling reads pixels from a tiled DEM through a tile cache.
-  Increase the cache size for large DEMs, lower for memory-constrained environments.
+Elevation sampling reads pixels from a tiled DEM through Imagen's tile cache. Sizing the
+cache to fit the DEM working set turns repeated tile decompressions into cache hits.
+Increase for large DEMs, lower for memory-constrained environments. The cache lives
+inside the JVM heap and must fit inside `-Xmx`.
 
 
 <h3 id="graph">graph</h3>


### PR DESCRIPTION
### Summary

Make the Imagen tile-cache memory budget configurable from `build-config.json` via a new `elevationTileCacheSizeMB` field (default **100 MB**). The graph builder applies it to `ImageN.getDefaultInstance().getTileCache()` once at the start of `ElevationModule.buildGraph`, before any DEM tile is fetched.

### Motivation

Elevation sampling reads pixels from a tiled DEM through Imagen's tile cache. With the default Imagen capacity (16 MB), hot DEM tiles repeatedly fall out of the cache and have to be re-decompressed during the elevation pass — that decompression dominates the build's wall-clock on regional DEMs.

Empirical measurements with a single regional GeoTIFF DEM (~1.6 GB, sample distance 25 m, 4 worker threads), all other settings unchanged:

| `elevationTileCacheSizeMB` | Elevation pass | Total `--buildStreet` |
|---:|---:|---:|
| 16 (Imagen default) | 20m35s | 30m42s |
| 500 | 5m54s | 16m20s |
| 1024 | 2m13s | 12m03s |
| 2048 | 1m35s | 11m22s |

Roughly halving the elevation pass each time the cache size doubles, until the hot working set fits.

### Approach

- New build-config field `elevationTileCacheSizeMB` (`integer`, default `100`, since `2.10`).
- `ElevationModule.configureTileCache()` calls `ImageN.getDefaultInstance().getTileCache().setMemoryCapacity(bytes)` once before any DEM tile is loaded, and logs the change.
- The cache is process-global, so both `GeotiffGridCoverageFactoryImpl` (single GeoTIFF) and `NEDGridCoverageFactoryImpl` (multi-region NED stack) benefit identically.
- Default raised from Imagen's 16 MB to a conservative 100 MB: a clear improvement over the default on small DEMs without surprising users with extra heap pressure on existing builds. Builds against full-country DEMs should raise this to 1–2 GB. The cache lives inside the JVM heap and must fit inside `-Xmx`.

### Unit tests

No

### Documentation

Updated configuration doc
