### PR TITLE
Add names to stops of carpooling itineraries

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
@@ -4,19 +4,52 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
+import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPath;
+import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
+import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
+import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createSimpleTrip;
 
+import java.time.Duration;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Locale;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
+import org.opentripplanner.ext.carpooling.routing.EndpointLabel;
+import org.opentripplanner.ext.carpooling.routing.InsertionCandidate;
+import org.opentripplanner.framework.model.TimeAndCost;
+import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.organization.ContactInfo;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
 
 /**
  * Unit tests for {@link CarpoolItineraryMapper}.
+ * <p>
+ * Two concerns are pinned here:
+ * <ul>
+ *   <li>{@link CarpoolItineraryMapper#toBookingInfo} — the pickup booking-info derivation from
+ *       the trip's public contact details.</li>
+ *   <li>Endpoint-naming precedence for itinerary boundaries:
+ *     <ol>
+ *       <li>Transit stop (Place#forStop) — when the chain ends at a transit stop</li>
+ *       <li>User input location (Place#forGenericLocation) — the request's from/to label, with a
+ *           localized "Origin"/"Destination" fallback when the label is null</li>
+ *       <li>Vertex intersection name (StreetVertex#getIntersectionName) — for intermediate
+ *           boundaries between walk and carpool legs</li>
+ *     </ol>
+ *   </li>
+ * </ul>
  */
 class CarpoolItineraryMapperTest {
 
@@ -33,6 +66,33 @@ class CarpoolItineraryMapperTest {
 
   private static final WgsCoordinate PICKUP = new WgsCoordinate(59.910000, 10.750000);
   private static final WgsCoordinate DROPOFF = new WgsCoordinate(59.920000, 10.760000);
+
+  private static final Duration STOP_DURATION = Duration.ofMinutes(2);
+  private static final int PICKUP_POSITION = 1;
+  private static final int DROPOFF_POSITION = 2;
+  private static final Duration PICKUP_SEGMENT_DURATION = Duration.ofMinutes(1);
+  private static final Duration SHARED_SEGMENT_DURATION = Duration.ofSeconds(60);
+  private static final double CARPOOL_RELUCTANCE = 1.0;
+
+  /**
+   * Every GraphPath produced by {@link org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder}
+   * has a single outgoing street edge named "segment-0", so the FIRST vertex of each path
+   * (which carries that edge as outgoing) resolves to that name via
+   * {@link org.opentripplanner.street.model.vertex.StreetVertex#getIntersectionName()}.
+   */
+  private static final String NAMED_INTERSECTION = "segment-0";
+
+  /**
+   * The LAST vertex of each test GraphPath has the segment edge only as <em>incoming</em> — there
+   * are no outgoing street edges — so {@code getIntersectionName()} falls back to its
+   * {@code LocalizedString("unnamedStreet")} branch, which resolves to "unnamed" in English. The
+   * point of asserting this value is to prove it's a getIntersectionName() output (not the user's
+   * "Office" label leaking through).
+   */
+  private static final String UNNAMED_INTERSECTION = "unnamed";
+
+  private final CarpoolItineraryMapper mapper = new CarpoolItineraryMapper();
+  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
 
   @Test
   void nullContact_returnsNull() {
@@ -202,5 +262,195 @@ class CarpoolItineraryMapperTest {
     assertNotNull(latest);
     assertEquals(LocalTime.of(8, 30), latest.getTime());
     assertEquals(0, latest.getDaysPrior());
+  }
+
+  /**
+   * Tier 2 — outer endpoints carry the user's from/to label when present. Without a transit
+   * stop in play, the labels passed via {@code fromLocation}/{@code toLocation} reach the first
+   * leg's {@code from} and the last leg's {@code to} directly.
+   */
+  @Test
+  void outerEndpointsUseUserSuppliedLabels() {
+    var candidate = newCandidate(
+      createGraphPath(Duration.ofSeconds(80)),
+      createGraphPath(Duration.ofSeconds(40))
+    );
+
+    var itinerary = mapper.toItinerary(
+      candidate,
+      CARPOOL_RELUCTANCE,
+      GenericLocation.fromCoordinate(59.91, 10.74, "Home"),
+      GenericLocation.fromCoordinate(59.95, 10.80, "Office")
+    );
+
+    var legs = itinerary.legs();
+    assertEquals("Home", legs.getFirst().from().name.toString());
+    assertEquals("Office", legs.getLast().to().name.toString());
+  }
+
+  /**
+   * Tier 2 fallback — when the GenericLocation has no label (coordinate-only request) the mapper
+   * falls back to the "Origin"/"Destination" strings.
+   */
+  @Test
+  void outerEndpointsFallBackToLocalizedOriginDestination() {
+    var candidate = newCandidate(
+      createGraphPath(Duration.ofSeconds(80)),
+      createGraphPath(Duration.ofSeconds(40))
+    );
+
+    var itinerary = mapper.toItinerary(
+      candidate,
+      CARPOOL_RELUCTANCE,
+      GenericLocation.fromCoordinate(59.91, 10.74, null),
+      GenericLocation.fromCoordinate(59.95, 10.80, null)
+    );
+
+    var legs = itinerary.legs();
+    assertEquals("Origin", legs.getFirst().from().name.toString());
+    assertEquals("Destination", legs.getLast().to().name.toString());
+  }
+
+  /**
+   * Tier 2 fallback — same as the null-label case but for the empty-string label that
+   * {@link org.opentripplanner.apis.transmodel.mapping.GenericLocationMapper} produces when the
+   * GraphQL request omits {@code name}.
+   */
+  @Test
+  void outerEndpointsFallBackWhenLabelIsEmptyString() {
+    var candidate = newCandidate(
+      createGraphPath(Duration.ofSeconds(80)),
+      createGraphPath(Duration.ofSeconds(40))
+    );
+
+    var itinerary = mapper.toItinerary(
+      candidate,
+      CARPOOL_RELUCTANCE,
+      GenericLocation.fromCoordinate(59.91, 10.74, ""),
+      GenericLocation.fromCoordinate(59.95, 10.80, "")
+    );
+
+    var legs = itinerary.legs();
+    assertEquals("Origin", legs.getFirst().from().name.toString());
+    assertEquals("Destination", legs.getLast().to().name.toString());
+  }
+
+  /**
+   * Tier 3 — intermediate boundaries (between a walk leg and the carpool leg) are
+   * vertex-derived via {@link
+   * org.opentripplanner.street.model.vertex.StreetVertex#getIntersectionName()} and must NOT
+   * inherit the user's from/to label. This is what keeps the carpool leg's pickup/dropoff
+   * looking like actual street locations rather than the rider's labelled origin/destination.
+   */
+  @Test
+  void carpoolBoundaryUsesIntersectionNameNotUserLabel() {
+    var candidate = newCandidate(
+      createGraphPath(Duration.ofSeconds(80)),
+      createGraphPath(Duration.ofSeconds(40))
+    );
+
+    var itinerary = mapper.toItinerary(
+      candidate,
+      CARPOOL_RELUCTANCE,
+      GenericLocation.fromCoordinate(59.91, 10.74, "Home"),
+      GenericLocation.fromCoordinate(59.95, 10.80, "Office")
+    );
+
+    var legs = itinerary.legs();
+    // Walk-to-pickup's TO == carpool's FROM == pickup vertex.
+    // The pickup vertex is the FIRST vertex of the shared GraphPath and carries the segment edge
+    // as outgoing, so getIntersectionName() returns the edge name "segment-0".
+    assertEquals(NAMED_INTERSECTION, legs.getFirst().to().name.toString());
+    assertEquals(NAMED_INTERSECTION, legs.get(1).from().name.toString());
+    // Carpool's TO == walk-from-dropoff's FROM == dropoff vertex.
+    // The dropoff vertex is the LAST vertex of the shared GraphPath and has no outgoing street
+    // edges, so getIntersectionName() falls back to "unnamed". Crucially, this is NOT the user's
+    // "Office" label — that's the property under test.
+    assertEquals(UNNAMED_INTERSECTION, legs.get(1).to().name.toString());
+    assertEquals(UNNAMED_INTERSECTION, legs.getLast().from().name.toString());
+  }
+
+  /**
+   * Tier 1 — for an access itinerary (passenger origin → walk → carpool → transit stop), the
+   * carpool leg's {@code to} (which is the last leg, since no walk-from-dropoff is needed when
+   * the carpool ends at the stop) carries the transit stop's name. Transit stop wins over both
+   * the intersection name and any user-supplied destination label.
+   * <p>
+   * The first leg's {@code from} simultaneously verifies that the passenger origin label is
+   * still applied on the user-side end of an access chain.
+   */
+  @Test
+  void accessItineraryLastLegToCarriesTransitStopName() {
+    RegularStop stop = testModel.stop("Central Station", 59.91, 10.74).build();
+    GenericLocation passengerOrigin = GenericLocation.fromCoordinate(59.92, 10.75, "Home");
+    var candidate = newCandidate(
+      createGraphPath(Duration.ofSeconds(80)),
+      // Access: the carpool ends at the transit stop, no walk-from-dropoff.
+      null
+    );
+    var accessEgress = new CarpoolAccessEgress(
+      0,
+      0,
+      candidate,
+      TimeAndCost.ZERO,
+      CARPOOL_RELUCTANCE,
+      EndpointLabel.forLocation(passengerOrigin),
+      EndpointLabel.forStop(stop)
+    );
+
+    var itinerary = mapper.toItinerary(accessEgress);
+
+    var legs = itinerary.legs();
+    assertEquals("Home", legs.getFirst().from().name.toString());
+    assertEquals("Central Station", legs.getLast().to().name.toString());
+  }
+
+  /**
+   * Tier 1 symmetric to {@link #accessItineraryLastLegToCarriesTransitStopName()} — for an egress
+   * itinerary (transit stop → carpool → walk → passenger destination), the carpool leg's
+   * {@code from} (the first leg, since no walk-to-pickup is needed when the carpool starts at the
+   * stop) carries the transit stop's name. The last walk leg's {@code to} simultaneously verifies
+   * that the passenger destination label is still applied on the user-side end of an egress chain.
+   */
+  @Test
+  void egressItineraryFirstLegFromCarriesTransitStopName() {
+    RegularStop stop = testModel.stop("Central Station", 59.91, 10.74).build();
+    GenericLocation passengerDestination = GenericLocation.fromCoordinate(59.92, 10.75, "Office");
+    var candidate = newCandidate(
+      // Egress: the carpool starts at the transit stop, no walk-to-pickup.
+      null,
+      createGraphPath(Duration.ofSeconds(40))
+    );
+    var accessEgress = new CarpoolAccessEgress(
+      0,
+      0,
+      candidate,
+      TimeAndCost.ZERO,
+      CARPOOL_RELUCTANCE,
+      EndpointLabel.forStop(stop),
+      EndpointLabel.forLocation(passengerDestination)
+    );
+
+    var itinerary = mapper.toItinerary(accessEgress);
+
+    var legs = itinerary.legs();
+    assertEquals("Central Station", legs.getFirst().from().name.toString());
+    assertEquals("Office", legs.getLast().to().name.toString());
+  }
+
+  private InsertionCandidate newCandidate(
+    @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+    @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff
+  ) {
+    return new InsertionCandidate(
+      createSimpleTrip(OSLO_CENTER, OSLO_NORTH),
+      PICKUP_POSITION,
+      DROPOFF_POSITION,
+      List.of(createGraphPath(PICKUP_SEGMENT_DURATION), createGraphPath(SHARED_SEGMENT_DURATION)),
+      STOP_DURATION,
+      null,
+      walkToPickup,
+      walkFromDropoff
+    );
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
@@ -166,7 +166,9 @@ class CarpoolAccessEgressTest {
       passengerDepartureTime,
       candidate,
       TimeAndCost.ZERO,
-      carpoolReluctance
+      carpoolReluctance,
+      EndpointLabel.EMPTY,
+      EndpointLabel.EMPTY
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -12,10 +12,14 @@ import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.core.model.basic.Cost;
+import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.core.model.i18n.LocalizedString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
+import org.opentripplanner.ext.carpooling.routing.EndpointLabel;
 import org.opentripplanner.ext.carpooling.routing.InsertionCandidate;
+import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
@@ -23,13 +27,17 @@ import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.transit.model.organization.ContactInfo;
+import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
 import org.opentripplanner.transit.model.timetable.booking.BookingTime;
+import org.opentripplanner.utils.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +71,22 @@ import org.slf4j.LoggerFactory;
  * committed schedule and cannot wait. Whether the passenger should show up early or be matched
  * at all is a filtering concern upstream of this mapper.
  *
+ * <h2>Place naming</h2>
+ * <p>
+ * The itinerary's outermost endpoints (first leg's {@code from}, last leg's {@code to}) are
+ * resolved with this precedence:
+ * <ol>
+ *   <li>If the endpoint is a transit stop (access/egress), label with the stop's name via
+ *       {@link Place#forStop(StopLocation)}.</li>
+ *   <li>Else if the endpoint is the user's input location, label with the user-supplied
+ *       label when present, falling back to the localized {@code "origin"} /
+ *       {@code "destination"} names that the standard request flow produces.
+ *   <li>Else (intermediate boundaries between walk and carpool legs) fall back to vertex-based
+ *       naming via {@link #makePlace(Vertex)}: {@link StreetVertex#getIntersectionName()} for
+ *       street intersections (composed from OSM street names; mode-agnostic), the vertex's
+ *       pre-set name for {@link TemporaryStreetLocation}s.</li>
+ * </ol>
+ *
  * <h2>Package Location</h2>
  * <p>
  * This class is in the {@code internal} package because it's an implementation detail of
@@ -75,6 +99,8 @@ import org.slf4j.LoggerFactory;
 public class CarpoolItineraryMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(CarpoolItineraryMapper.class);
+  private static final I18NString ORIGIN_DEFAULT_NAME = new LocalizedString("origin");
+  private static final I18NString DESTINATION_DEFAULT_NAME = new LocalizedString("destination");
 
   /**
    * Converts an insertion candidate into an OTP itinerary representing the passenger's journey.
@@ -86,11 +112,20 @@ public class CarpoolItineraryMapper {
    *        optional walk paths around the carpool pickup/dropoff
    * @param carpoolReluctance multiplier applied to ride seconds when computing the carpool leg's
    *        {@code generalizedCost}.
+   * @param fromLocation the request's {@code from} location (passenger origin), used to label
+   *        the first leg's {@code from} place.
+   * @param toLocation the request's {@code to} location (passenger destination), used to label
+   *        the last leg's {@code to} place.
    * @return an itinerary for the passenger's journey, or {@code null} if the candidate has no
    *         shared segments (a safety check that should not trigger for valid candidates)
    */
   @Nullable
-  public Itinerary toItinerary(InsertionCandidate candidate, double carpoolReluctance) {
+  public Itinerary toItinerary(
+    InsertionCandidate candidate,
+    double carpoolReluctance,
+    GenericLocation fromLocation,
+    GenericLocation toLocation
+  ) {
     var sharedSegments = candidate.getSharedSegments();
     if (sharedSegments.isEmpty()) {
       return null;
@@ -104,6 +139,8 @@ public class CarpoolItineraryMapper {
       carpoolStart,
       carpoolEnd,
       candidate.getPassengerRideWeight(carpoolReluctance),
+      EndpointLabel.forLocation(fromLocation),
+      EndpointLabel.forLocation(toLocation),
       toBookingInfo(
         candidate.trip().publicContactInformation(),
         candidate.trip().startTime(),
@@ -118,14 +155,10 @@ public class CarpoolItineraryMapper {
     ZonedDateTime startTime,
     ZonedDateTime endTime,
     double rideWeight,
+    Place fromPlace,
+    Place toPlace,
     @Nullable BookingInfo bookingInfo
   ) {
-    var firstSegment = sharedSegments.getFirst();
-    var lastSegment = sharedSegments.getLast();
-
-    Vertex fromVertex = firstSegment.states.getFirst().getVertex();
-    Vertex toVertex = lastSegment.states.getLast().getVertex();
-
     var allEdges = sharedSegments
       .stream()
       .flatMap(seg -> seg.edges.stream())
@@ -134,8 +167,8 @@ public class CarpoolItineraryMapper {
     return CarpoolLeg.of()
       .withStartTime(startTime)
       .withEndTime(endTime)
-      .withFrom(Place.normal(fromVertex, new NonLocalizedString("Carpool boarding")))
-      .withTo(Place.normal(toVertex, new NonLocalizedString("Carpool alighting")))
+      .withFrom(fromPlace)
+      .withTo(toPlace)
       .withGeometry(GeometryUtils.concatenateLineStrings(allEdges, Edge::getGeometry))
       .withDistanceMeters(allEdges.stream().mapToDouble(Edge::getDistanceMeters).sum())
       .withGeneralizedCost((int) rideWeight)
@@ -146,11 +179,10 @@ public class CarpoolItineraryMapper {
   private static StreetLeg buildWalkLeg(
     GraphPath<State, Edge, Vertex> walkPath,
     ZonedDateTime startTime,
-    ZonedDateTime endTime
+    ZonedDateTime endTime,
+    Place fromPlace,
+    Place toPlace
   ) {
-    Vertex fromVertex = walkPath.states.getFirst().getVertex();
-    Vertex toVertex = walkPath.states.getLast().getVertex();
-
     LineString geometry = GeometryUtils.concatenateLineStrings(walkPath.edges, Edge::getGeometry);
     double distance = walkPath.edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
 
@@ -158,8 +190,8 @@ public class CarpoolItineraryMapper {
       .withMode(TraverseMode.WALK)
       .withStartTime(startTime)
       .withEndTime(endTime)
-      .withFrom(Place.normal(fromVertex, fromVertex.getName()))
-      .withTo(Place.normal(toVertex, toVertex.getName()))
+      .withFrom(fromPlace)
+      .withTo(toPlace)
       .withGeometry(geometry)
       .withDistanceMeters(distance)
       .withGeneralizedCost((int) walkPath.getWeight())
@@ -168,9 +200,10 @@ public class CarpoolItineraryMapper {
 
   /**
    * Converts a Raptor carpool access/egress leg back into an OTP itinerary for the response. Same
-   * shape as {@link #toItinerary(InsertionCandidate, double)} — an optional WALK leg, the carpool
-   * leg, and an optional WALK leg — but driven from the {@link CarpoolAccessEgress} accessors so
-   * the displayed times and ride cost agree with the values Raptor used during the search.
+   * shape as {@link #toItinerary(InsertionCandidate, double, GenericLocation, GenericLocation)} —
+   * an optional WALK leg, the carpool leg, and an optional WALK leg — but driven from the
+   * {@link CarpoolAccessEgress} accessors so the displayed times and ride cost agree with the
+   * values Raptor used during the search.
    *
    * @return the itinerary, or {@code null} if the access/egress has no shared segments (a safety
    *         check that should not trigger for valid legs)
@@ -188,6 +221,8 @@ public class CarpoolItineraryMapper {
       accessEgress.getCarpoolStart(),
       accessEgress.getCarpoolEnd(),
       accessEgress.getPassengerRideWeight(),
+      accessEgress.startLabel(),
+      accessEgress.endLabel(),
       toBookingInfo(
         accessEgress.trip().publicContactInformation(),
         accessEgress.trip().startTime(),
@@ -201,6 +236,10 @@ public class CarpoolItineraryMapper {
    * Assembles a WALK + CARPOOL + WALK itinerary around the shared ride. Walk legs are omitted
    * when their corresponding path is {@code null}; the walk legs' outer times are derived from
    * {@code carpoolStart}/{@code carpoolEnd} plus the walk durations.
+   * <p>
+   * Boundary-place precedence at the chain's outermost endpoints follows the {@link EndpointLabel}
+   * contract: a stop wins over a user location, which wins over the vertex-derived fallback name
+   * via {@link #makePlace(Vertex)}.
    */
   private static Itinerary buildItinerary(
     List<GraphPath<State, Edge, Vertex>> sharedSegments,
@@ -209,17 +248,47 @@ public class CarpoolItineraryMapper {
     ZonedDateTime carpoolStart,
     ZonedDateTime carpoolEnd,
     double rideWeight,
+    EndpointLabel startLabel,
+    EndpointLabel endLabel,
     @Nullable BookingInfo bookingInfo
   ) {
+    Vertex pickupVertex = sharedSegments.getFirst().states.getFirst().getVertex();
+    Vertex dropoffVertex = sharedSegments.getLast().states.getLast().getVertex();
+    Place pickupPlace = makePlace(pickupVertex);
+    Place dropoffPlace = makePlace(dropoffVertex);
+
+    Vertex startBoundaryVertex = walkToPickup != null
+      ? walkToPickup.states.getFirst().getVertex()
+      : pickupVertex;
+    Vertex endBoundaryVertex = walkFromDropoff != null
+      ? walkFromDropoff.states.getLast().getVertex()
+      : dropoffVertex;
+
+    Place itineraryStart = boundaryPlace(startLabel, ORIGIN_DEFAULT_NAME, startBoundaryVertex);
+    Place itineraryEnd = boundaryPlace(endLabel, DESTINATION_DEFAULT_NAME, endBoundaryVertex);
+
+    Place carpoolFromPlace = walkToPickup != null ? pickupPlace : itineraryStart;
+    Place carpoolToPlace = walkFromDropoff != null ? dropoffPlace : itineraryEnd;
+
     List<Leg> legs = new ArrayList<>(3);
     if (walkToPickup != null) {
       var walkStart = carpoolStart.minusSeconds(walkToPickup.getDuration());
-      legs.add(buildWalkLeg(walkToPickup, walkStart, carpoolStart));
+      legs.add(buildWalkLeg(walkToPickup, walkStart, carpoolStart, itineraryStart, pickupPlace));
     }
-    legs.add(buildCarpoolLeg(sharedSegments, carpoolStart, carpoolEnd, rideWeight, bookingInfo));
+    legs.add(
+      buildCarpoolLeg(
+        sharedSegments,
+        carpoolStart,
+        carpoolEnd,
+        rideWeight,
+        carpoolFromPlace,
+        carpoolToPlace,
+        bookingInfo
+      )
+    );
     if (walkFromDropoff != null) {
       var walkEnd = carpoolEnd.plusSeconds(walkFromDropoff.getDuration());
-      legs.add(buildWalkLeg(walkFromDropoff, carpoolEnd, walkEnd));
+      legs.add(buildWalkLeg(walkFromDropoff, carpoolEnd, walkEnd, dropoffPlace, itineraryEnd));
     }
 
     int totalCost = legs.stream().mapToInt(Leg::generalizedCost).sum();
@@ -353,5 +422,51 @@ public class CarpoolItineraryMapper {
       LOG.warn("Failed to parse carpool booking URL '{}'; dropping URL from booking info", url, e);
       return null;
     }
+  }
+
+  /**
+   * Resolves the outermost endpoint of an itinerary using the precedence transit stop &gt;
+   * user input location &gt; vertex-derived name. The first two are needed because the
+   * underlying State chain doesn't always carry a vertex with the right name — the transit-side
+   * end of an access/egress walk is a regular street vertex, and when no walk is needed at all
+   * the State chain skips the user's temporary origin/destination vertex and starts straight at
+   * the snapped pickup/dropoff (which has only an OSM intersection name).
+   */
+  private static Place boundaryPlace(
+    EndpointLabel label,
+    I18NString locationDefaultName,
+    Vertex fallbackVertex
+  ) {
+    if (label.stop() != null) {
+      return Place.forStop(label.stop());
+    }
+    if (label.location() != null) {
+      // Place.forGenericLocation only swaps in defaultName when label() is null, but
+      // GenericLocationMapper coerces an absent GraphQL "name" to "" — so without StringUtils'
+      // null/blank check the Place name would render as a blank string instead of the localized
+      // "origin"/"destination" fallback.
+      var loc = label.location();
+      I18NString name = StringUtils.hasValue(loc.label())
+        ? new NonLocalizedString(loc.label())
+        : locationDefaultName;
+      return loc.wgsCoordinate() != null
+        ? Place.normal(loc.wgsCoordinate(), name)
+        : Place.noCoords(name);
+    }
+    return makePlace(fallbackVertex);
+  }
+
+  /**
+   * Builds a {@link Place} from a vertex using the same naming logic the core street-leg
+   * mapper applies for any mode. {@link StreetVertex} intersections get the localized
+   * "corner of X and Y" name composed from the outgoing OSM street names (mode-agnostic);
+   * {@link TemporaryStreetLocation}s (passenger origin/destination) keep the name they were
+   * created with; everything else falls back to {@link Vertex#getName()}.
+   */
+  private static Place makePlace(Vertex vertex) {
+    if (vertex instanceof StreetVertex sv && !(vertex instanceof TemporaryStreetLocation)) {
+      return Place.normal(vertex, sv.getIntersectionName());
+    }
+    return Place.normal(vertex, vertex.getName());
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -53,6 +53,9 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
   private final TimeAndCost penalty;
   private final double carpoolReluctance;
 
+  private final EndpointLabel startLabel;
+  private final EndpointLabel endLabel;
+
   /**
    * @param stop Raptor stop index of the transit-side endpoint — the stop the passenger boards
    *        transit at (for access) or alights from transit at (for egress).
@@ -63,20 +66,31 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
    * @param penalty optional Raptor time/cost penalty added on top of the leg, applied via
    *        {@link #withPenalty(TimeAndCost)}; pass {@link TimeAndCost#ZERO} for no penalty.
    * @param carpoolReluctance multiplier on ride seconds when computing {@link #c1()}; the walk
-   *        portions use the walks' own A* weights and are not multiplied by this.
+   *        portions are billed at the walks' own A* weights and are not multiplied by this.
+   * @param startLabel label data for the first leg's {@code from} place. For an access this is
+   *        the passenger origin ({@link EndpointLabel#forLocation(org.opentripplanner.model.GenericLocation)});
+   *        for an egress it is the transit stop the passenger alighted from
+   *        ({@link EndpointLabel#forStop(org.opentripplanner.transit.model.site.StopLocation)}).
+   *        The mapper resolves the label into a {@code Place}.
+   * @param endLabel symmetric to {@code startLabel}: label data for the last leg's {@code to}
+   *        place. Transit stop for an access, passenger destination for an egress.
    */
   public CarpoolAccessEgress(
     int stop,
     int passengerDepartureTime,
     InsertionCandidate insertionCandidate,
     TimeAndCost penalty,
-    double carpoolReluctance
+    double carpoolReluctance,
+    EndpointLabel startLabel,
+    EndpointLabel endLabel
   ) {
     this.stop = stop;
     this.passengerDepartureTime = passengerDepartureTime;
     this.insertionCandidate = insertionCandidate;
     this.penalty = penalty;
     this.carpoolReluctance = carpoolReluctance;
+    this.startLabel = startLabel;
+    this.endLabel = endLabel;
     this.timePenalty = penalty.isZero() ? RaptorConstants.TIME_NOT_SET : penalty.timeInSeconds();
 
     var walkToPickup = insertionCandidate.walkToPickup();
@@ -186,7 +200,9 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
       this.passengerDepartureTime,
       this.insertionCandidate,
       penalty,
-      this.carpoolReluctance
+      this.carpoolReluctance,
+      this.startLabel,
+      this.endLabel
     );
   }
 
@@ -198,6 +214,23 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
    */
   public CarpoolTrip trip() {
     return insertionCandidate.trip();
+  }
+
+  /**
+   * Label data for the first leg's {@code from} place. For an access this carries the passenger
+   * origin; for an egress, the transit stop the passenger alighted from. Read by the itinerary
+   * mapper to name the chain's outermost start endpoint.
+   */
+  public EndpointLabel startLabel() {
+    return startLabel;
+  }
+
+  /**
+   * Symmetric to {@link #startLabel()}: label data for the last leg's {@code to} place. Transit
+   * stop for an access, passenger destination for an egress.
+   */
+  public EndpointLabel endLabel() {
+    return endLabel;
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/EndpointLabel.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/EndpointLabel.java
@@ -1,0 +1,58 @@
+package org.opentripplanner.ext.carpooling.routing;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.transit.model.site.StopLocation;
+
+/**
+ * Label data for one outermost endpoint of a carpool itinerary, consumed by the itinerary mapper
+ * to name the corresponding {@code Place} in the API response.
+ * <p>
+ * The carpool flow has two independent label sources at each endpoint: a resolved transit stop
+ * (for the transit-side end of an access/egress chain) or the user's {@code from}/{@code to}
+ * input (for the passenger-side end). Exactly three states are valid, each produced by a single
+ * factory:
+ * <ul>
+ *   <li>{@link #forStop(StopLocation)} — transit stop only</li>
+ *   <li>{@link #forLocation(GenericLocation)} — user input location only</li>
+ *   <li>{@link #EMPTY} — neither; the mapper falls back to vertex-derived naming</li>
+ * </ul>
+ * The canonical constructor rejects the fourth combination (both fields non-null), so callers
+ * cannot accidentally build a label carrying both a stop and a user location.
+ * <p>
+ * The mapper enforces the precedence transit stop &gt; user input &gt; vertex; this record only
+ * carries the two pre-resolved candidates.
+ *
+ * @param stop the transit-side stop, set on the transit end of an access/egress chain;
+ *        {@code null} when the endpoint is not a transit stop.
+ * @param location the passenger-side input location (the request's {@code from} or {@code to}),
+ *        set on the user end of an access/egress chain or on both ends of a direct carpool
+ *        itinerary; {@code null} when the endpoint is not the user's input.
+ */
+public record EndpointLabel(@Nullable StopLocation stop, @Nullable GenericLocation location) {
+  /**
+   * Use when the caller has neither a transit stop nor a user input location — the mapper will
+   * name the endpoint from the underlying street vertex instead.
+   */
+  public static final EndpointLabel EMPTY = new EndpointLabel(null, null);
+
+  public EndpointLabel {
+    if (stop != null && location != null) {
+      throw new IllegalArgumentException(
+        "EndpointLabel carries either a stop or a user location, never both; " +
+          "use the forStop/forLocation factories or EMPTY."
+      );
+    }
+  }
+
+  /** Use on the transit-side end of an access/egress chain. */
+  public static EndpointLabel forStop(StopLocation stop) {
+    return new EndpointLabel(Objects.requireNonNull(stop, "stop"), null);
+  }
+
+  /** Use on the passenger-side end (the request's {@code from} or {@code to} location). */
+  public static EndpointLabel forLocation(GenericLocation location) {
+    return new EndpointLabel(null, Objects.requireNonNull(location, "location"));
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -17,6 +17,7 @@ import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.CarpoolStreetRouter;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTreeStreetRouter;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTripWithVertices;
+import org.opentripplanner.ext.carpooling.routing.EndpointLabel;
 import org.opentripplanner.ext.carpooling.routing.InsertionCandidate;
 import org.opentripplanner.ext.carpooling.routing.InsertionEvaluator;
 import org.opentripplanner.ext.carpooling.routing.InsertionPosition;
@@ -48,6 +49,7 @@ import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.streetadapter.StreetSearchRequestMapper;
 import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.service.TransitServiceResolver;
 import org.opentripplanner.utils.time.TimeUtils;
@@ -301,7 +303,9 @@ public class DefaultCarpoolingService implements CarpoolingService {
       var carpoolReluctance = request.preferences().car().reluctance();
       itineraries = insertionCandidates
         .stream()
-        .map(candidate -> itineraryMapper.toItinerary(candidate, carpoolReluctance))
+        .map(candidate ->
+          itineraryMapper.toItinerary(candidate, carpoolReluctance, request.from(), request.to())
+        )
         .filter(Objects::nonNull)
         .toList();
     }
@@ -567,7 +571,9 @@ public class DefaultCarpoolingService implements CarpoolingService {
               Using the reluctance of mode car.
               TODO: Figure out whether carpooling should have its own reluctance variable
              */
-            request.preferences().car().reluctance()
+            request.preferences().car().reluctance(),
+            accessOrEgress,
+            passengerLocation
           )
         )
         .toList();
@@ -593,7 +599,9 @@ public class DefaultCarpoolingService implements CarpoolingService {
     TransitServiceResolver transitServiceResolver,
     InsertionCandidate insertionCandidate,
     ZonedDateTime transitSearchTimeZero,
-    double carpoolReluctance
+    double carpoolReluctance,
+    AccessEgressType accessOrEgress,
+    GenericLocation passengerLocation
   ) {
     var carpoolPickupTime = insertionCandidate
       .trip()
@@ -608,12 +616,23 @@ public class DefaultCarpoolingService implements CarpoolingService {
       passengerStartTime.toInstant()
     );
 
+    StopLocation transitStopLocation = transitServiceResolver.getStopLocation(
+      insertionCandidate.transitStop().stopId
+    );
+    EndpointLabel stopLabel = EndpointLabel.forStop(transitStopLocation);
+    EndpointLabel passengerLabel = EndpointLabel.forLocation(passengerLocation);
+
+    EndpointLabel startLabel = accessOrEgress.isAccess() ? passengerLabel : stopLabel;
+    EndpointLabel endLabel = accessOrEgress.isAccess() ? stopLabel : passengerLabel;
+
     return new CarpoolAccessEgress(
-      transitServiceResolver.getStopLocation(insertionCandidate.transitStop().stopId).getIndex(),
+      transitStopLocation.getIndex(),
       passengerDepartureTime,
       insertionCandidate,
       TimeAndCost.ZERO,
-      carpoolReluctance
+      carpoolReluctance,
+      startLabel,
+      endLabel
     );
   }
 }


### PR DESCRIPTION
### Summary

It replaces the stops of carpooling itineraries from the previous placeholder names "carpooling waypoint" with actual stop places. 

### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?

Yes, the CarpoolItineraryMapperTest file is added, which tests the names of stops of carpool itineraries. 

- Was any manual verification done?

yes

- Was the code designed so it is unit testable?

yes

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

yes

- Were all non-trivial public classes and methods documented with Javadoc?

yes

- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?

no