### PR TITLE
Skip dedup in HashGridSpatialIndex.query for single-bin queries

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/geometry/HashGridSpatialIndex.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/HashGridSpatialIndex.java
@@ -95,11 +95,29 @@ public class HashGridSpatialIndex<T> implements SpatialIndex, Serializable {
 
   @Override
   public final List<T> query(Envelope envelope) {
-    final Set<T> ret = new HashSet<>(1024);
+    // Collect the bins the envelope touches. insert() stores each item once per bin, so a single
+    // touched bin has no duplicates: return its contents directly and skip the dedup HashSet (and
+    // its per-query allocation). Dedup is only needed when the envelope straddles bin boundaries
+    // (2+ bins), where an item indexed in several of them would otherwise be returned more than once.
+    final List<List<T>> hitBins = new ArrayList<>(4);
     visit(envelope, false, (bin, mapKey) -> {
-      ret.addAll(bin);
+      hitBins.add(bin);
       return false;
     });
+    if (hitBins.isEmpty()) {
+      return new ArrayList<>();
+    }
+    if (hitBins.size() == 1) {
+      return new ArrayList<>(hitBins.get(0));
+    }
+    int total = 0;
+    for (List<T> bin : hitBins) {
+      total += bin.size();
+    }
+    final Set<T> ret = HashSet.newHashSet(total);
+    for (List<T> bin : hitBins) {
+      ret.addAll(bin);
+    }
     return new ArrayList<>(ret);
   }
 

--- a/street/src/test/java/org/opentripplanner/street/geometry/HashGridSpatialIndexTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/HashGridSpatialIndexTest.java
@@ -1,0 +1,63 @@
+package org.opentripplanner.street.geometry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+
+class HashGridSpatialIndexTest {
+
+  // 1-degree bins so cell = round(coord) and tests can place items in known cells.
+  private static HashGridSpatialIndex<Integer> index() {
+    return new HashGridSpatialIndex<>(1.0, 1.0);
+  }
+
+  @Test
+  void singleBinReturnsAllItemsOnce() {
+    var idx = index();
+    idx.insert(new Envelope(new Coordinate(0.2, 0.1)), 1);
+    idx.insert(new Envelope(new Coordinate(0.4, 0.3)), 2);
+
+    List<Integer> result = idx.query(new Envelope(new Coordinate(0.25, 0.2)));
+
+    assertEquals(2, result.size(), "single bin should return each item exactly once");
+    assertEquals(Set.of(1, 2), Set.copyOf(result));
+  }
+
+  @Test
+  void straddlingItemIsDedupedAcrossBins() {
+    var idx = index();
+    // cell (0,0)
+    idx.insert(new Envelope(new Coordinate(0.2, 0.1)), 1);
+    // cell (0,0)
+    idx.insert(new Envelope(new Coordinate(0.4, 0.3)), 2);
+    // Item 3 spans x in [0.4, 0.6] -> indexed in cells (0,0) and (1,0).
+    idx.insert(new Envelope(0.4, 0.6, 0.1, 0.1), 3);
+
+    // Query spans cells (0,0) and (1,0), so item 3 is found in both bins.
+    List<Integer> result = idx.query(new Envelope(0.3, 0.7, 0.0, 0.2));
+
+    assertEquals(Set.of(1, 2, 3), Set.copyOf(result));
+    assertEquals(
+      1,
+      result
+        .stream()
+        .filter(i -> i == 3)
+        .count(),
+      "straddling item must be deduped"
+    );
+    assertEquals(3, result.size(), "no duplicates across the two touched bins");
+  }
+
+  @Test
+  void emptyEnvelopeReturnsEmpty() {
+    var idx = index();
+    idx.insert(new Envelope(new Coordinate(0.2, 0.1)), 1);
+
+    assertTrue(idx.query(new Envelope(new Coordinate(100.0, 100.0))).isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

`HashGridSpatialIndex.query()` always allocated a `HashSet` and re-hashed every candidate in order to deduplicate items the index stores in more than one cell. But `insert()` stores each item **once per cell**, so when an envelope touches a **single cell** there are no duplicates to remove. This PR returns that cell's contents directly and skips the `HashSet` in that case; dedup runs only when the envelope straddles 2+ cells, and the set is then sized to the actual candidate count instead of a fixed `1024`.

```java
final List<List<T>> hitBins = new ArrayList<>(4);
visit(envelope, false, (bin, mapKey) -> { hitBins.add(bin); return false; });
if (hitBins.isEmpty()) return new ArrayList<>();
if (hitBins.size() == 1) return new ArrayList<>(hitBins.get(0)); // no dedup needed
int total = 0; for (var bin : hitBins) total += bin.size();
final Set<T> ret = HashSet.newHashSet(total);
for (var bin : hitBins) ret.addAll(bin);
return new ArrayList<>(ret);
```

Behaviour is unchanged (same items, deduped); it just avoids the `HashSet` allocation + hashing on the common single-cell path. A new `HashGridSpatialIndexTest` covers the single-bin, multi-bin-dedup, and empty-envelope cases.

## Why it helps (and when)

The skip only fires for single-cell queries. With the historical street-linking envelopes (≥100 m, which span 2–4 of the ~500 m grid cells) it would essentially never trigger. It becomes worthwhile with **small search envelopes** — in particular the reduced real-time rental linking radius in #7694, where at Norwegian latitudes ~74% of rental queries touch a single cell.

