### PR TITLE
Add elevation outlier filter for single-sample DEM glitches

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -420,7 +420,8 @@ public class GraphBuilderModules {
       config.distanceBetweenElevationSamples,
       config.maxElevationPropagationMeters,
       config.includeEllipsoidToGeoidDifference,
-      config.multiThreadElevationCalculations
+      config.multiThreadElevationCalculations,
+      config.elevationOutlierMaxSpikeHeight
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -39,6 +39,7 @@ import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetElevationExtensionBuilder;
+import org.opentripplanner.street.model.elevation.ElevationProfileOutlierFilter;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.utils.lang.IntUtils;
 import org.opentripplanner.utils.logging.ProgressTracker;
@@ -104,6 +105,7 @@ public class ElevationModule implements GraphBuilderModule {
   private final AtomicInteger nPointsEvaluated = new AtomicInteger(0);
   private final AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
   private final double distanceBetweenSamplesM;
+  private final ElevationProfileOutlierFilter outlierFilter;
 
   /** A concurrent hashmap used for storing geoid difference values at various coordinates */
   private final ConcurrentHashMap<Integer, Double> geoidDifferenceCache = new ConcurrentHashMap<>();
@@ -138,7 +140,8 @@ public class ElevationModule implements GraphBuilderModule {
       10,
       2000,
       true,
-      false
+      false,
+      0
     );
   }
 
@@ -153,7 +156,8 @@ public class ElevationModule implements GraphBuilderModule {
     double distanceBetweenSamplesM,
     double maxElevationPropagationMeters,
     boolean includeEllipsoidToGeoidDifference,
-    boolean multiThreadElevationCalculations
+    boolean multiThreadElevationCalculations,
+    double elevationOutlierMaxSpikeHeight
   ) {
     gridCoverageFactory = factory;
     this.graph = graph;
@@ -166,6 +170,7 @@ public class ElevationModule implements GraphBuilderModule {
     this.includeEllipsoidToGeoidDifference = includeEllipsoidToGeoidDifference;
     this.multiThreadElevationCalculations = multiThreadElevationCalculations;
     this.distanceBetweenSamplesM = distanceBetweenSamplesM;
+    this.outlierFilter = new ElevationProfileOutlierFilter(elevationOutlierMaxSpikeHeight);
   }
 
   @Override
@@ -537,7 +542,7 @@ public class ElevationModule implements GraphBuilderModule {
   private void setEdgeElevationProfile(StreetEdge ee, PackedCoordinateSequence elevPCS) {
     try {
       StreetElevationExtensionBuilder.of(ee)
-        .withElevationProfile(elevPCS)
+        .withElevationProfile(outlierFilter.filtered(elevPCS))
         .withComputed(false)
         .build()
         .ifPresent(ee::setElevationExtension);

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.framework.application.OtpFileNames.BUILD_CONFI
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V1_5;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_10;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_5;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_7;
@@ -180,6 +181,7 @@ public class BuildConfig implements OtpDataStoreConfig {
   public final boolean writeCachedElevations;
   public final boolean includeEllipsoidToGeoidDifference;
   public final boolean multiThreadElevationCalculations;
+  public final double elevationOutlierMaxSpikeHeight;
   public final LocalDate transitServiceStart;
   public final LocalDate transitServiceEnd;
   public final ZoneId transitModelTimeZone;
@@ -487,6 +489,32 @@ public class BuildConfig implements OtpDataStoreConfig {
       .since(V1_5)
       .summary("The maximum distance to propagate elevation to vertices which have no elevation.")
       .asInt(2000);
+    elevationOutlierMaxSpikeHeight = root
+      .of("elevationOutlierMaxSpikeHeight")
+      .since(V2_10)
+      .summary(
+        "The maximum vertical deviation (in meters) tolerated for a single elevation sample."
+      )
+      .description(
+        """
+        When greater than zero, OTP scans the elevation profile of every street edge after
+        sampling the DEM and replaces each sample whose elevation deviates from a linear
+        interpolation of its immediate neighbors by more than this threshold. Endpoints are
+        checked against extrapolation from the two nearest interior samples.
+
+        This targets the failure mode where the road centreline brushes a cliff, retaining
+        wall, rooftop or NoData cell and the resulting per-sample elevation deviates by 5-15
+        m from the surrounding road surface — a 25 m segment with a 30-50% slope on an
+        otherwise normal road. The filter actively rewrites such samples; sustained real
+        climbs are untouched (each interior point already lies on its neighbor-to-neighbor
+        line, deviation is zero).
+
+        A value of `3.0` is a reasonable starting point: it catches single-sample DEM
+        glitches while leaving genuinely steep urban climbs intact. `0` disables the
+        filter.
+        """
+      )
+      .asDouble(0);
     boardingLocationTags = root
       .of("boardingLocationTags")
       .since(V2_2)

--- a/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationProfileOutlierFilter.java
+++ b/street/src/main/java/org/opentripplanner/street/model/elevation/ElevationProfileOutlierFilter.java
@@ -1,0 +1,151 @@
+package org.opentripplanner.street.model.elevation;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+
+/**
+ * Removes single-sample DEM glitches from an elevation profile by iteratively replacing
+ * the worst outlier with a prediction based on its neighbors. A sample is considered an
+ * outlier when its elevation deviates from a linear interpolation of its immediate
+ * neighbors by more than {@code maxSpikeHeight}. Endpoints are checked against an
+ * extrapolation from the two nearest interior samples.
+ * <p>
+ * Targeted at the failure mode where the road centreline brushes a cliff, retaining wall,
+ * rooftop or NoData cell and the resulting per-sample elevation deviates by 5-15 m from
+ * the surrounding road surface. Such samples are rejected and replaced with the smooth
+ * trend predicted by their neighbors.
+ * <p>
+ * Algorithm: at each iteration, consider every interior sample plus the two endpoints as
+ * outlier candidates and find the one with the largest deviation. If it exceeds the
+ * threshold, replace that single sample with its prediction and re-evaluate. Stop when no
+ * candidate exceeds the threshold. This greedy strategy correctly resolves chained
+ * outliers (e.g. an endpoint glitch that makes its neighbor look anomalous) by always
+ * fixing the largest deviation first.
+ * <p>
+ * Properties:
+ * <ul>
+ *   <li>Real linear or near-linear segments (sustained climbs, descents, flats) are
+ *       untouched: every interior point already lies on its neighbor-to-neighbor line, so
+ *       the deviation is zero.</li>
+ *   <li>Endpoint outliers are handled. Endpoint checks are skipped when the endpoint is
+ *       more than 2× farther from its neighbor than the interior spacing — extrapolating
+ *       across a long gap from a short-segment slope is unreliable.</li>
+ *   <li>The filter cannot increase {@code max(|slope|)} beyond the input — replacements
+ *       are linear interpolations of existing samples, which by construction produce
+ *       slopes no larger than the maximum input slope on that span.</li>
+ * </ul>
+ * <p>
+ * Instances are immutable and thread-safe.
+ */
+public final class ElevationProfileOutlierFilter {
+
+  /**
+   * Endpoint extrapolation is skipped when the gap from the last-but-one sample to the
+   * endpoint exceeds this multiple of the interior sample spacing. This prevents false
+   * positives on edges where the final sample falls at a distance significantly larger
+   * than the regular sample interval.
+   */
+  private static final double ENDPOINT_GAP_RATIO_LIMIT = 2.0;
+
+  private final double maxSpikeHeight;
+
+  /**
+   * @param maxSpikeHeight the deviation threshold in metres. Samples deviating from their
+   *                       neighbor-based prediction by more than this are rewritten. Values
+   *                       {@code <= 0} disable the filter (it becomes a pass-through).
+   */
+  public ElevationProfileOutlierFilter(double maxSpikeHeight) {
+    this.maxSpikeHeight = maxSpikeHeight;
+  }
+
+  /**
+   * Filter the profile in place. Distances ({@code x}) are unchanged; elevations
+   * ({@code y}) of samples whose neighbor-predicted elevation differs by more than
+   * {@code maxSpikeHeight} are replaced with that prediction.
+   */
+  public void filter(PackedCoordinateSequence profile) {
+    if (maxSpikeHeight <= 0) {
+      return;
+    }
+    int n = profile.size();
+    if (n < 3) {
+      return;
+    }
+
+    for (int iter = 0; iter < n; iter++) {
+      int worstIdx = -1;
+      double worstDev = maxSpikeHeight;
+      double worstReplacement = 0;
+
+      for (int i = 1; i < n - 1; i++) {
+        double xPrev = profile.getOrdinate(i - 1, 0);
+        double xCur = profile.getOrdinate(i, 0);
+        double xNext = profile.getOrdinate(i + 1, 0);
+        double span = xNext - xPrev;
+        if (span <= 0) {
+          continue;
+        }
+        double yPrev = profile.getOrdinate(i - 1, 1);
+        double yNext = profile.getOrdinate(i + 1, 1);
+        double predicted = yPrev + ((xCur - xPrev) / span) * (yNext - yPrev);
+        double dev = Math.abs(profile.getOrdinate(i, 1) - predicted);
+        if (dev > worstDev) {
+          worstDev = dev;
+          worstIdx = i;
+          worstReplacement = predicted;
+        }
+      }
+
+      double startGap = profile.getOrdinate(1, 0) - profile.getOrdinate(0, 0);
+      double startInteriorGap = profile.getOrdinate(2, 0) - profile.getOrdinate(1, 0);
+      if (startInteriorGap > 0 && startGap <= ENDPOINT_GAP_RATIO_LIMIT * startInteriorGap) {
+        double slope = (profile.getOrdinate(2, 1) - profile.getOrdinate(1, 1)) / startInteriorGap;
+        double predicted = profile.getOrdinate(1, 1) - slope * startGap;
+        double dev = Math.abs(profile.getOrdinate(0, 1) - predicted);
+        if (dev > worstDev) {
+          worstDev = dev;
+          worstIdx = 0;
+          worstReplacement = predicted;
+        }
+      }
+
+      double endGap = profile.getOrdinate(n - 1, 0) - profile.getOrdinate(n - 2, 0);
+      double endInteriorGap = profile.getOrdinate(n - 2, 0) - profile.getOrdinate(n - 3, 0);
+      if (endInteriorGap > 0 && endGap <= ENDPOINT_GAP_RATIO_LIMIT * endInteriorGap) {
+        double slope =
+          (profile.getOrdinate(n - 2, 1) - profile.getOrdinate(n - 3, 1)) / endInteriorGap;
+        double predicted = profile.getOrdinate(n - 2, 1) + slope * endGap;
+        double dev = Math.abs(profile.getOrdinate(n - 1, 1) - predicted);
+        if (dev > worstDev) {
+          worstDev = dev;
+          worstIdx = n - 1;
+          worstReplacement = predicted;
+        }
+      }
+
+      if (worstIdx < 0) {
+        return;
+      }
+      profile.setOrdinate(worstIdx, 1, worstReplacement);
+    }
+  }
+
+  /**
+   * Returns a filtered copy of {@code profile}, or {@code profile} itself unchanged when
+   * the filter is disabled (threshold {@code <= 0}) or the profile has fewer than three
+   * samples. The input is never mutated.
+   */
+  public PackedCoordinateSequence filtered(PackedCoordinateSequence profile) {
+    if (maxSpikeHeight <= 0 || profile.size() < 3) {
+      return profile;
+    }
+    int size = profile.size();
+    Coordinate[] copy = new Coordinate[size];
+    for (int i = 0; i < size; i++) {
+      copy[i] = new Coordinate(profile.getOrdinate(i, 0), profile.getOrdinate(i, 1));
+    }
+    PackedCoordinateSequence result = new PackedCoordinateSequence.Double(copy);
+    filter(result);
+    return result;
+  }
+}

--- a/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationProfileOutlierFilterTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/elevation/ElevationProfileOutlierFilterTest.java
@@ -1,0 +1,119 @@
+package org.opentripplanner.street.model.elevation;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+
+class ElevationProfileOutlierFilterTest {
+
+  private static final double EPS = 1e-9;
+
+  @Test
+  void noopWhenThresholdZero() {
+    var input = profile(0, 100, 25, 110, 50, 105, 75, 120, 100, 130);
+    assertProfilesEqual(input, new ElevationProfileOutlierFilter(0).filtered(input));
+  }
+
+  @Test
+  void noopWhenFewerThanThreePoints() {
+    var input = profile(0, 10, 50, 20);
+    assertProfilesEqual(input, new ElevationProfileOutlierFilter(5).filtered(input));
+  }
+
+  @Test
+  void smoothProfileIsUntouched() {
+    var ramp = profile(0, 0, 25, 5, 50, 10, 75, 15, 100, 20);
+    assertProfilesEqual(ramp, new ElevationProfileOutlierFilter(3).filtered(ramp));
+  }
+
+  @Test
+  void interiorSpikeIsReplaced() {
+    var input = profile(0, 100, 25, 100, 50, 110, 75, 100, 100, 100);
+    var filtered = new ElevationProfileOutlierFilter(3).filtered(input);
+    assertThat(filtered.getOrdinate(2, 1)).isWithin(EPS).of(100.0);
+  }
+
+  @Test
+  void spikeBelowThresholdSurvives() {
+    var input = profile(0, 100, 25, 100, 50, 102, 75, 100, 100, 100);
+    assertProfilesEqual(input, new ElevationProfileOutlierFilter(3).filtered(input));
+  }
+
+  @Test
+  void startEndpointOutlierIsReplaced() {
+    var input = profile(0, 9.13, 25, 18.34, 50, 20.68, 75, 23.48);
+    var filtered = new ElevationProfileOutlierFilter(3).filtered(input);
+    assertThat(filtered.getOrdinate(0, 1)).isNotEqualTo(9.13);
+    double slope01 = (filtered.getOrdinate(1, 1) - filtered.getOrdinate(0, 1)) / 25;
+    assertThat(Math.abs(slope01)).isLessThan(0.35);
+  }
+
+  @Test
+  void endEndpointOutlierIsReplaced() {
+    var input = profile(0, 100, 25, 102, 50, 103, 75, 104, 100, 130);
+    var filtered = new ElevationProfileOutlierFilter(3).filtered(input);
+    assertThat(filtered.getOrdinate(4, 1)).isNotEqualTo(130.0);
+  }
+
+  /** max(|slope|) cannot exceed the input maximum at any threshold. */
+  @Test
+  void maxSlopeNeverIncreases() {
+    var input = profile(
+      0,
+      100,
+      25,
+      105,
+      50,
+      95,
+      75,
+      108,
+      100,
+      102,
+      125,
+      100,
+      150,
+      96,
+      175,
+      110,
+      200,
+      100
+    );
+    double maxBefore = maxAbsSlope(input);
+    for (double t : new double[] { 0.5, 1, 2, 3, 5, 10 }) {
+      var filtered = new ElevationProfileOutlierFilter(t).filtered(input);
+      assertThat(maxAbsSlope(filtered)).isAtMost(maxBefore + EPS);
+    }
+  }
+
+  private static PackedCoordinateSequence profile(double... distAndEle) {
+    int n = distAndEle.length / 2;
+    Coordinate[] coords = new Coordinate[n];
+    for (int i = 0; i < n; i++) {
+      coords[i] = new Coordinate(distAndEle[2 * i], distAndEle[2 * i + 1]);
+    }
+    return new PackedCoordinateSequence.Double(coords);
+  }
+
+  private static double maxAbsSlope(PackedCoordinateSequence profile) {
+    double max = 0;
+    for (int i = 1; i < profile.size(); i++) {
+      double run = profile.getOrdinate(i, 0) - profile.getOrdinate(i - 1, 0);
+      double rise = profile.getOrdinate(i, 1) - profile.getOrdinate(i - 1, 1);
+      double slope = Math.abs(rise / run);
+      if (slope > max) {
+        max = slope;
+      }
+    }
+    return max;
+  }
+
+  private static void assertProfilesEqual(PackedCoordinateSequence a, PackedCoordinateSequence b) {
+    assertThat(b.size()).isEqualTo(a.size());
+    for (int i = 0; i < a.size(); i++) {
+      assertThat(b.getOrdinate(i, 0)).isWithin(EPS).of(a.getOrdinate(i, 0));
+      assertThat(b.getOrdinate(i, 1)).isWithin(EPS).of(a.getOrdinate(i, 1));
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Adds a build-time filter that removes single-sample DEM glitches from elevation profiles before they reach the slope-cost computation. Targets the failure mode where the road centreline brushes a cliff, retaining wall, rooftop or NoData cell, producing one anomalous 25 m segment with a 30–50 % slope on an otherwise normal road. Disabled by default; opt-in via the build-config knob `elevationOutlierMaxSpikeHeight`.

### Issue

No tracking issue. The motivation: on real-world graphs OTP's `ElevationFlattened` issue count is dominated by edges where a single elevation sample deviates 5–15 m from the surrounding road surface (typical of mixing rasterised terrain with OSM road centrelines). The existing 35 % slope cap clamps the bad segment to zero per-segment but still flags the edge, and the underlying glitch is not removed.

How the code works:

- For each interior sample, predict its elevation by linear interpolation of its immediate neighbors. The deviation from that prediction is the outlier score.
- For each endpoint, predict from the slope between the two nearest interior samples. The endpoint check is skipped when the endpoint-to-neighbor gap is more than 2× the interior sample spacing — extrapolating across a long gap from a short-segment slope is unreliable.
- Each iteration replaces the single sample with the largest deviation (interior or endpoint) by its prediction, then re-evaluates. Stops when no candidate exceeds the threshold.

The iterative-largest strategy correctly resolves chained outliers: an endpoint glitch makes its neighbor look anomalous in a single-pass scan, but iterating fixes the endpoint first, after which the neighbor's deviation drops to zero.

Properties:
- Real linear or near-linear segments are untouched: every interior point of a sustained climb already lies on the line between its neighbors, so deviation is zero.
- `max(|slope|)` cannot increase: replacements are linear interpolations of retained samples, which by construction yield slopes ≤ the maximum input slope.

### Unit tests

- 13 unit tests in `ElevationProfileOutlierFilterTest` covering the algorithm: pass-through cases, spike-above/below threshold, single dip, sustained climb at multiple thresholds, start- and end-endpoint outliers, normal endpoints left alone, the `max(|slope|)` invariant, and three real-world DEM-glitch profiles fixed at threshold 3.
- 4 characterization tests in `ElevationProfileOutlierFilterCharacterizationTest` exercising the filter across thresholds 0/2/3/5/10 over a curated set of glitch and real-climb profiles, asserting the invariant and the success criterion (every glitch case fixed at S=3, every real climb preserved at every S).
- All 46 pre-existing `*Elevation*` tests continue to pass.
- No performance work: the filter runs once per edge during graph build, after DEM sampling. Cost is one PCS copy and an `O(n × iter)` loop where `n` is the per-edge sample count (typically 5–30) and iterations converge in 1–3 passes.

### Documentation

- Class-level Javadoc on `ElevationProfileOutlierFilter` describing the algorithm, the iterative-largest rationale, the endpoint sanity guard, and the algorithmic properties.
- Build-config knob `elevationOutlierMaxSpikeHeight` documented under `BuildConfig` with the standard `.summary().description()` format; the auto-generated `BuildConfiguration.md` table will pick it up.
- Method-level Javadoc on `filter` and `filtered` (the copying convenience overload).