### PR TITLE
Don't run DirectTransitSearch for via searches

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DirectTransitRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DirectTransitRequestMapper.java
@@ -18,6 +18,10 @@ public class DirectTransitRequestMapper {
     RouteRequest request,
     SearchParams searchParamsUsed
   ) {
+    if (request.isViaSearch()) {
+      // The direct transit search is not compatible with via points
+      return Optional.empty();
+    }
     var directTransitRequestOpt = request.preferences().transit().directTransit();
     if (directTransitRequestOpt.isEmpty()) {
       return Optional.empty();

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DirectTransitRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DirectTransitRequestMapperTest.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.via.VisitViaLocation;
+
+class DirectTransitRequestMapperTest {
+
+  @Test
+  void noDirectTransitForViaPoints() {
+    var req = RouteRequest.of()
+      .withFrom(GenericLocation.fromCoordinate(0, 0))
+      .withTo(GenericLocation.fromCoordinate(1, 1))
+      .withViaLocations(List.of(new VisitViaLocation(null, null, List.of(id("stopX")), null)))
+      .buildRequest();
+    var params = new RaptorRequestBuilder<>().searchParams().buildSearchParam();
+
+    // We don't have any support for via points in the direct transit search.
+    // Until we do the direct transit search should be disabled if there are via points
+    assertEquals(Optional.empty(), DirectTransitRequestMapper.map(req, params));
+  }
+}


### PR DESCRIPTION
### Summary

The DirectTransitSearch is not compatible with via points since it will find all direct transit with no regards to via-points. This PR disables the DirectTransitSearch if there are any via points.

### Issue

Minor bugfix. No issue.

### Changelog

Skip

### Bumping the serialization version id

No