### PR TITLE
Align parking model naming: builder() -> of()

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingGroupsLayerTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingGroupsLayerTest.java
@@ -53,7 +53,7 @@ public class VehicleParkingGroupsLayerTest {
       )
       .withCoordinate(new WgsCoordinate(1.9, 1.1))
       .build();
-    vehicleParking = VehicleParking.builder()
+    vehicleParking = VehicleParking.of()
       .id(ID)
       .name(
         TranslatedString.getI18NString(
@@ -75,9 +75,9 @@ public class VehicleParkingGroupsLayerTest {
       .note(new NonLocalizedString("note"))
       .tags(List.of("tag1", "tag2"))
       .state(VehicleParkingState.OPERATIONAL)
-      .capacity(VehicleParkingSpaces.builder().bicycleSpaces(5).carSpaces(6).build())
+      .capacity(VehicleParkingSpaces.of().bicycleSpaces(5).carSpaces(6).build())
       .availability(
-        VehicleParkingSpaces.builder().wheelchairAccessibleCarSpaces(1).bicycleSpaces(1).build()
+        VehicleParkingSpaces.of().wheelchairAccessibleCarSpaces(1).bicycleSpaces(1).build()
       )
       .vehicleParkingGroup(vehicleParkingGroup)
       .build();

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingsLayerTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingsLayerTest.java
@@ -56,7 +56,7 @@ public class VehicleParkingsLayerTest {
       .on(LocalDate.of(2022, Month.APRIL, 1))
       .add();
 
-    vehicleParking = VehicleParking.builder()
+    vehicleParking = VehicleParking.of()
       .id(ID)
       .name(
         TranslatedString.getI18NString(Map.of("", "default name", "de", "deutscher Name"), false)
@@ -71,9 +71,9 @@ public class VehicleParkingsLayerTest {
       .tags(List.of("tag1", "tag2"))
       .openingHoursCalendar(calBuilder.build())
       .state(VehicleParkingState.OPERATIONAL)
-      .capacity(VehicleParkingSpaces.builder().bicycleSpaces(5).carSpaces(6).build())
+      .capacity(VehicleParkingSpaces.of().bicycleSpaces(5).carSpaces(6).build())
       .availability(
-        VehicleParkingSpaces.builder().wheelchairAccessibleCarSpaces(1).bicycleSpaces(1).build()
+        VehicleParkingSpaces.of().wheelchairAccessibleCarSpaces(1).bicycleSpaces(1).build()
       )
       .build();
   }

--- a/application/src/ext/java/org/opentripplanner/ext/vehicleparking/bikeep/BikeepUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehicleparking/bikeep/BikeepUpdater.java
@@ -42,12 +42,10 @@ public class BikeepUpdater extends GenericJsonDataSource<VehicleParking> {
 
       List<String> tags = STRING_LIST_READER.readValue(props.path("tags"));
 
-      var availability = VehicleParkingSpaces.builder()
+      var availability = VehicleParkingSpaces.of()
         .bicycleSpaces(parking.get("available").asInt())
         .build();
-      var capacity = VehicleParkingSpaces.builder()
-        .bicycleSpaces(parking.get("total").asInt())
-        .build();
+      var capacity = VehicleParkingSpaces.of().bicycleSpaces(parking.get("total").asInt()).build();
 
       VehicleParking.VehicleParkingEntranceCreator entrance = builder ->
         builder
@@ -56,7 +54,7 @@ public class BikeepUpdater extends GenericJsonDataSource<VehicleParking> {
           .walkAccessible(true)
           .carAccessible(true);
 
-      return VehicleParking.builder()
+      return VehicleParking.of()
         .id(vehicleParkId)
         .name(name)
         .state(VehicleParkingState.OPERATIONAL)

--- a/application/src/ext/java/org/opentripplanner/ext/vehicleparking/bikely/BikelyUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehicleparking/bikely/BikelyUpdater.java
@@ -108,12 +108,12 @@ public class BikelyUpdater implements DataSource<VehicleParking> {
           .walkAccessible(true)
           .carAccessible(false);
 
-      return VehicleParking.builder()
+      return VehicleParking.of()
         .id(vehicleParkId)
         .name(name)
         .bicyclePlaces(true)
-        .capacity(VehicleParkingSpaces.builder().bicycleSpaces(totalSpots).build())
-        .availability(VehicleParkingSpaces.builder().bicycleSpaces(freeSpots).build())
+        .capacity(VehicleParkingSpaces.of().bicycleSpaces(totalSpots).build())
+        .availability(VehicleParkingSpaces.of().bicycleSpaces(freeSpots).build())
         .state(toState(isUnderMaintenance))
         .coordinate(coord)
         .entrance(entrance)

--- a/application/src/ext/java/org/opentripplanner/ext/vehicleparking/liipi/LiipiParkToVehicleParkingMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehicleparking/liipi/LiipiParkToVehicleParkingMapper.java
@@ -109,7 +109,7 @@ public class LiipiParkToVehicleParkingMapper {
       var openingHoursCalendar = parseOpeningHours(openingHoursByDayType);
       VehicleParkingGroup vehicleParkingGroup = hubForPark.get(vehicleParkId);
 
-      return VehicleParking.builder()
+      return VehicleParking.of()
         .id(vehicleParkId)
         .name(name)
         .state(state)
@@ -158,7 +158,7 @@ public class LiipiParkToVehicleParkingMapper {
     Integer wheelchairAccessibleCarSpaces,
     Integer bicycleSpaces
   ) {
-    return VehicleParkingSpaces.builder()
+    return VehicleParkingSpaces.of()
       .bicycleSpaces(bicycleSpaces)
       .carSpaces(carSpaces)
       .wheelchairAccessibleCarSpaces(wheelchairAccessibleCarSpaces)

--- a/application/src/ext/java/org/opentripplanner/ext/vehicleparking/liipi/LiipiParkUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehicleparking/liipi/LiipiParkUpdater.java
@@ -129,7 +129,7 @@ public class LiipiParkUpdater implements DataSource<VehicleParking> {
   }
 
   private static VehicleParkingSpaces createVehicleAvailability(List<LiipiParkPatch> patches) {
-    VehicleParkingSpacesBuilder availabilityBuilder = VehicleParkingSpaces.builder();
+    VehicleParkingSpacesBuilder availabilityBuilder = VehicleParkingSpaces.of();
     boolean hasHandledSpaces = false;
 
     for (LiipiParkPatch patch : patches) {

--- a/application/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
@@ -98,7 +98,7 @@ abstract class ParkAPIUpdater extends GenericJsonDataSource<VehicleParking> {
       .map(c -> hasPlaces(capacity.getWheelchairAccessibleCarSpaces()))
       .orElse(false);
 
-    return VehicleParking.builder()
+    return VehicleParking.of()
       .id(vehicleParkId)
       .name(new NonLocalizedString(jsonNode.path("name").asText()))
       .state(state)
@@ -143,7 +143,7 @@ abstract class ParkAPIUpdater extends GenericJsonDataSource<VehicleParking> {
     Integer wheelchairAccessibleCarSpaces,
     Integer bicycleSpaces
   ) {
-    return VehicleParkingSpaces.builder()
+    return VehicleParkingSpaces.of()
       .bicycleSpaces(bicycleSpaces)
       .carSpaces(carSpaces)
       .wheelchairAccessibleCarSpaces(wheelchairAccessibleCarSpaces)

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -338,7 +338,7 @@ class ParkingProcessor {
       carCapacity.isPresent() ||
       wheelchairAccessibleCarCapacity.isPresent()
     ) {
-      vehicleParkingSpaces = VehicleParkingSpaces.builder()
+      vehicleParkingSpaces = VehicleParkingSpaces.of()
         .bicycleSpaces(bicycleCapacity.isPresent() ? bicycleCapacity.getAsInt() : null)
         .carSpaces(carCapacity.isPresent() ? carCapacity.getAsInt() : null)
         .wheelchairAccessibleCarSpaces(
@@ -379,7 +379,7 @@ class ParkingProcessor {
       tags.add("osm:surveillance");
     }
 
-    return VehicleParking.builder()
+    return VehicleParking.of()
       .id(id)
       .name(creativeName)
       .coordinate(new WgsCoordinate(coordinate))

--- a/application/src/main/java/org/opentripplanner/netex/mapping/VehicleParkingMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/VehicleParkingMapper.java
@@ -43,7 +43,7 @@ class VehicleParkingMapper {
       );
       return null;
     }
-    return VehicleParking.builder()
+    return VehicleParking.of()
       .id(idFactory.createId(parking.getId()))
       .name(NonLocalizedString.ofNullable(parking.getName().getValue()))
       .coordinate(WgsCoordinateMapper.mapToDomain(parking.getCentroid()))
@@ -80,7 +80,7 @@ class VehicleParkingMapper {
   }
 
   private static VehicleParkingSpaces mapCapacity(Parking parking) {
-    var builder = VehicleParkingSpaces.builder();
+    var builder = VehicleParkingSpaces.of();
     int capacity = parking.getTotalCapacity().intValue();
 
     // we assume that if we have something bicycle-like in the vehicle types it's a bicycle parking

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdater.java
@@ -77,7 +77,7 @@ public class VehicleParkingAvailabilityUpdater extends PollingGraphUpdater {
         );
       } else {
         var parking = parkingById.get(update.vehicleParkingId());
-        var builder = VehicleParkingSpaces.builder();
+        var builder = VehicleParkingSpaces.of();
         if (parking.hasCarPlaces()) {
           builder.carSpaces(update.spacesAvailable());
         }

--- a/application/src/test-fixtures/java/org/opentripplanner/street/model/StreetModelForTest.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/street/model/StreetModelForTest.java
@@ -142,7 +142,7 @@ public class StreetModelForTest {
   }
 
   public static VehicleParking.VehicleParkingBuilder vehicleParking() {
-    return VehicleParking.builder().id(id("vehicle-parking-1")).coordinate(WgsCoordinate.GREENWICH);
+    return VehicleParking.of().id(id("vehicle-parking-1")).coordinate(WgsCoordinate.GREENWICH);
   }
 
   static class GraphBuilder {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -198,7 +198,7 @@ class GraphQLIntegrationTest {
   static void setup() {
     PARKING_REPOSITORY.updateVehicleParking(
       List.of(
-        VehicleParking.builder()
+        VehicleParking.of()
           .id(id("parking-1"))
           .coordinate(WgsCoordinate.GREENWICH)
           .name(NonLocalizedString.ofNullable("parking"))

--- a/application/src/test/java/org/opentripplanner/netex/mapping/VehicleParkingMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/VehicleParkingMapperTest.java
@@ -42,7 +42,7 @@ class VehicleParkingMapperTest {
     var vp = mapper().map(parking(vehicleTypes));
     assertCommonProperties(vp);
     assertTrue(vp.hasAnyCarPlaces());
-    assertEquals(VehicleParkingSpaces.builder().carSpaces(10).build(), vp.getCapacity());
+    assertEquals(VehicleParkingSpaces.of().carSpaces(10).build(), vp.getCapacity());
   }
 
   public static List<Set<ParkingVehicleEnumeration>> bicycleCases() {
@@ -55,7 +55,7 @@ class VehicleParkingMapperTest {
     var vp = mapper().map(parking(vehicleTypes));
     assertCommonProperties(vp);
     assertTrue(vp.hasBicyclePlaces());
-    assertEquals(VehicleParkingSpaces.builder().bicycleSpaces(10).build(), vp.getCapacity());
+    assertEquals(VehicleParkingSpaces.of().bicycleSpaces(10).build(), vp.getCapacity());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -438,7 +438,7 @@ public abstract class GraphRoutingTest {
       List<VehicleParkingEntranceCreator> entrances,
       String... tags
     ) {
-      var vehicleParking = VehicleParking.builder()
+      var vehicleParking = VehicleParking.of()
         .id(id(id))
         .coordinate(new WgsCoordinate(y, x))
         .bicyclePlaces(bicyclePlaces)

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
@@ -48,7 +48,7 @@ class VehicleParkingAvailabilityUpdaterTest {
 
   @Test
   void updateCarAvailability() {
-    var service = buildParkingRepository(VehicleParkingSpaces.builder().carSpaces(10).build());
+    var service = buildParkingRepository(VehicleParkingSpaces.of().carSpaces(10).build());
     var updater = new VehicleParkingAvailabilityUpdater(
       PARAMETERS,
       new StubDataSource(DEFAULT_UPDATE),
@@ -65,7 +65,7 @@ class VehicleParkingAvailabilityUpdaterTest {
 
   @Test
   void updateBicycleAvailability() {
-    var service = buildParkingRepository(VehicleParkingSpaces.builder().bicycleSpaces(15).build());
+    var service = buildParkingRepository(VehicleParkingSpaces.of().bicycleSpaces(15).build());
     var updater = new VehicleParkingAvailabilityUpdater(
       PARAMETERS,
       new StubDataSource(DEFAULT_UPDATE),
@@ -82,7 +82,7 @@ class VehicleParkingAvailabilityUpdaterTest {
 
   @Test
   void notFound() {
-    var service = buildParkingRepository(VehicleParkingSpaces.builder().bicycleSpaces(15).build());
+    var service = buildParkingRepository(VehicleParkingSpaces.of().bicycleSpaces(15).build());
     var updater = new VehicleParkingAvailabilityUpdater(
       PARAMETERS,
       new StubDataSource(new AvailabiltyUpdate(id("not-found"), 100)),
@@ -109,7 +109,7 @@ class VehicleParkingAvailabilityUpdaterTest {
   }
 
   private static VehicleParking.VehicleParkingBuilder parkingBuilder() {
-    return VehicleParking.builder()
+    return VehicleParking.of()
       .id(ID)
       .name(I18NString.of("parking"))
       .coordinate(WgsCoordinate.GREENWICH);

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -98,7 +98,7 @@ class VehicleParkingUpdaterTest {
 
   @Test
   void updateVehicleParkingTest() {
-    var vehiclePlaces = VehicleParkingSpaces.builder().bicycleSpaces(1).build();
+    var vehiclePlaces = VehicleParkingSpaces.of().bicycleSpaces(1).build();
 
     var vehicleParkings = List.of(
       VehicleParkingTestUtil.createParkingWithEntrances("1", 0.0001, 0, vehiclePlaces)
@@ -117,7 +117,7 @@ class VehicleParkingUpdaterTest {
     assertEquals(vehiclePlaces, vehicleParkingInGraph.getAvailability());
     assertEquals(vehiclePlaces, vehicleParkingInGraph.getCapacity());
 
-    vehiclePlaces = VehicleParkingSpaces.builder().bicycleSpaces(2).build();
+    vehiclePlaces = VehicleParkingSpaces.of().bicycleSpaces(2).build();
     vehicleParkings = List.of(
       VehicleParkingTestUtil.createParkingWithEntrances("1", 0.0001, 0, vehiclePlaces)
     );
@@ -171,7 +171,7 @@ class VehicleParkingUpdaterTest {
 
   @Test
   void updateNotOperatingVehicleParkingTest() {
-    var vehiclePlaces = VehicleParkingSpaces.builder().bicycleSpaces(1).build();
+    var vehiclePlaces = VehicleParkingSpaces.of().bicycleSpaces(1).build();
 
     var vehicleParking = StreetModelForTest.vehicleParking()
       .availability(vehiclePlaces)
@@ -188,7 +188,7 @@ class VehicleParkingUpdaterTest {
     );
     assertVehicleParkingNotLinked();
 
-    vehiclePlaces = VehicleParkingSpaces.builder().bicycleSpaces(2).build();
+    vehiclePlaces = VehicleParkingSpaces.of().bicycleSpaces(2).build();
 
     vehicleParking = StreetModelForTest.vehicleParking()
       .availability(vehiclePlaces)

--- a/street/src/main/java/org/opentripplanner/service/vehicleparking/model/VehicleParking.java
+++ b/street/src/main/java/org/opentripplanner/service/vehicleparking/model/VehicleParking.java
@@ -142,7 +142,7 @@ public class VehicleParking implements Serializable {
     this.vehicleParkingGroup = vehicleParkingGroup;
   }
 
-  public static VehicleParkingBuilder builder() {
+  public static VehicleParkingBuilder of() {
     return new VehicleParkingBuilder();
   }
 
@@ -323,9 +323,7 @@ public class VehicleParking implements Serializable {
   }
 
   private void addEntrance(VehicleParkingEntranceCreator creator) {
-    var entrance = creator
-      .updateValues(VehicleParkingEntrance.builder().vehicleParking(this))
-      .build();
+    var entrance = creator.updateValues(VehicleParkingEntrance.of().vehicleParking(this)).build();
 
     entrances.add(entrance);
   }

--- a/street/src/main/java/org/opentripplanner/service/vehicleparking/model/VehicleParkingEntrance.java
+++ b/street/src/main/java/org/opentripplanner/service/vehicleparking/model/VehicleParkingEntrance.java
@@ -43,7 +43,7 @@ public class VehicleParkingEntrance implements Serializable {
     this.walkAccessible = walkAccessible;
   }
 
-  public static VehicleParkingEntranceBuilder builder() {
+  public static VehicleParkingEntranceBuilder of() {
     return new VehicleParkingEntranceBuilder();
   }
 

--- a/street/src/main/java/org/opentripplanner/service/vehicleparking/model/VehicleParkingSpaces.java
+++ b/street/src/main/java/org/opentripplanner/service/vehicleparking/model/VehicleParkingSpaces.java
@@ -34,7 +34,7 @@ public class VehicleParkingSpaces implements Serializable {
     this.wheelchairAccessibleCarSpaces = wheelchairAccessibleCarSpaces;
   }
 
-  public static VehicleParkingSpacesBuilder builder() {
+  public static VehicleParkingSpacesBuilder of() {
     return new VehicleParkingSpacesBuilder();
   }
 

--- a/street/src/test-fixtures/java/org/opentripplanner/street/model/StreetModelFactory.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/model/StreetModelFactory.java
@@ -135,7 +135,7 @@ public class StreetModelFactory {
   }
 
   public static VehicleParking.VehicleParkingBuilder vehicleParking() {
-    return VehicleParking.builder().id(id("vehicle-parking-1")).coordinate(WgsCoordinate.GREENWICH);
+    return VehicleParking.of().id(id("vehicle-parking-1")).coordinate(WgsCoordinate.GREENWICH);
   }
 
   public static VehicleRentalPlaceVertex rentalVertex(RentalFormFactor formFactor) {

--- a/street/src/test/java/org/opentripplanner/street/integration/GraphRoutingTest.java
+++ b/street/src/test/java/org/opentripplanner/street/integration/GraphRoutingTest.java
@@ -260,7 +260,7 @@ abstract class GraphRoutingTest {
       List<VehicleParkingEntranceCreator> entrances,
       String... tags
     ) {
-      var vehicleParking = VehicleParking.builder()
+      var vehicleParking = VehicleParking.of()
         .id(id(id))
         .coordinate(new WgsCoordinate(y, x))
         .bicyclePlaces(bicyclePlaces)

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetVehicleParkingLinkTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetVehicleParkingLinkTest.java
@@ -104,13 +104,13 @@ class StreetVehicleParkingLinkTest {
   }
 
   private static VehicleParkingEntranceVertex buildVertex(Set<String> parkingTags) {
-    var parking = VehicleParking.builder()
+    var parking = VehicleParking.of()
       .id(id("parking"))
       .coordinate(new WgsCoordinate(1, 1))
       .tags(parkingTags)
       .build();
 
-    var entrance = VehicleParkingEntrance.builder()
+    var entrance = VehicleParkingEntrance.of()
       .vehicleParking(parking)
       .entranceId(id("entrance"))
       .coordinate(new WgsCoordinate(1, 1))

--- a/street/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingEdgeTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingEdgeTest.java
@@ -46,7 +46,7 @@ class VehicleParkingEdgeTest {
       StreetMode.CAR_TO_PARK,
       false,
       true,
-      VehicleParkingSpaces.builder().carSpaces(1).build()
+      VehicleParkingSpaces.of().carSpaces(1).build()
     );
 
     var s1 = traverse();
@@ -87,7 +87,7 @@ class VehicleParkingEdgeTest {
       StreetMode.BIKE_TO_PARK,
       true,
       false,
-      VehicleParkingSpaces.builder().bicycleSpaces(1).build()
+      VehicleParkingSpaces.of().bicycleSpaces(1).build()
     );
 
     var s1 = traverse();

--- a/street/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingPreferredTagsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/VehicleParkingPreferredTagsTest.java
@@ -68,10 +68,10 @@ class VehicleParkingPreferredTagsTest {
   ) {
     var parking = StreetModelFactory.vehicleParking()
       .tags(parkingTags)
-      .availability(VehicleParkingSpaces.builder().bicycleSpaces(100).build())
+      .availability(VehicleParkingSpaces.of().bicycleSpaces(100).build())
       .bicyclePlaces(true)
       .build();
-    var entrance = VehicleParkingEntrance.builder()
+    var entrance = VehicleParkingEntrance.of()
       .name(new NonLocalizedString("bike parking"))
       .vehicleParking(parking)
       .walkAccessible(true)


### PR DESCRIPTION
### Summary

A simple change that aligns the parking model classes with the rest of the code by renaming the static builder factory models from `builder()` to `of()`.