### PR TITLE
Disallow incorrect time in StateEditor

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -361,16 +361,6 @@ public final class State implements AStarState<State, Edge, Vertex> {
   }
 
   /**
-   * Whether we know or don't know the rental network (yet).
-   * <p>
-   * When doing a arriveBy search it is possible to be in a renting state without knowing which
-   * network it is.
-   */
-  public boolean unknownRentalNetwork() {
-    return stateData.vehicleRentalNetwork == null;
-  }
-
-  /**
    * Reverse the path implicit in the given state, the path will be reversed but will have the same
    * duration. This is the result of combining the functions from GraphPath optimize and reverse.
    *

--- a/street/src/main/java/org/opentripplanner/street/search/state/State.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/State.java
@@ -581,16 +581,4 @@ public final class State implements AStarState<State, Edge, Vertex> {
     newStateData.backMode = null;
     return new State(this.vertex, getTime(), newStateData, reversedRequest);
   }
-
-  /**
-   * This exception is thrown when an edge has a negative weight. Dijkstra's algorithm (and A*) don't
-   * work on graphs that have negative weights.  This exception almost always indicates a programming
-   * error, but could be caused by bad GTFS data.
-   */
-  private static class NegativeWeightException extends RuntimeException {
-
-    public NegativeWeightException(String message) {
-      super(message);
-    }
-  }
 }

--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -2,7 +2,6 @@ package org.opentripplanner.street.search.state;
 
 import java.util.HashSet;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType.PropulsionType;
 import org.opentripplanner.service.vehiclerental.street.geofencing.GeofencingBoundaryExtension;
@@ -97,7 +96,6 @@ public class StateEditor {
   /**
    * Builds a new state from the current state editor.
    */
-  @Nullable
   public State makeState() {
     if (backState != null) {
       // check that time changes are coherent with edge traversal

--- a/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
+++ b/street/src/main/java/org/opentripplanner/street/search/state/StateEditor.java
@@ -12,8 +12,6 @@ import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is a wrapper around a new State that provides it with setter and increment methods,
@@ -25,7 +23,6 @@ import org.slf4j.LoggerFactory;
  */
 public class StateEditor {
 
-  private static final Logger LOG = LoggerFactory.getLogger(StateEditor.class);
   private final StreetSearchRequest request;
   private final State backState;
   private final Edge backEdge;
@@ -97,15 +94,8 @@ public class StateEditor {
     }
   }
 
-  /* PUBLIC METHODS */
-
   /**
-   *
-   * Why can a state editor only be used once? If you modify some component of state with and
-   * editor, use the editor to create a new state, and then make more modifications, these
-   * modifications will be applied to the previously created state. Reusing the state editor to make
-   * several states would modify an existing state somewhere earlier in the search, messing up the
-   * shortest path tree.
+   * Builds a new state from the current state editor.
    */
   @Nullable
   public State makeState() {
@@ -114,8 +104,10 @@ public class StateEditor {
       // direction
       double timeDelta = time_ms - backState.getTimeMilliseconds();
       if (traversingBackward ? (timeDelta > 0) : (timeDelta < 0)) {
-        LOG.trace("Time was incremented the wrong direction during state editing. {}", backEdge);
-        return null;
+        throw new IllegalStateException(
+          "Time was incremented the wrong direction during state editing, while traversing " +
+            backEdge
+        );
       }
     }
     return new State(
@@ -141,8 +133,6 @@ public class StateEditor {
   public String toString() {
     return "StateEditor{" + backState + "}";
   }
-
-  /* PUBLIC METHODS TO MODIFY A STATE BEFORE IT IS USED */
 
   /* Incrementors */
 
@@ -188,8 +178,6 @@ public class StateEditor {
     }
     this.traversalDistance_m += length;
   }
-
-  /* Basic Setters */
 
   public void resetEnteredNoThroughTrafficArea() {
     if (!stateData.enteredNoThroughTrafficArea) {
@@ -437,13 +425,9 @@ public class StateEditor {
     this.time_ms = 1000 * seconds;
   }
 
-  /* PUBLIC GETTER METHODS */
-
   public State getBackState() {
     return backState;
   }
-
-  /* PRIVATE METHODS */
 
   /**
    * To be called before modifying anything in the child's StateData. Makes sure that changes are


### PR DESCRIPTION
### Summary

This is the next in a long series of PRs that make the StateEditor reject invalid data with an exception rather than allowing it to silently carry on.

### Issue

Follow up to #7670