### PR TITLE
Refactor NearbyPlaceFinder documentation and parameters

### DIFF
--- a/application/src/main/java/org/opentripplanner/place/NearbyPlaceFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/NearbyPlaceFinder.java
@@ -8,30 +8,29 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
- * Interface for finding places (stops, rental stations etc.).
+ * Functional interface for finding nearby places such as stops, rental stations, and parking.
  */
 @FunctionalInterface
 public interface NearbyPlaceFinder {
+
   /**
-   * Search closest places, including stops, bike rental stations, bike and car parking etc, from a
-   * given coordinate, extending up to a specified max radius.
+   * Search for the closest places (stops, bike rental stations, bike and car parking, etc.)
+   * from a given coordinate, within a specified radius.
    *
-   * @param lat                        Origin latitude
-   * @param lon                        Origin longitude
-   * @param radiusMeters               Search radius from the origin in meters
-   * @param maxResults                 Maximum number of results to return within the search
-   *                                   radius.
-   * @param filterByModes              A list of TransitModes for which to find Stops and
-   *                                   PatternAtStops. Use null to disable the filtering.
-   * @param filterByPlaceTypes         A list of PlaceTypes to search for. Use null to disable the
-   *                                   filtering, and search for all types.
-   * @param filterByStops              A list of Stop ids for which to find Stops and
-   *                                   PatternAtStops. Use null to disable the filtering.
-   * @param filterByRoutes             A list of Route ids used for filtering Stops. Only the stops
-   *                                   which are served by the route are returned. Use null to
-   *                                   disable the filtering.
-   * @param filterByBikeRentalStations A list of VehicleRentalStation ids to use in filtering. Use
-   *                                   null to disable the filtering.
+   * @param lat                  Origin latitude
+   * @param lon                  Origin longitude
+   * @param radiusMeters         Search radius from the origin in meters
+   * @param maxResults           Maximum number of results to return
+   * @param filterByModes        Transit modes to filter stops and patterns. Use {@code null} for no filtering.
+   * @param filterByPlaceTypes   Place types to include in the search. Use {@code null} for all types.
+   * @param filterByStops        Specific stop IDs to include. Use {@code null} for no filtering.
+   * @param filterByStations     Specific station IDs to include. Use {@code null} for no filtering.
+   * @param filterByRoutes       Route IDs to filter stops served by those routes. Use {@code null} for no filtering.
+   * @param filterByRentalStations Vehicle rental station IDs to filter. Use {@code null} for no filtering.
+   * @param filterByNetworks     Rental networks to filter. Use {@code null} for no filtering.
+   * @param transitService       Transit service reference for querying transit data
+   *
+   * @return A list of nearby places within the given radius, subject to filters
    */
   List<PlaceAtDistance> findClosestPlaces(
     double lat,
@@ -43,8 +42,8 @@ public interface NearbyPlaceFinder {
     List<FeedScopedId> filterByStops,
     List<FeedScopedId> filterByStations,
     List<FeedScopedId> filterByRoutes,
-    List<String> filterByBikeRentalStations,
-    List<String> filterByNetwork,
+    List<String> filterByRentalStations,
+    List<String> filterByNetworks,
     TransitService transitService
   );
 }


### PR DESCRIPTION
Key Updates
Improved Javadoc clarity: Each parameter now has a concise explanation with consistent phrasing.

Renamed parameters for clarity:

filterByBikeRentalStations → filterByRentalStations

filterByNetwork → filterByNetworks

Consistent null handling: Explicitly documented that null disables filtering.

Return value description: Added a clear explanation of what the method returns.

## PR Instructions

Please read our [contribution guidelines](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/CONTRIBUTING.md) before creating a PR.

When creating a pull request, please follow the format below. For each section, *replace* the
guidance text with your own text, keeping the section heading. If you have nothing to say in a
particular section, you can completely delete the section including its heading to indicate that you
have taken the requested steps. None of these instructions or the guidance text (non-heading text)
should be present in the submitted PR. These sections serve as a checklist: when you have replaced
or deleted all of them, the PR is considered complete. As of 2021, most regular OTP contributors
participate in our twice-weekly conference calls. For all but the simplest and smallest PRs,
participation in these discussions is necessary to facilitate the review and merge process. Other
developers can ask questions and provide immediate feedback on technical design and code style, and
resolve any concerns about long term maintenance and comprehension of new code.

### Summary

Explain in one or two sentences what this PR achieves.

### Issue

Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that
describes the relevant feature or bug. You need not create an issue for small bugfixes and code
cleanups, but in that case do describe the problem clearly and completely in the "summary" section
above. In the linked issue (or summary section for smaller PRs) please describe:

- Motivation (problem or need encountered)
- How the code works
- Technical approach and any design considerations or decisions

Remember that the PR will be reviewed by another developer who may not be familiar with your use
cases or the code you're modifying. It generally takes much less effort for the author of a PR to
explain the background and technical details than for a reviewer to infer or deduce them. PRs may be
closed if they or their linked issues do not contain sufficient information for a reviewer to
proceed.

Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's
description, for example:

Closes #45

### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?
- Was any manual verification done?
- Any observations on changes to performance?
- Was the code designed so it is unit testable?
- Were any tests applied to the smallest appropriate unit?
- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

### Documentation

- Have you added documentation in code covering design and rationale behind the code?
- Were all non-trivial public classes and methods documented with Javadoc?
- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add the label `+Skip Changelog` to the PR.

### Bumping the serialization version id

If you have made changes to the way the routing graph is serialized, for example by renaming a field
in one of the edges, then you must add the label `+Bump Serialization Id` to the PR. With this label
Github Actions will increase the field `otp.serialization.version.id` in `pom.xml`.
