### PR TITLE
Throw exception when A* traversal direction is incorrect

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -88,10 +88,11 @@ public class StateEditor {
     }
 
     if (traversingBackward != parent.getRequest().arriveBy()) {
-      LOG.error(
-        "Actual traversal direction does not match traversal direction in TraverseOptions."
+      throw new IllegalStateException(
+        "Actual traversal direction does not match traversal direction in %s".formatted(
+          parent.getRequest()
+        )
       );
-      defectiveTraversal = true;
     }
   }
 
@@ -388,10 +389,6 @@ public class StateEditor {
 
   public void setTimeSeconds(long seconds) {
     this.time_ms = 1000 * seconds;
-  }
-
-  public void setTimeMilliseconds(long milliseconds) {
-    this.time_ms = milliseconds;
   }
 
   /* PUBLIC GETTER METHODS */


### PR DESCRIPTION
### Summary

This is a follow up of #7519 where I convert one more warning in the A* builder to an exception.