### PR TITLE
Fix shutdown issue in SiriAzureUpdater

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
@@ -439,7 +439,10 @@ public class SiriAzureUpdater implements GraphUpdater {
         f.get();
       }
       LOG.info("{} updater initialized in {} ms.", updaterType, (System.currentTimeMillis() - t1));
-    } catch (ExecutionException | InterruptedException e) {
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new SiriAzureInitializationException("Interrupted while applying history", e);
+    } catch (ExecutionException e) {
       throw new SiriAzureInitializationException("Error applying history", e);
     }
   }


### PR DESCRIPTION
### Summary

Once InterruptedException is catched upon SiriUpdaterInitialization, we interrupt the thread.

### Unit tests

No new tests added.

### Documentation

No new documentation because it is a minor bug fix.

### Changelog

skip

### Bumping the serialization version id

No
