### PR TITLE
filtering out cancelled carpooling trips / carpooling trip calls

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolEstimatedVehicleJourneyData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolEstimatedVehicleJourneyData.java
@@ -142,6 +142,56 @@ public class CarpoolEstimatedVehicleJourneyData {
     return journey;
   }
 
+  /**
+   * A minimal complete journey flagged as cancelled at the trip level.
+   */
+  public static EstimatedVehicleJourney cancelledJourney() {
+    var journey = minimalCompleteJourney();
+    journey.setCancellation(true);
+    return journey;
+  }
+
+  /**
+   * A 3-stop journey where the intermediate call is flagged as cancelled — the driver still
+   * drives origin → destination but skips the middle waypoint.
+   */
+  public static EstimatedVehicleJourney journeyWithCancelledIntermediateCall() {
+    var journey = minimalCompleteJourney();
+    var calls = journey.getEstimatedCalls().getEstimatedCalls();
+    var base = calls.getFirst().getAimedDepartureTime();
+
+    var intermediate = forPoint(OSLO_NORTH);
+    intermediate.setAimedArrivalTime(base.plusMinutes(20));
+    intermediate.setAimedDepartureTime(base.plusMinutes(20));
+    intermediate.setCancellation(true);
+    addStopName(intermediate, "Cancelled intermediate");
+
+    calls.add(1, intermediate);
+    return journey;
+  }
+
+  /**
+   * A 3-stop journey where two of three calls are cancelled, leaving fewer than 2 active calls.
+   */
+  public static EstimatedVehicleJourney journeyWithAllButOneCallCancelled() {
+    var journey = journeyWithCancelledIntermediateCall();
+    journey.getEstimatedCalls().getEstimatedCalls().getLast().setCancellation(true);
+    return journey;
+  }
+
+  /**
+   * Same trip id as {@link #minimalCompleteJourney()} but with the last call's aimed arrival
+   * time set before the first call's aimed departure time, causing the mapper to throw during
+   * call-order validation. Not flagged as cancelled.
+   */
+  public static EstimatedVehicleJourney malformedNonCancelledJourney() {
+    var journey = minimalCompleteJourney();
+    var calls = journey.getEstimatedCalls().getEstimatedCalls();
+    var firstDeparture = calls.getFirst().getAimedDepartureTime();
+    calls.getLast().setAimedArrivalTime(firstDeparture.minusMinutes(45));
+    return journey;
+  }
+
   public static EstimatedVehicleJourney stopTimesAreOutOfOrder() {
     var journey = new EstimatedVehicleJourney();
     journey.setEstimatedCalls(new EstimatedVehicleJourney.EstimatedCalls());

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.arrivalIsAfterDepartureTime;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithAllButOneCallCancelled;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithCancelledIntermediateCall;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithDifferentCapacitiesPerCall;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithLatestExpectedArrivalTime;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithLatestExpectedArrivalTimeAimedOnly;
@@ -23,6 +25,7 @@ import static org.opentripplanner.ext.carpooling.model.CarpoolStop.DEFAULT_ONBOA
 import static org.opentripplanner.ext.carpooling.model.CarpoolTrip.DEFAULT_TOTAL_CAPACITY;
 
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import uk.org.siri.siri21.EstimatedCall;
 
@@ -228,6 +231,26 @@ public class CarpoolSiriMapperTest {
     var mapped = mapper.mapSiriToCarpoolTrip(journeyWithLatestExpectedArrivalTime(10, 5));
     var lastStop = mapped.stops().getLast();
     assertEquals(Duration.ZERO, lastStop.getDeviationBudget());
+  }
+
+  // -- cancellation tests --
+
+  @Test
+  void mapSiriToCarpoolTrip_intermediateCallCancelled_dropsThatCall() {
+    var mapped = mapper.mapSiriToCarpoolTrip(journeyWithCancelledIntermediateCall());
+
+    assertNotNull(mapped);
+    var stopIds = mapped
+      .stops()
+      .stream()
+      .map(s -> s.getId().getId())
+      .toList();
+    assertEquals(List.of("unittest_trip_origin", "unittest_trip_destination"), stopIds);
+  }
+
+  @Test
+  void mapSiriToCarpoolTrip_fewerThanTwoActiveCalls_returnsNull() {
+    assertNull(mapper.mapSiriToCarpoolTrip(journeyWithAllButOneCallCancelled()));
   }
 
   @Test

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdaterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdaterTest.java
@@ -1,0 +1,109 @@
+package org.opentripplanner.ext.carpooling.updater;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.cancelledJourney;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithAllButOneCallCancelled;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.malformedNonCancelledJourney;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.minimalCompleteJourney;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
+import org.opentripplanner.framework.io.HttpHeaders;
+import org.opentripplanner.updater.trip.siri.updater.DefaultSiriETUpdaterParameters;
+
+class SiriETCarpoolingUpdaterTest {
+
+  private DefaultCarpoolingRepository repository;
+  private SiriETCarpoolingUpdater updater;
+  private final CarpoolSiriMapper mapper = new CarpoolSiriMapper();
+
+  @BeforeEach
+  void setUp() {
+    repository = new DefaultCarpoolingRepository();
+    var params = new DefaultSiriETUpdaterParameters(
+      "carpool-test",
+      "ENT",
+      false,
+      "http://localhost/never-fetched",
+      Duration.ofMinutes(1),
+      "test-requestor",
+      Duration.ofSeconds(30),
+      Duration.ofMinutes(15),
+      false,
+      HttpHeaders.empty(),
+      false
+    );
+    updater = new SiriETCarpoolingUpdater(params, repository);
+  }
+
+  @Test
+  void processEstimatedVehicleJourney_active_upsertsTrip() {
+    var journey = minimalCompleteJourney();
+
+    updater.processEstimatedVehicleJourney(journey);
+
+    assertTrue(tripIsInRepository(mapper.tripId(journey)));
+  }
+
+  @Test
+  void processEstimatedVehicleJourney_wholeTripCancellation_removesTrip() {
+    var tripId = seedActiveTrip();
+
+    updater.processEstimatedVehicleJourney(cancelledJourney());
+
+    assertFalse(tripIsInRepository(tripId));
+  }
+
+  @Test
+  void processEstimatedVehicleJourney_fewerThanTwoActiveCalls_removesTrip() {
+    var tripId = seedActiveTrip();
+
+    updater.processEstimatedVehicleJourney(journeyWithAllButOneCallCancelled());
+
+    assertFalse(tripIsInRepository(tripId));
+  }
+
+  @Test
+  void processEstimatedVehicleJourney_cancellationForUnknownTrip_isNoOp() {
+    updater.processEstimatedVehicleJourney(cancelledJourney());
+
+    assertTrue(repository.getCarpoolTrips().isEmpty());
+  }
+
+  @Test
+  void processEstimatedVehicleJourney_malformedNonCancellation_doesNotRemoveOrReplaceExistingTrip() {
+    // Sanity-check the fixture: a direct mapper call must throw, otherwise the updater test
+    // below would silently degrade into "upsert replaces the seeded trip" and still pass.
+    assertThrows(Exception.class, () ->
+      mapper.mapSiriToCarpoolTrip(malformedNonCancelledJourney())
+    );
+
+    seedActiveTrip();
+    var seededTrip = repository.getCarpoolTrips().iterator().next();
+
+    updater.processEstimatedVehicleJourney(malformedNonCancelledJourney());
+
+    assertSame(seededTrip, repository.getCarpoolTrips().iterator().next());
+  }
+
+  private FeedScopedId seedActiveTrip() {
+    var journey = minimalCompleteJourney();
+    updater.processEstimatedVehicleJourney(journey);
+    var tripId = mapper.tripId(journey);
+    assertTrue(tripIsInRepository(tripId));
+    return tripId;
+  }
+
+  private boolean tripIsInRepository(FeedScopedId id) {
+    return repository
+      .getCarpoolTrips()
+      .stream()
+      .anyMatch(t -> t.getId().equals(id));
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.carpooling;
 
 import java.util.Collection;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 
 /**
@@ -39,4 +40,9 @@ public interface CarpoolingRepository {
    * @throws IllegalArgumentException if trip is null
    */
   void upsertCarpoolTrip(CarpoolTrip trip);
+
+  /**
+   * Removes the carpool trip with the given id. No-op if no trip with this id exists.
+   */
+  void removeCarpoolTrip(FeedScopedId id);
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepository.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepository.java
@@ -29,4 +29,14 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
       LOG.debug("Added new carpool trip {} with {} stops", trip.getId(), trip.stops().size());
     }
   }
+
+  @Override
+  public void removeCarpoolTrip(FeedScopedId id) {
+    CarpoolTrip removed = trips.remove(id);
+    if (removed != null) {
+      LOG.debug("Removed carpool trip {}", id);
+    } else {
+      LOG.debug("Tried to remove unknown carpool trip {}", id);
+    }
+  }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import net.opengis.gml.siri.LinearRingType;
 import net.opengis.gml.siri.PolygonType;
 import org.locationtech.jts.geom.Coordinate;
@@ -37,6 +38,26 @@ public class CarpoolSiriMapper {
   private static final String FEED_ID = "ENT";
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
+  /**
+   * Returns the trip id for the given journey.
+   */
+  FeedScopedId tripId(EstimatedVehicleJourney journey) {
+    return new FeedScopedId(FEED_ID, journey.getEstimatedVehicleJourneyCode());
+  }
+
+  private static boolean isCancelled(EstimatedCall call) {
+    return Boolean.TRUE.equals(call.isCancellation());
+  }
+
+  /**
+   * Maps a SIRI {@link EstimatedVehicleJourney} to a {@link CarpoolTrip}. Calls flagged as
+   * cancelled are filtered out before stops are built. Returns {@code null} when fewer than
+   * 2 non-cancelled calls remain.
+   *
+   * @throws IllegalArgumentException if the raw message is malformed (fewer than 2 calls
+   *         before filtering, calls out of order, missing flexible areas, etc.)
+   */
+  @Nullable
   public CarpoolTrip mapSiriToCarpoolTrip(EstimatedVehicleJourney journey) {
     var calls = journey.getEstimatedCalls().getEstimatedCalls();
     if (calls.size() < 2) {
@@ -46,14 +67,28 @@ public class CarpoolSiriMapper {
     }
 
     var tripId = journey.getEstimatedVehicleJourneyCode();
-    validateEstimatedCallOrder(calls);
+    var activeCalls = calls
+      .stream()
+      .filter(c -> !isCancelled(c))
+      .toList();
+    if (activeCalls.size() < 2) {
+      LOG.info(
+        "Trip {}: fewer than 2 non-cancelled calls remain ({} of {}), treating as cancellation",
+        tripId,
+        activeCalls.size(),
+        calls.size()
+      );
+      return null;
+    }
+
+    validateEstimatedCallOrder(activeCalls);
 
     List<CarpoolStop> stops = new ArrayList<>();
 
-    for (int i = 0; i < calls.size(); i++) {
-      EstimatedCall call = calls.get(i);
+    for (int i = 0; i < activeCalls.size(); i++) {
+      EstimatedCall call = activeCalls.get(i);
       boolean isFirst = (i == 0);
-      boolean isLast = (i == calls.size() - 1);
+      boolean isLast = (i == activeCalls.size() - 1);
 
       var stop = buildCarpoolStopForPosition(call, tripId, i, isFirst, isLast);
       stops.add(stop);
@@ -71,7 +106,7 @@ public class CarpoolSiriMapper {
       ? lastStop.getExpectedArrivalTime()
       : lastStop.getAimedArrivalTime();
 
-    int totalCapacity = extractTotalCapacity(tripId, calls);
+    int totalCapacity = extractTotalCapacity(tripId, activeCalls);
 
     var builder = new CarpoolTripBuilder(new FeedScopedId(FEED_ID, tripId))
       .withStartTime(startTime)
@@ -121,10 +156,11 @@ public class CarpoolSiriMapper {
 
   /**
    * Extracts the total capacity from the EstimatedCalls' ExpectedDepartureCapacities.
-   * Only the first element of each call's capacities list is inspected; additional
-   * entries are ignored. Uses the value from the first call that has it. Logs a warning
-   * if different calls report different capacity values. Returns
-   * {@link CarpoolTrip#DEFAULT_TOTAL_CAPACITY} if no call has capacity data or if the value is invalid.
+   * Expects the cancelled calls to have already been filtered out. Only the first element
+   * of each call's capacities list is inspected; additional entries are ignored. Uses the
+   * value from the first call that has it. Logs a warning if calls report different capacity
+   * values. Returns {@link CarpoolTrip#DEFAULT_TOTAL_CAPACITY} if no call has capacity data
+   * or if the value is invalid.
    */
   private int extractTotalCapacity(String tripId, List<EstimatedCall> calls) {
     Integer firstCapacity = null;

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdater.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.carpooling.updater;
 
 import java.util.List;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.support.siri.SiriFileLoader;
@@ -96,17 +97,22 @@ public class SiriETCarpoolingUpdater extends PollingGraphUpdater {
   }
 
   /**
-   * Processes a single estimated vehicle journey, mapping it to a carpool trip and upserting it
-   * to the repository.
-   *
-   * @param estimatedVehicleJourney the estimated vehicle journey to process
+   * Maps a single estimated vehicle journey to a carpool trip and upserts it, or removes the
+   * trip when the journey is cancelled or has fewer than 2 non-cancelled calls.
    */
-  private void processEstimatedVehicleJourney(EstimatedVehicleJourney estimatedVehicleJourney) {
+  void processEstimatedVehicleJourney(EstimatedVehicleJourney estimatedVehicleJourney) {
     try {
-      var carpoolTrip = mapper.mapSiriToCarpoolTrip(estimatedVehicleJourney);
-      if (carpoolTrip != null) {
-        repository.upsertCarpoolTrip(carpoolTrip);
+      FeedScopedId tripId = mapper.tripId(estimatedVehicleJourney);
+      if (Boolean.TRUE.equals(estimatedVehicleJourney.isCancellation())) {
+        repository.removeCarpoolTrip(tripId);
+        return;
       }
+      var carpoolTrip = mapper.mapSiriToCarpoolTrip(estimatedVehicleJourney);
+      if (carpoolTrip == null) {
+        repository.removeCarpoolTrip(tripId);
+        return;
+      }
+      repository.upsertCarpoolTrip(carpoolTrip);
     } catch (Exception e) {
       LOG.warn("Failed to process EstimatedVehicleJourney: {}", e.getMessage());
     }


### PR DESCRIPTION
### Summary

Cancelled carpooling trips are filtered out and removed from DefaultCarpoolingRepository.

### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?

Yes

- Was the code designed so it is unit testable?

Yes

- Were any tests applied to the smallest appropriate unit?

Yes

- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

Yes

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

Yes

- Were all non-trivial public classes and methods documented with Javadoc?

Yes

- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?

no.
