### PR TITLE
Hide area and group stops debug layers by default

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -223,7 +223,8 @@ public class DebugStyleSpec {
         .fillOpacity(0.5f)
         .fillOutlineColor(BLACK)
         .minZoom(6)
-        .maxZoom(MAX_ZOOM),
+        .maxZoom(MAX_ZOOM)
+        .intiallyHidden(),
       StyleBuilder.ofId("group-stop")
         .group(STOPS_GROUP)
         .typeFill()
@@ -232,7 +233,8 @@ public class DebugStyleSpec {
         .fillOpacity(0.5f)
         .fillOutlineColor(BLACK)
         .minZoom(6)
-        .maxZoom(MAX_ZOOM),
+        .maxZoom(MAX_ZOOM)
+        .intiallyHidden(),
       StyleBuilder.ofId("regular-stop")
         .group(STOPS_GROUP)
         .typeCircle()

--- a/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -2188,6 +2188,9 @@
         "fill-opacity" : 0.5,
         "fill-outline-color" : "#140d0e"
       },
+      "layout" : {
+        "visibility" : "none"
+      },
       "metadata" : {
         "group" : "Stops"
       }
@@ -2203,6 +2206,9 @@
         "fill-color" : "#22DD9E",
         "fill-opacity" : 0.5,
         "fill-outline-color" : "#140d0e"
+      },
+      "layout" : {
+        "visibility" : "none"
       },
       "metadata" : {
         "group" : "Stops"


### PR DESCRIPTION
### Summary

This was discussed on Gitter and everyone found it annoying. Therefore I'm hiding it by default. 

If you wish to use it, you can still activate it.