### PR TITLE
Add booking information to carpooling

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolBookingUrlTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolBookingUrlTestData.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.ext.carpooling;
+
+import java.util.Locale;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+
+/**
+ * Shared expected-URL formatter for tests that assert the carpool booking URL has been augmented
+ * with passenger pickup/dropoff coordinates. Centralised so the production
+ * {@code "from_coordinate=lat,lon&to_coordinate=lat,lon"} contract — coordinate precision,
+ * parameter names, and ordering — is pinned down in one place that all
+ * {@code CarpoolItineraryMapper} tests assert against.
+ */
+public final class CarpoolBookingUrlTestData {
+
+  private CarpoolBookingUrlTestData() {}
+
+  /**
+   * Returns the booking URL that {@code CarpoolItineraryMapper.toBookingInfo} is expected to
+   * produce when augmenting {@code baseUrl} with the given carpool boarding ({@code pickup}) and
+   * alighting ({@code dropoff}) coordinates. Assumes {@code baseUrl} carries no existing query
+   * string and no fragment.
+   */
+  public static String expectedAugmentedUrl(
+    String baseUrl,
+    WgsCoordinate pickup,
+    WgsCoordinate dropoff
+  ) {
+    return String.format(
+      Locale.ROOT,
+      "%s?from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f",
+      baseUrl,
+      pickup.latitude(),
+      pickup.longitude(),
+      dropoff.latitude(),
+      dropoff.longitude()
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolEstimatedVehicleJourneyData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolEstimatedVehicleJourneyData.java
@@ -20,6 +20,7 @@ import uk.org.siri.siri21.EstimatedVehicleJourney;
 import uk.org.siri.siri21.NaturalLanguageStringStructure;
 import uk.org.siri.siri21.OperatorRefStructure;
 import uk.org.siri.siri21.PassengerCapacityStructure;
+import uk.org.siri.siri21.SimpleContactStructure;
 import uk.org.siri.siri21.StopAssignmentStructure;
 import uk.org.siri.siri21.VehicleOccupancyStructure;
 
@@ -129,6 +130,15 @@ public class CarpoolEstimatedVehicleJourneyData {
     lastStop.setAimedArrivalTime(null);
     lastStop.setExpectedArrivalTime(ZonedDateTime.now().plusMinutes(45));
 
+    return journey;
+  }
+
+  public static EstimatedVehicleJourney journeyWithPublicContact(String phoneNumber, String url) {
+    var journey = minimalCompleteJourney();
+    var contact = new SimpleContactStructure();
+    contact.setPhoneNumber(phoneNumber);
+    contact.setUrl(url);
+    journey.setPublicContact(contact);
     return journey;
   }
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
@@ -3,12 +3,15 @@ package org.opentripplanner.ext.carpooling.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
 
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.EnumSet;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
 
@@ -28,9 +31,12 @@ class CarpoolItineraryMapperTest {
     ZoneOffset.UTC
   );
 
+  private static final WgsCoordinate PICKUP = new WgsCoordinate(59.910000, 10.750000);
+  private static final WgsCoordinate DROPOFF = new WgsCoordinate(59.920000, 10.760000);
+
   @Test
   void nullContact_returnsNull() {
-    assertNull(CarpoolItineraryMapper.toBookingInfo(null, TRIP_START));
+    assertNull(CarpoolItineraryMapper.toBookingInfo(null, TRIP_START, PICKUP, DROPOFF));
   }
 
   /**
@@ -44,18 +50,138 @@ class CarpoolItineraryMapperTest {
   void contactWithNeitherPhoneNorUrl_returnsNull() {
     var contact = ContactInfo.of().withContactPerson("Alice").build();
 
-    assertNull(CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START));
+    assertNull(CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF));
   }
 
   @Test
   void phoneOnly_addsCallOfficeAndPreservesContactUnchanged() {
     var contact = ContactInfo.of().withPhoneNumber("+4712345678").build();
 
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START);
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
 
     assertNotNull(info);
     assertEquals(EnumSet.of(BookingMethod.CALL_OFFICE), info.bookingMethods());
     assertEquals(contact, info.getContactInfo());
+  }
+
+  @Test
+  void urlOnly_addsOnlineAndAppendsPickupAndDropoffCoordinatesToUrl() {
+    var contact = ContactInfo.of().withBookingUrl("https://book.example.com").build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNotNull(info);
+    assertEquals(EnumSet.of(BookingMethod.ONLINE), info.bookingMethods());
+    assertEquals(
+      expectedAugmentedUrl("https://book.example.com", PICKUP, DROPOFF),
+      info.getContactInfo().getBookingUrl()
+    );
+  }
+
+  /**
+   * Guards against the easy bug of unconditionally appending {@code ?from_coordinate=…}, which
+   * would yield an invalid double-{@code ?} URL when the provider's booking URL already carries
+   * its own query string (e.g. tracking parameters). The coordinate parameters must be appended
+   * with {@code &} in that case.
+   */
+  @Test
+  void urlWithExistingQueryString_usesAmpersandSeparator() {
+    var contact = ContactInfo.of().withBookingUrl("https://book.example.com/?ref=foo").build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNotNull(info);
+    var expected = String.format(
+      Locale.ROOT,
+      "https://book.example.com/?ref=foo&from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f",
+      PICKUP.latitude(),
+      PICKUP.longitude(),
+      DROPOFF.latitude(),
+      DROPOFF.longitude()
+    );
+    assertEquals(expected, info.getContactInfo().getBookingUrl());
+  }
+
+  @Test
+  void phoneAndUrl_addsBothMethodsAndOnlyRewritesUrl() {
+    var contact = ContactInfo.of()
+      .withPhoneNumber("+4712345678")
+      .withBookingUrl("https://book.example.com")
+      .build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNotNull(info);
+    assertEquals(
+      EnumSet.of(BookingMethod.CALL_OFFICE, BookingMethod.ONLINE),
+      info.bookingMethods()
+    );
+    var augmented = info.getContactInfo();
+    assertEquals("+4712345678", augmented.getPhoneNumber());
+    assertEquals(
+      expectedAugmentedUrl("https://book.example.com", PICKUP, DROPOFF),
+      augmented.getBookingUrl()
+    );
+  }
+
+  /**
+   * Pins down the URL with a {@code #fragment}: the appended coordinate parameters must end up
+   * in the query (before the fragment), not inside the fragment. The string-level
+   * {@code url.contains("?")} predicate doesn't catch this — switching to {@link java.net.URI}
+   * parsing does, because the fragment is split off the URL before it can swallow the params.
+   */
+  @Test
+  void urlWithFragment_appendsParamsBeforeFragment() {
+    var contact = ContactInfo.of().withBookingUrl("https://book.example.com/page#bookform").build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNotNull(info);
+    var expected = String.format(
+      Locale.ROOT,
+      "https://book.example.com/page?from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f#bookform",
+      PICKUP.latitude(),
+      PICKUP.longitude(),
+      DROPOFF.latitude(),
+      DROPOFF.longitude()
+    );
+    assertEquals(expected, info.getContactInfo().getBookingUrl());
+  }
+
+  /**
+   * When the booking URL is unparseable, the URL is dropped from the contact and
+   * {@link BookingMethod#ONLINE} is removed from the booking methods rather than left in place
+   * pointing nowhere. If the contact carried only the (now-dropped) URL, no actionable booking
+   * method remains and {@code toBookingInfo} returns {@code null}, matching the
+   * "non-null return ⇒ at least one usable method" contract.
+   */
+  @Test
+  void malformedUrlOnly_returnsNull() {
+    var contact = ContactInfo.of().withBookingUrl("https://book.example.com/has space").build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNull(info);
+  }
+
+  /**
+   * Same malformed-URL handling as {@link #malformedUrlOnly_returnsNull()} but with a phone
+   * number also present: the call-office method survives, the dropped URL is reflected as
+   * {@code null} on the returned contact, and {@code ONLINE} is absent from the booking methods.
+   */
+  @Test
+  void malformedUrlWithPhone_keepsCallOfficeAndDropsUrl() {
+    var contact = ContactInfo.of()
+      .withPhoneNumber("+4712345678")
+      .withBookingUrl("https://book.example.com/has space")
+      .build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNotNull(info);
+    assertEquals(EnumSet.of(BookingMethod.CALL_OFFICE), info.bookingMethods());
+    assertEquals("+4712345678", info.getContactInfo().getPhoneNumber());
+    assertNull(info.getContactInfo().getBookingUrl());
   }
 
   /**
@@ -69,7 +195,7 @@ class CarpoolItineraryMapperTest {
   void latestBookingTime_isTripStartTimeOfDayAtDaysPriorZero() {
     var contact = ContactInfo.of().withPhoneNumber("+4712345678").build();
 
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START);
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
 
     assertNotNull(info);
     var latest = info.getLatestBookingTime();

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
@@ -1,0 +1,80 @@
+package org.opentripplanner.ext.carpooling.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.EnumSet;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.organization.ContactInfo;
+import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
+
+/**
+ * Unit tests for {@link CarpoolItineraryMapper}.
+ */
+class CarpoolItineraryMapperTest {
+
+  private static final ZonedDateTime TRIP_START = ZonedDateTime.of(
+    2026,
+    5,
+    13,
+    8,
+    30,
+    0,
+    0,
+    ZoneOffset.UTC
+  );
+
+  @Test
+  void nullContact_returnsNull() {
+    assertNull(CarpoolItineraryMapper.toBookingInfo(null, TRIP_START));
+  }
+
+  /**
+   * A contact that carries neither a phone number nor a booking URL has no actionable booking
+   * method, so {@code toBookingInfo} must return {@code null} rather than a {@code BookingInfo}
+   * with an empty {@code bookingMethods} set — otherwise the non-null return would
+   * misleadingly suggest the leg is bookable. Consumers therefore may treat a non-null return
+   * as "this leg has at least one booking method."
+   */
+  @Test
+  void contactWithNeitherPhoneNorUrl_returnsNull() {
+    var contact = ContactInfo.of().withContactPerson("Alice").build();
+
+    assertNull(CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START));
+  }
+
+  @Test
+  void phoneOnly_addsCallOfficeAndPreservesContactUnchanged() {
+    var contact = ContactInfo.of().withPhoneNumber("+4712345678").build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START);
+
+    assertNotNull(info);
+    assertEquals(EnumSet.of(BookingMethod.CALL_OFFICE), info.bookingMethods());
+    assertEquals(contact, info.getContactInfo());
+  }
+
+  /**
+   * Pins down the placeholder behaviour documented on {@code toBookingInfo}: {@code
+   * latestBookingTime} must be non-null with {@code daysPrior == 0} and the time-of-day taken
+   * from the driver's trip start. This shape is load-bearing for the Transmodel
+   * {@code BookingArrangement.bookWhen} mapping, which collapses to {@code "timeOfTravelOnly"}
+   * if {@code latestBookingTime} is null.
+   */
+  @Test
+  void latestBookingTime_isTripStartTimeOfDayAtDaysPriorZero() {
+    var contact = ContactInfo.of().withPhoneNumber("+4712345678").build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START);
+
+    assertNotNull(info);
+    var latest = info.getLatestBookingTime();
+    assertNotNull(latest);
+    assertEquals(LocalTime.of(8, 30), latest.getTime());
+    assertEquals(0, latest.getDaysPrior());
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/model/CarpoolTripBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/model/CarpoolTripBuilderTest.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.ext.carpooling.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_EAST;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createSimpleTrip;
@@ -10,6 +12,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.transit.model.organization.ContactInfo;
 
 public class CarpoolTripBuilderTest {
 
@@ -48,5 +51,68 @@ public class CarpoolTripBuilderTest {
     assertEquals(original.endTime(), trip.endTime());
     assertEquals(original.stops().getFirst(), trip.stops().getFirst());
     assertEquals(original.stops().getLast(), trip.stops().getLast());
+  }
+
+  @Test
+  void buildFromValues_withPublicContactInformation_storesContactInfo() {
+    var contact = ContactInfo.of()
+      .withPhoneNumber("+4712345678")
+      .withBookingUrl("https://example.com/book")
+      .build();
+    var stop = createStopAt(1, OSLO_EAST);
+
+    var trip = new CarpoolTripBuilder(new FeedScopedId("feed", "contact-test"))
+      .withStartTime(ZonedDateTime.now())
+      .withEndTime(ZonedDateTime.now().plusMinutes(30))
+      .withStops(List.of(stop))
+      .withPublicContactInformation(contact)
+      .buildFromValues();
+
+    assertNotNull(trip.publicContactInformation());
+    assertEquals("+4712345678", trip.publicContactInformation().getPhoneNumber());
+    assertEquals("https://example.com/book", trip.publicContactInformation().getBookingUrl());
+  }
+
+  @Test
+  void buildFromValues_withNullableContactFields_allowsNulls() {
+    var contactPhoneOnly = ContactInfo.of().withPhoneNumber("+4712345678").build();
+    var contactUrlOnly = ContactInfo.of().withBookingUrl("https://example.com/book").build();
+    var stop = createStopAt(1, OSLO_EAST);
+
+    var tripWithPhone = new CarpoolTripBuilder(new FeedScopedId("feed", "phone-only"))
+      .withStartTime(ZonedDateTime.now())
+      .withEndTime(ZonedDateTime.now().plusMinutes(30))
+      .withStops(List.of(stop))
+      .withPublicContactInformation(contactPhoneOnly)
+      .buildFromValues();
+
+    assertEquals("+4712345678", tripWithPhone.publicContactInformation().getPhoneNumber());
+    assertNull(tripWithPhone.publicContactInformation().getBookingUrl());
+
+    var tripWithUrl = new CarpoolTripBuilder(new FeedScopedId("feed", "url-only"))
+      .withStartTime(ZonedDateTime.now())
+      .withEndTime(ZonedDateTime.now().plusMinutes(30))
+      .withStops(List.of(stop))
+      .withPublicContactInformation(contactUrlOnly)
+      .buildFromValues();
+
+    assertNull(tripWithUrl.publicContactInformation().getPhoneNumber());
+    assertEquals(
+      "https://example.com/book",
+      tripWithUrl.publicContactInformation().getBookingUrl()
+    );
+  }
+
+  @Test
+  void buildFromValues_withoutPublicContactInformation_defaultsToNull() {
+    var stop = createStopAt(1, OSLO_EAST);
+
+    var trip = new CarpoolTripBuilder(new FeedScopedId("feed", "no-contact"))
+      .withStartTime(ZonedDateTime.now())
+      .withEndTime(ZonedDateTime.now().plusMinutes(30))
+      .withStops(List.of(stop))
+      .buildFromValues();
+
+    assertNull(trip.publicContactInformation());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -18,10 +19,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.ext.carpooling.internal.CarpoolItineraryMapper;
 import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
+import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTreeStreetRouter;
 import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -35,7 +40,9 @@ import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.service.TransitServiceResolver;
@@ -784,5 +791,75 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
           "time from P2 to stop"
       );
     }
+  }
+
+  /**
+   * Verifies the booking URL is rewritten with passenger pickup/dropoff query parameters when an
+   * access leg is mapped to an itinerary. To make the walk-vs-carpool distinction non-trivial,
+   * the {@code stopT5} access path is targeted: the carpool drops at {@code D} (the only drivable
+   * vertex incident to T5's pedestrian-only side branch) and the passenger then walks
+   * {@code D → T5}. The resulting itinerary therefore contains a walk leg after the carpool leg,
+   * so the URL must use the carpool's <em>alighting</em> coordinate ({@code D}) and not the
+   * walking endpoint ({@code T5}), and equally not the driver's trip origin ({@code A}).
+   */
+  @Test
+  void accessItinerary_appendsCarpoolBoardingAndAlightingCoords_notWalkLegCoords() {
+    var departureTime = SEARCH_TIME.plusMinutes(30);
+    var baseTrip = CarpoolTripTestData.createSimpleTripWithTime(coordA, coordD, departureTime);
+    var trip = new CarpoolTripBuilder(baseTrip)
+      .withPublicContactInformation(
+        ContactInfo.of().withBookingUrl("https://book.example.com").build()
+      )
+      .build();
+    repository.upsertCarpoolTrip(trip);
+
+    var request = buildCarpoolRequest(coordP2, coordP3, SEARCH_TIME);
+    var results = service.routeAccessEgress(
+      request,
+      new StreetRequest(StreetMode.CARPOOL),
+      AccessEgressType.ACCESS,
+      transitServiceResolver,
+      SEARCH_TIME
+    );
+
+    int stopT5Index = transitServiceResolver.getStop(stopT5.getId()).getIndex();
+    var stopT5Result = results
+      .stream()
+      .filter(r -> r.stop() == stopT5Index)
+      .findFirst()
+      .orElseThrow(() ->
+        new AssertionError("Expected an access result for stopT5 (forces a walk-from-dropoff leg)")
+      );
+
+    var mapper = new CarpoolItineraryMapper();
+    var itinerary = mapper.toItinerary(stopT5Result);
+    assertNotNull(itinerary);
+
+    // Sanity: the test only distinguishes carpool alighting (D) from the walk-leg endpoint
+    // (T5) if a WALK leg is actually present.
+    assertTrue(
+      itinerary
+        .legs()
+        .stream()
+        .anyMatch(l -> l instanceof StreetLeg sl && sl.getMode() == TraverseMode.WALK)
+    );
+
+    var carpoolLeg = itinerary
+      .legs()
+      .stream()
+      .filter(l -> l instanceof CarpoolLeg)
+      .findFirst()
+      .orElseThrow();
+    var bookingInfo = carpoolLeg.pickupBookingInfo();
+    assertNotNull(bookingInfo);
+
+    assertEquals(
+      expectedAugmentedUrl(
+        "https://book.example.com",
+        carpoolLeg.from().coordinate,
+        carpoolLeg.to().coordinate
+      ),
+      bookingInfo.getContactInfo().getBookingUrl()
+    );
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
@@ -3,7 +3,9 @@ package org.opentripplanner.ext.carpooling.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -16,6 +18,7 @@ import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.filter.DistanceBasedFilter;
 import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTreeStreetRouter;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
@@ -29,6 +32,7 @@ import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -481,5 +485,56 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
           "to dropoff"
       );
     }
+  }
+
+  /**
+   * Verifies that the booking URL on the carpool leg is augmented with {@code from_coordinate}
+   * and {@code to_coordinate} query parameters reflecting the passenger's carpool boarding and
+   * alighting points. In this graph the passenger's requested pickup is itself a graph vertex
+   * (P) and the carpool ride goes P → Q, so the URL coordinates equal P/Q (which are also the
+   * passenger's request endpoints here — distinguishing them from a separate walk leg is the job
+   * of {@link DefaultCarpoolingServiceWalkLegsTest}). The exact-equality assertion also pins
+   * down that the URL does NOT use the driver's origin (A) or destination (D).
+   */
+  @Test
+  void directItinerary_appendsCarpoolPickupAndDropoffCoordsToBookingUrl() {
+    var departureTime = SEARCH_TIME.plusMinutes(10);
+    var baseTrip = CarpoolTripTestData.createSimpleTripWithTime(tripStart, tripEnd, departureTime);
+    var trip = new CarpoolTripBuilder(baseTrip)
+      .withPublicContactInformation(
+        ContactInfo.of().withBookingUrl("https://book.example.com").build()
+      )
+      .build();
+    repository.upsertCarpoolTrip(trip);
+
+    var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
+    var results = service.routeDirect(request);
+    assertFalse(results.isEmpty());
+
+    var bookingInfo = results.getFirst().legs().getFirst().pickupBookingInfo();
+    assertNotNull(bookingInfo);
+
+    assertEquals(
+      expectedAugmentedUrl("https://book.example.com", passengerPickup, passengerDropoff),
+      bookingInfo.getContactInfo().getBookingUrl()
+    );
+  }
+
+  /**
+   * When the trip has no {@code publicContactInformation} the carpool leg's
+   * {@code pickupBookingInfo} must be {@code null} — i.e. a {@code BookingInfo} is not
+   * fabricated out of thin air just because a trip is present.
+   */
+  @Test
+  void directItinerary_withoutPublicContact_hasNullPickupBookingInfo() {
+    var departureTime = SEARCH_TIME.plusMinutes(10);
+    var trip = CarpoolTripTestData.createSimpleTripWithTime(tripStart, tripEnd, departureTime);
+    repository.upsertCarpoolTrip(trip);
+
+    var request = buildDirectCarpoolRequest(passengerPickup, passengerDropoff, SEARCH_TIME);
+    var results = service.routeDirect(request);
+    assertFalse(results.isEmpty());
+
+    assertNull(results.getFirst().legs().getFirst().pickupBookingInfo());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
@@ -2,7 +2,9 @@ package org.opentripplanner.ext.carpooling.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -13,6 +15,7 @@ import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
@@ -28,6 +31,7 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -283,5 +287,40 @@ class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
           walkFromDropoff.to().coordinate
       );
     }
+  }
+
+  /**
+   * Verifies that {@code from_coordinate} / {@code to_coordinate} on the booking URL reference the
+   * carpool boarding/alighting vertices (B and C — where the passenger actually gets in and out
+   * of the car) and NOT the passenger's walking endpoints (P and Q). This is the case the user's
+   * spec explicitly called out: the coordinates must not be where the passenger starts/finishes
+   * walking.
+   */
+  @Test
+  void walkLegItinerary_bookingUrlUsesCarpoolBoardingPoints_notPassengerWalkEndpoints() {
+    var departureTime = SEARCH_TIME.plusMinutes(10);
+    var baseTrip = CarpoolTripTestData.createSimpleTripWithTime(
+      TRIP_START,
+      TRIP_END,
+      departureTime
+    );
+    var trip = new CarpoolTripBuilder(baseTrip)
+      .withPublicContactInformation(
+        ContactInfo.of().withBookingUrl("https://book.example.com").build()
+      )
+      .build();
+    repository.upsertCarpoolTrip(trip);
+
+    var results = service.routeDirect(buildDirectCarpoolRequest(SEARCH_TIME));
+    assertFalse(results.isEmpty());
+
+    var carpoolLeg = results.getFirst().legs().get(1);
+    var bookingInfo = carpoolLeg.pickupBookingInfo();
+    assertNotNull(bookingInfo);
+
+    assertEquals(
+      expectedAugmentedUrl("https://book.example.com", B_COORD, C_COORD),
+      bookingInfo.getContactInfo().getBookingUrl()
+    );
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.carpooling.updater;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.arrivalIsAfterDepartureTime;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithDifferentCapacitiesPerCall;
@@ -9,6 +10,7 @@ import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyD
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithLatestExpectedArrivalTimeAimedOnly;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithOnboardCounts;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithPerStopLatestExpectedArrivalTimes;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithPublicContact;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithTotalCapacity;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.lessThanTwoStops;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.minimalCompleteJourney;
@@ -239,5 +241,25 @@ public class CarpoolSiriMapperTest {
     assertEquals(Duration.ZERO, mapped.stops().get(0).getDeviationBudget());
     assertEquals(Duration.ofMinutes(3), mapped.stops().get(1).getDeviationBudget());
     assertEquals(Duration.ofMinutes(10), mapped.stops().get(2).getDeviationBudget());
+  }
+
+  // -- publicContact tests --
+
+  @Test
+  void mapSiriToCarpoolTrip_withPublicContact_mapsContactInformation() {
+    var journey = journeyWithPublicContact("+4712345678", "https://example.com/book");
+    var mapped = mapper.mapSiriToCarpoolTrip(journey);
+
+    assertNotNull(mapped.publicContactInformation());
+    assertEquals("+4712345678", mapped.publicContactInformation().getPhoneNumber());
+    assertEquals("https://example.com/book", mapped.publicContactInformation().getBookingUrl());
+  }
+
+  @Test
+  void mapSiriToCarpoolTrip_withoutPublicContact_contactInformationIsNull() {
+    var journey = minimalCompleteJourney();
+    var mapped = mapper.mapSiriToCarpoolTrip(journey);
+
+    assertNull(mapped.publicContactInformation());
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -1,9 +1,13 @@
 package org.opentripplanner.ext.carpooling.internal;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.astar.model.GraphPath;
@@ -17,6 +21,7 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
@@ -25,6 +30,8 @@ import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
 import org.opentripplanner.transit.model.timetable.booking.BookingTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maps carpooling insertion candidates to OTP itineraries for API responses.
@@ -67,6 +74,8 @@ import org.opentripplanner.transit.model.timetable.booking.BookingTime;
  */
 public class CarpoolItineraryMapper {
 
+  private static final Logger LOG = LoggerFactory.getLogger(CarpoolItineraryMapper.class);
+
   /**
    * Converts an insertion candidate into an OTP itinerary representing the passenger's journey.
    * The itinerary contains a {@link CarpoolLeg} for the shared ride, optionally preceded by a
@@ -95,7 +104,12 @@ public class CarpoolItineraryMapper {
       carpoolStart,
       carpoolEnd,
       candidate.getPassengerRideWeight(carpoolReluctance),
-      toBookingInfo(candidate.trip().publicContactInformation(), candidate.trip().startTime())
+      toBookingInfo(
+        candidate.trip().publicContactInformation(),
+        candidate.trip().startTime(),
+        boardingCoordinate(sharedSegments),
+        alightingCoordinate(sharedSegments)
+      )
     );
   }
 
@@ -174,7 +188,12 @@ public class CarpoolItineraryMapper {
       accessEgress.getCarpoolStart(),
       accessEgress.getCarpoolEnd(),
       accessEgress.getPassengerRideWeight(),
-      toBookingInfo(accessEgress.trip().publicContactInformation(), accessEgress.trip().startTime())
+      toBookingInfo(
+        accessEgress.trip().publicContactInformation(),
+        accessEgress.trip().startTime(),
+        boardingCoordinate(sharedSegments),
+        alightingCoordinate(sharedSegments)
+      )
     );
   }
 
@@ -210,6 +229,19 @@ public class CarpoolItineraryMapper {
   /**
    * Builds the carpool leg's {@code pickupBookingInfo} from the trip's public-contact details.
    * <p>
+   * The contact's {@code bookingUrl} (if present) is augmented with {@code from_coordinate} and
+   * {@code to_coordinate} query parameters reflecting the passenger's carpool boarding and
+   * alighting vertices — i.e. where the passenger gets in/out of the driver's car. These are
+   * distinct from the passenger's walking endpoints (handled by the surrounding walk legs) and
+   * from the driver's trip origin/destination.
+   * <p>
+   * If the contact's booking URL cannot be parsed as a valid {@link URI}, the URL is dropped from
+   * the returned {@code BookingInfo} (a malformed URL is logged as a warning and treated as if
+   * the trip published no booking URL at all) and {@link BookingMethod#ONLINE} is omitted from
+   * the booking methods. This keeps the "non-null return ⇒ at least one usable booking method"
+   * contract honest: a {@code BookingInfo} is never returned advertising {@code ONLINE} without
+   * a URL the user can actually open.
+   * <p>
    * {@code latestBookingTime} is a temporary placeholder: how a real booking deadline should be
    * sourced for carpool trips is yet to be decided, so it is approximated by the trip's
    * departure time-of-day at {@code daysPrior=0} — good enough until the source is settled. The
@@ -223,14 +255,24 @@ public class CarpoolItineraryMapper {
    * @param contact the trip's public-contact details, or {@code null} if the trip publishes none.
    * @param tripStartTime the driver's trip start time; only the time-of-day is used, as the
    *        placeholder source for {@code latestBookingTime}.
+   * @param pickup the carpool boarding coordinate (where the passenger gets into the car), used to
+   *        augment the booking URL with {@code from_coordinate}.
+   * @param dropoff the carpool alighting coordinate (where the passenger gets out of the car),
+   *        used to augment the booking URL with {@code to_coordinate}.
    * @return a booking info populated with the contact details and derived booking methods
-   *         (CALL_OFFICE if phone is set, ONLINE if URL is set), or {@code null} when
-   *         {@code contact} is {@code null} or carries neither a phone number nor a booking URL —
-   *         i.e. when no actionable booking method can be derived. Consumers may therefore treat
-   *         a non-null return as "this leg has at least one booking method."
+   *         (CALL_OFFICE if phone is set, ONLINE if URL is set and parses), or {@code null} when
+   *         no actionable booking method can be derived — i.e. {@code contact} is {@code null},
+   *         the contact carries neither a phone number nor a booking URL, or the only booking
+   *         channel was a malformed URL. Consumers may therefore treat a non-null return as
+   *         "this leg has at least one booking method."
    */
   @Nullable
-  static BookingInfo toBookingInfo(@Nullable ContactInfo contact, ZonedDateTime tripStartTime) {
+  static BookingInfo toBookingInfo(
+    @Nullable ContactInfo contact,
+    ZonedDateTime tripStartTime,
+    WgsCoordinate pickup,
+    WgsCoordinate dropoff
+  ) {
     if (contact == null || (contact.getPhoneNumber() == null && contact.getBookingUrl() == null)) {
       return null;
     }
@@ -238,14 +280,78 @@ public class CarpoolItineraryMapper {
     if (contact.getPhoneNumber() != null) {
       bookingMethods.add(BookingMethod.CALL_OFFICE);
     }
-    if (contact.getBookingUrl() != null) {
+    String effectiveUrl = contact.getBookingUrl() == null
+      ? null
+      : appendPassengerCoordinates(contact.getBookingUrl(), pickup, dropoff);
+    if (effectiveUrl != null) {
       bookingMethods.add(BookingMethod.ONLINE);
     }
+    if (bookingMethods.isEmpty()) {
+      return null;
+    }
+    ContactInfo effectiveContact = Objects.equals(effectiveUrl, contact.getBookingUrl())
+      ? contact
+      : contact.copy().withBookingUrl(effectiveUrl).build();
 
     return BookingInfo.of()
-      .withContactInfo(contact)
+      .withContactInfo(effectiveContact)
       .withBookingMethods(bookingMethods)
       .withLatestBookingTime(new BookingTime(tripStartTime.toLocalTime(), 0))
       .build();
+  }
+
+  private static WgsCoordinate boardingCoordinate(
+    List<GraphPath<State, Edge, Vertex>> sharedSegments
+  ) {
+    return sharedSegments.getFirst().states.getFirst().getVertex().toWgsCoordinate();
+  }
+
+  private static WgsCoordinate alightingCoordinate(
+    List<GraphPath<State, Edge, Vertex>> sharedSegments
+  ) {
+    return sharedSegments.getLast().states.getLast().getVertex().toWgsCoordinate();
+  }
+
+  /**
+   * Appends {@code from_coordinate} and {@code to_coordinate} query parameters to the booking URL
+   * so the carpool provider's booking page can pre-fill the passenger's pickup and dropoff.
+   * <p>
+   * The URL is parsed via {@link URI} so that any existing query string is merged with {@code &}
+   * (rather than a second {@code ?}) and any fragment ends up after the appended parameters
+   * rather than swallowing them.
+   *
+   * @return the augmented URL, or {@code null} if the input is not a parseable URI — in which
+   *         case a warning is logged and the caller should drop the URL (and the
+   *         {@link BookingMethod#ONLINE} booking method along with it).
+   */
+  @Nullable
+  private static String appendPassengerCoordinates(
+    String url,
+    WgsCoordinate pickup,
+    WgsCoordinate dropoff
+  ) {
+    String addedQuery = String.format(
+      Locale.ROOT,
+      "from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f",
+      pickup.latitude(),
+      pickup.longitude(),
+      dropoff.latitude(),
+      dropoff.longitude()
+    );
+    try {
+      URI uri = new URI(url);
+      String existingQuery = uri.getQuery();
+      String mergedQuery = existingQuery == null ? addedQuery : existingQuery + "&" + addedQuery;
+      return new URI(
+        uri.getScheme(),
+        uri.getAuthority(),
+        uri.getPath(),
+        mergedQuery,
+        uri.getFragment()
+      ).toString();
+    } catch (URISyntaxException e) {
+      LOG.warn("Failed to parse carpool booking URL '{}'; dropping URL from booking info", url, e);
+      return null;
+    }
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.carpooling.internal;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
@@ -20,6 +21,10 @@ import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.transit.model.organization.ContactInfo;
+import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
+import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
+import org.opentripplanner.transit.model.timetable.booking.BookingTime;
 
 /**
  * Maps carpooling insertion candidates to OTP itineraries for API responses.
@@ -89,7 +94,8 @@ public class CarpoolItineraryMapper {
       candidate.walkFromDropoff(),
       carpoolStart,
       carpoolEnd,
-      candidate.getPassengerRideWeight(carpoolReluctance)
+      candidate.getPassengerRideWeight(carpoolReluctance),
+      toBookingInfo(candidate.trip().publicContactInformation(), candidate.trip().startTime())
     );
   }
 
@@ -97,7 +103,8 @@ public class CarpoolItineraryMapper {
     List<GraphPath<State, Edge, Vertex>> sharedSegments,
     ZonedDateTime startTime,
     ZonedDateTime endTime,
-    double rideWeight
+    double rideWeight,
+    @Nullable BookingInfo bookingInfo
   ) {
     var firstSegment = sharedSegments.getFirst();
     var lastSegment = sharedSegments.getLast();
@@ -118,6 +125,7 @@ public class CarpoolItineraryMapper {
       .withGeometry(GeometryUtils.concatenateLineStrings(allEdges, Edge::getGeometry))
       .withDistanceMeters(allEdges.stream().mapToDouble(Edge::getDistanceMeters).sum())
       .withGeneralizedCost((int) rideWeight)
+      .withPickupBookingInfo(bookingInfo)
       .build();
   }
 
@@ -165,7 +173,8 @@ public class CarpoolItineraryMapper {
       accessEgress.walkFromDropoff(),
       accessEgress.getCarpoolStart(),
       accessEgress.getCarpoolEnd(),
-      accessEgress.getPassengerRideWeight()
+      accessEgress.getPassengerRideWeight(),
+      toBookingInfo(accessEgress.trip().publicContactInformation(), accessEgress.trip().startTime())
     );
   }
 
@@ -180,14 +189,15 @@ public class CarpoolItineraryMapper {
     @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff,
     ZonedDateTime carpoolStart,
     ZonedDateTime carpoolEnd,
-    double rideWeight
+    double rideWeight,
+    @Nullable BookingInfo bookingInfo
   ) {
     List<Leg> legs = new ArrayList<>(3);
     if (walkToPickup != null) {
       var walkStart = carpoolStart.minusSeconds(walkToPickup.getDuration());
       legs.add(buildWalkLeg(walkToPickup, walkStart, carpoolStart));
     }
-    legs.add(buildCarpoolLeg(sharedSegments, carpoolStart, carpoolEnd, rideWeight));
+    legs.add(buildCarpoolLeg(sharedSegments, carpoolStart, carpoolEnd, rideWeight, bookingInfo));
     if (walkFromDropoff != null) {
       var walkEnd = carpoolEnd.plusSeconds(walkFromDropoff.getDuration());
       legs.add(buildWalkLeg(walkFromDropoff, carpoolEnd, walkEnd));
@@ -195,5 +205,47 @@ public class CarpoolItineraryMapper {
 
     int totalCost = legs.stream().mapToInt(Leg::generalizedCost).sum();
     return Itinerary.ofDirect(legs).withGeneralizedCost(Cost.costOfSeconds(totalCost)).build();
+  }
+
+  /**
+   * Builds the carpool leg's {@code pickupBookingInfo} from the trip's public-contact details.
+   * <p>
+   * {@code latestBookingTime} is a temporary placeholder: how a real booking deadline should be
+   * sourced for carpool trips is yet to be decided, so it is approximated by the trip's
+   * departure time-of-day at {@code daysPrior=0} — good enough until the source is settled. The
+   * {@code daysPrior=0} value is also load-bearing for the Transmodel API:
+   * {@code BookingArrangement.bookWhen} returns {@code "advanceAndDayOfTravel"} when
+   * {@code latestBookingTime.daysPrior == 0}, but collapses to {@code "timeOfTravelOnly"} if
+   * {@code latestBookingTime} is null — which would misrepresent the carpool product as not
+   * bookable in advance. See
+   * {@code org.opentripplanner.apis.transmodel.mapping.BookingInfoMapper#mapToBookWhen}.
+   *
+   * @param contact the trip's public-contact details, or {@code null} if the trip publishes none.
+   * @param tripStartTime the driver's trip start time; only the time-of-day is used, as the
+   *        placeholder source for {@code latestBookingTime}.
+   * @return a booking info populated with the contact details and derived booking methods
+   *         (CALL_OFFICE if phone is set, ONLINE if URL is set), or {@code null} when
+   *         {@code contact} is {@code null} or carries neither a phone number nor a booking URL —
+   *         i.e. when no actionable booking method can be derived. Consumers may therefore treat
+   *         a non-null return as "this leg has at least one booking method."
+   */
+  @Nullable
+  static BookingInfo toBookingInfo(@Nullable ContactInfo contact, ZonedDateTime tripStartTime) {
+    if (contact == null || (contact.getPhoneNumber() == null && contact.getBookingUrl() == null)) {
+      return null;
+    }
+    var bookingMethods = EnumSet.noneOf(BookingMethod.class);
+    if (contact.getPhoneNumber() != null) {
+      bookingMethods.add(BookingMethod.CALL_OFFICE);
+    }
+    if (contact.getBookingUrl() != null) {
+      bookingMethods.add(BookingMethod.ONLINE);
+    }
+
+    return BookingInfo.of()
+      .withContactInfo(contact)
+      .withBookingMethods(bookingMethods)
+      .withLatestBookingTime(new BookingTime(tripStartTime.toLocalTime(), 0))
+      .build();
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolLeg.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolLeg.java
@@ -58,6 +58,9 @@ public class CarpoolLeg implements Leg {
 
   private final double distanceMeters;
 
+  @Nullable
+  private final BookingInfo pickupBookingInfo;
+
   CarpoolLeg(CarpoolLegBuilder builder) {
     this.startTime = Objects.requireNonNull(builder.startTime());
     this.endTime = Objects.requireNonNull(builder.endTime());
@@ -68,6 +71,7 @@ public class CarpoolLeg implements Leg {
     this.to = builder.to();
     this.geometry = builder.geometry();
     this.distanceMeters = builder.distanceMeters();
+    this.pickupBookingInfo = builder.pickupBookingInfo();
   }
 
   /**
@@ -325,8 +329,7 @@ public class CarpoolLeg implements Leg {
   @Nullable
   @Override
   public BookingInfo pickupBookingInfo() {
-    // TODO CARPOOLING
-    return null;
+    return pickupBookingInfo;
   }
 
   @Nullable

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolLegBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolLegBuilder.java
@@ -4,10 +4,12 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.model.plan.Emission;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 
 public class CarpoolLegBuilder {
 
@@ -21,6 +23,9 @@ public class CarpoolLegBuilder {
   private LineString geometry;
   private double distanceMeters;
 
+  @Nullable
+  private BookingInfo pickupBookingInfo;
+
   CarpoolLegBuilder() {}
 
   CarpoolLegBuilder(CarpoolLeg original) {
@@ -33,6 +38,7 @@ public class CarpoolLegBuilder {
     to = original.to();
     geometry = original.legGeometry();
     distanceMeters = original.distanceMeters();
+    pickupBookingInfo = original.pickupBookingInfo();
   }
 
   public CarpoolLegBuilder withStartTime(ZonedDateTime startTime) {
@@ -114,6 +120,16 @@ public class CarpoolLegBuilder {
 
   public double distanceMeters() {
     return distanceMeters;
+  }
+
+  public CarpoolLegBuilder withPickupBookingInfo(@Nullable BookingInfo pickupBookingInfo) {
+    this.pickupBookingInfo = pickupBookingInfo;
+    return this;
+  }
+
+  @Nullable
+  public BookingInfo pickupBookingInfo() {
+    return pickupBookingInfo;
   }
 
   public CarpoolLeg build() {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
@@ -3,11 +3,13 @@ package org.opentripplanner.ext.carpooling.model;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.LogInfo;
 import org.opentripplanner.transit.model.framework.TransitBuilder;
+import org.opentripplanner.transit.model.organization.ContactInfo;
 
 /**
  * Represents a driver's carpool journey with planned route, timing, and passenger capacity.
@@ -65,6 +67,9 @@ public class CarpoolTrip
   // Ordered list of stops along the carpool route where passengers can be picked up or dropped off
   private final List<CarpoolStop> stops;
 
+  @Nullable
+  private final ContactInfo publicContactInformation;
+
   public CarpoolTrip(CarpoolTripBuilder builder) {
     super(builder.getId());
     this.startTime = builder.startTime();
@@ -72,6 +77,7 @@ public class CarpoolTrip
     this.provider = builder.provider();
     this.totalCapacity = builder.totalCapacity();
     this.stops = Collections.unmodifiableList(builder.stops());
+    this.publicContactInformation = builder.publicContactInformation();
   }
 
   /**
@@ -131,6 +137,11 @@ public class CarpoolTrip
    */
   public List<CarpoolStop> stops() {
     return stops;
+  }
+
+  @Nullable
+  public ContactInfo publicContactInformation() {
+    return publicContactInformation;
   }
 
   /**
@@ -226,7 +237,8 @@ public class CarpoolTrip
       getId().equals(other.getId()) &&
       startTime.equals(other.startTime) &&
       endTime.equals(other.endTime) &&
-      stops.equals(other.stops)
+      stops.equals(other.stops) &&
+      Objects.equals(publicContactInformation, other.publicContactInformation)
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTripBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTripBuilder.java
@@ -3,8 +3,10 @@ package org.opentripplanner.ext.carpooling.model;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.model.framework.AbstractEntityBuilder;
+import org.opentripplanner.transit.model.organization.ContactInfo;
 
 /**
  * Builder for {@link CarpoolTrip} instances.
@@ -17,6 +19,9 @@ public class CarpoolTripBuilder extends AbstractEntityBuilder<CarpoolTrip, Carpo
   private int totalCapacity = CarpoolTrip.DEFAULT_TOTAL_CAPACITY;
   private List<CarpoolStop> stops = new ArrayList<>();
 
+  @Nullable
+  private ContactInfo publicContactInformation;
+
   public CarpoolTripBuilder(FeedScopedId id) {
     super(id);
   }
@@ -28,6 +33,7 @@ public class CarpoolTripBuilder extends AbstractEntityBuilder<CarpoolTrip, Carpo
     this.provider = original.provider();
     this.totalCapacity = original.totalCapacity();
     this.stops = new ArrayList<>(original.stops());
+    this.publicContactInformation = original.publicContactInformation();
   }
 
   public CarpoolTripBuilder withStartTime(ZonedDateTime startTime) {
@@ -64,6 +70,18 @@ public class CarpoolTripBuilder extends AbstractEntityBuilder<CarpoolTrip, Carpo
 
   public int totalCapacity() {
     return totalCapacity;
+  }
+
+  public CarpoolTripBuilder withPublicContactInformation(
+    @Nullable ContactInfo publicContactInformation
+  ) {
+    this.publicContactInformation = publicContactInformation;
+    return this;
+  }
+
+  @Nullable
+  public ContactInfo publicContactInformation() {
+    return publicContactInformation;
   }
 
   public CarpoolTripBuilder withStops(List<CarpoolStop> stops) {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.raptor.spi.RaptorConstants;
@@ -187,6 +188,16 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
       penalty,
       this.carpoolReluctance
     );
+  }
+
+  /**
+   * The underlying carpool trip — i.e. the driver's committed route, schedule, and public-contact
+   * details. Exposed for the itinerary mapper, which reads trip-level metadata (start time,
+   * {@code publicContactInformation}, ...) to build the carpool leg's {@code pickupBookingInfo}.
+   * Mirrors how the direct path reads the same data straight off the {@link InsertionCandidate}.
+   */
+  public CarpoolTrip trip() {
+    return insertionCandidate.trip();
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -19,6 +19,7 @@ import org.opentripplanner.ext.carpooling.model.CarpoolStop;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.siri.siri21.AimedFlexibleArea;
@@ -72,13 +73,24 @@ public class CarpoolSiriMapper {
 
     int totalCapacity = extractTotalCapacity(tripId, calls);
 
-    return new CarpoolTripBuilder(new FeedScopedId(FEED_ID, tripId))
+    var builder = new CarpoolTripBuilder(new FeedScopedId(FEED_ID, tripId))
       .withStartTime(startTime)
       .withEndTime(endTime)
       .withProvider(journey.getOperatorRef().getValue())
       .withTotalCapacity(totalCapacity)
-      .withStops(stops)
-      .build();
+      .withStops(stops);
+
+    var publicContact = journey.getPublicContact();
+    if (publicContact != null) {
+      builder.withPublicContactInformation(
+        ContactInfo.of()
+          .withPhoneNumber(publicContact.getPhoneNumber())
+          .withBookingUrl(publicContact.getUrl())
+          .build()
+      );
+    }
+
+    return builder.build();
   }
 
   /**


### PR DESCRIPTION
### Summary

We read booking information (url, phone number) from SIRI ET messages, and inject it into carpool itineraries. 

### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?

Yes, a new test file CarpoolItineraryMapperTest which tests the mapping of booking information extensively has been added. There are also integration tests added.

- Was any manual verification done?

Yes.

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

Yes. 

- Were all non-trivial public classes and methods documented with Javadoc?

Yes.

- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?

No.