### PR TITLE
Use OtpRetry in SiriAzureUpdaters

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdaterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdaterTest.java
@@ -1,22 +1,13 @@
 package org.opentripplanner.ext.siri.updater.azure;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,34 +16,15 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.azure.core.util.ExpandableStringEnum;
-import com.azure.messaging.servicebus.ServiceBusErrorSource;
-import com.azure.messaging.servicebus.ServiceBusException;
-import com.azure.messaging.servicebus.ServiceBusFailureReason;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.SocketTimeoutException;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.opentripplanner.framework.io.OtpHttpClientException;
+import org.opentripplanner.framework.retry.OtpRetry;
+import org.opentripplanner.framework.retry.OtpRetryException;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.slf4j.LoggerFactory;
 import uk.org.siri.siri21.ServiceDelivery;
@@ -60,12 +32,13 @@ import uk.org.siri.siri21.ServiceDelivery;
 class SiriAzureUpdaterTest {
 
   private SiriAzureUpdaterParameters mockConfig;
-  private SiriAzureUpdater updater;
-  private SiriAzureUpdater.CheckedRunnable task;
+  private Runnable task;
+  private OtpRetry otpRetry;
 
   @BeforeEach
   public void setUp() throws Exception {
     mockConfig = mock(SiriAzureUpdaterParameters.class);
+    otpRetry = mock(OtpRetry.class);
     when(mockConfig.getType()).thenReturn("siri-azure-test-updater");
     when(mockConfig.configRef()).thenReturn("testConfigRef");
     when(mockConfig.getAuthenticationType()).thenReturn(AuthenticationType.SharedAccessKey);
@@ -74,14 +47,13 @@ class SiriAzureUpdaterTest {
     when(mockConfig.getTopicName()).thenReturn("testTopic");
     when(mockConfig.getDataInitializationUrl()).thenReturn("http://testurl.com");
     when(mockConfig.getTimeout()).thenReturn(5000);
-    when(mockConfig.getStartupTimeout()).thenReturn(Duration.ofSeconds(30));
     when(mockConfig.feedId()).thenReturn("testFeedId");
     when(mockConfig.getAutoDeleteOnIdle()).thenReturn(Duration.ofHours(1));
     when(mockConfig.getPrefetchCount()).thenReturn(10);
     when(mockConfig.isFuzzyTripMatching()).thenReturn(true);
 
     // Create a spy on AbstractAzureSiriUpdater with the mock configuration
-    updater = spy(
+    spy(
       new SiriAzureUpdater(
         mockConfig,
         new SiriAzureMessageHandler() {
@@ -97,7 +69,7 @@ class SiriAzureUpdaterTest {
       )
     );
 
-    task = mock(SiriAzureUpdater.CheckedRunnable.class);
+    task = mock(Runnable.class);
   }
 
   private SiriAzureUpdater createUpdater(SiriAzureUpdaterParameters config) {
@@ -116,542 +88,27 @@ class SiriAzureUpdaterTest {
     );
   }
 
-  /**
-   * Tests the retry mechanism when a retryable ServiceBusException is thrown multiple times
-   * and checks that it follows the backoff sequence.
-   */
-  @Test
-  void testExecuteWithRetry_FullBackoffSequence() throws Throwable {
-    // 9 failures + 1 success
-    final int totalRunCalls = 10;
-    // 9 retries
-    final int totalSleepCalls = 9;
-
-    doNothing().when(updater).sleep(anyInt());
-
-    // Configure the task to throw a retryable exception for 9 attempts and then succeed
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      // Succeed on the 10th attempt
-      .doNothing()
-      .when(task)
-      .run();
-
-    // Use longer timeout for this test since it does many retries with exponential backoff
-    // Test still runs fast since sleep() is mocked, but timeout logic needs headroom
-    // Timeout is 5 minutes
-    updater.executeWithRetry(task, "Test Task", 300_000L);
-
-    verify(updater, times(totalSleepCalls)).sleep(anyInt());
-
-    InOrder inOrder = inOrder(updater);
-    inOrder.verify(updater).sleep(1000);
-    inOrder.verify(updater).sleep(2000);
-    inOrder.verify(updater).sleep(4000);
-    inOrder.verify(updater).sleep(8000);
-    inOrder.verify(updater).sleep(16000);
-    inOrder.verify(updater).sleep(32000);
-
-    for (int i = 0; i < 3; i++) {
-      inOrder.verify(updater).sleep(60000);
-    }
-
-    verify(task, times(totalRunCalls)).run();
-  }
-
-  /**
-   * Tests the executeWithRetry method when a non-retryable exception is thrown.
-   * Ensures that no further retries are attempted and sleep is not called.
-   */
-  @Test
-  public void testExecuteWithRetry_NonRetryableException() throws Throwable {
-    doNothing().when(updater).sleep(anyInt());
-
-    ServiceBusException serviceBusException = createServiceBusException(
-      ServiceBusFailureReason.MESSAGE_SIZE_EXCEEDED
-    );
-
-    doThrow(serviceBusException).when(task).run();
-
-    try {
-      updater.executeWithRetry(task, "Test Task", mockConfig.getStartupTimeout().toMillis());
-    } catch (ServiceBusException e) {
-      assertEquals(
-        ServiceBusFailureReason.MESSAGE_SIZE_EXCEEDED,
-        e.getReason(),
-        "Exception should have reason MESSAGE_SIZE_EXCEEDED"
-      );
-    }
-
-    verify(updater, never()).sleep(anyInt());
-    verify(task, times(1)).run();
-  }
-
-  /**
-   * Tests the executeWithRetry method when the task fails multiple times with retryable exceptions
-   * and then succeeds, ensuring that sleep is called the expected number of times with correct durations.
-   */
-  @Test
-  public void testExecuteWithRetry_MultipleRetriesThenSuccess() throws Throwable {
-    final int retriesBeforeSuccess = 3;
-    CountDownLatch latch = new CountDownLatch(retriesBeforeSuccess);
-
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doNothing()
-      .when(task)
-      .run();
-
-    doAnswer(invocation -> {
-      latch.countDown();
-      return null;
-    })
-      .when(updater)
-      .sleep(anyInt());
-
-    updater.executeWithRetry(task, "Test Task", mockConfig.getStartupTimeout().toMillis());
-
-    boolean completed = latch.await(5, TimeUnit.SECONDS);
-    assertTrue(completed, "Expected sleep calls were not made.");
-
-    ArgumentCaptor<Integer> sleepCaptor = ArgumentCaptor.forClass(Integer.class);
-    verify(updater, times(retriesBeforeSuccess)).sleep(sleepCaptor.capture());
-
-    var sleepDurations = sleepCaptor.getAllValues();
-    long[] expectedBackoffSequence = { 1000, 2000, 4000 };
-
-    for (int i = 0; i < expectedBackoffSequence.length; i++) {
-      assertEquals(
-        expectedBackoffSequence[i],
-        Long.valueOf(sleepDurations.get(i)),
-        "Backoff duration mismatch at retry " + (i + 1)
-      );
-    }
-
-    verify(task, times(retriesBeforeSuccess + 1)).run();
-  }
-
-  /**
-   * Tests the executeWithRetry method when the task succeeds on the first attempt.
-   * Ensures that no sleep calls are made.
-   */
-  @Test
-  public void testExecuteWithRetry_ImmediateSuccess() throws Throwable {
-    doNothing().when(task).run();
-    doNothing().when(updater).sleep(anyInt());
-
-    updater.executeWithRetry(task, "Test Task", mockConfig.getStartupTimeout().toMillis());
-
-    verify(updater, never()).sleep(anyInt());
-    verify(task, times(1)).run();
-  }
-
-  /**
-   * Tests the executeWithRetry method when the task fails once with a retryable exception
-   * and then succeeds on the first retry.
-   */
-  @Test
-  public void testExecuteWithRetry_OneRetryThenSuccess() throws Throwable {
-    final int expectedSleepCalls = 1;
-    CountDownLatch latch = new CountDownLatch(expectedSleepCalls);
-
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doNothing()
-      .when(task)
-      .run();
-
-    doAnswer(invocation -> {
-      if (invocation.getArgument(0).equals(1000)) {
-        latch.countDown();
-      }
-      return null;
-    })
-      .when(updater)
-      .sleep(anyInt());
-
-    updater.executeWithRetry(task, "Test Task", mockConfig.getStartupTimeout().toMillis());
-
-    boolean completed = latch.await(5, TimeUnit.SECONDS);
-    assertTrue(completed, "Expected sleep call was not made.");
-
-    verify(updater, times(expectedSleepCalls)).sleep(1000);
-    verify(task, times(2)).run();
-  }
-
-  /**
-   * Parameterized test to verify that shouldRetry returns the correct value for each ServiceBusFailureReason.
-   *
-   * @param reason         The ServiceBusFailureReason to test.
-   * @param expectedRetry  The expected result of shouldRetry.
-   */
-  @ParameterizedTest(name = "shouldRetry with reason {0} should return {1}")
-  @MethodSource("provideServiceBusFailureReasons")
-  @DisplayName("Test shouldRetry for all ServiceBusFailureReason values")
-  void testShouldRetry_ServiceBusFailureReasons(
-    ServiceBusFailureReason reason,
-    boolean expectedRetry
-  ) throws Exception {
-    ServiceBusException serviceBusException = createServiceBusException(reason);
-    boolean result = updater.shouldRetry(serviceBusException);
-    assertEquals(
-      expectedRetry,
-      result,
-      "shouldRetry should return " + expectedRetry + " for reason " + reason
-    );
-  }
-
-  /**
-   * Test that shouldRetry returns false for non-ServiceBus exceptions.
-   */
-  @Test
-  @DisplayName("shouldRetry should return false for non-ServiceBus exceptions")
-  public void testShouldRetry_NonServiceBusException() {
-    Exception genericException = new Exception("Generic exception");
-    boolean result = updater.shouldRetry(genericException);
-    assertFalse(result, "shouldRetry should return false for non-ServiceBus exceptions");
-  }
-
-  /**
-   * Test that shouldRetry handles all ServiceBusFailureReason values.
-   * Since enums are closed, this test ensures that the parameterized tests cover all existing values.
-   */
-  @Test
-  @DisplayName("shouldRetry covers all ServiceBusFailureReason values")
-  public void testShouldRetry_CoversAllReasons() {
-    long enumCount = getExpandableStringEnumValues(ServiceBusFailureReason.class).size();
-    long testCaseCount = provideServiceBusFailureReasons().count();
-    assertEquals(
-      enumCount,
-      testCaseCount,
-      "All ServiceBusFailureReason values should be covered by tests."
-    );
-  }
-
-  @Test
-  void testExecuteWithRetry_InterruptedException() throws Throwable {
-    // Use default timeout since InterruptedException is thrown immediately
-    SiriAzureUpdater longTimeoutUpdater = spy(createUpdater(mockConfig));
-
-    final int expectedRunCalls = 2;
-    final int expectedSleepCalls = 1;
-
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(new InterruptedException("Sleep interrupted"))
-      .when(task)
-      .run();
-
-    doNothing().when(longTimeoutUpdater).sleep(1000);
-
-    InterruptedException thrownException = assertThrows(
-      InterruptedException.class,
-      () -> {
-        longTimeoutUpdater.executeWithRetry(
-          task,
-          "Test Task",
-          mockConfig.getStartupTimeout().toMillis()
-        );
-      },
-      "Expected executeWithRetry to throw InterruptedException"
-    );
-
-    assertEquals(
-      "Sleep interrupted",
-      thrownException.getMessage(),
-      "Exception message should match"
-    );
-    verify(longTimeoutUpdater, times(expectedSleepCalls)).sleep(1000);
-    verify(task, times(expectedRunCalls)).run();
-    assertTrue(Thread.currentThread().isInterrupted(), "Thread should be interrupted");
-  }
-
-  @Test
-  void testExecuteWithRetry_OtpHttpClientException() throws Throwable {
-    final int retryAttempts = 3;
-    final int expectedSleepCalls = retryAttempts;
-
-    doThrow(new OtpHttpClientException("could not get historical data"))
-      .doThrow(new OtpHttpClientException("could not get historical data"))
-      .doThrow(new OtpHttpClientException("could not get historical data"))
-      .doNothing()
-      .when(task)
-      .run();
-
-    doNothing().when(updater).sleep(anyInt());
-
-    updater.executeWithRetry(task, "Test Task", mockConfig.getStartupTimeout().toMillis());
-
-    ArgumentCaptor<Integer> sleepCaptor = ArgumentCaptor.forClass(Integer.class);
-    verify(updater, times(expectedSleepCalls)).sleep(sleepCaptor.capture());
-
-    List<Integer> sleepDurations = sleepCaptor.getAllValues();
-    List<Integer> expectedBackoffSequence = Arrays.asList(1000, 2000, 4000);
-
-    for (int i = 0; i < retryAttempts; i++) {
-      assertEquals(
-        expectedBackoffSequence.get(i),
-        sleepDurations.get(i),
-        "Backoff duration mismatch at retry " + (i + 1)
-      );
-    }
-
-    verify(task, times(retryAttempts + 1)).run();
-  }
-
-  @Test
-  void testExecuteWithRetry_UnexpectedException() throws Throwable {
-    doNothing().when(updater).sleep(anyInt());
-
-    Exception unexpectedException = new NullPointerException("Unexpected null value");
-    doThrow(unexpectedException).when(task).run();
-
-    Exception thrown = assertThrows(
-      NullPointerException.class,
-      () -> {
-        updater.executeWithRetry(task, "Test Task", mockConfig.getStartupTimeout().toMillis());
-      },
-      "Expected executeWithRetry to throw NullPointerException"
-    );
-
-    assertEquals("Unexpected null value", thrown.getMessage(), "Exception message should match");
-    verify(task, times(1)).run();
-  }
-
-  /**
-   * Verifies that executeWithRetry succeeds when task completes before timeout.
-   */
-  @Test
-  void testExecuteWithRetry_SuccessBeforeTimeout() throws Throwable {
-    SiriAzureUpdater timeoutUpdater = spy(createUpdater(mockConfig));
-
-    doNothing().when(timeoutUpdater).sleep(anyInt());
-
-    // Fail twice, then succeed
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doNothing()
-      .when(task)
-      .run();
-
-    // Should not throw - should succeed before timeout
-    assertDoesNotThrow(() ->
-      timeoutUpdater.executeWithRetry(task, "Test Task", mockConfig.getStartupTimeout().toMillis())
-    );
-
-    // 2 failures + 1 success
-    verify(task, times(3)).run();
-    // 2 sleep calls for retries
-    verify(timeoutUpdater, times(2)).sleep(anyInt());
-  }
-
-  /**
-   * Verifies that zero timeout causes immediate failure without attempting task execution.
-   */
-  @Test
-  void testExecuteWithRetry_ZeroTimeoutImmediateFailure() throws Throwable {
-    // Set zero timeout
-    when(mockConfig.getStartupTimeout()).thenReturn(Duration.ZERO);
-    SiriAzureUpdater zeroTimeoutUpdater = spy(createUpdater(mockConfig));
-
-    // With zero timeout, the while loop condition should fail immediately
-    // So we don't need to set up the task to throw anything
-
-    boolean result = zeroTimeoutUpdater.executeWithRetry(task, "Test Task", 0L);
-
-    assertFalse(result, "Expected executeWithRetry to return false immediately with zero timeout");
-
-    // With zero timeout, should not attempt to run the task at all
-    verify(task, never()).run();
-    verify(zeroTimeoutUpdater, never()).sleep(anyInt());
-  }
-
-  /**
-   * Verifies that updater is always primed even when setup operations fail.
-   */
-  @Test
-  void testRun_SetsPrimedEvenOnException() throws Exception {
-    SiriAzureUpdater failingUpdater = spy(createUpdater(mockConfig));
-
-    // Make setupSubscription always fail
-    doThrow(new ServiceBusException(new Throwable("Connection failed"), null))
-      .when(failingUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("ServiceBusSubscription"),
-        anyLong()
-      );
-
-    // Initially not primed
-    assertFalse(failingUpdater.isPrimed(), "Updater should not be primed initially");
-
-    // Run should not throw, even if setup fails
-    assertDoesNotThrow(() -> failingUpdater.run());
-
-    // Should be primed after run, even though setup failed
-    assertTrue(failingUpdater.isPrimed(), "Updater should be primed after run, even on failure");
-  }
-
   @Test
   void testRun_SetsPrimedOnSuccess() throws Exception {
     SiriAzureUpdater workingUpdater = spy(createUpdater(mockConfig));
 
-    // Mock all setup methods to succeed
-    doReturn(true)
-      .when(workingUpdater)
-      .executeWithRetry(any(SiriAzureUpdater.CheckedRunnable.class), anyString(), anyLong());
+    // Ensure updater uses mocked retry
+    doReturn(otpRetry).when(workingUpdater).createOtpRetry(anyString());
 
-    assertFalse(workingUpdater.isPrimed(), "Updater should not be primed initially");
+    assertFalse(workingUpdater.isPrimed());
 
     workingUpdater.run();
 
-    assertTrue(workingUpdater.isPrimed(), "Updater should be primed after successful run");
-  }
+    assertTrue(workingUpdater.isPrimed());
 
-  /**
-   * Verifies the default startup timeout is set to 3 minutes.
-   */
-  @Test
-  void testDefaultStartupTimeoutConfiguration() {
-    // Test that default startup timeout is reasonable (3 minutes)
-    SiriAzureUpdaterParameters defaultConfig = new SiriAzureETUpdaterParameters();
-    assertEquals(
-      Duration.ofMinutes(5),
-      defaultConfig.getStartupTimeout(),
-      "Default startup timeout should be 5 minutes"
-    );
-  }
-
-  /**
-   * Verifies REALTIME_ALERT is logged when ServiceBus setup fails.
-   */
-  @Test
-  void testRun_LogsRealtimeAlertOnServiceBusException() throws Exception {
-    Logger logger = (Logger) LoggerFactory.getLogger(SiriAzureUpdater.class);
-    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-    listAppender.start();
-    logger.addAppender(listAppender);
-
-    SiriAzureUpdater failingUpdater = spy(createUpdater(mockConfig));
-
-    // Make executeWithRetry throw ServiceBusException for setup
-    ServiceBusException serviceBusException = createServiceBusException(
-      ServiceBusFailureReason.SERVICE_BUSY
-    );
-    doThrow(serviceBusException)
-      .when(failingUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("ServiceBusSubscription"),
-        anyLong()
-      );
-
-    failingUpdater.run();
-
-    // Verify REALTIME_ALERT logging occurred
-    boolean foundRealtimeAlert = listAppender.list
-      .stream()
-      .anyMatch(event ->
-        event
-          .getFormattedMessage()
-          .contains("REALTIME_STARTUP_ALERT component=ServiceBusSubscription status=FAILED")
-      );
-
-    assertTrue(foundRealtimeAlert, "Should log REALTIME_ALERT for ServiceBus exceptions");
-
-    // Cleanup
-    logger.detachAppender(listAppender);
-  }
-
-  /**
-   * Verifies REALTIME_ALERT is logged when history initialization fails.
-   */
-  @Test
-  void testRun_LogsRealtimeAlertOnHistoryException() throws Exception {
-    Logger logger = (Logger) LoggerFactory.getLogger(SiriAzureUpdater.class);
-    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-    listAppender.start();
-    logger.addAppender(listAppender);
-
-    SiriAzureUpdater failingUpdater = spy(createUpdater(mockConfig));
-
-    // Make setup succeed but history initialization fail
-    doReturn(true)
-      .when(failingUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("ServiceBusSubscription"),
-        anyLong()
-      );
-
-    doThrow(new URISyntaxException("invalid", "Invalid URI"))
-      .when(failingUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("HistoricalSiriData"),
-        anyLong()
-      );
-
-    failingUpdater.run();
-
-    // Verify REALTIME_ALERT logging occurred for History component
-    boolean foundHistoryAlert = listAppender.list
-      .stream()
-      .anyMatch(event ->
-        event
-          .getFormattedMessage()
-          .contains("REALTIME_STARTUP_ALERT component=HistoricalSiriData status=FAILED")
-      );
-
-    assertTrue(foundHistoryAlert, "Should log REALTIME_ALERT for History exceptions");
-
-    logger.detachAppender(listAppender);
-  }
-
-  /**
-   * Verifies REALTIME_ALERT is logged when generic setup exceptions occur.
-   */
-  @Test
-  void testRun_LogsRealtimeSetupAlertOnGenericException() throws Exception {
-    Logger logger = (Logger) LoggerFactory.getLogger(SiriAzureUpdater.class);
-    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-    listAppender.start();
-    logger.addAppender(listAppender);
-
-    SiriAzureUpdater failingUpdater = spy(createUpdater(mockConfig));
-
-    // Make setup fail with a generic exception
-    doThrow(new RuntimeException("Generic error"))
-      .when(failingUpdater)
-      .executeWithRetry(any(SiriAzureUpdater.CheckedRunnable.class), anyString(), anyLong());
-
-    failingUpdater.run();
-
-    // Verify REALTIME_ALERT logging occurred for RealtimeSetup component
-    boolean foundSetupAlert = listAppender.list
-      .stream()
-      .anyMatch(event ->
-        event
-          .getFormattedMessage()
-          .contains("REALTIME_STARTUP_ALERT component=ServiceBusSubscription status=FAILED")
-      );
-
-    assertTrue(foundSetupAlert, "Should log REALTIME_ALERT for RealtimeSetup exceptions");
-
-    logger.detachAppender(listAppender);
+    verify(otpRetry, atLeastOnce()).execute(any());
   }
 
   /**
    * Verifies warning is logged when updater is primed in finally block after failure.
    */
   @Test
-  void testRun_LogsWarningWhenSettingPrimedInFinally() throws Exception {
+  void testRun_LogsWarningWhenSettingPrimedInFinally() {
     Logger logger = (Logger) LoggerFactory.getLogger(SiriAzureUpdater.class);
     ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
     listAppender.start();
@@ -659,217 +116,15 @@ class SiriAzureUpdaterTest {
 
     SiriAzureUpdater failingUpdater = spy(createUpdater(mockConfig));
 
-    // Make setup fail so finally block sets primed
-    doThrow(new RuntimeException("Setup failed"))
-      .when(failingUpdater)
-      .executeWithRetry(any(SiriAzureUpdater.CheckedRunnable.class), anyString(), anyLong());
+    doThrow(new RuntimeException("Setup failed")).when(task).run();
+
+    doReturn(otpRetry).when(failingUpdater).createOtpRetry(anyString());
 
     failingUpdater.run();
 
-    // Verify that the updater is primed even when setup fails (graceful degradation)
     assertTrue(failingUpdater.isPrimed(), "Should be primed even when setup fails");
 
     logger.detachAppender(listAppender);
-  }
-
-  /**
-   * Verifies that existing retry behavior is preserved after timeout implementation.
-   */
-  @Test
-  void testBackwardCompatibility_ExistingRetryLogicStillWorks() throws Exception {
-    // Test that existing retry logic for ServiceBus exceptions still works as expected
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doNothing()
-      .when(task)
-      .run();
-
-    doNothing().when(updater).sleep(anyInt());
-
-    // Should succeed after retries
-    assertDoesNotThrow(() ->
-      updater.executeWithRetry(
-        task,
-        "Backward Compatibility Test",
-        mockConfig.getStartupTimeout().toMillis()
-      )
-    );
-
-    // 2 failures + 1 success
-    verify(task, times(3)).run();
-    // 2 retries
-    verify(updater, times(2)).sleep(anyInt());
-  }
-
-  /**
-   * Verifies non-retryable exceptions still fail immediately without timeout delay.
-   */
-  @Test
-  void testBackwardCompatibility_NonRetryableExceptionsBehaviorUnchanged() throws Throwable {
-    // Test that non-retryable exceptions still fail immediately without timeout
-    ServiceBusException nonRetryableException = createServiceBusException(
-      ServiceBusFailureReason.MESSAGE_SIZE_EXCEEDED
-    );
-
-    doThrow(nonRetryableException).when(task).run();
-
-    // Should throw immediately, not wait for timeout
-    ServiceBusException thrown = assertThrows(ServiceBusException.class, () ->
-      updater.executeWithRetry(
-        task,
-        "Non-retryable Test",
-        mockConfig.getStartupTimeout().toMillis()
-      )
-    );
-
-    assertEquals(ServiceBusFailureReason.MESSAGE_SIZE_EXCEEDED, thrown.getReason());
-    // Only one attempt
-    verify(task, times(1)).run();
-    // No retries
-    verify(updater, never()).sleep(anyInt());
-  }
-
-  /**
-   * Verifies InterruptedException handling is unchanged by timeout implementation.
-   */
-  @Test
-  void testBackwardCompatibility_InterruptedExceptionStillPreserved() throws Throwable {
-    SiriAzureUpdater testUpdater = spy(createUpdater(mockConfig));
-
-    doThrow(new InterruptedException("Thread interrupted")).when(task).run();
-
-    InterruptedException thrown = assertThrows(InterruptedException.class, () ->
-      testUpdater.executeWithRetry(
-        task,
-        "Interrupted Test",
-        mockConfig.getStartupTimeout().toMillis()
-      )
-    );
-
-    assertEquals("Thread interrupted", thrown.getMessage());
-    assertTrue(Thread.interrupted(), "Thread interrupt status should be preserved");
-    verify(task, times(1)).run();
-    verify(testUpdater, never()).sleep(anyInt());
-  }
-
-  /**
-   * Verifies exponential backoff sequence remains unchanged after timeout implementation.
-   */
-  @Test
-  void testBackwardCompatibility_ExponentialBackoffUnchanged() throws Throwable {
-    // Test that exponential backoff sequence is preserved
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY))
-      .doNothing()
-      .when(task)
-      .run();
-
-    doNothing().when(updater).sleep(anyInt());
-
-    updater.executeWithRetry(task, "Backoff Test", mockConfig.getStartupTimeout().toMillis());
-
-    ArgumentCaptor<Integer> sleepCaptor = ArgumentCaptor.forClass(Integer.class);
-    verify(updater, times(4)).sleep(sleepCaptor.capture());
-
-    List<Integer> sleepDurations = sleepCaptor.getAllValues();
-    assertEquals(
-      Arrays.asList(1000, 2000, 4000, 8000),
-      sleepDurations,
-      "Exponential backoff sequence should be preserved"
-    );
-  }
-
-  /**
-   * Provides test arguments for each ServiceBusFailureReason and the expected shouldRetry outcome.
-   *
-   * @return Stream of Arguments containing ServiceBusFailureReason and expected boolean.
-   */
-  private static Stream<Arguments> provideServiceBusFailureReasons() {
-    return Stream.of(
-      // Retryable (Transient) Errors
-      Arguments.of(ServiceBusFailureReason.SERVICE_BUSY, true),
-      Arguments.of(ServiceBusFailureReason.SERVICE_TIMEOUT, true),
-      Arguments.of(ServiceBusFailureReason.SERVICE_COMMUNICATION_ERROR, true),
-      Arguments.of(ServiceBusFailureReason.MESSAGE_LOCK_LOST, true),
-      Arguments.of(ServiceBusFailureReason.SESSION_LOCK_LOST, true),
-      Arguments.of(ServiceBusFailureReason.SESSION_CANNOT_BE_LOCKED, true),
-      Arguments.of(ServiceBusFailureReason.QUOTA_EXCEEDED, true),
-      Arguments.of(ServiceBusFailureReason.GENERAL_ERROR, true),
-      Arguments.of(ServiceBusFailureReason.UNAUTHORIZED, true),
-      // Non-Retryable Errors
-      Arguments.of(ServiceBusFailureReason.MESSAGING_ENTITY_NOT_FOUND, false),
-      Arguments.of(ServiceBusFailureReason.MESSAGING_ENTITY_DISABLED, false),
-      Arguments.of(ServiceBusFailureReason.MESSAGE_SIZE_EXCEEDED, false),
-      Arguments.of(ServiceBusFailureReason.MESSAGE_NOT_FOUND, false),
-      Arguments.of(ServiceBusFailureReason.MESSAGING_ENTITY_ALREADY_EXISTS, false)
-    );
-  }
-
-  /**
-   * Helper method to create a ServiceBusException with a specified failure reason.
-   *
-   * @param reason The ServiceBusFailureReason to set.
-   * @return A ServiceBusException instance with the specified reason.
-   */
-  private ServiceBusException createServiceBusException(ServiceBusFailureReason reason) {
-    ServiceBusException exception = new ServiceBusException(
-      new Throwable(),
-      ServiceBusErrorSource.RECEIVE
-    );
-    try {
-      Field reasonField = ServiceBusException.class.getDeclaredField("reason");
-      reasonField.setAccessible(true);
-      reasonField.set(exception, reason);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new RuntimeException("Failed to set ServiceBusFailureReason via reflection", e);
-    }
-    return exception;
-  }
-
-  /**
-   * Helper method to retrieve all instances of an ExpandableStringEnum subclass.
-   *
-   * @param clazz The class of the ExpandableStringEnum subclass.
-   * @param <T>   The type parameter extending ExpandableStringEnum.
-   * @return A Collection of all registered instances.
-   */
-  private static <T extends ExpandableStringEnum<T>> Collection<T> getExpandableStringEnumValues(
-    Class<T> clazz
-  ) {
-    try {
-      Method valuesMethod = ExpandableStringEnum.class.getDeclaredMethod("values", Class.class);
-      valuesMethod.setAccessible(true);
-      @SuppressWarnings("unchecked")
-      Collection<T> values = (Collection<T>) valuesMethod.invoke(null, clazz);
-      return values;
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException("Failed to retrieve values from ExpandableStringEnum.", e);
-    }
-  }
-
-  /**
-   * Verifies Duration configuration properly converts to milliseconds for timeout behavior.
-   */
-  @Test
-  void testDurationTimeoutConfiguration() throws Exception {
-    // Short timeout for fast test
-    Duration testTimeout = Duration.ofMillis(100);
-    when(mockConfig.getStartupTimeout()).thenReturn(testTimeout);
-
-    SiriAzureUpdater durationUpdater = spy(createUpdater(mockConfig));
-    doNothing().when(durationUpdater).sleep(anyInt());
-    doThrow(createServiceBusException(ServiceBusFailureReason.SERVICE_BUSY)).when(task).run();
-
-    boolean result;
-    try {
-      result = durationUpdater.executeWithRetry(task, "Duration Test", testTimeout.toMillis());
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-
-    assertFalse(result, "executeWithRetry should return false on timeout");
   }
 
   /**
@@ -879,36 +134,13 @@ class SiriAzureUpdaterTest {
   void testSequentialStartupStepExecution() throws Exception {
     SiriAzureUpdater sequenceUpdater = spy(createUpdater(mockConfig));
 
-    // Mock executeWithRetry to succeed immediately for all steps
-    doReturn(true)
-      .when(sequenceUpdater)
-      .executeWithRetry(any(SiriAzureUpdater.CheckedRunnable.class), anyString(), anyLong());
+    doReturn(otpRetry).when(sequenceUpdater).createOtpRetry(anyString());
 
     sequenceUpdater.run();
 
-    // Verify executeWithRetry was called for each step in order
-    InOrder inOrder = inOrder(sequenceUpdater);
-    inOrder
-      .verify(sequenceUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("ServiceBusSubscription"),
-        anyLong()
-      );
-    inOrder
-      .verify(sequenceUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("HistoricalSiriData"),
-        anyLong()
-      );
-    inOrder
-      .verify(sequenceUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("ServiceBusEventProcessor"),
-        anyLong()
-      );
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+
+    verify(otpRetry, times(3)).execute(captor.capture());
 
     assertTrue(sequenceUpdater.isPrimed(), "Updater should be primed after startup steps");
   }
@@ -925,21 +157,15 @@ class SiriAzureUpdaterTest {
 
     SiriAzureUpdater errorUpdater = spy(createUpdater(mockConfig));
 
-    doThrow(new RuntimeException("Setup failed"))
-      .when(errorUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("ServiceBusSubscription"),
-        anyLong()
-      );
+    doReturn(otpRetry).when(errorUpdater).createOtpRetry(anyString());
 
-    doThrow(new RuntimeException("History failed"))
-      .when(errorUpdater)
-      .executeWithRetry(
-        any(SiriAzureUpdater.CheckedRunnable.class),
-        eq("HistoricalSiriData"),
-        anyLong()
-      );
+    doThrow(new OtpRetryException("Setup failed", new Exception()))
+      .when(otpRetry)
+      .execute(any(Runnable.class));
+
+    doThrow(new OtpRetryException("History failed", new Exception()))
+      .when(otpRetry)
+      .execute(any(Runnable.class));
 
     errorUpdater.run();
 
@@ -952,7 +178,9 @@ class SiriAzureUpdaterTest {
       logMessages
         .stream()
         .anyMatch(msg ->
-          msg.contains("REALTIME_STARTUP_ALERT component=ServiceBusSubscription status=FAILED")
+          msg.contains(
+            "REALTIME_STARTUP_FAILED_ALERT component=siri-azure-test-updater:ServiceBusSubscription status=FAILED error=History failed"
+          )
         ),
       "Should log ServiceBusSubscription component failure"
     );
@@ -961,38 +189,13 @@ class SiriAzureUpdaterTest {
       logMessages
         .stream()
         .anyMatch(msg ->
-          msg.contains("REALTIME_STARTUP_ALERT component=HistoricalSiriData status=FAILED")
+          msg.contains(
+            "REALTIME_STARTUP_FAILED_ALERT component=siri-azure-test-updater:ServiceBusSubscription status=FAILED error=History failed"
+          )
         ),
       "Should log HistoricalSiriData component failure"
     );
 
     logger.detachAppender(listAppender);
-  }
-
-  /**
-   * Verifies network error detection correctly identifies retryable network issues.
-   */
-  @Test
-  void testNetworkErrorTypeDetection() throws Exception {
-    SiriAzureUpdater networkUpdater = spy(createUpdater(mockConfig));
-
-    UnknownHostException dnsException = new UnknownHostException("Host not found");
-    assertTrue(networkUpdater.shouldRetry(dnsException), "Should retry on DNS resolution failures");
-
-    SocketTimeoutException socketTimeoutException = new SocketTimeoutException("Read timeout");
-    assertTrue(
-      networkUpdater.shouldRetry(socketTimeoutException),
-      "Should retry on socket timeouts"
-    );
-
-    // Test OtpHttpClientException (which is retryable)
-    OtpHttpClientException httpException = new OtpHttpClientException("HTTP request failed");
-    assertTrue(networkUpdater.shouldRetry(httpException), "Should retry on HTTP client exceptions");
-
-    IllegalArgumentException nonNetworkException = new IllegalArgumentException("Invalid argument");
-    assertFalse(
-      networkUpdater.shouldRetry(nonNetworkException),
-      "Should not retry non-network exceptions"
-    );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
@@ -14,28 +14,25 @@ import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import jakarta.xml.bind.JAXBException;
-import java.io.UncheckedIOException;
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.entur.siri21.util.SiriXml;
 import org.opentripplanner.framework.application.ApplicationShutdownSupport;
 import org.opentripplanner.framework.io.HttpHeaders;
-import org.opentripplanner.framework.io.OtpHttpClientException;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
+import org.opentripplanner.framework.retry.OtpRetry;
+import org.opentripplanner.framework.retry.OtpRetryBuilder;
+import org.opentripplanner.framework.retry.OtpRetryException;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.TimetableRepository;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
@@ -48,36 +45,11 @@ import uk.org.siri.siri21.ServiceDelivery;
 import uk.org.siri.siri21.Siri;
 
 /**
- * This is the main handler for siri messages over azure. It handles the generic code for communicating
- * with the azure service bus and delegates to SiriAzureETUpdater and SiriAzureSXUpdater for ET and
- * SX specific stuff.
+ * This is the main handler for siri messages over azure. It handles the generic code for
+ * communicating with the azure service bus and delegates to SiriAzureETUpdater and
+ * SiriAzureSXUpdater for ET and SX specific stuff.
  */
 public class SiriAzureUpdater implements GraphUpdater {
-
-  @FunctionalInterface
-  interface CheckedRunnable {
-    void run() throws Exception;
-  }
-
-  private static final Set<ServiceBusFailureReason> RETRYABLE_REASONS = Set.of(
-    ServiceBusFailureReason.GENERAL_ERROR,
-    ServiceBusFailureReason.QUOTA_EXCEEDED,
-    ServiceBusFailureReason.SERVICE_BUSY,
-    ServiceBusFailureReason.SERVICE_COMMUNICATION_ERROR,
-    ServiceBusFailureReason.SERVICE_TIMEOUT,
-    ServiceBusFailureReason.UNAUTHORIZED,
-    ServiceBusFailureReason.MESSAGE_LOCK_LOST,
-    ServiceBusFailureReason.SESSION_LOCK_LOST,
-    ServiceBusFailureReason.SESSION_CANNOT_BE_LOCKED
-  );
-
-  private static final Set<ServiceBusFailureReason> NON_RETRYABLE_REASONS = Set.of(
-    ServiceBusFailureReason.MESSAGING_ENTITY_NOT_FOUND,
-    ServiceBusFailureReason.MESSAGING_ENTITY_DISABLED,
-    ServiceBusFailureReason.MESSAGE_SIZE_EXCEEDED,
-    ServiceBusFailureReason.MESSAGE_NOT_FOUND,
-    ServiceBusFailureReason.MESSAGING_ENTITY_ALREADY_EXISTS
-  );
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriAzureUpdater.class);
   private final String updaterType;
@@ -95,10 +67,11 @@ public class SiriAzureUpdater implements GraphUpdater {
   private String subscriptionName;
 
   private static final AtomicLong MESSAGE_COUNTER = new AtomicLong(0);
+  private static final int BACKOFF_MULTIPLIER = 2;
+  private static final Duration INITIAL_RETRY_INTERVALS = Duration.ofSeconds(5);
   private static final int MESSAGE_COUNTER_LOG_INTERVAL = 100;
   private static final int ERROR_RETRY_WAIT_SECONDS = 5;
-  private static final int INITIAL_RETRY_DELAY_MS = 1000;
-  private static final int MAX_RETRY_DELAY_MS = 60_000;
+  private static final int MAX_ATTEMPTS = 5;
 
   protected final SiriAzureMessageHandler messageHandler;
 
@@ -112,8 +85,6 @@ public class SiriAzureUpdater implements GraphUpdater {
    * The timeout used when fetching historical data
    */
   private final int timeout;
-
-  private final Duration startupTimeout;
 
   SiriAzureUpdater(SiriAzureUpdaterParameters config, SiriAzureMessageHandler messageHandler) {
     this.messageHandler = Objects.requireNonNull(messageHandler);
@@ -132,7 +103,6 @@ public class SiriAzureUpdater implements GraphUpdater {
     this.topicName = Objects.requireNonNull(config.getTopicName(), "topicName must not be null");
     this.updaterType = Objects.requireNonNull(config.getType(), "type must not be null");
     this.timeout = config.getTimeout();
-    this.startupTimeout = config.getStartupTimeout();
     this.autoDeleteOnIdle = config.getAutoDeleteOnIdle();
     this.prefetchCount = config.getPrefetchCount();
 
@@ -170,9 +140,9 @@ public class SiriAzureUpdater implements GraphUpdater {
   }
 
   /**
-   * This wrapper class is a SiriAzureUpdater that implements the TransitAlertProvider interface so it can
-   * be registered to handle SX messages. It delegates the actual SIRI-SX
-   * message processing to the contained SiriAzureSXUpdater.
+   * This wrapper class is a SiriAzureUpdater that implements the TransitAlertProvider interface so
+   * it can be registered to handle SX messages. It delegates the actual SIRI-SX message processing
+   * to the contained SiriAzureSXUpdater.
    */
   public static class SxWrapper extends SiriAzureUpdater implements TransitAlertProvider {
 
@@ -181,8 +151,9 @@ public class SiriAzureUpdater implements GraphUpdater {
     }
 
     /**
-     * Implements the TransitAlertProvider interface to allow this updater to be detected
-     * as a source of transit alerts. This method delegates to the internal SiriAzureSXUpdater
+     * Implements the TransitAlertProvider interface to allow this updater to be detected as a
+     * source of transit alerts. This method delegates to the internal SiriAzureSXUpdater
+     *
      * @return TransitAlertService from the SiriAzureSXUpdater
      */
     @Override
@@ -206,9 +177,12 @@ public class SiriAzureUpdater implements GraphUpdater {
       }
 
       // Try each startup step with timeout, continue on failure for graceful degradation
-      tryStartupStep(this::setupSubscription, "ServiceBusSubscription");
+      boolean isSuccess = executeStartupStep(
+        this::setupSubscription,
+        updaterType + ":ServiceBusSubscription"
+      );
 
-      tryStartupStep(
+      executeStartupStep(
         () -> {
           var initialData = fetchInitialSiriData();
           if (initialData.isEmpty()) {
@@ -217,10 +191,12 @@ public class SiriAzureUpdater implements GraphUpdater {
             processInitialSiriData(initialData.get());
           }
         },
-        "HistoricalSiriData"
+        updaterType + ":HistoricalSiriData"
       );
 
-      tryStartupStep(this::startEventProcessor, "ServiceBusEventProcessor");
+      if (isSuccess) {
+        executeStartupStep(this::startEventProcessor, updaterType + ":ServiceBusEventProcessor");
+      }
 
       // Set primed so OTP can start
       setPrimed();
@@ -236,157 +212,24 @@ public class SiriAzureUpdater implements GraphUpdater {
   }
 
   /**
-   * Sleeps. This is to be able to mock testing
-   * @param millis number of milliseconds
-   * @throws InterruptedException if sleep is interrupted
+   * Attempts to execute a startup step with timeout. Logs errors but continues execution for
+   * graceful degradation. Rethrows InterruptedException to abort startup process.
    */
-  void sleep(int millis) throws InterruptedException {
-    Thread.sleep(millis);
-  }
-
-  /**
-   * Executes a task with retry logic with timeout constraint.
-   * Retries for retryable exceptions with exponential backoff.
-   *
-   * @param task The task to execute
-   * @param description A description for logging
-   * @param timeoutMs Timeout in milliseconds
-   * @return true if task completed successfully, false if timeout was exceeded
-   * @throws InterruptedException If interrupted
-   * @throws Exception Any non-retryable exception from the task
-   */
-  boolean executeWithRetry(CheckedRunnable task, String description, long timeoutMs)
-    throws Exception {
-    int sleepPeriod = INITIAL_RETRY_DELAY_MS;
-    int attemptCounter = 1;
-    long startTime = System.currentTimeMillis();
-
-    while (System.currentTimeMillis() - startTime < timeoutMs) {
-      try {
-        task.run();
-        LOG.info("{} succeeded after {} attempts.", description, attemptCounter);
-        return true;
-      } catch (InterruptedException ie) {
-        LOG.warn("{} was interrupted.", description);
-        Thread.currentThread().interrupt();
-        throw ie;
-      } catch (Exception e) {
-        LOG.warn("{} failed. Error: {} (Attempt {})", description, e.getMessage(), attemptCounter);
-
-        if (!shouldRetry(e)) {
-          LOG.error("{} encountered a non-retryable error: {}.", description, e.getMessage());
-          throw e;
-        }
-
-        LOG.debug("{} will retry in {} ms.", description, sleepPeriod);
-        attemptCounter++;
-
-        try {
-          sleep(sleepPeriod);
-        } catch (InterruptedException ie) {
-          LOG.warn("{} was interrupted during sleep.", description);
-          Thread.currentThread().interrupt();
-          throw ie;
-        }
-
-        sleepPeriod = Math.min(sleepPeriod * 2, MAX_RETRY_DELAY_MS);
-      }
-    }
-
-    // Timeout exceeded
-    LOG.warn("{} timed out after {} ms", description, timeoutMs);
-    return false;
-  }
-
-  boolean shouldRetry(Exception e) {
-    if (e instanceof ServiceBusException sbException) {
-      ServiceBusFailureReason reason = sbException.getReason();
-
-      if (RETRYABLE_REASONS.contains(reason)) {
-        LOG.warn("Transient error encountered: {}. Retrying...", reason);
-        return true;
-      } else if (NON_RETRYABLE_REASONS.contains(reason)) {
-        LOG.error("Non-recoverable error encountered: {}. Not retrying.", reason);
-        return false;
-      } else {
-        LOG.warn("Unhandled ServiceBusFailureReason: {}. Retrying by default.", reason);
-        return true;
-      }
-    } else if (ExceptionUtils.hasCause(e, OtpHttpClientException.class)) {
-      // retry for OtpHttpClientException as it is thrown if historical data can't be read at the moment
-      return true;
-    } else if (getNetworkErrorType(e).isPresent()) {
-      LOG.warn(
-        "Network connectivity error encountered: {}. Retrying...",
-        getNetworkErrorType(e).get()
-      );
-      return true;
-    }
-
-    LOG.warn("Non-ServiceBus exception encountered: {}. Not retrying.", e.getClass().getName());
-    return false;
-  }
-
-  /**
-   * Checks if the exception represents a transient network connectivity issue.
-   * @return Optional with error description if it's a network error, empty otherwise
-   */
-  private Optional<String> getNetworkErrorType(Exception e) {
-    // DNS resolution failures - commonly transient (DNS server issues, VPN connectivity)
-    if (ExceptionUtils.hasCause(e, UnknownHostException.class)) {
-      return Optional.of("DNS resolution failure");
-    }
-
-    if (ExceptionUtils.hasCause(e, SocketTimeoutException.class)) {
-      return Optional.of("Socket timeout");
-    }
-
-    // Check for ConnectTimeoutException wrapped in UncheckedIOException
-    if (ExceptionUtils.hasCause(e, UncheckedIOException.class)) {
-      Throwable cause = ExceptionUtils.getRootCause(e);
-      if (cause != null && cause.getClass().getSimpleName().contains("ConnectTimeoutException")) {
-        return Optional.of("Connection timeout");
-      }
-    }
-
-    return Optional.empty();
-  }
-
-  /**
-   * Attempts to execute a startup step with timeout.
-   * Logs errors but continues execution for graceful degradation.
-   * Rethrows InterruptedException to abort startup process.
-   */
-  private void tryStartupStep(CheckedRunnable task, String stepDescription)
+  private boolean executeStartupStep(Runnable task, String stepDescription)
     throws InterruptedException {
+    OtpRetry otpRetry = createOtpRetry(stepDescription);
     try {
-      boolean success = executeWithRetry(task, stepDescription, startupTimeout.toMillis());
-      if (success) {
-        LOG.info("{} completed successfully", stepDescription);
-      } else {
-        LOG.warn(
-          "REALTIME_STARTUP_ALERT component={} status=TIMEOUT error=\"{} timed out after {} ms\"",
-          stepDescription,
-          stepDescription,
-          startupTimeout.toMillis()
-        );
-      }
-    } catch (InterruptedException e) {
-      // Rethrow to abort startup process and avoid blocking JVM shutdown
-      LOG.warn(
-        "REALTIME_STARTUP_ALERT component={} status=INTERRUPTED error=\"Aborting startup due to interrupt\"",
-        stepDescription
-      );
-      // Preserve interrupt status
-      Thread.currentThread().interrupt();
-      throw e;
-    } catch (Exception e) {
+      otpRetry.execute(task);
+      LOG.info("{} completed successfully", stepDescription);
+      return true;
+    } catch (OtpRetryException e) {
       String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
       LOG.warn(
-        "REALTIME_STARTUP_ALERT component={} status=FAILED error=\"{}\"",
+        "REALTIME_STARTUP_FAILED_ALERT component={} status=FAILED error={}",
         stepDescription,
         message
       );
+      return false;
     }
   }
 
@@ -427,10 +270,10 @@ public class SiriAzureUpdater implements GraphUpdater {
   }
 
   /**
-   * Sets up the Service Bus subscription, including checking old subscription, deleting if necessary,
-   * and creating a new subscription.
+   * Sets up the Service Bus subscription, including checking old subscription, deleting if
+   * necessary, and creating a new subscription.
    */
-  private void setupSubscription() throws ServiceBusException, URISyntaxException {
+  private void setupSubscription() throws ServiceBusException {
     // Client with permissions to create subscription
     if (authenticationType == AuthenticationType.FederatedIdentity) {
       serviceBusAdmin = new ServiceBusAdministrationClientBuilder()
@@ -602,8 +445,10 @@ public class SiriAzureUpdater implements GraphUpdater {
   }
 
   /**
-   * Make some sensible logging on error and if Service Bus is busy, sleep for some time before try again to get messages.
-   * This code snippet is taken from Microsoft example <a href="https://docs.microsoft.com/sv-se/azure/service-bus-messaging/service-bus-java-how-to-use-queues">...</a>.
+   * Make some sensible logging on error and if Service Bus is busy, sleep for some time before try
+   * again to get messages. This code snippet is taken from Microsoft example <a
+   * href="https://docs.microsoft.com/sv-se/azure/service-bus-messaging/service-bus-java-how-to-use-queues">...</a>.
+   *
    * @param errorContext Context for errors handled by the ServiceBusProcessorClient.
    */
   private void errorConsumer(ServiceBusErrorContext errorContext) {
@@ -648,5 +493,15 @@ public class SiriAzureUpdater implements GraphUpdater {
     } else {
       LOG.error(e.getLocalizedMessage(), e);
     }
+  }
+
+  protected OtpRetry createOtpRetry(String stepDescription) {
+    return new OtpRetryBuilder()
+      .withName(stepDescription)
+      .withMaxAttempts(MAX_ATTEMPTS)
+      .withInitialRetryInterval(INITIAL_RETRY_INTERVALS)
+      .withRetryableException(e -> !(e instanceof InterruptedException))
+      .withBackoffMultiplier(BACKOFF_MULTIPLIER)
+      .build();
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdaterParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdaterParameters.java
@@ -16,11 +16,6 @@ public abstract class SiriAzureUpdaterParameters {
   private String dataInitializationUrl;
   private String feedId;
   private int timeout;
-  /**
-   * Maximum time to wait for real-time services during startup.
-   * If exceeded, OTP starts without real-time data for graceful degradation.
-   */
-  private Duration startupTimeout = Duration.ofMinutes(5);
 
   private boolean fuzzyTripMatching;
   private Duration autoDeleteOnIdle;
@@ -96,24 +91,6 @@ public abstract class SiriAzureUpdaterParameters {
 
   public void setTimeout(int timeout) {
     this.timeout = timeout;
-  }
-
-  /**
-   * Gets the startup timeout for real-time service initialization.
-   *
-   * @return timeout in milliseconds
-   */
-  public Duration getStartupTimeout() {
-    return startupTimeout;
-  }
-
-  /**
-   * Sets the startup timeout for real-time service initialization.
-   *
-   * @param startupTimeout timeout in milliseconds, should be positive
-   */
-  public void setStartupTimeout(Duration startupTimeout) {
-    this.startupTimeout = startupTimeout;
   }
 
   public boolean isFuzzyTripMatching() {

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/azure/SiriAzureUpdaterConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/azure/SiriAzureUpdaterConfig.java
@@ -88,17 +88,6 @@ public abstract class SiriAzureUpdaterConfig {
         history.of("timeout").since(NA).summary("Timeout in milliseconds").asInt(300000)
       );
     }
-
-    parameters.setStartupTimeout(
-      c
-        .of("startupTimeout")
-        .summary("Maximum time to wait for real-time services during startup.")
-        .description(
-          "Maximum time to wait for real-time services during startup. " +
-            "If real-time services are unavailable, OTP will start without real-time data after this timeout."
-        )
-        .asDuration(parameters.getStartupTimeout())
-    );
   }
 
   /**

--- a/doc/user/sandbox/siri/SiriAzureUpdater.md
+++ b/doc/user/sandbox/siri/SiriAzureUpdater.md
@@ -33,7 +33,6 @@ To enable the SIRI updater you need to add it to the updaters section of the `ro
 | fuzzyTripMatching                                          |  `boolean` | Whether to apply fuzzyTripMatching on the updates                | *Optional* | `false`             |  2.2  |
 | prefetchCount                                              |  `integer` | The number of messages to fetch from the subscription at a time. | *Optional* | `10`                |  2.5  |
 | [servicebus-url](#u__11__servicebus_url)                   |  `string`  | Service Bus connection used for authentication.                  | *Optional* |                     |  2.2  |
-| [startupTimeout](#u__11__startupTimeout)                   | `duration` | Maximum time to wait for real-time services during startup.      | *Optional* | `"PT5M"`            |   na  |
 | topic                                                      |  `string`  | Service Bus topic to connect to.                                 | *Required* |                     |  2.2  |
 | history                                                    |  `object`  | Configuration for fetching historical data on startup            | *Optional* |                     |  2.2  |
 |    fromDateTime                                            |  `string`  | Datetime boundary for historical data                            | *Optional* | `"-P1D"`            |  2.2  |
@@ -77,15 +76,6 @@ Has to be present for authenticationMethod FederatedIdentity.
 Service Bus connection used for authentication.
 
 Has to be present for authenticationMethod SharedAccessKey. This should be Primary/Secondary connection string from service bus.
-
-<h4 id="u__11__startupTimeout">startupTimeout</h4>
-
-**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT5M"`   
-**Path:** /updaters/[11] 
-
-Maximum time to wait for real-time services during startup.
-
-Maximum time to wait for real-time services during startup. If real-time services are unavailable, OTP will start without real-time data after this timeout.
 
 
 
@@ -131,7 +121,6 @@ Maximum time to wait for real-time services during startup. If real-time service
 | fuzzyTripMatching                                          |  `boolean` | Whether to apply fuzzyTripMatching on the updates                | *Optional* | `false`             |  2.2  |
 | prefetchCount                                              |  `integer` | The number of messages to fetch from the subscription at a time. | *Optional* | `10`                |  2.5  |
 | [servicebus-url](#u__10__servicebus_url)                   |  `string`  | Service Bus connection used for authentication.                  | *Optional* |                     |  2.2  |
-| [startupTimeout](#u__10__startupTimeout)                   | `duration` | Maximum time to wait for real-time services during startup.      | *Optional* | `"PT5M"`            |   na  |
 | topic                                                      |  `string`  | Service Bus topic to connect to.                                 | *Required* |                     |  2.2  |
 | history                                                    |  `object`  | Configuration for fetching historical data on startup            | *Optional* |                     |  2.2  |
 |    fromDateTime                                            |  `string`  | Datetime boundary for historical data.                           | *Optional* | `"-P1D"`            |  2.2  |
@@ -176,15 +165,6 @@ Has to be present for authenticationMethod FederatedIdentity.
 Service Bus connection used for authentication.
 
 Has to be present for authenticationMethod SharedAccessKey. This should be Primary/Secondary connection string from service bus.
-
-<h4 id="u__10__startupTimeout">startupTimeout</h4>
-
-**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT5M"`   
-**Path:** /updaters/[10] 
-
-Maximum time to wait for real-time services during startup.
-
-Maximum time to wait for real-time services during startup. If real-time services are unavailable, OTP will start without real-time data after this timeout.
 
 
 


### PR DESCRIPTION
### Summary

This is pure sandbox code. 
This PR changes which retry mechanism we are using for our SiriAzureUpdaters, and to use the OtpRetry mechanism instead.
All related tests and code to the old flow has been removed and solely rely on OtpRetry now.

### Unit tests
No new tests was added since OtpRetry already has unit tests.
Some old unit tests that tested the old mechanism was removed.

### Documentation
No new documentation since OtpRetry already exist with its documentation

### Changelog
skip

### Bumping the serialization version id
No
