### PR TITLE
Add query for fetching number of canceled trips grouped by routes and patterns to GTFS API

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/LayerFilters.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/LayerFilters.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import org.opentripplanner.apis.gtfs.model.LocalDateRange;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
@@ -832,8 +832,8 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
   public DataFetcher<CanceledTripsSummary> canceledTripsSummary() {
     return environment -> {
       var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(environment);
-      var trips = getTransitService(environment).findCanceledTrips(request);
       var transitService = getTransitService(environment);
+      var trips = transitService.findCanceledTrips(request);
       var patternTripCounts = trips
         .stream()
         .collect(

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
@@ -35,6 +35,7 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLQueryTypeStop
 import org.opentripplanner.apis.gtfs.mapping.CanceledTripsFilterMapper;
 import org.opentripplanner.apis.gtfs.mapping.routerequest.LegacyRouteRequestMapper;
 import org.opentripplanner.apis.gtfs.mapping.routerequest.RouteRequestMapper;
+import org.opentripplanner.apis.gtfs.model.CanceledTripsSummary;
 import org.opentripplanner.apis.gtfs.support.filter.PatternByDateFilterUtil;
 import org.opentripplanner.apis.gtfs.support.time.LocalDateRangeUtil;
 import org.opentripplanner.core.model.id.FeedScopedId;
@@ -824,6 +825,27 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
       var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(environment);
       var trips = getTransitService(environment).findCanceledTrips(request);
       return new SimpleCountedListConnection<>(trips).get(environment);
+    };
+  }
+
+  @Override
+  public DataFetcher<CanceledTripsSummary> canceledTripsSummary() {
+    return environment -> {
+      var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(environment);
+      var trips = getTransitService(environment).findCanceledTrips(request);
+      var transitService = getTransitService(environment);
+      var patternTripCounts = trips
+        .stream()
+        .collect(
+          Collectors.groupingBy(
+            t -> t.getTrip().getRoute(),
+            Collectors.groupingBy(
+              t -> transitService.findPattern(t.getTrip(), t.getServiceDate()),
+              Collectors.counting()
+            )
+          )
+        );
+      return new CanceledTripsSummary(patternTripCounts);
     };
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -28,6 +28,9 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLVerticalDirec
 import org.opentripplanner.apis.gtfs.model.CallRealTime;
 import org.opentripplanner.apis.gtfs.model.CallSchedule;
 import org.opentripplanner.apis.gtfs.model.CallScheduledTime;
+import org.opentripplanner.apis.gtfs.model.CanceledTripsSummary;
+import org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryPattern;
+import org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryRoute;
 import org.opentripplanner.apis.gtfs.model.FeedPublisher;
 import org.opentripplanner.apis.gtfs.model.PlanPageInfo;
 import org.opentripplanner.apis.gtfs.model.RideHailingProvider;
@@ -212,6 +215,27 @@ public class GraphQLDataFetchers {
 
   /** Location where a transit vehicle stops at. */
   public interface GraphQLCallStopLocation extends TypeResolver {}
+
+  /** Cancellation statistics grouped by entities. */
+  public interface GraphQLCanceledTripsSummary {
+    public DataFetcher<Iterable<CanceledTripsSummaryRoute>> routes();
+  }
+
+  /** Contains pattern and the information for how many canceled trips there for the pattern. */
+  public interface GraphQLCanceledTripsSummaryPattern {
+    public DataFetcher<Integer> cancellationCount();
+    public DataFetcher<TripPattern> pattern();
+  }
+
+  /**
+   * Contains route, how many canceled trips there for the route and cancellation statistics grouped by
+   * patterns.
+   */
+  public interface GraphQLCanceledTripsSummaryRoute {
+    public DataFetcher<Integer> cancellationCount();
+    public DataFetcher<Iterable<CanceledTripsSummaryPattern>> patterns();
+    public DataFetcher<Route> route();
+  }
 
   /** Car park represents a location where cars can be parked. */
   public interface GraphQLCarPark {
@@ -663,6 +687,7 @@ public class GraphQLDataFetchers {
     public DataFetcher<VehicleRentalPlace> bikeRentalStation();
     public DataFetcher<Iterable<VehicleRentalPlace>> bikeRentalStations();
     public DataFetcher<CountedConnection<TripOnServiceDate>> canceledTrips();
+    public DataFetcher<CanceledTripsSummary> canceledTripsSummary();
     public DataFetcher<Iterable<TripTimeOnDate>> cancelledTripTimes();
     public DataFetcher<VehicleParking> carPark();
     public DataFetcher<Iterable<VehicleParking>> carParks();

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -221,15 +221,15 @@ public class GraphQLDataFetchers {
     public DataFetcher<Iterable<CanceledTripsSummaryRoute>> routes();
   }
 
-  /** Contains pattern and the information for how many canceled trips there for the pattern. */
+  /** Contains pattern and the information for how many canceled trips there are for the pattern. */
   public interface GraphQLCanceledTripsSummaryPattern {
     public DataFetcher<Integer> cancellationCount();
     public DataFetcher<TripPattern> pattern();
   }
 
   /**
-   * Contains route, how many canceled trips there for the route and cancellation statistics grouped by
-   * patterns.
+   * Contains route, how many canceled trips there are for the route and cancellation statistics grouped
+   * by patterns.
    */
   public interface GraphQLCanceledTripsSummaryRoute {
     public DataFetcher<Integer> cancellationCount();

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -560,6 +560,85 @@ public class GraphQLTypes {
     }
   }
 
+  public static class GraphQLCanceledTripsSummaryFilterInput {
+
+    private List<GraphQLCanceledTripsSummaryFilterSelectInput> exclude;
+    private List<GraphQLCanceledTripsSummaryFilterSelectInput> include;
+
+    public GraphQLCanceledTripsSummaryFilterInput(Map<String, Object> args) {
+      if (args != null) {
+        if (args.get("exclude") != null) {
+          this.exclude = ((List<Map<String, Object>>) args.get("exclude")).stream()
+            .map(o -> o == null ? null : new GraphQLCanceledTripsSummaryFilterSelectInput(o))
+            .collect(Collectors.toList());
+        }
+        if (args.get("include") != null) {
+          this.include = ((List<Map<String, Object>>) args.get("include")).stream()
+            .map(o -> o == null ? null : new GraphQLCanceledTripsSummaryFilterSelectInput(o))
+            .collect(Collectors.toList());
+        }
+      }
+    }
+
+    public List<GraphQLCanceledTripsSummaryFilterSelectInput> getGraphQLExclude() {
+      return this.exclude;
+    }
+
+    public List<GraphQLCanceledTripsSummaryFilterSelectInput> getGraphQLInclude() {
+      return this.include;
+    }
+
+    public void setGraphQLExclude(List<GraphQLCanceledTripsSummaryFilterSelectInput> exclude) {
+      this.exclude = exclude;
+    }
+
+    public void setGraphQLInclude(List<GraphQLCanceledTripsSummaryFilterSelectInput> include) {
+      this.include = include;
+    }
+  }
+
+  public static class GraphQLCanceledTripsSummaryFilterSelectInput {
+
+    private List<GraphQLTransitMode> modes;
+    private List<GraphQLLocalDateRangeInput> serviceDateRanges;
+
+    public GraphQLCanceledTripsSummaryFilterSelectInput(Map<String, Object> args) {
+      if (args != null) {
+        if (args.get("modes") != null) {
+          this.modes = ((List<Object>) args.get("modes")).stream()
+            .map(item ->
+              item instanceof GraphQLTransitMode ? item : GraphQLTransitMode.valueOf((String) item)
+            )
+            .map(GraphQLTransitMode.class::cast)
+            .collect(Collectors.toList());
+        }
+        if (args.get("serviceDateRanges") != null) {
+          this.serviceDateRanges = ((List<Map<String, Object>>) args.get(
+              "serviceDateRanges"
+            )).stream()
+            .map(o -> o == null ? null : new GraphQLLocalDateRangeInput(o))
+            .collect(Collectors.toList());
+        }
+      }
+    }
+
+    public List<GraphQLTransitMode> getGraphQLModes() {
+      return this.modes;
+    }
+
+    public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
+      return this.serviceDateRanges;
+    }
+
+    public void setGraphQLModes(List<GraphQLTransitMode> modes) {
+      this.modes = modes;
+    }
+
+    public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {
+      this.serviceDateRanges = serviceDateRanges;
+    }
+  }
+
   public static class GraphQLCarParkNameArgs {
 
     private String language;
@@ -2775,6 +2854,29 @@ public class GraphQLTypes {
 
     public void setGraphQLLast(Integer last) {
       this.last = last;
+    }
+  }
+
+  public static class GraphQLQueryTypeCanceledTripsSummaryArgs {
+
+    private List<GraphQLCanceledTripsSummaryFilterInput> filters;
+
+    public GraphQLQueryTypeCanceledTripsSummaryArgs(Map<String, Object> args) {
+      if (args != null) {
+        if (args.get("filters") != null) {
+          this.filters = ((List<Map<String, Object>>) args.get("filters")).stream()
+            .map(o -> o == null ? null : new GraphQLCanceledTripsSummaryFilterInput(o))
+            .collect(Collectors.toList());
+        }
+      }
+    }
+
+    public List<GraphQLCanceledTripsSummaryFilterInput> getGraphQLFilters() {
+      return this.filters;
+    }
+
+    public void setGraphQLFilters(List<GraphQLCanceledTripsSummaryFilterInput> filters) {
+      this.filters = filters;
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -537,6 +537,7 @@ public class GraphQLTypes {
   public static class GraphQLCanceledTripsFilterSelectInput {
 
     private List<GraphQLTransitMode> modes;
+    private List<GraphQLLocalDateRangeInput> serviceDateRanges;
 
     public GraphQLCanceledTripsFilterSelectInput(Map<String, Object> args) {
       if (args != null) {
@@ -548,6 +549,13 @@ public class GraphQLTypes {
             .map(GraphQLTransitMode.class::cast)
             .collect(Collectors.toList());
         }
+        if (args.get("serviceDateRanges") != null) {
+          this.serviceDateRanges = ((List<Map<String, Object>>) args.get(
+              "serviceDateRanges"
+            )).stream()
+            .map(o -> o == null ? null : new GraphQLLocalDateRangeInput(o))
+            .collect(Collectors.toList());
+        }
       }
     }
 
@@ -555,8 +563,16 @@ public class GraphQLTypes {
       return this.modes;
     }
 
+    public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
+      return this.serviceDateRanges;
+    }
+
     public void setGraphQLModes(List<GraphQLTransitMode> modes) {
       this.modes = modes;
+    }
+
+    public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {
+      this.serviceDateRanges = serviceDateRanges;
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -142,3 +142,6 @@ config:
     CallScheduledTime: org.opentripplanner.apis.gtfs.model.CallScheduledTime#CallScheduledTime
     RentalVehicleFuel: org.opentripplanner.service.vehiclerental.model.RentalVehicleFuel#RentalVehicleFuel
     ViaLocationType: org.opentripplanner.model.plan.leg.ViaLocationType#ViaLocationType
+    CanceledTripsSummary: org.opentripplanner.apis.gtfs.model.CanceledTripsSummary#CanceledTripsSummary
+    CanceledTripsSummaryPattern: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryPattern#CanceledTripsSummaryPattern
+    CanceledTripsSummaryRoute: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryRoute#CanceledTripsSummaryRoute

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapper.java
@@ -1,13 +1,16 @@
 package org.opentripplanner.apis.gtfs.mapping;
 
 import graphql.schema.DataFetchingEnvironment;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.support.InvalidInputException;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -20,68 +23,185 @@ public class CanceledTripsFilterMapper {
   public static TripOnServiceDateRequest mapToTripOnServiceDateRequest(
     DataFetchingEnvironment env
   ) {
-    var filters = new GraphQLTypes.GraphQLQueryTypeCanceledTripsArgs(
-      env.getArguments()
-    ).getGraphQLFilters();
+    var filters = mapList(env.getArgument("filters"), "filters");
     if (CollectionUtils.isEmpty(filters)) {
       return TripOnServiceDateRequest.of().build();
     }
-    if (filters.size() > 1) {
-      throw new InvalidInputException("Only one filter is allowed for now.");
-    }
-    var filter = filters.getFirst();
-    var includes = filter.getGraphQLInclude();
-    var excludes = filter.getGraphQLExclude();
+
+    var filterRequests = filters.stream().map(CanceledTripsFilterMapper::toFilterRequest).toList();
+    return TripOnServiceDateRequest.of().withFilters(filterRequests).build();
+  }
+
+  private static FilterRequest<TripOnServiceDateSelectRequest> toFilterRequest(
+    Map<String, Object> filter
+  ) {
+    var includes = mapList(filter.get("include"), "filters.include");
+    var excludes = mapList(filter.get("exclude"), "filters.exclude");
     CollectionUtils.requireNullOrNonEmpty(includes, "filters.include");
     CollectionUtils.requireNullOrNonEmpty(excludes, "filters.exclude");
-    var modesToInclude = CanceledTripsFilterMapper.toTransitModes(includes);
-    var modesToExclude = CanceledTripsFilterMapper.toTransitModes(excludes);
 
-    // Because only one filter is allowed for now, we can create a single flat list of includes/excludes
     var filterRequestBuilder = FilterRequest.<TripOnServiceDateSelectRequest>of();
-    if (modesToInclude != null) {
-      filterRequestBuilder.addSelect(
-        TripOnServiceDateSelectRequest.of()
-          .withTransportModes(MainAndSubMode.ofTransitModes(modesToInclude))
-          .build()
-      );
+    var includeSelect = toSelectRequest(includes);
+    if (includeSelect != null) {
+      filterRequestBuilder.addSelect(includeSelect);
     }
-    if (modesToExclude != null) {
-      filterRequestBuilder.addNot(
-        TripOnServiceDateSelectRequest.of()
-          .withTransportModes(MainAndSubMode.ofTransitModes(modesToExclude))
-          .build()
-      );
+    var excludeSelect = toSelectRequest(excludes);
+    if (excludeSelect != null) {
+      filterRequestBuilder.addNot(excludeSelect);
     }
-    var filterRequest = filterRequestBuilder.build();
-    return TripOnServiceDateRequest.of().withFilters(List.of(filterRequest)).build();
+    return filterRequestBuilder.build();
   }
 
   @Nullable
-  private static Set<TransitMode> toTransitModes(
-    List<GraphQLTypes.GraphQLCanceledTripsFilterSelectInput> inputs
-  ) {
+  private static TripOnServiceDateSelectRequest toSelectRequest(List<Map<String, Object>> inputs) {
+    var modes = toTransitModes(inputs);
+    var serviceDateRanges = toServiceDateRanges(inputs);
+    if (modes == null && serviceDateRanges == null) {
+      return null;
+    }
+
+    var builder = TripOnServiceDateSelectRequest.of();
+    if (modes != null) {
+      builder.withTransportModes(MainAndSubMode.ofTransitModes(modes));
+    }
+    if (serviceDateRanges != null) {
+      builder.withServiceDateRanges(serviceDateRanges);
+    }
+    return builder.build();
+  }
+
+  @Nullable
+  private static Set<TransitMode> toTransitModes(List<Map<String, Object>> inputs) {
     if (inputs == null) {
       return null;
     }
     if (
       inputs
         .stream()
-        .anyMatch(input -> input.getGraphQLModes() != null && input.getGraphQLModes().isEmpty())
+        .anyMatch(
+          input ->
+            list(input.get("modes"), "filters.*.modes") != null &&
+            list(input.get("modes"), "filters.*.modes").isEmpty()
+        )
     ) {
       throw new InvalidInputException(
         "Mode filter must be either null or have at least one entry."
       );
     }
-    return inputs
+    var modes = inputs
       .stream()
       .flatMap(include -> {
-        var modes = include.getGraphQLModes();
-        if (modes == null) {
+        var modeValues = list(include.get("modes"), "filters.*.modes");
+        if (modeValues == null) {
           return Stream.of();
         }
-        return include.getGraphQLModes().stream().map(TransitModeMapper::map);
+        return modeValues.stream().map(CanceledTripsFilterMapper::mapTransitMode);
       })
       .collect(Collectors.toSet());
+
+    return modes.isEmpty() ? null : modes;
+  }
+
+  @Nullable
+  private static List<LocalDateRange> toServiceDateRanges(List<Map<String, Object>> inputs) {
+    if (inputs == null) {
+      return null;
+    }
+    if (
+      inputs
+        .stream()
+        .anyMatch(
+          input ->
+            mapList(input.get("serviceDateRanges"), "filters.*.serviceDateRanges") != null &&
+            mapList(input.get("serviceDateRanges"), "filters.*.serviceDateRanges").isEmpty()
+        )
+    ) {
+      throw new InvalidInputException(
+        "Service date range filter must be either null or have at least one entry."
+      );
+    }
+
+    var ranges = inputs
+      .stream()
+      .flatMap(input -> {
+        var rangeInputs = mapList(input.get("serviceDateRanges"), "filters.*.serviceDateRanges");
+        if (rangeInputs == null) {
+          return Stream.of();
+        }
+        return rangeInputs.stream().map(CanceledTripsFilterMapper::mapLocalDateRange);
+      })
+      .toList();
+
+    return ranges.isEmpty() ? null : ranges;
+  }
+
+  private static LocalDateRange mapLocalDateRange(Map<String, Object> rangeInput) {
+    return new LocalDateRange(
+      localDate(rangeInput.get("start"), "filters.*.serviceDateRanges.start"),
+      localDate(rangeInput.get("end"), "filters.*.serviceDateRanges.end")
+    );
+  }
+
+  private static TransitMode mapTransitMode(Object value) {
+    var mode = switch (value) {
+      case Enum<?> enumValue -> enumValue.name();
+      case String stringValue -> stringValue;
+      default -> throw new InvalidInputException("Invalid mode value: " + value);
+    };
+    try {
+      return TransitMode.valueOf(mode);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException("Unknown transit mode: " + mode);
+    }
+  }
+
+  @Nullable
+  private static LocalDate localDate(@Nullable Object value, String path) {
+    if (value == null) {
+      return null;
+    }
+    return switch (value) {
+      case LocalDate localDate -> localDate;
+      case String stringValue -> LocalDate.parse(stringValue);
+      default -> throw new InvalidInputException("Expected LocalDate at '" + path + "'.");
+    };
+  }
+
+  @Nullable
+  private static List<Object> list(@Nullable Object value, String path) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof List<?> list) {
+      return new ArrayList<>(list);
+    }
+    throw new InvalidInputException("Expected list at '" + path + "'.");
+  }
+
+  @Nullable
+  private static List<Map<String, Object>> mapList(@Nullable Object value, String path) {
+    var list = list(value, path);
+    if (list == null) {
+      return null;
+    }
+    var result = new ArrayList<Map<String, Object>>(list.size());
+    for (var item : list) {
+      if (!(item instanceof Map<?, ?> map)) {
+        throw new InvalidInputException("Expected object entries in list at '" + path + "'.");
+      }
+      result.add(stringObjectMap(map, path));
+    }
+    return result;
+  }
+
+  private static Map<String, Object> stringObjectMap(Map<?, ?> source, String path) {
+    var result = new java.util.LinkedHashMap<String, Object>(source.size());
+    for (var entry : source.entrySet()) {
+      if (!(entry.getKey() instanceof String key)) {
+        throw new InvalidInputException("Expected string keys in object at '" + path + "'.");
+      }
+      result.put(key, entry.getValue());
+    }
+    return result;
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.apis.gtfs.mapping;
 import graphql.schema.DataFetchingEnvironment;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -195,7 +196,7 @@ public class CanceledTripsFilterMapper {
   }
 
   private static Map<String, Object> stringObjectMap(Map<?, ?> source, String path) {
-    var result = new java.util.LinkedHashMap<String, Object>(source.size());
+    var result = new LinkedHashMap<String, Object>(source.size());
     for (var entry : source.entrySet()) {
       if (!(entry.getKey() instanceof String key)) {
         throw new InvalidInputException("Expected string keys in object at '" + path + "'.");

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/model/CanceledTripsSummary.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/model/CanceledTripsSummary.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.apis.gtfs.model;
+
+import java.util.List;
+import java.util.Map;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.TripPattern;
+
+public class CanceledTripsSummary {
+
+  private final Map<Route, Map<TripPattern, Long>> cancellationSummaryForRoutes;
+
+  public CanceledTripsSummary(Map<Route, Map<TripPattern, Long>> cancellationSummaryForRoutes) {
+    this.cancellationSummaryForRoutes = cancellationSummaryForRoutes;
+  }
+
+  public List<CanceledTripsSummaryRoute> routes() {
+    return cancellationSummaryForRoutes
+      .entrySet()
+      .stream()
+      .map(entry -> new CanceledTripsSummaryRoute(entry.getKey(), entry.getValue()))
+      .toList();
+  }
+}

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/model/CanceledTripsSummaryPattern.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/model/CanceledTripsSummaryPattern.java
@@ -1,0 +1,5 @@
+package org.opentripplanner.apis.gtfs.model;
+
+import org.opentripplanner.transit.model.network.TripPattern;
+
+public record CanceledTripsSummaryPattern(TripPattern pattern, long cancellationCount) {}

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/model/CanceledTripsSummaryRoute.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/model/CanceledTripsSummaryRoute.java
@@ -1,0 +1,36 @@
+package org.opentripplanner.apis.gtfs.model;
+
+import java.util.List;
+import java.util.Map;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.TripPattern;
+
+public class CanceledTripsSummaryRoute {
+
+  private final Route route;
+  private final Map<TripPattern, Long> cancellationCountsForPatterns;
+
+  public CanceledTripsSummaryRoute(
+    Route route,
+    Map<TripPattern, Long> cancellationCountsForPatterns
+  ) {
+    this.route = route;
+    this.cancellationCountsForPatterns = cancellationCountsForPatterns;
+  }
+
+  public Route route() {
+    return this.route;
+  }
+
+  public int cancellationCount() {
+    return cancellationCountsForPatterns.values().stream().mapToInt(Long::intValue).sum();
+  }
+
+  public List<CanceledTripsSummaryPattern> patterns() {
+    return cancellationCountsForPatterns
+      .entrySet()
+      .stream()
+      .map(e -> new CanceledTripsSummaryPattern(e.getKey(), e.getValue()))
+      .toList();
+  }
+}

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/PatternByDateFilterUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/support/filter/PatternByDateFilterUtil.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.apis.gtfs.support.filter;
 
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
-import org.opentripplanner.apis.gtfs.model.LocalDateRange;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.service.PatternByServiceDatesFilter;
 import org.opentripplanner.transit.service.TransitService;
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/support/time/LocalDateRangeUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/support/time/LocalDateRangeUtil.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.apis.gtfs.support.time;
 
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
-import org.opentripplanner.apis.gtfs.model.LocalDateRange;
+import org.opentripplanner.core.model.time.LocalDateRange;
 
 public class LocalDateRangeUtil {
 

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.api.request;
 import java.time.LocalDate;
 import java.util.List;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -20,6 +21,7 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 public class TripOnServiceDateRequest {
 
   private final FilterValues<LocalDate> includeServiceDates;
+  private final FilterValues<LocalDateRange> includeServiceDateRanges;
   private final FilterValues<FeedScopedId> includeAgencies;
   private final FilterValues<FeedScopedId> includeRoutes;
   private final FilterValues<FeedScopedId> includeServiceJourneys;
@@ -30,6 +32,7 @@ public class TripOnServiceDateRequest {
 
   TripOnServiceDateRequest(
     FilterValues<LocalDate> includeServiceDates,
+    FilterValues<LocalDateRange> includeServiceDateRanges,
     FilterValues<FeedScopedId> includeAgencies,
     FilterValues<FeedScopedId> includeRoutes,
     FilterValues<FeedScopedId> includeServiceJourneys,
@@ -39,6 +42,7 @@ public class TripOnServiceDateRequest {
     List<FilterRequest<TripOnServiceDateSelectRequest>> filters
   ) {
     this.includeServiceDates = includeServiceDates;
+    this.includeServiceDateRanges = includeServiceDateRanges;
     this.includeAgencies = includeAgencies;
     this.includeRoutes = includeRoutes;
     this.includeServiceJourneys = includeServiceJourneys;
@@ -78,6 +82,10 @@ public class TripOnServiceDateRequest {
 
   public FilterValues<LocalDate> includeServiceDates() {
     return includeServiceDates;
+  }
+
+  public FilterValues<LocalDateRange> includeServiceDateRanges() {
+    return includeServiceDateRanges;
   }
 
   public FilterValues<TransitMode> includeModes() {

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.api.request;
 import java.time.LocalDate;
 import java.util.List;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.filter.selector.FilterRequest;
 import org.opentripplanner.transit.model.filter.transit.TripOnServiceDateSelectRequest;
@@ -36,6 +37,10 @@ public class TripOnServiceDateRequestBuilder {
   );
   private FilterValues<LocalDate> includeServiceDates = FilterValues.ofEmptyIsEverything(
     "includeServiceDates",
+    List.of()
+  );
+  private FilterValues<LocalDateRange> includeServiceDateRanges = FilterValues.ofEmptyIsEverything(
+    "includeServiceDateRanges",
     List.of()
   );
   private List<FilterRequest<TripOnServiceDateSelectRequest>> filters = List.of();
@@ -85,6 +90,13 @@ public class TripOnServiceDateRequestBuilder {
     return this;
   }
 
+  public TripOnServiceDateRequestBuilder withIncludeServiceDateRanges(
+    FilterValues<LocalDateRange> serviceDateRanges
+  ) {
+    this.includeServiceDateRanges = serviceDateRanges;
+    return this;
+  }
+
   public TripOnServiceDateRequestBuilder withFilters(
     List<FilterRequest<TripOnServiceDateSelectRequest>> filters
   ) {
@@ -95,6 +107,7 @@ public class TripOnServiceDateRequestBuilder {
   public TripOnServiceDateRequest build() {
     return new TripOnServiceDateRequest(
       includeServiceDates,
+      includeServiceDateRanges,
       includeAgencies,
       includeRoutes,
       includeServiceJourneys,

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -2,6 +2,7 @@ package org.opentripplanner.transit.model.filter.transit;
 
 import java.time.LocalDate;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.model.modes.AllowTransitModeFilter;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model.basic.NarrowedTransitMode;
@@ -46,6 +47,10 @@ public class TripOnServiceDateMatcherFactory {
       request.includeServiceDates(),
       TripOnServiceDateMatcherFactory::serviceDate
     );
+    expr.atLeastOneMatch(
+      request.includeServiceDateRanges(),
+      TripOnServiceDateMatcherFactory::serviceDateRange
+    );
     expr.atLeastOneMatch(request.includeAgencies(), TripOnServiceDateMatcherFactory::agencyId);
     expr.atLeastOneMatch(request.includeRoutes(), TripOnServiceDateMatcherFactory::routeId);
     expr.atLeastOneMatch(
@@ -77,6 +82,10 @@ public class TripOnServiceDateMatcherFactory {
 
     expr.atLeastOneMatch(selector.agencies(), TripOnServiceDateMatcherFactory::agencyId);
     expr.atLeastOneMatch(selector.routes(), TripOnServiceDateMatcherFactory::routeId);
+    expr.atLeastOneMatch(
+      selector.serviceDateRanges(),
+      TripOnServiceDateMatcherFactory::serviceDateRange
+    );
 
     if (!selector.transportModes().includeEverything()) {
       var transportModeFilter = AllowTransitModeFilter.of(
@@ -123,6 +132,12 @@ public class TripOnServiceDateMatcherFactory {
 
   static Matcher<TripOnServiceDate> serviceDate(LocalDate date) {
     return new EqualityMatcher<>("serviceDate", date, TripOnServiceDate::getServiceDate);
+  }
+
+  static Matcher<TripOnServiceDate> serviceDateRange(LocalDateRange dateRange) {
+    return new GenericUnaryMatcher<>("serviceDateRange", date ->
+      dateRange.contains(date.getServiceDate())
+    );
   }
 
   static Matcher<TripOnServiceDate> alteration(TripAlteration alteration) {

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateSelectRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateSelectRequest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.model.filter.transit;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -18,11 +19,16 @@ public class TripOnServiceDateSelectRequest {
   private final FilterValues<FeedScopedId> agencies;
   private final FilterValues<FeedScopedId> routes;
   private final FilterValues<MainAndSubMode> transportModes;
+  private final FilterValues<LocalDateRange> serviceDateRanges;
 
   private TripOnServiceDateSelectRequest(Builder builder) {
     this.agencies = FilterValues.ofNullIsEverything("agencies", builder.agencies);
     this.routes = FilterValues.ofNullIsEverything("routes", builder.routes);
     this.transportModes = FilterValues.ofNullIsEverything("transportModes", builder.transportModes);
+    this.serviceDateRanges = FilterValues.ofNullIsEverything(
+      "serviceDateRanges",
+      builder.serviceDateRanges
+    );
   }
 
   public static Builder of() {
@@ -41,6 +47,10 @@ public class TripOnServiceDateSelectRequest {
     return transportModes;
   }
 
+  public FilterValues<LocalDateRange> serviceDateRanges() {
+    return serviceDateRanges;
+  }
+
   @Override
   public String toString() {
     var builder = ToStringBuilder.ofEmbeddedType();
@@ -52,6 +62,9 @@ public class TripOnServiceDateSelectRequest {
     }
     if (!transportModes.includeEverything()) {
       builder.addCol("transportModes", transportModes.get());
+    }
+    if (!serviceDateRanges.includeEverything()) {
+      builder.addCol("serviceDateRanges", serviceDateRanges.get());
     }
     return builder.toString();
   }
@@ -67,6 +80,9 @@ public class TripOnServiceDateSelectRequest {
     @Nullable
     private List<MainAndSubMode> transportModes;
 
+    @Nullable
+    private List<LocalDateRange> serviceDateRanges;
+
     public Builder withAgencies(List<FeedScopedId> agencies) {
       this.agencies = agencies;
       return this;
@@ -79,6 +95,11 @@ public class TripOnServiceDateSelectRequest {
 
     public Builder withTransportModes(List<MainAndSubMode> transportModes) {
       this.transportModes = transportModes;
+      return this;
+    }
+
+    public Builder withServiceDateRanges(List<LocalDateRange> serviceDateRanges) {
+      this.serviceDateRanges = serviceDateRanges;
       return this;
     }
 

--- a/application/src/main/java/org/opentripplanner/transit/service/PatternByServiceDatesFilter.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/PatternByServiceDatesFilter.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Function;
-import org.opentripplanner.apis.gtfs.model.LocalDateRange;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -346,6 +346,33 @@ type CallSchedule {
   time: CallScheduledTime
 }
 
+"Cancellation statistics grouped by entities."
+type CanceledTripsSummary {
+  "How many canceled trips there are for the routes which have any cancellations."
+  routes: [CanceledTripsSummaryRoute!]!
+}
+
+"Contains pattern and the information for how many canceled trips there are for the pattern."
+type CanceledTripsSummaryPattern {
+  "How many canceled trips there are for the pattern."
+  cancellationCount: Int!
+  "The pattern for which the cancellation statistics are provided for."
+  pattern: Pattern!
+}
+
+"""
+Contains route, how many canceled trips there are for the route and cancellation statistics grouped
+by patterns.
+"""
+type CanceledTripsSummaryRoute {
+  "How many canceled trips there are for the route."
+  cancellationCount: Int!
+  "How many canceled trips there are for the patterns which have any cancellations."
+  patterns: [CanceledTripsSummaryPattern!]!
+  "The route for which the cancellation statistics are provided for."
+  route: Route!
+}
+
 "Car park represents a location where cars can be parked."
 type CarPark implements Node & PlaceInterface {
   "ID of the car park"
@@ -1366,6 +1393,18 @@ type QueryType {
     """
     last: Int
   ): TripOnServiceDateConnection @timingData
+  """
+  Summary of canceled trips. Can be used as a preliminary query before `canceledTrips` to get an idea of how many canceled
+  trips there are and what filters to use.
+  """
+  canceledTripsSummary(
+    """
+    Can be used to filter the results.
+        
+    An empty list of filters or no value means that all cancellations should be included.
+    """
+    filters: [CanceledTripsSummaryFilterInput!]
+  ): CanceledTripsSummary @timingData
   "Get canceled TripTimes."
   cancelledTripTimes(
     "Feed feedIds (e.g. [\"HSL\"])."
@@ -4332,6 +4371,33 @@ means everything is allowed to be returned and empty lists are not allowed.
 input CanceledTripsFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
+}
+
+"Used to limit which canceled trips are included for the summary."
+input CanceledTripsSummaryFilterInput {
+  """
+  A list of selectors for excluding canceled trips.
+    
+  An empty list or a list containing `null` is forbidden.
+  """
+  exclude: [CanceledTripsSummaryFilterSelectInput!]
+  """
+  A list of selectors for including canceled trips.
+    
+  An empty list or a list containing `null` is forbidden.
+  """
+  include: [CanceledTripsSummaryFilterSelectInput!]
+}
+
+"Filter options for including or excluding canceled trips from the canceled trips summary."
+input CanceledTripsSummaryFilterSelectInput {
+  "Canceled trips from these transit modes should be included/excluded."
+  modes: [TransitMode!]
+  """
+  Canceled trips are included/excluded based on if their service date is within any of these time
+  ranges.
+  """
+  serviceDateRanges: [LocalDateRangeInput!]
 }
 
 "Preferences for car parking facilities used during the routing."

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1400,8 +1400,8 @@ type QueryType {
     last: Int
   ): TripOnServiceDateConnection @timingData
   """
-  Summary of canceled trips. Can be used as a preliminary query before `canceledTrips` to get an idea of how many canceled
-  trips there are and what filters to use.
+  Summary of canceled trips. Can be used as a preliminary query before using other
+  queries to fetch the details of the canceled trips.
   """
   canceledTripsSummary(
     """

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -4378,7 +4378,7 @@ input CanceledTripsFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
   """
-  Canceled trips are included/excluded based on if their service date is within any of these time
+  Canceled trips are included/excluded based on if their service date (but not necessarily their running date)  is within any of these time
   ranges.
   """
   serviceDateRanges: [LocalDateRangeInput!]

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1377,8 +1377,14 @@ type QueryType {
     """
     Can be used to filter the results. When paging, the filter should not be changed between pages.
         
-    An empty list of filters or no value means that all trips should be included. Only one filter
-    is allowed for now. Once new filtering criteria is introduced, this limitation will be removed.
+    An empty list of filters or no value means that all trips should be included. Multiple filters
+    are allowed.
+    
+    Filter order does not matter. Each filter entry is evaluated independently and the final result
+    is the union (OR) of all matching filter entries.
+    
+    Inside one filter entry, selectors in `include` are combined with OR, selectors in `exclude`
+    are combined with OR, and the final match is `include AND NOT(exclude)`.
     """
     filters: [CanceledTripsFilterInput!],
     """
@@ -4346,10 +4352,10 @@ input BoardPreferencesInput {
 }
 
 """
-A collection of selectors for including or excluding trips from canceled trips search. Currently,
-you can only use either include or exclude filter (as filtering is only supported with transit modes).
+A collection of selectors for including or excluding trips from canceled trips search. Excludes
+override includes.
 """
-input CanceledTripsFilterInput @oneOf {
+input CanceledTripsFilterInput {
   """
   A list of selectors for excluding canceled trips.
     
@@ -4371,6 +4377,11 @@ means everything is allowed to be returned and empty lists are not allowed.
 input CanceledTripsFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
+  """
+  Canceled trips are included/excluded based on if their service date is within any of these time
+  ranges.
+  """
+  serviceDateRanges: [LocalDateRangeInput!]
 }
 
 "Used to limit which canceled trips are included for the summary."

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapperTest.java
@@ -8,12 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.apis.support.graphql.DataFetchingSupport;
+import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 
 class CanceledTripsFilterMapperTest {
@@ -96,15 +99,27 @@ class CanceledTripsFilterMapperTest {
 
   @Test
   void testMultipleFilters() {
+    var bus = TransitMode.BUS;
+    var tram = TransitMode.TRAM;
     Map<String, Object> args = Map.of(
       "filters",
-      List.of(Map.of("include", List.of()), Map.of("include", List.of()))
+      List.of(
+        Map.of("include", List.of(Map.of("modes", List.of(TransitModeMapper.map(bus))))),
+        Map.of("include", List.of(Map.of("modes", List.of(TransitModeMapper.map(tram)))))
+      )
     );
-    var environment = getEnvironment(args);
-    var exception = assertThrows(InvalidInputException.class, () ->
-      CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(environment)
+
+    var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(getEnvironment(args));
+    assertThat(request.filters()).hasSize(2);
+    var firstFilterModes = request.filters().get(0).select().getFirst().transportModes().get();
+    var secondFilterModes = request.filters().get(1).select().getFirst().transportModes().get();
+
+    assertThat(firstFilterModes).containsExactlyElementsIn(
+      MainAndSubMode.ofTransitModes(Set.of(bus))
     );
-    assertEquals("Only one filter is allowed for now.", exception.getMessage());
+    assertThat(secondFilterModes).containsExactlyElementsIn(
+      MainAndSubMode.ofTransitModes(Set.of(tram))
+    );
   }
 
   @Test
@@ -139,6 +154,64 @@ class CanceledTripsFilterMapperTest {
     );
     assertEquals(
       "Mode filter must be either null or have at least one entry.",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  void testIncludeWithServiceDateRanges() {
+    var start = LocalDate.parse("2026-06-01");
+    var end = LocalDate.parse("2026-06-10");
+    Map<String, Object> args = Map.of(
+      "filters",
+      List.of(
+        Map.of(
+          "include",
+          List.of(Map.of("serviceDateRanges", List.of(Map.of("start", start, "end", end))))
+        )
+      )
+    );
+
+    var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(getEnvironment(args));
+    assertThat(request.filters()).hasSize(1);
+    var include = request.filters().getFirst().select().getFirst();
+    assertThat(include.serviceDateRanges().get()).hasSize(1);
+    var includeRange = include.serviceDateRanges().get().iterator().next();
+    assertEquals(start, includeRange.startInclusive());
+    assertEquals(end, includeRange.endExclusive());
+  }
+
+  @Test
+  void testExcludeWithServiceDateRanges() {
+    var start = LocalDate.parse("2026-07-01");
+    Map<String, Object> args = Map.of(
+      "filters",
+      List.of(
+        Map.of("exclude", List.of(Map.of("serviceDateRanges", List.of(Map.of("start", start)))))
+      )
+    );
+
+    var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(getEnvironment(args));
+    assertThat(request.filters()).hasSize(1);
+    var exclude = request.filters().getFirst().not().getFirst();
+    assertThat(exclude.serviceDateRanges().get()).hasSize(1);
+    var excludeRange = exclude.serviceDateRanges().get().iterator().next();
+    assertEquals(start, excludeRange.startInclusive());
+    assertNull(excludeRange.endExclusive());
+  }
+
+  @Test
+  void testEmptyServiceDateRanges() {
+    Map<String, Object> args = Map.of(
+      "filters",
+      List.of(Map.of("include", List.of(Map.of("serviceDateRanges", List.of()))))
+    );
+    var environment = getEnvironment(args);
+    var exception = assertThrows(InvalidInputException.class, () ->
+      CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(environment)
+    );
+    assertEquals(
+      "Service date range filter must be either null or have at least one entry.",
       exception.getMessage()
     );
   }

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
@@ -58,7 +59,7 @@ class TripOnServiceDateMatcherFactoryTest {
           )
           .build()
       )
-      .withServiceDate(LocalDate.of(2024, 2, 22))
+      .withServiceDate(LocalDate.of(2024, 2, 23))
       .build();
 
     tripOnServiceDateAkt = TripOnServiceDate.of(id("AKT:route:trip:date:1"))
@@ -75,12 +76,12 @@ class TripOnServiceDateMatcherFactoryTest {
           )
           .build()
       )
-      .withServiceDate(LocalDate.of(2024, 2, 22))
+      .withServiceDate(LocalDate.of(2024, 2, 24))
       .build();
   }
 
   @Test
-  void testMatchOperatingDays() {
+  void testMatchServiceDates() {
     TripOnServiceDateRequest request = TripOnServiceDateRequest.of()
       .withIncludeServiceDates(
         FilterValues.ofRequired("serviceDates", List.of(LocalDate.of(2024, 2, 22)))
@@ -90,8 +91,26 @@ class TripOnServiceDateMatcherFactoryTest {
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
 
     assertTrue(matcher.match(tripOnServiceDateRut));
+    assertFalse(matcher.match(tripOnServiceDateRut2));
+    assertFalse(matcher.match(tripOnServiceDateAkt));
+  }
+
+  @Test
+  void testMatchServiceDateRanges() {
+    TripOnServiceDateRequest request = TripOnServiceDateRequest.of()
+      .withIncludeServiceDateRanges(
+        FilterValues.ofRequired(
+          "serviceDateRanges",
+          List.of(new LocalDateRange(LocalDate.of(2024, 2, 22), LocalDate.of(2024, 2, 24)))
+        )
+      )
+      .build();
+
+    Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(request);
+
+    assertTrue(matcher.match(tripOnServiceDateRut));
     assertTrue(matcher.match(tripOnServiceDateRut2));
-    assertTrue(matcher.match(tripOnServiceDateAkt));
+    assertFalse(matcher.match(tripOnServiceDateAkt));
   }
 
   @Test
@@ -129,7 +148,10 @@ class TripOnServiceDateMatcherFactoryTest {
   void testMatchMultipleServiceJourneyMatchers() {
     TripOnServiceDateRequest request = TripOnServiceDateRequest.of()
       .withIncludeServiceDates(
-        FilterValues.ofRequired("serviceDates", List.of(LocalDate.of(2024, 2, 22)))
+        FilterValues.ofRequired(
+          "serviceDates",
+          List.of(LocalDate.of(2024, 2, 22), LocalDate.of(2024, 2, 23))
+        )
       )
       .withIncludeAgencies(
         FilterValues.ofEmptyIsEverything("agencies", List.of(id("RUT:1"), id("RUT:2")))

--- a/application/src/test/java/org/opentripplanner/transit/service/PatternByServiceDatesFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/PatternByServiceDatesFilterTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opentripplanner.apis.gtfs.model.LocalDateRange;
+import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.model._data.PatternTestModel;
 import org.opentripplanner.transit.model.network.TripPattern;
 

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/canceled-trips-summary.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/canceled-trips-summary.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "canceledTripsSummary": {
+      "routes": [
+        {
+          "route": {
+            "gtfsId": "F:R321Canceled"
+          },
+          "cancellationCount": 1,
+          "patterns": [
+            {
+              "cancellationCount": 1,
+              "pattern": {
+                "code": "F:BUS"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/canceled-trips-summary.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/canceled-trips-summary.graphql
@@ -1,0 +1,25 @@
+{
+  canceledTripsSummary(
+    filters: [
+      {
+        include: {
+          modes: [BUS]
+          serviceDateRanges: [{ start: "2024-01-01", end: "2024-09-01" }]
+        }
+      }
+    ]
+  ) {
+    routes {
+      route {
+        gtfsId
+      }
+      cancellationCount
+      patterns {
+        cancellationCount
+        pattern {
+          code
+        }
+      }
+    }
+  }
+}

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/canceled-trips.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/canceled-trips.graphql
@@ -1,5 +1,17 @@
 {
-  canceledTrips(first: 2, filters: [{ include: [{ modes: [BUS] }] }]) {
+  canceledTrips(
+    first: 2
+    filters: [
+      {
+        include: [
+          {
+            modes: [BUS]
+            serviceDateRanges: [{ start: "2024-08-09", end: "2024-08-10" }]
+          }
+        ]
+      }
+    ]
+  ) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/domain-core/src/main/java/org/opentripplanner/core/model/time/LocalDateRange.java
+++ b/domain-core/src/main/java/org/opentripplanner/core/model/time/LocalDateRange.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.apis.gtfs.model;
+package org.opentripplanner.core.model.time;
 
 import java.time.LocalDate;
 import javax.annotation.Nullable;

--- a/domain-core/src/test/java/org/opentripplanner/core/model/time/LocalDateRangeTest.java
+++ b/domain-core/src/test/java/org/opentripplanner/core/model/time/LocalDateRangeTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.apis.gtfs.model;
+package org.opentripplanner.core.model.time;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
### Summary

This adds new `canceledTripsSummary` query and adds `serviceDateRanges` to the existing `canceledTrips` query.

I will create a follow up pr where I merge `LocalDateRange` and `LocalDateInterval`.

### Issue

Closes #7487

### Unit tests

Added tests

### Documentation

Updated schema docs

### Changelog

From title
