### PR TITLE
Rename metrics to use dots instead of underscores

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilterTest.java
@@ -31,7 +31,7 @@ class HttpResponseTimeMetricsFilterTest {
   private static final String TRANSMODEL_ENDPOINT = "/transmodel/v3";
   private static final String GTFS_ENDPOINT = "/gtfs/v1/";
   private static final Set<String> MONITORED_ENDPOINTS = Set.of(TRANSMODEL_ENDPOINT, GTFS_ENDPOINT);
-  private static final String METRIC_NAME = "otp_http_server_requests";
+  private static final String METRIC_NAME = "otp.http.server.requests";
   private static final Duration MIN_EXPECTED_RESPONSE_TIME = Duration.ofMillis(10);
   private static final Duration MAX_EXPECTED_RESPONSE_TIME = Duration.ofMillis(10_000);
   private SimpleMeterRegistry registry;
@@ -162,7 +162,7 @@ class HttpResponseTimeMetricsFilterTest {
 
   private Timer findTotalTimer(String client, String endpoint) {
     return registry
-      .find(METRIC_NAME + "_total_time")
+      .find(METRIC_NAME + ".total.time")
       .tag(CLIENT_TAG, client)
       .tag(URI_TAG, endpoint)
       .timer();

--- a/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsFilter.java
@@ -89,7 +89,7 @@ public class HttpResponseTimeMetricsFilter
       registry
     );
     this.totalTimers = createTimers(
-      metricName + "_total_time",
+      metricName + ".total.time",
       "Total client-perceived HTTP request time including thread pool queue wait",
       Objects.requireNonNull(minExpectedResponseTime),
       Objects.requireNonNull(maxExpectedResponseTime),

--- a/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsParameters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/httpresponsetimemetrics/HttpResponseTimeMetricsParameters.java
@@ -26,7 +26,7 @@ public record HttpResponseTimeMetricsParameters(
     "/transmodel/v3",
     "/gtfs/v1/"
   );
-  public static final String DEFAULT_METRIC_NAME = "otp_http_server_requests";
+  public static final String DEFAULT_METRIC_NAME = "otp.http.server.requests";
   public static final Duration DEFAULT_MIN_EXPECTED_RESPONSE_TIME = Duration.ofMillis(10);
   public static final Duration DEFAULT_MAX_EXPECTED_RESPONSE_TIME = Duration.ofMillis(10_000);
 

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttEstimatedTimetableSource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttEstimatedTimetableSource.java
@@ -182,29 +182,29 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
   }
 
   private void registerMetrics() {
-    FunctionCounter.builder("mqtt_siri_message_size", liveMessageSize, AtomicLong::get)
+    FunctionCounter.builder("mqtt.siri.message.size", liveMessageSize, AtomicLong::get)
       .tags("type", "live", "stage", "received")
       .register(Metrics.globalRegistry);
-    FunctionCounter.builder("mqtt_siri_message_size", primingMessageSize, AtomicLong::get)
+    FunctionCounter.builder("mqtt.siri.message.size", primingMessageSize, AtomicLong::get)
       .tags("type", "priming", "stage", "received")
       .register(Metrics.globalRegistry);
-    FunctionCounter.builder("mqtt_siri_messages", liveMessageCounter, AtomicLong::get)
+    FunctionCounter.builder("mqtt.siri.messages", liveMessageCounter, AtomicLong::get)
       .tags("type", "live", "stage", "received")
       .register(Metrics.globalRegistry);
-    FunctionCounter.builder("mqtt_siri_messages", primingMessageCounter, AtomicLong::get)
+    FunctionCounter.builder("mqtt.siri.messages", primingMessageCounter, AtomicLong::get)
       .tags("type", "priming", "stage", "received")
       .register(Metrics.globalRegistry);
-    FunctionCounter.builder("mqtt_siri_messages", processedLiveMessageCounter, AtomicLong::get)
+    FunctionCounter.builder("mqtt.siri.messages", processedLiveMessageCounter, AtomicLong::get)
       .tags("type", "live", "stage", "processed")
       .register(Metrics.globalRegistry);
-    FunctionCounter.builder("mqtt_siri_messages", processedPrimingMessageCounter, AtomicLong::get)
+    FunctionCounter.builder("mqtt.siri.messages", processedPrimingMessageCounter, AtomicLong::get)
       .tags("type", "priming", "stage", "processed")
       .register(Metrics.globalRegistry);
 
-    Gauge.builder("mqtt_siri_queue_size", primingMessageQueue, Collection::size)
+    Gauge.builder("mqtt.siri.queue.size", primingMessageQueue, Collection::size)
       .tags("type", "priming")
       .register(Metrics.globalRegistry);
-    Gauge.builder("mqtt_siri_queue_size", liveMessageQueue, Collection::size)
+    Gauge.builder("mqtt.siri.queue.size", liveMessageQueue, Collection::size)
       .tags("type", "live")
       .register(Metrics.globalRegistry);
   }

--- a/application/src/main/java/org/opentripplanner/updater/trip/metrics/BatchTripUpdateMetrics.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/metrics/BatchTripUpdateMetrics.java
@@ -24,7 +24,7 @@ import org.opentripplanner.updater.trip.UrlUpdaterParameters;
  */
 public class BatchTripUpdateMetrics extends TripUpdateMetrics {
 
-  protected static final String METRICS_PREFIX = "batch_trip_updates";
+  protected static final String METRICS_PREFIX = "batch.trip.updates";
   private final AtomicInteger successfulGauge;
   private final AtomicInteger failureGauge;
   private final AtomicInteger warningsGauge;

--- a/application/src/main/java/org/opentripplanner/updater/trip/metrics/StreamingTripUpdateMetrics.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/metrics/StreamingTripUpdateMetrics.java
@@ -21,7 +21,7 @@ import org.opentripplanner.updater.trip.UrlUpdaterParameters;
  */
 public class StreamingTripUpdateMetrics extends TripUpdateMetrics {
 
-  protected static final String METRICS_PREFIX = "streaming_trip_updates";
+  protected static final String METRICS_PREFIX = "streaming.trip.updates";
   private final boolean producerMetrics;
 
   public StreamingTripUpdateMetrics(UrlUpdaterParameters parameters) {


### PR DESCRIPTION
## Summary

Follow-up to #7453 ([comment](https://github.com/opentripplanner/OpenTripPlanner/pull/7453#issuecomment-4564131680)). Rename OTP-defined metrics that still used underscores so all source metric names follow the Micrometer dot convention. The Prometheus exporter continues to translate dots to underscores when emitting metrics, so the names exposed to Prometheus scrapers are unchanged.

### Renames

| Before | After |
|---|---|
| `mqtt_siri_message_size` | `mqtt.siri.message.size` |
| `mqtt_siri_messages` | `mqtt.siri.messages` |
| `mqtt_siri_queue_size` | `mqtt.siri.queue.size` |
| `streaming_trip_updates.*` | `streaming.trip.updates.*` |
| `batch_trip_updates.*` | `batch.trip.updates.*` |
| `otp_http_server_requests` | `otp.http.server.requests` |
| `..._total_time` suffix | `....total.time` suffix |

### Unit tests

`HttpResponseTimeMetricsFilterTest` was updated to reflect the new naming and passes.