### PR TITLE
Extract multi-area edge ownership selection and add a midpoint fast path

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/linking/AreaEdgeSelector.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/AreaEdgeSelector.java
@@ -1,0 +1,102 @@
+package org.opentripplanner.street.linking;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.locationtech.jts.algorithm.locate.SimplePointInAreaLocator;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Location;
+import org.opentripplanner.street.model.edge.Area;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Picks which {@link Area} of a multi-area {@link org.opentripplanner.street.model.edge.AreaGroup}
+ * owns a newly created visibility edge, so that the edge can borrow the area's name, permission and
+ * safety factors.
+ * <p>
+ * The constants form an ordered fallback chain run by {@link #resolve}: each is tried in turn and
+ * the first one that resolves an area wins. A selector returns {@code null} to signal "I cannot
+ * decide - try the next one".
+ */
+enum AreaEdgeSelector {
+  /**
+   * Returns the first area whose interior or boundary contains the edge midpoint, using a cheap
+   * point-in-area scan with no allocation. This is exact whenever the edge lies within a single
+   * sub-area (the common case) and avoids the constructive {@code polygon.intersection(line)}
+   * overlay - a major allocation source during real-time rental linking. Returns {@code null} when
+   * the midpoint falls outside every sub-area (e.g. in a hole, an uncovered part of the group, or
+   * for a forced edge leaving the group).
+   */
+  MIDPOINT_CONTAINS {
+    @Override
+    @Nullable
+    Area select(List<Area> areas, LineString line) {
+      var from = line.getCoordinateN(0);
+      var to = line.getCoordinateN(1);
+      var midpoint = new Coordinate((from.x + to.x) / 2, (from.y + to.y) / 2);
+      for (Area area : areas) {
+        if (SimplePointInAreaLocator.locate(midpoint, area.getGeometry()) != Location.EXTERIOR) {
+          return area;
+        }
+      }
+      return null;
+    }
+  },
+  /**
+   * Returns the first area whose intersection with the edge has positive length. This builds a
+   * constructive JTS overlay geometry and is therefore relatively expensive; it is used only as a
+   * fallback when the cheaper {@link #MIDPOINT_CONTAINS} cannot decide. It still handles edges whose
+   * midpoint falls in a hole or uncovered part of the group but which nonetheless cross a sub-area.
+   * Returns {@code null} when the edge crosses no sub-area.
+   */
+  LINE_INTERSECTION {
+    @Override
+    @Nullable
+    Area select(List<Area> areas, LineString line) {
+      for (Area area : areas) {
+        if (area.getGeometry().intersection(line).getLength() > INTERSECTION_EPSILON) {
+          return area;
+        }
+      }
+      return null;
+    }
+  };
+
+  private static final Logger LOG = LoggerFactory.getLogger(AreaEdgeSelector.class);
+
+  private static final double INTERSECTION_EPSILON = 0.000001;
+
+  /**
+   * The area that owns this edge, or {@code null} if this selector cannot decide.
+   *
+   * @param areas the candidate sub-areas of the group (never empty)
+   * @param line  the 2-point segment of the edge being created
+   */
+  @Nullable
+  abstract Area select(List<Area> areas, LineString line);
+
+  /**
+   * Resolves which {@link Area} owns the edge. Never returns {@code null}: a single-area group
+   * trivially resolves to its only area (skipping the geometric tests and the multi-area warning),
+   * and a multi-area group falls back to the first area when no selector matches - unexpected for a
+   * multi-area group, so it is logged.
+   *
+   * @param areas the candidate sub-areas of the group (never empty)
+   * @param line  the 2-point segment of the edge being created
+   */
+  static Area resolve(List<Area> areas, LineString line) {
+    if (areas.size() == 1) {
+      return areas.getFirst();
+    }
+    for (AreaEdgeSelector selector : values()) {
+      Area hit = selector.select(areas, line);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    // neither geometric test found an owner: force-linked point from outside the group
+    LOG.warn("No intersecting area found. This may indicate a bug.");
+    return areas.getFirst();
+  }
+}

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -34,8 +34,6 @@ import org.opentripplanner.street.model.vertex.TemporarySplitterVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class links transit stops to streets by splitting the streets (unless the stop is extremely
@@ -54,8 +52,6 @@ import org.slf4j.LoggerFactory;
  * replacement of the stop linker, #1305.
  */
 public class VertexLinker {
-
-  private static final Logger LOG = LoggerFactory.getLogger(VertexLinker.class);
 
   /**
    * if there are two ways and the distances to them differ by less than this value, we link to both
@@ -727,26 +723,8 @@ public class VertexLinker {
     Scope scope,
     DisposableEdgeCollection tempEdges
   ) {
-    Area hit = null;
-    var areas = ag.getAreas();
-    if (areas.size() == 1) {
-      hit = areas.getFirst();
-    } else {
-      // If more than one area intersects, we pick first one for the name & properties
-      for (Area area : areas) {
-        Geometry polygon = area.getGeometry();
-        Geometry intersection = polygon.intersection(line);
-        if (intersection.getLength() > 0.000001) {
-          hit = area;
-          break;
-        }
-      }
-    }
-    // hit may be null when force linking a point from outside
-    if (hit == null) {
-      LOG.warn("No intersecting area found. This may indicate a bug.");
-      hit = areas.getFirst();
-    }
+    // Pick the area that owns this edge for its name, permission and safety factors.
+    Area hit = AreaEdgeSelector.resolve(ag.getAreas(), line);
     double length = SphericalDistanceLibrary.distance(to.getCoordinate(), from.getCoordinate());
     // apply consistent NoThru restrictions
     // if all joining edges are nothru, then the new edge should be as well

--- a/street/src/test/java/org/opentripplanner/street/linking/AreaEdgeSelectorTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/AreaEdgeSelectorTest.java
@@ -1,0 +1,102 @@
+package org.opentripplanner.street.linking;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Polygon;
+import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.model.edge.Area;
+
+class AreaEdgeSelectorTest {
+
+  private static final GeometryFactory GF = GeometryUtils.getGeometryFactory();
+
+  // Two squares sharing the edge x=10: A covers x in [0,10], B covers x in [10,20], both y in [0,10].
+  private static final Area A = area(square(0, 10));
+  private static final Area B = area(square(10, 20));
+  private static final List<Area> AREAS = List.of(A, B);
+
+  @Test
+  void midpointPicksAreaContainingMidpoint() {
+    // midpoint (5,5) is inside A
+    assertSame(A, AreaEdgeSelector.MIDPOINT_CONTAINS.select(AREAS, line(2, 5, 8, 5)));
+    // midpoint (15,5) is inside B
+    assertSame(B, AreaEdgeSelector.MIDPOINT_CONTAINS.select(AREAS, line(12, 5, 18, 5)));
+  }
+
+  @Test
+  void midpointReturnsNullWhenMidpointOutsideAllAreas() {
+    // midpoint (23,5) is outside both squares, even though the line clips B
+    assertNull(AreaEdgeSelector.MIDPOINT_CONTAINS.select(AREAS, line(16, 5, 30, 5)));
+  }
+
+  @Test
+  void intersectionPicksFirstAreaTheLineCrosses() {
+    // line clips B (x in [16,20] at y=5) but not A
+    assertSame(B, AreaEdgeSelector.LINE_INTERSECTION.select(AREAS, line(16, 5, 30, 5)));
+  }
+
+  @Test
+  void intersectionReturnsNullWhenLineCrossesNothing() {
+    assertNull(AreaEdgeSelector.LINE_INTERSECTION.select(AREAS, line(25, 25, 30, 30)));
+  }
+
+  @Test
+  void resolvesViaMidpoint() {
+    // midpoint (5,5) is inside A
+    assertSame(A, AreaEdgeSelector.resolve(AREAS, line(2, 5, 8, 5)));
+  }
+
+  @Test
+  void resolvesViaIntersectionFallback() {
+    // midpoint (23,5) is outside both squares, but the line clips B -> intersection fallback wins
+    assertSame(B, AreaEdgeSelector.resolve(AREAS, line(16, 5, 30, 5)));
+  }
+
+  @Test
+  void resolvesViaFirstAreaFallback() {
+    // neither geometric test matches -> terminal first-area fallback
+    assertSame(A, AreaEdgeSelector.resolve(AREAS, line(25, 25, 30, 30)));
+  }
+
+  @Test
+  void singleAreaGroupReturnsOnlyAreaWithoutGeometricTests() {
+    // The line neither contains B's midpoint nor crosses B, yet a single-area group resolves to its
+    // only area via the size-1 shortcut.
+    assertSame(B, AreaEdgeSelector.resolve(List.of(B), line(2, 5, 8, 5)));
+  }
+
+  @Test
+  void midpointTakesPrecedenceOverIntersection() {
+    // The line crosses A first (x in [9,10]) but its midpoint (14,5) lies in B. Intersection would
+    // pick A; midpoint runs first and picks B, proving the chain order.
+    assertSame(B, AreaEdgeSelector.resolve(AREAS, line(9, 5, 19, 5)));
+  }
+
+  private static Area area(Polygon geometry) {
+    var area = new Area();
+    area.setGeometry(geometry);
+    return area;
+  }
+
+  private static Polygon square(double minX, double maxX) {
+    return GF.createPolygon(
+      new Coordinate[] {
+        new Coordinate(minX, 0),
+        new Coordinate(maxX, 0),
+        new Coordinate(maxX, 10),
+        new Coordinate(minX, 10),
+        new Coordinate(minX, 0),
+      }
+    );
+  }
+
+  private static LineString line(double x1, double y1, double x2, double y2) {
+    return GF.createLineString(new Coordinate[] { new Coordinate(x1, y1), new Coordinate(x2, y2) });
+  }
+}


### PR DESCRIPTION
### Summary

When `VertexLinker.createEdges` builds a visibility edge inside a multi-area `AreaGroup`, it must
pick which sub-area "owns" the edge so the edge can borrow that area's name, permission and safety
factors. The previous implementation did this inline, and for every multi-area group it built a
constructive JTS overlay (`polygon.intersection(line)`) for each candidate sub-area until one had
positive length. That overlay is a significant allocation source during real-time rental
(GBFS) linking, where this path runs on the single graph-writer thread.

This PR does two things:

1. **Adds a midpoint point-in-area fast path.** For the common case where the edge lies within a
   single sub-area, an allocation-free `SimplePointInAreaLocator.locate` on the segment midpoint
   resolves the owner without constructing any geometry. The constructive line-intersection test is
   kept only as a fallback for edges whose midpoint falls in a hole / uncovered part of the group
   but which still cross a sub-area.
2. **Extracts the selection logic** out of `VertexLinker` into a small, self-contained
   `AreaEdgeSelector` enum. Each geometric strategy is a named enum constant; the static
   `AreaEdgeSelector.resolve` runs the ordered fallback chain and owns the single-area shortcut, the
   first-area terminal fallback and the "no intersecting area found" warning.

**Behaviour note:** this is *not* strictly behaviour-preserving in ambiguous geometry. When an edge
crosses one sub-area but its midpoint lies in another, the midpoint area is now chosen where the old
code chose the first-crossed area. This only affects which sub-area's name/permission/safety the
visibility edge borrows in genuinely overlapping multi-area groups; Everything else (single-area shortcut, the
force-linked-from-outside fallback, the warning) is preserved.

### Validation: how often do the two selectors actually differ?

| scope | multi-area edges | divergences | of which: different name (material) | same name (cosmetic) | distinct locations |
|---|--:|--:|--:|--:|--:|
| Build-time (PERMANENT) | 3,320 | **660 (~20%)** | 486 | 174 | 64 |
| Real-time GBFS (REALTIME) | 20,000* | **4,877 (~24%)** | 4,150 | 770 | 267 |

<sub>* real-time count grows with uptime because rental updaters re-link every 15s; the **rate** is the stable figure.</sub>

So the two selectors disagree on roughly **1 in 5–6 multi-area edges**, and ~85% of those land on an
area with a **different name** (hence usually a different permission / bike-walk-safety / no-thru
profile). All divergences are genuine — both selectors matched but chose a different sub-area; none
are the "intersection abstained → first area" fallback.

**Why:** OSM maps large pedestrian squares as a patchwork of adjacent/overlapping `area=yes` tiles
(a named `place=square` plus unnamed `highway=pedestrian` "open area" and `highway=steps` tiles). A
visibility edge routinely straddles two tiles, so "area containing the midpoint" and "first area the
line crosses (list order)" legitimately differ. Most frequent material swaps: `steps ↔ open area`,
`platform ↔ path`, and named squares ↔ `open area`.

### How often is the expensive `LINE_INTERSECTION` fallback actually needed?

Separately, I measured how often `MIDPOINT_CONTAINS` returns `null` and the chain must fall back to
the constructive `polygon.intersection(line)` test (the allocation this PR is trying to avoid):

| scope | multi-area edges | midpoint returned `null` → fallback | of which intersection resolved | both `null` → first-area |
|---|--:|--:|--:|--:|
| Build-time (PERMANENT) | ~3,300 | **0 (0.0%)** | 0 | 0 |
| Real-time GBFS (REALTIME) | 22,000 | **0 (0.0%)** | 0 | 0 |

Across ~25,000 multi-area resolutions in both scopes, the midpoint matched a sub-area **every time** —
the constructive overlay was **never executed**, and the first-area terminal fallback never fired.
This is expected: visibility edges connect points *within* an `AreaGroup` whose sub-areas tile/overlap
to cover it, so the edge midpoint always lands inside at least one sub-area. The fallback only
triggers for a midpoint in a hole / uncovered gap / a forced edge leaving the group — which does not
occur in the Norway data. So the allocation win is effectively total at runtime: `LINE_INTERSECTION`
remains only as correctness insurance for the pathological cases.

#### Worked example 1 — build-time, Oslo Vika (group of 13 sub-areas)

The edge overlaps both sub-areas. Its midpoint sits inside *7. juni-plassen* (the named square), so
**midpoint** picks that; the unnamed pedestrian *open area* also has a positive-length intersection
with the edge and comes first in the group's area list, so **intersection** picks the open area
instead. ("First" in the intersection test means list order, not order along the edge.)

<img width="1800" height="1280" alt="area-selector-divergence-vika" src="https://github.com/user-attachments/assets/8dfb3de8-17db-41d8-94b5-ce385ba3f53f" />


Areas involved: [7. juni-plassen way/90966485](https://www.openstreetmap.org/way/90966485) ·
[open area way/950082256](https://www.openstreetmap.org/way/950082256) ·
[steps way/1497349765](https://www.openstreetmap.org/way/1497349765) ·
[map](https://www.openstreetmap.org/#map=19/59.91421/10.72990)

#### Worked example 2 — real-time GBFS rental, Oslo Aker Brygge (group of 21 sub-areas)

A rental vehicle's visibility edge starts at the linked vertex inside *Brynjulf Bulls plass* and
overlaps both sub-areas. Its midpoint is inside *Brynjulf Bulls plass*, so **midpoint** picks that;
the unnamed *open area* also intersects the edge and comes first in the group's area list, so
**intersection** picks the open area instead — a list-order tie-break, not order along the edge.

<img width="1800" height="1280" alt="area-selector-divergence-akerbrygge" src="https://github.com/user-attachments/assets/86a88516-919e-44b0-99f4-0e0c60abf3c4" />


Areas involved: [Brynjulf Bulls plass way/1060298499](https://www.openstreetmap.org/way/1060298499) ·
[open area way/111763361](https://www.openstreetmap.org/way/111763361) ·
[map](https://www.openstreetmap.org/#map=19/59.911176/10.730097)

### Unit tests

Added unit tests

### Documentation

No

### Changelog

Skip

