### PR TITLE
Add tag mapper for Twin Cities

### DIFF
--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapperSource.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/OsmTagMapperSource.java
@@ -14,6 +14,7 @@ public enum OsmTagMapperSource {
   ATLANTA,
   HOUSTON,
   PORTLAND,
+  TWIN_CITIES,
   CONSTANT_SPEED_FINLAND;
 
   public OsmTagMapper getInstance() {
@@ -27,6 +28,7 @@ public enum OsmTagMapperSource {
       case ATLANTA -> new AtlantaMapper();
       case HOUSTON -> new HoustonMapper();
       case PORTLAND -> new PortlandMapper();
+      case TWIN_CITIES -> new TwinCitiesMapper();
       case CONSTANT_SPEED_FINLAND -> new ConstantSpeedMapper();
     };
   }

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapper.java
@@ -11,7 +11,7 @@ import org.opentripplanner.osm.wayproperty.specifier.ExactMatchSpecifier;
  * The Twin Cities of Minneapolis and St. Paul, Minnesota have so-called skyways, which are elevated
  * walkways that connect buildings and neighborhoods. These skyways are typically pedestrian-only.
  * Access to them is time-restricted and can be unpredictable.
- * Therefore, we don't add the to the graph.
+ * Therefore, we don't add them to the graph.
  */
 class TwinCitiesMapper extends OsmTagMapper {
 
@@ -20,6 +20,10 @@ class TwinCitiesMapper extends OsmTagMapper {
     var props = WayPropertySet.of();
     props.setProperties(
       new ExactMatchSpecifier(new Condition.Equals("name", "Minneapolis Skyway")),
+      withModes(NONE)
+    );
+    props.setProperties(
+      new ExactMatchSpecifier(new Condition.Equals("name", "Saint Paul Skyway")),
       withModes(NONE)
     );
 

--- a/application/src/main/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapper.java
+++ b/application/src/main/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapper.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.osm.tagmapping;
+
+import static org.opentripplanner.osm.wayproperty.WayPropertiesBuilder.withModes;
+import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
+
+import org.opentripplanner.osm.wayproperty.WayPropertySet;
+import org.opentripplanner.osm.wayproperty.specifier.Condition;
+import org.opentripplanner.osm.wayproperty.specifier.ExactMatchSpecifier;
+
+/**
+ * The Twin Cities of Minneapolis and St. Paul, Minnesota have so-called skyways, which are elevated
+ * walkways that connect buildings and neighborhoods. These skyways are typically pedestrian-only.
+ * Access to them is time-restricted and can be unpredictable.
+ * Therefore, we don't add the to the graph.
+ */
+class TwinCitiesMapper extends OsmTagMapper {
+
+  @Override
+  public WayPropertySet buildWayPropertySet() {
+    var props = WayPropertySet.of();
+    props.setProperties(
+      new ExactMatchSpecifier(new Condition.Equals("name", "Minneapolis Skyway")),
+      withModes(NONE)
+    );
+
+    props.addPickers(super.buildWayPropertySet());
+    return props.build();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/generate/doc/OsmMapperDocTest.java
+++ b/application/src/test/java/org/opentripplanner/generate/doc/OsmMapperDocTest.java
@@ -11,6 +11,7 @@ import static org.opentripplanner.osm.tagmapping.OsmTagMapperSource.CONSTANT_SPE
 import static org.opentripplanner.osm.tagmapping.OsmTagMapperSource.HAMBURG;
 import static org.opentripplanner.osm.tagmapping.OsmTagMapperSource.HOUSTON;
 import static org.opentripplanner.osm.tagmapping.OsmTagMapperSource.PORTLAND;
+import static org.opentripplanner.osm.tagmapping.OsmTagMapperSource.TWIN_CITIES;
 import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 
 import java.io.File;
@@ -37,7 +38,8 @@ public class OsmMapperDocTest {
     HOUSTON,
     PORTLAND,
     HAMBURG,
-    CONSTANT_SPEED_FINLAND
+    CONSTANT_SPEED_FINLAND,
+    TWIN_CITIES
   );
 
   public static List<OsmTagMapperSource> mappers() {

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapperTest.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.osm.tagmapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.osm.model.OsmWay;
+import org.opentripplanner.osm.wayproperty.WayPropertySet;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+
+class TwinCitiesMapperTest {
+
+  private static final WayPropertySet WPS = new TwinCitiesMapper().buildWayPropertySet();
+
+  @Test
+  void minneapolisSkyway() {
+    var way = OsmWay.of()
+      .withTag("highway", "footway")
+      .withTag("name", "Minneapolis Skyway")
+      .build();
+
+    assertEquals(StreetTraversalPermission.NONE, WPS.getDataForEntity(way).getPermission());
+  }
+
+  @Test
+  void regularFootway() {
+    var way = OsmWay.of().withTag("highway", "footway").build();
+
+    assertEquals(StreetTraversalPermission.PEDESTRIAN, WPS.getDataForEntity(way).getPermission());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/osm/tagmapping/TwinCitiesMapperTest.java
@@ -3,6 +3,8 @@ package org.opentripplanner.osm.tagmapping;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.osm.wayproperty.WayPropertySet;
 import org.opentripplanner.street.model.StreetTraversalPermission;
@@ -11,12 +13,10 @@ class TwinCitiesMapperTest {
 
   private static final WayPropertySet WPS = new TwinCitiesMapper().buildWayPropertySet();
 
-  @Test
-  void minneapolisSkyway() {
-    var way = OsmWay.of()
-      .withTag("highway", "footway")
-      .withTag("name", "Minneapolis Skyway")
-      .build();
+  @ParameterizedTest
+  @ValueSource(strings = { "Saint Paul Skyway", "Minneapolis Skyway" })
+  void removeSkyway(String name) {
+    var way = OsmWay.of().withTag("highway", "footway").withTag("name", name).build();
 
     assertEquals(StreetTraversalPermission.NONE, WPS.getDataForEntity(way).getPermission());
   }

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -981,7 +981,7 @@ the local filesystem.
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osm/[0]   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `hamburg` | `atlanta` | `houston` | `portland` | `constant-speed-finland`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `hamburg` | `atlanta` | `houston` | `portland` | `twin-cities` | `constant-speed-finland`
 
 The named set of mapping rules applied when parsing OSM tags. Overrides the value specified in `osmDefaults`.
 
@@ -989,7 +989,7 @@ The named set of mapping rules applied when parsing OSM tags. Overrides the valu
 
 **Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
 **Path:** /osmDefaults   
-**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `hamburg` | `atlanta` | `houston` | `portland` | `constant-speed-finland`
+**Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `hamburg` | `atlanta` | `houston` | `portland` | `twin-cities` | `constant-speed-finland`
 
 The named set of mapping rules applied when parsing OSM tags.
 


### PR DESCRIPTION
### Summary

It adds a new tag mapper specific for the new OTP deployment in the twin cities of Minneapolis and St. Paul, Minnesota.

There we want to exclude some special elevated tunnels from the street network.

### Issue

No issue.

### Unit tests

Added.

### Documentation

Javadoc.