### PR TITLE
Use edge endpoint instead of splitting very close to the end of an edge

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -465,11 +465,17 @@ public class VertexLinker {
     var projection = ll.getCoordinate(geom);
 
     // if we're very close to one end of the edge, don't split
-    var startDistance = SphericalDistanceLibrary.fastDistance(projection, edge.getFromVertex().getCoordinate());
+    var startDistance = SphericalDistanceLibrary.fastDistance(
+      projection,
+      edge.getFromVertex().getCoordinate()
+    );
     if (startDistance < 0.1) {
       return (IntersectionVertex) edge.getFromVertex();
     }
-    var toDistance = SphericalDistanceLibrary.fastDistance(projection, edge.getToVertex().getCoordinate());
+    var toDistance = SphericalDistanceLibrary.fastDistance(
+      projection,
+      edge.getToVertex().getCoordinate()
+    );
     if (toDistance < 0.1) {
       return (IntersectionVertex) edge.getToVertex();
     }

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -83,6 +83,12 @@ public class VertexLinker {
     TraverseMode.CAR
   );
 
+  /**
+   * If vertex linking tries to split an edge very close to the endpoint, do not split the edge,
+   * use the existing edge endpoint instead. This is the limit of how far we still use the endpoint.
+   */
+  private static final double EDGE_SPLIT_END_TOLERANCE_METERS = 0.1;
+
   private final Graph graph;
 
   private final VisibilityMode visibilityMode;
@@ -469,14 +475,14 @@ public class VertexLinker {
       projection,
       edge.getFromVertex().getCoordinate()
     );
-    if (startDistance < 0.1) {
+    if (startDistance < EDGE_SPLIT_END_TOLERANCE_METERS) {
       return (IntersectionVertex) edge.getFromVertex();
     }
     var toDistance = SphericalDistanceLibrary.fastDistance(
       projection,
       edge.getToVertex().getCoordinate()
     );
-    if (toDistance < 0.1) {
+    if (toDistance < EDGE_SPLIT_END_TOLERANCE_METERS) {
       return (IntersectionVertex) edge.getToVertex();
     }
 

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -462,24 +462,20 @@ public class VertexLinker {
     LineString transformed = equirectangularProject(geom, xScale);
     LocationIndexedLine il = new LocationIndexedLine(transformed);
     LinearLocation ll = il.project(new Coordinate(vertex.getLon() * xScale, vertex.getLat()));
-    double length = SphericalDistanceLibrary.length(geom);
+    var projection = ll.getCoordinate(geom);
 
     // if we're very close to one end of the edge, don't split
-    if (
-      ll.getSegmentIndex() == 0 &&
-      (ll.getSegmentFraction() < 1e-8 || ll.getSegmentFraction() * length < 0.1)
-    ) {
+    var startDistance = SphericalDistanceLibrary.fastDistance(projection, edge.getFromVertex().getCoordinate());
+    if (startDistance < 0.1) {
       return (IntersectionVertex) edge.getFromVertex();
-    } else if (ll.getSegmentIndex() == geom.getNumPoints() - 1) {
-      return (IntersectionVertex) edge.getToVertex();
-    } else if (
-      ll.getSegmentIndex() == geom.getNumPoints() - 2 &&
-      (ll.getSegmentFraction() > 1 - 1e-8 || (1 - ll.getSegmentFraction()) * length < 0.1)
-    ) {
+    }
+    var toDistance = SphericalDistanceLibrary.fastDistance(projection, edge.getToVertex().getCoordinate());
+    if (toDistance < 0.1) {
       return (IntersectionVertex) edge.getToVertex();
     }
+
     // split the edge and return the split vertex
-    return split(edge, ll.getCoordinate(geom), scope, direction, tempEdges);
+    return split(edge, projection, scope, direction, tempEdges);
   }
 
   /**

--- a/street/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertexBuilder.java
+++ b/street/src/main/java/org/opentripplanner/street/model/vertex/TransitStopVertexBuilder.java
@@ -28,8 +28,8 @@ public class TransitStopVertexBuilder {
     return this;
   }
 
-  public TransitStopVertexBuilder withCoordinate(double lat, double lon) {
-    this.coordinate = new WgsCoordinate(lon, lat);
+  public TransitStopVertexBuilder withCoordinate(double lon, double lat) {
+    this.coordinate = new WgsCoordinate(lat, lon);
     return this;
   }
 

--- a/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironment.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironment.java
@@ -12,9 +12,12 @@ import org.opentripplanner.street.graph.DisposableEdgeDataFetcher;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.graph.GraphDataFetcher;
 import org.opentripplanner.street.model.StreetConstants;
+import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
 import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
 
 /**
@@ -54,6 +57,21 @@ public class LinkingEnvironment {
         List.of(TemporaryFreeEdge.createTemporaryFreeEdge((TemporaryStreetLocation) v1, v2))
     );
     return disposable;
+  }
+
+  public void linkVertexPermanently(Vertex linkedVertex) {
+    linker.linkVertexPermanently(
+      linkedVertex,
+      new TraverseModeSet(TraverseMode.WALK),
+      BIDIRECTIONAL,
+      ((vertex, streetVertex) -> {
+        var s = (TransitStopVertex) vertex;
+        return List.of(
+          StreetTransitStopLink.createStreetTransitStopLink(s, streetVertex),
+          StreetTransitStopLink.createStreetTransitStopLink(streetVertex, s)
+        );
+      })
+    );
   }
 
   public void disposeEdges() {

--- a/street/src/test/java/org/opentripplanner/street/linking/IdenticalCoordinateLinkingTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/IdenticalCoordinateLinkingTest.java
@@ -3,15 +3,11 @@ package org.opentripplanner.street.linking;
 import static com.google.common.truth.Truth.assertThat;
 import static org.opentripplanner.core.model.id.FeedScopedIdFactory.id;
 import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
-import static org.opentripplanner.street.search.TraverseMode.WALK;
 
-import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opentripplanner.street.model.StreetModelFactory;
-import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
-import org.opentripplanner.street.search.TraverseModeSet;
 
 /// Tests that linking a vertex with identical coordinates results in the same vertex being re-used
 /// and no split edges/vertices being created.
@@ -35,20 +31,7 @@ class IdenticalCoordinateLinkingTest {
       .withCoordinate(v1.getLat() + offset, v1.getLat() + offset)
       .withId(id("stop"))
       .build();
-    env
-      .linker()
-      .linkVertexPermanently(
-        stopVertex,
-        new TraverseModeSet(WALK),
-        LinkingDirection.BIDIRECTIONAL,
-        ((vertex, streetVertex) -> {
-          var s = (TransitStopVertex) vertex;
-          return List.of(
-            StreetTransitStopLink.createStreetTransitStopLink(s, streetVertex),
-            StreetTransitStopLink.createStreetTransitStopLink(streetVertex, s)
-          );
-        })
-      );
+    env.linkVertexPermanently(stopVertex);
 
     assertThat(env.graph().listStreetEdges()).hasSize(1);
     assertThat(env.graph().summarizeEdges()).containsExactly(

--- a/street/src/test/java/org/opentripplanner/street/linking/LinkingNearEndTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/LinkingNearEndTest.java
@@ -24,41 +24,38 @@ import org.opentripplanner.street.search.TraverseModeSet;
  * Test that linking very near the end of the edge doesn't split but uses the endpoint instead.
  */
 public class LinkingNearEndTest {
+
   /* An edge with a very short first segment which caused problems in production. */
-  private static final Coordinate[] points = {
+  private static final Coordinate[] POINTS = {
     new Coordinate(25.007039006519058, 60.140565999664084),
     new Coordinate(25.007039, 60.140566),
-    new Coordinate(25.006999800000003, 60.1403405)
+    new Coordinate(25.006999800000003, 60.1403405),
   };
 
-  private static final WgsCoordinate stop = new WgsCoordinate(60.1405804,25.007042);
+  private static final WgsCoordinate STOP = new WgsCoordinate(60.1405804, 25.007042);
 
   @Test
   void linkingNearStart() {
-    var v1 = intersectionVertex(points[0]);
-    var v2 = intersectionVertex(points[points.length - 1]);
+    var v1 = intersectionVertex(POINTS[0]);
+    var v2 = intersectionVertex(POINTS[POINTS.length - 1]);
     var sequence = new CoordinateArrayListSequence();
-    sequence.extend(points);
+    sequence.extend(POINTS);
     linking(v1, v2, sequence);
   }
 
   @Test
   void linkingNearEnd() {
-    var v2 = intersectionVertex(points[points.length - 1]);
-    var v1 = intersectionVertex(points[0]);
+    var v2 = intersectionVertex(POINTS[POINTS.length - 1]);
+    var v1 = intersectionVertex(POINTS[0]);
     var sequence = new CoordinateArrayListSequence();
-    for (int i = points.length - 1; i >= 0; i--) {
-      sequence.add(points[i]);
+    for (int i = POINTS.length - 1; i >= 0; i--) {
+      sequence.add(POINTS[i]);
     }
     linking(v2, v1, sequence);
   }
 
   private void linking(StreetVertex v1, StreetVertex v2, CoordinateArrayListSequence sequence) {
-
-    var stopVertex = TransitStopVertex.of()
-      .withCoordinate(stop)
-      .withId(id("stop"))
-      .build();
+    var stopVertex = TransitStopVertex.of().withCoordinate(STOP).withId(id("stop")).build();
 
     var geom = new LineString(sequence, GeometryUtils.getGeometryFactory());
 
@@ -67,7 +64,9 @@ public class LinkingNearEndTest {
       v2,
       SphericalDistanceLibrary.distance(v1.getCoordinate(), v2.getCoordinate()),
       StreetTraversalPermission.ALL
-    ).withGeometry(geom).buildAndConnect();
+    )
+      .withGeometry(geom)
+      .buildAndConnect();
     var env = new LinkingEnvironment(v1, v2);
 
     env
@@ -87,5 +86,4 @@ public class LinkingNearEndTest {
 
     assertThat(env.graph().listStreetEdges()).hasSize(1);
   }
-
 }

--- a/street/src/test/java/org/opentripplanner/street/linking/LinkingNearEndTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/LinkingNearEndTest.java
@@ -1,0 +1,91 @@
+package org.opentripplanner.street.linking;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.core.model.id.FeedScopedIdFactory.id;
+import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.street.geometry.CoordinateArrayListSequence;
+import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetModelFactory;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.edge.StreetTransitStopLink;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.street.search.TraverseMode;
+import org.opentripplanner.street.search.TraverseModeSet;
+
+/**
+ * Test that linking very near the end of the edge doesn't split but uses the endpoint instead.
+ */
+public class LinkingNearEndTest {
+  /* An edge with a very short first segment which caused problems in production. */
+  private static final Coordinate[] points = {
+    new Coordinate(25.007039006519058, 60.140565999664084),
+    new Coordinate(25.007039, 60.140566),
+    new Coordinate(25.006999800000003, 60.1403405)
+  };
+
+  private static final WgsCoordinate stop = new WgsCoordinate(60.1405804,25.007042);
+
+  @Test
+  void linkingNearStart() {
+    var v1 = intersectionVertex(points[0]);
+    var v2 = intersectionVertex(points[points.length - 1]);
+    var sequence = new CoordinateArrayListSequence();
+    sequence.extend(points);
+    linking(v1, v2, sequence);
+  }
+
+  @Test
+  void linkingNearEnd() {
+    var v2 = intersectionVertex(points[points.length - 1]);
+    var v1 = intersectionVertex(points[0]);
+    var sequence = new CoordinateArrayListSequence();
+    for (int i = points.length - 1; i >= 0; i--) {
+      sequence.add(points[i]);
+    }
+    linking(v2, v1, sequence);
+  }
+
+  private void linking(StreetVertex v1, StreetVertex v2, CoordinateArrayListSequence sequence) {
+
+    var stopVertex = TransitStopVertex.of()
+      .withCoordinate(stop)
+      .withId(id("stop"))
+      .build();
+
+    var geom = new LineString(sequence, GeometryUtils.getGeometryFactory());
+
+    StreetModelFactory.streetEdgeBuilder(
+      v1,
+      v2,
+      SphericalDistanceLibrary.distance(v1.getCoordinate(), v2.getCoordinate()),
+      StreetTraversalPermission.ALL
+    ).withGeometry(geom).buildAndConnect();
+    var env = new LinkingEnvironment(v1, v2);
+
+    env
+      .linker()
+      .linkVertexPermanently(
+        stopVertex,
+        new TraverseModeSet(TraverseMode.WALK),
+        LinkingDirection.BIDIRECTIONAL,
+        ((vertex, streetVertex) -> {
+          var s = (TransitStopVertex) vertex;
+          return List.of(
+            StreetTransitStopLink.createStreetTransitStopLink(s, streetVertex),
+            StreetTransitStopLink.createStreetTransitStopLink(streetVertex, s)
+          );
+        })
+      );
+
+    assertThat(env.graph().listStreetEdges()).hasSize(1);
+  }
+
+}

--- a/street/src/test/java/org/opentripplanner/street/linking/LinkingNearEndTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/LinkingNearEndTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.opentripplanner.core.model.id.FeedScopedIdFactory.id;
 import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
 
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
@@ -14,11 +13,8 @@ import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.StreetModelFactory;
 import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
-import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.street.search.TraverseModeSet;
 
 /**
  * Test that linking very near the end of the edge doesn't split but uses the endpoint instead.
@@ -69,21 +65,12 @@ public class LinkingNearEndTest {
       .buildAndConnect();
     var env = new LinkingEnvironment(v1, v2);
 
-    env
-      .linker()
-      .linkVertexPermanently(
-        stopVertex,
-        new TraverseModeSet(TraverseMode.WALK),
-        LinkingDirection.BIDIRECTIONAL,
-        ((vertex, streetVertex) -> {
-          var s = (TransitStopVertex) vertex;
-          return List.of(
-            StreetTransitStopLink.createStreetTransitStopLink(s, streetVertex),
-            StreetTransitStopLink.createStreetTransitStopLink(streetVertex, s)
-          );
-        })
-      );
+    env.linkVertexPermanently(stopVertex);
 
     assertThat(env.graph().listStreetEdges()).hasSize(1);
+    assertThat(env.graph().summarizeEdges()).containsAtLeast(
+      "(60.140566,25.007039) linked to (60.14058,25.007042)[street:stop]",
+      "(60.14058,25.007042)[street:stop] linked to (60.140566,25.007039)"
+    );
   }
 }


### PR DESCRIPTION
### Summary

There were cases where edge splitting did not use the endpoint and forgo splitting even when the split point was very close to the end.

Fixes the root cause of #7618 which is now not strictly necessary (but could be included for belt-and-suspenders reasons).

### Issue

The code used an incorrect length (the length of the entire edge, not just the segment) in the comparison, and failed to consider that even in a middle segment the split point can be arbitrarily close to the end.

### Unit tests

Added LinkingNearEndTest with two completely new tests.

### Documentation

Couple of comments in the code.

### Changelog

Probably?

### Bumping the serialization version id

No.