### PR TITLE
Clarify error codes of SIRI fuzzy trip matcher

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcher.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.updater.trip.siri;
 
+import static org.opentripplanner.updater.spi.UpdateErrorType.INVALID_DEPARTURE_TIME;
 import static org.opentripplanner.updater.spi.UpdateErrorType.NO_FUZZY_TRIP_MATCH;
 import static org.opentripplanner.updater.spi.UpdateErrorType.NO_VALID_STOPS;
+import static org.opentripplanner.updater.spi.UpdateErrorType.UNKNOWN_STOP;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -72,7 +74,7 @@ public class SiriFuzzyTripMatcher {
     }
 
     if (calls.getFirst().getAimedDepartureTime() == null) {
-      throw UpdateException.of(NO_FUZZY_TRIP_MATCH);
+      throw UpdateException.of(INVALID_DEPARTURE_TIME);
     }
 
     Set<Trip> trips = null;
@@ -89,7 +91,7 @@ public class SiriFuzzyTripMatcher {
       // quay ids also work
       RegularStop stop = entityResolver.resolveQuay(lastCall.getStopPointRef());
       if (stop == null) {
-        throw UpdateException.of(NO_FUZZY_TRIP_MATCH);
+        throw UpdateException.of(UNKNOWN_STOP);
       }
       ZonedDateTime arrivalTime = lastCall.getAimedArrivalTime() != null
         ? lastCall.getAimedArrivalTime()

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
@@ -2,8 +2,9 @@ package org.opentripplanner.updater.trip.siri;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+import static org.opentripplanner.updater.spi.UpdateErrorType.INVALID_DEPARTURE_TIME;
 import static org.opentripplanner.updater.spi.UpdateErrorType.MULTIPLE_FUZZY_TRIP_MATCHES;
-import static org.opentripplanner.updater.spi.UpdateErrorType.NO_FUZZY_TRIP_MATCH;
+import static org.opentripplanner.updater.spi.UpdateErrorType.UNKNOWN_STOP;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
 import org.junit.jupiter.api.Test;
@@ -83,7 +84,26 @@ class SiriFuzzyTripMatcherTest implements RealtimeTestConstants {
       )
       .buildEstimatedVehicleJourney();
 
-    assertFailure(NO_FUZZY_TRIP_MATCH, () -> match(journey, env));
+    assertFailure(UNKNOWN_STOP, () -> match(journey, env));
+  }
+
+  @Test
+  void noDepartureTime() {
+    var trip1input = tripInput(TRIP_1_ID);
+
+    var env = ENV_BUILDER.addTrip(trip1input).build();
+
+    var journey = new SiriEtBuilder(env.localTimeParser())
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected(null, null)
+          .call("SOME_MADE_UP_ID")
+          .arriveAimedExpected("00:20:00", "00:20:00")
+      )
+      .buildEstimatedVehicleJourney();
+
+    assertFailure(INVALID_DEPARTURE_TIME, () -> match(journey, env));
   }
 
   private static TripAndPattern match(EstimatedVehicleJourney evj, TransitTestEnvironment env)

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/fuzzymatching/FuzzyTripMatchingTest.java
@@ -76,7 +76,7 @@ class FuzzyTripMatchingTest implements RealtimeTestConstants {
 
     var result = siri.applyEstimatedTimetableWithFuzzyMatcher(updates);
     assertEquals(0, result.successful(), "Should fail gracefully");
-    assertFailure(UpdateErrorType.NO_FUZZY_TRIP_MATCH, result);
+    assertFailure(UpdateErrorType.INVALID_DEPARTURE_TIME, result);
   }
 
   /**


### PR DESCRIPTION
### Summary

This is a simple PR that clarifies the error codes in the SIRI fuzzy trip matcher. Precise error codes help a lot when debugging why SIRI feeds don't apply cleanly.

Changes are:

- When the stop cannot be resolved UNKNOWN_STOP is thrown, rather than NO_FUZZY_TRIP_MATCH
- When the first stop doesn't have a departure time INVALID_DEPARTURE_TIME is thrown instead of NO_FUZZY_TRIP_MATCH

### Issue

None.

### Unit tests

Added.