### PR TITLE
Refactor street search builder

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
@@ -147,13 +147,7 @@ public final class CarAccessibleVertexSnapper {
       .withMode(StreetMode.WALK)
       .withArriveBy(arriveBy)
       .build();
-    // Pin the heuristic explicitly: A* expands states in order of f = g + h, where g is the
-    // actual cost from the start, h is the heuristic's estimate of the remaining cost to the
-    // goal, and f is the resulting priority used to pick the next state. The termination
-    // strategy fires per state in cost-ascending order only when expansion is by g alone —
-    // i.e. when h = 0 and so f == g. The trivial heuristic returns 0 for every state, which
-    // satisfies that. Any other heuristic would let a state with smaller g be expanded after a
-    // state with larger g but smaller h, breaking the "first match is cheapest" guarantee.
+    // We can't use a heuristic since there isn't a fixed destination.
     var builder = StreetSearchBuilder.of()
       .withRequest(request)
       .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(maxWalk))

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarAccessibleVertexSnapper.java
@@ -3,7 +3,6 @@ package org.opentripplanner.ext.carpooling.util;
 import java.time.Duration;
 import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
-import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
 import org.opentripplanner.astar.spi.SearchTerminationStrategy;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
 import org.opentripplanner.street.model.StreetMode;
@@ -157,7 +156,6 @@ public final class CarAccessibleVertexSnapper {
     // state with larger g but smaller h, breaking the "first match is cheapest" guarantee.
     var builder = StreetSearchBuilder.of()
       .withRequest(request)
-      .withHeuristic(RemainingWeightHeuristic.TRIVIAL)
       .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(maxWalk))
       .withDominanceFunction(new DominanceFunctions.MinimumWeight())
       .withTerminationStrategy(terminator);

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinder.java
@@ -190,9 +190,9 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
         StreetSearchRequestMapper.map(request)
           .withMode(streetMode)
           .withExtensionRequestContexts(extensionRequestContexts)
+          .withArriveBy(reverseDirection)
           .build()
       )
-      .withArriveBy(reverseDirection)
       .withFrom(reverseDirection ? null : originVertices)
       .withTo(reverseDirection ? originVertices : null);
 

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -42,7 +42,9 @@ public class AStar<
   @Nullable
   private final Set<Vertex> toVertices;
 
+  @Nullable
   private final RemainingWeightHeuristic<State> heuristic;
+
   private final Runnable preSearchHook;
 
   @Nullable
@@ -64,8 +66,11 @@ public class AStar<
   private State u;
   private int nVisited;
 
+  /// Create an AStar search
+  /// @param heuristic An astar heuristic that estimates a lower bound of the weight to the destination. If set to null the search will be a basic Dijkstra search.
+  /// @param arriveBy If set to true we will do a backwards search by traversing the incoming edges from each vertex.
   AStar(
-    RemainingWeightHeuristic<State> heuristic,
+    @Nullable RemainingWeightHeuristic<State> heuristic,
     Runnable preSearchHook,
     @Nullable SkipEdgeStrategy<State, Edge> skipEdgeStrategy,
     @Nullable TraverseVisitor<State, Edge> traverseVisitor,
@@ -77,7 +82,7 @@ public class AStar<
     Collection<State> initialStates,
     StatisticsCallback<Vertex> statisticsCallback
   ) {
-    this.heuristic = Objects.requireNonNull(heuristic);
+    this.heuristic = heuristic;
     this.skipEdgeStrategy = skipEdgeStrategy;
     this.traverseVisitor = traverseVisitor;
     this.fromVertices = initialStates
@@ -157,7 +162,7 @@ public class AStar<
           traverseVisitor.visitEdge(edge);
         }
 
-        double remaining_w = heuristic.estimateRemainingWeight(v);
+        double remaining_w = heuristic != null ? heuristic.estimateRemainingWeight(v) : 0;
 
         if (remaining_w < 0 || Double.isInfinite(remaining_w)) {
           continue;

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -70,7 +70,6 @@ public class AStar<
     @Nullable SkipEdgeStrategy<State, Edge> skipEdgeStrategy,
     @Nullable TraverseVisitor<State, Edge> traverseVisitor,
     boolean arriveBy,
-    Set<Vertex> fromVertices,
     @Nullable Set<Vertex> toVertices,
     @Nullable SearchTerminationStrategy<State> terminationStrategy,
     DominanceFunction<State> dominanceFunction,
@@ -81,7 +80,10 @@ public class AStar<
     this.heuristic = Objects.requireNonNull(heuristic);
     this.skipEdgeStrategy = skipEdgeStrategy;
     this.traverseVisitor = traverseVisitor;
-    this.fromVertices = fromVertices;
+    this.fromVertices = initialStates
+      .stream()
+      .map(AStarState::getVertex)
+      .collect(Collectors.toSet());
     this.toVertices = toVertices;
     this.arriveBy = arriveBy;
     this.terminationStrategy = terminationStrategy;

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -67,19 +67,25 @@ public class AStar<
   private int nVisited;
 
   /// Create an AStar search
-  /// @param heuristic An astar heuristic that estimates a lower bound of the weight to the destination. If set to null the search will be a basic Dijkstra search.
+  /// @param initialStates The initial states to start the search from.
   /// @param arriveBy If set to true we will do a backwards search by traversing the incoming edges from each vertex.
+  /// @param dominanceFunction A dominance function that determines which states we should keep during the search.
+  /// @param goalVertices The search stops once the first goal vertex is reached.
+  /// @param heuristic An astar heuristic that estimates a lower bound of the weight to the destination. If set to null the search will be a basic Dijkstra search.
+  /// @param timeout A timeout that exits the search.
+  /// @param preSearchHook A runnable that is run before the search starts.
+  /// @param statisticsCallback A pluggable callback for logging metrics.
   AStar(
-    @Nullable RemainingWeightHeuristic<State> heuristic,
-    Runnable preSearchHook,
-    @Nullable SkipEdgeStrategy<State, Edge> skipEdgeStrategy,
-    @Nullable TraverseVisitor<State, Edge> traverseVisitor,
-    boolean arriveBy,
-    @Nullable Set<Vertex> toVertices,
-    @Nullable SearchTerminationStrategy<State> terminationStrategy,
-    DominanceFunction<State> dominanceFunction,
-    Duration timeout,
     Collection<State> initialStates,
+    boolean arriveBy,
+    DominanceFunction<State> dominanceFunction,
+    @Nullable Set<Vertex> goalVertices,
+    @Nullable RemainingWeightHeuristic<State> heuristic,
+    @Nullable TraverseVisitor<State, Edge> traverseVisitor,
+    @Nullable SkipEdgeStrategy<State, Edge> skipEdgeStrategy,
+    @Nullable SearchTerminationStrategy<State> terminationStrategy,
+    Duration timeout,
+    Runnable preSearchHook,
     StatisticsCallback<Vertex> statisticsCallback
   ) {
     this.heuristic = heuristic;
@@ -89,7 +95,7 @@ public class AStar<
       .stream()
       .map(AStarState::getVertex)
       .collect(Collectors.toSet());
-    this.toVertices = toVertices;
+    this.toVertices = goalVertices;
     this.arriveBy = arriveBy;
     this.terminationStrategy = terminationStrategy;
     this.timeout = Objects.requireNonNull(timeout);

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -102,8 +102,8 @@ public class AStar<
 
     this.spt = new ShortestPathTree<>(Objects.requireNonNull(dominanceFunction));
 
-    this.statisticsCallback = statisticsCallback;
-    this.preSearchHook = preSearchHook;
+    this.preSearchHook = Objects.requireNonNull(preSearchHook);
+    this.statisticsCallback = Objects.requireNonNull(statisticsCallback);
 
     // Initialized with a reasonable size, see #4445
     this.pq = new BinHeap<>(1000);

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -37,10 +37,10 @@ public class AStar<
   private static final Logger LOG = LoggerFactory.getLogger(AStar.class);
 
   private final boolean arriveBy;
-  private final Set<Vertex> fromVertices;
+  private final Set<Vertex> initialVertices;
 
   @Nullable
-  private final Set<Vertex> toVertices;
+  private final Set<Vertex> goalVertices;
 
   @Nullable
   private final RemainingWeightHeuristic<State> heuristic;
@@ -91,11 +91,11 @@ public class AStar<
     this.heuristic = heuristic;
     this.skipEdgeStrategy = skipEdgeStrategy;
     this.traverseVisitor = traverseVisitor;
-    this.fromVertices = initialStates
+    this.initialVertices = initialStates
       .stream()
       .map(AStarState::getVertex)
       .collect(Collectors.toSet());
-    this.toVertices = goalVertices;
+    this.goalVertices = goalVertices;
     this.arriveBy = arriveBy;
     this.terminationStrategy = terminationStrategy;
     this.timeout = Objects.requireNonNull(timeout);
@@ -203,7 +203,7 @@ public class AStar<
        * expensive to fetch the current time, compared to just running one more round.
        */
       if (nVisited % 128 == 0 && System.currentTimeMillis() > abortTime) {
-        LOG.warn("Search timeout. origin={} target={}", fromVertices, toVertices);
+        LOG.warn("Search timeout. origin={} target={}", initialVertices, goalVertices);
         break;
       }
 
@@ -225,7 +225,7 @@ public class AStar<
           break;
         }
       }
-      if (toVertices != null && toVertices.contains(u.getVertex()) && u.isFinal()) {
+      if (goalVertices != null && goalVertices.contains(u.getVertex()) && u.isFinal()) {
         targetAcceptedStates.add(u);
 
         // Break out of the search if we've found the requested number of paths.
@@ -234,6 +234,6 @@ public class AStar<
       }
     }
 
-    statisticsCallback.searchFinished(fromVertices, toVertices, nVisited);
+    statisticsCallback.searchFinished(initialVertices, goalVertices, nVisited);
   }
 }

--- a/astar/src/main/java/org/opentripplanner/astar/AStar.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStar.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.BinHeap;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
@@ -37,12 +38,22 @@ public class AStar<
 
   private final boolean arriveBy;
   private final Set<Vertex> fromVertices;
+
+  @Nullable
   private final Set<Vertex> toVertices;
+
   private final RemainingWeightHeuristic<State> heuristic;
   private final Runnable preSearchHook;
+
+  @Nullable
   private final SkipEdgeStrategy<State, Edge> skipEdgeStrategy;
+
+  @Nullable
   private final SearchTerminationStrategy<State> terminationStrategy;
+
+  @Nullable
   private final TraverseVisitor<State, Edge> traverseVisitor;
+
   private final StatisticsCallback<Vertex> statisticsCallback;
   private final Duration timeout;
 
@@ -56,18 +67,18 @@ public class AStar<
   AStar(
     RemainingWeightHeuristic<State> heuristic,
     Runnable preSearchHook,
-    SkipEdgeStrategy<State, Edge> skipEdgeStrategy,
-    TraverseVisitor<State, Edge> traverseVisitor,
+    @Nullable SkipEdgeStrategy<State, Edge> skipEdgeStrategy,
+    @Nullable TraverseVisitor<State, Edge> traverseVisitor,
     boolean arriveBy,
     Set<Vertex> fromVertices,
-    Set<Vertex> toVertices,
-    SearchTerminationStrategy<State> terminationStrategy,
+    @Nullable Set<Vertex> toVertices,
+    @Nullable SearchTerminationStrategy<State> terminationStrategy,
     DominanceFunction<State> dominanceFunction,
     Duration timeout,
     Collection<State> initialStates,
     StatisticsCallback<Vertex> statisticsCallback
   ) {
-    this.heuristic = heuristic;
+    this.heuristic = Objects.requireNonNull(heuristic);
     this.skipEdgeStrategy = skipEdgeStrategy;
     this.traverseVisitor = traverseVisitor;
     this.fromVertices = fromVertices;
@@ -76,7 +87,7 @@ public class AStar<
     this.terminationStrategy = terminationStrategy;
     this.timeout = Objects.requireNonNull(timeout);
 
-    this.spt = new ShortestPathTree<>(dominanceFunction);
+    this.spt = new ShortestPathTree<>(Objects.requireNonNull(dominanceFunction));
 
     this.statisticsCallback = statisticsCallback;
     this.preSearchHook = preSearchHook;
@@ -178,7 +189,7 @@ public class AStar<
        * Terminate based on timeout. We don't check the termination on every round, as it is
        * expensive to fetch the current time, compared to just running one more round.
        */
-      if (timeout != null && nVisited % 100 == 0 && System.currentTimeMillis() > abortTime) {
+      if (nVisited % 128 == 0 && System.currentTimeMillis() > abortTime) {
         LOG.warn("Search timeout. origin={} target={}", fromVertices, toVertices);
         break;
       }

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -29,7 +29,6 @@ public class AStarBuilder<
   private SkipEdgeStrategy<State, Edge> skipEdgeStrategy;
   private TraverseVisitor<State, Edge> traverseVisitor;
   private boolean arriveBy;
-  private Set<Vertex> origin;
   private Set<Vertex> destination;
   private SearchTerminationStrategy<State> terminationStrategy;
   private DominanceFunction<State> dominanceFunction;
@@ -85,11 +84,6 @@ public class AStarBuilder<
     return arriveBy;
   }
 
-  public AStarBuilder<State, Edge, Vertex> withOrigin(Set<Vertex> originVertices) {
-    this.origin = originVertices;
-    return this;
-  }
-
   public AStarBuilder<State, Edge, Vertex> withDestination(Set<Vertex> destinationVertices) {
     this.destination = destinationVertices;
     return this;
@@ -127,7 +121,6 @@ public class AStarBuilder<
       skipEdgeStrategy,
       traverseVisitor,
       arriveBy,
-      origin,
       destination,
       terminationStrategy,
       dominanceFunction,

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -29,7 +29,7 @@ public class AStarBuilder<
   private SkipEdgeStrategy<State, Edge> skipEdgeStrategy;
   private TraverseVisitor<State, Edge> traverseVisitor;
   private boolean arriveBy;
-  private Set<Vertex> destination;
+  private Set<Vertex> goalVertices;
   private SearchTerminationStrategy<State> terminationStrategy;
   private DominanceFunction<State> dominanceFunction;
   private StatisticsCallback<Vertex> statisticsCallback = StatisticsCallback.NOOP;
@@ -84,8 +84,8 @@ public class AStarBuilder<
     return arriveBy;
   }
 
-  public AStarBuilder<State, Edge, Vertex> withDestination(Set<Vertex> destinationVertices) {
-    this.destination = destinationVertices;
+  public AStarBuilder<State, Edge, Vertex> withGoalVertices(Set<Vertex> goalVertices) {
+    this.goalVertices = goalVertices;
     return this;
   }
 
@@ -119,7 +119,7 @@ public class AStarBuilder<
       initialStates,
       arriveBy,
       dominanceFunction,
-      destination,
+      goalVertices,
       heuristic,
       traverseVisitor,
       skipEdgeStrategy,

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -25,7 +25,7 @@ public class AStarBuilder<
 
   private Runnable preStartHook = () ->
     LOG.warn("No pre-start hook provided. Call withPreStartHook() to set one.");
-  private RemainingWeightHeuristic<State> heuristic = RemainingWeightHeuristic.TRIVIAL;
+  private RemainingWeightHeuristic<State> heuristic;
   private SkipEdgeStrategy<State, Edge> skipEdgeStrategy;
   private TraverseVisitor<State, Edge> traverseVisitor;
   private boolean arriveBy;

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -80,10 +80,6 @@ public class AStarBuilder<
     return this;
   }
 
-  protected boolean arriveBy() {
-    return arriveBy;
-  }
-
   public AStarBuilder<State, Edge, Vertex> withGoalVertices(Set<Vertex> goalVertices) {
     this.goalVertices = goalVertices;
     return this;

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -116,16 +116,16 @@ public class AStarBuilder<
 
   public AStar<State, Edge, Vertex> build() {
     return new AStar<>(
-      heuristic,
-      preStartHook,
-      skipEdgeStrategy,
-      traverseVisitor,
-      arriveBy,
-      destination,
-      terminationStrategy,
-      dominanceFunction,
-      timeout,
       initialStates,
+      arriveBy,
+      dominanceFunction,
+      destination,
+      heuristic,
+      traverseVisitor,
+      skipEdgeStrategy,
+      terminationStrategy,
+      timeout,
+      preStartHook,
       statisticsCallback
     );
   }

--- a/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
+++ b/astar/src/main/java/org/opentripplanner/astar/AStarBuilder.java
@@ -2,8 +2,6 @@ package org.opentripplanner.astar;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
 import java.util.Set;
 import org.opentripplanner.astar.spi.AStarEdge;
 import org.opentripplanner.astar.spi.AStarState;
@@ -17,113 +15,112 @@ import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class AStarBuilder<
+public class AStarBuilder<
   State extends AStarState<State, Edge, Vertex>,
   Edge extends AStarEdge<State, Edge, Vertex>,
-  Vertex extends AStarVertex<State, Edge, Vertex>,
-  Builder extends AStarBuilder<State, Edge, Vertex, Builder>
+  Vertex extends AStarVertex<State, Edge, Vertex>
 > {
 
   Logger LOG = LoggerFactory.getLogger(AStarBuilder.class);
 
-  private Builder builder;
   private Runnable preStartHook = () ->
     LOG.warn("No pre-start hook provided. Call withPreStartHook() to set one.");
   private RemainingWeightHeuristic<State> heuristic = RemainingWeightHeuristic.TRIVIAL;
   private SkipEdgeStrategy<State, Edge> skipEdgeStrategy;
   private TraverseVisitor<State, Edge> traverseVisitor;
   private boolean arriveBy;
-  private Set<Vertex> fromVertices;
-  private Set<Vertex> toVertices;
+  private Set<Vertex> origin;
+  private Set<Vertex> destination;
   private SearchTerminationStrategy<State> terminationStrategy;
   private DominanceFunction<State> dominanceFunction;
   private StatisticsCallback<Vertex> statisticsCallback = StatisticsCallback.NOOP;
+  private Duration timeout;
+  private Collection<State> initialStates;
 
-  protected AStarBuilder() {}
+  public AStarBuilder() {}
 
-  protected void setBuilder(Builder builder) {
-    this.builder = builder;
-  }
-
-  public Builder withHeuristic(RemainingWeightHeuristic<State> heuristic) {
+  public AStarBuilder<State, Edge, Vertex> withHeuristic(
+    RemainingWeightHeuristic<State> heuristic
+  ) {
     this.heuristic = heuristic;
-    return builder;
+    return this;
   }
 
   /**
    * Set a function that will be called before the search begins. Useful for checking that
    * a timeout has not been reached before the search begins.
    */
-  public Builder withPreStartHook(Runnable hook) {
+  public AStarBuilder<State, Edge, Vertex> withPreStartHook(Runnable hook) {
     this.preStartHook = hook;
-    return builder;
+    return this;
   }
 
-  public Builder withSkipEdgeStrategy(SkipEdgeStrategy<State, Edge> skipEdgeStrategy) {
+  public AStarBuilder<State, Edge, Vertex> withSkipEdgeStrategy(
+    SkipEdgeStrategy<State, Edge> skipEdgeStrategy
+  ) {
     this.skipEdgeStrategy = skipEdgeStrategy;
-    return builder;
+    return this;
   }
 
-  public Builder withTraverseVisitor(TraverseVisitor<State, Edge> traverseVisitor) {
+  public AStarBuilder<State, Edge, Vertex> withTraverseVisitor(
+    TraverseVisitor<State, Edge> traverseVisitor
+  ) {
     this.traverseVisitor = traverseVisitor;
-    return builder;
+    return this;
   }
 
-  public Builder withStatisticsCallback(StatisticsCallback<Vertex> statisticsCallback) {
+  public AStarBuilder<State, Edge, Vertex> withStatisticsCallback(
+    StatisticsCallback<Vertex> statisticsCallback
+  ) {
     this.statisticsCallback = statisticsCallback;
-    return builder;
+    return this;
   }
 
-  public Builder withArriveBy(boolean arriveBy) {
+  public AStarBuilder<State, Edge, Vertex> withArriveBy(boolean arriveBy) {
     this.arriveBy = arriveBy;
-    return builder;
+    return this;
   }
 
   protected boolean arriveBy() {
     return arriveBy;
   }
 
-  public Builder withFrom(Set<Vertex> fromVertices) {
-    this.fromVertices = fromVertices;
-    return builder;
+  public AStarBuilder<State, Edge, Vertex> withOrigin(Set<Vertex> originVertices) {
+    this.origin = originVertices;
+    return this;
   }
 
-  public Builder withFrom(Vertex fromVertex) {
-    this.fromVertices = Collections.singleton(fromVertex);
-    return builder;
+  public AStarBuilder<State, Edge, Vertex> withDestination(Set<Vertex> destinationVertices) {
+    this.destination = destinationVertices;
+    return this;
   }
 
-  public Builder withTo(Set<Vertex> toVertices) {
-    this.toVertices = toVertices;
-    return builder;
-  }
-
-  public Builder withTo(Vertex toVertex) {
-    this.toVertices = Collections.singleton(toVertex);
-    return builder;
-  }
-
-  public Builder withTerminationStrategy(SearchTerminationStrategy<State> terminationStrategy) {
+  public AStarBuilder<State, Edge, Vertex> withTerminationStrategy(
+    SearchTerminationStrategy<State> terminationStrategy
+  ) {
     this.terminationStrategy = terminationStrategy;
-    return builder;
+    return this;
   }
 
   /** The function that compares paths converging on the same vertex to decide which ones continue to be explored. */
-  public Builder withDominanceFunction(DominanceFunction<State> dominanceFunction) {
+  public AStarBuilder<State, Edge, Vertex> withDominanceFunction(
+    DominanceFunction<State> dominanceFunction
+  ) {
     this.dominanceFunction = dominanceFunction;
-    return builder;
+    return this;
   }
 
-  protected abstract Duration streetRoutingTimeout();
+  public AStarBuilder<State, Edge, Vertex> withTimeout(Duration timeout) {
+    this.timeout = timeout;
+    return this;
+  }
 
-  protected AStar<State, Edge, Vertex> build() {
-    final Set<Vertex> origin = arriveBy ? toVertices : fromVertices;
-    final Set<Vertex> destination = arriveBy ? fromVertices : toVertices;
+  public AStarBuilder<State, Edge, Vertex> withInitialStates(Collection<State> initialStates) {
+    this.initialStates = initialStates;
+    return this;
+  }
 
-    Collection<State> initialStates = createInitialStates(origin);
-
-    initializeHeuristic(heuristic, origin, destination, arriveBy);
-
+  public AStar<State, Edge, Vertex> build() {
     return new AStar<>(
       heuristic,
       preStartHook,
@@ -133,21 +130,10 @@ public abstract class AStarBuilder<
       origin,
       destination,
       terminationStrategy,
-      Optional.ofNullable(dominanceFunction).orElseGet(this::createDefaultDominanceFunction),
-      streetRoutingTimeout(),
+      dominanceFunction,
+      timeout,
       initialStates,
       statisticsCallback
     );
   }
-
-  protected abstract Collection<State> createInitialStates(Set<Vertex> originVertices);
-
-  protected abstract void initializeHeuristic(
-    RemainingWeightHeuristic<State> heuristic,
-    Set<Vertex> origin,
-    Set<Vertex> destination,
-    boolean arriveBy
-  );
-
-  protected abstract DominanceFunction<State> createDefaultDominanceFunction();
 }

--- a/astar/src/main/java/org/opentripplanner/astar/spi/RemainingWeightHeuristic.java
+++ b/astar/src/main/java/org/opentripplanner/astar/spi/RemainingWeightHeuristic.java
@@ -5,12 +5,5 @@ package org.opentripplanner.astar.spi;
  * path to the target, starting from a given state.
  */
 public interface RemainingWeightHeuristic<State extends AStarState<State, ?, ?>> {
-  /**
-   * A trivial heuristic that always returns 0, which is always admissible. For use in testing,
-   * troubleshooting, and spatial analysis applications where there is no target.
-   */
-  @SuppressWarnings("rawtypes")
-  RemainingWeightHeuristic TRIVIAL = s -> 0;
-
   double estimateRemainingWeight(State s);
 }

--- a/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
+++ b/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
@@ -11,7 +11,7 @@ public class TestAStarBuilder {
     TestVertex destination
   ) {
     return new AStarBuilder<TestState, TestEdge, TestVertex>()
-      .withDestination(Set.of(destination))
+      .withGoalVertices(Set.of(destination))
       .withTimeout(Duration.ofMinutes(5))
       .withDominanceFunction((a, b) -> a.getWeight() <= b.getWeight())
       .withInitialStates(List.of(createInitialState(origin)));

--- a/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
+++ b/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 public class TestAStarBuilder {
 
-  public static AStarBuilder<TestState, TestEdge, TestVertex> of(
+  public static AStarBuilder<TestState, TestEdge, TestVertex> ofDefault(
     TestVertex origin,
     TestVertex destination
   ) {

--- a/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
+++ b/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
@@ -1,54 +1,24 @@
 package org.opentripplanner.astar;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import org.opentripplanner.astar.model.GraphPath;
-import org.opentripplanner.astar.model.ShortestPathTree;
-import org.opentripplanner.astar.spi.DominanceFunction;
-import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
 
-public class TestAStarBuilder
-  extends AStarBuilder<TestState, TestEdge, TestVertex, TestAStarBuilder> {
+public class TestAStarBuilder {
 
-  TestAStarBuilder() {
-    super();
-    setBuilder(this);
-    super.withDominanceFunction((a, b) -> a.getWeight() <= b.getWeight());
+  public static AStarBuilder<TestState, TestEdge, TestVertex> of(
+    TestVertex origin,
+    TestVertex destination
+  ) {
+    return new AStarBuilder<TestState, TestEdge, TestVertex>()
+      .withOrigin(Set.of(origin))
+      .withDestination(Set.of(destination))
+      .withTimeout(Duration.ofMinutes(5))
+      .withDominanceFunction((a, b) -> a.getWeight() <= b.getWeight())
+      .withInitialStates(List.of(createInitialState(origin)));
   }
 
-  @Override
-  protected Duration streetRoutingTimeout() {
-    return Duration.ofMinutes(1);
-  }
-
-  @Override
-  protected Collection<TestState> createInitialStates(Set<TestVertex> originVertices) {
-    return originVertices
-      .stream()
-      .map(v -> new TestState(v, 0))
-      .toList();
-  }
-
-  @Override
-  protected void initializeHeuristic(
-    RemainingWeightHeuristic heuristic,
-    Set origin,
-    Set destination,
-    boolean arriveBy
-  ) {}
-
-  @Override
-  protected DominanceFunction createDefaultDominanceFunction() {
-    return null;
-  }
-
-  public ShortestPathTree<TestState, TestEdge, TestVertex> getShortestPathTree() {
-    return build().getShortestPathTree();
-  }
-
-  public List<GraphPath<TestState, TestEdge, TestVertex>> getPathsToTarget() {
-    return build().getPathsToTarget();
+  private static TestState createInitialState(TestVertex vertex) {
+    return new TestState(vertex, 0);
   }
 }

--- a/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
+++ b/astar/src/test-fixtures/java/org/opentripplanner/astar/TestAStarBuilder.java
@@ -11,7 +11,6 @@ public class TestAStarBuilder {
     TestVertex destination
   ) {
     return new AStarBuilder<TestState, TestEdge, TestVertex>()
-      .withOrigin(Set.of(origin))
       .withDestination(Set.of(destination))
       .withTimeout(Duration.ofMinutes(5))
       .withDominanceFunction((a, b) -> a.getWeight() <= b.getWeight())

--- a/astar/src/test/java/org/opentripplanner/astar/AStarTest.java
+++ b/astar/src/test/java/org/opentripplanner/astar/AStarTest.java
@@ -15,7 +15,7 @@ class AStarTest {
     edges(vA, vB, 10);
     edges(vB, vC, 10);
 
-    var tree = new TestAStarBuilder().withFrom(vA).withTo(vC).getShortestPathTree();
+    var tree = TestAStarBuilder.of(vA, vC).build().getShortestPathTree();
 
     var path = tree.getPath(vC);
 
@@ -38,7 +38,7 @@ class AStarTest {
     edges(vB1, vC, 11);
     edges(vB2, vC, 11);
 
-    var tree = new TestAStarBuilder().withFrom(vA).withTo(vC).getShortestPathTree();
+    var tree = TestAStarBuilder.of(vA, vC).build().getShortestPathTree();
 
     var path = tree.getPath(vC);
 
@@ -63,7 +63,7 @@ class AStarTest {
     edges(vB2, vC, 5);
     edges(vC, to, 5);
 
-    var tree = new TestAStarBuilder().withFrom(from).withTo(to).getShortestPathTree();
+    var tree = TestAStarBuilder.of(from, to).build().getShortestPathTree();
 
     var path = tree.getPath(to);
 

--- a/astar/src/test/java/org/opentripplanner/astar/AStarTest.java
+++ b/astar/src/test/java/org/opentripplanner/astar/AStarTest.java
@@ -15,7 +15,7 @@ class AStarTest {
     edges(vA, vB, 10);
     edges(vB, vC, 10);
 
-    var tree = TestAStarBuilder.of(vA, vC).build().getShortestPathTree();
+    var tree = TestAStarBuilder.ofDefault(vA, vC).build().getShortestPathTree();
 
     var path = tree.getPath(vC);
 
@@ -38,7 +38,7 @@ class AStarTest {
     edges(vB1, vC, 11);
     edges(vB2, vC, 11);
 
-    var tree = TestAStarBuilder.of(vA, vC).build().getShortestPathTree();
+    var tree = TestAStarBuilder.ofDefault(vA, vC).build().getShortestPathTree();
 
     var path = tree.getPath(vC);
 
@@ -63,7 +63,7 @@ class AStarTest {
     edges(vB2, vC, 5);
     edges(vC, to, 5);
 
-    var tree = TestAStarBuilder.of(from, to).build().getShortestPathTree();
+    var tree = TestAStarBuilder.ofDefault(from, to).build().getShortestPathTree();
 
     var path = tree.getPath(to);
 

--- a/street/src/main/java/org/opentripplanner/street/search/EuclideanRemainingWeightHeuristic.java
+++ b/street/src/main/java/org/opentripplanner/street/search/EuclideanRemainingWeightHeuristic.java
@@ -35,11 +35,11 @@ public class EuclideanRemainingWeightHeuristic implements RemainingWeightHeurist
 
   // TODO This currently only uses the first toVertex. If there are multiple toVertices, it will
   //      not work correctly.
-  public void initialize(Set<Vertex> toVertices, boolean arriveBy, StreetSearchRequest req) {
+  public void initialize(Set<Vertex> toVertices, StreetSearchRequest req) {
     Vertex target = toVertices.iterator().next();
     maxStreetSpeed = getStreetSpeedUpperBound(req);
     walkingSpeed = req.walk().speed();
-    this.arriveBy = arriveBy;
+    this.arriveBy = req.arriveBy();
 
     if (target.getDegreeIn() == 1) {
       Edge edge = target.getIncoming().iterator().next();

--- a/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.opentripplanner.astar.AStar;
 import org.opentripplanner.astar.AStarBuilder;
 import org.opentripplanner.astar.model.ShortestPathTree;
@@ -26,7 +27,7 @@ public class StreetSearchBuilder {
   private StreetSearchRequest request;
   private Set<Vertex> fromVertices;
   private Set<Vertex> toVertices;
-  private RemainingWeightHeuristic<State> heuristic = RemainingWeightHeuristic.TRIVIAL;
+  private RemainingWeightHeuristic<State> heuristic;
 
   public static StreetSearchBuilder of() {
     return new StreetSearchBuilder();
@@ -123,12 +124,10 @@ public class StreetSearchBuilder {
 
   private AStar<State, Edge, Vertex> buildAstar() {
     Objects.requireNonNull(request);
-    Objects.requireNonNull(heuristic);
     var arriveBy = request.arriveBy();
     var originVertices = arriveBy ? toVertices : fromVertices;
     var destinationVertices = arriveBy ? fromVertices : toVertices;
     var initialStates = State.getInitialStates(originVertices, request);
-
     var heuristic = initializedHeuristic(destinationVertices);
 
     return aStarBuilder
@@ -138,12 +137,11 @@ public class StreetSearchBuilder {
       .build();
   }
 
+  @Nullable
   private RemainingWeightHeuristic<State> initializedHeuristic(Set<Vertex> destination) {
-    if (heuristic.equals(RemainingWeightHeuristic.TRIVIAL)) {
-      // No initialization needed
-    } else if (heuristic instanceof EuclideanRemainingWeightHeuristic euclideanHeuristic) {
+    if (heuristic instanceof EuclideanRemainingWeightHeuristic euclideanHeuristic) {
       euclideanHeuristic.initialize(destination, request);
-    } else {
+    } else if (heuristic != null) {
       throw new IllegalArgumentException("Unknown heuristic type: " + heuristic);
     }
     return heuristic;

--- a/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
@@ -126,21 +126,21 @@ public class StreetSearchBuilder {
     Objects.requireNonNull(request);
     var arriveBy = request.arriveBy();
     var originVertices = arriveBy ? toVertices : fromVertices;
-    var destinationVertices = arriveBy ? fromVertices : toVertices;
+    var goalVertices = arriveBy ? fromVertices : toVertices;
     var initialStates = State.getInitialStates(originVertices, request);
-    var heuristic = initializedHeuristic(destinationVertices);
+    var heuristic = initializedHeuristic(goalVertices);
 
     return aStarBuilder
-      .withDestination(destinationVertices)
+      .withGoalVertices(goalVertices)
       .withInitialStates(initialStates)
       .withHeuristic(heuristic)
       .build();
   }
 
   @Nullable
-  private RemainingWeightHeuristic<State> initializedHeuristic(Set<Vertex> destination) {
+  private RemainingWeightHeuristic<State> initializedHeuristic(Set<Vertex> goalVertices) {
     if (heuristic instanceof EuclideanRemainingWeightHeuristic euclideanHeuristic) {
-      euclideanHeuristic.initialize(destination, request);
+      euclideanHeuristic.initialize(goalVertices, request);
     } else if (heuristic != null) {
       throw new IllegalArgumentException("Unknown heuristic type: " + heuristic);
     }

--- a/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
@@ -132,7 +132,6 @@ public class StreetSearchBuilder {
     var heuristic = initializedHeuristic(destinationVertices);
 
     return aStarBuilder
-      .withOrigin(originVertices)
       .withDestination(destinationVertices)
       .withInitialStates(initialStates)
       .withHeuristic(heuristic)

--- a/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/search/StreetSearchBuilder.java
@@ -1,13 +1,17 @@
 package org.opentripplanner.street.search;
 
-import java.time.Duration;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import org.opentripplanner.astar.AStar;
 import org.opentripplanner.astar.AStarBuilder;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.spi.DominanceFunction;
 import org.opentripplanner.astar.spi.RemainingWeightHeuristic;
+import org.opentripplanner.astar.spi.SearchTerminationStrategy;
+import org.opentripplanner.astar.spi.SkipEdgeStrategy;
+import org.opentripplanner.astar.spi.TraverseVisitor;
 import org.opentripplanner.astar.strategy.PathComparator;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.path.StreetPath;
@@ -16,77 +20,133 @@ import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.strategy.DominanceFunctions;
 
-public class StreetSearchBuilder extends AStarBuilder<State, Edge, Vertex, StreetSearchBuilder> {
+public class StreetSearchBuilder {
 
+  private final AStarBuilder<State, Edge, Vertex> aStarBuilder;
   private StreetSearchRequest request;
+  private Set<Vertex> fromVertices;
+  private Set<Vertex> toVertices;
+  private RemainingWeightHeuristic<State> heuristic = RemainingWeightHeuristic.TRIVIAL;
 
   public static StreetSearchBuilder of() {
     return new StreetSearchBuilder();
   }
 
   private StreetSearchBuilder() {
-    super();
-    setBuilder(this);
+    aStarBuilder = new AStarBuilder<State, Edge, Vertex>().withDominanceFunction(
+      new DominanceFunctions.Pareto()
+    );
   }
 
   public StreetSearchBuilder withRequest(StreetSearchRequest request) {
     this.request = request;
-    withArriveBy(request.arriveBy());
+    aStarBuilder.withTimeout(request.timeout());
+    aStarBuilder.withArriveBy(request.arriveBy());
     return this;
   }
 
-  @Override
-  protected Duration streetRoutingTimeout() {
-    return request.timeout();
+  public StreetSearchBuilder withFrom(Set<Vertex> fromVertices) {
+    this.fromVertices = fromVertices;
+    return this;
   }
 
-  @Override
-  protected Collection<State> createInitialStates(Set<Vertex> originVertices) {
-    StreetSearchRequest streetSearchRequest = StreetSearchRequest.copyOf(request)
-      .withArriveBy(arriveBy())
-      .build();
-
-    return State.getInitialStates(originVertices, streetSearchRequest);
+  public StreetSearchBuilder withFrom(Vertex fromVertex) {
+    fromVertices = Collections.singleton(fromVertex);
+    return this;
   }
 
-  @Override
-  protected void initializeHeuristic(
-    RemainingWeightHeuristic<State> heuristic,
-    Set<Vertex> ignored,
-    Set<Vertex> destination,
-    boolean arriveBy
+  public StreetSearchBuilder withTo(Set<Vertex> toVertices) {
+    this.toVertices = toVertices;
+    return this;
+  }
+
+  public StreetSearchBuilder withTo(Vertex toVertex) {
+    toVertices = Collections.singleton(toVertex);
+    return this;
+  }
+
+  public StreetSearchBuilder withHeuristic(RemainingWeightHeuristic<State> heuristic) {
+    this.heuristic = heuristic;
+    return this;
+  }
+
+  public StreetSearchBuilder withDominanceFunction(DominanceFunction<State> dominanceFunction) {
+    aStarBuilder.withDominanceFunction(dominanceFunction);
+    return this;
+  }
+
+  public StreetSearchBuilder withSkipEdgeStrategy(SkipEdgeStrategy<State, Edge> skipEdgeStrategy) {
+    aStarBuilder.withSkipEdgeStrategy(skipEdgeStrategy);
+    return this;
+  }
+
+  public StreetSearchBuilder withTraverseVisitor(TraverseVisitor<State, Edge> traverseVisitor) {
+    aStarBuilder.withTraverseVisitor(traverseVisitor);
+    return this;
+  }
+
+  public StreetSearchBuilder withTerminationStrategy(
+    SearchTerminationStrategy<State> terminationStrategy
   ) {
-    if (heuristic.equals(RemainingWeightHeuristic.TRIVIAL)) {
-      // No initialization needed
-    } else if (heuristic instanceof EuclideanRemainingWeightHeuristic euclideanHeuristic) {
-      euclideanHeuristic.initialize(destination, arriveBy, request);
-    } else {
-      throw new IllegalArgumentException("Unknown heuristic type: " + heuristic);
-    }
+    aStarBuilder.withTerminationStrategy(terminationStrategy);
+    return this;
   }
 
-  @Override
-  protected DominanceFunction<State> createDefaultDominanceFunction() {
-    return new DominanceFunctions.Pareto();
+  /**
+   * Set a function that will be called before the search begins. Useful for checking that
+   * a timeout has not been reached before the search begins.
+   */
+  public StreetSearchBuilder withPreStartHook(Runnable hook) {
+    aStarBuilder.withPreStartHook(hook);
+    return this;
   }
 
   /// Run the street search, returning nothing
   public void run() {
-    build().getShortestPathTree();
+    buildAstar().getShortestPathTree();
   }
 
   /// Run the search returning the shortestPathTree
   public ShortestPathTree<State, Edge, Vertex> getShortestPathTree() {
-    return build().getShortestPathTree();
+    return buildAstar().getShortestPathTree();
   }
 
   /// Run the street search, returning all paths found
   public List<StreetPath> getPathsToTarget() {
-    return build()
+    return buildAstar()
       .getPathsToTarget()
       .stream()
-      .sorted(new PathComparator(arriveBy()))
+      .sorted(new PathComparator(request.arriveBy()))
       .map(StreetPath::new)
       .toList();
+  }
+
+  private AStar<State, Edge, Vertex> buildAstar() {
+    Objects.requireNonNull(request);
+    Objects.requireNonNull(heuristic);
+    var arriveBy = request.arriveBy();
+    var originVertices = arriveBy ? toVertices : fromVertices;
+    var destinationVertices = arriveBy ? fromVertices : toVertices;
+    var initialStates = State.getInitialStates(originVertices, request);
+
+    var heuristic = initializedHeuristic(destinationVertices);
+
+    return aStarBuilder
+      .withOrigin(originVertices)
+      .withDestination(destinationVertices)
+      .withInitialStates(initialStates)
+      .withHeuristic(heuristic)
+      .build();
+  }
+
+  private RemainingWeightHeuristic<State> initializedHeuristic(Set<Vertex> destination) {
+    if (heuristic.equals(RemainingWeightHeuristic.TRIVIAL)) {
+      // No initialization needed
+    } else if (heuristic instanceof EuclideanRemainingWeightHeuristic euclideanHeuristic) {
+      euclideanHeuristic.initialize(destination, request);
+    } else {
+      throw new IllegalArgumentException("Unknown heuristic type: " + heuristic);
+    }
+    return heuristic;
   }
 }


### PR DESCRIPTION
### Summary

This is a pure refactor of the StreetSearchBuilder/AStarBuilder in order to make them less coupled. 

- Use composition instead of inheritance.
- The arriveBy flag could be set either in the StreetSearchRequest or in the StreetSearchBuilder, this was confusing. Now we use the arriveBy value from the request and use that as the single source of truth.
- Mark optional stuff as nullable.
- Add some documentation.

### Documentation
 
I added some documentation to the astar constructor.

### Changelog

Skip

### Bumping the serialization version id

No
