### PR TITLE
Reuse a prepared geometry index for area visibility-edge linking

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
@@ -1,0 +1,68 @@
+package org.opentripplanner.street.linking;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.operation.relateng.RelateNG;
+import org.locationtech.jts.operation.relateng.RelatePredicate;
+import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.model.edge.AreaGroup;
+
+/**
+ * An {@link AreaGroup} together with a lazily built, reusable spatial index over its polygon, used to
+ * answer the repeated {@code contains} checks performed while linking a vertex to the area's
+ * visibility vertices.
+ * <p>
+ * A plain {@code Polygon.contains(...)} rebuilds a sweep-line index over the polygon boundary on
+ * every call. By preparing the polygon once with {@link RelateNG} and reusing the cached index
+ * across all candidate checks, we build that index a single time per linking operation. RelateNG is
+ * also tolerant of invalid / self-intersecting OSM polygons (it does not throw
+ * {@code TopologyException}).
+ * <p>
+ * The index is built lazily on the first {@link #containsSegment(Coordinate, Coordinate)} call, so
+ * the forced-edge linking paths — which skip the boundary check — never pay for it. An instance is
+ * created and used within a single linking call and never escapes that thread, so the unsynchronized
+ * lazy field is not a concern.
+ */
+final class PreparedAreaGroup {
+
+  private static final GeometryFactory GEOMETRY_FACTORY = GeometryUtils.getGeometryFactory();
+
+  /**
+   * Factor by which a candidate segment is shrunk at each end before the containment test. Floating
+   * point math cannot represent boundaries precisely, so the segment between two boundary points is
+   * pulled slightly inward to make the test robust.
+   */
+  private static final double AREA_INTERSECTION_SHRINKING = 0.0001;
+
+  private final AreaGroup areaGroup;
+  private RelateNG prepared;
+
+  PreparedAreaGroup(AreaGroup areaGroup) {
+    this.areaGroup = areaGroup;
+  }
+
+  AreaGroup areaGroup() {
+    return areaGroup;
+  }
+
+  /**
+   * Whether the area polygon contains the segment between the two coordinates. The segment is shrunk
+   * slightly at both ends first, so that a segment connecting two boundary points is not rejected by
+   * floating point imprecision at the boundary. Reuses a cached prepared index across calls.
+   */
+  boolean containsSegment(Coordinate from, Coordinate to) {
+    if (prepared == null) {
+      prepared = RelateNG.prepare(areaGroup.getGeometry());
+    }
+    return prepared.evaluate(createShrunkLine(from, to), RelatePredicate.contains());
+  }
+
+  private static LineString createShrunkLine(Coordinate from, Coordinate to) {
+    var dx = AREA_INTERSECTION_SHRINKING * (to.x - from.x);
+    var dy = AREA_INTERSECTION_SHRINKING * (to.y - from.y);
+    var c1 = new Coordinate(from.x + dx, from.y + dy);
+    var c2 = new Coordinate(to.x - dx, to.y - dy);
+    return GEOMETRY_FACTORY.createLineString(new Coordinate[] { c1, c2 });
+  }
+}

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -65,12 +65,6 @@ public class VertexLinker {
     SphericalDistanceLibrary.metersToDegrees(0.001);
 
   /**
-   * Edge - area intersection often tests edges which start/end at area edge.
-   * Shrink egde slightly to avoid accuracy errors
-   */
-  private static final double AREA_INTERSECTION_SHRINKING = 0.0001;
-
-  /**
    * Minimal distance for considering two nodes the same
    */
   private static final double DUPLICATE_NODE_EPSILON_DEGREES_SQUARED =
@@ -425,7 +419,7 @@ public class VertexLinker {
         // vertex is inside the area. try connecting the vertex to the edge's split point, because
         // connections to visibility vertices may fail or do not always provide an optimal route
         // note that by definition, connection to closest edge cannot be blocked and edge can be forced
-        addVisibilityEdges(start, split, ag, scope, tempEdges, true);
+        addVisibilityEdges(start, split, new PreparedAreaGroup(ag), scope, tempEdges, true);
       } else {
         // vertex is outside an area. Use split point for area connections
         start = split;
@@ -618,6 +612,8 @@ public class VertexLinker {
     boolean force
   ) {
     Geometry polygon = areaGroup.getGeometry();
+    // Reused across all candidate contains() checks below so the spatial index is built only once.
+    var area = new PreparedAreaGroup(areaGroup);
 
     int added = 0;
 
@@ -643,7 +639,7 @@ public class VertexLinker {
       }
     }
     for (IntersectionVertex v : visibilityVertices) {
-      if (addVisibilityEdges(newVertex, v, areaGroup, scope, tempEdges, false)) {
+      if (addVisibilityEdges(newVertex, v, area, scope, tempEdges, false)) {
         added++;
       }
     }
@@ -667,7 +663,7 @@ public class VertexLinker {
           nearest = areaGroup.visibilityVertices().stream().findFirst();
         }
         if (nearest.isPresent()) {
-          return addVisibilityEdges(newVertex, nearest.get(), areaGroup, scope, tempEdges, true);
+          return addVisibilityEdges(newVertex, nearest.get(), area, scope, tempEdges, true);
         }
       }
       return false;
@@ -692,25 +688,11 @@ public class VertexLinker {
     return modes;
   }
 
-  /**
-   * Create a slightly shortened line between two coordinates.
-   * This is used when testing if a polygon contains a line between two
-   * of its boundary points. Floating point math cannot represent boundaries
-   * precisely, so we need to shrink the line to ensure robust testing.
-   */
-  private LineString createShrunkLine(Coordinate from, Coordinate to) {
-    var dx = AREA_INTERSECTION_SHRINKING * (to.x - from.x);
-    var dy = AREA_INTERSECTION_SHRINKING * (to.y - from.y);
-    var c1 = new Coordinate(from.x + dx, from.y + dy);
-    var c2 = new Coordinate(to.x - dx, to.y - dy);
-    return GEOMETRY_FACTORY.createLineString(new Coordinate[] { c1, c2 });
-  }
-
   /* Check if an edge candiate does not cross the area boundary and add it if it does not */
   private boolean addVisibilityEdges(
     IntersectionVertex from,
     IntersectionVertex to,
-    AreaGroup ag,
+    PreparedAreaGroup area,
     Scope scope,
     DisposableEdgeCollection tempEdges,
     boolean force
@@ -726,12 +708,12 @@ public class VertexLinker {
     var c1 = from.getCoordinate();
     var c2 = to.getCoordinate();
     // ensure that new edge does not leave the bounds of the area or hit any holes
-    if (!force && !ag.getGeometry().contains(createShrunkLine(c1, c2))) {
+    if (!force && !area.containsSegment(c1, c2)) {
       return false;
     }
     LineString line = GEOMETRY_FACTORY.createLineString(new Coordinate[] { c1, c2 });
     // add connecting edges
-    createEdges(line, from, to, ag, scope, tempEdges);
+    createEdges(line, from, to, area.areaGroup(), scope, tempEdges);
 
     return true;
   }

--- a/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
@@ -1,0 +1,75 @@
+package org.opentripplanner.street.linking;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.model.edge.AreaGroup;
+
+class PreparedAreaGroupTest {
+
+  private static final GeometryFactory GF = GeometryUtils.getGeometryFactory();
+
+  // A 10x10 square with a 2x2 hole in the centre (x,y in (4,6)).
+  private static final Polygon SQUARE_WITH_HOLE = squareWithHole();
+
+  private final PreparedAreaGroup area = new PreparedAreaGroup(new AreaGroup(SQUARE_WITH_HOLE));
+
+  @Test
+  void containsInteriorSegment() {
+    assertTrue(area.containsSegment(new Coordinate(1, 1), new Coordinate(1, 9)));
+  }
+
+  @Test
+  void containsBoundaryToBoundarySegmentThroughInterior() {
+    // Visibility vertices sit on the area boundary; a connection between two of them that stays
+    // inside the area must be accepted. Here x=2 runs from the bottom edge to the top edge, left of
+    // the hole.
+    assertTrue(area.containsSegment(new Coordinate(2, 0), new Coordinate(2, 10)));
+  }
+
+  @Test
+  void doesNotContainHoleCrossingSegment() {
+    // A horizontal segment at y=5 from the left edge to the right edge passes through the hole.
+    assertFalse(area.containsSegment(new Coordinate(1, 5), new Coordinate(9, 5)));
+  }
+
+  @Test
+  void doesNotContainExteriorSegment() {
+    assertFalse(area.containsSegment(new Coordinate(11, 11), new Coordinate(12, 12)));
+  }
+
+  @Test
+  void exposesWrappedAreaGroup() {
+    var ag = new AreaGroup(SQUARE_WITH_HOLE);
+    assertSame(ag, new PreparedAreaGroup(ag).areaGroup());
+  }
+
+  private static Polygon squareWithHole() {
+    LinearRing shell = GF.createLinearRing(
+      new Coordinate[] {
+        new Coordinate(0, 0),
+        new Coordinate(10, 0),
+        new Coordinate(10, 10),
+        new Coordinate(0, 10),
+        new Coordinate(0, 0),
+      }
+    );
+    LinearRing hole = GF.createLinearRing(
+      new Coordinate[] {
+        new Coordinate(4, 4),
+        new Coordinate(6, 4),
+        new Coordinate(6, 6),
+        new Coordinate(4, 6),
+        new Coordinate(4, 4),
+      }
+    );
+    return GF.createPolygon(shell, new LinearRing[] { hole });
+  }
+}


### PR DESCRIPTION
### Summary

When a vertex (e.g. a free-floating rental vehicle) is linked into a walkable `AreaGroup`, `VertexLinker.addAreaVertex` tests each candidate visibility edge against the area polygon with a `contains()` check. The previous code called `Polygon.contains()` once **per candidate**, and each call rebuilds a JTS sweep-line index over the polygon's boundary from scratch. This PR prepares the polygon **once per `addAreaVertex` call** with `RelateNG.prepare(...)` and reuses the cached index across all candidate checks, eliminating the repeated index construction.

### Issue

**Motivation.** Profiling the `graph-writer` thread during the GBFS rental-vehicle initialization at startup (when many vehicles are linked into pedestrian areas / plazas / large parking polygons) showed area visibility-edge linking as the dominant allocation and a major CPU cost — the per-candidate sweep-line index rebuild (`SweepLineEvent`, `MonotoneChain`, `Object[]`, `int[]`, `TopologyLocation`). The flood is CPU-bound on a single graph-writer thread, so this work directly delays the initial real-time apply / readiness.

**How the code works.** `addAreaVertex` already loops over the area's visibility vertices, calling `addVisibilityEdges` (which performs the `contains` boundary test) for each. JTS predicate calls are stateless — every `Polygon.contains(line)` builds and then discards a boundary index. Since all N candidates test the *same*, immutable `AreaGroup` polygon, we build the index once via `RelateNG.prepare(polygon)` and pass it down so each candidate reuses it.

**Technical approach and design considerations.**

- **RelateNG vs the old `PreparedGeometry`.** RelateNG (JTS 1.20.0) is the maintained replacement for both `RelateOp` and the `prep` package, and is robust to invalid / self-intersecting OSM polygons (no `TopologyException`).
- **Intentionally out of scope.** `createEdges` still uses `polygon.intersection(line)` — an *overlay* operation, not a predicate, which neither prepared API accelerates. It runs only after `contains` has already passed (far fewer calls), so it is left unchanged.

### Unit tests

- No new unit tests: this is a behavior-preserving optimization of an existing path.

