### PR TITLE
Reuse regex Matcher in transit-group priority lookup

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/network/grouppriority/Matchers.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/grouppriority/Matchers.java
@@ -123,6 +123,7 @@ final class Matchers {
 
     private final String typeName;
     private final Pattern[] patterns;
+    private final java.util.regex.Matcher[] matchers;
     private final Function<EntityAdapter, String> toValue;
 
     public RegExpMatcher(
@@ -132,14 +133,20 @@ final class Matchers {
     ) {
       this.typeName = typeName;
       this.patterns = regexps.stream().map(Pattern::compile).toArray(Pattern[]::new);
+      // The enclosing service is request-scoped and single-threaded
+      // (TransitGroupPriorityService is not thread-safe), so we can safely reuse
+      // one Matcher per Pattern across calls instead of allocating per match.
+      this.matchers = Arrays.stream(this.patterns)
+        .map(p -> p.matcher(""))
+        .toArray(java.util.regex.Matcher[]::new);
       this.toValue = toValue;
     }
 
     @Override
     public boolean match(EntityAdapter entity) {
       var value = toValue.apply(entity);
-      for (Pattern p : patterns) {
-        if (p.matcher(value).matches()) {
+      for (java.util.regex.Matcher m : matchers) {
+        if (m.reset(value).matches()) {
           return true;
         }
       }

--- a/application/src/main/java/org/opentripplanner/transit/model/network/grouppriority/Matchers.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/grouppriority/Matchers.java
@@ -26,6 +26,12 @@ import org.opentripplanner.transit.model.basic.TransitMode;
  * value in the "select", then the list of non-empty matchers is merged into
  * a `CompositeMatcher`. So, a new matcher is only created if the field in the
  * select is present.
+ * <p>
+ * THE MATCHERS PRODUCED BY THIS CLASS ARE NOT THREAD-SAFE. The regex matcher
+ * keeps a reusable {@link java.util.regex.Matcher} per pattern that is mutated
+ * on each {@code match} call; concurrent invocation would corrupt its state.
+ * The enclosing {@link TransitGroupPriorityService} is request-scoped and
+ * single-threaded, which is what makes this safe.
  */
 final class Matchers {
 
@@ -133,9 +139,6 @@ final class Matchers {
     ) {
       this.typeName = typeName;
       this.patterns = regexps.stream().map(Pattern::compile).toArray(Pattern[]::new);
-      // The enclosing service is request-scoped and single-threaded
-      // (TransitGroupPriorityService is not thread-safe), so we can safely reuse
-      // one Matcher per Pattern across calls instead of allocating per match.
       this.matchers = Arrays.stream(this.patterns)
         .map(p -> p.matcher(""))
         .toArray(java.util.regex.Matcher[]::new);


### PR DESCRIPTION
### Summary

Reuse one `java.util.regex.Matcher` per `Pattern` inside `Matchers.RegExpMatcher` instead of allocating a new matcher on every `match()` call, via the standard `Matcher.reset(value).matches()` idiom.

### Issue

Profiling an OTP pod under realistic load showed `RegExpMatcher.match` as a top allocation site: ~3.5% of all sampled allocations (6 168 of 178 000 sampled events at 512 KB sampling, ~50 MB/s/pod) were `java.util.regex.Matcher` instances allocated by `Pattern.matcher(value)` inside the regex matcher used by `TransitGroupPriorityService`. The compiled `Pattern` is cached and reused across requests, but `Pattern.matcher(...)` returns a fresh `Matcher` on every call. `lookupTransitGroupPriorityId` is invoked once per `TripPatternForDates` during per-request transit-data setup, so with several patterns per selector the per-request count is non-trivial.

Pre-creating one `Matcher` per compiled `Pattern` at construction time and resetting it on each call eliminates that allocation without changing the externally observable behaviour of `match(EntityAdapter)`.

This is safe because the enclosing `TransitGroupPriorityService` is request-scoped: it is constructed inside `RoutingWorker`, which is `new`-ed per request from `DefaultRoutingService.route()`. The class header already declares it `NOT THREAD-SAFE`.

### Performance impact

The throughput effect of this change in isolation is small: TLAB bump cost per allocation is a few ns, and removing ~3.5% of total sampled allocations extends the young-GC interval by a similar percentage (the profiled pod was running young GC every ~8.1 s for ~63 ms — well inside noise on a single benchmark). The value here is cumulative: this is one of several allocation-rate cuts identified in the same profile (`Path.dummyPath` sentinel at 10.6% of allocations, per-request `TripPatternForDates` rebuild). Expect the impact to show up as a small extension of young-GC interval over several hours of steady traffic, not as a measurable single-PR throughput delta.

### Unit tests

No behaviour change, so no new tests were added. The existing tests under `org.opentripplanner.transit.model.network.grouppriority.*Test` cover the regex matcher path through `MatchersTest`, `TransitGroupPriorityServiceTest`, `DefaultTransitGroupPriorityCalculatorTest`, `TransitGroupPriority32nTest` and `TripAdapterTest` (20 tests in total). All pass with the change.

### Documentation

The class-level Javadoc on `Matchers` was updated to document the thread-safety contract explicitly: matchers produced by this class are not thread-safe because `RegExpMatcher` keeps a mutable `java.util.regex.Matcher` per pattern, and the request-scoped, single-threaded `TransitGroupPriorityService` is what makes the reuse safe. The redundant inline comment that previously lived in the constructor was removed in favour of the class-level note.