### PR TITLE
Apply free transfers only when category and medium matches

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/model/FareProductTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/model/FareProductTest.java
@@ -1,10 +1,14 @@
 package org.opentripplanner.ext.fares.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,6 +47,57 @@ class FareProductTest {
     var instanceId = fareProduct.uniqueInstanceId(startTime);
 
     assertEquals(expectedInstanceId, instanceId);
+  }
+
+  @Test
+  void equalEligibilityBothNullCategoryAndMedium() {
+    var a = fareProduct(null, null);
+    var b = fareProduct(null, null);
+    assertTrue(a.equalEligibility(b));
+  }
+
+  @Test
+  void equalEligibilitySameCategoryAndMedium() {
+    var a = fareProduct(CATEGORY, MEDIUM);
+    var b = fareProduct(CATEGORY, MEDIUM);
+    assertTrue(a.equalEligibility(b));
+  }
+
+  @Test
+  void equalEligibilitySameCategoryNullMedium() {
+    var a = fareProduct(CATEGORY, null);
+    var b = fareProduct(CATEGORY, null);
+    assertTrue(a.equalEligibility(b));
+  }
+
+  @Test
+  void equalEligibilityDifferentCategory() {
+    var otherCategory = RiderCategory.of(id("students")).withName("Students").build();
+    var a = fareProduct(CATEGORY, MEDIUM);
+    var b = fareProduct(otherCategory, MEDIUM);
+    assertFalse(a.equalEligibility(b));
+  }
+
+  @Test
+  void equalEligibilityDifferentMedium() {
+    var otherMedium = new FareMedium(id("card"), "Card");
+    var a = fareProduct(CATEGORY, MEDIUM);
+    var b = fareProduct(CATEGORY, otherMedium);
+    assertFalse(a.equalEligibility(b));
+  }
+
+  @Test
+  void equalEligibilityNullCategoryVsNonNull() {
+    var a = fareProduct(null, MEDIUM);
+    var b = fareProduct(CATEGORY, MEDIUM);
+    assertFalse(a.equalEligibility(b));
+  }
+
+  @Test
+  void equalEligibilityNullMediumVsNonNull() {
+    var a = fareProduct(CATEGORY, null);
+    var b = fareProduct(CATEGORY, MEDIUM);
+    assertFalse(a.equalEligibility(b));
   }
 
   private static FareProduct fareProduct(RiderCategory cat, FareMedium medium) {

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferAcrossNetworksTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferAcrossNetworksTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.fares.service.gtfs.v2;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.List;
@@ -39,26 +40,26 @@ class CostedTransferAcrossNetworksTest implements PlanTestConstants, FareTestCon
       List.of(
         // transferring from A to A is free
         FareTransferRule.of()
-          .withId(FeedScopedIdForTestFactory.id("t1"))
+          .withId(id("t1"))
           .withFromLegGroup(LEG_GROUP_A)
           .withToLegGroup(LEG_GROUP_A)
           .build(),
         // transferring from B to B is also free
         FareTransferRule.of()
-          .withId(FeedScopedIdForTestFactory.id("t2"))
+          .withId(id("t2"))
           .withFromLegGroup(LEG_GROUP_B)
           .withToLegGroup(LEG_GROUP_B)
           .build(),
         // transferring from A to B costs one EUR
         FareTransferRule.of()
-          .withId(FeedScopedIdForTestFactory.id("t3"))
+          .withId(id("t3"))
           .withFromLegGroup(LEG_GROUP_A)
           .withToLegGroup(LEG_GROUP_B)
           .withFareProducts(TRANSFER_1)
           .build(),
         // transferring from B to A is free
         FareTransferRule.of()
-          .withId(FeedScopedIdForTestFactory.id("t4"))
+          .withId(id("t4"))
           .withFromLegGroup(LEG_GROUP_B)
           .withToLegGroup(LEG_GROUP_A)
           .build()

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferAcrossNetworksTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferAcrossNetworksTest.java
@@ -7,7 +7,6 @@ import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.FareTestConstants;
 import org.opentripplanner.ext.fares.model.FareTransferRule;

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferWithCategoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferWithCategoryTest.java
@@ -15,6 +15,9 @@ import org.opentripplanner.model.plan.TestItinerary;
 import org.opentripplanner.model.plan.TestTransitLeg;
 import org.opentripplanner.transit.model.basic.Money;
 
+/// The free transfer is only valid for the youth fare product, because it is the only one that
+/// has the "youth" category. Fare product A has no category therefore doesn't qualify for the
+/// free transfer.
 class FreeTransferWithCategoryTest implements PlanTestConstants, FareTestConstants {
 
   private static final FareProduct YOUTH_PRODUCT = FareProduct.of(

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferWithCategoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferWithCategoryTest.java
@@ -1,0 +1,71 @@
+package org.opentripplanner.ext.fares.service.gtfs.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.model.FareLegRule;
+import org.opentripplanner.ext.fares.model.FareTestConstants;
+import org.opentripplanner.ext.fares.model.FareTransferRule;
+import org.opentripplanner.model.fare.FareOffer;
+import org.opentripplanner.model.fare.FareProduct;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.TestItinerary;
+import org.opentripplanner.model.plan.TestTransitLeg;
+import org.opentripplanner.transit.model.basic.Money;
+
+class FreeTransferWithCategoryTest implements PlanTestConstants, FareTestConstants {
+
+  private static final FareProduct YOUTH_PRODUCT = FareProduct.of(
+    id("youth"),
+    "youth",
+    Money.euros(4)
+  )
+    .withCategory(CATEGORY_ALPHA)
+    .build();
+  private static final FareProduct YOUTH_TRANSFER_PRODUCT = FareProduct.of(
+    id("youth-transfer"),
+    "youth",
+    Money.euros(0)
+  )
+    .withCategory(CATEGORY_ALPHA)
+    .build();
+  private static final GtfsFaresV2Service SERVICE = GtfsFaresV2Service.of()
+    .withLegRules(
+      FareLegRule.of(id("adult"), FARE_PRODUCT_A).withLegGroupId(LEG_GROUP_A).build(),
+      FareLegRule.of(id("youth"), YOUTH_PRODUCT).withLegGroupId(LEG_GROUP_A).build()
+    )
+    .withTransferRules(
+      FareTransferRule.of()
+        .withId(id(1))
+        .withFromLegGroup(LEG_GROUP_A)
+        .withToLegGroup(LEG_GROUP_A)
+        .withFareProducts(YOUTH_TRANSFER_PRODUCT)
+        .build()
+    )
+    .build();
+
+  @Test
+  void freeTransfer() {
+    var firstLeg = TestTransitLeg.of().withStartTime("10:00").withEndTime("11:00").build();
+    var secondLeg = TestTransitLeg.of().withStartTime("11:00").withEndTime("12:00").build();
+
+    var result = SERVICE.calculateFares(TestItinerary.of(firstLeg, secondLeg).build());
+
+    assertThat(result.offersForLeg(firstLeg)).containsExactly(
+      FareOffer.of(firstLeg.startTime(), FARE_PRODUCT_A),
+      FareOffer.of(firstLeg.startTime(), YOUTH_PRODUCT)
+    );
+
+    assertThat(result.offersForLeg(secondLeg)).containsExactly(
+      FareOffer.of(secondLeg.startTime(), FARE_PRODUCT_A),
+      FareOffer.of(firstLeg.startTime(), YOUTH_PRODUCT),
+      FareOffer.of(
+        firstLeg.startTime(),
+        YOUTH_TRANSFER_PRODUCT,
+        List.of(YOUTH_PRODUCT, FARE_PRODUCT_A)
+      )
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferWithoutEligibilityTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferWithoutEligibilityTest.java
@@ -1,0 +1,50 @@
+package org.opentripplanner.ext.fares.service.gtfs.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.model.FareLegRule;
+import org.opentripplanner.ext.fares.model.FareTestConstants;
+import org.opentripplanner.ext.fares.model.FareTransferRule;
+import org.opentripplanner.model.fare.FareOffer;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.model.plan.TestItinerary;
+import org.opentripplanner.model.plan.TestTransitLeg;
+
+class FreeTransferWithoutEligibilityTest implements PlanTestConstants, FareTestConstants {
+
+  private static final GtfsFaresV2Service SERVICE = GtfsFaresV2Service.of()
+    .withLegRules(
+      FareLegRule.of(id("adult"), FARE_PRODUCT_A).withLegGroupId(LEG_GROUP_A).build(),
+      FareLegRule.of(id("youth"), FARE_PRODUCT_B).withLegGroupId(LEG_GROUP_A).build()
+    )
+    .withTransferRules(
+      FareTransferRule.of()
+        .withId(id(1))
+        .withFromLegGroup(LEG_GROUP_A)
+        .withToLegGroup(LEG_GROUP_A)
+        .withFareProducts(List.of())
+        .build()
+    )
+    .build();
+
+  @Test
+  void freeTransfer() {
+    var firstLeg = TestTransitLeg.of().withStartTime("10:00").withEndTime("11:00").build();
+    var secondLeg = TestTransitLeg.of().withStartTime("11:00").withEndTime("12:00").build();
+
+    var result = SERVICE.calculateFares(TestItinerary.of(firstLeg, secondLeg).build());
+
+    assertThat(result.offersForLeg(firstLeg)).containsExactly(
+      FareOffer.of(firstLeg.startTime(), FARE_PRODUCT_A),
+      FareOffer.of(firstLeg.startTime(), FARE_PRODUCT_B)
+    );
+
+    assertThat(result.offersForLeg(secondLeg)).containsExactly(
+      FareOffer.of(firstLeg.startTime(), FARE_PRODUCT_A),
+      FareOffer.of(firstLeg.startTime(), FARE_PRODUCT_B)
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/SameGroupIdPriorityTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/SameGroupIdPriorityTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.fares.service.gtfs.v2;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+import static org.opentripplanner.ext.fares.service.gtfs.v2.FareLookupService.DEFAULT_FREE_TRANSFER_MATCH_PREDICATE;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -115,7 +116,8 @@ class SameGroupIdPriorityTest implements FareTestConstants {
       List.of(r1, r2),
       List.of(),
       tc.stopAreas,
-      ImmutableMultimap.of()
+      ImmutableMultimap.of(),
+      DEFAULT_FREE_TRANSFER_MATCH_PREDICATE
     );
 
     assertThat(service.legRules(leg()).stream().map(FareLegRule::id)).containsExactlyElementsIn(

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TimeframeMatcherTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TimeframeMatcherTest.java
@@ -22,7 +22,7 @@ class TimeframeMatcherTest implements FareTestConstants {
     .withFromTimeframes(List.of(TIMEFRAME_TWELVE_TO_TWO))
     .withToTimeframes(List.of(TIMEFRAME_THREE_TO_FIVE))
     .build();
-  public static final FeedScopedId ID2 = FeedScopedIdForTestFactory.id("2");
+  public static final FeedScopedId ID2 = id("2");
 
   private static List<Arguments> outsideTimeframeCases() {
     return List.of(

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TimeframeMatcherTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/TimeframeMatcherTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.FareTestConstants;
 import org.opentripplanner.model.plan.TestTransitLeg;

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactoryTest.java
@@ -32,7 +32,10 @@ class OregonHopFareFactoryTest implements FareTestConstants {
     TRIMET_ADULT_SINGLE_RIDE,
     "regular",
     Money.usDollars(10)
-  ).build();
+  )
+    .withCategory(CATEGORY_ADULT)
+    .withMedium(HOP_FASTPASS)
+    .build();
 
   private static final FareProduct FP_CTRAN_REGIONAL = FareProduct.of(
     ADULT_REGIONAL_SINGLE_RIDE,

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -153,7 +153,7 @@ class FareLookupService implements Serializable {
           .fromLegRule()
           .fareProducts()
           .stream()
-          .filter(p -> !p.isFree())
+          .filter(t::matchesEligibility)
           .map(product ->
             LegOffer.of(
               FareOffer.of(head.startTime(), product, dependencies.get(product)),

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,14 +29,14 @@ class FareLookupService implements Serializable {
   /// The interpretation of this implementation is that transfers apply to only those fare
   /// products that share the same category and fare medium.
   /// - [Github issue](https://github.com/google/transit/pull/423)
-  static final BiPredicate<TransferMatch, FareProduct> DEFAULT_FREE_TRANSFER_MATCH_PREDICATE =
+  static final FreeTransferEligibility DEFAULT_FREE_TRANSFER_MATCH_PREDICATE =
     TransferMatch::matchesEligibility;
   private final List<FareLegRule> legRules;
   private final List<FareTransferRule> transferRules;
   private final AreaMatcher areaMatcher;
   private final NetworkMatcher networkMatcher;
   private final TimeframeMatcher timeframeMatcher;
-  private final BiPredicate<TransferMatch, FareProduct> freeTransferEligibility;
+  private final FreeTransferEligibility freeTransferEligibility;
 
   /// @param freeTransferEligibility A bi-predicate that determines if a free transfer applies
   /// to a given transfer match and fare product. This needs to be configurable because of custom
@@ -47,7 +46,7 @@ class FareLookupService implements Serializable {
     List<FareTransferRule> fareTransferRules,
     Multimap<FeedScopedId, FeedScopedId> stopAreas,
     Multimap<FeedScopedId, LocalDate> serviceDates,
-    BiPredicate<TransferMatch, FareProduct> freeTransferEligibility
+    FreeTransferEligibility freeTransferEligibility
   ) {
     this.legRules = List.copyOf(legRules);
     this.transferRules = List.copyOf(fareTransferRules);

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -25,20 +26,27 @@ import org.opentripplanner.utils.collection.SetUtils;
  */
 class FareLookupService implements Serializable {
 
+  public static final BiPredicate<
+    TransferMatch,
+    FareProduct
+  > DEFAULT_FREE_TRANSFER_MATCH_PREDICATE = TransferMatch::matchesEligibility;
   private final List<FareLegRule> legRules;
   private final List<FareTransferRule> transferRules;
   private final AreaMatcher areaMatcher;
   private final NetworkMatcher networkMatcher;
   private final TimeframeMatcher timeframeMatcher;
+  private final BiPredicate<TransferMatch, FareProduct> freeTransferEligibility;
 
   FareLookupService(
     List<FareLegRule> legRules,
     List<FareTransferRule> fareTransferRules,
     Multimap<FeedScopedId, FeedScopedId> stopAreas,
-    Multimap<FeedScopedId, LocalDate> serviceDates
+    Multimap<FeedScopedId, LocalDate> serviceDates,
+    BiPredicate<TransferMatch, FareProduct> freeTransferEligibility
   ) {
     this.legRules = List.copyOf(legRules);
     this.transferRules = List.copyOf(fareTransferRules);
+    this.freeTransferEligibility = freeTransferEligibility;
 
     var rulePriorityMatcher = new RulePriorityMatcher(legRules);
     this.areaMatcher = new AreaMatcher(rulePriorityMatcher, legRules, stopAreas);
@@ -153,7 +161,7 @@ class FareLookupService implements Serializable {
           .fromLegRule()
           .fareProducts()
           .stream()
-          .filter(t::matchesEligibility)
+          .filter(p -> freeTransferEligibility.test(t, p))
           .map(product ->
             LegOffer.of(
               FareOffer.of(head.startTime(), product, dependencies.get(product)),

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -26,7 +26,10 @@ import org.opentripplanner.utils.collection.SetUtils;
  */
 class FareLookupService implements Serializable {
 
-  public static final BiPredicate<
+  /// The GTFS spec is underspecified about which fare products gree transfers should apply to.
+  /// The interpretation of this implementation is that transfers apply to only those fare
+  /// products that share the same category and fare medium.
+  static final BiPredicate<
     TransferMatch,
     FareProduct
   > DEFAULT_FREE_TRANSFER_MATCH_PREDICATE = TransferMatch::matchesEligibility;
@@ -37,6 +40,9 @@ class FareLookupService implements Serializable {
   private final TimeframeMatcher timeframeMatcher;
   private final BiPredicate<TransferMatch, FareProduct> freeTransferEligibility;
 
+  /// @param freeTransferEligibility A bi-predicate that determines if a free transfer applies
+  /// to a given transfer match and fare product. This needs to be configurable because of custom
+  /// fare services.
   FareLookupService(
     List<FareLegRule> legRules,
     List<FareTransferRule> fareTransferRules,
@@ -161,6 +167,8 @@ class FareLookupService implements Serializable {
           .fromLegRule()
           .fareProducts()
           .stream()
+          // the GTFS spec is underspecified about whether transfers apply only to specific
+          // fare products or all of them
           .filter(p -> freeTransferEligibility.test(t, p))
           .map(product ->
             LegOffer.of(

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -29,10 +29,8 @@ class FareLookupService implements Serializable {
   /// The GTFS spec is underspecified about which fare products gree transfers should apply to.
   /// The interpretation of this implementation is that transfers apply to only those fare
   /// products that share the same category and fare medium.
-  static final BiPredicate<
-    TransferMatch,
-    FareProduct
-  > DEFAULT_FREE_TRANSFER_MATCH_PREDICATE = TransferMatch::matchesEligibility;
+  static final BiPredicate<TransferMatch, FareProduct> DEFAULT_FREE_TRANSFER_MATCH_PREDICATE =
+    TransferMatch::matchesEligibility;
   private final List<FareLegRule> legRules;
   private final List<FareTransferRule> transferRules;
   private final AreaMatcher areaMatcher;

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -29,6 +29,7 @@ class FareLookupService implements Serializable {
   /// The GTFS spec is underspecified about which fare products gree transfers should apply to.
   /// The interpretation of this implementation is that transfers apply to only those fare
   /// products that share the same category and fare medium.
+  /// - [Github issue](https://github.com/google/transit/pull/423)
   static final BiPredicate<TransferMatch, FareProduct> DEFAULT_FREE_TRANSFER_MATCH_PREDICATE =
     TransferMatch::matchesEligibility;
   private final List<FareLegRule> legRules;
@@ -166,7 +167,7 @@ class FareLookupService implements Serializable {
           .fareProducts()
           .stream()
           // the GTFS spec is underspecified about whether transfers apply only to specific
-          // fare products or all of them
+          // fare products or all of them: https://github.com/google/transit/pull/423
           .filter(p -> freeTransferEligibility.test(t, p))
           .map(product ->
             LegOffer.of(

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -153,6 +153,7 @@ class FareLookupService implements Serializable {
           .fromLegRule()
           .fareProducts()
           .stream()
+          .filter(p -> !p.isFree())
           .map(product ->
             LegOffer.of(
               FareOffer.of(head.startTime(), product, dependencies.get(product)),

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FareLookupService.java
@@ -25,7 +25,7 @@ import org.opentripplanner.utils.collection.SetUtils;
  */
 class FareLookupService implements Serializable {
 
-  /// The GTFS spec is underspecified about which fare products gree transfers should apply to.
+  /// The GTFS spec is underspecified about which fare products free transfers should apply to.
   /// The interpretation of this implementation is that transfers apply to only those fare
   /// products that share the same category and fare medium.
   /// - [Github issue](https://github.com/google/transit/pull/423)

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferEligibility.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferEligibility.java
@@ -1,0 +1,18 @@
+package org.opentripplanner.ext.fares.service.gtfs.v2;
+
+import org.opentripplanner.model.fare.FareProduct;
+
+/// Determines whether a free transfer applies to a given fare product.
+///
+/// The GTFS Fares V2 spec is underspecified about which fare products a free transfer should cover.
+/// This interface allows custom fare services to plug in their own eligibility logic while the
+/// default implementation ([FareLookupService#DEFAULT_FREE_TRANSFER_MATCH_PREDICATE]) matches
+/// on equal rider category and fare medium.
+///
+/// @see <a href="https://github.com/google/transit/pull/423">GTFS spec discussion</a>
+@FunctionalInterface
+public interface FreeTransferEligibility {
+  /// Returns `true` if the free transfer described by `transfer` applies to
+  /// `product`.
+  boolean test(TransferMatch transfer, FareProduct product);
+}

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2Service.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2Service.java
@@ -5,11 +5,13 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.model.fare.FareOffer;
+import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.utils.collection.ListUtils;
 
@@ -24,13 +26,15 @@ public final class GtfsFaresV2Service implements Serializable {
     List<FareLegRule> legRules,
     List<FareTransferRule> fareTransferRules,
     Multimap<FeedScopedId, FeedScopedId> stopAreas,
-    Multimap<FeedScopedId, LocalDate> serviceDatesForServiceId
+    Multimap<FeedScopedId, LocalDate> serviceDatesForServiceId,
+    BiPredicate<TransferMatch, FareProduct> freeTransferMatchPredicate
   ) {
     this.lookup = new FareLookupService(
       legRules,
       fareTransferRules,
       stopAreas,
-      serviceDatesForServiceId
+      serviceDatesForServiceId,
+      freeTransferMatchPredicate
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2Service.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2Service.java
@@ -5,13 +5,11 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
-import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.model.fare.FareOffer;
-import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.utils.collection.ListUtils;
 
@@ -27,7 +25,7 @@ public final class GtfsFaresV2Service implements Serializable {
     List<FareTransferRule> fareTransferRules,
     Multimap<FeedScopedId, FeedScopedId> stopAreas,
     Multimap<FeedScopedId, LocalDate> serviceDatesForServiceId,
-    BiPredicate<TransferMatch, FareProduct> freeTransferMatchPredicate
+    FreeTransferEligibility freeTransferMatchPredicate
   ) {
     this.lookup = new FareLookupService(
       legRules,

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2ServiceBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2ServiceBuilder.java
@@ -8,11 +8,9 @@ import com.google.common.collect.Multimap;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.BiPredicate;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
-import org.opentripplanner.model.fare.FareProduct;
 
 public class GtfsFaresV2ServiceBuilder {
 
@@ -20,8 +18,7 @@ public class GtfsFaresV2ServiceBuilder {
   private List<FareTransferRule> fareTransferRules = List.of();
   private Multimap<FeedScopedId, FeedScopedId> stopAreas = ImmutableMultimap.of();
   private Multimap<FeedScopedId, LocalDate> serviceDatesForServiceId = HashMultimap.create();
-  private BiPredicate<TransferMatch, FareProduct> freeTransferMatchPredicate =
-    DEFAULT_FREE_TRANSFER_MATCH_PREDICATE;
+  private FreeTransferEligibility freeTransferElibility = DEFAULT_FREE_TRANSFER_MATCH_PREDICATE;
 
   public GtfsFaresV2ServiceBuilder withLegRules(List<FareLegRule> legRules) {
     this.legRules = legRules;
@@ -59,9 +56,9 @@ public class GtfsFaresV2ServiceBuilder {
   }
 
   public GtfsFaresV2ServiceBuilder withFreeTransferMatchPredicate(
-    BiPredicate<TransferMatch, FareProduct> freeTransferMatchPredicate
+    FreeTransferEligibility freeTranferElibility
   ) {
-    this.freeTransferMatchPredicate = freeTransferMatchPredicate;
+    this.freeTransferElibility = freeTranferElibility;
     return this;
   }
 
@@ -71,7 +68,7 @@ public class GtfsFaresV2ServiceBuilder {
       fareTransferRules,
       stopAreas,
       serviceDatesForServiceId,
-      freeTransferMatchPredicate
+      freeTransferElibility
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2ServiceBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2ServiceBuilder.java
@@ -1,14 +1,18 @@
 package org.opentripplanner.ext.fares.service.gtfs.v2;
 
+import static org.opentripplanner.ext.fares.service.gtfs.v2.FareLookupService.DEFAULT_FREE_TRANSFER_MATCH_PREDICATE;
+
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiPredicate;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
+import org.opentripplanner.model.fare.FareProduct;
 
 public class GtfsFaresV2ServiceBuilder {
 
@@ -16,6 +20,8 @@ public class GtfsFaresV2ServiceBuilder {
   private List<FareTransferRule> fareTransferRules = List.of();
   private Multimap<FeedScopedId, FeedScopedId> stopAreas = ImmutableMultimap.of();
   private Multimap<FeedScopedId, LocalDate> serviceDatesForServiceId = HashMultimap.create();
+  private BiPredicate<TransferMatch, FareProduct> freeTransferMatchPredicate =
+    DEFAULT_FREE_TRANSFER_MATCH_PREDICATE;
 
   public GtfsFaresV2ServiceBuilder withLegRules(List<FareLegRule> legRules) {
     this.legRules = legRules;
@@ -52,7 +58,20 @@ public class GtfsFaresV2ServiceBuilder {
     return this;
   }
 
+  public GtfsFaresV2ServiceBuilder withFreeTransferMatchPredicate(
+    BiPredicate<TransferMatch, FareProduct> freeTransferMatchPredicate
+  ) {
+    this.freeTransferMatchPredicate = freeTransferMatchPredicate;
+    return this;
+  }
+
   public GtfsFaresV2Service build() {
-    return new GtfsFaresV2Service(legRules, fareTransferRules, stopAreas, serviceDatesForServiceId);
+    return new GtfsFaresV2Service(
+      legRules,
+      fareTransferRules,
+      stopAreas,
+      serviceDatesForServiceId,
+      freeTransferMatchPredicate
+    );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferMatch.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferMatch.java
@@ -5,7 +5,7 @@ import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.model.fare.FareProduct;
 
 /// A rule for transferring from one leg to another one.
-record TransferMatch(
+public record TransferMatch(
   FareTransferRule transferRule,
   FareLegRule fromLegRule,
   FareLegRule toLegRule
@@ -16,7 +16,7 @@ record TransferMatch(
 
   /// Is there a product in the transfer products that matches the given product's category and
   /// medium?
-  /// If there the list of transfer products is empty, then the transfer is eligible for all products.
+  /// If the list of transfer products is empty, then the transfer is eligible for all products.
   public boolean matchesEligibility(FareProduct product) {
     if (transferRule.fareProducts().isEmpty()) {
       return true;

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferMatch.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/TransferMatch.java
@@ -2,10 +2,9 @@ package org.opentripplanner.ext.fares.service.gtfs.v2;
 
 import org.opentripplanner.ext.fares.model.FareLegRule;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
+import org.opentripplanner.model.fare.FareProduct;
 
-/**
- * A rule for transferring from one leg to another one.
- */
+/// A rule for transferring from one leg to another one.
 record TransferMatch(
   FareTransferRule transferRule,
   FareLegRule fromLegRule,
@@ -13,5 +12,15 @@ record TransferMatch(
 ) {
   public boolean isFree() {
     return transferRule.isFree();
+  }
+
+  /// Is there a product in the transfer products that matches the given product's category and
+  /// medium?
+  /// If there the list of transfer products is empty, then the transfer is eligible for all products.
+  public boolean matchesEligibility(FareProduct product) {
+    if (transferRule.fareProducts().isEmpty()) {
+      return true;
+    }
+    return transferRule.fareProducts().stream().anyMatch(product::equalEligibility);
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
@@ -446,47 +446,10 @@ public class OregonHopFareFactory extends GtfsFareServiceFactory {
       .withTransferRules(this.fareTransferRules)
       .withStopAreas(this.stopAreas)
       .withServiceIds(this.serviceDates)
-      .withFreeTransferMatchPredicate((transferMatch, product) -> {
-        return transferMatch
-          .transferRule()
-          .fareProducts()
-          .stream()
-          .anyMatch(transferProduct -> {
-            if (
-              transferProduct.category() == null &&
-              transferProduct.medium() == null &&
-              transferProduct.isFree()
-            ) {
-              return true;
-            } else {
-              return (
-                mediaMatches(transferProduct.medium(), product.medium()) &&
-                categoryMatches(transferProduct.category(), product.category())
-              );
-            }
-          });
-      })
+      .withFreeTransferMatchPredicate(TransferRules.predicate())
       .build();
 
     return new GtfsFaresService(fareService, faresV2Service);
-  }
-
-  private boolean categoryMatches(RiderCategory cat1, RiderCategory cat2) {
-    if (cat1 == null && cat2 == null) {
-      return true;
-    } else if (cat1 == null || cat2 == null) {
-      return false;
-    }
-    return cat1.id().getId().equals(cat2.id().getId());
-  }
-
-  private boolean mediaMatches(FareMedium medium, FareMedium medium1) {
-    if (medium == null && medium1 == null) {
-      return true;
-    } else if (medium == null || medium1 == null) {
-      return false;
-    }
-    return medium.id().getId().equals(medium1.id().getId());
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
@@ -446,9 +446,47 @@ public class OregonHopFareFactory extends GtfsFareServiceFactory {
       .withTransferRules(this.fareTransferRules)
       .withStopAreas(this.stopAreas)
       .withServiceIds(this.serviceDates)
+      .withFreeTransferMatchPredicate((transferMatch, product) -> {
+        return transferMatch
+          .transferRule()
+          .fareProducts()
+          .stream()
+          .anyMatch(transferProduct -> {
+            if (
+              transferProduct.category() == null &&
+              transferProduct.medium() == null &&
+              transferProduct.isFree()
+            ) {
+              return true;
+            } else {
+              return (
+                mediaMatches(transferProduct.medium(), product.medium()) &&
+                categoryMatches(transferProduct.category(), product.category())
+              );
+            }
+          });
+      })
       .build();
 
     return new GtfsFaresService(fareService, faresV2Service);
+  }
+
+  private boolean categoryMatches(RiderCategory cat1, RiderCategory cat2) {
+    if (cat1 == null && cat2 == null) {
+      return true;
+    } else if (cat1 == null || cat2 == null) {
+      return false;
+    }
+    return cat1.id().getId().equals(cat2.id().getId());
+  }
+
+  private boolean mediaMatches(FareMedium medium, FareMedium medium1) {
+    if (medium == null && medium1 == null) {
+      return true;
+    } else if (medium == null || medium1 == null) {
+      return false;
+    }
+    return medium.id().getId().equals(medium1.id().getId());
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/OregonHopFareFactory.java
@@ -446,7 +446,7 @@ public class OregonHopFareFactory extends GtfsFareServiceFactory {
       .withTransferRules(this.fareTransferRules)
       .withStopAreas(this.stopAreas)
       .withServiceIds(this.serviceDates)
-      .withFreeTransferMatchPredicate(TransferRules.predicate())
+      .withFreeTransferMatchPredicate(TransferRules.transferEligibility())
       .build();
 
     return new GtfsFaresService(fareService, faresV2Service);

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/TransferRules.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/TransferRules.java
@@ -1,16 +1,14 @@
 package org.opentripplanner.ext.fares.service.gtfs.v2.custom;
 
-import java.util.function.BiPredicate;
-import org.opentripplanner.ext.fares.service.gtfs.v2.TransferMatch;
+import org.opentripplanner.ext.fares.service.gtfs.v2.FreeTransferEligibility;
 import org.opentripplanner.model.fare.FareMedium;
-import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.fare.RiderCategory;
 
 /// Special predicate for when free transfers apply in the HOP fare calculator. They apply when
 /// the transfer rule has no category or medium specified, or when the ID (ignoring feed id) matches.
 class TransferRules {
 
-  static BiPredicate<TransferMatch, FareProduct> predicate() {
+  static FreeTransferEligibility transferEligibility() {
     return (transferMatch, product) -> {
       if (transferMatch.transferRule().fareProducts().isEmpty()) {
         return true;

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/TransferRules.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/TransferRules.java
@@ -1,0 +1,52 @@
+package org.opentripplanner.ext.fares.service.gtfs.v2.custom;
+
+import java.util.function.BiPredicate;
+import org.opentripplanner.ext.fares.service.gtfs.v2.TransferMatch;
+import org.opentripplanner.model.fare.FareMedium;
+import org.opentripplanner.model.fare.FareProduct;
+import org.opentripplanner.model.fare.RiderCategory;
+
+/// Special predicate for when free transfers apply in the HOP fare calculator. They apply when
+/// the transfer rule has no category or medium specified, or when the ID (ignoring feed id) matches.
+class TransferRules {
+
+  static BiPredicate<TransferMatch, FareProduct> predicate() {
+    return (transferMatch, product) ->
+      transferMatch
+        .transferRule()
+        .fareProducts()
+        .stream()
+        .anyMatch(transferProduct -> {
+          if (
+            transferProduct.category() == null &&
+            transferProduct.medium() == null &&
+            transferProduct.isFree()
+          ) {
+            return true;
+          } else {
+            return (
+              mediaMatches(transferProduct.medium(), product.medium()) &&
+              categoryMatches(transferProduct.category(), product.category())
+            );
+          }
+        });
+  }
+
+  private static boolean categoryMatches(RiderCategory cat1, RiderCategory cat2) {
+    if (cat1 == null && cat2 == null) {
+      return true;
+    } else if (cat1 == null || cat2 == null) {
+      return false;
+    }
+    return cat1.id().getId().equals(cat2.id().getId());
+  }
+
+  private static boolean mediaMatches(FareMedium medium, FareMedium medium1) {
+    if (medium == null && medium1 == null) {
+      return true;
+    } else if (medium == null || medium1 == null) {
+      return false;
+    }
+    return medium.id().getId().equals(medium1.id().getId());
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/TransferRules.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v2/custom/TransferRules.java
@@ -11,25 +11,30 @@ import org.opentripplanner.model.fare.RiderCategory;
 class TransferRules {
 
   static BiPredicate<TransferMatch, FareProduct> predicate() {
-    return (transferMatch, product) ->
-      transferMatch
-        .transferRule()
-        .fareProducts()
-        .stream()
-        .anyMatch(transferProduct -> {
-          if (
-            transferProduct.category() == null &&
-            transferProduct.medium() == null &&
-            transferProduct.isFree()
-          ) {
-            return true;
-          } else {
-            return (
-              mediaMatches(transferProduct.medium(), product.medium()) &&
-              categoryMatches(transferProduct.category(), product.category())
-            );
-          }
-        });
+    return (transferMatch, product) -> {
+      if (transferMatch.transferRule().fareProducts().isEmpty()) {
+        return true;
+      } else {
+        return transferMatch
+          .transferRule()
+          .fareProducts()
+          .stream()
+          .anyMatch(transferProduct -> {
+            if (
+              transferProduct.category() == null &&
+              transferProduct.medium() == null &&
+              transferProduct.isFree()
+            ) {
+              return true;
+            } else {
+              return (
+                mediaMatches(transferProduct.medium(), product.medium()) &&
+                categoryMatches(transferProduct.category(), product.category())
+              );
+            }
+          });
+      }
+    };
   }
 
   private static boolean categoryMatches(RiderCategory cat1, RiderCategory cat2) {

--- a/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
+++ b/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
@@ -95,6 +95,10 @@ public final class FareProduct implements Serializable {
     return price.isZero();
   }
 
+  public boolean equalEligibility(FareProduct p) {
+    return Objects.equals(p.category, this.category) && Objects.equals(p.medium, this.medium);
+  }
+
   @Nullable
   public RiderCategory category() {
     return category;

--- a/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
+++ b/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
@@ -99,6 +99,10 @@ public final class FareProduct implements Serializable {
     return Objects.equals(p.category, this.category) && Objects.equals(p.medium, this.medium);
   }
 
+  public boolean noEligbilityRestrictions() {
+    return category == null && medium == null;
+  }
+
   @Nullable
   public RiderCategory category() {
     return category;

--- a/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
+++ b/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
@@ -99,10 +99,6 @@ public final class FareProduct implements Serializable {
     return Objects.equals(p.category, this.category) && Objects.equals(p.medium, this.medium);
   }
 
-  public boolean noEligbilityRestrictions() {
-    return category == null && medium == null;
-  }
-
   @Nullable
   public RiderCategory category() {
     return category;

--- a/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
+++ b/application/src/main/java/org/opentripplanner/model/fare/FareProduct.java
@@ -95,6 +95,7 @@ public final class FareProduct implements Serializable {
     return price.isZero();
   }
 
+  /// Does this FareProduct have the same category and medium as another FareProduct?
   public boolean equalEligibility(FareProduct p) {
     return Objects.equals(p.category, this.category) && Objects.equals(p.medium, this.medium);
   }

--- a/application/src/test-fixtures/java/org/opentripplanner/ext/fares/model/FareTestConstants.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/ext/fares/model/FareTestConstants.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.fare.FareProduct;
+import org.opentripplanner.model.fare.RiderCategory;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
 
@@ -15,6 +16,10 @@ public interface FareTestConstants {
   FareProduct FARE_PRODUCT_A = fareProduct("A");
   FareProduct FARE_PRODUCT_B = fareProduct("B");
   FareProduct TRANSFER_1 = FareProduct.of(id("transfer:1"), "transfer 1", Money.euros(1)).build();
+
+  RiderCategory CATEGORY_ALPHA = RiderCategory.of(id("cat-alpha"))
+    .withName("Category Alpha")
+    .build();
 
   GroupOfRoutes NETWORK_A = groupOfRoutes("A").build();
   GroupOfRoutes NETWORK_B = groupOfRoutes("B").build();


### PR DESCRIPTION
### Summary

It makes sure that free transfers only apply when the first leg's product's rider category and fare medium match.

Sadly, this is a bit of an inference because GTFS is underspecified about this topic. There is an unmerged PR about clarifying this aspect: https://github.com/google/transit/pull/423

Because some fare implementation have special logic for transfers, this also needs to be configurable.

### Issue

Sandbox feature, so no issue.

### Unit tests

Lots added.

cc @miles-grant-ibigroup 