### PR TITLE
Reuse the prepared area index for the point-in-area test

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/PreparedAreaGroup.java
@@ -54,10 +54,21 @@ final class PreparedAreaGroup {
    * indexed {@link #areasCrossedBy} crossing test on this same group.
    */
   boolean containsSegment(Coordinate from, Coordinate to) {
+    return preparedGroup().contains(createShrunkLine(from, to));
+  }
+
+  /**
+   * Whether the area group polygon contains the given point.
+   */
+  boolean containsPoint(Coordinate point) {
+    return preparedGroup().contains(GEOMETRY_FACTORY.createPoint(point));
+  }
+
+  private PreparedGeometry preparedGroup() {
     if (preparedGroup == null) {
       preparedGroup = PreparedGeometryFactory.prepare(areaGroup.getGeometry());
     }
-    return preparedGroup.contains(createShrunkLine(from, to));
+    return preparedGroup;
   }
 
   /**

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -451,10 +451,11 @@ public class VertexLinker {
       edge instanceof AreaEdge aEdge
     ) {
       AreaGroup ag = aEdge.getArea();
+      var area = new PreparedAreaGroup(ag);
       // is area already linked ?
       start = linkedAreas.get(ag);
       if (start == null) {
-        if (ag.getGeometry().contains(GEOMETRY_FACTORY.createPoint(vertex.getCoordinate()))) {
+        if (area.containsPoint(vertex.getCoordinate())) {
           // vertex is inside an area
           if (distSquared(vertex, split) <= DUPLICATE_NODE_EPSILON_DEGREES_SQUARED) {
             // vertex is so close to the edge that we can use the split point directly
@@ -473,14 +474,14 @@ public class VertexLinker {
         // vertex is inside the area. try connecting the vertex to the edge's split point, because
         // connections to visibility vertices may fail or do not always provide an optimal route
         // note that by definition, connection to closest edge cannot be blocked and edge can be forced
-        addVisibilityEdges(start, split, new PreparedAreaGroup(ag), scope, tempEdges, true);
+        addVisibilityEdges(start, split, area, scope, tempEdges, true);
       } else {
         // vertex is outside an area. Use split point for area connections
         start = split;
       }
       // connect start point to area visibility points to achieve optimal paths
       if (!ag.visibilityVertices().contains(start)) {
-        addAreaVertex(start, ag, scope, tempEdges, false);
+        addAreaVertex(start, area, scope, tempEdges, false);
       }
     } else {
       start = split;
@@ -661,7 +662,7 @@ public class VertexLinker {
    * Link a new vertex permanently with area geometry
    */
   public boolean addPermanentAreaVertex(IntersectionVertex newVertex, AreaGroup areaGroup) {
-    return addAreaVertex(newVertex, areaGroup, Scope.PERMANENT, null, true);
+    return addAreaVertex(newVertex, new PreparedAreaGroup(areaGroup), Scope.PERMANENT, null, true);
   }
 
   /**
@@ -681,14 +682,13 @@ public class VertexLinker {
    */
   private boolean addAreaVertex(
     IntersectionVertex newVertex,
-    AreaGroup areaGroup,
+    PreparedAreaGroup area,
     Scope scope,
     DisposableEdgeCollection tempEdges,
     boolean force
   ) {
+    AreaGroup areaGroup = area.areaGroup();
     Geometry polygon = areaGroup.getGeometry();
-    // Reused across all candidate contains() checks below so the spatial index is built only once.
-    var area = new PreparedAreaGroup(areaGroup);
 
     int added = 0;
 

--- a/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/PreparedAreaGroupTest.java
@@ -51,6 +51,22 @@ class PreparedAreaGroupTest {
   }
 
   @Test
+  void containsInteriorPoint() {
+    assertTrue(area.containsPoint(new Coordinate(1, 1)));
+  }
+
+  @Test
+  void doesNotContainPointInHole() {
+    // The 2x2 hole is centred at x,y in (4,6); a point in its middle is not inside the area.
+    assertFalse(area.containsPoint(new Coordinate(5, 5)));
+  }
+
+  @Test
+  void doesNotContainExteriorPoint() {
+    assertFalse(area.containsPoint(new Coordinate(11, 11)));
+  }
+
+  @Test
   void exposesWrappedAreaGroup() {
     var ag = new AreaGroup(SQUARE_WITH_HOLE);
     assertSame(ag, new PreparedAreaGroup(ag).areaGroup());


### PR DESCRIPTION
When linking a vertex into a walkable area, `VertexLinker.snapAndLink` did the vertex-in-area check with a raw `Polygon.contains(point)`, which rebuilds a sweep-line index over the polygon boundary on every call. Separately, `addAreaVertex` built a `PreparedGeometry` for the visibility-edge fan-out. So a single rental-in-area landing could build the area index up to three times.

This change builds **one** `PreparedAreaGroup` per area in `snapAndLink` and reuses it for:
- the point-in-area test (new `PreparedAreaGroup.containsPoint`),
- the forced split-point edge, and
- the `addAreaVertex` visibility fan-out (and, via #7722, the per-sub-area crossing checks).

`addAreaVertex` now takes the prepared group instead of rebuilding it.
