### PR TITLE
Aggregate elevation lookup failures for points outside DEM coverage

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -266,6 +266,15 @@ public class ElevationModule implements GraphBuilderModule {
       }
     }
 
+    int pointsOutsideDEM = nPointsOutsideDEM.get();
+    if (pointsOutsideDEM > 0) {
+      issueStore.add(
+        "ElevationProfilePointsOutsideDEM",
+        "Elevation lookup failed at %d sample points that lie outside the DEM coverage area.",
+        pointsOutsideDEM
+      );
+    }
+
     LOG.info(progress.completeMessage());
 
     // Iterate again to find edges that had elevation calculated.
@@ -520,7 +529,12 @@ public class ElevationModule implements GraphBuilderModule {
       );
 
       setEdgeElevationProfile(ee, elevPCS);
-    } catch (ElevationLookupException e) {
+    } catch (PointOutsideCoverageException _) {
+      // Do not create an issue for each edge that falls out of coverage
+      // (there can be many of them).
+      // The total number of ignored edges is reported in a single issue
+      // ElevationProfilePointsOutsideDEM.
+    } catch (ArrayIndexOutOfBoundsException | TransformException e) {
       issueStore.add(new ElevationProfileFailure(ee, e.getMessage()));
     }
   }
@@ -551,7 +565,11 @@ public class ElevationModule implements GraphBuilderModule {
           // point on the edge to initialize these other items.
           try {
             getElevation(coverage, examplarCoordinate);
-          } catch (ElevationLookupException e) {
+          } catch (
+            PointOutsideCoverageException
+            | ArrayIndexOutOfBoundsException
+            | TransformException e
+          ) {
             LOG.warn(
               "Error processing elevation for coordinate: {} due to error: {}",
               examplarCoordinate,
@@ -593,21 +611,9 @@ public class ElevationModule implements GraphBuilderModule {
    * @param c        the coordinate (NAD83)
    * @return elevation in meters
    */
-  private double getElevation(Coverage coverage, Coordinate c) throws ElevationLookupException {
-    try {
-      return getElevation(coverage, c.x, c.y);
-    } catch (
-      ArrayIndexOutOfBoundsException
-      | PointOutsideCoverageException
-      | TransformException e
-    ) {
-      // Each of the above exceptions can occur when finding the elevation at a coordinate.
-      // - The ArrayIndexOutOfBoundsException seems to occur at the edges of some elevation tiles that
-      //     might have areas with NoData. See https://github.com/opentripplanner/OpenTripPlanner/issues/2792
-      // - The PointOutsideCoverageException can be thrown for points that are outside of the elevation tile area.
-      // - The TransformException can occur when trying to compute the EllipsoidToGeoidDifference.
-      throw new ElevationLookupException(e);
-    }
+  private double getElevation(Coverage coverage, Coordinate c)
+    throws PointOutsideCoverageException, TransformException {
+    return getElevation(coverage, c.x, c.y);
   }
 
   /**
@@ -618,6 +624,10 @@ public class ElevationModule implements GraphBuilderModule {
    * @param x        the query longitude (NAD83)
    * @param y        the query latitude (NAD83)
    * @return elevation in meters
+   * @throws PointOutsideCoverageException if the point lies outside the elevation tile area.
+   * @throws TransformException if computing the EllipsoidToGeoidDifference fails.
+   * @throws ArrayIndexOutOfBoundsException at the edges of some elevation tiles with NoData
+   *         regions, see <a href="https://github.com/opentripplanner/OpenTripPlanner/issues/2792">#2792</a>.
    */
   private double getElevation(Coverage coverage, double x, double y)
     throws PointOutsideCoverageException, TransformException {
@@ -675,15 +685,5 @@ public class ElevationModule implements GraphBuilderModule {
       geoidDifferenceCache.put(hash, difference);
     }
     return difference;
-  }
-
-  /**
-   * A custom exception wrapper for all known elevation lookup exceptions
-   */
-  static class ElevationLookupException extends Exception {
-
-    public ElevationLookupException(Exception e) {
-      super(e);
-    }
   }
 }


### PR DESCRIPTION
### Summary

Replace per-edge `ElevationProfileFailure` issues with one aggregate `ElevationProfilePointsOutsideDEM` issue when sample lookups fall outside the DEM.

### Issue
**Motivation.** A graph build whose OSM input extends past the DEM coverage area produced:

- `ElevationProfileFailure` count: **2,316,269**
- Data-import-issue report phase wall time: **11m 9s**
- Each per-type bucket caps at `maxDataImportIssuesPerFile=1000`, so this produced ~2,300 `ElevationProfileFailureN.html` files (each ~700 KB, dominated by an O(N²) navigation menu) plus ~2,300 GeoJSON files, all uploaded sequentially to the configured report storage.

The 2.3 M issues all describe the same condition — sample point lies outside the DEM raster — so they carry no per-edge actionable detail.

**How it works.**

- `getElevation(Coverage, double, double)` already increments an `AtomicInteger nPointsOutsideDEM` whenever `coverage.evaluate(...)` throws `PointOutsideCoverageException` (used today for the existing > 50 % "DEM may be for the wrong region" Graphwide warning).
- `processEdge` now catches `PointOutsideCoverageException` distinctly and lets the existing counter do the bookkeeping; the per-edge `ElevationProfileFailure` is no longer added on this code path.
- After the parallel elevation pass, if the counter is non-zero a single issue is emitted via `issueStore.add("ElevationProfilePointsOutsideDEM", "Elevation lookup failed at %d sample points that lie outside the DEM coverage area.", count)`.
- Other elevation lookup causes (`ArrayIndexOutOfBoundsException`, `TransformException`) keep emitting per-edge `ElevationProfileFailure` — they're rare and carry actionable detail.
- `MissingElevationHandler` is **not** changed; it remains the per-edge issue source for failed elevation propagation, which is a separate code path.

**Design notes.**

- The `ElevationLookupException` wrapper around the three GeoTools exceptions is removed. Once `PointOutsideCoverageException` is handled distinctly the wrapper no longer unifies all elevation-lookup failures, and only adds an extra exception allocation per failed sample. `getElevation(Coverage, Coordinate)` now declares `throws PointOutsideCoverageException, TransformException` and `processEdge` plus `getThreadSpecificCoverageInterpolator` catch via multi-catch.


**Note.** `DefaultDataImportIssueStore.issues` is a plain `ArrayList` and `add(...)` is not synchronized; it's exercised concurrently by `ForkJoinPool.commonPool` workers from `parallelStream().forEach(...)` in `ElevationModule.buildGraph`.
This is a pre-existing bug that should be fixed in a separate PR. 

### Unit tests
No

### Documentation
No
