### PR TITLE
Size carpool access/egress driver-baseline trees to the trip

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/CarpoolingServiceTestContext.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/CarpoolingServiceTestContext.java
@@ -1,0 +1,63 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import org.opentripplanner.TestOtpModel;
+import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
+import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
+import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.transit.service.TransitServiceResolver;
+
+/**
+ * Wires a {@link DefaultCarpoolingService} with an empty repository and in-memory dependencies on
+ * top of a {@link org.opentripplanner.routing.algorithm.GraphRoutingTest} street graph model.
+ */
+record CarpoolingServiceTestContext(
+  DefaultCarpoolingService service,
+  CarpoolingRepository repository,
+  TransitServiceResolver transitServiceResolver
+) {
+  private static final StreetLimitationParametersService STREET_LIMITATION_PARAMETERS =
+    new StreetLimitationParametersService() {
+      @Override
+      public float maxCarSpeed() {
+        return 40.0f;
+      }
+
+      @Override
+      public int maxAreaNodes() {
+        return 500;
+      }
+
+      @Override
+      public float getBestWalkSafety() {
+        return 1;
+      }
+
+      @Override
+      public float getBestBikeSafety() {
+        return 1;
+      }
+    };
+
+  static CarpoolingServiceTestContext of(TestOtpModel model) {
+    var vertexCreationService = new VertexCreationService(
+      VertexLinkerTestFactory.of(model.graph())
+    );
+    TransitService transitService = new DefaultTransitService(model.timetableRepository());
+    var repository = new DefaultCarpoolingRepository();
+    var service = new DefaultCarpoolingService(
+      repository,
+      STREET_LIMITATION_PARAMETERS,
+      transitService,
+      vertexCreationService
+    );
+    return new CarpoolingServiceTestContext(
+      service,
+      repository,
+      new TransitServiceResolver(transitService)
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.internal.CarpoolItineraryMapper;
-import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
@@ -31,20 +30,13 @@ import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
-import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.model.organization.ContactInfo;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.service.TransitServiceResolver;
 
 /**
@@ -200,43 +192,10 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       }
     );
 
-    Graph graph = model.graph();
-    var timetableRepository = model.timetableRepository();
-    VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
-    var vertexCreationService = new VertexCreationService(vertexLinker);
-    TransitService transitService = new DefaultTransitService(timetableRepository);
-    transitServiceResolver = new TransitServiceResolver(transitService);
-    repository = new DefaultCarpoolingRepository();
-
-    StreetLimitationParametersService streetLimitationParams =
-      new StreetLimitationParametersService() {
-        @Override
-        public float maxCarSpeed() {
-          return 40.0f;
-        }
-
-        @Override
-        public int maxAreaNodes() {
-          return 500;
-        }
-
-        @Override
-        public float getBestWalkSafety() {
-          return 1;
-        }
-
-        @Override
-        public float getBestBikeSafety() {
-          return 1;
-        }
-      };
-
-    service = new DefaultCarpoolingService(
-      repository,
-      streetLimitationParams,
-      transitService,
-      vertexCreationService
-    );
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
+    transitServiceResolver = context.transitServiceResolver();
   }
 
   private IntersectionVertex vertexA;

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceCrossLegInsertionTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceCrossLegInsertionTest.java
@@ -1,0 +1,205 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.ext.carpooling.model.CarpoolStop;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitServiceResolver;
+
+/**
+ * Regression test for {@link DefaultCarpoolingService#routeAccessEgress} on a cross-leg insertion
+ * — pickup inserted on one leg of a multi-stop driver trip, dropoff on a later leg — where the
+ * drive from the passenger's pickup to the next driver waypoint exceeds the nearby-stop search
+ * radius ({@link DefaultCarpoolingService#MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS},
+ * 60 minutes).
+ * <p>
+ * Every segment from/to the passenger in a modified route lies on a single leg of the trip, so its
+ * drive is bounded by that leg's duration plus detour allowance. The passenger vertex's trees must
+ * therefore span the longest candidate leg limit — a fixed cap silently drops budget-feasible
+ * insertions whose {@code passenger → next waypoint} segment is longer than the cap, because
+ * {@code route()} never falls back to the waypoint's correctly sized reverse tree while the
+ * passenger has a forward tree of its own.
+ *
+ * <pre>
+ * Graph (one-way driver legs, distances/speeds chosen so legs are 70 and 60 min):
+ *
+ *   P (10 m N of A)              S (10 m S of D, transit stop)
+ *    \                          /
+ *     A ==========> X ========> M   one-way A → M via X, 37 km + 5 km (61.7 + 8.3 min)
+ *     A &lt;-- 6 km local road --&gt; D   bidirectional (10 min)
+ *               M ===========> D    one-way M → D, 36 km (60 min)
+ *
+ *   Driver trip: A → M → D. The route bends back: D is only 6 km from A, while the
+ *   driver goes out to M and returns. Deviation budget 10 min at M and D.
+ *
+ *   Access request: passenger at P. The only stop, S, sits on leg M → D, 10 car-minutes
+ *   from P via the local road — within the nearby-stop radius.
+ *
+ *   The only budget-feasible insertion is cross-leg: pickup P on leg A → M, dropoff S on
+ *   leg M → D (route A → P → M → S → D, detour ≈ two dwells). Dropping S on the first leg
+ *   instead would force S → M via the local road and A (80 min vs 70 scheduled), breaching
+ *   the 10-min budget at M. The cross-leg insertion's passenger → M segment is a 70-min
+ *   drive, beyond the 60-min nearby-stop radius — reachable only because the passenger
+ *   trees are sized to the largest candidate leg limit (1.5 × 70 + 10 = 115 min).
+ *
+ *   X matters because {@code DurationSkipEdgeStrategy} prunes edges by the elapsed time at
+ *   the edge's from-state, overshooting a tree's limit by one edge: a single 42-km A → M
+ *   edge would be traversed from an elapsed time of ~0 and defeat any limit. With X at
+ *   61.7 min, a 60-min tree reaches X but prunes X → M, while the 115-min tree spans the leg.
+ * </pre>
+ */
+class DefaultCarpoolingServiceCrossLegInsertionTest extends GraphRoutingTest {
+
+  private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
+  private static final ZoneId ZONE = ZoneId.of("Europe/Oslo");
+  private static final ZonedDateTime SEARCH_TIME = LocalDateTime.of(2025, 6, 15, 12, 0).atZone(
+    ZONE
+  );
+
+  // 10 m/s car speed keeps the arithmetic obvious: seconds == metres / 10.
+  private static final float CAR_SPEED_MPS = 10.0f;
+  private static final Duration BUDGET = Duration.ofMinutes(10);
+
+  private DefaultCarpoolingService service;
+  private CarpoolingRepository repository;
+  private TransitServiceResolver transitServiceResolver;
+
+  private TransitStopVertex stopS;
+  private WgsCoordinate coordA;
+  private WgsCoordinate coordM;
+  private WgsCoordinate coordD;
+  private WgsCoordinate coordP;
+
+  @BeforeEach
+  void setUp() {
+    var model = modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          var A = intersection("A", ORIGIN);
+          var X = intersection("X", ORIGIN.moveEastMeters(37000));
+          var M = intersection("M", ORIGIN.moveEastMeters(42000));
+          var D = intersection("D", ORIGIN.moveEastMeters(6000));
+
+          coordA = A.toWgsCoordinate();
+          coordM = M.toWgsCoordinate();
+          coordD = D.toWgsCoordinate();
+
+          // One-way driver legs: out to M via X, back past A's area to D. X sits beyond the
+          // 60-min mark so a tree capped there prunes X → M and cannot reach M (see class doc).
+          street(A, X, 37000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(X, M, 5000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(M, D, 36000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          // Bidirectional local road tying A's area to D's, so the stop search from P reaches S
+          // and an early dropoff of S has a (budget-breaching) way back to M.
+          street(A, D, 6000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(D, A, 6000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+
+          // Passenger spur just north of A and a transit stop spur just south of D, both on the
+          // drivable network so pickup/dropoff need no walking.
+          var iP = intersection("iP", ORIGIN.moveNorthMeters(10));
+          biStreet(A, iP, 10);
+          coordP = iP.toWgsCoordinate();
+
+          var iS = intersection("iS", ORIGIN.moveEastMeters(6000).moveSouthMeters(10));
+          biStreet(D, iS, 10);
+          stopS = stop("S", iS.toWgsCoordinate());
+          biLink(iS, stopS);
+        }
+      }
+    );
+
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
+    transitServiceResolver = context.transitServiceResolver();
+  }
+
+  @Test
+  void findsCrossLegInsertionWithPassengerSegmentLongerThanNearbyStopRadius() {
+    var tripStart = SEARCH_TIME.plusMinutes(30);
+    repository.upsertCarpoolTrip(trip(tripStart));
+
+    var request = RouteRequest.of()
+      .withFrom(GenericLocation.fromCoordinate(coordP.latitude(), coordP.longitude()))
+      .withTo(GenericLocation.fromCoordinate(coordM.latitude(), coordM.longitude()))
+      .withDateTime(SEARCH_TIME.toInstant())
+      .withJourney(j -> j.withAccess(new StreetRequest(StreetMode.CARPOOL)))
+      .buildRequest();
+
+    var results = service.routeAccessEgress(
+      request,
+      new StreetRequest(StreetMode.CARPOOL),
+      AccessEgressType.ACCESS,
+      transitServiceResolver,
+      SEARCH_TIME
+    );
+
+    assertFalse(
+      results.isEmpty(),
+      "A budget-feasible cross-leg insertion whose passenger → waypoint segment exceeds the " +
+        "nearby-stop radius should produce access candidates; an empty result means the " +
+        "passenger trees are capped below the largest candidate leg limit."
+    );
+
+    int stopSIndex = transitServiceResolver.getStop(stopS.getId()).getIndex();
+    assertTrue(
+      results.stream().anyMatch(r -> r.stop() == stopSIndex),
+      "Access results should include stop S on the trip's second leg"
+    );
+  }
+
+  /**
+   * A → M → D with scheduled legs of 70 and 60 minutes, matching the street network's actual
+   * driving times, and a 10-minute deviation budget at M and D.
+   */
+  private CarpoolTrip trip(ZonedDateTime tripStart) {
+    var origin = CarpoolStop.of(stopId("A"))
+      .withCoordinate(coordA)
+      .withOnboardCount(1)
+      .withDeviationBudget(Duration.ZERO)
+      .build();
+    var intermediate = CarpoolStop.of(stopId("M"))
+      .withCoordinate(coordM)
+      .withOnboardCount(1)
+      .withExpectedArrivalTime(tripStart.plusMinutes(70))
+      .withDeviationBudget(BUDGET)
+      .build();
+    var destination = CarpoolStop.of(stopId("D"))
+      .withCoordinate(coordD)
+      .withOnboardCount(1)
+      .withExpectedArrivalTime(tripStart.plusMinutes(130))
+      .withDeviationBudget(BUDGET)
+      .build();
+    return new CarpoolTripBuilder(FeedScopedId.ofNullable("TEST", "trip-bent-route"))
+      .withStops(List.of(origin, intermediate, destination))
+      .withTotalCapacity(CarpoolTrip.DEFAULT_TOTAL_CAPACITY)
+      .withStartTime(tripStart)
+      .withEndTime(tripStart.plusMinutes(130))
+      .build();
+  }
+
+  private static FeedScopedId stopId(String id) {
+    return FeedScopedId.ofNullable("TEST", "stop-" + id);
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
@@ -17,24 +17,16 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.filter.DistanceTripFilter;
-import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTreeStreetRouter;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
-import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
-import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.model.organization.ContactInfo;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Integration tests for {@link DefaultCarpoolingService#routeDirect}.
@@ -139,42 +131,9 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
       }
     );
 
-    Graph graph = model.graph();
-    var timetableRepository = model.timetableRepository();
-    VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
-    var vertexCreationService = new VertexCreationService(vertexLinker);
-    TransitService transitService = new DefaultTransitService(timetableRepository);
-    repository = new DefaultCarpoolingRepository();
-
-    StreetLimitationParametersService streetLimitationParams =
-      new StreetLimitationParametersService() {
-        @Override
-        public float maxCarSpeed() {
-          return 40.0f;
-        }
-
-        @Override
-        public int maxAreaNodes() {
-          return 500;
-        }
-
-        @Override
-        public float getBestWalkSafety() {
-          return 1;
-        }
-
-        @Override
-        public float getBestBikeSafety() {
-          return 1;
-        }
-      };
-
-    service = new DefaultCarpoolingService(
-      repository,
-      streetLimitationParams,
-      transitService,
-      vertexCreationService
-    );
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
   }
 
   private RouteRequest buildDirectCarpoolRequest(

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceLongTripAccessTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceLongTripAccessTest.java
@@ -1,0 +1,150 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
+import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitServiceResolver;
+
+/**
+ * Regression test for {@link DefaultCarpoolingService#routeAccessEgress} on a driver trip whose
+ * end-to-end driving time exceeds the nearby-stop search radius
+ * ({@link DefaultCarpoolingService#MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS}, 60
+ * minutes).
+ * <p>
+ * Access/egress baseline routing builds shortest-path trees rooted at the driver trip's own
+ * waypoints. When those trees borrowed the 60-minute nearby-stop radius as their expansion limit,
+ * the baseline {@code origin → destination} route of any trip longer than 60 minutes could not be
+ * reconstructed: the frontier died at an intermediate vertex before reaching the destination, so
+ * the whole trip was silently discarded and produced no access candidates. The trees are now sized
+ * per leg from the trip's scheduled timeline (see
+ * {@link DefaultCarpoolingService#driverLegTreeLimits}).
+ *
+ * <pre>
+ * Graph (going east, distances/speeds chosen so A → D drives in ~80 min):
+ *
+ *   P (10 m N of A)        S (10 m S of A, transit stop)
+ *    \                    /
+ *     A ===== M ========= D
+ *      70 min     10 min
+ *
+ *   Carpool trip: A → D  (single leg, scheduled span 60 min → limit 60 × 1.5 + 10 min budget =
+ *   100 min)
+ *   A → M takes ~70 min, M → D ~10 min, so the baseline A → D is ~80 min: unreachable under
+ *   the old 60-min tree cap (M sits past it and is never expanded to D), reachable under 100 min.
+ *   Access request: passenger at P, dropped at stop S.
+ * </pre>
+ */
+class DefaultCarpoolingServiceLongTripAccessTest extends GraphRoutingTest {
+
+  private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
+  private static final ZoneId ZONE = ZoneId.of("Europe/Oslo");
+  private static final ZonedDateTime SEARCH_TIME = LocalDateTime.of(2025, 6, 15, 12, 0).atZone(
+    ZONE
+  );
+
+  // 10 m/s car speed keeps the arithmetic obvious: seconds == metres / 10.
+  private static final float CAR_SPEED_MPS = 10.0f;
+
+  private DefaultCarpoolingService service;
+  private CarpoolingRepository repository;
+  private TransitServiceResolver transitServiceResolver;
+
+  private TransitStopVertex stopS;
+  private WgsCoordinate coordA;
+  private WgsCoordinate coordD;
+  private WgsCoordinate coordP;
+
+  @BeforeEach
+  void setUp() {
+    var model = modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          var A = intersection("A", ORIGIN);
+          // M is ~70 min from A, D another ~10 min — so the only path to D runs through a vertex
+          // that lies beyond the old 60-min tree cap.
+          var M = intersection("M", ORIGIN.moveEastMeters(42000));
+          var D = intersection("D", ORIGIN.moveEastMeters(48000));
+
+          coordA = A.toWgsCoordinate();
+          coordD = D.toWgsCoordinate();
+
+          // Bidirectional, speed-controlled car streets so A → D drives in ~80 min.
+          street(A, M, 42000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(M, A, 42000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(M, D, 6000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(D, M, 6000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+
+          // Passenger spur just north of A and a transit stop spur just south of A, both on the
+          // drivable network so pickup/dropoff need no walking.
+          var iP = intersection("iP", ORIGIN.moveNorthMeters(10));
+          biStreet(A, iP, 10);
+          coordP = iP.toWgsCoordinate();
+
+          var iS = intersection("iS", ORIGIN.moveSouthMeters(10));
+          biStreet(A, iS, 10);
+          stopS = stop("S", iS.toWgsCoordinate());
+          biLink(iS, stopS);
+        }
+      }
+    );
+
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
+    transitServiceResolver = context.transitServiceResolver();
+  }
+
+  @Test
+  void findsAccessResultsForTripLongerThanNearbyStopRadius() {
+    // Scheduled span is exactly 60 min, so the driver tree limit is 60 × 1.5 + 10 min budget =
+    // 100 min — enough to span the ~80-min A → D baseline, which the old 60-min cap could not.
+    var tripStart = SEARCH_TIME.plusMinutes(30);
+    var tripEnd = tripStart.plusMinutes(60);
+    var trip = CarpoolTripTestData.createSimpleTripWithTimes(coordA, coordD, tripStart, tripEnd);
+    repository.upsertCarpoolTrip(trip);
+
+    var request = RouteRequest.of()
+      .withFrom(GenericLocation.fromCoordinate(coordP.latitude(), coordP.longitude()))
+      .withTo(GenericLocation.fromCoordinate(coordD.latitude(), coordD.longitude()))
+      .withDateTime(SEARCH_TIME.toInstant())
+      .withJourney(j -> j.withAccess(new StreetRequest(StreetMode.CARPOOL)))
+      .buildRequest();
+
+    var results = service.routeAccessEgress(
+      request,
+      new StreetRequest(StreetMode.CARPOOL),
+      AccessEgressType.ACCESS,
+      transitServiceResolver,
+      SEARCH_TIME
+    );
+
+    assertFalse(
+      results.isEmpty(),
+      "A carpool trip longer than the 60-min nearby-stop radius should still produce access " +
+        "candidates; an empty result means the driver-baseline tree was capped at that radius."
+    );
+
+    int stopSIndex = transitServiceResolver.getStop(stopS.getId()).getIndex();
+    assertTrue(
+      results.stream().anyMatch(r -> r.stop() == stopSIndex),
+      "Access results should include stop S near the passenger origin"
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceTreeLimitTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceTreeLimitTest.java
@@ -1,0 +1,285 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.service.DefaultCarpoolingService.MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.carpooling.model.CarpoolStop;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+
+/**
+ * Unit tests for {@link DefaultCarpoolingService#driverLegTreeLimits}, which sizes the street
+ * routing tree at each driver waypoint to its own leg of the route instead of to the whole trip.
+ * <p>
+ * These guard the properties the rest of the access/egress routing relies on:
+ * <ul>
+ *   <li>each leg gets {@code pad(leg) + smallestDownstreamBudget} — so a viable, budget-respecting
+ *       detour inserted on a leg always stays within the tree, while a stop too far to reach is one
+ *       whose detour would breach some downstream stop's budget and be rejected by the delay
+ *       constraints anyway;</li>
+ *   <li>multi-leg trips produce per-leg limits well below the whole-trip limit — the actual point
+ *       of the change;</li>
+ *   <li>an incomplete or non-monotonic timeline falls back to whole-trip sizing for every leg.</li>
+ * </ul>
+ */
+class DefaultCarpoolingServiceTreeLimitTest {
+
+  private static final ZoneId ZONE = ZoneId.of("Europe/Oslo");
+  private static final ZonedDateTime BASE = LocalDateTime.of(2025, 1, 1, 12, 0).atZone(ZONE);
+  private static final WgsCoordinate COORD = new WgsCoordinate(59.9139, 10.7522);
+  private static final Duration BUDGET = Duration.ofMinutes(10);
+
+  private static int idCounter = 0;
+
+  /**
+   * A leg is padded 50% and its detour allowance — the smallest deviation budget among the stops
+   * downstream of the leg — added, matching the production formula.
+   */
+  private static Duration expectedLimit(Duration leg, Duration allowance) {
+    return leg.multipliedBy(3).dividedBy(2).plus(allowance);
+  }
+
+  @Test
+  void sizesEachLegIndependentlyAndWellBelowWholeTrip() {
+    // origin 12:00, intermediate arrives 13:00 (60-min leg), destination 14:40 (100-min leg).
+    var trip = trip(
+      BASE.plusMinutes(160),
+      originStop(BUDGET),
+      intermediateStop(BASE.plusMinutes(60), BUDGET),
+      destinationStop(BASE.plusMinutes(160), BUDGET)
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    var leg0 = expectedLimit(Duration.ofMinutes(60), BUDGET);
+    var leg1 = expectedLimit(Duration.ofMinutes(100), BUDGET);
+
+    // limits[k] sizes the leg from waypoint k to k+1 — waypoint k's forward tree and waypoint k+1's
+    // reverse tree. One entry per leg: the origin has no reverse tree, the destination no forward.
+    assertEquals(2, limits.length);
+    assertEquals(leg0, limits[0]);
+    assertEquals(leg1, limits[1]);
+
+    // The whole point of per-leg sizing: each leg is far smaller than the whole-trip span (160 min)
+    // would have produced.
+    var wholeTrip = expectedLimit(Duration.ofMinutes(160), BUDGET);
+    assertTrue(
+      limits[0].compareTo(wholeTrip) < 0,
+      "per-leg limit should be smaller than the whole-trip limit"
+    );
+  }
+
+  @Test
+  void usesSmallestDownstreamBudgetAsDetourAllowance() {
+    // A detour on a leg delays every downstream stop, and each stop is checked against its own
+    // deviation budget — so the smallest downstream budget is the most a feasible detour can add.
+    // Budgets: origin 50, intermediate 5, destination 40; both legs are 60 min scheduled.
+    var trip = trip(
+      BASE.plusMinutes(120),
+      originStop(Duration.ofMinutes(50)),
+      intermediateStop(BASE.plusMinutes(60), Duration.ofMinutes(5)),
+      destinationStop(BASE.plusMinutes(120), Duration.ofMinutes(40))
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    // Leg 0 delays both the intermediate stop (5) and the destination (40): allowance min(5, 40)
+    // = 5 → pad(60) + 5 = 95. The origin's 50-min budget never participates — no detour can delay
+    // the origin.
+    assertEquals(Duration.ofMinutes(95), limits[0]);
+    // Leg 1 only delays the destination: allowance 40 → pad(60) + 40 = 130. A budget-sized detour
+    // (60-min leg + 40-min budget) stays inside the tree; without the allowance term it would not.
+    assertEquals(Duration.ofMinutes(130), limits[1]);
+  }
+
+  @Test
+  void sizesShortLegsWellBelowNearbyStopRadius() {
+    // 5-min legs get only their padded duration plus the budget — no nearby-stop-radius floor — so
+    // their trees stay small instead of expanding into a region-wide SPT. A stop too far to reach
+    // within that limit is one whose detour would breach the budget and be rejected anyway.
+    var trip = trip(
+      BASE.plusMinutes(10),
+      originStop(Duration.ofMinutes(2)),
+      intermediateStop(BASE.plusMinutes(5), Duration.ofMinutes(2)),
+      destinationStop(BASE.plusMinutes(10), Duration.ofMinutes(2))
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    var leg = expectedLimit(Duration.ofMinutes(5), Duration.ofMinutes(2));
+    assertEquals(leg, limits[0]);
+    assertEquals(leg, limits[1]);
+    assertTrue(
+      limits[0].compareTo(MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS) < 0,
+      "short legs should not be inflated to the nearby-stop radius"
+    );
+  }
+
+  @Test
+  void usesAimedArrivalWhenExpectedMissing() {
+    var trip = trip(
+      BASE.plusMinutes(90),
+      originStop(BUDGET),
+      intermediateAimedStop(BASE.plusMinutes(50), BUDGET),
+      destinationStop(BASE.plusMinutes(90), BUDGET)
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    assertEquals(expectedLimit(Duration.ofMinutes(50), BUDGET), limits[0]);
+    assertEquals(expectedLimit(Duration.ofMinutes(40), BUDGET), limits[1]);
+  }
+
+  @Test
+  void destinationLatestArrivalDoesNotInflateLastLeg() {
+    // The destination's latest expected arrival is its scheduled arrival plus its deviation
+    // budget. The last leg must be sized from the scheduled (expected) arrival — the budget enters
+    // the limit exactly once, via the detour allowance, not baked into the leg duration as well.
+    var trip = trip(
+      BASE.plusMinutes(120),
+      originStop(BUDGET),
+      intermediateStop(BASE.plusMinutes(60), BUDGET),
+      destinationStopWithTimes(BASE.plusMinutes(120), BASE.plusMinutes(160), BUDGET)
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    // Last leg is the scheduled 60 min (12:00+60 → +120), not the 100 min the latest expected
+    // arrival (+160) would give.
+    assertEquals(expectedLimit(Duration.ofMinutes(60), BUDGET), limits[1]);
+  }
+
+  @Test
+  void twoWaypointTripSizesTheSingleLegToTheWholeSpan() {
+    var trip = trip(
+      BASE.plusMinutes(60),
+      originStop(BUDGET),
+      destinationStop(BASE.plusMinutes(60), BUDGET)
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    var legLimit = expectedLimit(Duration.ofMinutes(60), BUDGET);
+    assertEquals(1, limits.length);
+    assertEquals(legLimit, limits[0]);
+  }
+
+  @Test
+  void fallsBackToWholeTripWhenIntermediateTimeMissing() {
+    var trip = trip(
+      BASE.plusMinutes(120),
+      originStop(BUDGET),
+      intermediateStop(null, BUDGET),
+      destinationStop(BASE.plusMinutes(120), BUDGET)
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    var wholeTrip = expectedLimit(Duration.ofMinutes(120), BUDGET);
+    assertEquals(wholeTrip, limits[0]);
+    assertEquals(wholeTrip, limits[1]);
+  }
+
+  @Test
+  void fallsBackToWholeTripWhenDestinationTimeMissing() {
+    // The destination is not special-cased: like any other stop, a missing arrival time means the
+    // timeline is incomplete and every leg falls back to the whole-trip span.
+    var trip = trip(
+      BASE.plusMinutes(120),
+      originStop(BUDGET),
+      intermediateStop(BASE.plusMinutes(60), BUDGET),
+      destinationStop(null, BUDGET)
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    var wholeTrip = expectedLimit(Duration.ofMinutes(120), BUDGET);
+    assertEquals(wholeTrip, limits[0]);
+    assertEquals(wholeTrip, limits[1]);
+  }
+
+  @Test
+  void fallsBackToWholeTripWhenTimelineNotMonotonic() {
+    // Intermediate arrival is before the trip start — an impossible timeline that must not yield a
+    // negative leg; the whole-trip span sizes every leg instead.
+    var trip = trip(
+      BASE.plusMinutes(120),
+      originStop(BUDGET),
+      intermediateStop(BASE.minusMinutes(10), BUDGET),
+      destinationStop(BASE.plusMinutes(120), BUDGET)
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(trip);
+
+    var wholeTrip = expectedLimit(Duration.ofMinutes(120), BUDGET);
+    assertEquals(wholeTrip, limits[0]);
+    assertEquals(wholeTrip, limits[1]);
+  }
+
+  private static CarpoolTrip trip(ZonedDateTime endTime, CarpoolStop... stops) {
+    return new CarpoolTripBuilder(FeedScopedId.ofNullable("TEST", "trip-" + ++idCounter))
+      .withStops(List.of(stops))
+      .withTotalCapacity(CarpoolTrip.DEFAULT_TOTAL_CAPACITY)
+      .withStartTime(BASE)
+      .withEndTime(endTime)
+      .build();
+  }
+
+  private static CarpoolStop originStop(Duration budget) {
+    return CarpoolStop.of(nextId())
+      .withCoordinate(COORD)
+      .withOnboardCount(1)
+      .withDeviationBudget(budget)
+      .build();
+  }
+
+  private static CarpoolStop destinationStop(@Nullable ZonedDateTime arrival, Duration budget) {
+    return intermediateStop(arrival, budget);
+  }
+
+  private static CarpoolStop destinationStopWithTimes(
+    ZonedDateTime expectedArrival,
+    ZonedDateTime latestExpectedArrival,
+    Duration budget
+  ) {
+    return CarpoolStop.of(nextId())
+      .withCoordinate(COORD)
+      .withOnboardCount(1)
+      .withExpectedArrivalTime(expectedArrival)
+      .withLatestExpectedArrivalTime(latestExpectedArrival)
+      .withDeviationBudget(budget)
+      .build();
+  }
+
+  private static CarpoolStop intermediateStop(@Nullable ZonedDateTime arrival, Duration budget) {
+    return CarpoolStop.of(nextId())
+      .withCoordinate(COORD)
+      .withOnboardCount(1)
+      .withExpectedArrivalTime(arrival)
+      .withDeviationBudget(budget)
+      .build();
+  }
+
+  private static CarpoolStop intermediateAimedStop(ZonedDateTime arrival, Duration budget) {
+    return CarpoolStop.of(nextId())
+      .withCoordinate(COORD)
+      .withOnboardCount(1)
+      .withAimedArrivalTime(arrival)
+      .withDeviationBudget(budget)
+      .build();
+  }
+
+  private static FeedScopedId nextId() {
+    return FeedScopedId.ofNullable("TEST", "stop-" + ++idCounter);
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
-import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.model.GenericLocation;
@@ -21,19 +20,12 @@ import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
-import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.organization.ContactInfo;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Integration tests that exercise the walk-to/from-carpool behavior added to
@@ -119,42 +111,9 @@ class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
       }
     );
 
-    Graph graph = model.graph();
-    var timetableRepository = model.timetableRepository();
-    VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
-    var vertexCreationService = new VertexCreationService(vertexLinker);
-    TransitService transitService = new DefaultTransitService(timetableRepository);
-    repository = new DefaultCarpoolingRepository();
-
-    StreetLimitationParametersService streetLimitationParams =
-      new StreetLimitationParametersService() {
-        @Override
-        public float maxCarSpeed() {
-          return 40.0f;
-        }
-
-        @Override
-        public int maxAreaNodes() {
-          return 500;
-        }
-
-        @Override
-        public float getBestWalkSafety() {
-          return 1;
-        }
-
-        @Override
-        public float getBestBikeSafety() {
-          return 1;
-        }
-      };
-
-    service = new DefaultCarpoolingService(
-      repository,
-      streetLimitationParams,
-      transitService,
-      vertexCreationService
-    );
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
   }
 
   private RouteRequest buildDirectCarpoolRequest(ZonedDateTime dateTime) {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolStop.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolStop.java
@@ -73,6 +73,17 @@ public class CarpoolStop extends AbstractTransitEntity<CarpoolStop, CarpoolStopB
   }
 
   /**
+   * The arrival time the trip is currently scheduled to reach this stop: the expected arrival,
+   * falling back to the aimed arrival when no expected time is provided.
+   *
+   * @return The scheduled arrival time, or null if not applicable (e.g., origin stop)
+   */
+  @Nullable
+  public ZonedDateTime getScheduledArrivalTime() {
+    return expectedArrivalTime != null ? expectedArrivalTime : aimedArrivalTime;
+  }
+
+  /**
    * @return The latest expected arrival time, or null if not provided
    */
   @Nullable

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -2,12 +2,14 @@ package org.opentripplanner.ext.carpooling.service;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
@@ -15,6 +17,7 @@ import org.opentripplanner.ext.carpooling.filter.CarpoolingRequest;
 import org.opentripplanner.ext.carpooling.filter.ItineraryPostFilters;
 import org.opentripplanner.ext.carpooling.filter.TripPreFilters;
 import org.opentripplanner.ext.carpooling.internal.CarpoolItineraryMapper;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.CarpoolStreetRouter;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTreeStreetRouter;
@@ -482,25 +485,24 @@ public class DefaultCarpoolingService implements CarpoolingService {
       );
       candidateTripsWithVertices.forEach(tripWithVertices -> {
         var vertices = tripWithVertices.vertices();
-        carpoolTreeVertexRouter.addVertex(
-          vertices.getFirst(),
-          CarpoolTreeStreetRouter.Direction.FROM,
-          MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
-        );
-        carpoolTreeVertexRouter.addVertex(
-          vertices.getLast(),
-          CarpoolTreeStreetRouter.Direction.TO,
-          MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
-        );
-
-        var middleVertices = vertices.subList(1, vertices.size() - 1);
-        middleVertices.forEach(vertex -> {
+        // Each waypoint's tree only has to span its own leg of the route — toward the next waypoint
+        // for the forward tree, back toward the previous one for the reverse tree — plus the detour
+        // a passenger insertion on that leg can add. Sizing every waypoint to the whole trip turns
+        // each into a region-wide car SPT even when consecutive waypoints are minutes apart, the
+        // dominant cost for long or multi-waypoint trips.
+        var legLimits = driverLegTreeLimits(tripWithVertices.trip());
+        for (int leg = 0; leg < legLimits.length; leg++) {
           carpoolTreeVertexRouter.addVertex(
-            vertex,
-            CarpoolTreeStreetRouter.Direction.BOTH,
-            MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
+            vertices.get(leg),
+            CarpoolTreeStreetRouter.Direction.FROM,
+            legLimits[leg]
           );
-        });
+          carpoolTreeVertexRouter.addVertex(
+            vertices.get(leg + 1),
+            CarpoolTreeStreetRouter.Direction.TO,
+            legLimits[leg]
+          );
+        }
       });
 
       var stopDuration = request.preferences().car().pickupTime();
@@ -563,6 +565,86 @@ public class DefaultCarpoolingService implements CarpoolingService {
         )
         .toList();
     }
+  }
+
+  /**
+   * Sizes the street routing tree for each leg of a driver trip to the leg it actually has to span,
+   * rather than to the whole trip. {@code result[k]} is the limit for the leg from waypoint
+   * {@code k} to waypoint {@code k + 1}, so the forward tree rooted at waypoint {@code k} grows
+   * toward the next waypoint under {@code result[k]} and the reverse tree rooted at waypoint
+   * {@code k} grows back toward the previous one under {@code result[k - 1]}. The returned array has
+   * one entry per leg ({@code stops - 1}); the origin has no reverse tree and the destination no
+   * forward tree.
+   * <p>
+   * A leg's limit only has to reach the adjacent waypoint plus any pickup or dropoff inserted on
+   * that leg. Sizing every waypoint to the full
+   * {@link CarpoolTrip#startTime()}→{@link CarpoolTrip#endTime()} span makes each tree a
+   * region-wide car SPT even when consecutive waypoints are minutes apart, which is the dominant
+   * cost for long or multi-waypoint trips.
+   * <p>
+   * Each leg is sized from its scheduled duration (see {@link #scheduledLegDurations}) padded by
+   * 50% to absorb the difference between the platform's scheduled durations and OTP's car routing
+   * model, plus the leg's detour allowance: the smallest deviation budget among the stops
+   * downstream of the leg. A detour inserted on a leg delays every downstream stop, and
+   * {@link org.opentripplanner.ext.carpooling.constraints.PassengerDelayConstraints} checks each
+   * against its own budget, so the smallest downstream budget is the most a feasible detour can
+   * add. The allowance is what bounds the tree: a pickup or dropoff far enough from the leg to
+   * fall outside it would also push the insertion detour past some downstream stop's budget, so
+   * the delay constraints reject it regardless — the tree only has to reach as far as a
+   * budget-respecting detour can, and no floor is needed to keep viable insertions in range. When
+   * the scheduled timeline is incomplete or not non-decreasing the whole-trip span sizes every leg
+   * as a safe fallback.
+   */
+  static Duration[] driverLegTreeLimits(CarpoolTrip trip) {
+    var stops = trip.stops();
+    int n = stops.size();
+
+    var legDurations = scheduledLegDurations(trip);
+    if (legDurations == null) {
+      legDurations = new Duration[n - 1];
+      Arrays.fill(legDurations, Duration.between(trip.startTime(), trip.endTime()));
+    }
+
+    // Scheduled leg duration padded 50% (platform-vs-OTP model slack) plus the leg's detour
+    // allowance — the deviation budgets' backward running minimum, i.e. the smallest budget among
+    // the stops downstream of the leg. The origin's budget never participates: no detour can delay
+    // the origin.
+    var legLimits = new Duration[n - 1];
+    var detourAllowance = stops.get(n - 1).getDeviationBudget();
+    for (int k = n - 2; k >= 0; k--) {
+      var budget = stops.get(k + 1).getDeviationBudget();
+      if (budget.compareTo(detourAllowance) < 0) {
+        detourAllowance = budget;
+      }
+      legLimits[k] = legDurations[k].multipliedBy(3).dividedBy(2).plus(detourAllowance);
+    }
+    return legLimits;
+  }
+
+  /**
+   * Computes each leg's scheduled driving duration from the trip's waypoint arrival timeline —
+   * {@code startTime} at the origin and each subsequent stop's
+   * {@link org.opentripplanner.ext.carpooling.model.CarpoolStop#getScheduledArrivalTime() scheduled}
+   * arrival time. The destination's <em>latest</em> expected arrival is deliberately not used: it
+   * already contains the destination's deviation budget, which the leg limit adds separately as
+   * the detour allowance. Returns {@code null} when an arrival time is missing or the timeline is
+   * not non-decreasing, signalling the caller to fall back to whole-trip sizing.
+   */
+  @Nullable
+  private static Duration[] scheduledLegDurations(CarpoolTrip trip) {
+    var stops = trip.stops();
+    int n = stops.size();
+    var legDurations = new Duration[n - 1];
+    var legStart = trip.startTime();
+    for (int k = 1; k < n; k++) {
+      var arrival = stops.get(k).getScheduledArrivalTime();
+      if (arrival == null || arrival.isBefore(legStart)) {
+        return null;
+      }
+      legDurations[k - 1] = Duration.between(legStart, arrival);
+      legStart = arrival;
+    }
+    return legDurations;
   }
 
   private void validateRequest(RouteRequest request) throws RoutingValidationException {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -102,9 +102,7 @@ public class CarpoolSiriMapper {
       ? firstStop.getExpectedDepartureTime()
       : firstStop.getAimedDepartureTime();
 
-    var endTime = lastStop.getExpectedArrivalTime() != null
-      ? lastStop.getExpectedArrivalTime()
-      : lastStop.getAimedArrivalTime();
+    var endTime = lastStop.getScheduledArrivalTime();
 
     int totalCapacity = extractTotalCapacity(tripId, activeCalls);
 


### PR DESCRIPTION
### Summary

The trees rooted at a driver trip's waypoints were sized to the 60-min nearby-stop radius, so any trip longer than that couldn't reconstruct its origin->destination baseline and was silently dropped. Size them to the trip's start-to-latest-end span (padded 50%, floored at the radius) instead.

### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?

yes

- Was any manual verification done?

yes

- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

yes

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

yes

- Were all non-trivial public classes and methods documented with Javadoc?

yes