### PR TITLE
Import experimental GTFS notices, add API

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -288,7 +288,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>13.0.1-SNAPSHOT</version>
+            <version>14.0.0</version>
         </dependency>
         <!-- Used in DegreeGridNEDTileSource to fetch tiles from Amazon S3 -->
         <dependency>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -288,7 +288,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>12.0.1</version>
+            <version>13.0.1-SNAPSHOT</version>
         </dependency>
         <!-- Used in DegreeGridNEDTileSource to fetch tiles from Amazon S3 -->
         <dependency>

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/SchemaFactory.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/SchemaFactory.java
@@ -40,6 +40,7 @@ import org.opentripplanner.apis.gtfs.datafetchers.LocationGroupImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.LocationImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.MoneyImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.NodeTypeResolver;
+import org.opentripplanner.apis.gtfs.datafetchers.NoticeImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.OpeningHoursImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.PatternImpl;
 import org.opentripplanner.apis.gtfs.datafetchers.PlaceImpl;
@@ -216,6 +217,7 @@ public class SchemaFactory {
         .type(typeWiring.build(StairsUseImpl.class))
         .type(typeWiring.build(ElevatorUseImpl.class))
         .type(typeWiring.build(RiderCategoryImpl.class))
+        .type(typeWiring.build(NoticeImpl.class))
         .build();
 
       SchemaGenerator schemaGenerator = new SchemaGenerator();

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/NoticeImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/NoticeImpl.java
@@ -1,0 +1,18 @@
+package org.opentripplanner.apis.gtfs.datafetchers;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
+import org.opentripplanner.transit.model.basic.Notice;
+
+public class NoticeImpl implements GraphQLDataFetchers.GraphQLNotice {
+
+  @Override
+  public DataFetcher<String> text() {
+    return env -> source(env).text();
+  }
+
+  private static Notice source(DataFetchingEnvironment env) {
+    return env.getSource();
+  }
+}

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
@@ -19,6 +19,7 @@ import org.opentripplanner.apis.gtfs.support.time.LocalDateRangeUtil;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -183,6 +184,11 @@ public class RouteImpl implements GraphQLDataFetchers.GraphQLRoute {
   @Override
   public DataFetcher<GraphQLTransitMode> mode() {
     return environment -> TransitModeMapper.map(getSource(environment).getMode());
+  }
+
+  @Override
+  public DataFetcher<Iterable<Notice>> notices() {
+    return env -> getTransitService(env).findNotices(getSource(env));
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
@@ -31,6 +31,7 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
+import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -263,6 +264,11 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
       getTransitService(environment)
         .getReplacementHelper()
         .isReplacementTrip(getSource(environment));
+  }
+
+  @Override
+  public DataFetcher<Iterable<Notice>> notices() {
+    return env -> getTransitService(env).findNotices(getSource(env));
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -548,6 +548,10 @@ public class GraphQLDataFetchers {
     }
   }
 
+  public interface GraphQLNotice {
+    public DataFetcher<String> text();
+  }
+
   public interface GraphQLOpeningHours {
     public DataFetcher<Iterable<Object>> dates();
     public DataFetcher<String> osm();
@@ -834,6 +838,7 @@ public class GraphQLDataFetchers {
     public DataFetcher<Boolean> isReplacement();
     public DataFetcher<String> longName();
     public DataFetcher<GraphQLTransitMode> mode();
+    public DataFetcher<Iterable<org.opentripplanner.transit.model.basic.Notice>> notices();
     public DataFetcher<Iterable<TripPattern>> patterns();
     public DataFetcher<Boolean> replacementsExist();
     public DataFetcher<String> shortName();

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -1027,6 +1027,7 @@ public class GraphQLDataFetchers {
     public DataFetcher<String> gtfsId();
     public DataFetcher<graphql.relay.Relay.ResolvedGlobalId> id();
     public DataFetcher<Boolean> isReplacement();
+    public DataFetcher<Iterable<org.opentripplanner.transit.model.basic.Notice>> notices();
     public DataFetcher<TripOccupancy> occupancy();
     public DataFetcher<TripPattern> pattern();
     public DataFetcher<Boolean> replacementsExist();

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -145,3 +145,4 @@ config:
     CanceledTripsSummary: org.opentripplanner.apis.gtfs.model.CanceledTripsSummary#CanceledTripsSummary
     CanceledTripsSummaryPattern: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryPattern#CanceledTripsSummaryPattern
     CanceledTripsSummaryRoute: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryRoute#CanceledTripsSummaryRoute
+    Notice: org.opentripplanner.transit.model.basic.Notice

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToTransitDataImportMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToTransitDataImportMapper.java
@@ -87,6 +87,9 @@ public class GTFSToTransitDataImportMapper {
 
   private final StopAreaMapper stopAreaMapper;
 
+  private final NoticeMapper noticeMapper;
+  private final NoticeAssignmentMapper noticeAssignmentMapper;
+
   private final TranslationHelper translationHelper;
   private final boolean discardMinTransferTimes;
 
@@ -167,6 +170,14 @@ public class GTFSToTransitDataImportMapper {
     );
     fareTransferRuleMapper = new FareTransferRuleMapper(idFactory, fareProductMapper);
     stopAreaMapper = new StopAreaMapper(idFactory);
+    noticeMapper = new NoticeMapper(idFactory);
+    noticeAssignmentMapper = new NoticeAssignmentMapper(
+      idFactory,
+      issueStore,
+      noticeMapper,
+      tripMapper,
+      routeMapper
+    );
   }
 
   public TransitDataImportBuilder getBuilder() {
@@ -218,6 +229,11 @@ public class GTFSToTransitDataImportMapper {
       .fareTransferRules()
       .addAll(fareTransferRuleMapper.map(data.getAllFareTransferRules()));
     fareRulesBuilder.stopAreas().putAll(stopAreaMapper.map(data.getAllStopAreaElements()));
+
+    noticeMapper.map(data.getAllNotices());
+    builder
+      .getNoticeAssignments()
+      .putAll(noticeAssignmentMapper.map(data.getAllNoticeAssignments()));
   }
 
   private void mapGtfsStopsToOtpTypes(Collection<Stop> stops) {

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.onebusaway.gtfs.model.NoticeAssignment;
@@ -48,15 +49,16 @@ class NoticeAssignmentMapper {
       .collect(Collectors.toMap(Trip::getId, Function.identity()));
     var routes = routeMapper.mappedRoutes();
     for (var assignment : assignments) {
-      mapOne(noticeMapper.mappedNotices(), assignment, result, trips, routes);
+      mapOne(noticeMapper.mappedNotices(), assignment, trips, routes).ifPresent(entry ->
+        result.put(entry.getKey(), entry.getValue())
+      );
     }
     return result;
   }
 
-  private void mapOne(
+  private Optional<Map.Entry<AbstractTransitEntity, Notice>> mapOne(
     Map<FeedScopedId, Notice> notices,
     NoticeAssignment assignment,
-    Multimap<AbstractTransitEntity, Notice> result,
     Map<FeedScopedId, Trip> trips,
     Map<FeedScopedId, Route> routes
   ) {
@@ -69,7 +71,7 @@ class NoticeAssignmentMapper {
         "Notice in notice assignment is missing for assignment %s",
         assignment
       );
-      return;
+      return Optional.empty();
     }
 
     var recordId = idFactory.createId(assignment.getRecordId(), "NoticeAssignment.recordId");
@@ -87,9 +89,9 @@ class NoticeAssignmentMapper {
         assignment.getTableName(),
         assignment.getRecordId()
       );
-      return;
+      return Optional.empty();
     }
 
-    result.put(entity, notice);
+    return Optional.of(Map.entry(entity, notice));
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
@@ -49,7 +49,7 @@ class NoticeAssignmentMapper {
       .collect(Collectors.toMap(Trip::getId, Function.identity()));
     var routes = routeMapper.mappedRoutes();
     for (var assignment : assignments) {
-      mapOne(noticeMapper.mappedNotices(), assignment, trips, routes).ifPresent(entry ->
+      mapOne(assignment, noticeMapper.mappedNotices(), trips, routes).ifPresent(entry ->
         result.put(entry.getKey(), entry.getValue())
       );
     }
@@ -57,8 +57,8 @@ class NoticeAssignmentMapper {
   }
 
   private Optional<Map.Entry<AbstractTransitEntity, Notice>> mapOne(
-    Map<FeedScopedId, Notice> notices,
     NoticeAssignment assignment,
+    Map<FeedScopedId, Notice> notices,
     Map<FeedScopedId, Trip> trips,
     Map<FeedScopedId, Route> routes
   ) {

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
@@ -1,0 +1,95 @@
+package org.opentripplanner.gtfs.mapping;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.onebusaway.gtfs.model.NoticeAssignment;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.transit.model.basic.Notice;
+import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.timetable.Trip;
+
+/**
+ * Maps GTFS notice_assignments.txt entries to OTP notice assignments, connecting each
+ * {@link Notice} to its target {@link Route} or {@link Trip}.
+ */
+class NoticeAssignmentMapper {
+
+  private final IdFactory idFactory;
+  private final DataImportIssueStore issueStore;
+  private final NoticeMapper noticeMapper;
+  private final RouteMapper routeMapper;
+  private final TripMapper tripMapper;
+
+  NoticeAssignmentMapper(
+    IdFactory idFactory,
+    DataImportIssueStore issueStore,
+    NoticeMapper noticeMapper,
+    TripMapper tripMapper,
+    RouteMapper routeMapper
+  ) {
+    this.idFactory = idFactory;
+    this.issueStore = issueStore;
+    this.noticeMapper = noticeMapper;
+    this.routeMapper = routeMapper;
+    this.tripMapper = tripMapper;
+  }
+
+  Multimap<AbstractTransitEntity, Notice> map(Collection<NoticeAssignment> assignments) {
+    Multimap<AbstractTransitEntity, Notice> result = ArrayListMultimap.create();
+    var trips = tripMapper
+      .getMappedTrips()
+      .stream()
+      .collect(Collectors.toMap(Trip::getId, Function.identity()));
+    var routes = routeMapper.mappedRoutes();
+    for (var assignment : assignments) {
+      mapOne(noticeMapper.mappedNotices(), assignment, result, trips, routes);
+    }
+    return result;
+  }
+
+  private void mapOne(
+    Map<FeedScopedId, Notice> notices,
+    NoticeAssignment assignment,
+    Multimap<AbstractTransitEntity, Notice> result,
+    Map<FeedScopedId, Trip> trips,
+    Map<FeedScopedId, Route> routes
+  ) {
+    var notice = notices.get(
+      idFactory.createId(assignment.getNoticeId(), "notice_id in notice assignment")
+    );
+    if (notice == null) {
+      issueStore.add(
+        "NoticeAssignmentWithoutNotice",
+        "Notice in notice assignment is missing for assignment %s",
+        assignment
+      );
+      return;
+    }
+
+    var recordId = idFactory.createId(assignment.getRecordId(), "NoticeAssignment.recordId");
+
+    AbstractTransitEntity entity = switch (assignment.getTableName()) {
+      case routes -> routes.get(recordId);
+      case trips -> trips.get(recordId);
+    };
+
+    if (entity == null) {
+      issueStore.add(
+        "NoticeAssignmentWithUnknownEntity",
+        "Could not map notice assignment %s for %s with id %s",
+        assignment.getId(),
+        assignment.getTableName(),
+        assignment.getRecordId()
+      );
+      return;
+    }
+
+    result.put(entity, notice);
+  }
+}

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeMapper.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.gtfs.mapping;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.transit.model.basic.Notice;
+
+/**
+ * Responsible for mapping onebusaway GTFS Notice into the OTP model.
+ * Caches mapped instances so that the same GTFS notice produces the same OTP notice object.
+ */
+class NoticeMapper {
+
+  private final IdFactory idFactory;
+  private final Map<FeedScopedId, Notice> cache = new HashMap<>();
+
+  NoticeMapper(IdFactory idFactory) {
+    this.idFactory = idFactory;
+  }
+
+  Collection<Notice> map(Collection<org.onebusaway.gtfs.model.Notice> gtfsNotices) {
+    return gtfsNotices.stream().map(this::map).toList();
+  }
+
+  Notice map(org.onebusaway.gtfs.model.Notice gtfsNotice) {
+    var notice = Notice.of(idFactory.createId(gtfsNotice.getId(), "Notice"))
+      .withText(gtfsNotice.getDisplayText())
+      .build();
+    return cache.computeIfAbsent(notice.getId(), _ -> notice);
+  }
+
+  Map<FeedScopedId, Notice> mappedNotices() {
+    return Collections.unmodifiableMap(cache);
+  }
+}

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeMapper.java
@@ -20,8 +20,8 @@ class NoticeMapper {
     this.idFactory = idFactory;
   }
 
-  Collection<Notice> map(Collection<org.onebusaway.gtfs.model.Notice> gtfsNotices) {
-    return gtfsNotices.stream().map(this::map).toList();
+  Collection<Notice> map(Collection<org.onebusaway.gtfs.model.Notice> notices) {
+    return notices.stream().map(this::map).toList();
   }
 
   Notice map(org.onebusaway.gtfs.model.Notice gtfsNotice) {

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -103,5 +105,12 @@ class RouteMapper {
     } else {
       return List.of(idFactory.createId(rhs.getNetworkId(), "route's network"));
     }
+  }
+
+  Map<FeedScopedId, Route> mappedRoutes() {
+    return mappedRoutes
+      .values()
+      .stream()
+      .collect(Collectors.toMap(Route::getId, Function.identity()));
   }
 }

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1050,6 +1050,17 @@ type Money {
   currency: Currency!
 }
 
+"""
+A textual message about a transit entity that is already known at planning time.
+
+It is not intended to convey real-time or emergency updates of the transit system but information that
+is known well ahead of time.
+"""
+type Notice {
+  "Textual representation of the message"
+  text: String
+}
+
 type OpeningHours {
   """
   Opening hours for the selected dates using the local time of the parking lot.
@@ -2243,6 +2254,8 @@ type Route implements Node {
   ): String
   "Transport mode of this route, e.g. `BUS`"
   mode: TransitMode
+  "Notices of this trip which are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   "List of patterns which operate on this route"
   patterns(
     """
@@ -2749,6 +2762,7 @@ type Trip implements Node {
   link in a DatedServiceJourney.
   """
   isReplacement: Boolean!
+  notices: [Notice!]!
   """
   The latest real-time occupancy information for the latest occurance of this
   trip.

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2762,7 +2762,8 @@ type Trip implements Node {
   link in a DatedServiceJourney.
   """
   isReplacement: Boolean!
-  notices: [Notice!]!
+  "Notices of the trip that are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   """
   The latest real-time occupancy information for the latest occurance of this
   trip.

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/NoticeImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/NoticeImplTest.java
@@ -1,0 +1,20 @@
+package org.opentripplanner.apis.gtfs.datafetchers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.apis.support.graphql.DataFetchingSupport.dataFetchingEnvironment;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.basic.Notice;
+
+class NoticeImplTest {
+
+  private static final NoticeImpl SUBJECT = new NoticeImpl();
+  private static final Notice NOTICE = Notice.of(id(1)).withText("AAA").build();
+
+  @Test
+  void text() throws Exception {
+    var env = dataFetchingEnvironment(NOTICE);
+    assertEquals("AAA", SUBJECT.text().get(env));
+  }
+}

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -2,8 +2,6 @@ package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.trip;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -13,7 +11,6 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
-import org.opentripplanner.transit.model.framework.DefaultEntityById;
 
 class NoticeAssignmentMapperTest {
 
@@ -23,6 +20,8 @@ class NoticeAssignmentMapperTest {
   private static final String NOTICE_ID = "N1";
   private static final String NOTICE_TEXT = "Platform change";
 
+  private static final GtfsTestData DATA = new GtfsTestData();
+
   private static final org.onebusaway.gtfs.model.Notice GTFS_NOTICE;
 
   static {
@@ -31,19 +30,39 @@ class NoticeAssignmentMapperTest {
     GTFS_NOTICE.setDisplayText(NOTICE_TEXT);
   }
 
+  private static RouteMapper createRouteMapper() {
+    return new RouteMapper(
+      ID_FACTORY,
+      new AgencyMapper(ID_FACTORY),
+      new RouteNetworkAssignmentMapper(ID_FACTORY),
+      DataImportIssueStore.NOOP,
+      new TranslationHelper()
+    );
+  }
+
+  private static TripMapper createTripMapper(RouteMapper routeMapper) {
+    return new TripMapper(
+      ID_FACTORY,
+      routeMapper,
+      new DirectionMapper(DataImportIssueStore.NOOP),
+      new TranslationHelper()
+    );
+  }
+
   @Test
   void mapNoticeAssignmentOnRoute() {
-    var route = route("R1").build();
+    var routeMapper = createRouteMapper();
+    var route = routeMapper.map(DATA.route);
 
-    var routesById = new DefaultEntityById<org.opentripplanner.transit.model.network.Route>();
-    routesById.add(route);
+    var noticeMapper = new NoticeMapper(ID_FACTORY);
+    noticeMapper.map(GTFS_NOTICE);
 
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       DataImportIssueStore.NOOP,
-      List.of(GTFS_NOTICE),
-      routesById,
-      new DefaultEntityById<>()
+      noticeMapper,
+      createTripMapper(routeMapper),
+      routeMapper
     );
 
     var assignment = new NoticeAssignment();
@@ -61,17 +80,19 @@ class NoticeAssignmentMapperTest {
 
   @Test
   void mapNoticeAssignmentOnTrip() {
-    var trip = trip("T1").build();
+    var routeMapper = createRouteMapper();
+    var tripMapper = createTripMapper(routeMapper);
+    var trip = tripMapper.map(DATA.trip);
 
-    var tripsById = new DefaultEntityById<org.opentripplanner.transit.model.timetable.Trip>();
-    tripsById.add(trip);
+    var noticeMapper = new NoticeMapper(ID_FACTORY);
+    noticeMapper.map(GTFS_NOTICE);
 
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       DataImportIssueStore.NOOP,
-      List.of(GTFS_NOTICE),
-      new DefaultEntityById<>(),
-      tripsById
+      noticeMapper,
+      tripMapper,
+      routeMapper
     );
 
     var assignment = new NoticeAssignment();
@@ -89,12 +110,14 @@ class NoticeAssignmentMapperTest {
   @Test
   void missingNoticeLogsIssue() {
     var issues = new DefaultDataImportIssueStore();
+    var noticeMapper = new NoticeMapper(ID_FACTORY);
+
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       issues,
-      List.of(),
-      new DefaultEntityById<>(),
-      new DefaultEntityById<>()
+      noticeMapper,
+      createTripMapper(createRouteMapper()),
+      createRouteMapper()
     );
 
     var assignment = new NoticeAssignment();
@@ -114,12 +137,15 @@ class NoticeAssignmentMapperTest {
   @Test
   void missingRouteEntityLogsIssue() {
     var issues = new DefaultDataImportIssueStore();
+    var noticeMapper = new NoticeMapper(ID_FACTORY);
+    noticeMapper.map(GTFS_NOTICE);
+
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       issues,
-      List.of(GTFS_NOTICE),
-      new DefaultEntityById<>(),
-      new DefaultEntityById<>()
+      noticeMapper,
+      createTripMapper(createRouteMapper()),
+      createRouteMapper()
     );
 
     var assignment = new NoticeAssignment();
@@ -139,12 +165,15 @@ class NoticeAssignmentMapperTest {
   @Test
   void missingTripEntityLogsIssue() {
     var issues = new DefaultDataImportIssueStore();
+    var noticeMapper = new NoticeMapper(ID_FACTORY);
+    noticeMapper.map(GTFS_NOTICE);
+
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       issues,
-      List.of(GTFS_NOTICE),
-      new DefaultEntityById<>(),
-      new DefaultEntityById<>()
+      noticeMapper,
+      createTripMapper(createRouteMapper()),
+      createRouteMapper()
     );
 
     var assignment = new NoticeAssignment();
@@ -163,20 +192,21 @@ class NoticeAssignmentMapperTest {
 
   @Test
   void multipleAssignmentsMappedTogether() {
-    var route = route("R1").build();
-    var trip = trip("T1").build();
+    var routeMapper = createRouteMapper();
+    var tripMapper = createTripMapper(routeMapper);
 
-    var routesById = new DefaultEntityById<org.opentripplanner.transit.model.network.Route>();
-    routesById.add(route);
-    var tripsById = new DefaultEntityById<org.opentripplanner.transit.model.timetable.Trip>();
-    tripsById.add(trip);
+    var route = routeMapper.map(DATA.route);
+    var trip = tripMapper.map(DATA.trip);
+
+    var noticeMapper = new NoticeMapper(ID_FACTORY);
+    noticeMapper.map(GTFS_NOTICE);
 
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       DataImportIssueStore.NOOP,
-      List.of(GTFS_NOTICE),
-      routesById,
-      tripsById
+      noticeMapper,
+      tripMapper,
+      routeMapper
     );
 
     var routeAssignment = new NoticeAssignment();

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -1,0 +1,198 @@
+package org.opentripplanner.gtfs.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.trip;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.NoticeAssignment;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.framework.DefaultEntityById;
+
+class NoticeAssignmentMapperTest {
+
+  private static final String FEED_ID = TimetableRepositoryForTest.FEED_ID;
+  private static final IdFactory ID_FACTORY = new IdFactory(FEED_ID);
+
+  private static final String NOTICE_ID = "N1";
+  private static final String NOTICE_TEXT = "Platform change";
+
+  private static final org.onebusaway.gtfs.model.Notice GTFS_NOTICE;
+
+  static {
+    GTFS_NOTICE = new org.onebusaway.gtfs.model.Notice();
+    GTFS_NOTICE.setId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    GTFS_NOTICE.setDisplayText(NOTICE_TEXT);
+  }
+
+  @Test
+  void mapNoticeAssignmentOnRoute() {
+    var route = route("R1").build();
+
+    var routesById = new DefaultEntityById<org.opentripplanner.transit.model.network.Route>();
+    routesById.add(route);
+
+    var mapper = new NoticeAssignmentMapper(
+      ID_FACTORY,
+      DataImportIssueStore.NOOP,
+      List.of(GTFS_NOTICE),
+      routesById,
+      new DefaultEntityById<>()
+    );
+
+    var assignment = new NoticeAssignment();
+    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setTableName(NoticeAssignment.TableName.routes);
+    assignment.setRecordId(new AgencyAndId(FEED_ID, "R1"));
+
+    var result = mapper.map(List.of(assignment));
+
+    assertEquals(1, result.size());
+    var notice = result.get(route).iterator().next();
+    assertEquals(NOTICE_ID, notice.getId().getId());
+    assertEquals(NOTICE_TEXT, notice.text());
+  }
+
+  @Test
+  void mapNoticeAssignmentOnTrip() {
+    var trip = trip("T1").build();
+
+    var tripsById = new DefaultEntityById<org.opentripplanner.transit.model.timetable.Trip>();
+    tripsById.add(trip);
+
+    var mapper = new NoticeAssignmentMapper(
+      ID_FACTORY,
+      DataImportIssueStore.NOOP,
+      List.of(GTFS_NOTICE),
+      new DefaultEntityById<>(),
+      tripsById
+    );
+
+    var assignment = new NoticeAssignment();
+    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setTableName(NoticeAssignment.TableName.trips);
+    assignment.setRecordId(new AgencyAndId(FEED_ID, "T1"));
+
+    var result = mapper.map(List.of(assignment));
+
+    assertEquals(1, result.size());
+    var notice = result.get(trip).iterator().next();
+    assertEquals(NOTICE_ID, notice.getId().getId());
+  }
+
+  @Test
+  void missingNoticeLogsIssue() {
+    var issues = new DefaultDataImportIssueStore();
+    var mapper = new NoticeAssignmentMapper(
+      ID_FACTORY,
+      issues,
+      List.of(),
+      new DefaultEntityById<>(),
+      new DefaultEntityById<>()
+    );
+
+    var assignment = new NoticeAssignment();
+    assignment.setNoticeId(new AgencyAndId(FEED_ID, "NONEXISTENT"));
+    assignment.setTableName(NoticeAssignment.TableName.routes);
+    assignment.setRecordId(new AgencyAndId(FEED_ID, "R1"));
+
+    var result = mapper.map(List.of(assignment));
+
+    assertTrue(result.isEmpty());
+    assertEquals(
+      List.of("NoticeAssignmentWithoutNotice"),
+      issues.listIssues().stream().map(DataImportIssue::getType).toList()
+    );
+  }
+
+  @Test
+  void missingRouteEntityLogsIssue() {
+    var issues = new DefaultDataImportIssueStore();
+    var mapper = new NoticeAssignmentMapper(
+      ID_FACTORY,
+      issues,
+      List.of(GTFS_NOTICE),
+      new DefaultEntityById<>(),
+      new DefaultEntityById<>()
+    );
+
+    var assignment = new NoticeAssignment();
+    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setTableName(NoticeAssignment.TableName.routes);
+    assignment.setRecordId(new AgencyAndId(FEED_ID, "NONEXISTENT"));
+
+    var result = mapper.map(List.of(assignment));
+
+    assertTrue(result.isEmpty());
+    assertEquals(
+      List.of("NoticeAssignmentWithUnknownEntity"),
+      issues.listIssues().stream().map(DataImportIssue::getType).toList()
+    );
+  }
+
+  @Test
+  void missingTripEntityLogsIssue() {
+    var issues = new DefaultDataImportIssueStore();
+    var mapper = new NoticeAssignmentMapper(
+      ID_FACTORY,
+      issues,
+      List.of(GTFS_NOTICE),
+      new DefaultEntityById<>(),
+      new DefaultEntityById<>()
+    );
+
+    var assignment = new NoticeAssignment();
+    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setTableName(NoticeAssignment.TableName.trips);
+    assignment.setRecordId(new AgencyAndId(FEED_ID, "NONEXISTENT"));
+
+    var result = mapper.map(List.of(assignment));
+
+    assertTrue(result.isEmpty());
+    assertEquals(
+      List.of("NoticeAssignmentWithUnknownEntity"),
+      issues.listIssues().stream().map(DataImportIssue::getType).toList()
+    );
+  }
+
+  @Test
+  void multipleAssignmentsMappedTogether() {
+    var route = route("R1").build();
+    var trip = trip("T1").build();
+
+    var routesById = new DefaultEntityById<org.opentripplanner.transit.model.network.Route>();
+    routesById.add(route);
+    var tripsById = new DefaultEntityById<org.opentripplanner.transit.model.timetable.Trip>();
+    tripsById.add(trip);
+
+    var mapper = new NoticeAssignmentMapper(
+      ID_FACTORY,
+      DataImportIssueStore.NOOP,
+      List.of(GTFS_NOTICE),
+      routesById,
+      tripsById
+    );
+
+    var routeAssignment = new NoticeAssignment();
+    routeAssignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    routeAssignment.setTableName(NoticeAssignment.TableName.routes);
+    routeAssignment.setRecordId(new AgencyAndId(FEED_ID, "R1"));
+
+    var tripAssignment = new NoticeAssignment();
+    tripAssignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    tripAssignment.setTableName(NoticeAssignment.TableName.trips);
+    tripAssignment.setRecordId(new AgencyAndId(FEED_ID, "T1"));
+
+    var result = mapper.map(List.of(routeAssignment, tripAssignment));
+
+    assertEquals(2, result.size());
+    assertEquals(1, result.get(route).size());
+    assertEquals(1, result.get(trip).size());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.gtfs.mapping;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.onebusaway.gtfs.model.AgencyAndIdFactory.obaId;
 
 import java.util.List;
@@ -111,13 +111,14 @@ class NoticeAssignmentMapperTest {
   void missingNoticeLogsIssue() {
     var issues = new DefaultDataImportIssueStore();
     var noticeMapper = new NoticeMapper(ID_FACTORY);
+    var routeMapper = createRouteMapper();
 
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       issues,
       noticeMapper,
-      createTripMapper(createRouteMapper()),
-      createRouteMapper()
+      createTripMapper(routeMapper),
+      routeMapper
     );
 
     var assignment = new NoticeAssignment();
@@ -127,10 +128,9 @@ class NoticeAssignmentMapperTest {
 
     var result = mapper.map(List.of(assignment));
 
-    assertTrue(result.isEmpty());
-    assertEquals(
-      List.of("NoticeAssignmentWithoutNotice"),
-      issues.listIssues().stream().map(DataImportIssue::getType).toList()
+    assertThat(result).isEmpty();
+    assertThat(issues.listIssues().stream().map(DataImportIssue::getType)).containsExactly(
+      "NoticeAssignmentWithoutNotice"
     );
   }
 
@@ -139,13 +139,14 @@ class NoticeAssignmentMapperTest {
     var issues = new DefaultDataImportIssueStore();
     var noticeMapper = new NoticeMapper(ID_FACTORY);
     noticeMapper.map(GTFS_NOTICE);
+    var routeMapper = createRouteMapper();
 
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       issues,
       noticeMapper,
-      createTripMapper(createRouteMapper()),
-      createRouteMapper()
+      createTripMapper(routeMapper),
+      routeMapper
     );
 
     var assignment = new NoticeAssignment();
@@ -155,10 +156,9 @@ class NoticeAssignmentMapperTest {
 
     var result = mapper.map(List.of(assignment));
 
-    assertTrue(result.isEmpty());
-    assertEquals(
-      List.of("NoticeAssignmentWithUnknownEntity"),
-      issues.listIssues().stream().map(DataImportIssue::getType).toList()
+    assertThat(result).isEmpty();
+    assertThat(issues.listIssues().stream().map(DataImportIssue::getType).toList()).containsExactly(
+      "NoticeAssignmentWithUnknownEntity"
     );
   }
 
@@ -167,13 +167,14 @@ class NoticeAssignmentMapperTest {
     var issues = new DefaultDataImportIssueStore();
     var noticeMapper = new NoticeMapper(ID_FACTORY);
     noticeMapper.map(GTFS_NOTICE);
+    var routeMapper = createRouteMapper();
 
     var mapper = new NoticeAssignmentMapper(
       ID_FACTORY,
       issues,
       noticeMapper,
-      createTripMapper(createRouteMapper()),
-      createRouteMapper()
+      createTripMapper(routeMapper),
+      routeMapper
     );
 
     var assignment = new NoticeAssignment();
@@ -183,10 +184,9 @@ class NoticeAssignmentMapperTest {
 
     var result = mapper.map(List.of(assignment));
 
-    assertTrue(result.isEmpty());
-    assertEquals(
-      List.of("NoticeAssignmentWithUnknownEntity"),
-      issues.listIssues().stream().map(DataImportIssue::getType).toList()
+    assertThat(result).isEmpty();
+    assertThat(issues.listIssues().stream().map(DataImportIssue::getType).toList()).containsExactly(
+      "NoticeAssignmentWithUnknownEntity"
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -2,10 +2,10 @@ package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.onebusaway.gtfs.model.AgencyAndIdFactory.obaId;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.NoticeAssignment;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -26,7 +26,7 @@ class NoticeAssignmentMapperTest {
 
   static {
     GTFS_NOTICE = new org.onebusaway.gtfs.model.Notice();
-    GTFS_NOTICE.setId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    GTFS_NOTICE.setId(obaId(NOTICE_ID));
     GTFS_NOTICE.setDisplayText(NOTICE_TEXT);
   }
 
@@ -66,9 +66,9 @@ class NoticeAssignmentMapperTest {
     );
 
     var assignment = new NoticeAssignment();
-    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setNoticeId(obaId(NOTICE_ID));
     assignment.setTableName(NoticeAssignment.TableName.routes);
-    assignment.setRecordId(new AgencyAndId(FEED_ID, "R1"));
+    assignment.setRecordId(obaId("R1"));
 
     var result = mapper.map(List.of(assignment));
 
@@ -96,9 +96,9 @@ class NoticeAssignmentMapperTest {
     );
 
     var assignment = new NoticeAssignment();
-    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setNoticeId(obaId(NOTICE_ID));
     assignment.setTableName(NoticeAssignment.TableName.trips);
-    assignment.setRecordId(new AgencyAndId(FEED_ID, "T1"));
+    assignment.setRecordId(obaId("T1"));
 
     var result = mapper.map(List.of(assignment));
 
@@ -121,9 +121,9 @@ class NoticeAssignmentMapperTest {
     );
 
     var assignment = new NoticeAssignment();
-    assignment.setNoticeId(new AgencyAndId(FEED_ID, "NONEXISTENT"));
+    assignment.setNoticeId(obaId("NONEXISTENT"));
     assignment.setTableName(NoticeAssignment.TableName.routes);
-    assignment.setRecordId(new AgencyAndId(FEED_ID, "R1"));
+    assignment.setRecordId(obaId("R1"));
 
     var result = mapper.map(List.of(assignment));
 
@@ -149,9 +149,9 @@ class NoticeAssignmentMapperTest {
     );
 
     var assignment = new NoticeAssignment();
-    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setNoticeId(obaId(NOTICE_ID));
     assignment.setTableName(NoticeAssignment.TableName.routes);
-    assignment.setRecordId(new AgencyAndId(FEED_ID, "NONEXISTENT"));
+    assignment.setRecordId(obaId("NONEXISTENT"));
 
     var result = mapper.map(List.of(assignment));
 
@@ -177,9 +177,9 @@ class NoticeAssignmentMapperTest {
     );
 
     var assignment = new NoticeAssignment();
-    assignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    assignment.setNoticeId(obaId(NOTICE_ID));
     assignment.setTableName(NoticeAssignment.TableName.trips);
-    assignment.setRecordId(new AgencyAndId(FEED_ID, "NONEXISTENT"));
+    assignment.setRecordId(obaId("NONEXISTENT"));
 
     var result = mapper.map(List.of(assignment));
 
@@ -210,14 +210,14 @@ class NoticeAssignmentMapperTest {
     );
 
     var routeAssignment = new NoticeAssignment();
-    routeAssignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    routeAssignment.setNoticeId(obaId(NOTICE_ID));
     routeAssignment.setTableName(NoticeAssignment.TableName.routes);
-    routeAssignment.setRecordId(new AgencyAndId(FEED_ID, "R1"));
+    routeAssignment.setRecordId(obaId("R1"));
 
     var tripAssignment = new NoticeAssignment();
-    tripAssignment.setNoticeId(new AgencyAndId(FEED_ID, NOTICE_ID));
+    tripAssignment.setNoticeId(obaId(NOTICE_ID));
     tripAssignment.setTableName(NoticeAssignment.TableName.trips);
-    tripAssignment.setRecordId(new AgencyAndId(FEED_ID, "T1"));
+    tripAssignment.setRecordId(obaId("T1"));
 
     var result = mapper.map(List.of(routeAssignment, tripAssignment));
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.onebusaway.gtfs.model.AgencyAndIdFactory.obaId;
 import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
@@ -34,7 +35,7 @@ class NoticeMapperTest {
   @Test
   void testPublicCodeIsNull() {
     var result = subject.map(GTFS_NOTICE);
-    assertEquals(null, result.publicCode());
+    assertNull(result.publicCode());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
@@ -2,10 +2,10 @@ package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.onebusaway.gtfs.model.AgencyAndIdFactory.obaId;
+import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
 
 import org.junit.jupiter.api.Test;
-import org.onebusaway.gtfs.model.AgencyAndId;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 
 class NoticeMapperTest {
 
@@ -16,19 +16,17 @@ class NoticeMapperTest {
 
   static {
     GTFS_NOTICE = new org.onebusaway.gtfs.model.Notice();
-    GTFS_NOTICE.setId(new AgencyAndId(TimetableRepositoryForTest.FEED_ID, NOTICE_ID));
+    GTFS_NOTICE.setId(obaId(NOTICE_ID));
     GTFS_NOTICE.setDisplayText(DISPLAY_TEXT);
   }
 
-  private final NoticeMapper subject = new NoticeMapper(
-    new IdFactory(TimetableRepositoryForTest.FEED_ID)
-  );
+  private final NoticeMapper subject = new NoticeMapper(new IdFactory(FEED_ID));
 
   @Test
   void testMap() {
     var result = subject.map(GTFS_NOTICE);
 
-    assertEquals(TimetableRepositoryForTest.FEED_ID, result.getId().getFeedId());
+    assertEquals(FEED_ID, result.getId().getFeedId());
     assertEquals(NOTICE_ID, result.getId().getId());
     assertEquals(DISPLAY_TEXT, result.text());
   }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
@@ -1,0 +1,48 @@
+package org.opentripplanner.gtfs.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+
+class NoticeMapperTest {
+
+  private static final String NOTICE_ID = "N1";
+  private static final String DISPLAY_TEXT = "Platform change";
+
+  private static final org.onebusaway.gtfs.model.Notice GTFS_NOTICE;
+
+  static {
+    GTFS_NOTICE = new org.onebusaway.gtfs.model.Notice();
+    GTFS_NOTICE.setId(new AgencyAndId(TimetableRepositoryForTest.FEED_ID, NOTICE_ID));
+    GTFS_NOTICE.setDisplayText(DISPLAY_TEXT);
+  }
+
+  private final NoticeMapper subject = new NoticeMapper(
+    new IdFactory(TimetableRepositoryForTest.FEED_ID)
+  );
+
+  @Test
+  void testMap() {
+    var result = subject.map(GTFS_NOTICE);
+
+    assertEquals(TimetableRepositoryForTest.FEED_ID, result.getId().getFeedId());
+    assertEquals(NOTICE_ID, result.getId().getId());
+    assertEquals(DISPLAY_TEXT, result.text());
+  }
+
+  @Test
+  void testPublicCodeIsNull() {
+    var result = subject.map(GTFS_NOTICE);
+    assertEquals(null, result.publicCode());
+  }
+
+  @Test
+  void testMapCacheReturnsSameInstance() {
+    var result1 = subject.map(GTFS_NOTICE);
+    var result2 = subject.map(GTFS_NOTICE);
+    assertSame(result1, result2);
+  }
+}


### PR DESCRIPTION
### Summary

This parses the GTFS spec proposal for notices into our internal data model. This internal model is used already by NeTEx and the GTFS equivalent is very similar. In fact the GTFS spec proposal is heavily influenced by NeTEx.

It also adds resolvers to the GTFS API. In order to give ourselves the opportunity to change the API I marked them as deprecated and added a warning.

### Issue

https://github.com/google/transit/issues/620

### Unit tests

Lots added.

### Documentation

Javadoc and schema docs.

### Changelog

Yes.

### Bumping the serialization version id

No serialized object changed, so no bump necessary.

cc @alec-georgoff @sebastianknopf