### PR TITLE
Deprecate serviceJourneys filter in Transmodel

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/SelectInputType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/SelectInputType.java
@@ -39,6 +39,7 @@ public class SelectInputType {
           "Set of ids for service journeys that should be included in/excluded from search"
         )
         .type(new GraphQLList(new GraphQLNonNull(Scalars.GraphQLID)))
+        .deprecate("This field is not implemented and has no effect.")
         .build()
     )
     .field(

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -2528,7 +2528,7 @@ input TripFilterSelectInput {
   "Set of ids for lines that should be included in/excluded from search"
   lines: [ID!]
   "Set of ids for service journeys that should be included in/excluded from search"
-  serviceJourneys: [ID!]
+  serviceJourneys: [ID!] @deprecated(reason : "This field is not implemented and has no effect.")
   "The allowed modes for the transit part of the trip. Use an empty list to disallow transit for this search. If the element is not present or null, it will default to all transport modes."
   transportModes: [TransportModes!]
 }


### PR DESCRIPTION
### Summary
This PR marks the serviceJourneys filter field as deprecated in the Transmodel API. I originally set out to add this missing implementation, but after discussion we decided we don't want the complexity and performance impact that comes with it. Deprecating the field is therefore the better option. I also discussed with the client that originally reported this what their actual needs were for using this filter, and it seems they rather need something like the refetch itinerary feature (#7649)

See below for more description of the field.

---  

The Transmodel API has a `serviceJourneys` input on the selector based filters, but this one was never actually applied.

```graphql
trip(
  from: ...
  to: ...
  filters: {
    select: {
      lines: [],
      serviceJourneys: ["RUT:ServiceJourney:2918ef0a781acff443371086fee030f1"] # <-- This one
    }
  }
) { ... }
```

The (existing) graphql schema documents how the field is supposed to work, but it isn't actually implemented.
```
Set of ids for service journeys that should be included in/excluded from search
```

### Issue
No issue.

Reported by Entur production users.

### Unit tests
N/A

### Documentation
Deprecation added