### PR TITLE
Make trip times required in ScheduledTransitLeg

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/model/ConsolidatedStopLegBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/model/ConsolidatedStopLegBuilderTest.java
@@ -15,9 +15,12 @@ import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
-import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
+import org.opentripplanner.transit.model._data.TripOnDateDataFetcher;
 import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.timetable.TripTimes;
 
 class ConsolidatedStopLegBuilderTest implements PlanTestConstants {
 
@@ -25,25 +28,26 @@ class ConsolidatedStopLegBuilderTest implements PlanTestConstants {
   private static final Set<TransitAlert> ALERTS = Set.of(
     TransitAlert.of(id("alert")).withDescriptionText(I18NString.of("alert")).build()
   );
-  private static final TimetableRepositoryForTest MODEL = TimetableRepositoryForTest.of();
-  private static final TripPattern PATTERN = MODEL.pattern(TransitMode.BUS)
-    .withStopPattern(
-      TimetableRepositoryForTest.stopPattern(
-        MODEL.stop("S0", 60.0, 10.0).build(),
-        MODEL.stop("S1", 60.0, 10.01).build(),
-        MODEL.stop("S2", 60.0, 10.02).build()
-      )
-    )
-    .build();
+  private static final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
+  private static final TransitTestEnvironment ENV = ENV_BUILDER.addTrip(
+    TripInput.of("test-trip")
+      .addStop(ENV_BUILDER.stop("S0", b -> b.withCoordinate(60.0, 10.0)), "08:00", "08:00")
+      .addStop(ENV_BUILDER.stop("S1", b -> b.withCoordinate(60.0, 10.01)), "08:05", "08:05")
+      .addStop(ENV_BUILDER.stop("S2", b -> b.withCoordinate(60.0, 10.02)), "08:10", "08:10")
+  ).build();
+  private static final TripOnDateDataFetcher TRIP_DATA = ENV.tripData("test-trip");
+  private static final TripPattern PATTERN = TRIP_DATA.tripPattern();
+  private static final TripTimes TRIP_TIMES = TRIP_DATA.scheduledTripTimes();
   private static final ScheduledTransitLeg SCHEDULED_TRANSIT_LEG =
     new ScheduledTransitLegBuilder<>()
-      .withZoneId(ZoneIds.BERLIN)
+      .withTripTimes(TRIP_TIMES)
       .withTripPattern(PATTERN)
       .withBoardStopIndexInPattern(0)
       .withAlightStopIndexInPattern(1)
       .withStartTime(TIME)
       .withEndTime(TIME)
       .withServiceDate(TIME.toLocalDate())
+      .withZoneId(ZoneIds.BERLIN)
       .build();
   private static final List<FareOffer> FARES = List.of(ANY_FARE_OFFER);
 

--- a/application/src/main/java/org/opentripplanner/model/plan/leg/ScheduledTransitLeg.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/leg/ScheduledTransitLeg.java
@@ -86,9 +86,7 @@ public class ScheduledTransitLeg implements TransitLeg {
   private final List<FareOffer> fareOffers;
 
   protected ScheduledTransitLeg(ScheduledTransitLegBuilder<?> builder) {
-    // TODO - Add requireNonNull for trip-times. Some tests fails when this is done, these tests
-    //        should be fixed.
-    this.tripTimes = builder.tripTimes();
+    this.tripTimes = Objects.requireNonNull(builder.tripTimes());
     this.tripPattern = Objects.requireNonNull(builder.tripPattern());
 
     int maxStopPosInPatternLimit = tripPattern.numberOfStops() - 1;

--- a/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTripSchedule.java
+++ b/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTripSchedule.java
@@ -31,6 +31,7 @@ public class TestTripSchedule implements TripSchedule {
   private final int transitReluctanceIndex;
   private final Accessibility wheelchairBoarding;
   private final TripPattern originalPattern;
+  private final TripTimes tripTimes;
 
   protected TestTripSchedule(
     TestTripPattern pattern,
@@ -38,7 +39,8 @@ public class TestTripSchedule implements TripSchedule {
     int[] departureTimes,
     int transitReluctanceIndex,
     Accessibility wheelchairBoarding,
-    TripPattern originalPattern
+    TripPattern originalPattern,
+    TripTimes tripTimes
   ) {
     this.pattern = pattern;
     this.arrivalTimes = arrivalTimes;
@@ -46,6 +48,7 @@ public class TestTripSchedule implements TripSchedule {
     this.transitReluctanceIndex = transitReluctanceIndex;
     this.wheelchairBoarding = wheelchairBoarding;
     this.originalPattern = originalPattern;
+    this.tripTimes = tripTimes;
   }
 
   public static TestTripSchedule.Builder schedule() {
@@ -122,7 +125,7 @@ public class TestTripSchedule implements TripSchedule {
 
   @Override
   public TripTimes getOriginalTripTimes() {
-    return null;
+    return tripTimes;
   }
 
   @Override
@@ -145,6 +148,7 @@ public class TestTripSchedule implements TripSchedule {
     private int transitReluctanceIndex = 0;
     private Accessibility wheelchairBoarding = NO_INFORMATION;
     private TripPattern originalPattern;
+    private TripTimes tripTimes;
 
     public TestTripSchedule.Builder pattern(TestTripPattern pattern) {
       this.pattern = pattern;
@@ -153,6 +157,11 @@ public class TestTripSchedule implements TripSchedule {
 
     public TestTripSchedule.Builder originalPattern(TripPattern pattern) {
       this.originalPattern = pattern;
+      return this;
+    }
+
+    public TestTripSchedule.Builder withTripTimes(TripTimes tripTimes) {
+      this.tripTimes = tripTimes;
       return this;
     }
 
@@ -254,7 +263,8 @@ public class TestTripSchedule implements TripSchedule {
         departureTimes,
         transitReluctanceIndex,
         wheelchairBoarding,
-        originalPattern
+        originalPattern,
+        tripTimes
       );
     }
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
@@ -59,10 +59,13 @@ import org.opentripplanner.street.search.state.TestStateBuilder;
 import org.opentripplanner.transfer.regular.model.DefaultRaptorTransfer;
 import org.opentripplanner.transfer.regular.model.PathTransfer;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.model.timetable.booking.RoutingBookingInfo;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TimetableRepository;
@@ -232,6 +235,7 @@ public class RaptorPathToItineraryMapperTest {
   private TestTripSchedule transferAtSameStopSchedule() {
     TestTransitData data = new TestTransitData();
     var pattern = TestTripPattern.pattern("TestPattern", 1, 2, 3, 2, 1).withRoute(ROUTE);
+    var originalPattern = getOriginalPattern(pattern);
 
     var timetable = new TestTripSchedule.Builder()
       .times(
@@ -242,7 +246,8 @@ public class RaptorPathToItineraryMapperTest {
         TimeUtils.time("10:20")
       )
       .pattern(pattern)
-      .originalPattern(getOriginalPattern(pattern))
+      .originalPattern(originalPattern)
+      .withTripTimes(buildTripTimes(originalPattern))
       .build();
 
     data.withRoutes(TestRoute.route("TransferAtSameStop", 1, 2, 3, 2, 1).withTimetable(timetable));
@@ -259,6 +264,21 @@ public class RaptorPathToItineraryMapperTest {
     );
     var itinerary = mapper.createItinerary(path);
     assertTrue(itinerary.isSearchWindowAware());
+  }
+
+  private TripTimes buildTripTimes(TripPattern originalPattern) {
+    var trip = TimetableRepositoryForTest.trip("test").build();
+    var stopTimes = new ArrayList<StopTime>();
+    for (int i = 0; i < originalPattern.numberOfStops(); i++) {
+      var st = new StopTime();
+      st.setTrip(trip);
+      st.setStop(originalPattern.getStop(i));
+      st.setStopSequence(i);
+      st.setArrivalTime(TRANSIT_START + i * 300);
+      st.setDepartureTime(TRANSIT_START + i * 300);
+      stopTimes.add(st);
+    }
+    return TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
   }
 
   private TripPattern getOriginalPattern(TestTripPattern pattern) {
@@ -294,6 +314,7 @@ public class RaptorPathToItineraryMapperTest {
       .toInstant();
     TimetableRepository timetableRepository = new TimetableRepository();
     timetableRepository.initTimeZone(ZoneIds.CET);
+    timetableRepository.index();
     return new RaptorPathToItineraryMapper<>(
       new Graph(),
       new DefaultTransitService(timetableRepository),
@@ -324,6 +345,7 @@ public class RaptorPathToItineraryMapperTest {
   private TestTripSchedule getTestTripSchedule2() {
     TestTransitData data = new TestTransitData();
     var pattern = TestTripPattern.pattern("TestPattern", 1, 2, 3, 2, 1).withRoute(ROUTE);
+    var originalPattern = getOriginalPattern(pattern);
 
     var timetable = new TestTripSchedule.Builder()
       .times(
@@ -334,7 +356,8 @@ public class RaptorPathToItineraryMapperTest {
         TimeUtils.time("10:20")
       )
       .pattern(pattern)
-      .originalPattern(getOriginalPattern(pattern))
+      .originalPattern(originalPattern)
+      .withTripTimes(buildTripTimes(originalPattern))
       .build();
 
     data.withRoutes(TestRoute.route("TestRoute_1", 1, 2, 3, 2, 1).withTimetable(timetable));
@@ -345,11 +368,13 @@ public class RaptorPathToItineraryMapperTest {
   private TestTripSchedule getTestTripSchedule() {
     TestTransitData data = new TestTransitData();
     var pattern = TestTripPattern.pattern("TestPattern", 1, 2).withRoute(ROUTE);
+    var originalPattern = getOriginalPattern(pattern);
 
     var timetable = new TestTripSchedule.Builder()
       .times(TRANSIT_START, TRANSIT_END)
       .pattern(pattern)
-      .originalPattern(getOriginalPattern(pattern))
+      .originalPattern(originalPattern)
+      .withTripTimes(buildTripTimes(originalPattern))
       .build();
 
     data.withRoutes(TestRoute.route("TestRoute_1", 1, 2).withTimetable(timetable));


### PR DESCRIPTION
### Summary

It enforces the non-nullability of `ScheduledTransitLeg#tripTimes`. In production code this was already non-null but this PR sets it in tests.

### Issue

No issue, just a test clean up.

### Unit tests

Updated.