### PR TITLE
Merge multi-area visibility-edge properties via prepared geometry

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -734,6 +734,7 @@ class WalkableAreaBuilder {
       namedArea.setWalkSafety((float) wayData.walkSafety());
       namedArea.setGeometry(intersection);
       namedArea.setPermission(wayData.getPermission());
+      namedArea.setWheelchairAccessible(areaEntity.isWheelchairAccessible());
       areaGroup.addArea(namedArea);
 
       if (areaEntity.isBoardingLocation()) {

--- a/street/src/main/java/org/opentripplanner/street/linking/AreaEdgeProperties.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/AreaEdgeProperties.java
@@ -13,13 +13,16 @@ import org.opentripplanner.street.model.edge.Area;
  * intersection (AND) of their permissions and the safety factors are the maximum (worst) of theirs,
  * so the edge is never more permissive or safer than any tile it physically crosses (e.g. an edge
  * crossing a {@code steps} tile cannot keep an adjacent square's flat walk cost or bike permission).
- * The name is cosmetic and is taken from the first crossed sub-area.
+ * Wheelchair-accessibility is likewise merged with a logical AND, so any non-accessible tile the
+ * edge crosses makes the whole edge non-accessible. The name is cosmetic and is taken from the first
+ * crossed sub-area.
  */
 record AreaEdgeProperties(
   I18NString name,
   StreetTraversalPermission permission,
   float bicycleSafety,
-  float walkSafety
+  float walkSafety,
+  boolean wheelchairAccessible
 ) {
   /**
    * Folds the worst-case properties over every area in {@code crossed}, which must be non-empty (see
@@ -38,7 +41,8 @@ record AreaEdgeProperties(
       area.getName(),
       area.getPermission(),
       area.getBicycleSafety(),
-      area.getWalkSafety()
+      area.getWalkSafety(),
+      area.isWheelchairAccessible()
     );
   }
 
@@ -47,7 +51,8 @@ record AreaEdgeProperties(
       name,
       permission.intersection(area.getPermission()),
       Math.max(bicycleSafety, area.getBicycleSafety()),
-      Math.max(walkSafety, area.getWalkSafety())
+      Math.max(walkSafety, area.getWalkSafety()),
+      wheelchairAccessible && area.isWheelchairAccessible()
     );
   }
 }

--- a/street/src/main/java/org/opentripplanner/street/linking/AreaEdgeProperties.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/AreaEdgeProperties.java
@@ -1,0 +1,53 @@
+package org.opentripplanner.street.linking;
+
+import java.util.List;
+import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.edge.Area;
+
+/**
+ * The name, permission and safety factors a visibility edge borrows from the area(s) it crosses.
+ * A multi-area group's sub-areas tile/overlap to cover the group, so a visibility edge routinely
+ * crosses more than one. Rather than borrow a single (arbitrarily chosen) sub-area's properties,
+ * the edge inherits the <em>worst case</em> over every sub-area it crosses: the permission is the
+ * intersection (AND) of their permissions and the safety factors are the maximum (worst) of theirs,
+ * so the edge is never more permissive or safer than any tile it physically crosses (e.g. an edge
+ * crossing a {@code steps} tile cannot keep an adjacent square's flat walk cost or bike permission).
+ * The name is cosmetic and is taken from the first crossed sub-area.
+ */
+record AreaEdgeProperties(
+  I18NString name,
+  StreetTraversalPermission permission,
+  float bicycleSafety,
+  float walkSafety
+) {
+  /**
+   * Folds the worst-case properties over every area in {@code crossed}, which must be non-empty (see
+   * {@link PreparedAreaGroup#areasCrossedBy(org.locationtech.jts.geom.LineString)}).
+   */
+  static AreaEdgeProperties merge(List<Area> crossed) {
+    var merged = of(crossed.getFirst());
+    for (int i = 1; i < crossed.size(); i++) {
+      merged = merged.mergeWith(crossed.get(i));
+    }
+    return merged;
+  }
+
+  private static AreaEdgeProperties of(Area area) {
+    return new AreaEdgeProperties(
+      area.getName(),
+      area.getPermission(),
+      area.getBicycleSafety(),
+      area.getWalkSafety()
+    );
+  }
+
+  private AreaEdgeProperties mergeWith(Area area) {
+    return new AreaEdgeProperties(
+      name,
+      permission.intersection(area.getPermission()),
+      Math.max(bicycleSafety, area.getBicycleSafety()),
+      Math.max(walkSafety, area.getWalkSafety())
+    );
+  }
+}

--- a/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
@@ -1,30 +1,30 @@
 package org.opentripplanner.street.linking;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.locationtech.jts.operation.relateng.RelateNG;
 import org.locationtech.jts.operation.relateng.RelatePredicate;
 import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.model.edge.Area;
 import org.opentripplanner.street.model.edge.AreaGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * An {@link AreaGroup} together with a lazily built, reusable spatial index over its polygon, used to
- * answer the repeated {@code contains} checks performed while linking a vertex to the area's
- * visibility vertices.
- * <p>
- * A plain {@code Polygon.contains(...)} rebuilds a sweep-line index over the polygon boundary on
- * every call. By preparing the polygon once with {@link RelateNG} and reusing the cached index
- * across all candidate checks, we build that index a single time per linking operation. RelateNG is
- * also tolerant of invalid / self-intersecting OSM polygons (it does not throw
- * {@code TopologyException}).
- * <p>
- * The index is built lazily on the first {@link #containsSegment(Coordinate, Coordinate)} call, so
- * the forced-edge linking paths — which skip the boundary check — never pay for it. An instance is
- * created and used within a single linking call and never escapes that thread, so the unsynchronized
- * lazy field is not a concern.
+ * An {@link AreaGroup} together with lazily built, reusable spatial indexes over its polygons, used
+ * to answer the repeated geometric queries performed while linking a vertex to the area's visibility
+ * vertices. An instance is created once per linking call and reused across all candidate visibility
+ * edges, so each index is built a single time and amortized over those edges. It never escapes the
+ * linking thread, so the unsynchronized lazy fields are not a concern.
  */
 final class PreparedAreaGroup {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PreparedAreaGroup.class);
 
   private static final GeometryFactory GEOMETRY_FACTORY = GeometryUtils.getGeometryFactory();
 
@@ -37,6 +37,7 @@ final class PreparedAreaGroup {
 
   private final AreaGroup areaGroup;
   private RelateNG prepared;
+  private PreparedGeometry[] preparedAreas;
 
   PreparedAreaGroup(AreaGroup areaGroup) {
     this.areaGroup = areaGroup;
@@ -47,15 +48,62 @@ final class PreparedAreaGroup {
   }
 
   /**
-   * Whether the area polygon contains the segment between the two coordinates. The segment is shrunk
-   * slightly at both ends first, so that a segment connecting two boundary points is not rejected by
-   * floating point imprecision at the boundary. Reuses a cached prepared index across calls.
+   * Whether the area group polygon contains the segment between the two coordinates. The segment is
+   * shrunk slightly at both ends first, so that a segment connecting two boundary points is not
+   * rejected by floating point imprecision at the boundary. Reuses a cached prepared index across
+   * calls. A plain {@code Polygon.contains(...)} would rebuild a sweep-line index over the polygon
+   * boundary on every call; {@link RelateNG} builds it once and is also tolerant of invalid /
+   * self-intersecting OSM polygons (it does not throw {@code TopologyException}).
    */
   boolean containsSegment(Coordinate from, Coordinate to) {
     if (prepared == null) {
       prepared = RelateNG.prepare(areaGroup.getGeometry());
     }
     return prepared.evaluate(createShrunkLine(from, to), RelatePredicate.contains());
+  }
+
+  /**
+   * The sub-areas of this group that the visibility {@code line} crosses. A multi-area group's
+   * sub-areas tile/overlap to cover the group, so a visibility edge routinely crosses more than one;
+   * the caller merges their properties (see {@link AreaEdgeProperties#merge(List)}). The crossing test
+   * uses a per-sub-area {@link PreparedGeometry}, built once and reused across the group's edges; it
+   * allocates no overlay geometry. The line is shrunk slightly at both ends first (as
+   * {@link #containsSegment} does): its endpoints are visibility vertices sitting on the area boundary,
+   * so an un-shrunk {@code intersects} would also match any neighbouring sub-area the edge merely
+   * touches at that shared endpoint without ever crossing its interior — grafting that neighbour's
+   * (worse) properties onto the edge. Shrinking removes those 0-D boundary touches while keeping every
+   * genuine 1-D crossing. The returned list is never empty: if no sub-area is actually crossed (a point
+   * force-linked from outside the group) the first sub-area is returned as a fallback so the edge still
+   * receives some properties.
+   *
+   * @param line the visibility edge segment
+   */
+  List<Area> areasCrossedBy(LineString line) {
+    List<Area> areas = areaGroup.getAreas();
+    if (areas.size() == 1) {
+      return areas;
+    }
+    if (preparedAreas == null) {
+      preparedAreas = new PreparedGeometry[areas.size()];
+      for (int i = 0; i < areas.size(); i++) {
+        preparedAreas[i] = PreparedGeometryFactory.prepare(areas.get(i).getGeometry());
+      }
+    }
+    LineString probe = createShrunkLine(
+      line.getCoordinateN(0),
+      line.getCoordinateN(line.getNumPoints() - 1)
+    );
+    List<Area> crossed = new ArrayList<>(areas.size());
+    for (int i = 0; i < areas.size(); i++) {
+      if (preparedAreas[i].intersects(probe)) {
+        crossed.add(areas.get(i));
+      }
+    }
+    if (crossed.isEmpty()) {
+      LOG.warn("No intersecting area found. This may indicate a bug.");
+      return List.of(areas.getFirst());
+    }
+    return crossed;
   }
 
   private static LineString createShrunkLine(Coordinate from, Coordinate to) {

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -811,6 +811,7 @@ public class VertexLinker {
       .withPermission(hit.permission())
       .withBicycleSafetyFactor(hit.bicycleSafety())
       .withWalkSafetyFactor(hit.walkSafety())
+      .withWheelchairAccessible(hit.wheelchairAccessible())
       .withBack(false)
       .withArea(ag);
     for (TraverseMode tm : outgoingNoThruModes) {
@@ -830,6 +831,7 @@ public class VertexLinker {
       .withPermission(hit.permission())
       .withBicycleSafetyFactor(hit.bicycleSafety())
       .withWalkSafetyFactor(hit.walkSafety())
+      .withWheelchairAccessible(hit.wheelchairAccessible())
       .withBack(true)
       .withArea(ag);
     for (TraverseMode tm : incomingNoThruModes) {

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -25,7 +25,6 @@ import org.opentripplanner.street.Scope;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.model.edge.Area;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.edge.AreaEdgeBuilder;
 import org.opentripplanner.street.model.edge.AreaGroup;
@@ -38,8 +37,6 @@ import org.opentripplanner.street.model.vertex.TemporarySplitterVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class links transit stops to streets by splitting the streets (unless the stop is extremely
@@ -66,8 +63,6 @@ import org.slf4j.LoggerFactory;
  * within ~25 m of a street — and expands to 100 m).
  */
 public class VertexLinker {
-
-  private static final Logger LOG = LoggerFactory.getLogger(VertexLinker.class);
 
   /**
    * if there are two ways and the distances to them differ by less than this value, we link to both
@@ -784,7 +779,7 @@ public class VertexLinker {
     }
     LineString line = GEOMETRY_FACTORY.createLineString(new Coordinate[] { c1, c2 });
     // add connecting edges
-    createEdges(line, from, to, area.areaGroup(), scope, tempEdges);
+    createEdges(line, from, to, area, scope, tempEdges);
 
     return true;
   }
@@ -794,30 +789,13 @@ public class VertexLinker {
     LineString line,
     IntersectionVertex from,
     IntersectionVertex to,
-    AreaGroup ag,
+    PreparedAreaGroup area,
     Scope scope,
     DisposableEdgeCollection tempEdges
   ) {
-    Area hit = null;
-    var areas = ag.getAreas();
-    if (areas.size() == 1) {
-      hit = areas.getFirst();
-    } else {
-      // If more than one area intersects, we pick first one for the name & properties
-      for (Area area : areas) {
-        Geometry polygon = area.getGeometry();
-        Geometry intersection = polygon.intersection(line);
-        if (intersection.getLength() > 0.000001) {
-          hit = area;
-          break;
-        }
-      }
-    }
-    // hit may be null when force linking a point from outside
-    if (hit == null) {
-      LOG.warn("No intersecting area found. This may indicate a bug.");
-      hit = areas.getFirst();
-    }
+    AreaGroup ag = area.areaGroup();
+    // The edge borrows the worst-case name/permission/safety over every sub-area it crosses.
+    var hit = AreaEdgeProperties.merge(area.areasCrossedBy(line));
     double length = SphericalDistanceLibrary.distance(to.getCoordinate(), from.getCoordinate());
     // apply consistent NoThru restrictions
     // if all joining edges are nothru, then the new edge should be as well
@@ -828,11 +806,11 @@ public class VertexLinker {
       .withFromVertex(from)
       .withToVertex(to)
       .withGeometry(line)
-      .withName(hit.getName())
+      .withName(hit.name())
       .withMeterLength(length)
-      .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor(hit.getBicycleSafety())
-      .withWalkSafetyFactor(hit.getWalkSafety())
+      .withPermission(hit.permission())
+      .withBicycleSafetyFactor(hit.bicycleSafety())
+      .withWalkSafetyFactor(hit.walkSafety())
       .withBack(false)
       .withArea(ag);
     for (TraverseMode tm : outgoingNoThruModes) {
@@ -847,11 +825,11 @@ public class VertexLinker {
       .withFromVertex(to)
       .withToVertex(from)
       .withGeometry(line.reverse())
-      .withName(hit.getName())
+      .withName(hit.name())
       .withMeterLength(length)
-      .withPermission(hit.getPermission())
-      .withBicycleSafetyFactor(hit.getBicycleSafety())
-      .withWalkSafetyFactor(hit.getWalkSafety())
+      .withPermission(hit.permission())
+      .withBicycleSafetyFactor(hit.bicycleSafety())
+      .withWalkSafetyFactor(hit.walkSafety())
       .withBack(true)
       .withArea(ag);
     for (TraverseMode tm : incomingNoThruModes) {

--- a/street/src/main/java/org/opentripplanner/street/model/edge/Area.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/Area.java
@@ -16,6 +16,7 @@ public final class Area implements Serializable {
   private float bicycleSafety;
   private float walkSafety;
   private StreetTraversalPermission permission;
+  private boolean wheelchairAccessible = true;
 
   public I18NString getName() {
     return name;
@@ -55,6 +56,14 @@ public final class Area implements Serializable {
 
   public void setPermission(StreetTraversalPermission permission) {
     this.permission = permission;
+  }
+
+  public boolean isWheelchairAccessible() {
+    return wheelchairAccessible;
+  }
+
+  public void setWheelchairAccessible(boolean wheelchairAccessible) {
+    this.wheelchairAccessible = wheelchairAccessible;
   }
 
   /**

--- a/street/src/test/java/org/opentripplanner/street/linking/AreaEdgePropertiesTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/AreaEdgePropertiesTest.java
@@ -1,0 +1,55 @@
+package org.opentripplanner.street.linking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.edge.Area;
+
+class AreaEdgePropertiesTest {
+
+  // A flat, pedestrian-and-bicycle square and a steep, pedestrian-only "steps" tile.
+  private static final Area FRIENDLY = area(
+    "square",
+    StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,
+    1.0f,
+    1.0f
+  );
+  private static final Area STEPS = area("steps", StreetTraversalPermission.PEDESTRIAN, 8.0f, 8.0f);
+
+  @Test
+  void singleAreaKeepsItsProperties() {
+    var props = AreaEdgeProperties.merge(List.of(FRIENDLY));
+    assertEquals(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, props.permission());
+    assertEquals(1.0f, props.walkSafety());
+    assertEquals(1.0f, props.bicycleSafety());
+    assertEquals("square", props.name().toString());
+  }
+
+  @Test
+  void crossingTwoAreasMergesWorstCase() {
+    // permission AND-ed (bike dropped), safety MAX-ed.
+    var props = AreaEdgeProperties.merge(List.of(FRIENDLY, STEPS));
+    assertEquals(StreetTraversalPermission.PEDESTRIAN, props.permission());
+    assertEquals(8.0f, props.walkSafety());
+    assertEquals(8.0f, props.bicycleSafety());
+    // name comes from the first area in list order (FRIENDLY).
+    assertEquals("square", props.name().toString());
+  }
+
+  private static Area area(
+    String name,
+    StreetTraversalPermission permission,
+    float walk,
+    float bike
+  ) {
+    var a = new Area();
+    a.setName(I18NString.of(name));
+    a.setPermission(permission);
+    a.setWalkSafety(walk);
+    a.setBicycleSafety(bike);
+    return a;
+  }
+}

--- a/street/src/test/java/org/opentripplanner/street/linking/AreaEdgePropertiesTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/AreaEdgePropertiesTest.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.street.linking;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -10,14 +12,22 @@ import org.opentripplanner.street.model.edge.Area;
 
 class AreaEdgePropertiesTest {
 
-  // A flat, pedestrian-and-bicycle square and a steep, pedestrian-only "steps" tile.
+  // A flat, pedestrian-and-bicycle, wheelchair-accessible square and a steep, pedestrian-only "steps"
+  // tile that is not wheelchair accessible.
   private static final Area FRIENDLY = area(
     "square",
     StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,
     1.0f,
-    1.0f
+    1.0f,
+    true
   );
-  private static final Area STEPS = area("steps", StreetTraversalPermission.PEDESTRIAN, 8.0f, 8.0f);
+  private static final Area STEPS = area(
+    "steps",
+    StreetTraversalPermission.PEDESTRIAN,
+    8.0f,
+    8.0f,
+    false
+  );
 
   @Test
   void singleAreaKeepsItsProperties() {
@@ -25,16 +35,18 @@ class AreaEdgePropertiesTest {
     assertEquals(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, props.permission());
     assertEquals(1.0f, props.walkSafety());
     assertEquals(1.0f, props.bicycleSafety());
+    assertTrue(props.wheelchairAccessible());
     assertEquals("square", props.name().toString());
   }
 
   @Test
   void crossingTwoAreasMergesWorstCase() {
-    // permission AND-ed (bike dropped), safety MAX-ed.
+    // permission AND-ed (bike dropped), safety MAX-ed, wheelchair AND-ed (STEPS drops it).
     var props = AreaEdgeProperties.merge(List.of(FRIENDLY, STEPS));
     assertEquals(StreetTraversalPermission.PEDESTRIAN, props.permission());
     assertEquals(8.0f, props.walkSafety());
     assertEquals(8.0f, props.bicycleSafety());
+    assertFalse(props.wheelchairAccessible());
     // name comes from the first area in list order (FRIENDLY).
     assertEquals("square", props.name().toString());
   }
@@ -43,13 +55,15 @@ class AreaEdgePropertiesTest {
     String name,
     StreetTraversalPermission permission,
     float walk,
-    float bike
+    float bike,
+    boolean wheelchairAccessible
   ) {
     var a = new Area();
     a.setName(I18NString.of(name));
     a.setPermission(permission);
     a.setWalkSafety(walk);
     a.setBicycleSafety(bike);
+    a.setWheelchairAccessible(wheelchairAccessible);
     return a;
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
@@ -1,15 +1,21 @@
 package org.opentripplanner.street.linking;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Polygon;
+import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.edge.Area;
 import org.opentripplanner.street.model.edge.AreaGroup;
 
 class PreparedAreaGroupTest {
@@ -49,6 +55,82 @@ class PreparedAreaGroupTest {
   void exposesWrappedAreaGroup() {
     var ag = new AreaGroup(SQUARE_WITH_HOLE);
     assertSame(ag, new PreparedAreaGroup(ag).areaGroup());
+  }
+
+  @Test
+  void singleAreaGroupReturnsItsOnlyArea() {
+    var only = area(square(0, 10));
+    var g = new AreaGroup(square(0, 10));
+    g.addArea(only);
+    assertEquals(List.of(only), new PreparedAreaGroup(g).areasCrossedBy(line(1, 5, 4, 5)));
+  }
+
+  @Test
+  void edgeWithinOneSubAreaReturnsThatAreaOnly() {
+    // Two overlapping squares: friendly x in [0,10], steps x in [6,16]. x in [1,4] crosses only the
+    // first.
+    var friendly = area(square(0, 10));
+    var steps = area(square(6, 16));
+    var g = group(friendly, steps);
+    assertEquals(List.of(friendly), new PreparedAreaGroup(g).areasCrossedBy(line(1, 5, 4, 5)));
+  }
+
+  @Test
+  void edgeCrossingTwoSubAreasReturnsBoth() {
+    // x in [2,12] crosses both squares, in list order.
+    var friendly = area(square(0, 10));
+    var steps = area(square(6, 16));
+    var g = group(friendly, steps);
+    assertEquals(
+      List.of(friendly, steps),
+      new PreparedAreaGroup(g).areasCrossedBy(line(2, 5, 12, 5))
+    );
+  }
+
+  @Test
+  void edgeTouchingNeighbourOnlyAtEndpointExcludesIt() {
+    // Tile A x in [0,10] and tile B x in [10,20] share only the boundary line x=10 (the squares abut,
+    // they do not overlap). The edge (5,5)->(10,5) lies inside A and merely touches B at its endpoint
+    // (10,5). An un-shrunk intersects would wrongly count B; the shrink must drop that endpoint touch
+    // so only A is returned.
+    var a = area(square(0, 10));
+    var b = area(square(10, 20));
+    var g = new AreaGroup(square(0, 20));
+    g.addArea(a);
+    g.addArea(b);
+    assertEquals(List.of(a), new PreparedAreaGroup(g).areasCrossedBy(line(5, 5, 10, 5)));
+  }
+
+  private static AreaGroup group(Area... areas) {
+    var g = new AreaGroup(square(0, 16));
+    for (Area a : areas) {
+      g.addArea(a);
+    }
+    return g;
+  }
+
+  private static Area area(Polygon geometry) {
+    var a = new Area();
+    a.setGeometry(geometry);
+    a.setName(I18NString.of("area"));
+    a.setPermission(StreetTraversalPermission.PEDESTRIAN);
+    return a;
+  }
+
+  private static Polygon square(double minX, double maxX) {
+    return GF.createPolygon(
+      new Coordinate[] {
+        new Coordinate(minX, 0),
+        new Coordinate(maxX, 0),
+        new Coordinate(maxX, 10),
+        new Coordinate(minX, 10),
+        new Coordinate(minX, 0),
+      }
+    );
+  }
+
+  private static LineString line(double x1, double y1, double x2, double y2) {
+    return GF.createLineString(new Coordinate[] { new Coordinate(x1, y1), new Coordinate(x2, y2) });
   }
 
   private static Polygon squareWithHole() {

--- a/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Polygon;
 import org.opentripplanner.core.model.i18n.I18NString;
@@ -62,7 +61,10 @@ class PreparedAreaGroupTest {
     var only = area(square(0, 10));
     var g = new AreaGroup(square(0, 10));
     g.addArea(only);
-    assertEquals(List.of(only), new PreparedAreaGroup(g).areasCrossedBy(line(1, 5, 4, 5)));
+    assertEquals(
+      List.of(only),
+      new PreparedAreaGroup(g).areasCrossedBy(GeometryUtils.makeLineString(1, 5, 4, 5))
+    );
   }
 
   @Test
@@ -72,7 +74,10 @@ class PreparedAreaGroupTest {
     var friendly = area(square(0, 10));
     var steps = area(square(6, 16));
     var g = group(friendly, steps);
-    assertEquals(List.of(friendly), new PreparedAreaGroup(g).areasCrossedBy(line(1, 5, 4, 5)));
+    assertEquals(
+      List.of(friendly),
+      new PreparedAreaGroup(g).areasCrossedBy(GeometryUtils.makeLineString(1, 5, 4, 5))
+    );
   }
 
   @Test
@@ -83,7 +88,7 @@ class PreparedAreaGroupTest {
     var g = group(friendly, steps);
     assertEquals(
       List.of(friendly, steps),
-      new PreparedAreaGroup(g).areasCrossedBy(line(2, 5, 12, 5))
+      new PreparedAreaGroup(g).areasCrossedBy(GeometryUtils.makeLineString(2, 5, 12, 5))
     );
   }
 
@@ -98,7 +103,10 @@ class PreparedAreaGroupTest {
     var g = new AreaGroup(square(0, 20));
     g.addArea(a);
     g.addArea(b);
-    assertEquals(List.of(a), new PreparedAreaGroup(g).areasCrossedBy(line(5, 5, 10, 5)));
+    assertEquals(
+      List.of(a),
+      new PreparedAreaGroup(g).areasCrossedBy(GeometryUtils.makeLineString(5, 5, 10, 5))
+    );
   }
 
   private static AreaGroup group(Area... areas) {
@@ -127,10 +135,6 @@ class PreparedAreaGroupTest {
         new Coordinate(minX, 0),
       }
     );
-  }
-
-  private static LineString line(double x1, double y1, double x2, double y2) {
-    return GF.createLineString(new Coordinate[] { new Coordinate(x1, y1), new Coordinate(x2, y2) });
   }
 
   private static Polygon squareWithHole() {


### PR DESCRIPTION
### Summary

When `VertexLinker.createEdges` builds a visibility edge inside a multi-area `AreaGroup`, it must
decide which sub-area's properties the edge borrows. The previous code picked a **single** area — the
first sub-area whose constructive `polygon.intersection(line)` overlay had positive length — and
copied its properties. Because OSM maps large pedestrian squares as a patchwork of overlapping
`area=yes` tiles, a visibility edge routinely crosses **several** sub-areas, so that single pick is
somewhat arbitrary and can be too optimistic (e.g. an edge crossing a `steps` tile keeping an adjacent
square's flat walk cost, bike permission and wheelchair accessibility).

This PR changes the resolution to a **conservative worst-case merge** over *every* sub-area the edge
crosses:

- **permission** -> intersection / AND of the crossed areas' permissions
- **bicycleSafety / walkSafety** -> maximum (worst) of the crossed areas'
- **wheelchairAccessible** -> logical AND (any non-accessible crossed tile makes the edge non-accessible)
- **name** -> the first crossed area (cosmetic)

so the edge is never more permissive, safer or more accessible than any tile it physically crosses.

This mirrors the conservative permission/wheelchair merge OTP already performs for an area's *interior*
edges in `WalkableAreaBuilder.createEdgesForRingSegment`; it brings the visibility-edge path in line.

<img width="1800" height="1380" alt="area-edge-conservative-merge-vika" src="https://github.com/user-attachments/assets/ec692bc8-b267-4c14-bd2f-8a33645e3720" />


### Implementation

- A per-sub-area `PreparedGeometry` (built once per linking operation, reused across the group's edges) tests whether the edge crosses each sub-area; the crossed sub-areas' properties are then merged.
- The intersection length threshold (> 0.000001) is dropped.
- The probe line is **shrunk inward at both ends** before the per-area `intersects` test, exactly as `containsSegment` already does. The edge's endpoints are visibility vertices sitting on the area boundary, so without the shrink `intersects` would also match a neighbouring sub-area the edge merely *touches at that shared endpoint* without ever crossing its interior, merging that neighbour's worst-case properties into the edge. 
- Support for wheelchair is threaded from the parent `Area` and taken into account when merging area properties into the edge.

### Why `PreparedGeometry` (measured on real captured GBFS geometry)

Per-edge cost testing one rental visibility edge against all sub-areas of its group, on **real Oslo
geometry captured from live GBFS rental linking** (44 groups, 21,792 resolutions; polygon vertices
median 20 / max 188; ~72% of edges cross >= 2 sub-areas):

| primitive | ns / edge | alloc B / edge |
|---|--:|--:|
| `intersection().getLength()` (old) | 265,935 | 286,781 |
| `Geometry.intersects` (unprepared) | 29,835 | 57,453 |
| **`PreparedGeometry.intersects` (this PR)** | **1,423** | **3,037** |
| `RelateNG.intersects` (prepared) | 2,098 | 4,201 |

### Merged permission can be NONE

Permission AND can yield `NONE` if two crossed tiles share no common mode (e.g. a bike-only tile
overlapping a pedestrian-only tile), which would make the edge untraversable.

### Tests

- `AreaEdgePropertiesTest` covers the worst-case property fold (permission AND, safety MAX, wheelchair AND) with no geometry.
- `PreparedAreaGroupTest` covers `areasCrossedBy`, including a regression test that an edge touching a neighbouring tile only at its boundary endpoint does not pick up that neighbour.

### Changelog

Skip

### Follow-up
It seems that the RelateNG API used in PreparedAreaGroup is significantly slower than the PreparedGeometry API.
The new RelateNG is supposed to be more resilient to invalid geometries, but the input polygons are validated in the graph builder and updaters, limiting the benefits of the new API.
Benchmarking both APIs and possibly reverting to using only PreparedGeometry can be done in a follow-up PR.


