### PR TITLE
Raptor cleanup - Seal PatternRide hierarchy and fix tests

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/configure/GtfsSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/configure/GtfsSchema.java
@@ -6,7 +6,7 @@ import javax.inject.Qualifier;
 
 /**
  * This is used for dagger injection. Since we have multiple GraphQL APIs and therefore also
- * multiple GraphQL schemas, a qualifier is needed to tell dagger wich schema to inject where.
+ * multiple GraphQL schemas, a qualifier is needed to tell dagger which schema to inject where.
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchema.java
@@ -6,7 +6,7 @@ import javax.inject.Qualifier;
 
 /**
  * This is used for dagger injection. Since we have multiple GraphQL APIs and therefore also
- * multiple GraphQL schemas, a qualifier is needed to tell dagger wich schema to inject where.
+ * multiple GraphQL schemas, a qualifier is needed to tell dagger which schema to inject where.
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/application/src/main/java/org/opentripplanner/netex/package.md
+++ b/application/src/main/java/org/opentripplanner/netex/package.md
@@ -7,7 +7,7 @@ supported. When loading NeTEx data OTP should print warnings for all NeTEx data 
 
 OTP is tested with data from Entur which uses
 the [Nordic NeTEx profile](https://enturas.atlassian.net/wiki/spaces/PUBLIC/pages/728891481/Nordic+NeTEx+Profile) 
-and Data from HVV wich uses the [EPIP NeTEx Profile](http://www.normes-donnees-tc.org/wp-content/uploads/2019/11/WI00278457-TS16614-4-FV-e-Latest-Draft-sent-to-CEN.pdf). 
+and Data from HVV which uses the [EPIP NeTEx Profile](http://www.normes-donnees-tc.org/wp-content/uploads/2019/11/WI00278457-TS16614-4-FV-e-Latest-Draft-sent-to-CEN.pdf). 
 If you find that some part of your import is not imported/supported by OTP you will need to add
 support for it in this model. NeTEx is huge, and ONLY data relevant for travel planning should be
 imported.

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/internalapi/ParetoSetCost.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/internalapi/ParetoSetCost.java
@@ -23,7 +23,7 @@ public enum ParetoSetCost {
    */
   USE_C1_RELAXED_IF_C2_IS_OPTIMAL;
 
-  /// Return `true` if the c1 criteria is included in the pareto comparason.
+  /// Return `true` if the c1 criteria is included in the pareto comparison.
   public boolean useC1() {
     return this != NONE;
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/ArrivalParetoSetComparatorFactory.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/ArrivalParetoSetComparatorFactory.java
@@ -5,11 +5,11 @@ import org.opentripplanner.raptor.api.model.RelaxFunction;
 import org.opentripplanner.raptor.util.paretoset.ParetoComparator;
 
 /**
- * This class creates and hold two {@code ParetoComparator}s which is used in a single McRaptor
+ * This class creates and holds two {@code ParetoComparator}s which are used in a single McRaptor
  * search.
  *
  * The creation of the two {@link ParetoComparator}s should be done in such way that the JIT
- * compiler can inline all lamdas for the best possible performance. Changes this this class
+ * compiler can inline all lamdas for the best possible performance. Changes to this class
  * should be checked with the SpeedTest to avoid degration in performance.
  */
 public final class ArrivalParetoSetComparatorFactory<T extends McStopArrival<?>> {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/AbstractPatternRide.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/AbstractPatternRide.java
@@ -97,31 +97,31 @@ public abstract class AbstractPatternRide<T extends RaptorTripSchedule>
     return prevArrival;
   }
 
-  public int boardStopIndex() {
+  public final int boardStopIndex() {
     return boardStopIndex;
   }
 
-  public int boardPos() {
+  public final int boardPos() {
     return boardPos;
   }
 
-  public int boardTime() {
+  public final int boardTime() {
     return boardTime;
   }
 
-  public int boardC1() {
+  public final int boardC1() {
     return boardC1;
   }
 
-  public int relativeC1() {
+  public final int relativeC1() {
     return relativeC1;
   }
 
-  public int tripSortIndex() {
+  public final int tripSortIndex() {
     return tripSortIndex;
   }
 
-  public T trip() {
+  public final T trip() {
     return trip;
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/AbstractPatternRide.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/AbstractPatternRide.java
@@ -61,8 +61,9 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
  * <p>
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
-public abstract class AbstractPatternRide<T extends RaptorTripSchedule>
-  implements PatternRideView<T, McStopArrival<T>> {
+public abstract sealed class AbstractPatternRide<T extends RaptorTripSchedule>
+  implements PatternRideView<T, McStopArrival<T>>
+  permits PatternRideC1, PatternRideC2 {
 
   private final McStopArrival<T> prevArrival;
   private final int boardStopIndex;

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1.java
@@ -68,7 +68,7 @@ public class PatternRideC1<T extends RaptorTripSchedule> extends AbstractPattern
   }
 
   @Override
-  public int c2() {
+  public final int c2() {
     return RaptorCostCalculator.ZERO_COST;
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1.java
@@ -9,7 +9,7 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 /**
  * A {@link AbstractPatternRide} with support for c1 {@code generalized-cost}.
  */
-public class PatternRideC1<T extends RaptorTripSchedule> extends AbstractPatternRide<T> {
+public final class PatternRideC1<T extends RaptorTripSchedule> extends AbstractPatternRide<T> {
 
   // Pareto vector: [relativeCost, tripSortIndex]
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2.java
@@ -10,7 +10,7 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 /**
  * A {@link AbstractPatternRide} with support for c1 {@code generalized-cost} and c2 (custom-use-case-cost).
  */
-public class PatternRideC2<T extends RaptorTripSchedule> extends AbstractPatternRide<T> {
+public final class PatternRideC2<T extends RaptorTripSchedule> extends AbstractPatternRide<T> {
 
   private final int c2;
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2.java
@@ -48,7 +48,7 @@ public class PatternRideC2<T extends RaptorTripSchedule> extends AbstractPattern
         : l.compareC1(r));
   }
 
-  public int c2() {
+  public final int c2() {
     return c2;
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTransitDataProvider.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTransitDataProvider.java
@@ -26,8 +26,8 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
   int numberOfStops();
 
   /**
-   * This is the total number of trip patterns, it should be possible and all trip patterns must
-   * have a index ({@link RaptorTripPattern#patternIndex()}) < this value. Holes are acceptable.
+   * This is the total number of trip patterns. All trip patterns must have a index
+   * ({@link RaptorTripPattern#patternIndex()}) < this value. Holes are acceptable.
    */
   int numberOfTripPatterns();
 

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/D02_EarlyBoardingMatters.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/D02_EarlyBoardingMatters.java
@@ -1,0 +1,125 @@
+package org.opentripplanner.raptor.moduletests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.raptor.RaptorService;
+import org.opentripplanner.raptor._data.RaptorTestConstants;
+import org.opentripplanner.raptor._data.api.PathUtils;
+import org.opentripplanner.raptor._data.transit.TestTransitData;
+import org.opentripplanner.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
+import org.opentripplanner.raptor.configure.RaptorTestFactory;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+
+///
+/// In this test boarding a pattern at stop 1 is the only valid path to the destination via
+/// stop 2. But the pattern can be reached in eariler rounds at later stops. The point is to
+/// show that early round pattern arrivals does not dominate boardins early in the pattern.
+///
+/// **Network**
+/// ```
+///          (Destination)         R1
+///     E——————————F——————————G——————————H——————————I——————————J
+///     ⎮                     ⎮          ⎮          ⎮
+///     ⎮ R8                  ⎮ R6       ⎮ R4       ⎮ R2
+///     ⎮                     ⎮          ⎮          ⎮
+///     D ——————————————————— C ———————— B ———————— A (Origin)
+///                R7              R5         R3
+/// ```
+/// **Origin:** Stop A
+/// **Destination:** Stop E
+/// **Routes:**
+///    - R1 : E - F - G - H - I - J
+///    - R2 : A - I
+///    - R3 : A - B
+///    - R4 : B - H
+///    - R5 : B - C
+///    - R6 : C - G
+///    - R7 : C - D
+///    - R8 : D - E
+///
+/// **Only path to destination:** A ~ R3 ~ B ~ R5 ~ C ~ R7 ~ D ~ R8 ~ E ~ R1 ~ F
+public class D02_EarlyBoardingMatters implements RaptorTestConstants {
+
+  private static final int TX_4 = 4;
+
+  private final TestTransitData data = new TestTransitData();
+  private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = data.requestBuilder();
+  private final RaptorService<TestTripSchedule> raptorService = RaptorTestFactory.raptorService();
+
+  @BeforeEach
+  void setup() {
+    data
+      .access("Free ~ A")
+      .withTimetables(
+        """
+        -- R1
+        E      F      G      H      I      J
+        00:02  00:04  00:06  00:08  00:10  00:12
+        00:04  00:06  00:08  00:10  00:12  00:14
+        00:06  00:08  00:10  00:12  00:14  00:16
+        00:08  00:10  00:12  00:14  00:16  00:18
+        00:10  00:12  00:14  00:16  00:18  00:20
+        00:12  00:14  00:16  00:18  00:20  00:22
+        00:14  00:16  00:18  00:20  00:22  00:24
+        -- R2
+        A      I
+        00:03  00:05
+        -- R3
+        A      B
+        00:02  00:04
+        -- R4
+        B      H
+        00:06  00:08
+        -- R5
+        B      C
+        00:05  00:07
+        -- R6
+        C      G
+        00:09  00:11
+        -- R7
+        C      D
+        00:08  00:10
+        -- R8
+        D      E
+        00:11  00:13
+        """
+      )
+      .egress("F ~ Free");
+
+    requestBuilder
+      .searchParams()
+      .earliestDepartureTime(T00_00)
+      .latestArrivalTime(T01_00)
+      .searchWindow(Duration.ofMinutes(10))
+      .timetable(true);
+  }
+
+  static List<RaptorModuleTestCase> testCases() {
+    var path =
+      "A ~ BUS R3 0:02 0:04 ~ " +
+      "B ~ BUS R5 0:05 0:07 ~ " +
+      "C ~ BUS R7 0:08 0:10 ~ " +
+      "D ~ BUS R8 0:11 0:13 ~ " +
+      "E ~ BUS R1 0:14 0:16 ~ " +
+      "F [0:02 0:16 14m Tₙ4 C₁3_840]";
+    return RaptorModuleTestCase.of()
+      .addMinDuration("14m", TX_4, T00_00, T01_00)
+      .add(standard(), PathUtils.withoutCost(path))
+      .add(multiCriteria(), path)
+      .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    assertEquals(testCase.expected(), testCase.run(raptorService, data, requestBuilder));
+  }
+}

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/D02_EarlyBoardingMatters.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/D02_EarlyBoardingMatters.java
@@ -20,8 +20,8 @@ import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 
 ///
 /// In this test boarding a pattern at stop 1 is the only valid path to the destination via
-/// stop 2. But the pattern can be reached in eariler rounds at later stops. The point is to
-/// show that early round pattern arrivals does not dominate boardins early in the pattern.
+/// stop 2. But the pattern can be reached in earlier rounds at later stops. The point is to
+/// show that early round pattern arrivals does not dominate boarding early in the pattern.
 ///
 /// **Network**
 /// ```
@@ -34,7 +34,7 @@ import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 ///                R7              R5         R3
 /// ```
 /// **Origin:** Stop A
-/// **Destination:** Stop E
+/// **Destination:** Stop F
 /// **Routes:**
 ///    - R1 : E - F - G - H - I - J
 ///    - R2 : A - I

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/ArrivalParetoSetComparatorFactoryTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/ArrivalParetoSetComparatorFactoryTest.java
@@ -9,7 +9,6 @@ import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.model.DominanceFunction;
 import org.opentripplanner.raptor.api.model.RelaxFunction;
-import org.opentripplanner.raptor.util.paretoset.ParetoComparator;
 import org.opentripplanner.utils.time.TimeUtils;
 
 class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
@@ -41,7 +40,7 @@ class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
   /// - With c2 enable relaxed c1(+10) `[arrivalTime, round, c2 ? c1(+10) : c1, ...`
   ///
   /// For each of the 6 pareto-function variations we determine the dominance
-  /// `NONE | LEFT | RIGHT | BOTH`. The last column consist a string with the expected result
+  /// `NONE ≡ | LEFT ≺ | RIGHT ≻ | BOTH ∥`. The last column consist a string with the expected result
   ///  for these 6 variants.
   ///
   ///
@@ -49,46 +48,46 @@ class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
   @CsvSource(
     value = {
       // Case #1 - All criteria equals
-      "10:10 | 2 | 100 | 500 | false | NONE  NONE  - NONE  NONE  - NONE  NONE",
+      "10:10 | 2 | 100 | 500 | false |  ≡  ≡  ≡  ≡  ≡  ≡",
       // Case #2-6 - Single criteria better
-      "10:09 | 2 | 100 | 500 | false | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:10 | 1 | 100 | 500 | false | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:10 | 2 |  97 | 500 | false | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:10 | 2 | 100 | 499 | false | NONE  NONE  - LEFT  LEFT  - LEFT  LEFT",
-      "10:10 | 2 | 100 | 500 | true  | NONE  LEFT  - NONE  LEFT  - NONE  LEFT",
+      "10:09 | 2 | 100 | 500 | false |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:10 | 1 | 100 | 500 | false |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:10 | 2 |  97 | 500 | false |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:10 | 2 | 100 | 499 | false |  ≡  ≡  ≺  ≺  ≺  ≺",
+      "10:10 | 2 | 100 | 500 | true  |  ≡  ≺  ≡  ≺  ≡  ≺",
       // Case #7-9 - arrivalPath-time & round
-      "10:09 | 1 | 100 | 500 | false | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:09 | 3 | 100 | 500 | false | BOTH  BOTH  - BOTH  BOTH  - BOTH  BOTH",
-      "10:11 | 1 | 100 | 500 | false | BOTH  BOTH  - BOTH  BOTH  - BOTH  BOTH",
+      "10:09 | 1 | 100 | 500 | false |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:09 | 3 | 100 | 500 | false |  ∥  ∥  ∥  ∥  ∥  ∥",
+      "10:11 | 1 | 100 | 500 | false |  ∥  ∥  ∥  ∥  ∥  ∥",
       // Case #10-12 - arrivalPath-time & c1
-      "10:09 | 2 |  99 | 500 | false | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:11 | 2 |  99 | 500 | false | BOTH  BOTH  - BOTH  BOTH  - BOTH  BOTH",
-      "10:09 | 2 | 101 | 500 | false | BOTH  BOTH  - BOTH  BOTH  - BOTH  BOTH",
+      "10:09 | 2 |  99 | 500 | false |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:11 | 2 |  99 | 500 | false |  ∥  ∥  ∥  ∥  ∥  ∥",
+      "10:09 | 2 | 101 | 500 | false |  ∥  ∥  ∥  ∥  ∥  ∥",
       // Case #13-15 arrivalPath-time & c2
-      "10:09 | 2 | 100 | 499 | false | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:11 | 2 | 100 | 499 | false | RIGHT RIGHT - BOTH  BOTH  - BOTH  BOTH",
-      "10:09 | 2 | 100 | 501 | false | LEFT  LEFT  - BOTH  BOTH  - BOTH  BOTH",
+      "10:09 | 2 | 100 | 499 | false |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:11 | 2 | 100 | 499 | false |  ≻  ≻  ∥  ∥  ∥  ∥",
+      "10:09 | 2 | 100 | 501 | false |  ≺  ≺  ∥  ∥  ∥  ∥",
       // Case #16-17 arrivalPath-time & on-board
-      "10:09 | 2 | 100 | 500 | true  | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:11 | 2 | 100 | 500 | true  | RIGHT BOTH  - RIGHT BOTH  - RIGHT BOTH",
+      "10:09 | 2 | 100 | 500 | true  |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:11 | 2 | 100 | 500 | true  |  ≻  ∥  ≻  ∥  ≻  ∥",
       // Case #18-19  ride & on-board
-      "10:10 | 1 | 100 | 500 | true  | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:10 | 3 | 100 | 500 | true  | RIGHT BOTH  - RIGHT BOTH  - RIGHT BOTH",
+      "10:10 | 1 | 100 | 500 | true  |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:10 | 3 | 100 | 500 | true  |  ≻  ∥  ≻  ∥  ≻  ∥",
       // Case #20-21 - c1 & on-board
-      "10:10 | 2 |  99 | 500 | true  | LEFT  LEFT  - LEFT  LEFT  - LEFT  LEFT",
-      "10:10 | 2 | 101 | 500 | true  | RIGHT BOTH  - RIGHT BOTH  - RIGHT BOTH",
+      "10:10 | 2 |  99 | 500 | true  |  ≺  ≺  ≺  ≺  ≺  ≺",
+      "10:10 | 2 | 101 | 500 | true  |  ≻  ∥  ≻  ∥  ≻  ∥",
       // Case #22-25 - c1 & c2
-      "10:10 | 2 | 102 | 500 | false | RIGHT RIGHT - RIGHT RIGHT - RIGHT RIGHT",
-      "10:10 | 2 | 103 | 500 | false | RIGHT RIGHT - RIGHT RIGHT - RIGHT RIGHT",
-      "10:10 | 2 | 109 | 499 | false | RIGHT RIGHT - BOTH  BOTH  - BOTH  BOTH",
-      "10:10 | 2 | 110 | 499 | false | RIGHT RIGHT - BOTH  BOTH  - RIGHT RIGHT",
+      "10:10 | 2 | 102 | 500 | false |  ≻  ≻  ≻  ≻  ≻  ≻",
+      "10:10 | 2 | 103 | 500 | false |  ≻  ≻  ≻  ≻  ≻  ≻",
+      "10:10 | 2 | 109 | 499 | false |  ≻  ≻  ∥  ∥  ∥  ∥",
+      "10:10 | 2 | 110 | 499 | false |  ≻  ≻  ∥  ∥  ≻  ≻",
       // Case #26-31 - c1, c2 & on-board
-      "10:10 | 2 | 100 | 500 | true  | NONE  LEFT  - NONE  LEFT  - NONE  LEFT",
-      "10:10 | 2 | 102 | 500 | true  | RIGHT BOTH  - RIGHT BOTH  - RIGHT BOTH",
-      "10:10 | 2 | 103 | 500 | true  | RIGHT BOTH  - RIGHT BOTH  - RIGHT BOTH",
-      "10:10 | 2 | 109 | 499 | true  | RIGHT BOTH  - BOTH  BOTH  - BOTH  BOTH",
-      "10:10 | 2 | 109 | 500 | true  | RIGHT BOTH  - RIGHT BOTH  - RIGHT BOTH",
-      "10:10 | 2 | 110 | 499 | true  | RIGHT BOTH  - BOTH  BOTH  - RIGHT BOTH",
+      "10:10 | 2 | 100 | 500 | true  |  ≡  ≺  ≡  ≺  ≡  ≺",
+      "10:10 | 2 | 102 | 500 | true  |  ≻  ∥  ≻  ∥  ≻  ∥",
+      "10:10 | 2 | 103 | 500 | true  |  ≻  ∥  ≻  ∥  ≻  ∥",
+      "10:10 | 2 | 109 | 499 | true  |  ≻  ∥  ∥  ∥  ∥  ∥",
+      "10:10 | 2 | 109 | 500 | true  |  ≻  ∥  ≻  ∥  ≻  ∥",
+      "10:10 | 2 | 110 | 499 | true  |  ≻  ∥  ∥  ∥  ≻  ∥",
     },
     delimiter = '|'
   )
@@ -113,9 +112,9 @@ class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
       )
     );
     for (var factory : factories) {
-      result.append(" - ").append(toStr(factory, left, right));
+      result.append("  ").append(toStr(factory, left, right));
     }
-    assertEquals(expexted, result.toString().substring(3).trim());
+    assertEquals(expexted, result.toString().trim());
   }
 
   static String toStr(
@@ -123,9 +122,10 @@ class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
     McStopArrival<?> left,
     McStopArrival<?> right
   ) {
-    return "%-5s %-5s".formatted(
-      Dominance.from(factory.compareArrivalTimeRoundAndCost(), left, right),
-      Dominance.from(factory.compareArrivalTimeRoundCostAndOnBoardArrival(), left, right)
+    return (
+      factory.compareArrivalTimeRoundAndCost().compare(left, right).symbol() +
+      "  " +
+      factory.compareArrivalTimeRoundCostAndOnBoardArrival().compare(left, right).symbol()
     );
   }
 
@@ -138,24 +138,5 @@ class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
   ) {
     int arrTime = TimeUtils.time(arrivalTime);
     return TestStopArivalFactory.arrivalPath(DEPATURE_TIME, arrTime, round, c1, c2, arrivedOnBoard);
-  }
-
-  private static enum Dominance {
-    LEFT,
-    RIGHT,
-    BOTH,
-    NONE;
-
-    static Dominance from(
-      ParetoComparator<McStopArrival<?>> comp,
-      McStopArrival<?> left,
-      McStopArrival<?> right
-    ) {
-      if (comp.leftDominanceExist(left, right)) {
-        return comp.leftDominanceExist(right, left) ? Dominance.BOTH : Dominance.LEFT;
-      } else {
-        return comp.leftDominanceExist(right, left) ? Dominance.RIGHT : Dominance.NONE;
-      }
-    }
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/ArrivalParetoSetComparatorFactoryTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/ArrivalParetoSetComparatorFactoryTest.java
@@ -20,8 +20,8 @@ class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
 
   /// INPUT CRITERIA
   ///
-  /// This tests test the pareto-comparator produced by the factory. The 5 first colums are
-  /// input (criteria to compare) with a given value(same as thefirst row).
+  /// This test tests the pareto-comparator produced by the factory. The 5 first colums are
+  /// input (criteria to compare) with a given value(same as the first row).
   ///
   /// - `arrivalTime` : Arrive early is better
   /// - ´round´ : The second column is the Raptor round, but it is the pareto-round which is used
@@ -33,15 +33,15 @@ class ArrivalParetoSetComparatorFactoryTest implements RaptorTestConstants {
   ///
   /// EXPECTED
   ///
-  /// The las column is
-  /// the expected result. The factory can create 4 variants of the factory with 2
-  /// pareto-comparators in each (with and without arrive-on-board `...]` or `..., arriveOnBoard]`):
+  /// The last column is the expected result. The factory can create 4 variants of the factory with
+  /// 2 pareto-comparators in each (with and without arrive-on-board `...]` or `...,
+  /// arriveOnBoard]`):
   /// - With c1 `[arrivalTime, round, c1, ...`
   /// - With c1 & c2 `[arrivalTime, round, c1, c2, ...`
   /// - With c2 enable relaxed c1(+10) `[arrivalTime, round, c2 ? c1(+10) : c1, ...`
   ///
   /// For each of the 6 pareto-function variations we determine the dominance
-  /// `NONE | LEFFT | RIGHT | BOTH`. The last column consist a string with the expected result
+  /// `NONE | LEFT | RIGHT | BOTH`. The last column consist a string with the expected result
   ///  for these 6 variants.
   ///
   ///


### PR DESCRIPTION
### Summary

Minor code-quality cleanup in the Raptor multicriteria module: seals the `PatternRide` class
hierarchy, marks base-class accessors `final`, cleans up the `ArrivalParetoSetComparatorFactoryTest`
(unicode symbols instead of verbose string tokens), and adds a module test that documents the
invariant that an early-round arrival at a later stop in a pattern must not dominate a later-round
boarding at an earlier stop.

### Issue

No issue — these are housekeeping changes with no functional impact.

**Changes:**

- **`AbstractPatternRide`** is now `sealed` (`permits PatternRideC1, PatternRideC2`). All concrete
  implementations were already known; sealing lets the compiler enforce that and enables exhaustive
  pattern-matching at call sites in the future.
- **`AbstractPatternRide` accessors** (`boardStopIndex`, `boardPos`, `boardTime`, `boardC1`,
  `relativeC1`, `tripSortIndex`, `trip`) are marked `final`. The hierarchy is shallow and none of
  the subclasses override them; `final` documents the intent and prevents accidental override.
- **`ArrivalParetoSetComparatorFactoryTest`** — replaced the verbose `NONE LEFT RIGHT BOTH` string
  tokens in the parameterised CSV source with Unicode dominance symbols (`≡ ≺ ≻ ∥`). Removed the
  unused `ParetoComparator` import and corrected typos in the comments.
- **`D02_EarlyBoardingMatters`** — new module test asserting that boarding a pattern early in the
  pattern (round 4 via R3→R5→R7→R8→R1) is retained even though the same pattern (R1) is reachable
  with fewer transfers at a later stop (via R2→I→R1). This guards the invariant that
  earlier-round arrivals at later positions do not wrongly dominate earlier-position boardings.
- Various typo fixes in comments and Javadoc (`comparason` → `comparison`, `LEFFT` → `LEFT`, etc.).

### Unit tests

- `D02_EarlyBoardingMatters` is a new Raptor module test covering both standard and multi-criteria
  search modes.
- `ArrivalParetoSetComparatorFactoryTest` is cleaned up (same coverage, more readable assertions).
- All existing tests pass; no functional code changed.

### Documentation

Javadoc and inline comments corrected for typos. No new configuration options.

### Changelog

`+Skip Changelog` — pure refactoring and test additions, no user-visible change.

### Bumping the serialization version id

Not required — no graph serialization changes.
