### PR TITLE
Support multiple siri feeds for carpooling, purge expired carpooling trips

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolTripTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolTripTestData.java
@@ -262,13 +262,11 @@ public class CarpoolTripTestData {
     List<CarpoolStop> stops
   ) {
     var actualStartTime = startTime != null ? startTime : ZonedDateTime.now();
-    var builder = new CarpoolTripBuilder(FeedScopedId.ofNullable("TEST", "trip-" + ++idCounter))
+    return new CarpoolTripBuilder(FeedScopedId.ofNullable("TEST", "trip-" + ++idCounter))
       .withStops(stops)
       .withTotalCapacity(capacity)
-      .withStartTime(actualStartTime);
-    if (startTime != null) {
-      builder.withEndTime(startTime.plusHours(1));
-    }
-    return builder.build();
+      .withStartTime(actualStartTime)
+      .withEndTime(actualStartTime.plusHours(1))
+      .build();
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepositoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepositoryTest.java
@@ -1,0 +1,103 @@
+package org.opentripplanner.ext.carpooling.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
+import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_EAST;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+
+class DefaultCarpoolingRepositoryTest {
+
+  private static final ZonedDateTime NOON = ZonedDateTime.of(
+    2026,
+    6,
+    5,
+    12,
+    0,
+    0,
+    0,
+    ZoneId.of("Europe/Oslo")
+  );
+
+  @Test
+  void removesTripsThatEndedBeforeTheThreshold() {
+    var repository = new DefaultCarpoolingRepository();
+    var ended = tripEndingAt(NOON);
+    var ongoing = tripEndingAt(NOON.plusHours(2));
+    repository.upsertCarpoolTrip(ended);
+    repository.upsertCarpoolTrip(ongoing);
+
+    int removed = repository.removeExpiredTrips(NOON.plusHours(1).toInstant(), Duration.ZERO);
+
+    assertThat(removed).isEqualTo(1);
+    assertThat(repository.getCarpoolTrips()).containsExactly(ongoing);
+  }
+
+  @Test
+  void keepsTripsEndingExactlyAtTheThreshold() {
+    var repository = new DefaultCarpoolingRepository();
+    var trip = tripEndingAt(NOON);
+    repository.upsertCarpoolTrip(trip);
+
+    int removed = repository.removeExpiredTrips(NOON.toInstant(), Duration.ZERO);
+
+    assertThat(removed).isEqualTo(0);
+    assertThat(repository.getCarpoolTrips()).containsExactly(trip);
+  }
+
+  @Test
+  void appliesTheExpiryDurationToTheCutOff() {
+    var repository = new DefaultCarpoolingRepository();
+    var ended = tripEndingAt(NOON);
+    var ongoing = tripEndingAt(NOON.plusHours(2));
+    repository.upsertCarpoolTrip(ended);
+    repository.upsertCarpoolTrip(ongoing);
+
+    // Cut-off is NOON.plusHours(3) - 2h = NOON.plusHours(1), so only the trip ending at noon expires.
+    int removed = repository.removeExpiredTrips(NOON.plusHours(3).toInstant(), Duration.ofHours(2));
+
+    assertThat(removed).isEqualTo(1);
+    assertThat(repository.getCarpoolTrips()).containsExactly(ongoing);
+  }
+
+  @Test
+  void throttlesSweepsToOncePerInterval() {
+    var repository = new DefaultCarpoolingRepository();
+    repository.upsertCarpoolTrip(tripEndingAt(NOON));
+
+    // First sweep runs and purges the expired trip.
+    assertThat(
+      repository.removeExpiredTrips(NOON.plusHours(1).toInstant(), Duration.ZERO)
+    ).isEqualTo(1);
+
+    // A second, already-expired trip is added shortly after.
+    var addedAfterSweep = tripEndingAt(NOON);
+    repository.upsertCarpoolTrip(addedAfterSweep);
+
+    // A call within the sweep interval is throttled: nothing is scanned or removed.
+    assertThat(
+      repository.removeExpiredTrips(NOON.plusHours(1).plusMinutes(30).toInstant(), Duration.ZERO)
+    ).isEqualTo(0);
+    assertThat(repository.getCarpoolTrips()).containsExactly(addedAfterSweep);
+
+    // Once the interval has elapsed the next call sweeps again.
+    assertThat(
+      repository.removeExpiredTrips(NOON.plusHours(2).toInstant(), Duration.ZERO)
+    ).isEqualTo(1);
+    assertThat(repository.getCarpoolTrips()).isEmpty();
+  }
+
+  private static CarpoolTrip tripEndingAt(ZonedDateTime endTime) {
+    return CarpoolTripTestData.createSimpleTripWithTimes(
+      OSLO_CENTER,
+      OSLO_EAST,
+      endTime.minusHours(1),
+      endTime
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/model/CarpoolTripBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/model/CarpoolTripBuilderTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.carpooling.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_EAST;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createSimpleTrip;
@@ -21,6 +22,7 @@ public class CarpoolTripBuilderTest {
     var startTime = ZonedDateTime.now();
     var endTime = ZonedDateTime.now().plusMinutes(45);
     var stop = createStopAt(OSLO_EAST);
+    var destination = createStopAt(OSLO_NORTH);
 
     var builder = new CarpoolTripBuilder(new FeedScopedId("feed", "id"));
     var trip = builder
@@ -28,7 +30,7 @@ public class CarpoolTripBuilderTest {
       .withProvider("UNIT")
       .withStartTime(startTime)
       .withEndTime(endTime)
-      .withStops(List.of(stop))
+      .withStops(List.of(stop, destination))
       .buildFromValues();
 
     assertEquals(2, trip.totalCapacity());
@@ -59,12 +61,12 @@ public class CarpoolTripBuilderTest {
       .withPhoneNumber("+4712345678")
       .withBookingUrl("https://example.com/book")
       .build();
-    var stop = createStopAt(1, OSLO_EAST);
+    var stops = List.of(createStopAt(1, OSLO_EAST), createStopAt(1, OSLO_NORTH));
 
     var trip = new CarpoolTripBuilder(new FeedScopedId("feed", "contact-test"))
       .withStartTime(ZonedDateTime.now())
       .withEndTime(ZonedDateTime.now().plusMinutes(30))
-      .withStops(List.of(stop))
+      .withStops(stops)
       .withPublicContactInformation(contact)
       .buildFromValues();
 
@@ -77,12 +79,12 @@ public class CarpoolTripBuilderTest {
   void buildFromValues_withNullableContactFields_allowsNulls() {
     var contactPhoneOnly = ContactInfo.of().withPhoneNumber("+4712345678").build();
     var contactUrlOnly = ContactInfo.of().withBookingUrl("https://example.com/book").build();
-    var stop = createStopAt(1, OSLO_EAST);
+    var stops = List.of(createStopAt(1, OSLO_EAST), createStopAt(1, OSLO_NORTH));
 
     var tripWithPhone = new CarpoolTripBuilder(new FeedScopedId("feed", "phone-only"))
       .withStartTime(ZonedDateTime.now())
       .withEndTime(ZonedDateTime.now().plusMinutes(30))
-      .withStops(List.of(stop))
+      .withStops(stops)
       .withPublicContactInformation(contactPhoneOnly)
       .buildFromValues();
 
@@ -92,7 +94,7 @@ public class CarpoolTripBuilderTest {
     var tripWithUrl = new CarpoolTripBuilder(new FeedScopedId("feed", "url-only"))
       .withStartTime(ZonedDateTime.now())
       .withEndTime(ZonedDateTime.now().plusMinutes(30))
-      .withStops(List.of(stop))
+      .withStops(stops)
       .withPublicContactInformation(contactUrlOnly)
       .buildFromValues();
 
@@ -105,14 +107,24 @@ public class CarpoolTripBuilderTest {
 
   @Test
   void buildFromValues_withoutPublicContactInformation_defaultsToNull() {
-    var stop = createStopAt(1, OSLO_EAST);
+    var stops = List.of(createStopAt(1, OSLO_EAST), createStopAt(1, OSLO_NORTH));
 
     var trip = new CarpoolTripBuilder(new FeedScopedId("feed", "no-contact"))
       .withStartTime(ZonedDateTime.now())
       .withEndTime(ZonedDateTime.now().plusMinutes(30))
-      .withStops(List.of(stop))
+      .withStops(stops)
       .buildFromValues();
 
     assertNull(trip.publicContactInformation());
+  }
+
+  @Test
+  void buildFromValues_withFewerThanTwoStops_throws() {
+    var builder = new CarpoolTripBuilder(new FeedScopedId("feed", "too-few-stops"))
+      .withStartTime(ZonedDateTime.now())
+      .withEndTime(ZonedDateTime.now().plusMinutes(30))
+      .withStops(List.of(createStopAt(OSLO_EAST)));
+
+    assertThrows(IllegalArgumentException.class, builder::buildFromValues);
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
@@ -31,7 +31,7 @@ import uk.org.siri.siri21.EstimatedCall;
 
 public class CarpoolSiriMapperTest {
 
-  private final CarpoolSiriMapper mapper = new CarpoolSiriMapper();
+  private final CarpoolSiriMapper mapper = new CarpoolSiriMapper("EN");
 
   @Test
   void mapSiriToCarpoolTrip_arrivalIsAfterDepartureTime_throwsIllegalArgumentException() {

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/MultiFeedSiriETCarpoolingUpdaterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/MultiFeedSiriETCarpoolingUpdaterTest.java
@@ -1,0 +1,145 @@
+package org.opentripplanner.ext.carpooling.updater;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.cancelledJourney;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.minimalCompleteJourney;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.framework.io.HttpHeaders;
+import org.opentripplanner.updater.trip.siri.updater.DefaultSiriETUpdaterParameters;
+
+/**
+ * Verifies that two {@link SiriETCarpoolingUpdater} instances can share a single
+ * {@link DefaultCarpoolingRepository} without colliding when both receive a SIRI journey
+ * with the same {@code EstimatedVehicleJourneyCode}. The two updaters represent two
+ * independent SIRI-ET feeds; their feedIds are the only thing that should keep their
+ * trips apart in the shared repository.
+ *
+ * <p>The {@code processEstimatedTimetableDeliveries} pipeline is called once per updater
+ * per polling cycle and receives only the deliveries fetched from that updater's source
+ * URL — there is no per-call feed multiplexing inside a single delivery list, so the
+ * tests below invoke each updater explicitly.
+ */
+class MultiFeedSiriETCarpoolingUpdaterTest {
+
+  private static final String FEED_A = "EN";
+  private static final String FEED_B = "AT";
+
+  private DefaultCarpoolingRepository repository;
+  private SiriETCarpoolingUpdater updaterA;
+  private SiriETCarpoolingUpdater updaterB;
+  private final CarpoolSiriMapper mapperA = new CarpoolSiriMapper(FEED_A);
+  private final CarpoolSiriMapper mapperB = new CarpoolSiriMapper(FEED_B);
+
+  @BeforeEach
+  void setUp() {
+    repository = new DefaultCarpoolingRepository();
+    updaterA = new SiriETCarpoolingUpdater(paramsFor(FEED_A), repository);
+    updaterB = new SiriETCarpoolingUpdater(paramsFor(FEED_B), repository);
+  }
+
+  @Test
+  void sameJourneyCode_acrossFeeds_storedAsDistinctTrips() {
+    var journey = minimalCompleteJourney();
+
+    updaterA.processEstimatedVehicleJourney(journey);
+    updaterB.processEstimatedVehicleJourney(journey);
+
+    var idA = mapperA.tripId(journey);
+    var idB = mapperB.tripId(journey);
+
+    // Same local id, but different feed prefixes
+    assertEquals(idA.getId(), idB.getId());
+    assertEquals(FEED_A, idA.getFeedId());
+    assertEquals(FEED_B, idB.getFeedId());
+
+    Set<FeedScopedId> ids = repository
+      .getCarpoolTrips()
+      .stream()
+      .map(CarpoolTrip::getId)
+      .collect(Collectors.toSet());
+
+    assertEquals(Set.of(idA, idB), ids);
+  }
+
+  @Test
+  void cancellationOnOneFeed_doesNotRemoveTripOnOtherFeed() {
+    var journey = minimalCompleteJourney();
+    updaterA.processEstimatedVehicleJourney(journey);
+    updaterB.processEstimatedVehicleJourney(journey);
+
+    var idA = mapperA.tripId(journey);
+    var idB = mapperB.tripId(journey);
+    assertTrue(tripIsInRepository(idA));
+    assertTrue(tripIsInRepository(idB));
+
+    updaterA.processEstimatedVehicleJourney(cancelledJourney());
+
+    assertFalse(tripIsInRepository(idA));
+    assertTrue(tripIsInRepository(idB));
+  }
+
+  @Test
+  void everyTripCarriesItsOwnFeedPrefix() {
+    var journey = minimalCompleteJourney();
+    updaterA.processEstimatedVehicleJourney(journey);
+    updaterB.processEstimatedVehicleJourney(journey);
+
+    var feedPrefixes = repository
+      .getCarpoolTrips()
+      .stream()
+      .map(t -> t.getId().getFeedId())
+      .collect(Collectors.toSet());
+
+    assertEquals(Set.of(FEED_A, FEED_B), feedPrefixes);
+
+    // Every stop on every trip must inherit the trip's feed prefix — guards against
+    // a half-finished refactor where the trip id is parameterised but stop ids are not.
+    for (var trip : repository.getCarpoolTrips()) {
+      var expectedFeed = trip.getId().getFeedId();
+      for (var stop : trip.stops()) {
+        assertEquals(
+          expectedFeed,
+          stop.getId().getFeedId(),
+          "Stop %s on trip %s should carry feed prefix %s".formatted(
+            stop.getId(),
+            trip.getId(),
+            expectedFeed
+          )
+        );
+      }
+    }
+  }
+
+  private static DefaultSiriETUpdaterParameters paramsFor(String feedId) {
+    return new DefaultSiriETUpdaterParameters(
+      "carpool-test-" + feedId,
+      feedId,
+      false,
+      "http://localhost/never-fetched-" + feedId,
+      Duration.ofMinutes(1),
+      "test-requestor",
+      Duration.ofSeconds(30),
+      Duration.ofMinutes(15),
+      false,
+      HttpHeaders.empty(),
+      false
+    );
+  }
+
+  private boolean tripIsInRepository(FeedScopedId id) {
+    return repository
+      .getCarpoolTrips()
+      .stream()
+      .anyMatch(t -> t.getId().equals(id));
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdaterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdaterTest.java
@@ -19,16 +19,18 @@ import org.opentripplanner.updater.trip.siri.updater.DefaultSiriETUpdaterParamet
 
 class SiriETCarpoolingUpdaterTest {
 
+  private static final String FEED_ID = "EN";
+
   private DefaultCarpoolingRepository repository;
   private SiriETCarpoolingUpdater updater;
-  private final CarpoolSiriMapper mapper = new CarpoolSiriMapper();
+  private final CarpoolSiriMapper mapper = new CarpoolSiriMapper(FEED_ID);
 
   @BeforeEach
   void setUp() {
     repository = new DefaultCarpoolingRepository();
     var params = new DefaultSiriETUpdaterParameters(
       "carpool-test",
-      "ENT",
+      FEED_ID,
       false,
       "http://localhost/never-fetched",
       Duration.ofMinutes(1),

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.carpooling;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
@@ -45,4 +47,28 @@ public interface CarpoolingRepository {
    * Removes the carpool trip with the given id. No-op if no trip with this id exists.
    */
   void removeCarpoolTrip(FeedScopedId id);
+
+  /**
+   * Removes all carpool trips that have already ended and are therefore no longer routable.
+   * <p>
+   * A trip is considered expired when its {@link CarpoolTrip#latestEndTime()} is before
+   * {@code now.minus(expiry)}. Removing such trips bounds the memory use of instances that run for a
+   * long time without restarting, since the SIRI source is not guaranteed to send an explicit
+   * cancellation for a journey once it has completed. This mirrors how real-time timetable data is
+   * purged once its service date has passed (see {@code TimetableSnapshot#purgeExpiredData}), with
+   * the difference that carpool trips carry a concrete instant rather than a service date.
+   * <p>
+   * The scan is throttled so that it runs at most once per sweep interval no matter how often it is
+   * called. The throttle state lives on the repository rather than on the caller, so when several
+   * updaters (one per SIRI feed) share a repository, the trips are swept at most once per interval
+   * in total instead of once per feed. Calls made before the interval has elapsed are a no-op and
+   * return {@code 0}. The method is safe to call concurrently from multiple updater threads.
+   *
+   * @param now the current instant, used both as the throttle reference and to derive the expiry
+   *            cut-off
+   * @param expiry how long a trip is retained after its latest end time before it becomes eligible
+   *               for removal
+   * @return the number of trips removed, or {@code 0} when the call was throttled
+   */
+  int removeExpiredTrips(Instant now, Duration expiry);
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepository.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepository.java
@@ -1,8 +1,11 @@
 package org.opentripplanner.ext.carpooling.internal;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
@@ -13,7 +16,17 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCarpoolingRepository.class);
 
+  /**
+   * Minimum time between expiry sweeps. Trips expire on a multi-day timescale, so scanning the
+   * repository on every poll is wasteful; sweeping at most this often keeps the work negligible
+   * regardless of how short — or how many — the polling feeds are.
+   */
+  private static final Duration SWEEP_INTERVAL = Duration.ofHours(1);
+
   private final Map<FeedScopedId, CarpoolTrip> trips = new ConcurrentHashMap<>();
+
+  /** The earliest instant at which the next expiry sweep is allowed to run. */
+  private final AtomicReference<Instant> nextSweep = new AtomicReference<>(Instant.MIN);
 
   @Override
   public Collection<CarpoolTrip> getCarpoolTrips() {
@@ -38,5 +51,28 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
     } else {
       LOG.debug("Tried to remove unknown carpool trip {}", id);
     }
+  }
+
+  @Override
+  public int removeExpiredTrips(Instant now, Duration expiry) {
+    Instant allowedAt = nextSweep.get();
+    if (now.isBefore(allowedAt) || !nextSweep.compareAndSet(allowedAt, now.plus(SWEEP_INTERVAL))) {
+      return 0;
+    }
+
+    Instant expiryThreshold = now.minus(expiry);
+    int removed = 0;
+    for (CarpoolTrip trip : trips.values()) {
+      if (
+        trip.latestEndTime().toInstant().isBefore(expiryThreshold) &&
+        trips.remove(trip.getId(), trip)
+      ) {
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      LOG.debug("Removed {} carpool trips that ended before {}", removed, expiryThreshold);
+    }
+    return removed;
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
@@ -72,8 +72,8 @@ public class CarpoolTrip
 
   public CarpoolTrip(CarpoolTripBuilder builder) {
     super(builder.getId());
-    this.startTime = builder.startTime();
-    this.endTime = builder.endTime();
+    this.startTime = Objects.requireNonNull(builder.startTime());
+    this.endTime = Objects.requireNonNull(builder.endTime());
     this.provider = builder.provider();
     this.totalCapacity = builder.totalCapacity();
     this.stops = Collections.unmodifiableList(builder.stops());

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
@@ -77,33 +77,26 @@ public class CarpoolTrip
     this.provider = builder.provider();
     this.totalCapacity = builder.totalCapacity();
     this.stops = Collections.unmodifiableList(builder.stops());
+    if (stops.size() < 2) {
+      throw new IllegalArgumentException(
+        "Carpool trip " + getId() + " must contain at least an origin and a destination stop"
+      );
+    }
     this.publicContactInformation = builder.publicContactInformation();
   }
 
   /**
    * Returns the origin stop (first stop in the trip).
-   *
-   * @return the origin stop
-   * @throws IllegalStateException if the trip has no stops
    */
   public CarpoolStop getOrigin() {
-    if (stops.isEmpty()) {
-      throw new IllegalStateException("Trip has no stops");
-    }
-    return stops.get(0);
+    return stops.getFirst();
   }
 
   /**
    * Returns the destination stop (last stop in the trip).
-   *
-   * @return the destination stop
-   * @throws IllegalStateException if the trip has no stops
    */
   public CarpoolStop getDestination() {
-    if (stops.isEmpty()) {
-      throw new IllegalStateException("Trip has no stops");
-    }
-    return stops.get(stops.size() - 1);
+    return stops.getLast();
   }
 
   public ZonedDateTime startTime() {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -66,7 +66,8 @@ public class CarpoolSiriMapper {
    * 2 non-cancelled calls remain.
    *
    * @throws IllegalArgumentException if the raw message is malformed (fewer than 2 calls
-   *         before filtering, calls out of order, missing flexible areas, etc.)
+   *         before filtering, calls out of order, missing flexible areas, no departure time
+   *         on the first call or no arrival time on the last call, etc.)
    */
   @Nullable
   public CarpoolTrip mapSiriToCarpoolTrip(EstimatedVehicleJourney journey) {
@@ -116,6 +117,17 @@ public class CarpoolSiriMapper {
     var endTime = lastStop.getExpectedArrivalTime() != null
       ? lastStop.getExpectedArrivalTime()
       : lastStop.getAimedArrivalTime();
+
+    if (startTime == null) {
+      throw new IllegalArgumentException(
+        "Trip " + tripId + ": first call has neither expected nor aimed departure time."
+      );
+    }
+    if (endTime == null) {
+      throw new IllegalArgumentException(
+        "Trip " + tripId + ": last call has neither expected nor aimed arrival time."
+      );
+    }
 
     int totalCapacity = extractTotalCapacity(tripId, activeCalls);
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -35,14 +35,25 @@ import uk.org.siri.siri21.EstimatedVehicleJourney;
 public class CarpoolSiriMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(CarpoolSiriMapper.class);
-  private static final String FEED_ID = "ENT";
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+  private final String feedId;
+
+  /**
+   * @param feedId the feed prefix used for every {@link FeedScopedId} this mapper produces.
+   *        Owned by the enclosing updater instance and supplied from
+   *        {@code router-config.json}, so one OTP can run multiple carpool updaters
+   *        side-by-side without trip-id collisions across feeds.
+   */
+  public CarpoolSiriMapper(String feedId) {
+    this.feedId = feedId;
+  }
 
   /**
    * Returns the trip id for the given journey.
    */
   FeedScopedId tripId(EstimatedVehicleJourney journey) {
-    return new FeedScopedId(FEED_ID, journey.getEstimatedVehicleJourneyCode());
+    return new FeedScopedId(feedId, journey.getEstimatedVehicleJourneyCode());
   }
 
   private static boolean isCancelled(EstimatedCall call) {
@@ -108,7 +119,7 @@ public class CarpoolSiriMapper {
 
     int totalCapacity = extractTotalCapacity(tripId, activeCalls);
 
-    var builder = new CarpoolTripBuilder(new FeedScopedId(FEED_ID, tripId))
+    var builder = new CarpoolTripBuilder(new FeedScopedId(feedId, tripId))
       .withStartTime(startTime)
       .withEndTime(endTime)
       .withProvider(journey.getOperatorRef().getValue())
@@ -348,7 +359,7 @@ public class CarpoolSiriMapper {
       ? toWgsCoordinate(toPolygon(legacyGeometry))
       : toWgsCoordinate(circleLocation);
 
-    return CarpoolStop.of(new FeedScopedId(FEED_ID, id))
+    return CarpoolStop.of(new FeedScopedId(feedId, id))
       .withCoordinate(centroid)
       .withAimedDepartureTime(isLast ? null : call.getAimedDepartureTime())
       .withExpectedDepartureTime(isLast ? null : call.getExpectedDepartureTime())

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdater.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.carpooling.updater;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
@@ -23,6 +25,16 @@ import uk.org.siri.siri21.ServiceDelivery;
 public class SiriETCarpoolingUpdater extends PollingGraphUpdater {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriETCarpoolingUpdater.class);
+
+  /**
+   * How long a carpool trip is kept after its latest end time before it is purged. The SIRI-ET
+   * source is not guaranteed to send an explicit cancellation once a journey has completed, so
+   * completed trips are removed once their latest end time is further in the past than this
+   * duration. This keeps instances that run for a long time from accumulating trips that can no
+   * longer be routed.
+   */
+  private static final Duration TRIP_EXPIRY = Duration.ofDays(2);
+
   private final EstimatedTimetableSource updateSource;
 
   private final CarpoolingRepository repository;
@@ -39,7 +51,7 @@ public class SiriETCarpoolingUpdater extends PollingGraphUpdater {
 
     LOG.info("Creating SIRI-ET updater running every {}: {}", pollingPeriod(), updateSource);
 
-    this.mapper = new CarpoolSiriMapper();
+    this.mapper = new CarpoolSiriMapper(config.feedId());
   }
 
   /**
@@ -51,6 +63,17 @@ public class SiriETCarpoolingUpdater extends PollingGraphUpdater {
     do {
       moreData = fetchAndProcessUpdates();
     } while (moreData);
+    removeExpiredTrips();
+  }
+
+  /**
+   * Asks the repository to purge trips that have ended more than {@link #TRIP_EXPIRY} ago, so
+   * completed trips are eventually removed even when the source stops sending updates for them. The
+   * repository throttles the actual scan and shares that throttle across every feed, so calling
+   * this on every poll is cheap.
+   */
+  private void removeExpiredTrips() {
+    repository.removeExpiredTrips(Instant.now(), TRIP_EXPIRY);
   }
 
   /**


### PR DESCRIPTION
### Summary

Lets a single OTP instance run several carpool SIRI-ET updaters side by side without trip-id collisions, and purges carpool trips once they have ended so long-running instances don't accumulate stale, unroutable trips.

### Issue

There was a single hardcoded SIRI feed that set FeedScopedId with a hardcoded "ENT" prefix. Also stale carpooling trips would live forever in OTP's memory.

### Unit tests

- Were unit tests added/updated?

Yes, new test files MultiFeedSiriETCarpoolingUpdaterTest and DefaultCarpoolingRepositoryTest tests multiple SIRI feeds and expiry of carpooling trips.

- Was any manual verification done?

Yes

- Was the code designed so it is unit testable?

- Were any tests applied to the smallest appropriate unit?

yes

- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

yes

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

yes

- Were all non-trivial public classes and methods documented with Javadoc?

yes

- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?

no