### PR TITLE
Make FLEX behave like a car in routing

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/ridehailing/DecorateWithRideHailing.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ridehailing/DecorateWithRideHailing.java
@@ -66,7 +66,7 @@ public class DecorateWithRideHailing implements ItineraryListFilter {
 
   private Leg decorateLegWithRideEstimate(Itinerary i, Leg leg, RideHailingService service) {
     try {
-      if (leg instanceof StreetLeg sl && sl.getMode().isInCar()) {
+      if (leg instanceof StreetLeg sl && sl.getMode().isDrivingIsh()) {
         var estimates = service.rideEstimates(
           leg.from().coordinate,
           leg.to().coordinate,

--- a/application/src/main/java/org/opentripplanner/routing/linking/LinkingContextFactory.java
+++ b/application/src/main/java/org/opentripplanner/routing/linking/LinkingContextFactory.java
@@ -278,10 +278,10 @@ public class LinkingContextFactory {
 
     var results = new HashSet<Vertex>();
     if (location.stopId() != null) {
-      if (!modes.stream().allMatch(TraverseMode::isInCar)) {
+      if (!modes.stream().allMatch(TraverseMode::isDrivingIsh)) {
         results.addAll(getStreetVerticesForStop(location));
       }
-      if (modes.stream().anyMatch(TraverseMode::isInCar)) {
+      if (modes.stream().anyMatch(TraverseMode::isDrivingIsh)) {
         // Ensure that there is a car routable vertex (that can originate from stop's coordinate).
         var carRoutableVertex = getCarRoutableStreetVertex(container, location, type);
         carRoutableVertex.ifPresent(results::add);

--- a/street/src/main/java/org/opentripplanner/street/internal/notes/StreetNotesService.java
+++ b/street/src/main/java/org/opentripplanner/street/internal/notes/StreetNotesService.java
@@ -49,7 +49,7 @@ public class StreetNotesService implements Serializable {
   public static final StreetNoteMatcher DRIVING_MATCHER = new StreetNoteMatcher() {
     @Override
     public boolean matches(State state) {
-      return state.getBackMode().isInCar();
+      return state.getBackMode().isDrivingIsh();
     }
   };
 

--- a/street/src/main/java/org/opentripplanner/street/search/TraverseMode.java
+++ b/street/src/main/java/org/opentripplanner/street/search/TraverseMode.java
@@ -16,7 +16,7 @@ public enum TraverseMode {
   }
 
   public boolean isInCar() {
-    return this == CAR;
+    return this == CAR || this == FLEX;
   }
 
   /**

--- a/street/src/main/java/org/opentripplanner/street/search/TraverseMode.java
+++ b/street/src/main/java/org/opentripplanner/street/search/TraverseMode.java
@@ -15,7 +15,10 @@ public enum TraverseMode {
     return STREET_MODES.contains(this);
   }
 
-  public boolean isInCar() {
+  /**
+   * For the purposes of this check, we pretend that flex is like a car.
+   */
+  public boolean isDrivingIsh() {
     return this == CAR || this == FLEX;
   }
 

--- a/street/src/main/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculator.java
+++ b/street/src/main/java/org/opentripplanner/street/search/intersection_model/SimpleIntersectionTraversalCalculator.java
@@ -32,7 +32,7 @@ public class SimpleIntersectionTraversalCalculator
       return 0;
     }
 
-    if (mode.isInCar()) {
+    if (mode.isDrivingIsh()) {
       return computeDrivingTraversalDuration(v, from, to);
     } else if (mode.isCyclingIsh()) {
       return computeCyclingTraversalDuration(v, from, to, toSpeed);

--- a/street/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -470,7 +470,7 @@ public final class State implements AStarState<State, Edge, Vertex> {
   public boolean containsModeCar() {
     var state = this;
     while (state != null) {
-      if (state.currentMode().isInCar()) {
+      if (state.currentMode().isDrivingIsh()) {
         return true;
       } else {
         state = state.getBackState();

--- a/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
+++ b/street/src/main/java/org/opentripplanner/street/search/strategy/DominanceFunctions.java
@@ -100,7 +100,7 @@ public abstract class DominanceFunctions implements Serializable, DominanceFunct
       a.backEdge != b.getBackEdge() &&
       (a.backEdge instanceof StreetEdge) &&
       a.getBackMode() != null &&
-      a.getBackMode().isInCar() &&
+      a.getBackMode().isDrivingIsh() &&
       a.getRequest().isCloseToStartOrEnd(a.getVertex())
     ) {
       return false;


### PR DESCRIPTION
### Summary

The convenience method TraverseMode.isInCar should return true for FLEX.

### Issue

Routing results were different for FLEX and CAR, which was ultimately traced down to FLEX behaving as walking in intersections, which is incorrect.

### Unit tests

No change.

### Documentation

No change.

### Changelog

Yes.

### Bumping the serialization version id

No.