### PR TITLE
Convert warning in A* StateEditor to exception

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -77,13 +77,14 @@ public class StateEditor {
       traversingBackward = true;
       this.vertex = fromVertex;
     } else {
-      // Parent state is not at either end of edge.
-      LOG.warn("Edge is not connected to parent state: {}", e);
-      LOG.warn("   from   vertex: {}", fromVertex);
-      LOG.warn("   to     vertex: {}", toVertex);
-      LOG.warn("   parent vertex: {}", parentVertex);
-      defectiveTraversal = true;
-      this.vertex = null;
+      throw new IllegalStateException(
+        "Edge is not connected to parent state: %s, from=%s, to=%s, parent=%s".formatted(
+          e,
+          fromVertex,
+          toVertex,
+          parentVertex
+        )
+      );
     }
 
     if (traversingBackward != parent.getRequest().arriveBy()) {

--- a/street/src/test/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStationTest.java
+++ b/street/src/test/java/org/opentripplanner/service/vehiclerental/model/VehicleRentalStationTest.java
@@ -1,0 +1,118 @@
+package org.opentripplanner.service.vehiclerental.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.street.model.RentalFormFactor;
+
+class VehicleRentalStationTest {
+
+  private static final RentalVehicleType BICYCLE = RentalVehicleType.DEFAULT;
+  private static final RentalFormFactor BICYCLE_FORM = RentalFormFactor.BICYCLE;
+
+  @Test
+  void allowPickupNow_openStationWithVehicles() {
+    var station = VehicleRentalStation.of().withIsRenting(true).withVehiclesAvailable(3).build();
+    assertTrue(station.allowPickupNow());
+  }
+
+  @Test
+  void allowPickupNow_openStationNoVehicles() {
+    var station = VehicleRentalStation.of().withIsRenting(true).withVehiclesAvailable(0).build();
+    assertFalse(station.allowPickupNow());
+  }
+
+  @Test
+  void allowPickupNow_closedStation() {
+    var station = VehicleRentalStation.of().withIsRenting(false).withVehiclesAvailable(5).build();
+    assertFalse(station.allowPickupNow());
+  }
+
+  @Test
+  void allowDropoffNow_openStationWithSpaces() {
+    var station = VehicleRentalStation.of().withIsReturning(true).withSpacesAvailable(3).build();
+    assertTrue(station.allowDropoffNow());
+  }
+
+  @Test
+  void allowDropoffNow_openStationNoSpaces() {
+    var station = VehicleRentalStation.of().withIsReturning(true).withSpacesAvailable(0).build();
+    assertFalse(station.allowDropoffNow());
+  }
+
+  @Test
+  void allowDropoffNow_closedStationWithSpaces() {
+    var station = VehicleRentalStation.of().withIsReturning(false).withSpacesAvailable(5).build();
+    assertFalse(station.allowDropoffNow());
+  }
+
+  @Test
+  void allowDropoffNow_overloadingAllowedNoSpaces() {
+    var station = VehicleRentalStation.of()
+      .withIsReturning(true)
+      .withSpacesAvailable(0)
+      .withOverloadingAllowed(true)
+      .build();
+    assertTrue(station.allowDropoffNow());
+  }
+
+  @Test
+  void allowDropoffNow_overloadingAllowedButClosed() {
+    var station = VehicleRentalStation.of()
+      .withIsReturning(false)
+      .withSpacesAvailable(0)
+      .withOverloadingAllowed(true)
+      .build();
+    assertFalse(station.allowDropoffNow());
+  }
+
+  @Test
+  void canDropOffFormFactor_anyTypeWithRealtimeAndSpaces() {
+    var station = VehicleRentalStation.of()
+      .withIsReturning(true)
+      .withSpacesAvailable(3)
+      .withReturnPolicy(ReturnPolicy.ANY_TYPE)
+      .build();
+    assertTrue(station.canDropOffFormFactor(BICYCLE_FORM, true));
+  }
+
+  @Test
+  void canDropOffFormFactor_anyTypeWithRealtimeClosedStation() {
+    var station = VehicleRentalStation.of()
+      .withIsReturning(false)
+      .withSpacesAvailable(5)
+      .withReturnPolicy(ReturnPolicy.ANY_TYPE)
+      .build();
+    assertFalse(station.canDropOffFormFactor(BICYCLE_FORM, true));
+  }
+
+  @Test
+  void canDropOffFormFactor_anyTypeNoRealtimeIgnoresClosedStation() {
+    var station = VehicleRentalStation.of()
+      .withIsReturning(false)
+      .withSpacesAvailable(0)
+      .withReturnPolicy(ReturnPolicy.ANY_TYPE)
+      .build();
+    assertTrue(station.canDropOffFormFactor(BICYCLE_FORM, false));
+  }
+
+  @Test
+  void canDropOffFormFactor_specificTypesSpacesAvailable() {
+    var station = VehicleRentalStation.of()
+      .withVehicleSpacesAvailable(Map.of(BICYCLE, 3))
+      .withReturnPolicy(ReturnPolicy.SPECIFIC_TYPES)
+      .build();
+    assertTrue(station.canDropOffFormFactor(BICYCLE_FORM, true));
+  }
+
+  @Test
+  void canDropOffFormFactor_specificTypesNoSpacesForType() {
+    var station = VehicleRentalStation.of()
+      .withVehicleSpacesAvailable(Map.of(BICYCLE, 0))
+      .withReturnPolicy(ReturnPolicy.SPECIFIC_TYPES)
+      .build();
+    assertFalse(station.canDropOffFormFactor(BICYCLE_FORM, true));
+  }
+}

--- a/street/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/VehicleRentalEdgeTest.java
@@ -135,21 +135,6 @@ class VehicleRentalEdgeTest {
   }
 
   @Test
-  void testReturningToClosedStation() {
-    initBicycleEdgeAndRequest(3, 3, true, true, true, false);
-
-    var s1 = rent();
-
-    assertFalse(State.isEmpty(s1));
-
-    initBicycleEdgeAndRequest(3, 3, true, false, true, false);
-
-    var s2 = dropOff(s1[0]);
-
-    assertTrue(State.isEmpty(s2));
-  }
-
-  @Test
   void testReturningAndReturningToClosedStationWithNoRealtimeUsage() {
     initBicycleEdgeAndRequest(3, 3, false, true, false, false);
 
@@ -446,10 +431,6 @@ class VehicleRentalEdgeTest {
 
   private State[] rentAndDropOff() {
     var s0 = singleState(vehicleRentalEdge.traverse(new State(vertex, request)));
-    return vehicleRentalEdge.traverse(s0);
-  }
-
-  private State[] dropOff(State s0) {
     return vehicleRentalEdge.traverse(s0);
   }
 


### PR DESCRIPTION
### Summary

In previous PR we decided that we wanted to remove the A* state construction warnings into exceptions.

This is the next step of this: it throws an exception if the parent state is not connected to the one under construction.

### Unit tests

It replaces a test that mistakenly relied on this behaviour with one that tests the actual domain model instead.