### PR TITLE
Implement getFinalState of CarpoolAccessEgress

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.carpooling.routing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPath;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
@@ -14,11 +15,13 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.core.model.basic.Cost;
 import org.opentripplanner.framework.model.TimeAndCost;
+import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.raptor.spi.RaptorConstants;
 import org.opentripplanner.raptor.spi.RaptorCostConverter;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 
 class CarpoolAccessEgressTest {
 
@@ -138,6 +141,85 @@ class CarpoolAccessEgressTest {
   }
 
   /**
+   * For an access the transit stop sits at the chain end, so the final state is the last state of
+   * the trailing walk from the dropoff to the stop.
+   */
+  @Test
+  void getFinalStateForAccessReturnsStateAtTransitStopChainEnd() {
+    var walkToPickup = createGraphPath(Duration.ofSeconds(80));
+    var walkFromDropoff = createGraphPath(Duration.ofSeconds(40));
+    var stop = TimetableRepositoryForTest.of().stop("Central Station", 59.91, 10.74).build();
+
+    var access = newAccessEgress(
+      1_000,
+      walkToPickup,
+      Duration.ofSeconds(60),
+      walkFromDropoff,
+      1.0,
+      EndpointLabel.forLocation(GenericLocation.fromCoordinate(59.92, 10.75, "Home")),
+      EndpointLabel.forStop(stop)
+    );
+
+    assertEquals(walkFromDropoff.states.getLast(), access.getFinalState());
+  }
+
+  /**
+   * For an egress the transit stop sits at the chain start, so the final state is the first state
+   * of the leading walk from the stop to the pickup.
+   */
+  @Test
+  void getFinalStateForEgressReturnsStateAtTransitStopChainStart() {
+    var walkToPickup = createGraphPath(Duration.ofSeconds(80));
+    var walkFromDropoff = createGraphPath(Duration.ofSeconds(40));
+    var stop = TimetableRepositoryForTest.of().stop("Central Station", 59.91, 10.74).build();
+
+    var egress = newAccessEgress(
+      1_000,
+      walkToPickup,
+      Duration.ofSeconds(60),
+      walkFromDropoff,
+      1.0,
+      EndpointLabel.forStop(stop),
+      EndpointLabel.forLocation(GenericLocation.fromCoordinate(59.92, 10.75, "Office"))
+    );
+
+    assertEquals(walkToPickup.states.getFirst(), egress.getFinalState());
+  }
+
+  /**
+   * With no walks bracketing the ride, the final state falls back to the shared ride segment
+   * endpoint at the transit stop — the last shared segment's last state for an access.
+   */
+  @Test
+  void getFinalStateWithoutWalksFallsBackToSharedSegment() {
+    var access = newAccessEgress(
+      0,
+      null,
+      Duration.ofSeconds(300),
+      null,
+      1.0,
+      EndpointLabel.EMPTY,
+      EndpointLabel.forStop(TimetableRepositoryForTest.of().stop("Stop", 59.91, 10.74).build())
+    );
+
+    assertEquals(access.sharedSegments().getLast().states.getLast(), access.getFinalState());
+  }
+
+  /** A carpool passenger rides in the driver's car, never a station-rented vehicle. */
+  @Test
+  void getFinalStateIsNotRentingVehicleFromStation() {
+    var access = newAccessEgress(
+      1_000,
+      createGraphPath(Duration.ofSeconds(80)),
+      Duration.ofSeconds(60),
+      createGraphPath(Duration.ofSeconds(40)),
+      1.0
+    );
+
+    assertFalse(access.getFinalState().isRentingVehicleFromStation());
+  }
+
+  /**
    * Builds a CarpoolAccessEgress with the passenger picked up mid-trip (pickupPos = 1, dropoffPos
    * = 2). The route segments list is therefore [pickupSegment, sharedSegment]: the driver runs
    * the first to reach the passenger and the second is the passenger's shared ride. The
@@ -150,6 +232,26 @@ class CarpoolAccessEgressTest {
     Duration sharedSegmentDuration,
     @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff,
     double carpoolReluctance
+  ) {
+    return newAccessEgress(
+      passengerDepartureTime,
+      walkToPickup,
+      sharedSegmentDuration,
+      walkFromDropoff,
+      carpoolReluctance,
+      EndpointLabel.EMPTY,
+      EndpointLabel.EMPTY
+    );
+  }
+
+  private static CarpoolAccessEgress newAccessEgress(
+    int passengerDepartureTime,
+    @Nullable GraphPath<State, Edge, Vertex> walkToPickup,
+    Duration sharedSegmentDuration,
+    @Nullable GraphPath<State, Edge, Vertex> walkFromDropoff,
+    double carpoolReluctance,
+    EndpointLabel startLabel,
+    EndpointLabel endLabel
   ) {
     var candidate = new InsertionCandidate(
       createSimpleTrip(OSLO_CENTER, OSLO_NORTH),
@@ -167,8 +269,8 @@ class CarpoolAccessEgressTest {
       candidate,
       TimeAndCost.ZERO,
       carpoolReluctance,
-      EndpointLabel.EMPTY,
-      EndpointLabel.EMPTY
+      startLabel,
+      endLabel
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -234,17 +234,49 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
   }
 
   /**
-   * Not implemented — Raptor never fetches the final State of a carpool access/egress leg.
-   * Itinerary mapping reads the leg's segments and times via the public accessors instead. May be
-   * implemented later if a caller starts requiring it.
+   * The A* state sitting at the transit-stop endpoint of the passenger leg.
+   * <p>
+   * The transit stop is the chain's far end — its end for an access (passenger origin → … → stop)
+   * and its start for an egress (stop → … → passenger destination). The transit side is identified
+   * from the labels, which carry the stop on the end label for an access and on the start label
+   * for an egress; the returned state is the segment endpoint touching the stop. When neither
+   * label carries a stop (e.g. a direct itinerary), the chain end is used.
    *
-   * @throws UnsupportedOperationException always.
+   * <h4>Limitation: this state does not head a full-leg pointer chain</h4>
+   * <p>
+   * The {@link RoutingAccessEgress#getFinalState()} contract expects the returned state to head a
+   * {@link State#getBackState()} chain that reconstructs the <em>entire</em> street search — that
+   * is the assumption behind callers such as {@code RaptorPathToItineraryMapper}, which wrap the
+   * state in a {@link org.opentripplanner.street.model.path.StreetPath} to rebuild the leg.
+   * <p>
+   * A carpool leg does not honour that assumption today. It is not one A* search but several
+   * independent ones stitched together in the domain layer: an optional walk to the pickup, the
+   * shared ride (segments taken off the driver's committed route), and an optional walk from the
+   * dropoff. These chains are not linked — the first state of each segment is a fresh search
+   * origin with a {@code null} back state, and nothing points across the pickup/dropoff vertices
+   * from one segment into the next. Following {@code getBackState()} from the returned state
+   * therefore reconstructs only the single terminal segment, not the whole walk + ride + walk leg.
+   * Splicing the segments into one continuous back-state chain is possible but not yet done, since
+   * no caller needs it.
+   * <p>
+   * This is sound only because no caller reconstructs a carpool leg from this state. Itinerary
+   * mapping for carpool legs is routed through {@link org.opentripplanner.ext.carpooling.internal.CarpoolItineraryMapper}
+   * instead, which rebuilds the WALK + CARPOOL + WALK legs directly from the segments and times
+   * via the public accessors. The state returned here is consumed only for the
+   * direction-independent scalar checks performed on every access/egress — notably
+   * {@link State#isRentingVehicleFromStation()}, which is always {@code false} since a passenger
+   * rides in the driver's car rather than a station-rented vehicle. Do not wrap this state in a
+   * {@code StreetPath} expecting the full leg; that path would silently omit the ride and the
+   * other walk.
    */
   @Override
   public State getFinalState() {
-    throw new UnsupportedOperationException(
-      "Fetching last state of CarpoolAccessEgress is not yet implemented"
-    );
+    if (startLabel.stop() != null) {
+      var firstSegment = walkToPickup() != null ? walkToPickup() : sharedSegments().getFirst();
+      return firstSegment.states.getFirst();
+    }
+    var lastSegment = walkFromDropoff() != null ? walkFromDropoff() : sharedSegments().getLast();
+    return lastSegment.states.getLast();
   }
 
   /** Always {@code false}: a carpool leg, by definition, contains a vehicle ride. */


### PR DESCRIPTION
Return the A* state at the transit-stop endpoint of the carpool leg instead of throwing. The transit stop is the chain end for an access and the chain start for an egress, identified from the endpoint labels.

The returned state heads a back-state chain covering only the terminal segment, not the whole walk + ride + walk leg, since the leg is built from several independent street searches that are not linked. This is sufficient for the only consumer (isRentingVehicleFromStation, always false for a carpool passenger); full-leg reconstruction is handled by CarpoolItineraryMapper. The limitation is documented on the method.

### Summary

Implements getFinalState of CarpoolAccessEgress to avoid exceptions in the RaptorPathToItineraryMapper code:

    // Map general itinerary fields
    var arrivedOnRental = egressPathLeg
      .egress()
      .findOriginal(RoutingAccessEgress.class)
      .stream()
      .anyMatch(leg -> leg.getFinalState().isRentingVehicleFromStation());

### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?

yes

- Was any manual verification done?

yes

- Was the code designed so it is unit testable?

yes

- Were any tests applied to the smallest appropriate unit?

yes

- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

yrd

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

yes

- Were all non-trivial public classes and methods documented with Javadoc?

yes

- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?


no