### PR TITLE
Disallow defective traversal in A* StateEditor

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -32,8 +32,6 @@ public class StateEditor {
   private long time_ms;
   private double traversalDistance_m;
 
-  private boolean defectiveTraversal = false;
-
   private boolean traversingBackward;
 
   /* CONSTRUCTORS */
@@ -108,12 +106,6 @@ public class StateEditor {
    */
   @Nullable
   public State makeState() {
-    // if something was flagged incorrect, do not make a new state
-    if (defectiveTraversal) {
-      LOG.error("Defective traversal flagged on edge " + backEdge);
-      return null;
-    }
-
     if (backState != null) {
       // check that time changes are coherent with edge traversal
       // direction
@@ -173,11 +165,9 @@ public class StateEditor {
    */
   public void incrementTimeInMilliseconds(long milliseconds) {
     if (milliseconds < 0) {
-      LOG.warn(
+      throw new IllegalArgumentException(
         "A state's time is being incremented by a negative amount while traversing edge " + backEdge
       );
-      defectiveTraversal = true;
-      return;
     }
     this.time_ms += (traversingBackward ? -milliseconds : milliseconds);
   }

--- a/street/src/test/java/org/opentripplanner/street/search/state/StateEditorTest.java
+++ b/street/src/test/java/org/opentripplanner/street/search/state/StateEditorTest.java
@@ -16,12 +16,12 @@ import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 
-public class StateEditorTest {
+class StateEditorTest {
 
   static Vertex vertex = StreetModelFactory.intersectionVertex(1, 1);
 
   @Test
-  public final void testIncrementTimeInMilliseconds() {
+  void testIncrementTimeInMilliseconds() {
     StateEditor stateEditor = new StateEditor(vertex, StreetSearchRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
@@ -31,7 +31,7 @@ public class StateEditorTest {
   }
 
   @Test
-  public final void testWeightIncrement() {
+  void testWeightIncrement() {
     StateEditor stateEditor = new StateEditor(vertex, StreetSearchRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
@@ -41,7 +41,7 @@ public class StateEditorTest {
   }
 
   @Test
-  public final void testNanWeightIncrement() {
+  void testNanWeightIncrement() {
     StateEditor stateEditor = new StateEditor(vertex, StreetSearchRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
@@ -49,13 +49,21 @@ public class StateEditorTest {
   }
 
   @Test
-  public final void testInfinityWeightIncrement() {
+  void testInfinityWeightIncrement() {
     StateEditor stateEditor = new StateEditor(vertex, StreetSearchRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
     assertThrows(IllegalArgumentException.class, () ->
       stateEditor.incrementWeight(Double.NEGATIVE_INFINITY)
     );
+  }
+
+  @Test
+  void negativeMillis() {
+    var stateEditor = new StateEditor(vertex, StreetSearchRequest.of().build());
+
+    stateEditor.setTimeSeconds(0);
+    assertThrows(IllegalArgumentException.class, () -> stateEditor.incrementTimeInMilliseconds(-1));
   }
 
   @Nested


### PR DESCRIPTION
### Summary

This converts the last warning in the A* StateBuilder to an exception and removes the boolean `defectiveTraversal`.

It's very similar to #7656.

Follow up to #7519.