### PR TITLE
Deduplicate edge spatial index queries by identity

### DIFF
--- a/application/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -48,6 +48,7 @@ import org.opentripplanner.service.worldenvelope.internal.DefaultWorldEnvelopeRe
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.street.StreetRepository;
+import org.opentripplanner.street.geometry.EdgeHashGridSpatialIndex;
 import org.opentripplanner.street.geometry.HashGridSpatialIndex;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.internal.DefaultStreetRepository;
@@ -85,6 +86,10 @@ public class GraphSerializationTest {
     org.slf4j.Logger.class,
     ch.qos.logback.classic.Logger.class,
     HashGridSpatialIndex.class,
+    // EdgeHashGridSpatialIndex is a HashGridSpatialIndex subclass; the differ matches by exact
+    // class, so it must be listed separately. Like its base it holds unordered bin lists that are
+    // rebuilt after deserialization.
+    EdgeHashGridSpatialIndex.class,
     Deduplicator.class
   ).toArray(Class[]::new);
 

--- a/street/src/main/java/org/opentripplanner/street/geometry/EdgeHashGridSpatialIndex.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/EdgeHashGridSpatialIndex.java
@@ -1,0 +1,48 @@
+package org.opentripplanner.street.geometry;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import org.opentripplanner.street.model.edge.Edge;
+
+/**
+ * A {@link HashGridSpatialIndex} specialised for {@link Edge}, deduplicating query results by
+ * reference identity instead of value.
+ * <p>
+ * {@link Edge#equals(Object)} is pure reference equality ({@code this == o}) and
+ * {@link Edge#hashCode()} is a value hash ({@code Objects.hash(fromv, tov)}) that allocates a
+ * varargs array per call and collides forward/reverse edges sharing an endpoint pair. The default
+ * value-deduplicating {@link java.util.HashSet} therefore already partitions edges purely by
+ * reference (the value hash only ever selects a bucket, it never merges two distinct references).
+ * Backing the result set with an {@link IdentityHashMap} collapses the identical equivalence classes
+ * — one survivor per distinct reference — while never calling {@code Edge.hashCode} or
+ * {@code Edge.equals}, removing the per-element varargs {@code Object[]} and the
+ * {@code HashMap.Node} allocations.
+ * <p>
+ * Correctness invariant: this is valid <em>only</em> because {@code Edge.equals} is reference
+ * identity. It must not be generalised to id-based-equals types (e.g. transit stops), where two
+ * distinct instances with the same id must collapse by value; identity dedup would wrongly keep
+ * both. The {@code extends HashGridSpatialIndex<Edge>} bound makes that mistake unreachable from any
+ * non-edge index.
+ * <p>
+ * Thread-safety: the {@link IdentityHashMap} is a fresh per-query local that never escapes the
+ * calling thread; no {@code ThreadLocal} is used. Probing it calls {@link System#identityHashCode},
+ * which lazily installs the identity hash into each {@code Edge}'s header on first access — an
+ * idempotent, benign write, not a query-visible mutation. The benign read-during-write race on the
+ * bins is identical to the generic path, neither improved nor worsened.
+ */
+public final class EdgeHashGridSpatialIndex extends HashGridSpatialIndex<Edge> {
+
+  public EdgeHashGridSpatialIndex() {
+    super();
+  }
+
+  public EdgeHashGridSpatialIndex(double xBinSize, double yBinSize) {
+    super(xBinSize, yBinSize);
+  }
+
+  @Override
+  protected Set<Edge> newResultSet(int sizeHint) {
+    return Collections.newSetFromMap(new IdentityHashMap<>(sizeHint));
+  }
+}

--- a/street/src/main/java/org/opentripplanner/street/geometry/HashGridSpatialIndex.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/HashGridSpatialIndex.java
@@ -50,6 +50,16 @@ public class HashGridSpatialIndex<T> implements SpatialIndex, Serializable {
    */
   private static final double DEFAULT_X_BIN_SIZE = 0.0035;
 
+  /**
+   * Initial capacity hint for the per-query dedup set. Per-query candidate counts are bimodal:
+   * tens of entries in rural bins, but ~2,500+ in dense city tiles (where real-time rentals link).
+   * 1024 — the historical default — avoids resizing for most dense single-tile queries without
+   * grossly over-allocating; the densest tiles still resize, which is cheap for an open-addressed
+   * identity set. The dominant win is removing the per-candidate {@code HashMap.Node}/value-hash
+   * cost, which is independent of this hint.
+   */
+  private static final int RESULT_SIZE_HINT = 1024;
+
   /* Size of bin in X and Y direction, in coordinates units. */
   private final double xBinSize;
   private final double yBinSize;
@@ -113,14 +123,9 @@ public class HashGridSpatialIndex<T> implements SpatialIndex, Serializable {
     return HashSet.newHashSet(sizeHint);
   }
 
-  /** A cheap, allocation-free result-size estimate, bounded so a large index never over-sizes. */
-  private int resultSizeHint() {
-    return Math.min(nEntries, 256);
-  }
-
   @Override
   public final List<T> query(Envelope envelope) {
-    final Set<T> ret = newResultSet(resultSizeHint());
+    final Set<T> ret = newResultSet(RESULT_SIZE_HINT);
     visit(envelope, false, (bin, mapKey) -> {
       ret.addAll(bin);
       return false;
@@ -189,7 +194,7 @@ public class HashGridSpatialIndex<T> implements SpatialIndex, Serializable {
    * their shared endpoint).
    */
   public Set<T> queryAlongLineStrings(Collection<LineString> lineStrings) {
-    Set<T> result = newResultSet(resultSizeHint());
+    Set<T> result = newResultSet(RESULT_SIZE_HINT);
     TLongSet keys = new TLongHashSet(256);
     for (LineString ls : lineStrings) {
       CoordinateSequence seq = ls.getCoordinateSequence();

--- a/street/src/main/java/org/opentripplanner/street/geometry/HashGridSpatialIndex.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/HashGridSpatialIndex.java
@@ -95,9 +95,32 @@ public class HashGridSpatialIndex<T> implements SpatialIndex, Serializable {
     nObjects++;
   }
 
+  /**
+   * Factory for the accumulator that deduplicates the (cross-bin and within-bin) duplicates while
+   * collecting query results. The default deduplicates by {@code equals}/{@code hashCode} (value
+   * semantics), which is correct for every element type — including the id-based-equals transit
+   * stop indexes.
+   * <p>
+   * {@code sizeHint} is a cheap upper-bound estimate, not an exact count: the returned set may
+   * resize once or be slightly over-allocated, both of which are acceptable. We deliberately avoid
+   * pre-traversing the bins to size it exactly, because a second read pass would double the bin
+   * reads and — since routing threads read the index while the graph-writer inserts (see
+   * {@code EdgeSpatialIndex} and #3351) — widen that benign read-during-write race.
+   *
+   * @see EdgeHashGridSpatialIndex
+   */
+  protected Set<T> newResultSet(int sizeHint) {
+    return HashSet.newHashSet(sizeHint);
+  }
+
+  /** A cheap, allocation-free result-size estimate, bounded so a large index never over-sizes. */
+  private int resultSizeHint() {
+    return Math.min(nEntries, 256);
+  }
+
   @Override
   public final List<T> query(Envelope envelope) {
-    final Set<T> ret = new HashSet<>(1024);
+    final Set<T> ret = newResultSet(resultSizeHint());
     visit(envelope, false, (bin, mapKey) -> {
       ret.addAll(bin);
       return false;
@@ -166,7 +189,7 @@ public class HashGridSpatialIndex<T> implements SpatialIndex, Serializable {
    * their shared endpoint).
    */
   public Set<T> queryAlongLineStrings(Collection<LineString> lineStrings) {
-    Set<T> result = new HashSet<>(1024);
+    Set<T> result = newResultSet(resultSizeHint());
     TLongSet keys = new TLongHashSet(256);
     for (LineString ls : lineStrings) {
       CoordinateSequence seq = ls.getCoordinateSequence();

--- a/street/src/main/java/org/opentripplanner/street/graph/EdgeSpatialIndex.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/EdgeSpatialIndex.java
@@ -6,7 +6,7 @@ import java.util.stream.Stream;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.street.Scope;
-import org.opentripplanner.street.geometry.HashGridSpatialIndex;
+import org.opentripplanner.street.geometry.EdgeHashGridSpatialIndex;
 import org.opentripplanner.street.model.edge.Edge;
 
 /**
@@ -34,9 +34,9 @@ import org.opentripplanner.street.model.edge.Edge;
  */
 class EdgeSpatialIndex {
 
-  private final HashGridSpatialIndex<Edge> permanentEdgeIndex = new HashGridSpatialIndex<>();
+  private final EdgeHashGridSpatialIndex permanentEdgeIndex = new EdgeHashGridSpatialIndex();
 
-  private final HashGridSpatialIndex<Edge> realTimeEdgeIndex = new HashGridSpatialIndex<>();
+  private final EdgeHashGridSpatialIndex realTimeEdgeIndex = new EdgeHashGridSpatialIndex();
 
   public void insert(Edge edge, Scope scope) {
     if (edge.hasGeometry()) {

--- a/street/src/test/java/org/opentripplanner/street/geometry/EdgeHashGridSpatialIndexTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/EdgeHashGridSpatialIndexTest.java
@@ -1,0 +1,281 @@
+package org.opentripplanner.street.geometry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
+import static org.opentripplanner.street.model.StreetModelFactory.streetEdge;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.street.model.vertex.StreetVertex;
+
+/**
+ * Tests for {@link EdgeHashGridSpatialIndex}, the identity-deduplicating edge index, and for the
+ * value-deduplicating behaviour of the generic {@link HashGridSpatialIndex} base it must NOT change.
+ * <p>
+ * Background: the default grid bins are ~0.0035° in longitude and ~0.005° in latitude, so an edge
+ * whose endpoints differ by more than ~0.0035° in longitude spans several bins and is stored once
+ * per touched bin — exactly the cross-bin duplication that {@code query()} must collapse.
+ */
+class EdgeHashGridSpatialIndexTest {
+
+  /**
+   * One edge spanning several bins, queried over an envelope covering those bins, must come back
+   * exactly once (identity dedup of cross-bin duplicates).
+   */
+  @Test
+  void crossBinDuplicatesAreCollapsed() {
+    var index = new EdgeHashGridSpatialIndex();
+    // ~0.01° of longitude => spans ~4 longitude bins at this latitude.
+    StreetEdge edge = edge(60.0, 10.0, 60.0, 10.01);
+    index.insert(edge.getGeometry(), edge);
+
+    List<Edge> result = index.query(new Envelope(10.0, 10.01, 60.0, 60.0));
+
+    assertThat(result).containsExactly(edge);
+  }
+
+  /**
+   * For a battery of random envelopes, the identity-backed edge index returns the same set of edges
+   * as the generic value-backed index. Because {@code Edge.equals} is reference identity, the two
+   * dedup strategies must produce identical result sets — this is the load-bearing equivalence proof.
+   */
+  @Test
+  void identityIndexMatchesGenericIndexForEdges() {
+    var identityIndex = new EdgeHashGridSpatialIndex();
+    var genericIndex = new HashGridSpatialIndex<Edge>();
+
+    var rnd = new Random(42);
+    for (int i = 0; i < 60; i++) {
+      StreetEdge edge = randomEdge(rnd);
+      identityIndex.insert(edge.getGeometry(), edge);
+      genericIndex.insert(edge.getGeometry(), edge);
+    }
+
+    for (int i = 0; i < 200; i++) {
+      Envelope env = randomEnvelope(rnd);
+      Set<Edge> fromIdentity = new HashSet<>(identityIndex.query(env));
+      Set<Edge> fromGeneric = new HashSet<>(genericIndex.query(env));
+      assertThat(fromIdentity).isEqualTo(fromGeneric);
+    }
+  }
+
+  /**
+   * Two distinct edges that share the same {@code (fromVertex, toVertex)} pair have an equal
+   * {@code Edge.hashCode()} ({@code Objects.hash(fromv, tov)}) but are different references. The
+   * index must return BOTH — identity dedup keeps references the value hash would have bucketed
+   * together, matching the old {@code HashSet} behaviour (whose membership also used identity
+   * {@code equals}).
+   */
+  @Test
+  void forwardReverseHashCollisionKeepsBothEdges() {
+    var index = new EdgeHashGridSpatialIndex();
+    var a = intersectionVertex("a", 60.0, 10.0);
+    var b = intersectionVertex("b", 60.0, 10.01);
+
+    StreetEdge edge1 = streetEdge(a, b);
+    StreetEdge edge2 = streetEdge(a, b);
+    assertThat(edge1).isNotSameInstanceAs(edge2);
+    assertThat(edge1.hashCode()).isEqualTo(edge2.hashCode());
+
+    index.insert(edge1.getGeometry(), edge1);
+    index.insert(edge2.getGeometry(), edge2);
+
+    List<Edge> result = index.query(new Envelope(10.0, 10.01, 60.0, 60.0));
+
+    assertThat(result).containsExactly(edge1, edge2);
+  }
+
+  /**
+   * The same edge reference inserted twice into one bin (permitted by the index contract for
+   * multi-envelope inserts) must still be returned once.
+   */
+  @Test
+  void withinBinDuplicateIsCollapsed() {
+    var index = new EdgeHashGridSpatialIndex();
+    // tiny extent so the edge lands in a single bin
+    StreetEdge edge = edge(60.0, 10.0, 60.0, 10.0005);
+    var pointEnvelope = new Envelope(new Coordinate(10.0, 60.0));
+
+    index.insert(pointEnvelope, edge);
+    index.insert(pointEnvelope, edge);
+
+    List<Edge> result = index.query(pointEnvelope);
+
+    assertThat(result).containsExactly(edge);
+  }
+
+  /**
+   * {@code queryAlongLineStrings} on the edge index also deduplicates by identity: an edge touched
+   * by many adjacent bins is returned once, and the result matches the generic index.
+   */
+  @Test
+  void queryAlongLineStringsDedupsByIdentity() {
+    var identityIndex = new EdgeHashGridSpatialIndex();
+    var genericIndex = new HashGridSpatialIndex<Edge>();
+
+    // spans many bins along its own line string
+    StreetEdge spanning = edge(60.0, 10.0, 60.0, 10.02);
+    StreetEdge other = edge(60.01, 10.0, 60.01, 10.001);
+    for (var index : List.of(identityIndex, genericIndex)) {
+      index.insert(spanning.getGeometry(), spanning);
+      index.insert(other.getGeometry(), other);
+    }
+
+    List<LineString> lines = List.of(spanning.getGeometry());
+    Set<Edge> fromIdentity = identityIndex.queryAlongLineStrings(lines);
+    Set<Edge> fromGeneric = genericIndex.queryAlongLineStrings(lines);
+
+    assertThat(fromIdentity).contains(spanning);
+    assertThat(fromIdentity).isEqualTo(fromGeneric);
+    // The spanning edge appears once despite touching many bins along its own line string.
+    assertThat(
+      fromIdentity
+        .stream()
+        .filter(e -> e == spanning)
+        .count()
+    ).isEqualTo(1);
+  }
+
+  /** An envelope touching no bins returns an empty (non-null) list; a dense envelope is correct. */
+  @Test
+  void emptyAndDenseQueries() {
+    var index = new EdgeHashGridSpatialIndex();
+    assertThat(index.query(new Envelope(10.0, 10.01, 60.0, 60.0))).isEmpty();
+
+    var distinct = new HashSet<Edge>();
+    var rnd = new Random(7);
+    for (int i = 0; i < 40; i++) {
+      // All within one small dense region so a single envelope catches them all.
+      StreetEdge edge = edge(
+        60.0 + rnd.nextDouble() * 0.001,
+        10.0 + rnd.nextDouble() * 0.001,
+        60.0 + rnd.nextDouble() * 0.001,
+        10.0 + rnd.nextDouble() * 0.001
+      );
+      index.insert(edge.getGeometry(), edge);
+      distinct.add(edge);
+    }
+
+    Set<Edge> result = new HashSet<>(index.query(new Envelope(9.99, 10.02, 59.99, 60.02)));
+    assertThat(result).isEqualTo(distinct);
+  }
+
+  /**
+   * Regression guard: the generic base index must keep deduplicating by VALUE, not identity. Two
+   * distinct objects that are {@code equals} (e.g. transit stops, whose {@code AbstractTransitEntity}
+   * equals/hashCode are id-based) must collapse to one — proving the identity behaviour was scoped to
+   * {@link EdgeHashGridSpatialIndex} and not leaked into the generic default used by the stop indexes.
+   */
+  @Test
+  void genericBaseStillDedupsByValueNotIdentity() {
+    var index = new HashGridSpatialIndex<IdKeyed>();
+    var first = new IdKeyed(7);
+    // distinct instance, equal by id
+    var second = new IdKeyed(7);
+    assertThat(first).isNotSameInstanceAs(second);
+    assertThat(first).isEqualTo(second);
+
+    var env = new Envelope(new Coordinate(10.0, 60.0));
+    index.insert(env, first);
+    index.insert(env, second);
+
+    assertThat(index.query(env)).hasSize(1);
+  }
+
+  /**
+   * The per-query dedup accumulator must be a fresh local with no shared/ThreadLocal state, so
+   * concurrent readers each get a correct, independently-deduplicated result.
+   * <p>
+   * This exercises concurrent READS on a populated index — the documented multi-thread-safe case.
+   * It deliberately does not perform concurrent writes, which the index contract leaves to the
+   * client to synchronize.
+   */
+  @Test
+  void concurrentReadersGetConsistentDedup() throws Exception {
+    var index = new EdgeHashGridSpatialIndex();
+    var rnd = new Random(99);
+    for (int i = 0; i < 80; i++) {
+      StreetEdge edge = randomEdge(rnd);
+      index.insert(edge.getGeometry(), edge);
+    }
+    var queryEnvelope = new Envelope(9.99, 10.06, 59.99, 60.04);
+    Set<Edge> expected = new HashSet<>(index.query(queryEnvelope));
+
+    int threads = 8;
+    var pool = Executors.newFixedThreadPool(threads);
+    try {
+      var tasks = new ArrayList<Callable<Set<Edge>>>();
+      for (int t = 0; t < threads; t++) {
+        tasks.add(() -> {
+          Set<Edge> last = null;
+          for (int i = 0; i < 500; i++) {
+            last = new HashSet<>(index.query(queryEnvelope));
+          }
+          return last;
+        });
+      }
+      var futures = pool.invokeAll(tasks);
+      for (Future<Set<Edge>> f : futures) {
+        assertThat(f.get()).isEqualTo(expected);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  // ---- helpers ----
+
+  private static StreetEdge edge(double latA, double lonA, double latB, double lonB) {
+    StreetVertex a = intersectionVertex("a_%s_%s".formatted(latA, lonA), latA, lonA);
+    StreetVertex b = intersectionVertex("b_%s_%s".formatted(latB, lonB), latB, lonB);
+    return streetEdge(a, b);
+  }
+
+  private static StreetEdge randomEdge(Random rnd) {
+    double latA = 60.0 + rnd.nextDouble() * 0.03;
+    double lonA = 10.0 + rnd.nextDouble() * 0.05;
+    double latB = latA + (rnd.nextDouble() - 0.5) * 0.01;
+    double lonB = lonA + (rnd.nextDouble() - 0.5) * 0.01;
+    return edge(latA, lonA, latB, lonB);
+  }
+
+  private static Envelope randomEnvelope(Random rnd) {
+    double lon = 10.0 + rnd.nextDouble() * 0.05;
+    double lat = 60.0 + rnd.nextDouble() * 0.03;
+    double w = rnd.nextDouble() * 0.01;
+    double h = rnd.nextDouble() * 0.01;
+    return new Envelope(lon, lon + w, lat, lat + h);
+  }
+
+  /** A value-equals stand-in for an id-based transit entity (see AbstractTransitEntity). */
+  private static final class IdKeyed {
+
+    private final int id;
+
+    private IdKeyed(int id) {
+      this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof IdKeyed other && other.id == id;
+    }
+
+    @Override
+    public int hashCode() {
+      return Integer.hashCode(id);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`HashGridSpatialIndex.query()` deduplicates results (an edge that spans several grid cells is stored once per cell) with a `HashSet`. For the **edge** index this pays `Edge.hashCode()` — `Objects.hash(fromv, tov)` — for every candidate: a value hash that allocates a varargs `Object[]` per call, collides forward/reverse edges that share an endpoint pair, and creates a `HashMap.Node` per distinct edge.

But `Edge.equals` is pure reference identity (`this == o`), so the `HashSet` already partitions edges purely by reference — the value hash only ever selects a bucket, it never merges two distinct references. Backing the result set with an `IdentityHashMap` (keyed on `==`/`System.identityHashCode`) collapses the **identical** equivalence classes while skipping `Edge.hashCode` entirely and storing keys in one flat array (no per-element `Node`).

The change is introduced behind a small `protected newResultSet(int)` factory on `HashGridSpatialIndex`. The default returns a (right-sized) `HashSet` — correct for every element type. A new `final EdgeHashGridSpatialIndex extends HashGridSpatialIndex<Edge>` overrides only that factory to return an `IdentityHashMap`-backed set. `EdgeSpatialIndex` switches its two fields to the subclass; all call sites are unchanged.

**Why scope it by type:** identity dedup is only behaviour-preserving when `equals` is reference identity. The stop indexes (`RegularStop`/`AreaStop` → `AbstractTransitEntity`) use **id-based** `equals`/`hashCode`, where two distinct same-id instances must collapse — identity dedup would wrongly keep both. The `extends HashGridSpatialIndex<Edge>` bound makes that mistake unreachable from any non-edge index; identity dedup is never the generic default.

## Result is identical

For the edge index the returned set is identical to the previous `HashSet` path (same survivor partition — one per distinct reference, including cross-bin and within-bin duplicates). A randomised equivalence test asserts this against the generic index over many envelopes; a forward/reverse hash-collision test asserts two distinct edges sharing `(fromv, tov)` are both returned (as before); a regression test asserts the generic base still deduplicates id-based-equals objects by value.

## Profiling (local, GBFS real-time rental-linking flood)

Measured on the graph-writer thread during the real-time vehicle-rental linking flood at startup (Norway graph, live GBFS feeds), JFR CPU + allocation, baseline vs change interleaved in one session:

- `Edge`/`Vertex` value-hash CPU (`Objects.hash`/`hashCode`): **3.3% → 0.4%** (≈ −88%).
- `HashMap.Node` allocation samples: **−91%**; allocation through `query()`: **−50%**.
- `query()`/dedup CPU overall: ~14.2% → ~11.6%.
- The `Objects.hash` varargs `Object[]` did **not** move — escape analysis already scalar-replaces it — so the realised win is the `Node` removal + the value-hash CPU, not the varargs array.
- The larger graph-writer costs (distance checks, area-visibility) are unchanged — the change is isolated to the dedup path.

The win scales with the per-query candidate count, which is large precisely where rentals link (dense city tiles), so the effect is concentrated on the realtime-linking hot path.

## Notes

- `GraphSerializationTest` compares the deserialized graph with an `ObjectDiffer` that ignores `HashGridSpatialIndex` by **exact** class; the new subclass is added to that ignore list. Real serialization is unaffected — the street index is `transient` and rebuilt after load.
- Follow-up to the closed #7695 (single-bin dedup skip), which was dropped because it relied on an unenforced per-bin uniqueness assumption and its benefit eroded at high latitude / on the larger search radius. This approach is latitude-independent and preserves the unconditional dedup guarantee.