### PR TITLE
Fix board stop for pass-through connections

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorAccessEgress.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorAccessEgress.java
@@ -290,7 +290,11 @@ public interface RaptorAccessEgress {
   /** Call this from toString or {@link #defaultToString()} */
   default String asString(boolean includeStop, boolean includeCost, @Nullable String summary) {
     StringBuilder buf = new StringBuilder();
-    if (isFree()) {
+
+    if (this instanceof RaptorStartOnBoardAccess sob) {
+      var boarding = sob.tripBoarding();
+      buf.append("StartOnBoard").append(boarding);
+    } else if (isFree()) {
       buf.append("Free");
     } else if (hasRides()) {
       buf.append(arrivedOnBoard() ? "Flex" : "Flex+Walk");
@@ -301,7 +305,9 @@ public interface RaptorAccessEgress {
       // which would be more precise.
       buf.append("Walk");
     }
-    buf.append(' ').append(DurationUtils.durationToStr(durationInSeconds()));
+    if (durationInSeconds() != 0) {
+      buf.append(' ').append(DurationUtils.durationToStr(durationInSeconds()));
+    }
     if (includeCost && c1() > 0) {
       buf.append(' ').append(C1.format(c1()));
     }

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorTripScheduleStopPosition.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/model/RaptorTripScheduleStopPosition.java
@@ -1,13 +1,13 @@
 package org.opentripplanner.raptor.api.model;
 
 import java.util.Objects;
-import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
  * This class contains information to identify a given stop in a stop pattern for a given trip
  * schedule in a route. This can for example be used to identify where a bording or alighting
  * happens.
  */
+@SuppressWarnings("ClassCanBeRecord")
 public final class RaptorTripScheduleStopPosition {
 
   private final int routeIndex;
@@ -62,10 +62,14 @@ public final class RaptorTripScheduleStopPosition {
   @Override
   public String toString() {
     // The field labels are shortened to improve reading - should be easy to get in the context
-    return ToStringBuilder.of(RaptorTripScheduleStopPosition.class)
-      .addNum("route", routeIndex)
-      .addNum("tripSchedule", tripScheduleIndex)
-      .addNum("stopPosition", stopPositionInPattern)
-      .toString();
+    return (
+      "[route: " +
+      routeIndex +
+      ", trip: " +
+      tripScheduleIndex +
+      ", pos: " +
+      stopPositionInPattern +
+      "]"
+    );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/DefaultRangeRaptorWorker.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/DefaultRangeRaptorWorker.java
@@ -230,12 +230,18 @@ public final class DefaultRangeRaptorWorker<T extends RaptorTripSchedule>
           transitWorker.alightOnlyRegularTransferExist(stopIndex, stopPos, alightSlack);
         }
       }
-      // attempt to board using on-board trip access
+
+      // attempt to board using on-board trip access/pass-though. This happens after
+      // the alight at the given stop position.
       if (onBoardArrivals != null && onBoardArrivals.arrivalExistForStopPosition(stopPos)) {
         for (var arrival : onBoardArrivals.listArrivals(stopPos)) {
           var boarding = arrival.boardingConstraint();
           var trip = route.timetable().getTripSchedule(boarding.tripScheduleIndex());
-          transitWorker.boardWithStartOnBoardAccess(arrival.accessStopArrival(), trip, stopPos);
+          transitWorker.boardWithStartOnBoardAccess(
+            arrival.accessStopArrival(),
+            trip,
+            boarding.stopPositionInPattern()
+          );
         }
       }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/DefaultRangeRaptorWorker.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/DefaultRangeRaptorWorker.java
@@ -43,7 +43,8 @@ import org.opentripplanner.raptor.spi.RaptorTripSchedule;
  *     (generating randomized schedules)
  * </ul>
  * <p>
- * This class originated as a rewrite of Conveyals RAPTOR code: https://github.com/conveyal/r5.
+ * This class originated as a rewrite of <a href="https://github.com/conveyal/r5">Conveyals RAPTOR
+ * code</a>.
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/internalapi/OnTripAccessArrivals.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/internalapi/OnTripAccessArrivals.java
@@ -9,8 +9,11 @@ import org.opentripplanner.raptor.api.view.ArrivalView;
 import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 
 /**
- * Holds all on-board trip access arrivals for a single route, indexed by stop position in the
- * route's stop pattern.
+ * Holds all on-board trip access arrivals for a single route, indexed by the stop position in the
+ * route's stop pattern where the ride must be injected. This is not the same as the board
+ * position. For example for a pass-through stop, the board position is where the route was
+ * boarded, but the ride is not injected into the algorithm before the pass-through stop. This
+ * prevents alighting the trip before the pass-through stop is visited.
  *
  * <p>An on-board trip access represents a passenger who is already on board a vehicle at the
  * start of the search — i.e., their "access leg" is the ride itself rather than a walk to a
@@ -32,15 +35,22 @@ public final class OnTripAccessArrivals<T extends RaptorTripSchedule> {
     return arrivalsForStopPosition.get(stopPos);
   }
 
-  /** Adds an on-board arrival, indexing it by its boarding stop position in the pattern. */
+  /// Adds an on-board arrival, indexing it by its boarding stop position in the pattern.
+  ///
+  /// @param startRoutingAtStopPosition The stop position in trip pattern where the algorithm will
+  ///   inject the boarding. The boarding position can be any position BEFORE or equal to this. The
+  ///   effect is that the algorithm will not alight before the next stop after this. This is used
+  ///   to support pass-through where we do not want to alight before the pass-through stop.
   public void add(
     ArrivalView<T> accessStopArrival,
+    int startRoutingAtStopPosition,
     RaptorTripScheduleStopPosition boardingConstraint
   ) {
-    var list = arrivalsForStopPosition.get(boardingConstraint.stopPositionInPattern());
+    var list = arrivalsForStopPosition.get(startRoutingAtStopPosition);
+
     if (list == null) {
       list = new ArrayList<>();
-      arrivalsForStopPosition.put(boardingConstraint.stopPositionInPattern(), list);
+      arrivalsForStopPosition.put(startRoutingAtStopPosition, list);
     }
     list.add(new OnTripAccessArrival<>(accessStopArrival, boardingConstraint));
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -116,7 +116,7 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   @Override
   public RaptorRouterResult<T> results() {
     arrivals.debugStateInfo();
-    return new McRaptorRouterResult<T>(arrivals, paths);
+    return new McRaptorRouterResult<>(arrivals, paths);
   }
 
   Iterable<? extends McStopArrival<T>> listStopArrivalsPreviousRound(int stop) {
@@ -128,9 +128,9 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
     return arrivals.consumeOnTripStopArrivalsForRoute(routeIndex);
   }
 
-  public void addOnTripAccessStopArrival(RaptorStartOnBoardAccess accessPath, int arrivalTime) {
-    var arrival = stopArrivalFactory.createAccessStopArrival(arrivalTime, accessPath);
-    arrivals.addOnBoardTripArrival(arrival, arrival.stop(), accessPath.tripBoarding());
+  public void addOnTripAccessStopArrival(RaptorStartOnBoardAccess access, int arrivalTime) {
+    var arrival = stopArrivalFactory.createAccessStopArrival(arrivalTime, access);
+    arrivals.addOnBoardTripArrival(arrival, arrival.stop(), access.tripBoarding());
   }
 
   /**

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -130,7 +130,13 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
 
   public void addOnTripAccessStopArrival(RaptorStartOnBoardAccess access, int arrivalTime) {
     var arrival = stopArrivalFactory.createAccessStopArrival(arrivalTime, access);
-    arrivals.addOnBoardTripArrival(arrival, arrival.stop(), access.tripBoarding());
+    var boardingConstraint = access.tripBoarding();
+    arrivals.addOnBoardTripArrival(
+      arrival,
+      arrival.stop(),
+      boardingConstraint.stopPositionInPattern(),
+      boardingConstraint
+    );
   }
 
   /**

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -108,6 +108,7 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     transfersCache.clear();
   }
 
+  @SuppressWarnings("RedundantLabeledSwitchRuleCodeBlock")
   @Override
   public void notifyElementAccepted(ArrivalView<T> newElement) {
     var arrival = (McStopArrival<T>) newElement;
@@ -132,7 +133,7 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     }
   }
 
-  /// We need to continue pass-through connections, even if they are better arrivals in the
+  /// We need to continue pass-through connections, even if better arrivals exist in the
   /// stop arrivals at the given stop - so we ignore the fact that the alighting is rejected.
   @Override
   public void notifyElementRejected(ArrivalView<T> arrival, ArrivalView<T> rejectedByElement) {
@@ -143,26 +144,26 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     }
   }
 
-  private void continueOnSameTripInNextSegment(ArrivalView<T> arrival) {
-    if (!arrival.arrivedBy(TRANSIT)) {
-      next.addStopArrival((McStopArrival<T>) arrival);
+  /// @param alightArrival Must be a transit arrival, if not it is ignored.
+  @SuppressWarnings("DataFlowIssue")
+  private void continueOnSameTripInNextSegment(ArrivalView<T> alightArrival) {
+    if (!alightArrival.arrivedBy(TRANSIT)) {
       return;
     }
-    T trip = arrival.transitPath().trip();
+    T trip = alightArrival.transitPath().trip();
     var info = tripInfoProvider.apply(trip);
 
-    var boardingArrival = arrival.previous();
+    var arrivalAtBoardStop = alightArrival.previous();
     int passThroughStopPos = trip.findDepartureStopPosition(
-      boardingArrival.arrivalTime(),
-      arrival.stop()
+      arrivalAtBoardStop.arrivalTime(),
+      alightArrival.stop()
     );
     var onBoardTripConstraint = new RaptorTripScheduleStopPosition(
       info.routeIndex(),
       info.tripScheduleIndex(),
       passThroughStopPos
     );
-
-    next.addOnBoardTripArrival(boardingArrival, arrival.stop(), onBoardTripConstraint);
+    next.addOnBoardTripArrival(arrivalAtBoardStop, alightArrival.stop(), onBoardTripConstraint);
   }
 
   private void continueFromSameStopArrival(

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -150,20 +150,30 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     if (!alightArrival.arrivedBy(TRANSIT)) {
       return;
     }
-    T trip = alightArrival.transitPath().trip();
+    var transitPath = alightArrival.transitPath();
+    T trip = transitPath.trip();
     var info = tripInfoProvider.apply(trip);
 
     var arrivalAtBoardStop = alightArrival.previous();
-    int passThroughStopPos = trip.findDepartureStopPosition(
+    int boardingStopPos = trip.findDepartureStopPosition(
       arrivalAtBoardStop.arrivalTime(),
+      transitPath.boardStop()
+    );
+    int startRoutingAtStopPosition = trip.findArrivalStopPosition(
+      alightArrival.arrivalTime(),
       alightArrival.stop()
     );
-    var onBoardTripConstraint = new RaptorTripScheduleStopPosition(
+    var boardingConstraint = new RaptorTripScheduleStopPosition(
       info.routeIndex(),
       info.tripScheduleIndex(),
-      passThroughStopPos
+      boardingStopPos
     );
-    next.addOnBoardTripArrival(arrivalAtBoardStop, alightArrival.stop(), onBoardTripConstraint);
+    next.addOnBoardTripArrival(
+      arrivalAtBoardStop,
+      alightArrival.stop(),
+      startRoutingAtStopPosition,
+      boardingConstraint
+    );
   }
 
   private void continueFromSameStopArrival(

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/McStopArrivals.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/McStopArrivals.java
@@ -206,27 +206,33 @@ public final class McStopArrivals<T extends RaptorTripSchedule> {
    * Also ensures the Pareto set for {@code applyToStopIndex} is initialised and marks the stop
    * as touched so the routing loop will visit it.
    *
-   * @param boardingArrival       the arrival state from which boarding occurs.
-   * @param applyToStopIndex      the stop where the on-board boarding should be applied.
-   * @param onBoardTripConstraint  the trip and stop-position constraint for the on-board access.
+   * @param boardingArrival            the arrival state from which boarding occurs.
+   * @param startRoutingAtStopIndex    the stop index where the new ride is applied in the
+   *                                   algorithm. The next stop in pattern will be the first
+   *                                   possible stop to alight. The boarding might be at an earlier
+   *                                   stop.
+   * @param startRoutingAtStopPosition Same as above, but the stop position in the trip pattern.
+   * @param boardingConstraint         the trip and stop-position for where the boarding happens.
    */
   public void addOnBoardTripArrival(
     ArrivalView<T> boardingArrival,
-    int applyToStopIndex,
-    RaptorTripScheduleStopPosition onBoardTripConstraint
+    int startRoutingAtStopIndex,
+    int startRoutingAtStopPosition,
+    RaptorTripScheduleStopPosition boardingConstraint
   ) {
-    int routeIndex = onBoardTripConstraint.routeIndex();
+    int routeIndex = boardingConstraint.routeIndex();
     var arrivalsForRoute = onBoardTripArrivalsByRouteQueue.get(routeIndex);
+
     if (arrivalsForRoute == null) {
       arrivalsForRoute = new OnTripAccessArrivals<>();
       onBoardTripArrivalsByRouteQueue.put(routeIndex, arrivalsForRoute);
     }
-    arrivalsForRoute.add(boardingArrival, onBoardTripConstraint);
+    arrivalsForRoute.add(boardingArrival, startRoutingAtStopPosition, boardingConstraint);
 
     // Then update the state, both touchedStops and init the pareto-set for the given stop to
     // prevent NPE when the state is fetched later. The set is empty, which is ok.
-    findOrCreateSet(applyToStopIndex);
-    touchedStops.set(applyToStopIndex);
+    findOrCreateSet(startRoutingAtStopIndex);
+    touchedStops.set(startRoutingAtStopIndex);
   }
 
   /* private methods */

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/McStopArrivals.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/McStopArrivals.java
@@ -218,7 +218,7 @@ public final class McStopArrivals<T extends RaptorTripSchedule> {
     int routeIndex = onBoardTripConstraint.routeIndex();
     var arrivalsForRoute = onBoardTripArrivalsByRouteQueue.get(routeIndex);
     if (arrivalsForRoute == null) {
-      arrivalsForRoute = new OnTripAccessArrivals<T>();
+      arrivalsForRoute = new OnTripAccessArrivals<>();
       onBoardTripArrivalsByRouteQueue.put(routeIndex, arrivalsForRoute);
     }
     arrivalsForRoute.add(boardingArrival, onBoardTripConstraint);

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
@@ -14,7 +14,8 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
  * well as the default state. There are relatively few access states, so the memory and performance
  * overhead is small.
  */
-public class AccessStopArrivalState<T extends RaptorTripSchedule> implements StopArrivalState<T> {
+public final class AccessStopArrivalState<T extends RaptorTripSchedule>
+  implements StopArrivalState<T> {
 
   private final DefaultStopArrivalState<T> delegate;
   private RaptorAccessEgress accessArriveOnStreet;

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/DefaultStopArrivalState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/DefaultStopArrivalState.java
@@ -22,7 +22,9 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
-class DefaultStopArrivalState<T extends RaptorTripSchedule> implements StopArrivalState<T> {
+sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
+  implements StopArrivalState<T>
+  permits EgressStopArrivalState {
 
   /**
    * Used to initialize all none time based attributes.

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPaths.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPaths.java
@@ -73,9 +73,7 @@ public class AccessPaths {
     RaptorProfile profile,
     SearchDirection searchDirection
   ) {
-    // On board access paths can not be filtered up-front to remove non-optimal accesses,
-    // and also cannot have time penalties, so we extract them from paths before removing.
-    var split = splitOutStartOnBoardPaths(paths);
+    var split = partitioningByStartOnBoard(paths);
     var onBoardAccessPaths = mapToStartOnBoardAccess(split.get(true));
 
     paths = split.get(false);
@@ -247,7 +245,12 @@ public class AccessPaths {
     return startOnBoardPaths.stream().map(RaptorStartOnBoardAccess.class::cast).toList();
   }
 
-  private static Map<Boolean, List<RaptorAccessEgress>> splitOutStartOnBoardPaths(
+  /// This method partition the input paths in two, the RaptorStartOnBoardAccess(key=true) in one
+  /// list and the rest in the other.
+  ///
+  /// Start on board access paths can not be filtered up-front to remove non-optimal accesses, and
+  /// also cannot have time penalties, so we extract them from paths before pressessing the rest.
+  private static Map<Boolean, List<RaptorAccessEgress>> partitioningByStartOnBoard(
     Collection<RaptorAccessEgress> paths
   ) {
     return paths

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPaths.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/AccessPaths.java
@@ -7,7 +7,9 @@ import static org.opentripplanner.raptor.rangeraptor.transit.AccessEgressFunctio
 import gnu.trove.map.TIntObjectMap;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.function.IntUnaryOperator;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.api.model.RaptorStartOnBoardAccess;
@@ -73,11 +75,10 @@ public class AccessPaths {
   ) {
     // On board access paths can not be filtered up-front to remove non-optimal accesses,
     // and also cannot have time penalties, so we extract them from paths before removing.
-    var onBoardAccessPaths = paths
-      .stream()
-      .filter(RaptorStartOnBoardAccess.class::isInstance)
-      .map(RaptorStartOnBoardAccess.class::cast)
-      .toList();
+    var split = splitOutStartOnBoardPaths(paths);
+    var onBoardAccessPaths = mapToStartOnBoardAccess(split.get(true));
+
+    paths = split.get(false);
 
     if (profile.is(RaptorProfile.MULTI_CRITERIA)) {
       paths = removeNonOptimalPathsForMcRaptor(paths);
@@ -238,6 +239,20 @@ public class AccessPaths {
       }
     }
     return false;
+  }
+
+  private static List<RaptorStartOnBoardAccess> mapToStartOnBoardAccess(
+    List<RaptorAccessEgress> startOnBoardPaths
+  ) {
+    return startOnBoardPaths.stream().map(RaptorStartOnBoardAccess.class::cast).toList();
+  }
+
+  private static Map<Boolean, List<RaptorAccessEgress>> splitOutStartOnBoardPaths(
+    Collection<RaptorAccessEgress> paths
+  ) {
+    return paths
+      .stream()
+      .collect(Collectors.partitioningBy(RaptorStartOnBoardAccess.class::isInstance));
   }
 
   /**

--- a/raptor/src/test/java/org/opentripplanner/raptor/api/model/RaptorTripScheduleStopPositionTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/api/model/RaptorTripScheduleStopPositionTest.java
@@ -65,9 +65,6 @@ class RaptorTripScheduleStopPositionTest {
 
   @Test
   void testToString() {
-    assertEquals(
-      "RaptorTripScheduleStopPosition{route: 7, tripSchedule: 3, stopPosition: 5}",
-      subject.toString()
-    );
+    assertEquals("[route: 7, trip: 3, pos: 5]", subject.toString());
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J01_PassThroughTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J01_PassThroughTest.java
@@ -12,6 +12,7 @@ import static org.opentripplanner.raptor.api.request.via.RaptorViaLocation.passT
 
 import java.time.Duration;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.raptor.RaptorService;
@@ -24,16 +25,16 @@ import org.opentripplanner.raptor.configure.RaptorTestFactory;
 
 /**
  * FEATURE UNDER TEST
- *
+ * <p>
  * Raptor should be able to handle a route request with a specified pass-through point.
  * If a stop point is specified as a pass-through point in the request, then all the results
  * returned from Raptor should include this stop point either as an alight or board point for a
  * trip or as an intermediate point in the trip.
- *
+ * <p>
  * It should be possible to specify more than one pass-through point. The result should include
  * stop points in the order in which they were specified in the request. Only alternatives that
  * pass through all stop points should be included in the result.
- *
+ * <p>
  * In order to support stop areas raptor should also support multiple stop points in the same
  * pass-through group. It should be possible to define both stop A and B as a pass-through. Then
  * alternatives that pass either stop A or B should not be dropped.
@@ -214,10 +215,11 @@ class J01_PassThroughTest {
     // Both include all the desired pass-through stop points but only one of them have correct order.
     data.withTimetables(
       """
-      -- R1
+      R1
       A     B     C     D
       0:05  0:10  0:15  0:20
-      -- R2
+      --
+      R2
       A     C     B     D
       0:05  0:10  0:15  0:17
       """
@@ -245,9 +247,11 @@ class J01_PassThroughTest {
     //  so that both routes should be valid
     data.withTimetables(
       """
+      R1
       A     C     E
       0:04  0:10  0:15
       --
+      R2
       B     D     E
       0:05  0:10  0:14
       """
@@ -255,18 +259,66 @@ class J01_PassThroughTest {
 
     // Both routes are pareto optimal.
     // Route 2 is faster but it contains more walk
-    data.access("Walk 30s ~ A", "Walk 2m ~ B").egress("E ~ Walk 30s");
+    // NOTE! There is a bug in the code for R1. OTP process the pass-through event in round 2, not
+    // 1. This result in adding transferCost to the stop arrival at E. If the walking distance is
+    // increased by 1 second then R1 will be dominated at E. The cost is calculated again by the
+    // path-mapper abd this time around the cost is correct as shown in the result.
+    //
+    // COST CALCULATION
+    //
+    //  |            | R1                | R2 |
+    //  | Access     | 29s   58    58 |  2m  240   240 |
+    //  | board-cost |      600   658 |      600   840 |
+    //  | Transit    | 11m  660  1318 |  9m  540  1380 |
+    //  | Egress     | 30s   60  1378 | 30s   60  1440 |
+    //
+    data.access("Walk 29s ~ A", "Walk 2m ~ B").egress("E ~ Walk 30s");
 
     var requestBuilder = prepareRequest();
 
     requestBuilder.searchParams().addViaLocations(PASS_THROUGH_STOP_B_OR_C);
 
-    // Verify that both routes are included as a valid result
     assertEquals(
       """
       Walk 2m ~ B ~ BUS R2 0:05 0:14 ~ E ~ Walk 30s [0:03 0:14:30 11m30s Tₙ0 C₁1_440]
-      Walk 30s ~ A ~ BUS R1 0:04 0:15 ~ E ~ Walk 30s [0:03:30 0:15:30 12m Tₙ0 C₁1_380]
+      Walk 29s ~ A ~ BUS R1 0:04 0:15 ~ E ~ Walk 30s [0:03:31 0:15:30 11m59s Tₙ0 C₁1_378]
       """.trim(),
+      pathsToString(raptorService.route(requestBuilder.build(), data))
+    );
+  }
+
+  @Test
+  @DisplayName(
+    """
+    When the pass-through stop is in the middle of a loop, the journey should board before it
+    and alight after it. For example with pattern A-B-C-A-B, board at A, pass-through at C, and
+    alight at B, then the journey must bard at A and ride the whole pattern to B. It can not
+    board at the second time it passes A, because the pass-through stop is missed.
+    """
+  )
+  @Disabled(
+    """
+    This test fails, because the PathMapper does not know if we should board at the first or
+    second time the trip visit stop A. The arrival state does not carry enough information
+    to determin this. In case there is no pass-though stop the algoritm should board at the
+    second pass to allow for a late depature and short duration.
+    """
+  )
+  void passThroughOnLoopRouteWithPassThroughStopInTheMiddle() {
+    data.withTimetables(
+      """
+      Loop
+      A     B     C     A     B
+      0:02  0:04  0:06  0:08  0:10
+      """
+    );
+    data.access("Free ~ A").egress("B ~ Free");
+
+    var requestBuilder = prepareRequest();
+    requestBuilder.searchParams().addViaLocation(PASS_THROUGH_STOP_C);
+
+    assertEquals(
+      "A ~ BUS Loop 0:02 0:10 ~ B [0:02 0:10 8m Tₙ1 C₁1_040]",
       pathsToString(raptorService.route(requestBuilder.build(), data))
     );
   }
@@ -277,33 +329,29 @@ class J01_PassThroughTest {
       "the same stop, then this should have no effect on the pass-through connection."
   )
   void passThroughStopVisitShouldNotBeDominatedByAnotherPath() {
-    // Create two routes.
-    // Route one includes STOP_B and route two includes STOP_C.
-    // Both stops will be part of the same pass-through group
-    //  so that both routes should be valid
+    // Create two routes that both arrive at stop C at the same time. R1 is faster and leaves
+    // from stop A later. Hence it will be part of an earlier RangeRaptor iteration - and the
+    // arrival at stop C is better than route R2.
     data.withTimetables(
       """
       -- R1
       A     C
-      0:01  0:10
+      0:02  0:10
       -- R2
       A     C     E
       0:00  0:10  0:15
       """
     );
-
-    // Both routes are pareto optimal.
-    // Route 2 is faster but it contains more walk
     data.access("Free ~ A").egress("E ~ Free");
 
     var requestBuilder = prepareRequest();
 
     requestBuilder.searchParams().addViaLocation(PASS_THROUGH_STOP_C);
 
-    // R2 is the only path which takes you to the destination, so the state should be copied over
-    // from segment 1 to segment 2 after stop C is "passed-through". Even when R1 ≺ R2 at stop
-    // arrival at stop C. R1 is optimal compared to R2 at stop arrival C, because the cost and
-    // departure time is better, while number of transfers and arrival time is the same.
+    // R2 is the only path which takes you all the way to the destination, so the state should be
+    // copied over from segment 1 to segment 2 after stop C is "passed-through". Even when R1 ≺ R2
+    // at stop arrival at stop C. R1 is optimal compared to R2 at stop arrival C, because the cost
+    // and departure time is better, while number of transfers and arrival time is the same.
     assertEquals(
       """
       A ~ BUS R2 0:00 0:15 ~ E [0:00 0:15 15m Tₙ0 C₁1_500]

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J01_PassThroughTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J01_PassThroughTest.java
@@ -262,7 +262,7 @@ class J01_PassThroughTest {
     // NOTE! There is a bug in the code for R1. OTP process the pass-through event in round 2, not
     // 1. This result in adding transferCost to the stop arrival at E. If the walking distance is
     // increased by 1 second then R1 will be dominated at E. The cost is calculated again by the
-    // path-mapper abd this time around the cost is correct as shown in the result.
+    // path-mapper and this time around the cost is correct as shown in the result.
     //
     // COST CALCULATION
     //

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/N01_OnBoardAccessTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/N01_OnBoardAccessTest.java
@@ -8,6 +8,7 @@ import static org.opentripplanner.raptor._data.RaptorTestConstants.STOP_C;
 import static org.opentripplanner.raptor._data.RaptorTestConstants.T00_00;
 import static org.opentripplanner.raptor._data.RaptorTestConstants.T01_00;
 import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
+import static org.opentripplanner.raptor.spi.RaptorConstants.ZERO;
 
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +24,7 @@ import org.opentripplanner.raptor.configure.RaptorTestFactory;
 
 /**
  * FEATURE UNDER TEST
+ * <p>
  * Raptor should handle access from on-board a transit vehicle. When given such access as input,
  * resulting paths should include a boarding at the stop given in the access, but only for the
  * specific route and trip. Apart from boarding cost, the cost of the access leg should be
@@ -30,6 +32,13 @@ import org.opentripplanner.raptor.configure.RaptorTestFactory;
  */
 class N01_OnBoardAccessTest {
 
+  private static final int R1_INDEX = 0;
+  private static final int R2_INDEX = 1;
+  private static final int TRIP_0 = 0;
+  private static final int TRIP_1 = 1;
+  private static final int STOP_POS_0 = 0;
+  private static final int STOP_POS_1 = 1;
+  private static final int STOP_POS_2 = 2;
   private final TestTransitData data = new TestTransitData();
 
   private final RaptorService<TestTripSchedule> raptorService = RaptorTestFactory.raptorService();
@@ -57,10 +66,11 @@ class N01_OnBoardAccessTest {
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C     D
         0:00  0:05  0:10  0:20
-        -- R2
+        --
+        R2
         A     B           D
         0:00  0:06        0:15
         """
@@ -87,10 +97,11 @@ class N01_OnBoardAccessTest {
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C     D
         0:00  0:05  0:10  0:20
-        -- R2
+        --
+        R2
         A     B     C     D
         0:00  0:06  0:12  0:15
         """
@@ -117,13 +128,15 @@ class N01_OnBoardAccessTest {
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C
         0:00  0:05  0:10
-        -- R2
+        --
+        R2
                     C      D
                     0:12   0:20
-        -- R3
+        --
+        R3
         A     B     C     D
         0:00  0:06  0:09  0:15
         """
@@ -148,7 +161,7 @@ class N01_OnBoardAccessTest {
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C     D     A     B     C     D
         0:00  0:05  0:10  0:20  0:30  0:35  0:40  0:50
         """
@@ -175,7 +188,7 @@ class N01_OnBoardAccessTest {
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C     D
         0:00  0:02  0:05  0:10
         0:00  0:05  0:10  0:20
@@ -203,7 +216,7 @@ class N01_OnBoardAccessTest {
       .access(new TestRaptorStartOnBoardAccess(1, 1, 1, STOP_B, 0))
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C     D
         0:00  0:02  0:05  0:10
         0:00  0:05  0:10  0:20
@@ -226,7 +239,7 @@ class N01_OnBoardAccessTest {
       .access(new TestRaptorStartOnBoardAccess(0, 3, 1, STOP_B, 0))
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     D
         0:00  0:05  0:10
         0:00  0:10  0:20
@@ -247,26 +260,27 @@ class N01_OnBoardAccessTest {
   void multipleAccesses() {
     data
       .access(
+        // Pareto-optimal - best arrival-time
+        new TestRaptorStartOnBoardAccess(R2_INDEX, TRIP_0, STOP_POS_0, STOP_A, ZERO),
         // Dominated by trip 1 @ C
-        new TestRaptorStartOnBoardAccess(0, 1, 1, STOP_B, 0),
-        // Pareto-optimal
-        new TestRaptorStartOnBoardAccess(0, 1, 2, STOP_C, 0),
-        // Pareto-optimal
-        new TestRaptorStartOnBoardAccess(1, 0, 0, STOP_A, 0)
+        new TestRaptorStartOnBoardAccess(R1_INDEX, TRIP_1, STOP_POS_1, STOP_B, ZERO),
+        // Pareto-optimal - best depature-time & c1
+        new TestRaptorStartOnBoardAccess(R1_INDEX, TRIP_1, STOP_POS_2, STOP_C, ZERO)
       )
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C     D
         0:00  0:05  0:10  0:15
         0:05  0:10  0:15  0:20
-        -- R2
+        --
+        R2
         A     B
         0:02  0:04
         """
       )
-      .egress("D ~ Walk 30s");
+      .egress("D ~ Walk 1m");
 
     var requestBuilder = prepareRequest();
 
@@ -275,8 +289,8 @@ class N01_OnBoardAccessTest {
     // Only accesses that yield a non-dominated path are included in the result
     assertEquals(
       """
-      A ~ BUS R2 0:02 0:04 ~ B ~ BUS R1 0:05 0:15 ~ D ~ Walk 30s [0:02 0:15:30 13m30s Tₙ1 C₁2_040]
-      C ~ BUS R1 0:15 0:20 ~ D ~ Walk 30s [0:15 0:20:30 5m30s Tₙ0 C₁960]""",
+      A ~ BUS R2 0:02 0:04 ~ B ~ BUS R1 0:05 0:15 ~ D ~ Walk 1m [0:02 0:16 14m Tₙ1 C₁2_100]
+      C ~ BUS R1 0:15 0:20 ~ D ~ Walk 1m [0:15 0:21 6m Tₙ0 C₁1_020]""",
       pathsToString(raptorResponse)
     );
   }
@@ -294,10 +308,11 @@ class N01_OnBoardAccessTest {
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B     C     D
         0:00  0:05  0:10  0:15
-        -- R2
+        --
+        R2
                     E     D
                     0:10  0:12
         """
@@ -328,7 +343,7 @@ class N01_OnBoardAccessTest {
       .withRoutes()
       .withTimetables(
         """
-        -- R1
+        R1
         A     B        C     D
         0:00  0:05:05  0:10  0:15
         0:05  0:10     0:15  0:20


### PR DESCRIPTION
### Summary

When a pass-through connection was forwarded to the next routing segment, two bugs caused incorrect results:

  1. **Wrong boarding stop**: The boarding position was set to the pass-through stop rather than the
     original boarding stop. `OnTripAccessArrivals` indexed arrivals by the boarding stop position,
     but it needs to index by the *pass-through* stop position so that the algorithm does not permit
     alighting before the pass-through stop is visited.

  2. **Circular lines**: For loop routes, the correct stop position for injecting the ride was not
     derived from the actual alighting stop — this caused the pass-through constraint to be applied
     at the wrong point in the pattern.

> **NOTE!** There are 2 reminding bugs, I will follow up with new PRs/Issues for them.

**Known bugs**
- The pass-though logic copy the start-on-board access event into the next segment. This is then processed in the next round. This lead to a slightly higer cost and maybe a risk of using round+1 in a pareto-comparason. 
- The Raptor router save as little information as possible during routing - so boardPosition is not saved. This works find everywhere except for pass-through. In a circular line A-B-C-A-B, pass-though stop C, origin A and destination B the current PathMapper will time-shift the boarding to the second A stop in the pattern. There is a module test for this (currently disabled: J01_PassThroughTest#passThroughOnLoopRouteWithPassThroughStopInTheMiddle())     


### Solution

  `OnTripAccessArrivals` now tracks two distinct positions:
  - `startRoutingAtStopPosition` — where the algorithm injects the ride (the pass-through stop).
    This prevents alighting before the constraint is satisfied.
  - `boardingConstraint.stopPositionInPattern()` — where the passenger actually boarded.

  In `ViaConnectionStopArrivalEventListener`, the board stop is now read from
  `transitPath.boardStop()` and the routing injection point from the alighting arrival, making
  them independent.

  A test for the remaining known limitation — loop routes where the PathMapper cannot determine
  whether to board at the first or second pass of a stop — is added as `@Disabled` to track the
  outstanding issue.

### Unit tests

✅  Existing tests are patched and some new tests are added.

### Documentation

✅  More doc i added

### Changelog

✅  Should be included

### Bumping the serialization version id

🟥  Not needed