### PR TITLE
Reduce flex allocations some more

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.application.OTPFeature;
@@ -30,6 +31,9 @@ import org.opentripplanner.utils.collection.MinMap;
  * post-scan filtering of {@code getAllStates()}.
  */
 class NearbyStopFinderVisitor implements TraverseVisitor<State, Edge> {
+
+  private static final Predicate<Edge> CAN_BOARD_FLEX_PREDICATE = e ->
+    e instanceof StreetEdge se && se.getPermission().allows(TraverseMode.CAR);
 
   private final Set<Vertex> originVertices;
   private final Set<Vertex> ignoreVertices;
@@ -90,12 +94,8 @@ class NearbyStopFinderVisitor implements TraverseVisitor<State, Edge> {
   }
 
   private boolean canBoardFlex(State state) {
-    var edges = reverseDirection
-      ? state.getVertex().getIncoming()
-      : state.getVertex().getOutgoing();
-
-    return edges
-      .stream()
-      .anyMatch(e -> e instanceof StreetEdge se && se.getPermission().allows(TraverseMode.CAR));
+    return reverseDirection
+      ? state.getVertex().checkIncoming(CAN_BOARD_FLEX_PREDICATE)
+      : state.getVertex().checkOutgoing(CAN_BOARD_FLEX_PREDICATE);
   }
 }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/nearbystops/NearbyStopFinderVisitor.java
@@ -95,7 +95,7 @@ class NearbyStopFinderVisitor implements TraverseVisitor<State, Edge> {
 
   private boolean canBoardFlex(State state) {
     return reverseDirection
-      ? state.getVertex().checkIncoming(CAN_BOARD_FLEX_PREDICATE)
-      : state.getVertex().checkOutgoing(CAN_BOARD_FLEX_PREDICATE);
+      ? state.getVertex().hasAnyIncomingMatching(CAN_BOARD_FLEX_PREDICATE)
+      : state.getVertex().hasAnyOutgoingMatching(CAN_BOARD_FLEX_PREDICATE);
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/linking/SameEdgeAdjuster.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/SameEdgeAdjuster.java
@@ -62,7 +62,7 @@ public class SameEdgeAdjuster {
         if (
           incoming instanceof TemporaryFreeEdge &&
           fromVertex instanceof StreetVertex &&
-          fromVertex.checkIncoming(edge -> edge instanceof TemporaryPartialStreetEdge)
+          fromVertex.hasAnyIncomingMatching(edge -> edge instanceof TemporaryPartialStreetEdge)
         ) {
           // The vertex is connected with an TemporaryFreeEdge connector to the
           // TemporaryPartialStreetEdge

--- a/application/src/main/java/org/opentripplanner/routing/linking/SameEdgeAdjuster.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/SameEdgeAdjuster.java
@@ -62,10 +62,7 @@ public class SameEdgeAdjuster {
         if (
           incoming instanceof TemporaryFreeEdge &&
           fromVertex instanceof StreetVertex &&
-          fromVertex
-            .getIncoming()
-            .stream()
-            .anyMatch(edge -> edge instanceof TemporaryPartialStreetEdge)
+          fromVertex.checkIncoming(edge -> edge instanceof TemporaryPartialStreetEdge)
         ) {
           // The vertex is connected with an TemporaryFreeEdge connector to the
           // TemporaryPartialStreetEdge

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -160,11 +160,11 @@ public class StreetEdge
    */
   public boolean canTraverse(TraverseMode mode) {
     StreetTraversalPermission permission = getPermission();
-    if (fromv instanceof BarrierVertex) {
-      permission = permission.intersection(((BarrierVertex) fromv).getBarrierPermissions());
+    if (fromv instanceof BarrierVertex bv) {
+      permission = permission.intersection(bv.getBarrierPermissions());
     }
-    if (tov instanceof BarrierVertex) {
-      permission = permission.intersection(((BarrierVertex) tov).getBarrierPermissions());
+    if (tov instanceof BarrierVertex bv) {
+      permission = permission.intersection(bv.getBarrierPermissions());
     }
 
     return permission.allows(mode);

--- a/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -108,22 +108,14 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
     return Arrays.asList(incoming);
   }
 
+  /// Check if any of the incoming edges satisfy the predicate.
   public boolean checkIncoming(Predicate<Edge> check) {
-    for (var e : incoming) {
-      if (check.test(e)) {
-        return true;
-      }
-    }
-    return false;
+    return checkEdges(incoming, check);
   }
 
+  /// Check if any of the outgoing edges satisfy the predicate.
   public boolean checkOutgoing(Predicate<Edge> check) {
-    for (var e : outgoing) {
-      if (check.test(e)) {
-        return true;
-      }
-    }
-    return false;
+    return checkEdges(outgoing, check);
   }
 
   public int getDegreeOut() {
@@ -292,6 +284,15 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
    */
   public Set<FeedScopedId> areaStops() {
     return Set.of();
+  }
+
+  private boolean checkEdges(Edge[] edges, Predicate<Edge> check) {
+    for (var e : edges) {
+      if (check.test(e)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -107,17 +107,17 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
   }
 
   /// Get the list of incoming edges. If you only want to check if an edge which matches a predicate
-  /// exists, then use [Vertex#hasAnyIncomingMatching(Predicate)(Predicate)()] instead.
+  /// exists, then use [Vertex#hasAnyIncomingMatching(Predicate)] instead.
   public Collection<Edge> getIncoming() {
     return Arrays.asList(incoming);
   }
 
-  /// Check if any of the incoming edges satisfies the predicate.
+  /// Check if any of the incoming edges satisfy the predicate.
   public boolean hasAnyIncomingMatching(Predicate<Edge> check) {
     return checkEdges(incoming, check);
   }
 
-  /// Check if any of the outgoing edges satisfies the predicate.
+  /// Check if any of the outgoing edges satisfy the predicate.
   public boolean hasAnyOutgoingMatching(Predicate<Edge> check) {
     return checkEdges(outgoing, check);
   }

--- a/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -101,24 +101,24 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
   }
 
   /// Get the list of outgoing edges. If you only want to check if an edge which matches a predicate
-  /// exists, then use [Vertex#checkOutgoing(Predicate)] instead.
+  /// exists, then use [Vertex#hasAnyOutgoingMatching(Predicate)] instead.
   public Collection<Edge> getOutgoing() {
     return Arrays.asList(outgoing);
   }
 
   /// Get the list of incoming edges. If you only want to check if an edge which matches a predicate
-  /// exists, then use [Vertex#checkOutgoing(Predicate)()] instead.
+  /// exists, then use [Vertex#hasAnyIncomingMatching(Predicate)(Predicate)()] instead.
   public Collection<Edge> getIncoming() {
     return Arrays.asList(incoming);
   }
 
   /// Check if any of the incoming edges satisfies the predicate.
-  public boolean checkIncoming(Predicate<Edge> check) {
+  public boolean hasAnyIncomingMatching(Predicate<Edge> check) {
     return checkEdges(incoming, check);
   }
 
   /// Check if any of the outgoing edges satisfies the predicate.
-  public boolean checkOutgoing(Predicate<Edge> check) {
+  public boolean hasAnyOutgoingMatching(Predicate<Edge> check) {
     return checkEdges(outgoing, check);
   }
 

--- a/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -100,20 +100,24 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
     }
   }
 
+  /// Get the list of outgoing edges. If you only want to check if an edge which matches a predicate
+  /// exists, then use [Vertex#checkOutgoing(Predicate)] instead.
   public Collection<Edge> getOutgoing() {
     return Arrays.asList(outgoing);
   }
 
+  /// Get the list of incoming edges. If you only want to check if an edge which matches a predicate
+  /// exists, then use [Vertex#checkOutgoing(Predicate)()] instead.
   public Collection<Edge> getIncoming() {
     return Arrays.asList(incoming);
   }
 
-  /// Check if any of the incoming edges satisfy the predicate.
+  /// Check if any of the incoming edges satisfies the predicate.
   public boolean checkIncoming(Predicate<Edge> check) {
     return checkEdges(incoming, check);
   }
 
-  /// Check if any of the outgoing edges satisfy the predicate.
+  /// Check if any of the outgoing edges satisfies the predicate.
   public boolean checkOutgoing(Predicate<Edge> check) {
     return checkEdges(outgoing, check);
   }

--- a/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
+++ b/street/src/main/java/org/opentripplanner/street/model/vertex/Vertex.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.astar.spi.AStarVertex;
 import org.opentripplanner.core.model.i18n.I18NString;
@@ -105,6 +106,24 @@ public abstract class Vertex implements AStarVertex<State, Edge, Vertex>, Serial
 
   public Collection<Edge> getIncoming() {
     return Arrays.asList(incoming);
+  }
+
+  public boolean checkIncoming(Predicate<Edge> check) {
+    for (var e : incoming) {
+      if (check.test(e)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean checkOutgoing(Predicate<Edge> check) {
+    for (var e : outgoing) {
+      if (check.test(e)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public int getDegreeOut() {

--- a/street/src/test/java/org/opentripplanner/street/model/vertex/VertexTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/vertex/VertexTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetModelFactory;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.StreetEdge;
 
 class VertexTest {
 
@@ -33,4 +36,53 @@ class VertexTest {
     Vertex v1 = new SimpleVertex("", LAT, LON);
     assertEquals(new WgsCoordinate(LAT, LON), v1.toWgsCoordinate());
   }
+
+  @Test
+  void checkIncomingReturnsTrueWhenPredicateMatches() {
+    var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
+    var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
+    StreetEdge edge = StreetModelFactory.streetEdge(from, to);
+
+    assertTrue(to.checkIncoming(e -> e == edge));
+  }
+
+  @Test
+  void checkIncomingReturnsFalseWhenPredicateDoesNotMatch() {
+    var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
+    var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
+    StreetModelFactory.streetEdge(from, to);
+
+    assertFalse(to.checkIncoming(Edge::isCrossing));
+  }
+
+  @Test
+  void checkIncomingReturnsFalseWhenNoEdges() {
+    var v = StreetModelFactory.intersectionVertex("v", LAT, LON);
+    assertFalse(v.checkIncoming(e -> true));
+  }
+
+  @Test
+  void checkOutgoingReturnsTrueWhenPredicateMatches() {
+    var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
+    var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
+    var edge = StreetModelFactory.streetEdge(from, to);
+
+    assertTrue(from.checkOutgoing(e -> e == edge));
+  }
+
+  @Test
+  void checkOutgoingReturnsFalseWhenPredicateDoesNotMatch() {
+    var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
+    var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
+    StreetModelFactory.streetEdge(from, to);
+
+    assertFalse(from.checkOutgoing(Edge::isCrossing));
+  }
+
+  @Test
+  void checkOutgoingReturnsFalseWhenNoEdges() {
+    var v = StreetModelFactory.intersectionVertex("v", LAT, LON);
+    assertFalse(v.checkOutgoing(e -> true));
+  }
+
 }

--- a/street/src/test/java/org/opentripplanner/street/model/vertex/VertexTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/vertex/VertexTest.java
@@ -38,50 +38,50 @@ class VertexTest {
   }
 
   @Test
-  void checkIncomingReturnsTrueWhenPredicateMatches() {
+  void hasAnyIncomingMatchingReturnsTrueWhenPredicateMatches() {
     var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
     var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
     StreetEdge edge = StreetModelFactory.streetEdge(from, to);
 
-    assertTrue(to.checkIncoming(e -> e == edge));
+    assertTrue(to.hasAnyIncomingMatching(e -> e == edge));
   }
 
   @Test
-  void checkIncomingReturnsFalseWhenPredicateDoesNotMatch() {
+  void hasAnyIncomingMatchingReturnsFalseWhenPredicateDoesNotMatch() {
     var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
     var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
     StreetModelFactory.streetEdge(from, to);
 
-    assertFalse(to.checkIncoming(Edge::isCrossing));
+    assertFalse(to.hasAnyIncomingMatching(Edge::isCrossing));
   }
 
   @Test
-  void checkIncomingReturnsFalseWhenNoEdges() {
+  void hasAnyIncomingMatchingReturnsFalseWhenNoEdges() {
     var v = StreetModelFactory.intersectionVertex("v", LAT, LON);
-    assertFalse(v.checkIncoming(e -> true));
+    assertFalse(v.hasAnyIncomingMatching(e -> true));
   }
 
   @Test
-  void checkOutgoingReturnsTrueWhenPredicateMatches() {
+  void hasAnyOutgoingMatchingReturnsTrueWhenPredicateMatches() {
     var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
     var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
     var edge = StreetModelFactory.streetEdge(from, to);
 
-    assertTrue(from.checkOutgoing(e -> e == edge));
+    assertTrue(from.hasAnyOutgoingMatching(e -> e == edge));
   }
 
   @Test
-  void checkOutgoingReturnsFalseWhenPredicateDoesNotMatch() {
+  void hasAnyOutgoingMatchingReturnsFalseWhenPredicateDoesNotMatch() {
     var from = StreetModelFactory.intersectionVertex("from", LAT, LON);
     var to = StreetModelFactory.intersectionVertex("to", LAT + 0.01, LON + 0.01);
     StreetModelFactory.streetEdge(from, to);
 
-    assertFalse(from.checkOutgoing(Edge::isCrossing));
+    assertFalse(from.hasAnyOutgoingMatching(Edge::isCrossing));
   }
 
   @Test
-  void checkOutgoingReturnsFalseWhenNoEdges() {
+  void hasAnyOutgoingMatchingReturnsFalseWhenNoEdges() {
     var v = StreetModelFactory.intersectionVertex("v", LAT, LON);
-    assertFalse(v.checkOutgoing(e -> true));
+    assertFalse(v.hasAnyOutgoingMatching(e -> true));
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/model/vertex/VertexTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/vertex/VertexTest.java
@@ -84,5 +84,4 @@ class VertexTest {
     var v = StreetModelFactory.intersectionVertex("v", LAT, LON);
     assertFalse(v.checkOutgoing(e -> true));
   }
-
 }


### PR DESCRIPTION
### Summary

During a flex search the `NearbyStopFinderTraverseVisitor` creates a stream for every vertex visited, of which there can be several hundred thousands. This is a hotspot for allocations and entirely avoidable, by iterating over the edge array. This has zero extra allocations.

### Unit tests

Added.

### Bumping the serialization version id

No.