### PR TITLE
Build scheduled transit leg geometry lazily

### DIFF
--- a/application/src/main/java/org/opentripplanner/model/plan/leg/ScheduledTransitLeg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/leg/ScheduledTransitLeg.java
@@ -61,7 +61,6 @@ public class ScheduledTransitLeg implements TransitLeg {
 
   private final ZonedDateTime startTime;
   private final ZonedDateTime endTime;
-  private final LineString legGeometry;
   private final Set<TransitAlert> transitAlerts;
   private final ConstrainedTransfer transferFromPrevLeg;
   private final ConstrainedTransfer transferToNextLeg;
@@ -117,7 +116,6 @@ public class ScheduledTransitLeg implements TransitLeg {
 
     this.generalizedCost = builder.generalizedCost();
 
-    this.legGeometry = tripPattern.geometryBetween(boardStopPosInPattern, alightStopPosInPattern);
     this.distanceMeters = tripPattern.distanceBetween(
       boardStopPosInPattern,
       alightStopPosInPattern
@@ -315,9 +313,13 @@ public class ScheduledTransitLeg implements TransitLeg {
     return visits;
   }
 
+  /**
+   * The leg geometry is built lazily by concatenating the trip pattern's hop geometries between
+   * the board and alight stops. It is not cached: each call recomputes it.
+   */
   @Override
   public LineString legGeometry() {
-    return legGeometry;
+    return tripPattern.geometryBetween(boardStopPosInPattern, alightStopPosInPattern);
   }
 
   @Override


### PR DESCRIPTION
### Summary

`ScheduledTransitLeg` used to build its leg geometry eagerly in the constructor
(`tripPattern.geometryBetween(boardStopPosInPattern, alightStopPosInPattern)`), which
decodes and concatenates the trip pattern's packed per-hop geometries into a JTS
`LineString`. This was done for every leg created during a routing request,
including the many legs produced and then discarded by the itinerary filter chain.

The geometry is only ever consumed during API serialization (`pointsOnLink` in the
Transmodel API, `legGeometry` in the GTFS API). This PR moves the computation into the
`legGeometry()` getter so it is built on demand: only for legs that survive to the
response and whose geometry field is actually selected in the GraphQL query. Legs that
are filtered out, or responses that don't request geometry, incur no geometry cost.

This change is self-contained and does not change graph serialization (the leg geometry is
a routing-result object, not part of the serialized graph), so no serialization id bump is needed.

### How often is leg geometry actually requested?

To understand the benefit profile, here is a full morning-peak hour of production traffic
on the Entur deployment (3.65M requests). Distinguishing true **leg** geometry from the
unrelated `journeyPattern.pointsOnLink` resolver (which this PR does not touch):

| metric | share |
|---|---|
| trip-planning requests (those that produce legs) | ~30% of all traffic |
| trip-planning requests that fetch leg geometry | **~95%** |

On Entur, essentially every interactive consumer app (journey planners, mobile apps) requests
the leg polyline on 100% of its trip-planning calls in order to draw the route on a map.

**This is deployment-specific.** The ~95% figure reflects Entur's predominantly map-based
clients. Other OTP deployments may request leg geometry far less, or not at all — e.g.
clients that only show a textual/structured itinerary (departure/arrival times, stops,
transfers) without rendering it on a map have no reason to select the geometry field. For
those deployments, this change avoids the eager geometry construction on the large majority
of legs outright.

The change only affects requests that build `ScheduledTransitLeg`s, i.e. trip-planning
requests (~30% of Entur traffic); non-routing requests produce no transit legs and never
incurred leg-geometry cost in the first place. Within trip-planning requests, the wins are:

1. **Filtered-out legs** — `ScheduledTransitLeg`s built for candidate itineraries that the
   filter chain discards before serialization no longer pay for geometry construction. This
   is the main saving on Entur and applies even to the ~95% of requests that do request
   geometry.
2. Trip-planning requests that don't select the geometry field no longer build it for any of
   their legs. On Entur this is only ~5% of routing requests, but on non-map-based
   deployments — where few or no clients request geometry — it is the dominant win.


### Unit tests

No new tests were added.


