### PR TITLE
Use PreparedGeometry instead of RelateNG for area containment

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
@@ -7,8 +7,6 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
-import org.locationtech.jts.operation.relateng.RelateNG;
-import org.locationtech.jts.operation.relateng.RelatePredicate;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.edge.Area;
 import org.opentripplanner.street.model.edge.AreaGroup;
@@ -36,7 +34,7 @@ final class PreparedAreaGroup {
   private static final double AREA_INTERSECTION_SHRINKING = 0.0001;
 
   private final AreaGroup areaGroup;
-  private RelateNG prepared;
+  private PreparedGeometry preparedGroup;
   private PreparedGeometry[] preparedAreas;
 
   PreparedAreaGroup(AreaGroup areaGroup) {
@@ -52,14 +50,14 @@ final class PreparedAreaGroup {
    * shrunk slightly at both ends first, so that a segment connecting two boundary points is not
    * rejected by floating point imprecision at the boundary. Reuses a cached prepared index across
    * calls. A plain {@code Polygon.contains(...)} would rebuild a sweep-line index over the polygon
-   * boundary on every call; {@link RelateNG} builds it once and is also tolerant of invalid /
-   * self-intersecting OSM polygons (it does not throw {@code TopologyException}).
+   * boundary on every call; a {@link PreparedGeometry} builds it once and reuses it, matching the
+   * indexed {@link #areasCrossedBy} crossing test on this same group.
    */
   boolean containsSegment(Coordinate from, Coordinate to) {
-    if (prepared == null) {
-      prepared = RelateNG.prepare(areaGroup.getGeometry());
+    if (preparedGroup == null) {
+      preparedGroup = PreparedGeometryFactory.prepare(areaGroup.getGeometry());
     }
-    return prepared.evaluate(createShrunkLine(from, to), RelatePredicate.contains());
+    return preparedGroup.contains(createShrunkLine(from, to));
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #7715. In `PreparedAreaGroup`, the `containsSegment` boundary check prepared and reused a spatial index over the area-group polygon using JTS `RelateNG`. Benchmarking (discussed on #7715) indicates the classic `PreparedGeometry` API is faster than `RelateNG` for this `contains` predicate. The sibling `areasCrossedBy` crossing test in the same class already uses `PreparedGeometry`, so this also makes the two paths consistent.

This PR replaces `RelateNG` with `PreparedGeometry.contains` in `containsSegment`:

- prepares the group polygon once via `PreparedGeometryFactory.prepare(...)` and reuses it across all candidate checks (the prepared-index reuse introduced in #7696 is preserved);
- restores the pre-#7696 semantics of plain `Polygon.contains` (which, unlike `RelateNG`, can throw `TopologyException` on invalid polygons — same behaviour as the code before #7696 and as the `areasCrossedBy` path).

