### PR TITLE
Sort trip's active dates in GTFS API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
@@ -52,6 +51,7 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
         .getCalendarService()
         .getServiceDatesForServiceId(getSource(environment).getServiceId())
         .stream()
+        .sorted()
         .map(ServiceDateUtils::asCompactString)
         .collect(Collectors.toList());
   }
@@ -419,31 +419,12 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
     return getTransitService(environment).findPattern(environment.getSource());
   }
 
-  private TripPattern getTripPattern(
-    DataFetchingEnvironment environment,
-    @Nullable LocalDate date
-  ) {
-    return date == null
-      ? getTripPattern(environment)
-      : getTransitService(environment).findPattern(environment.getSource(), date);
-  }
-
   private TransitService getTransitService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().transitService();
   }
 
   private RealtimeVehicleService getRealtimeVehiclesService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().realTimeVehicleService();
-  }
-
-  private static Optional<LocalDate> getOptionalServiceDateArgument(
-    DataFetchingEnvironment environment
-  ) throws ParseException {
-    var args = new GraphQLTypes.GraphQLTripArrivalStoptimeArgs(environment.getArguments());
-    if (args.getGraphQLServiceDate() != null) {
-      return Optional.of(ServiceDateUtils.parseString(args.getGraphQLServiceDate()));
-    }
-    return Optional.empty();
   }
 
   private Trip getSource(DataFetchingEnvironment environment) {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/TripImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/TripImplTest.java
@@ -1,0 +1,61 @@
+package org.opentripplanner.apis.gtfs.datafetchers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.support.graphql.DataFetchingSupport;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
+
+class TripImplTest {
+
+  private static final LocalDate SERVICE_DATE = LocalDate.of(2023, 6, 3);
+  private static final String TRIP_ID = "Trip1";
+
+  private final TransitTestEnvironmentBuilder envBuilder = TransitTestEnvironment.of(SERVICE_DATE);
+
+  private final TripInput TRIP_INPUT = TripInput.of(TRIP_ID)
+    .addStop(envBuilder.stop("A"), "12:00:00")
+    .addStop(envBuilder.stop("B"), "12:30:00");
+
+  @Test
+  void activeDatesReturnsSingleDate() throws Exception {
+    var realtimeEnv = envBuilder.addTrip(TRIP_INPUT).build();
+    var trip = realtimeEnv.tripData(TRIP_ID).trip();
+
+    var impl = new TripImpl();
+    var env = DataFetchingSupport.dataFetchingEnvironment(
+      trip,
+      Map.of(),
+      realtimeEnv.transitService()
+    );
+
+    var activeDates = impl.activeDates().get(env);
+    assertEquals(List.of("20230603"), activeDates);
+  }
+
+  @Test
+  void activeDatesReturnsSortedDates() throws Exception {
+    var tripInput = TRIP_INPUT.withServiceDates(
+      LocalDate.of(2023, 6, 5),
+      LocalDate.of(2023, 6, 1),
+      LocalDate.of(2023, 6, 3)
+    );
+    var realtimeEnv = envBuilder.addTrip(tripInput).build();
+    var trip = realtimeEnv.tripData(TRIP_ID).trip();
+
+    var impl = new TripImpl();
+    var env = DataFetchingSupport.dataFetchingEnvironment(
+      trip,
+      Map.of(),
+      realtimeEnv.transitService()
+    );
+
+    var activeDates = impl.activeDates().get(env);
+    assertEquals(List.of("20230601", "20230603", "20230605"), activeDates);
+  }
+}


### PR DESCRIPTION
### Summary

It sorts the field `Trip#activeDates` in the GTFS API.

There were also some unused methods in `TripImpl` which I removed.

### Unit tests

Added.

### Documentation

Don't know if we should communicate that they are in order.