### PR TITLE
Upgrade all CI action versions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -27,16 +27,16 @@ jobs:
     timeout-minutes: 20
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # nodejs is needed because the dynamic download of it via the prettier maven plugin often
       # times out
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       # Java setup step completes very fast, no need to run in a preconfigured docker container
       - name: Set up JDK 25
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 20
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
@@ -91,7 +91,7 @@ jobs:
       # on windows there are frequent failures caused by page files being too small
       # https://github.com/actions/virtual-environments/issues/785
       - name: Configure Windows Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.4
+        uses: al-cheb/configure-pagefile-action@v1.5
       - name: Run tests
         run: mvn test -P prettierSkip,checkstyleSkip
 
@@ -117,7 +117,7 @@ jobs:
           # was modified last
           fetch-depth: 1000
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         # for a simple PR where we don't push, we don't need any credentials
         if: github.event_name != 'push'
 
@@ -190,8 +190,8 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Run code generator
@@ -215,7 +215,7 @@ jobs:
       - build-windows
       - build-linux
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up JDK 25
@@ -224,7 +224,7 @@ jobs:
           java-version: 25
           distribution: temurin
           cache: maven
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - name: Build container image with Jib, push to Dockerhub

--- a/.github/workflows/close_stale_pr_and_issues.yml
+++ b/.github/workflows/close_stale_pr_and_issues.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6.0.1
+      - uses: actions/stale@v10.3.0
         id: stale
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days'

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # this is necessary so that the correct credentials are put into the git configuration
       # when we push to dev-2.x and push the compiled output to the git repo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set version
         run: echo "VERSION=`date +%Y/%m/%Y-%m-%dT%H:%M`" >> $GITHUB_ENV

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner' && contains( github.event.pull_request.labels.*.name, '+Integration Test' )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
@@ -63,7 +63,7 @@ jobs:
           git config --global user.email 'serialization-version-bot@opentripplanner.org'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 


### PR DESCRIPTION
### Summary

Today Github is forcing all actions to use Node 24 so it's time to upgrade our versions:

<img width="1563" height="657" alt="image" src="https://github.com/user-attachments/assets/8d6ee8a2-2347-4f87-a090-057b5fdbc507" />