### PR TITLE
Fix error message for maxDirectDurationForMode validation

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/StreetModeDurationInputType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/StreetModeDurationInputType.java
@@ -103,7 +103,7 @@ public class StreetModeDurationInputType {
   ) {
     if (defaultValue.minus(value).isNegative()) {
       throw new InvalidInputException(
-        "Invalid duration for mode %s. The value %s is not greater than the default %s.".formatted(
+        "Invalid duration for mode %s. The value %s is greater than the default %s.".formatted(
           key,
           DurationUtils.durationToStr(value),
           DurationUtils.durationToStr(defaultValue)

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
@@ -215,7 +215,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
       MAPPER.createRequest(executionContext(arguments))
     );
     assertEquals(
-      "Invalid duration for mode WALK. The value 45m1s is not greater than the default 45m.",
+      "Invalid duration for mode WALK. The value 45m1s is greater than the default 45m.",
       ex.getMessage()
     );
   }
@@ -230,7 +230,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
       MAPPER.createRequest(executionContext(arguments))
     );
     assertEquals(
-      "Invalid duration for mode FLEXIBLE. The value 20m1s is not greater than the default 20m.",
+      "Invalid duration for mode FLEXIBLE. The value 20m1s is greater than the default 20m.",
       ex.getMessage()
     );
   }
@@ -248,7 +248,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
       MAPPER.createRequest(executionContext(arguments))
     );
     assertEquals(
-      "Invalid duration for mode WALK. The value 4h1s is not greater than the default 4h.",
+      "Invalid duration for mode WALK. The value 4h1s is greater than the default 4h.",
       ex.getMessage()
     );
   }
@@ -263,7 +263,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
       MAPPER.createRequest(executionContext(arguments))
     );
     assertEquals(
-      "Invalid duration for mode FLEXIBLE. The value 20m1s is not greater than the default 20m.",
+      "Invalid duration for mode FLEXIBLE. The value 20m1s is greater than the default 20m.",
       ex.getMessage()
     );
   }


### PR DESCRIPTION
### Summary
This error message had an additional "not" in it, reversing its meaning and making it wrong. This PR corrects it.

The relevant doc entry for the field says what it actually should be:
> Maximum duration for access/egress for street searches per respective mode. Cannot be higher than default value. This is a performance optimisation parameter, avoid using it to limit the search. 

### Issue
No issue

### Unit tests
Updated

### Documentation
No changes
