### PR TITLE
Carpool bound access egress routing cost

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolEstimatedVehicleJourneyData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolEstimatedVehicleJourneyData.java
@@ -133,6 +133,24 @@ public class CarpoolEstimatedVehicleJourneyData {
     return journey;
   }
 
+  /**
+   * Aimed times are absent, so call-order validation cannot compare them — the inverted timeline
+   * is only visible on the derived expected start/end times.
+   */
+  public static EstimatedVehicleJourney expectedArrivalBeforeExpectedDeparture() {
+    var journey = minimalCompleteJourney();
+
+    var firstStop = journey.getEstimatedCalls().getEstimatedCalls().getFirst();
+    var lastStop = journey.getEstimatedCalls().getEstimatedCalls().getLast();
+
+    firstStop.setAimedDepartureTime(null);
+    firstStop.setExpectedDepartureTime(ZonedDateTime.now().plusMinutes(45));
+    lastStop.setAimedArrivalTime(null);
+    lastStop.setExpectedArrivalTime(ZonedDateTime.now());
+
+    return journey;
+  }
+
   public static EstimatedVehicleJourney journeyWithPublicContact(String phoneNumber, String url) {
     var journey = minimalCompleteJourney();
     var contact = new SimpleContactStructure();
@@ -290,6 +308,56 @@ public class CarpoolEstimatedVehicleJourneyData {
     var base = lastStop.getAimedArrivalTime();
     lastStop.setExpectedArrivalTime(null);
     lastStop.setLatestExpectedArrivalTime(base.plusMinutes(latestExpectedArrivalMinutes));
+    return journey;
+  }
+
+  /**
+   * A two-stop journey whose destination latest-expected arrival is 3 hours after departure —
+   * beyond the mapper's 2.5-hour maximum trip duration — used to exercise the max-duration
+   * safeguard. The scheduled arrival stays short, so only the latest-expected arrival pushes the
+   * span over the limit.
+   */
+  public static EstimatedVehicleJourney tripExceedingMaxDuration() {
+    var journey = minimalCompleteJourney();
+    var calls = journey.getEstimatedCalls().getEstimatedCalls();
+    var departure = calls.getFirst().getAimedDepartureTime();
+    calls.getLast().setLatestExpectedArrivalTime(departure.plusHours(3));
+    return journey;
+  }
+
+  /**
+   * A two-stop journey with no latest-expected arrival whose scheduled arrival (2h20m after
+   * departure) is within the 2.5-hour limit, but exceeds it once the default 15-minute deviation
+   * budget is added — exercising the safeguard's deviation-budget fallback.
+   */
+  public static EstimatedVehicleJourney tripExceedingMaxDurationViaDefaultDeviationBudget() {
+    var journey = minimalCompleteJourney();
+    var calls = journey.getEstimatedCalls().getEstimatedCalls();
+    var departure = calls.getFirst().getAimedDepartureTime();
+    calls.getLast().setAimedArrivalTime(departure.plusMinutes(140));
+    return journey;
+  }
+
+  /**
+   * A two-stop journey whose claimed schedule is short (well within the limit) but whose waypoints
+   * lie hundreds of kilometres apart, so the straight-line drive time exceeds the maximum trip
+   * duration even at the fastest modelled car speed. Exercises the geometry safeguard, which the
+   * timetable check cannot catch: a malformed feed can claim any times it likes regardless of how
+   * far apart the coordinates actually are.
+   */
+  public static EstimatedVehicleJourney tripWithWaypointsTooFarApart() {
+    var journey = minimalCompleteJourney();
+    var calls = journey.getEstimatedCalls().getEstimatedCalls();
+    var departure = calls.getFirst().getAimedDepartureTime();
+
+    // ~450 km north of the Oslo origin: unreachable within 2.5 h even at the maximum modelled car
+    // speed, yet the claimed arrival stays a plausible 45 minutes out.
+    var farStop = forPoint(new WgsCoordinate(64.0, 10.81));
+    farStop.setAimedDepartureTime(departure);
+    farStop.setAimedArrivalTime(departure.plusMinutes(45));
+    addStopName(farStop, "Far stop");
+    calls.set(1, farStop);
+
     return journey;
   }
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepositoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepositoryTest.java
@@ -7,9 +7,14 @@ import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_EAS
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
+import org.opentripplanner.ext.carpooling.model.CarpoolStop;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
+import org.opentripplanner.street.geometry.WgsCoordinate;
 
 class DefaultCarpoolingRepositoryTest {
 
@@ -90,6 +95,115 @@ class DefaultCarpoolingRepositoryTest {
       repository.removeExpiredTrips(NOON.plusHours(2).toInstant(), Duration.ZERO)
     ).isEqualTo(1);
     assertThat(repository.getCarpoolTrips()).isEmpty();
+  }
+
+  @Test
+  void keepsCachedRoutingAcrossASameGeometryUpsert() {
+    var repository = new DefaultCarpoolingRepository();
+    var trip = tripWithCoordinates("kept", OSLO_CENTER, OSLO_EAST, NOON.plusHours(1));
+    repository.upsertCarpoolTrip(trip);
+    repository.cacheBaselineRouting(trip, new Duration[] { Duration.ofMinutes(12) });
+
+    // A budget- or time-only update keeps the same route points, so the cache survives.
+    var updated = tripWithCoordinates("kept", OSLO_CENTER, OSLO_EAST, NOON.plusHours(2));
+    repository.upsertCarpoolTrip(updated);
+
+    var cached = repository.cachedBaselineRouting(updated);
+    assertThat(cached).isNotNull();
+    assertThat(cached.legDurations()).asList().containsExactly(Duration.ofMinutes(12));
+  }
+
+  @Test
+  void cachesAnUnroutableBaseline() {
+    var repository = new DefaultCarpoolingRepository();
+    var trip = tripWithCoordinates("unroutable", OSLO_CENTER, OSLO_EAST, NOON.plusHours(1));
+    repository.upsertCarpoolTrip(trip);
+    repository.cacheBaselineRouting(trip, null);
+
+    // A cached failure is a hit (so the trip is not re-routed) whose durations are absent.
+    var cached = repository.cachedBaselineRouting(trip);
+    assertThat(cached).isNotNull();
+    assertThat(cached.legDurations()).isNull();
+  }
+
+  @Test
+  void ignoresCachedRoutingWhenQueriedWithDifferentGeometry() {
+    var repository = new DefaultCarpoolingRepository();
+    var trip = tripWithCoordinates("guard", OSLO_CENTER, OSLO_EAST, NOON.plusHours(1));
+    repository.upsertCarpoolTrip(trip);
+    repository.cacheBaselineRouting(trip, new Duration[] { Duration.ofMinutes(12) });
+
+    // A concurrent re-route can leave an entry under this id while the trip already has new
+    // geometry. Validating against the trip's route points treats that as a miss rather than
+    // serving a stale verdict.
+    var moved = tripWithCoordinates("guard", OSLO_CENTER, new WgsCoordinate(60.0, 11.0), NOON);
+    assertThat(repository.cachedBaselineRouting(moved)).isNull();
+  }
+
+  @Test
+  void dropsCachedRoutingWhenTripRemoved() {
+    var repository = new DefaultCarpoolingRepository();
+    var trip = tripWithCoordinates("removed", OSLO_CENTER, OSLO_EAST, NOON.plusHours(1));
+    repository.upsertCarpoolTrip(trip);
+    repository.cacheBaselineRouting(trip, new Duration[] { Duration.ofMinutes(12) });
+
+    repository.removeCarpoolTrip(trip.getId());
+
+    assertThat(repository.cachedBaselineRouting(trip)).isNull();
+  }
+
+  @Test
+  void dropsCachedRoutingWhenTripExpires() {
+    var repository = new DefaultCarpoolingRepository();
+    var trip = tripWithCoordinates("expired", OSLO_CENTER, OSLO_EAST, NOON);
+    repository.upsertCarpoolTrip(trip);
+    repository.cacheBaselineRouting(trip, new Duration[] { Duration.ofMinutes(12) });
+
+    repository.removeExpiredTrips(NOON.plusHours(1).toInstant(), Duration.ZERO);
+
+    assertThat(repository.cachedBaselineRouting(trip)).isNull();
+  }
+
+  @Test
+  void returnsADefensiveCopyOfCachedDurations() {
+    var repository = new DefaultCarpoolingRepository();
+    var trip = tripWithCoordinates("copy", OSLO_CENTER, OSLO_EAST, NOON.plusHours(1));
+    repository.upsertCarpoolTrip(trip);
+    var stored = new Duration[] { Duration.ofMinutes(12) };
+    repository.cacheBaselineRouting(trip, stored);
+
+    // Neither mutating the stored source array nor the returned array may corrupt the cache.
+    stored[0] = Duration.ofMinutes(99);
+    repository.cachedBaselineRouting(trip).legDurations()[0] = Duration.ofMinutes(7);
+
+    assertThat(repository.cachedBaselineRouting(trip).legDurations())
+      .asList()
+      .containsExactly(Duration.ofMinutes(12));
+  }
+
+  private static CarpoolTrip tripWithCoordinates(
+    String id,
+    WgsCoordinate origin,
+    WgsCoordinate destination,
+    ZonedDateTime endTime
+  ) {
+    return new CarpoolTripBuilder(FeedScopedId.ofNullable("TEST", id))
+      .withStops(
+        List.of(
+          CarpoolStop.of(FeedScopedId.ofNullable("TEST", id + "-origin"))
+            .withCoordinate(origin)
+            .withOnboardCount(1)
+            .build(),
+          CarpoolStop.of(FeedScopedId.ofNullable("TEST", id + "-destination"))
+            .withCoordinate(destination)
+            .withOnboardCount(1)
+            .build()
+        )
+      )
+      .withTotalCapacity(CarpoolTrip.DEFAULT_TOTAL_CAPACITY)
+      .withStartTime(NOON)
+      .withEndTime(endTime)
+      .build();
   }
 
   private static CarpoolTrip tripEndingAt(ZonedDateTime endTime) {

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouterTest.java
@@ -9,15 +9,22 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.TestOtpModel;
+import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.linking.TemporaryVerticesContainer;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
+import org.opentripplanner.street.model.vertex.Vertex;
 
 class CarpoolTreeStreetRouterTest extends GraphRoutingTest {
 
   private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
   private static final Duration SEARCH_LIMIT = Duration.ofMinutes(30);
 
+  private TestOtpModel model;
   private IntersectionVertex vertexA;
   private IntersectionVertex vertexB;
   private IntersectionVertex vertexC;
@@ -28,7 +35,7 @@ class CarpoolTreeStreetRouterTest extends GraphRoutingTest {
 
   @BeforeEach
   void setUp() {
-    modelOf(
+    model = modelOf(
       new Builder() {
         @Override
         public void build() {
@@ -202,6 +209,59 @@ class CarpoolTreeStreetRouterTest extends GraphRoutingTest {
     assertFalse(path.states.isEmpty(), "Path states should not be empty");
     assertNotNull(path.edges, "Path should have edges");
     assertFalse(path.edges.isEmpty(), "Path edges should not be empty");
+  }
+
+  @Test
+  void coLocatedVerticesKeepTheLargestLimit() {
+    // Two driver-waypoint vertices at the same coordinate are distinct objects but compare equal
+    // (TemporaryStreetLocation equality is coordinate-based), so they share one registration.
+    // Registering the small limit last must not shrink the tree below the large one: D (1500 m,
+    // ~2 min by car) is reachable only under the 5-minute limit, not the 20-second one.
+    var shortLimit = Duration.ofSeconds(20);
+    var longLimit = Duration.ofMinutes(5);
+
+    var first = driverWaypointAt(ORIGIN);
+    var second = driverWaypointAt(ORIGIN);
+
+    router.addVertex(first, CarpoolTreeStreetRouter.Direction.FROM, longLimit);
+    router.addVertex(second, CarpoolTreeStreetRouter.Direction.FROM, shortLimit);
+
+    assertEquals(1, router.forwardTreeCount(), "Co-located vertices should share one tree");
+    assertNotNull(
+      router.route(first, vertexD),
+      "The shared tree must keep the larger limit and still reach the far vertex"
+    );
+  }
+
+  @Test
+  void coLocatedVerticesKeepTheLargestLimitRegardlessOfOrder() {
+    var shortLimit = Duration.ofSeconds(20);
+    var longLimit = Duration.ofMinutes(5);
+
+    var first = driverWaypointAt(ORIGIN);
+    var second = driverWaypointAt(ORIGIN);
+
+    // Small limit first, large limit second — the large limit must still win.
+    router.addVertex(first, CarpoolTreeStreetRouter.Direction.FROM, shortLimit);
+    router.addVertex(second, CarpoolTreeStreetRouter.Direction.FROM, longLimit);
+
+    assertNotNull(
+      router.route(first, vertexD),
+      "Registration order must not change the kept limit"
+    );
+  }
+
+  private Vertex driverWaypointAt(WgsCoordinate coord) {
+    var vertexCreationService = new VertexCreationService(
+      VertexLinkerTestFactory.of(model.graph())
+    );
+    var streetVertexUtils = new StreetVertexUtils(
+      vertexCreationService,
+      new TemporaryVerticesContainer()
+    );
+    var vertex = streetVertexUtils.createDriverWaypointVertex(coord);
+    assertNotNull(vertex, "Driver waypoint vertex should link to the graph");
+    return vertex;
   }
 
   @Test

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
@@ -80,8 +80,7 @@ class InsertionEvaluatorTest {
   }
 
   /**
-   * Helper method that mimics the old findOptimalInsertion() behavior for backwards compatibility in tests.
-   * This explicitly performs position finding followed by evaluation.
+   * Runs position finding followed by evaluation and returns the best insertion.
    */
   private InsertionCandidate findOptimalInsertion(
     CarpoolTrip trip,

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/CarpoolingServiceTestContext.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/CarpoolingServiceTestContext.java
@@ -1,0 +1,63 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import org.opentripplanner.TestOtpModel;
+import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
+import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.linking.internal.VertexCreationService;
+import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.transit.service.TransitServiceResolver;
+
+/**
+ * Wires a {@link DefaultCarpoolingService} with an empty repository and in-memory dependencies on
+ * top of a {@link org.opentripplanner.routing.algorithm.GraphRoutingTest} street graph model.
+ */
+record CarpoolingServiceTestContext(
+  DefaultCarpoolingService service,
+  CarpoolingRepository repository,
+  TransitServiceResolver transitServiceResolver
+) {
+  private static final StreetLimitationParametersService STREET_LIMITATION_PARAMETERS =
+    new StreetLimitationParametersService() {
+      @Override
+      public float maxCarSpeed() {
+        return 40.0f;
+      }
+
+      @Override
+      public int maxAreaNodes() {
+        return 500;
+      }
+
+      @Override
+      public float getBestWalkSafety() {
+        return 1;
+      }
+
+      @Override
+      public float getBestBikeSafety() {
+        return 1;
+      }
+    };
+
+  static CarpoolingServiceTestContext of(TestOtpModel model) {
+    var vertexCreationService = new VertexCreationService(
+      VertexLinkerTestFactory.of(model.graph())
+    );
+    TransitService transitService = new DefaultTransitService(model.timetableRepository());
+    var repository = new DefaultCarpoolingRepository();
+    var service = new DefaultCarpoolingService(
+      repository,
+      STREET_LIMITATION_PARAMETERS,
+      transitService,
+      vertexCreationService
+    );
+    return new CarpoolingServiceTestContext(
+      service,
+      repository,
+      new TransitServiceResolver(transitService)
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.internal.CarpoolItineraryMapper;
-import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
@@ -31,20 +30,13 @@ import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
-import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.model.organization.ContactInfo;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.service.TransitServiceResolver;
 
 /**
@@ -200,43 +192,10 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
       }
     );
 
-    Graph graph = model.graph();
-    var timetableRepository = model.timetableRepository();
-    VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
-    var vertexCreationService = new VertexCreationService(vertexLinker);
-    TransitService transitService = new DefaultTransitService(timetableRepository);
-    transitServiceResolver = new TransitServiceResolver(transitService);
-    repository = new DefaultCarpoolingRepository();
-
-    StreetLimitationParametersService streetLimitationParams =
-      new StreetLimitationParametersService() {
-        @Override
-        public float maxCarSpeed() {
-          return 40.0f;
-        }
-
-        @Override
-        public int maxAreaNodes() {
-          return 500;
-        }
-
-        @Override
-        public float getBestWalkSafety() {
-          return 1;
-        }
-
-        @Override
-        public float getBestBikeSafety() {
-          return 1;
-        }
-      };
-
-    service = new DefaultCarpoolingService(
-      repository,
-      streetLimitationParams,
-      transitService,
-      vertexCreationService
-    );
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
+    transitServiceResolver = context.transitServiceResolver();
   }
 
   private IntersectionVertex vertexA;

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceCrossLegInsertionTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceCrossLegInsertionTest.java
@@ -1,0 +1,215 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.ext.carpooling.model.CarpoolStop;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitServiceResolver;
+
+/**
+ * Tests {@link DefaultCarpoolingService#routeAccessEgress} on a cross-leg insertion — pickup on
+ * one leg of a multi-stop driver trip, dropoff on a later leg — whose
+ * {@code passenger → next waypoint} drive exceeds the nearby-stop search radius
+ * ({@link DefaultCarpoolingService#MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS},
+ * 60 minutes). It is found only because the passenger's routing tree is sized to the largest
+ * candidate leg limit, not to a fixed cap.
+ *
+ * <pre>
+ *   Right = EAST. The two legs run opposite ways over the same ground, so they are
+ *   drawn on two lines; the small vertical gap is NOT north/south.
+ *
+ *   P
+ *   │
+ *   A ━━━━━━━━━━━━━━━━━━━━━━━━━━━━▶ X ━▶ M
+ *    ╲                                   ┃
+ *     D ◀━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+ *     │
+ *     S
+ *
+ *   leg 1  A → X → M : one-way EAST, 37 + 5 km, 70 min  (X just W of M, the 61.7-min mark)
+ *   leg 2  M → D     : one-way WEST, 36 km, 60 min
+ *   A ↔ D            : two-way local road, 6 km, 10 min
+ *   A and D are close together; X and M are ~40 km EAST and only ~2 km north.
+ *   P = passenger (10 meters N of A)    S = only transit stop (10 meters S of D)
+ * </pre>
+ *
+ * Because the route loops far out to M and then doubles back to D right beside A, a cross-leg
+ * insertion is the only feasible one (see below). The 2 km north offset of X and M is only there to
+ * keep each waypoint off another street's geometry; every street length is declared (at a flat
+ * 10 m/s), so the leg times above are exact. Deviation budget: 10 min at M and D, 0 at A.
+ * <p>
+ * Access request: passenger at P, dropped at the only stop S. S is 10 car-minutes from P over the
+ * local road, so the nearby-stop search (≤ 60 min) finds it easily.
+ * <p>
+ * The only insertion that fits the budget is cross-leg: pick up P on leg A → M and drop S on leg
+ * M → D, giving A → P → M → S → D. Dropping S on the first leg instead (A → P → S → M) would reach
+ * M at ~90 min against a 70-min schedule, blowing the 10-min budget.
+ * <p>
+ * That makes the P → M ride a 70-min drive — longer than the 60-min radius — and it is routed
+ * solely through the passenger's own forward tree (inserted passenger segments have no
+ * goal-directed fallback). So it routes only because that tree is sized to the largest leg limit:
+ * 70 + 1 (slack) + 10 (budget) = 81 min.
+ * <p>
+ * X is what makes a too-small tree actually fail here: {@code DurationSkipEdgeStrategy} prunes an
+ * edge by the elapsed time at its start, so a single 42-km A → M edge would be crossed in one step
+ * from ~0 elapsed and defeat any limit. Splitting it at X (61.7 min) lets a 60-min tree reach X but
+ * prune X → M, while the 81-min tree spans the whole leg.
+ */
+class DefaultCarpoolingServiceCrossLegInsertionTest extends GraphRoutingTest {
+
+  private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
+  private static final ZoneId ZONE = ZoneId.of("Europe/Oslo");
+  private static final ZonedDateTime SEARCH_TIME = LocalDateTime.of(2025, 6, 15, 12, 0).atZone(
+    ZONE
+  );
+
+  // 10 m/s car speed keeps the arithmetic obvious: seconds == meters / 10.
+  private static final float CAR_SPEED_MPS = 10.0f;
+  private static final Duration BUDGET = Duration.ofMinutes(10);
+
+  private DefaultCarpoolingService service;
+  private CarpoolingRepository repository;
+  private TransitServiceResolver transitServiceResolver;
+
+  private TransitStopVertex stopS;
+  private WgsCoordinate coordA;
+  private WgsCoordinate coordM;
+  private WgsCoordinate coordD;
+  private WgsCoordinate coordP;
+
+  @BeforeEach
+  void setUp() {
+    var model = modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          var A = intersection("A", ORIGIN);
+          // X and M sit 2 km north of the A–D line. With all vertices collinear, D would lie
+          // exactly on the A → X street's geometry, so linking the D driver waypoint would split
+          // that street and open a shortcut from D's area onto the corridor — bypassing the
+          // one-way layout the test depends on.
+          var X = intersection("X", ORIGIN.moveEastMeters(37000).moveNorthMeters(2000));
+          var M = intersection("M", ORIGIN.moveEastMeters(42000).moveNorthMeters(2000));
+          var D = intersection("D", ORIGIN.moveEastMeters(6000));
+
+          coordA = A.toWgsCoordinate();
+          coordM = M.toWgsCoordinate();
+          coordD = D.toWgsCoordinate();
+
+          // One-way driver legs: out to M via X, back past A's area to D. X sits beyond the
+          // 60-min mark so a tree capped there prunes X → M and cannot reach M (see class doc).
+          street(A, X, 37000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(X, M, 5000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(M, D, 36000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          // Bidirectional local road tying A's area to D's, so the stop search from P reaches S
+          // and an early dropoff of S has a (budget-breaching) way back to M.
+          street(A, D, 6000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(D, A, 6000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+
+          // Passenger spur just north of A and a transit stop spur just south of D, both on the
+          // drivable network so pickup/dropoff need no walking.
+          var iP = intersection("iP", ORIGIN.moveNorthMeters(10));
+          biStreet(A, iP, 10);
+          coordP = iP.toWgsCoordinate();
+
+          var iS = intersection("iS", ORIGIN.moveEastMeters(6000).moveSouthMeters(10));
+          biStreet(D, iS, 10);
+          stopS = stop("S", iS.toWgsCoordinate());
+          biLink(iS, stopS);
+        }
+      }
+    );
+
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
+    transitServiceResolver = context.transitServiceResolver();
+  }
+
+  @Test
+  void findsCrossLegInsertionWithPassengerSegmentLongerThanNearbyStopRadius() {
+    var tripStart = SEARCH_TIME.plusMinutes(30);
+    repository.upsertCarpoolTrip(trip(tripStart));
+
+    var request = RouteRequest.of()
+      .withFrom(GenericLocation.fromCoordinate(coordP.latitude(), coordP.longitude()))
+      .withTo(GenericLocation.fromCoordinate(coordM.latitude(), coordM.longitude()))
+      .withDateTime(SEARCH_TIME.toInstant())
+      .withJourney(j -> j.withAccess(new StreetRequest(StreetMode.CARPOOL)))
+      .buildRequest();
+
+    var results = service.routeAccessEgress(
+      request,
+      new StreetRequest(StreetMode.CARPOOL),
+      AccessEgressType.ACCESS,
+      transitServiceResolver,
+      SEARCH_TIME
+    );
+
+    assertFalse(
+      results.isEmpty(),
+      "A budget-feasible cross-leg insertion whose passenger → waypoint segment exceeds the " +
+        "nearby-stop radius should produce access candidates"
+    );
+
+    int stopSIndex = transitServiceResolver.getStop(stopS.getId()).getIndex();
+    assertTrue(
+      results.stream().anyMatch(r -> r.stop() == stopSIndex),
+      "Access results should include stop S on the trip's second leg"
+    );
+  }
+
+  /**
+   * A → M → D with scheduled legs of 70 and 60 minutes, matching the street network's actual
+   * driving times, and a 10-minute deviation budget at M and D.
+   */
+  private CarpoolTrip trip(ZonedDateTime tripStart) {
+    var origin = CarpoolStop.of(stopId("A"))
+      .withCoordinate(coordA)
+      .withOnboardCount(1)
+      .withDeviationBudget(Duration.ZERO)
+      .build();
+    var intermediate = CarpoolStop.of(stopId("M"))
+      .withCoordinate(coordM)
+      .withOnboardCount(1)
+      .withExpectedArrivalTime(tripStart.plusMinutes(70))
+      .withDeviationBudget(BUDGET)
+      .build();
+    var destination = CarpoolStop.of(stopId("D"))
+      .withCoordinate(coordD)
+      .withOnboardCount(1)
+      .withExpectedArrivalTime(tripStart.plusMinutes(130))
+      .withDeviationBudget(BUDGET)
+      .build();
+    return new CarpoolTripBuilder(FeedScopedId.ofNullable("TEST", "trip-bent-route"))
+      .withStops(List.of(origin, intermediate, destination))
+      .withTotalCapacity(CarpoolTrip.DEFAULT_TOTAL_CAPACITY)
+      .withStartTime(tripStart)
+      .withEndTime(tripStart.plusMinutes(130))
+      .build();
+  }
+
+  private static FeedScopedId stopId(String id) {
+    return FeedScopedId.ofNullable("TEST", "stop-" + id);
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
@@ -17,24 +17,16 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.filter.DistanceTripFilter;
-import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTreeStreetRouter;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
-import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
-import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.model.organization.ContactInfo;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Integration tests for {@link DefaultCarpoolingService#routeDirect}.
@@ -139,42 +131,9 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
       }
     );
 
-    Graph graph = model.graph();
-    var timetableRepository = model.timetableRepository();
-    VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
-    var vertexCreationService = new VertexCreationService(vertexLinker);
-    TransitService transitService = new DefaultTransitService(timetableRepository);
-    repository = new DefaultCarpoolingRepository();
-
-    StreetLimitationParametersService streetLimitationParams =
-      new StreetLimitationParametersService() {
-        @Override
-        public float maxCarSpeed() {
-          return 40.0f;
-        }
-
-        @Override
-        public int maxAreaNodes() {
-          return 500;
-        }
-
-        @Override
-        public float getBestWalkSafety() {
-          return 1;
-        }
-
-        @Override
-        public float getBestBikeSafety() {
-          return 1;
-        }
-      };
-
-    service = new DefaultCarpoolingService(
-      repository,
-      streetLimitationParams,
-      transitService,
-      vertexCreationService
-    );
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
   }
 
   private RouteRequest buildDirectCarpoolRequest(

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceLongTripAccessTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceLongTripAccessTest.java
@@ -1,0 +1,145 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
+import org.opentripplanner.ext.carpooling.CarpoolingRepository;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitServiceResolver;
+
+/**
+ * Tests {@link DefaultCarpoolingService#routeAccessEgress} on a driver trip whose end-to-end
+ * driving time exceeds the nearby-stop search radius
+ * ({@link DefaultCarpoolingService#MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS}, 60
+ * minutes). Each leg's tree is sized from OTP's own routed leg duration (see
+ * {@link DefaultCarpoolingService#driverLegTreeLimits} and {@code resolveLegDurations}), not from
+ * the radius, so the leg's far waypoint stays inside the tree and the trip produces access
+ * candidates.
+ *
+ * <pre>
+ *   P  (10 meters N of A)
+ *   |
+ *   A ===[80 min]=== D
+ *   |
+ *   S  (10 meters S of A, transit stop)
+ * </pre>
+ *
+ * One straight road east at 10 meters/second: A to D is 48 km, so the carpool drives the single
+ * leg A to D in ~80 min, with a 10-min deviation budget at A and D. The access request has the
+ * passenger at P, dropped at stop S — both 10 meters from A.
+ * <p>
+ * The leg tree is sized from the routed baseline: 80 + 1 (slack) + 10 (budget) = 91 min, wider
+ * than the 60-min radius. After dropping the passenger at S the carpool still drives on to D, so
+ * the S-to-D segment (~80 min) must be routed; it goes only through D's waypoint tree (inserted
+ * passenger segments have no goal-directed fallback). A tree capped at the 60-min radius could not
+ * span it — S sits ~80 min back along the leg from D — so the insertion would be dropped and the
+ * trip would yield no access candidates.
+ */
+class DefaultCarpoolingServiceLongTripAccessTest extends GraphRoutingTest {
+
+  private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
+  private static final ZoneId ZONE = ZoneId.of("Europe/Oslo");
+  private static final ZonedDateTime SEARCH_TIME = LocalDateTime.of(2025, 6, 15, 12, 0).atZone(
+    ZONE
+  );
+
+  // 10 m/s car speed keeps the arithmetic obvious: seconds == meters / 10.
+  private static final float CAR_SPEED_MPS = 10.0f;
+
+  private DefaultCarpoolingService service;
+  private CarpoolingRepository repository;
+  private TransitServiceResolver transitServiceResolver;
+
+  private TransitStopVertex stopS;
+  private WgsCoordinate coordA;
+  private WgsCoordinate coordD;
+  private WgsCoordinate coordP;
+
+  @BeforeEach
+  void setUp() {
+    var model = modelOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          var A = intersection("A", ORIGIN);
+          // D is one long leg ~80 min from A — well beyond the 60-min nearby-stop radius.
+          var D = intersection("D", ORIGIN.moveEastMeters(48000));
+
+          coordA = A.toWgsCoordinate();
+          coordD = D.toWgsCoordinate();
+
+          // Bidirectional, speed-controlled car streets so A <-> D drives in ~80 min.
+          street(A, D, 48000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+          street(D, A, 48000, StreetTraversalPermission.ALL, CAR_SPEED_MPS);
+
+          // Passenger spur just north of A and a transit stop spur just south of A, both on the
+          // drivable network so pickup/dropoff need no walking.
+          var iP = intersection("iP", ORIGIN.moveNorthMeters(10));
+          biStreet(A, iP, 10);
+          coordP = iP.toWgsCoordinate();
+
+          var iS = intersection("iS", ORIGIN.moveSouthMeters(10));
+          biStreet(A, iS, 10);
+          stopS = stop("S", iS.toWgsCoordinate());
+          biLink(iS, stopS);
+        }
+      }
+    );
+
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
+    transitServiceResolver = context.transitServiceResolver();
+  }
+
+  @Test
+  void findsAccessResultsForTripLongerThanNearbyStopRadius() {
+    // Routed leg ~80 min → tree limit 80 + 1 min slack + 10 min budget = 91 min, spanning the
+    // A → D baseline.
+    var tripStart = SEARCH_TIME.plusMinutes(30);
+    var tripEnd = tripStart.plusMinutes(60);
+    var trip = CarpoolTripTestData.createSimpleTripWithTimes(coordA, coordD, tripStart, tripEnd);
+    repository.upsertCarpoolTrip(trip);
+
+    var request = RouteRequest.of()
+      .withFrom(GenericLocation.fromCoordinate(coordP.latitude(), coordP.longitude()))
+      .withTo(GenericLocation.fromCoordinate(coordD.latitude(), coordD.longitude()))
+      .withDateTime(SEARCH_TIME.toInstant())
+      .withJourney(j -> j.withAccess(new StreetRequest(StreetMode.CARPOOL)))
+      .buildRequest();
+
+    var results = service.routeAccessEgress(
+      request,
+      new StreetRequest(StreetMode.CARPOOL),
+      AccessEgressType.ACCESS,
+      transitServiceResolver,
+      SEARCH_TIME
+    );
+
+    assertFalse(
+      results.isEmpty(),
+      "A carpool trip driving longer than the 60-min nearby-stop radius should still produce " +
+        "access candidates"
+    );
+
+    int stopSIndex = transitServiceResolver.getStop(stopS.getId()).getIndex();
+    assertTrue(
+      results.stream().anyMatch(r -> r.stop() == stopSIndex),
+      "Access results should include stop S near the passenger origin"
+    );
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceTreeLimitTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceTreeLimitTest.java
@@ -1,0 +1,143 @@
+package org.opentripplanner.ext.carpooling.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.service.DefaultCarpoolingService.MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.ext.carpooling.model.CarpoolStop;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+
+/**
+ * Unit tests for {@link DefaultCarpoolingService#driverLegTreeLimits}: each leg gets
+ * {@code leg + slack + smallestDownstreamBudget} capped at {@link CarpoolTrip#MAX_TRIP_DURATION},
+ * and multi-leg trips get per-leg limits well below the whole-trip limit. The leg durations are
+ * passed in explicitly here; in production they are OTP's own routed durations (see
+ * {@link DefaultCarpoolingService#resolveLegDurations}).
+ */
+class DefaultCarpoolingServiceTreeLimitTest {
+
+  private static final ZoneId ZONE = ZoneId.of("Europe/Oslo");
+  private static final ZonedDateTime BASE = LocalDateTime.of(2025, 1, 1, 12, 0).atZone(ZONE);
+  private static final WgsCoordinate COORD = new WgsCoordinate(59.9139, 10.7522);
+  private static final Duration BUDGET = Duration.ofMinutes(10);
+
+  private static int idCounter = 0;
+
+  /** Mirrors the small slack {@link DefaultCarpoolingService#driverLegTreeLimits} adds per leg. */
+  private static final Duration SLACK = Duration.ofMinutes(1);
+
+  /** Matches the production formula: leg + flat slack + smallest downstream deviation budget. */
+  private static Duration expectedLimit(Duration leg, Duration allowance) {
+    return leg.plus(SLACK).plus(allowance);
+  }
+
+  @Test
+  void sizesEachLegFromItsDurationAndSmallestDownstreamBudget() {
+    // Budgets: origin 50, intermediate 5, destination 40. The origin's budget never participates —
+    // no detour can delay the origin.
+    var trip = trip(
+      stop(Duration.ofMinutes(50)),
+      stop(Duration.ofMinutes(5)),
+      stop(Duration.ofMinutes(40))
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(
+      trip,
+      new Duration[] { Duration.ofMinutes(60), Duration.ofMinutes(100) }
+    );
+
+    assertEquals(2, limits.length);
+    // Leg 0 allowance = min(downstream budgets) = min(5, 40) = 5.
+    assertEquals(expectedLimit(Duration.ofMinutes(60), Duration.ofMinutes(5)), limits[0]);
+    // Leg 1 only delays the destination: allowance 40.
+    assertEquals(expectedLimit(Duration.ofMinutes(100), Duration.ofMinutes(40)), limits[1]);
+
+    // Even the larger per-leg limit stays well below a whole-trip tree (160 min of travel).
+    assertTrue(
+      limits[1].compareTo(expectedLimit(Duration.ofMinutes(160), Duration.ofMinutes(40))) < 0,
+      "per-leg limits should be smaller than a whole-trip limit"
+    );
+  }
+
+  @Test
+  void sizesShortLegsWellBelowNearbyStopRadius() {
+    // 5-min legs get only duration + slack + budget — no nearby-stop-radius floor — so their
+    // trees stay small.
+    var trip = trip(
+      stop(Duration.ofMinutes(2)),
+      stop(Duration.ofMinutes(2)),
+      stop(Duration.ofMinutes(2))
+    );
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(
+      trip,
+      new Duration[] { Duration.ofMinutes(5), Duration.ofMinutes(5) }
+    );
+
+    var leg = expectedLimit(Duration.ofMinutes(5), Duration.ofMinutes(2));
+    assertEquals(leg, limits[0]);
+    assertEquals(leg, limits[1]);
+    assertTrue(
+      limits[0].compareTo(MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS) < 0,
+      "short legs should not be inflated to the nearby-stop radius"
+    );
+  }
+
+  @Test
+  void twoWaypointTripSizesTheSingleLeg() {
+    var trip = trip(stop(BUDGET), stop(BUDGET));
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(
+      trip,
+      new Duration[] { Duration.ofMinutes(60) }
+    );
+
+    assertEquals(1, limits.length);
+    assertEquals(expectedLimit(Duration.ofMinutes(60), BUDGET), limits[0]);
+  }
+
+  @Test
+  void capsEachLegLimitAtMaxTripDuration() {
+    // An inconsistent trip whose leg travel time already exceeds the trip cap (e.g. one that
+    // slipped past the mapper) must not size a tree beyond MAX_TRIP_DURATION; otherwise a single
+    // request could expand a multi-hour street tree.
+    var trip = trip(stop(BUDGET), stop(BUDGET));
+
+    var limits = DefaultCarpoolingService.driverLegTreeLimits(
+      trip,
+      new Duration[] { Duration.ofHours(4) }
+    );
+
+    assertEquals(CarpoolTrip.MAX_TRIP_DURATION, limits[0]);
+  }
+
+  private static CarpoolTrip trip(CarpoolStop... stops) {
+    return new CarpoolTripBuilder(FeedScopedId.ofNullable("TEST", "trip-" + ++idCounter))
+      .withStops(List.of(stops))
+      .withTotalCapacity(CarpoolTrip.DEFAULT_TOTAL_CAPACITY)
+      .withStartTime(BASE)
+      .withEndTime(BASE.plusHours(3))
+      .build();
+  }
+
+  private static CarpoolStop stop(Duration budget) {
+    return CarpoolStop.of(nextId())
+      .withCoordinate(COORD)
+      .withOnboardCount(1)
+      .withDeviationBudget(budget)
+      .build();
+  }
+
+  private static FeedScopedId nextId() {
+    return FeedScopedId.ofNullable("TEST", "stop-" + ++idCounter);
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.carpooling.CarpoolTripTestData;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
-import org.opentripplanner.ext.carpooling.internal.DefaultCarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.model.GenericLocation;
@@ -21,19 +20,12 @@ import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
-import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
-import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.organization.ContactInfo;
-import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Integration tests that exercise the walk-to/from-carpool behavior added to
@@ -119,42 +111,9 @@ class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
       }
     );
 
-    Graph graph = model.graph();
-    var timetableRepository = model.timetableRepository();
-    VertexLinker vertexLinker = VertexLinkerTestFactory.of(graph);
-    var vertexCreationService = new VertexCreationService(vertexLinker);
-    TransitService transitService = new DefaultTransitService(timetableRepository);
-    repository = new DefaultCarpoolingRepository();
-
-    StreetLimitationParametersService streetLimitationParams =
-      new StreetLimitationParametersService() {
-        @Override
-        public float maxCarSpeed() {
-          return 40.0f;
-        }
-
-        @Override
-        public int maxAreaNodes() {
-          return 500;
-        }
-
-        @Override
-        public float getBestWalkSafety() {
-          return 1;
-        }
-
-        @Override
-        public float getBestBikeSafety() {
-          return 1;
-        }
-      };
-
-    service = new DefaultCarpoolingService(
-      repository,
-      streetLimitationParams,
-      transitService,
-      vertexCreationService
-    );
+    var context = CarpoolingServiceTestContext.of(model);
+    service = context.service();
+    repository = context.repository();
   }
 
   private RouteRequest buildDirectCarpoolRequest(ZonedDateTime dateTime) {

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.arrivalIsAfterDepartureTime;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.expectedArrivalBeforeExpectedDeparture;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithAllButOneCallCancelled;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithCancelledIntermediateCall;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.journeyWithDifferentCapacitiesPerCall;
@@ -18,8 +19,11 @@ import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyD
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.minimalCompleteJourney;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.minimalCompleteJourneyWithPolygon;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.stopTimesAreOutOfOrder;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.tripExceedingMaxDuration;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.tripExceedingMaxDurationViaDefaultDeviationBudget;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.tripHasAimedTimesOnly;
 import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.tripHasExpectedTimesOnly;
+import static org.opentripplanner.ext.carpooling.CarpoolEstimatedVehicleJourneyData.tripWithWaypointsTooFarApart;
 import static org.opentripplanner.ext.carpooling.model.CarpoolStop.DEFAULT_DEVIATION_BUDGET;
 import static org.opentripplanner.ext.carpooling.model.CarpoolStop.DEFAULT_ONBOARD_COUNT;
 import static org.opentripplanner.ext.carpooling.model.CarpoolTrip.DEFAULT_TOTAL_CAPACITY;
@@ -44,6 +48,29 @@ public class CarpoolSiriMapperTest {
   void mapSiriToCarpoolTrip_lessThanTwoStops_throwsIllegalArgumentException() {
     assertThrows(IllegalArgumentException.class, () ->
       mapper.mapSiriToCarpoolTrip(lessThanTwoStops())
+    );
+  }
+
+  @Test
+  void mapSiriToCarpoolTrip_tripExceedsMaxDuration_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () ->
+      mapper.mapSiriToCarpoolTrip(tripExceedingMaxDuration())
+    );
+  }
+
+  @Test
+  void mapSiriToCarpoolTrip_tripExceedsMaxDurationViaDefaultDeviationBudget_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () ->
+      mapper.mapSiriToCarpoolTrip(tripExceedingMaxDurationViaDefaultDeviationBudget())
+    );
+  }
+
+  @Test
+  void mapSiriToCarpoolTrip_waypointsTooFarApart_throwsIllegalArgumentException() {
+    // Short claimed times but waypoints ~450 km apart: the timetable check passes, the geometry
+    // check rejects it.
+    assertThrows(IllegalArgumentException.class, () ->
+      mapper.mapSiriToCarpoolTrip(tripWithWaypointsTooFarApart())
     );
   }
 
@@ -121,6 +148,13 @@ public class CarpoolSiriMapperTest {
   void mapSiriToCarpoolTrip_stopTimesAreOutOfOrder_throwsIllegalArgumentException() {
     assertThrows(IllegalArgumentException.class, () ->
       mapper.mapSiriToCarpoolTrip(stopTimesAreOutOfOrder())
+    );
+  }
+
+  @Test
+  void mapSiriToCarpoolTrip_expectedArrivalBeforeExpectedDeparture_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () ->
+      mapper.mapSiriToCarpoolTrip(expectedArrivalBeforeExpectedDeparture())
     );
   }
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/BeelineEstimatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/BeelineEstimatorTest.java
@@ -1,288 +1,72 @@
 package org.opentripplanner.ext.carpooling.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_EAST;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
-import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTHEAST;
-import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTHWEST;
 
 import java.time.Duration;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
-import org.opentripplanner.street.geometry.WgsCoordinate;
 
 class BeelineEstimatorTest {
 
-  private BeelineEstimator estimator;
-
-  @BeforeEach
-  void setup() {
-    estimator = new BeelineEstimator();
-  }
-
   @Test
-  void estimateDuration_shortDistance_returnsReasonableDuration() {
-    // Oslo Center to Oslo East (~2.5km beeline)
-    Duration duration = estimator.estimateDuration(OSLO_CENTER, OSLO_EAST);
-
-    // With default parameters (1.3 detour factor, 10 m/s speed):
-    // Expected: ~2500m * 1.3 / 10 = ~325 seconds = ~5.4 minutes
-    // > 4 minutes
-    assertTrue(duration.getSeconds() > 240);
-    // < 8 minutes
-    assertTrue(duration.getSeconds() < 480);
-  }
-
-  @Test
-  void estimateDuration_mediumDistance_returnsReasonableDuration() {
-    // Oslo Center to Oslo North (~3.3km beeline)
-    Duration duration = estimator.estimateDuration(OSLO_CENTER, OSLO_NORTH);
-
-    // Expected: ~3300m * 1.3 / 10 = ~429 seconds = ~7.2 minutes
-    // > 5 minutes
-    assertTrue(duration.getSeconds() > 300);
-    // < 10 minutes
-    assertTrue(duration.getSeconds() < 600);
-  }
-
-  @Test
-  void estimateDuration_sameLocation_returnsZero() {
-    Duration duration = estimator.estimateDuration(OSLO_CENTER, OSLO_CENTER);
-    assertEquals(Duration.ZERO, duration);
-  }
-
-  @Test
-  void estimateDuration_veryShortDistance_roundsDownToZero() {
-    // Two points very close together (~10 meters)
-    var point1 = new WgsCoordinate(59.9139, 10.7522);
-    var point2 = new WgsCoordinate(59.9140, 10.7522);
-
-    Duration duration = estimator.estimateDuration(point1, point2);
-
-    // ~10m * 1.3 / 10 = ~1.3 seconds, rounds to 1
-    assertTrue(duration.getSeconds() <= 5);
-  }
-
-  @Test
-  void calculateCumulativeTimes_simpleRoute_calculatesCorrectly() {
-    // Route: Oslo Center → Oslo East → Oslo North
-    List<WgsCoordinate> points = List.of(OSLO_CENTER, OSLO_EAST, OSLO_NORTH);
-
-    Duration[] times = estimator.calculateCumulativeTimes(points, Duration.ZERO);
-
-    assertEquals(3, times.length);
-    // Start at 0
-    assertEquals(Duration.ZERO, times[0]);
-
-    // Each segment should add positive duration
-    assertTrue(times[1].compareTo(Duration.ZERO) > 0);
-    assertTrue(times[2].compareTo(times[1]) > 0);
-
-    // Total duration should be reasonable (sum of two ~3-5km segments)
-    // > 10 minutes
-    assertTrue(times[2].getSeconds() > 600);
-    // < 30 minutes
-    assertTrue(times[2].getSeconds() < 1800);
-  }
-
-  @Test
-  void calculateCumulativeTimes_singlePoint_returnsZero() {
-    List<WgsCoordinate> points = List.of(OSLO_CENTER);
-
-    Duration[] times = estimator.calculateCumulativeTimes(points, Duration.ZERO);
-
-    assertEquals(1, times.length);
-    assertEquals(Duration.ZERO, times[0]);
-  }
-
-  @Test
-  void calculateCumulativeTimes_emptyList_returnsEmptyArray() {
-    List<WgsCoordinate> points = List.of();
-
-    Duration[] times = estimator.calculateCumulativeTimes(points, Duration.ZERO);
-
-    assertEquals(0, times.length);
-  }
-
-  @Test
-  void calculateCumulativeTimes_multipleStops_timesAreMonotonic() {
-    // Route with multiple stops
-    List<WgsCoordinate> points = List.of(
-      OSLO_CENTER,
-      OSLO_EAST,
-      OSLO_NORTHEAST,
-      OSLO_NORTH,
-      OSLO_NORTHWEST
-    );
-
-    Duration[] times = estimator.calculateCumulativeTimes(points, Duration.ZERO);
-
-    // Times should be strictly increasing
-    for (int i = 1; i < times.length; i++) {
-      assertTrue(
-        times[i].compareTo(times[i - 1]) > 0,
-        "Time at position " + i + " should be greater than time at position " + (i - 1)
-      );
-    }
-  }
-
-  @Test
-  void customDetourFactor_increasedFactor_increasesEstimate() {
-    var defaultEstimator = new BeelineEstimator(1.3, 10.0);
-    var higherDetourEstimator = new BeelineEstimator(1.5, 10.0);
-
-    Duration defaultDuration = defaultEstimator.estimateDuration(OSLO_CENTER, OSLO_NORTH);
-    Duration higherDetourDuration = higherDetourEstimator.estimateDuration(OSLO_CENTER, OSLO_NORTH);
-
-    // Higher detour factor should give longer duration
-    assertTrue(higherDetourDuration.compareTo(defaultDuration) > 0);
-  }
-
-  @Test
-  void customSpeed_lowerSpeed_increasesEstimate() {
-    var defaultEstimator = new BeelineEstimator(1.3, 10.0);
-    var slowerEstimator = new BeelineEstimator(1.3, 5.0);
-
-    Duration defaultDuration = defaultEstimator.estimateDuration(OSLO_CENTER, OSLO_NORTH);
-    Duration slowerDuration = slowerEstimator.estimateDuration(OSLO_CENTER, OSLO_NORTH);
-
-    // Lower speed should give longer duration
-    assertTrue(slowerDuration.compareTo(defaultDuration) > 0);
-    // Should be approximately double
-    assertTrue(slowerDuration.getSeconds() > defaultDuration.getSeconds() * 1.8);
-    assertTrue(slowerDuration.getSeconds() < defaultDuration.getSeconds() * 2.2);
-  }
-
-  @Test
-  void customParameters_applyCorrectly() {
-    // Custom: 2x detour, 20 m/s speed
-    var customEstimator = new BeelineEstimator(2.0, 20.0);
-
-    // Calculate expected duration manually
-    double beelineDistance = SphericalDistanceLibrary.fastDistance(
+  void estimateDurationDividesBeelineDistanceBySpeed() {
+    double speed = 20.0;
+    double distance = SphericalDistanceLibrary.fastDistance(
       OSLO_CENTER.asJtsCoordinate(),
       OSLO_NORTH.asJtsCoordinate()
     );
-    double expectedSeconds = (beelineDistance * 2.0) / 20.0;
-    Duration expectedDuration = Duration.ofSeconds((long) expectedSeconds);
 
-    Duration actualDuration = customEstimator.estimateDuration(OSLO_CENTER, OSLO_NORTH);
-
-    // Should be very close (within 1 second due to rounding)
-    long diff = Math.abs(actualDuration.getSeconds() - expectedDuration.getSeconds());
-    assertTrue(diff <= 1);
-  }
-
-  @Test
-  void getDetourFactor_returnsConfiguredValue() {
-    assertEquals(1.3, estimator.getDetourFactor());
-
-    var customEstimator = new BeelineEstimator(1.5, 10.0);
-    assertEquals(1.5, customEstimator.getDetourFactor());
-  }
-
-  @Test
-  void getSpeedMps_returnsConfiguredValue() {
-    assertEquals(10.0, estimator.getSpeed());
-
-    var customEstimator = new BeelineEstimator(1.3, 15.0);
-    assertEquals(15.0, customEstimator.getSpeed());
-  }
-
-  @Test
-  void defaultDetourFactor_is1Point3() {
-    assertEquals(1.3, BeelineEstimator.DEFAULT_DETOUR_FACTOR);
-  }
-
-  @Test
-  void defaultSpeed_is10MetersPerSecond() {
-    assertEquals(10.0, BeelineEstimator.DEFAULT_SPEED_MPS);
-  }
-
-  @Test
-  void constructor_detourFactorLessThanOne_throwsException() {
-    assertThrows(
-      IllegalArgumentException.class,
-      () -> new BeelineEstimator(0.9, 10.0),
-      "detourFactor must be >= 1.0"
+    assertEquals(
+      Duration.ofSeconds((long) (distance / speed)),
+      new BeelineEstimator(speed).estimateDuration(OSLO_CENTER, OSLO_NORTH)
     );
   }
 
   @Test
-  void constructor_detourFactorExactlyOne_accepts() {
-    // Minimum valid detour factor (no detour)
-    var estimator = new BeelineEstimator(1.0, 10.0);
-    assertEquals(1.0, estimator.getDetourFactor());
+  void estimateDurationIsZeroBetweenIdenticalPoints() {
+    assertEquals(Duration.ZERO, new BeelineEstimator().estimateDuration(OSLO_CENTER, OSLO_CENTER));
   }
 
   @Test
-  void constructor_zeroSpeed_throwsException() {
-    assertThrows(
-      IllegalArgumentException.class,
-      () -> new BeelineEstimator(1.3, 0.0),
-      "speedMps must be positive"
+  void noArgConstructorUsesDefaultSpeed() {
+    assertEquals(BeelineEstimator.DEFAULT_SPEED_MPS, new BeelineEstimator().getSpeed());
+  }
+
+  @Test
+  void constructorRejectsNonPositiveSpeed() {
+    assertThrows(IllegalArgumentException.class, () -> new BeelineEstimator(0.0));
+    assertThrows(IllegalArgumentException.class, () -> new BeelineEstimator(-5.0));
+  }
+
+  @Test
+  void calculateCumulativeTimesIsEmptyForNoPoints() {
+    assertEquals(
+      0,
+      new BeelineEstimator().calculateCumulativeTimes(List.of(), Duration.ZERO).length
     );
   }
 
   @Test
-  void constructor_negativeSpeed_throwsException() {
-    assertThrows(
-      IllegalArgumentException.class,
-      () -> new BeelineEstimator(1.3, -5.0),
-      "speedMps must be positive"
-    );
-  }
+  void calculateCumulativeTimesAccumulatesPerSegmentEstimates() {
+    var estimator = new BeelineEstimator();
+    var stop = Duration.ofMinutes(1);
 
-  @Test
-  void estimateDuration_longDistance_scalesCorrectly() {
-    // Oslo to Bergen (~300km beeline)
-    var bergen = new WgsCoordinate(60.39, 5.32);
-
-    Duration duration = estimator.estimateDuration(OSLO_CENTER, bergen);
-
-    // Expected: ~300,000m * 1.3 / 10 = 39,000 seconds = 650 minutes
-    // This is just a sanity check - beeline is not accurate for such long distances
-    // > 8.3 hours
-    assertTrue(duration.getSeconds() > 30000);
-    // < 16.7 hours
-    assertTrue(duration.getSeconds() < 60000);
-  }
-
-  @Test
-  void calculateCumulativeTimes_twoPoints_calculatesCorrectly() {
-    List<WgsCoordinate> points = List.of(OSLO_CENTER, OSLO_NORTH);
-
-    Duration[] times = estimator.calculateCumulativeTimes(points, Duration.ZERO);
-
-    assertEquals(2, times.length);
-    assertEquals(Duration.ZERO, times[0]);
-    assertTrue(times[1].compareTo(Duration.ZERO) > 0);
-  }
-
-  @Test
-  void estimateDuration_optimisticEstimate_lessThanActualStreetRoute() {
-    // Beeline estimates should be optimistic (underestimate actual travel time)
-    // This is important for the heuristic to work correctly
-
-    // For urban areas, actual street routes are typically 1.3-1.5x beeline
-    // Our default detour factor of 1.3 is intentionally optimistic
-    Duration beelineEstimate = estimator.estimateDuration(OSLO_CENTER, OSLO_NORTH);
-
-    // Typical actual street route would be ~1.5x beeline at 10 m/s
-    double actualBeelineDistance = SphericalDistanceLibrary.fastDistance(
-      OSLO_CENTER.asJtsCoordinate(),
-      OSLO_NORTH.asJtsCoordinate()
-    );
-    Duration conservativeActualTime = Duration.ofSeconds(
-      (long) ((actualBeelineDistance * 1.5) / 10.0)
+    Duration[] times = estimator.calculateCumulativeTimes(
+      List.of(OSLO_CENTER, OSLO_EAST, OSLO_NORTH),
+      stop
     );
 
-    // Our estimate should be less than or equal to a conservative actual time
-    assertTrue(beelineEstimate.compareTo(conservativeActualTime) <= 0);
+    Duration firstLeg = estimator.estimateDuration(OSLO_CENTER, OSLO_EAST);
+    Duration secondLeg = estimator.estimateDuration(OSLO_EAST, OSLO_NORTH);
+    assertArrayEquals(
+      new Duration[] { Duration.ZERO, firstLeg, firstLeg.plus(stop).plus(secondLeg) },
+      times
+    );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.carpooling;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 
@@ -71,4 +72,39 @@ public interface CarpoolingRepository {
    * @return the number of trips removed, or {@code 0} when the call was throttled
    */
   int removeExpiredTrips(Instant now, Duration expiry);
+
+  /**
+   * Returns the cached outcome of routing the trip's baseline (its driver waypoints, in order), or
+   * {@code null} when there is no usable entry — either nothing is cached, or the cached entry was
+   * computed for a different route-point geometry than the trip now has.
+   * <p>
+   * This is a routing memoization, not part of the trip's domain data: the baseline route depends
+   * only on the trip's waypoint geometry and the static street graph, never on the passenger
+   * request, so it is computed once and reused across requests. The cache is keyed by trip id and
+   * validated against the trip's current route points, so a trip whose geometry changed — including
+   * after a concurrent re-route — never reads a stale entry; entries are also dropped when the trip
+   * is removed or expires. A successful outcome carries one routed duration per leg
+   * ({@code stops().size() - 1} entries); an unroutable outcome carries {@code null} durations (see
+   * {@link CachedBaselineRouting}). Returned durations are a copy the caller may not mutate into the
+   * cache.
+   */
+  @Nullable
+  CachedBaselineRouting cachedBaselineRouting(CarpoolTrip trip);
+
+  /**
+   * Stores the outcome of routing {@code trip}'s baseline, replacing any previous entry. Pass the
+   * routed per-leg durations, or {@code null} to record that the baseline is unroutable so later
+   * requests skip the trip without re-routing it. Durations are copied, so later mutation by the
+   * caller does not affect the cache. The entry is tagged with the trip's current route points and
+   * is ignored once those change (see {@link #cachedBaselineRouting}).
+   */
+  void cacheBaselineRouting(CarpoolTrip trip, @Nullable Duration[] legDurations);
+
+  /**
+   * A trip's cached baseline-routing outcome, valid only for the geometry it was routed against. A
+   * {@code null} {@link #legDurations()} means the baseline was found unroutable and the trip
+   * should be skipped without re-routing; otherwise the array holds one routed travel duration per
+   * leg.
+   */
+  record CachedBaselineRouting(@Nullable Duration[] legDurations) {}
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepository.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/DefaultCarpoolingRepository.java
@@ -3,12 +3,15 @@ package org.opentripplanner.ext.carpooling.internal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +28,14 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
 
   private final Map<FeedScopedId, CarpoolTrip> trips = new ConcurrentHashMap<>();
 
+  /**
+   * Outcome of routing each trip's baseline, memoized across requests and tagged with the geometry
+   * it was routed against. Kept in lockstep with {@link #trips}: an entry is dropped whenever the
+   * corresponding trip's route points change or the trip leaves the repository, and a geometry
+   * mismatch is ignored on read. See {@link #cachedBaselineRouting}.
+   */
+  private final Map<FeedScopedId, CacheEntry> baselineRouting = new ConcurrentHashMap<>();
+
   /** The earliest instant at which the next expiry sweep is allowed to run. */
   private final AtomicReference<Instant> nextSweep = new AtomicReference<>(Instant.MIN);
 
@@ -36,6 +47,13 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
   @Override
   public void upsertCarpoolTrip(CarpoolTrip trip) {
     CarpoolTrip existingTrip = trips.put(trip.getId(), trip);
+    // A read already validates the cached entry against the trip's geometry, so correctness does
+    // not depend on this drop; it just promptly frees an entry whose route points changed instead
+    // of letting it linger until the trip is removed or expires. A budget- or time-only update
+    // keeps the same route points, so the entry survives and is reused.
+    if (existingTrip == null || !existingTrip.routePoints().equals(trip.routePoints())) {
+      baselineRouting.remove(trip.getId());
+    }
     if (existingTrip != null) {
       LOG.debug("Updated carpool trip {} with {} stops", trip.getId(), trip.stops().size());
     } else {
@@ -46,6 +64,7 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
   @Override
   public void removeCarpoolTrip(FeedScopedId id) {
     CarpoolTrip removed = trips.remove(id);
+    baselineRouting.remove(id);
     if (removed != null) {
       LOG.debug("Removed carpool trip {}", id);
     } else {
@@ -67,6 +86,7 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
         trip.latestEndTime().toInstant().isBefore(expiryThreshold) &&
         trips.remove(trip.getId(), trip)
       ) {
+        baselineRouting.remove(trip.getId());
         removed++;
       }
     }
@@ -75,4 +95,31 @@ public class DefaultCarpoolingRepository implements CarpoolingRepository {
     }
     return removed;
   }
+
+  @Override
+  @Nullable
+  public CachedBaselineRouting cachedBaselineRouting(CarpoolTrip trip) {
+    CacheEntry entry = baselineRouting.get(trip.getId());
+    if (entry == null || !entry.routePoints().equals(trip.routePoints())) {
+      return null;
+    }
+    Duration[] legDurations = entry.legDurations();
+    return new CachedBaselineRouting(legDurations == null ? null : legDurations.clone());
+  }
+
+  @Override
+  public void cacheBaselineRouting(CarpoolTrip trip, @Nullable Duration[] legDurations) {
+    // routePoints() already returns a fresh immutable snapshot, so it is safe to store directly.
+    baselineRouting.put(
+      trip.getId(),
+      new CacheEntry(trip.routePoints(), legDurations == null ? null : legDurations.clone())
+    );
+  }
+
+  /**
+   * A cached baseline-routing outcome together with the route-point geometry it was computed for,
+   * so a trip whose geometry changed is treated as a miss on read. A {@code null}
+   * {@code legDurations} marks the baseline as unroutable.
+   */
+  private record CacheEntry(List<WgsCoordinate> routePoints, @Nullable Duration[] legDurations) {}
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolStop.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolStop.java
@@ -73,6 +73,17 @@ public class CarpoolStop extends AbstractTransitEntity<CarpoolStop, CarpoolStopB
   }
 
   /**
+   * The arrival time the trip is currently scheduled to reach this stop: the expected arrival,
+   * falling back to the aimed arrival when no expected time is provided.
+   *
+   * @return The scheduled arrival time, or null if not applicable (e.g., origin stop)
+   */
+  @Nullable
+  public ZonedDateTime getScheduledArrivalTime() {
+    return expectedArrivalTime != null ? expectedArrivalTime : aimedArrivalTime;
+  }
+
+  /**
    * @return The latest expected arrival time, or null if not provided
    */
   @Nullable
@@ -94,6 +105,17 @@ public class CarpoolStop extends AbstractTransitEntity<CarpoolStop, CarpoolStopB
   @Nullable
   public ZonedDateTime getExpectedDepartureTime() {
     return expectedDepartureTime;
+  }
+
+  /**
+   * The departure time the trip is currently scheduled to leave this stop: the expected departure,
+   * falling back to the aimed departure when no expected time is provided.
+   *
+   * @return The scheduled departure time, or null if not applicable (e.g., destination stop)
+   */
+  @Nullable
+  public ZonedDateTime getScheduledDepartureTime() {
+    return expectedDepartureTime != null ? expectedDepartureTime : aimedDepartureTime;
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/model/CarpoolTrip.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.carpooling.model;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -58,6 +59,13 @@ public class CarpoolTrip
 
   /** Default total capacity (including driver) when no capacity information is provided. */
   public static final int DEFAULT_TOTAL_CAPACITY = 5;
+
+  /**
+   * The longest span a carpool trip may have — from the first stop's departure to the
+   * destination's latest expected arrival. A trip longer than this is not shaped like a carpool
+   * journey and is not modelled as one.
+   */
+  public static final Duration MAX_TRIP_DURATION = Duration.ofHours(2).plusMinutes(30);
 
   private final ZonedDateTime startTime;
   private final ZonedDateTime endTime;

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
@@ -2,8 +2,7 @@ package org.opentripplanner.ext.carpooling.routing;
 
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -39,31 +38,20 @@ public class CarpoolStreetRouter implements CarpoolRouter {
   private static final Logger LOG = LoggerFactory.getLogger(CarpoolStreetRouter.class);
 
   private final StreetLimitationParametersService streetLimitationParametersService;
-  private final RouteRequest request;
 
   /**
    * Creates a new carpool street router.
    *
    * @param streetLimitationParametersService provides street routing parameters (speed limits, etc.)
-   * @param request the route request containing preferences and timing
    */
-  public CarpoolStreetRouter(
-    StreetLimitationParametersService streetLimitationParametersService,
-    RouteRequest request
-  ) {
+  public CarpoolStreetRouter(StreetLimitationParametersService streetLimitationParametersService) {
     this.streetLimitationParametersService = streetLimitationParametersService;
-    this.request = request;
   }
 
   @Override
   public GraphPath<State, Edge, Vertex> route(Vertex from, Vertex to) {
     try {
-      return carpoolRouting(
-        new StreetRequest(StreetMode.CAR),
-        from,
-        to,
-        streetLimitationParametersService
-      );
+      return carpoolRouting(from, to);
     } catch (Exception e) {
       LOG.warn("Routing failed from {} to {}: {}", from, to, e.getMessage());
       return null;
@@ -78,28 +66,20 @@ public class CarpoolStreetRouter implements CarpoolRouter {
    *   <li><strong>Heuristic:</strong> Euclidean distance with max car speed</li>
    *   <li><strong>Skip Strategy:</strong> Duration-based edge skipping</li>
    *   <li><strong>Dominance:</strong> Minimum weight</li>
-   *   <li><strong>Sorting:</strong> Results sorted by arrival/departure time</li>
    * </ul>
    *
-   * @param streetRequest the street request specifying CAR mode
    * @param fromVertex the origin vertex
    * @param toVertex the destination vertex
-   * @param maxCarSpeed maximum car speed in m/s
    * @return the first (best) path found, or null if no paths exist
    */
-  private GraphPath<State, Edge, Vertex> carpoolRouting(
-    StreetRequest streetRequest,
-    Vertex fromVertex,
-    Vertex toVertex,
-    StreetLimitationParametersService streetLimitationParametersService
-  ) {
-    var preferences = request.preferences().street();
+  private GraphPath<State, Edge, Vertex> carpoolRouting(Vertex fromVertex, Vertex toVertex) {
     var request = StreetSearchRequest.of().withMode(StreetMode.CAR).build();
     var streetSearch = StreetSearchBuilder.of()
       .withHeuristic(new EuclideanRemainingWeightHeuristic(streetLimitationParametersService))
-      .withSkipEdgeStrategy(
-        new DurationSkipEdgeStrategy(preferences.maxDirectDuration().valueOf(streetRequest.mode()))
-      )
+      // Bound the search at the carpool trip ceiling rather than the passenger request's
+      // maxDirectDuration: a driver leg is not a passenger direct trip, and a request-independent
+      // bound keeps the cached baseline leg durations request-independent too.
+      .withSkipEdgeStrategy(new DurationSkipEdgeStrategy(CarpoolTrip.MAX_TRIP_DURATION))
       .withDominanceFunction(new DominanceFunctions.MinimumWeight())
       .withRequest(request)
       .withFrom(fromVertex)

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouter.java
@@ -133,11 +133,32 @@ public class CarpoolTreeStreetRouter implements CarpoolRouter {
       );
     }
     if (direction == Direction.FROM || direction == Direction.BOTH) {
-      forwardRegistrations.put(vertex, new VertexRegistration(vertex, searchLimit));
+      registerLargest(forwardRegistrations, vertex, searchLimit);
     }
     if (direction == Direction.TO || direction == Direction.BOTH) {
-      reverseRegistrations.put(vertex, new VertexRegistration(vertex, searchLimit));
+      registerLargest(reverseRegistrations, vertex, searchLimit);
     }
+  }
+
+  /**
+   * Registers {@code vertex} keeping the larger of any already-registered limit and
+   * {@code searchLimit}. Distinct
+   * {@link org.opentripplanner.street.model.vertex.TemporaryStreetLocation}s at the same
+   * coordinate compare equal, so two trips — or two legs of one trip — routing through the same
+   * point collapse to a single registration here. The shared tree must span the longest leg
+   * registered at that point, so the largest limit wins: a smaller limit would build a tree too
+   * short for a longer leg's baseline, making it unroutable. An over-large tree only widens the
+   * search — any insertion it would wrongly admit is rejected by the delay constraints — so taking
+   * the maximum is always safe.
+   */
+  private static void registerLargest(
+    Map<Vertex, VertexRegistration> registrations,
+    Vertex vertex,
+    Duration searchLimit
+  ) {
+    registrations.merge(vertex, new VertexRegistration(vertex, searchLimit), (existing, added) ->
+      existing.searchLimit().compareTo(added.searchLimit()) >= 0 ? existing : added
+    );
   }
 
   /** Returns the total number of forward vertices (pending and computed). Package-private for testing. */

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -33,6 +33,10 @@ public class InsertionEvaluator {
   private static final Logger LOG = LoggerFactory.getLogger(InsertionEvaluator.class);
 
   private final CarpoolRouter carpoolRouter;
+
+  @Nullable
+  private final CarpoolRouter baselineFallbackRouter;
+
   private final Duration stopDuration;
 
   /**
@@ -44,7 +48,33 @@ public class InsertionEvaluator {
    *        passenger-ride durations.
    */
   public InsertionEvaluator(CarpoolRouter carpoolRouter, Duration stopDuration) {
+    this(carpoolRouter, null, stopDuration);
+  }
+
+  /**
+   * @param carpoolRouter routes a single street segment between two vertices in the candidate
+   *        carpool route — used both to build the baseline route and to re-route only the
+   *        segments that change when a passenger pickup/dropoff is inserted.
+   * @param baselineFallbackRouter re-routes a baseline leg that {@code carpoolRouter} could not,
+   *        or {@code null} for no fallback. Only the baseline route falls back. When
+   *        {@code carpoolRouter} is a tree router whose per-leg trees are sized to a bounded
+   *        per-leg limit, an underestimate of that limit would leave a waypoint outside its tree
+   *        and drop the whole trip; a goal-directed fallback re-routes just that leg instead.
+   *        Inserted passenger
+   *        segments deliberately do not fall back — a segment that cannot be routed within the
+   *        tree is an insertion the delay constraints reject anyway, so failing fast there is
+   *        correct and avoids a goal-directed search per nearby stop.
+   * @param stopDuration duration added at each intermediate stop (from the car {@code pickupTime}
+   *        preference); applied between consecutive segments when computing total trip and
+   *        passenger-ride durations.
+   */
+  public InsertionEvaluator(
+    CarpoolRouter carpoolRouter,
+    @Nullable CarpoolRouter baselineFallbackRouter,
+    Duration stopDuration
+  ) {
     this.carpoolRouter = carpoolRouter;
+    this.baselineFallbackRouter = baselineFallbackRouter;
     this.stopDuration = stopDuration;
   }
 
@@ -62,6 +92,12 @@ public class InsertionEvaluator {
       var to = routePoints.get(i + 1);
 
       GraphPath<State, Edge, Vertex> segment = carpoolRouter.route(from, to);
+      if (segment == null && baselineFallbackRouter != null) {
+        segment = baselineFallbackRouter.route(from, to);
+        if (segment != null) {
+          LOG.debug("Baseline segment {} → {} routed by the fallback router", i, i + 1);
+        }
+      }
       if (segment == null) {
         LOG.debug("Baseline routing failed for segment {} → {}", i, i + 1);
         return null;
@@ -82,6 +118,14 @@ public class InsertionEvaluator {
     TripWithViableAccessEgress tripWithViableAccessEgress
   ) {
     var tripWithVertices = tripWithViableAccessEgress.tripWithVertices();
+
+    // No nearby stop produced a viable insertion position for this trip, so there is nothing to
+    // evaluate. Return before routing the baseline: that routing builds the trip's street trees,
+    // which are expensive for long trips — wasted work for a trip that cannot yield an
+    // access/egress leg.
+    if (tripWithViableAccessEgress.viableAccessEgress().isEmpty()) {
+      return List.of();
+    }
 
     GraphPath<State, Edge, Vertex>[] baselineSegments = routeSegments(tripWithVertices.vertices());
     if (baselineSegments == null) {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -108,9 +108,10 @@ public class DefaultCarpoolingService implements CarpoolingService {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCarpoolingService.class);
 
   /**
-   * Caps the radius of the nearby-stop search used in access/egress routing. Required to keep
-   * computational complexity bounded; remove or widen only after the nearby-stop search is made
-   * smarter.
+   * Hard ceiling on the nearby-stop search radius used in access/egress routing. The search uses
+   * the request's {@code accessEgress} max duration for {@link StreetMode#CARPOOL}, but never more
+   * than this, so an unusually large preference cannot blow up the search. Lower or remove only
+   * once the nearby-stop search is made smarter.
    */
   public static final Duration MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS =
     Duration.ofMinutes(60);
@@ -421,11 +422,22 @@ public class DefaultCarpoolingService implements CarpoolingService {
         return List.of();
       }
 
-      var streetNearbyStopFinder = StreetNearbyStopFinder.of(
-        null,
-        MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS,
-        0
+      // A carpool access/egress leg is an access/egress leg, so the search may not exceed the
+      // request's accessEgress max duration: stops beyond that reach only yield legs that violate
+      // the cap. Bound it further by MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS so an
+      // unusually large preference cannot blow up the search.
+      var preferredSearchDuration = request
+        .preferences()
+        .street()
+        .accessEgress()
+        .maxDuration()
+        .valueOf(StreetMode.CARPOOL);
+      var nearbyStopSearchDuration = min(
+        preferredSearchDuration,
+        MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
       );
+
+      var streetNearbyStopFinder = StreetNearbyStopFinder.of(null, nearbyStopSearchDuration, 0);
 
       // CAR_PICKUP models a walk → drive → walk chain inside a single A*. Using it here (instead
       // of plain CAR) lets the search find transit stops whose link endpoint is only walk-reachable
@@ -565,6 +577,10 @@ public class DefaultCarpoolingService implements CarpoolingService {
         )
         .toList();
     }
+  }
+
+  private static Duration min(Duration a, Duration b) {
+    return a.compareTo(b) <= 0 ? a : b;
   }
 
   private void validateRequest(RouteRequest request) throws RoutingValidationException {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -2,12 +2,14 @@ package org.opentripplanner.ext.carpooling.service;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingRepository;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
@@ -15,7 +17,9 @@ import org.opentripplanner.ext.carpooling.filter.CarpoolingRequest;
 import org.opentripplanner.ext.carpooling.filter.ItineraryPostFilters;
 import org.opentripplanner.ext.carpooling.filter.TripPreFilters;
 import org.opentripplanner.ext.carpooling.internal.CarpoolItineraryMapper;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
+import org.opentripplanner.ext.carpooling.routing.CarpoolRouter;
 import org.opentripplanner.ext.carpooling.routing.CarpoolStreetRouter;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTreeStreetRouter;
 import org.opentripplanner.ext.carpooling.routing.CarpoolTripWithVertices;
@@ -212,7 +216,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
 
     var itineraries = List.<Itinerary>of();
     try (var temporaryVerticesContainer = new TemporaryVerticesContainer()) {
-      var router = new CarpoolStreetRouter(streetLimitationParametersService, request);
+      var router = new CarpoolStreetRouter(streetLimitationParametersService);
 
       var streetVertexUtils = new StreetVertexUtils(
         this.vertexCreationService,
@@ -489,39 +493,57 @@ public class DefaultCarpoolingService implements CarpoolingService {
         .filter(Objects::nonNull)
         .toList();
 
+      // Sizes each leg's tree from OTP's own routed leg durations (cached per trip) and re-routes
+      // any baseline leg the tree misses — see resolveLegDurations and the InsertionEvaluator
+      // fallback below.
+      var baselineRouter = new CarpoolStreetRouter(streetLimitationParametersService);
+
+      // Each waypoint's tree only has to span its own leg plus the feasible insertion detour —
+      // see driverLegTreeLimits.
+      var routableTrips = new ArrayList<CarpoolTripWithVertices>(candidateTripsWithVertices.size());
+      var passengerTreeLimit = Duration.ZERO;
+      for (var tripWithVertices : candidateTripsWithVertices) {
+        var legDurations = resolveLegDurations(tripWithVertices, baselineRouter);
+        // A trip whose baseline cannot be routed within the carpool bound cannot carry a passenger:
+        // skip it before sizing and building trees its baseline would fail to route in anyway.
+        if (legDurations == null) {
+          continue;
+        }
+        var legLimits = driverLegTreeLimits(tripWithVertices.trip(), legDurations);
+        var vertices = tripWithVertices.vertices();
+        for (int leg = 0; leg < legLimits.length; leg++) {
+          carpoolTreeVertexRouter.addVertex(
+            vertices.get(leg),
+            CarpoolTreeStreetRouter.Direction.FROM,
+            legLimits[leg]
+          );
+          carpoolTreeVertexRouter.addVertex(
+            vertices.get(leg + 1),
+            CarpoolTreeStreetRouter.Direction.TO,
+            legLimits[leg]
+          );
+          passengerTreeLimit = max(passengerTreeLimit, legLimits[leg]);
+        }
+        routableTrips.add(tripWithVertices);
+      }
+      // Every passenger segment lies on a single leg of some candidate trip, so the largest leg
+      // limit bounds them all. A smaller cap would silently drop feasible insertions: route()
+      // never falls back from the passenger's own forward tree.
       carpoolTreeVertexRouter.addVertex(
         passengerSnap.vertex(),
         CarpoolTreeStreetRouter.Direction.BOTH,
-        MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
+        passengerTreeLimit
       );
-      candidateTripsWithVertices.forEach(tripWithVertices -> {
-        var vertices = tripWithVertices.vertices();
-        carpoolTreeVertexRouter.addVertex(
-          vertices.getFirst(),
-          CarpoolTreeStreetRouter.Direction.FROM,
-          MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
-        );
-        carpoolTreeVertexRouter.addVertex(
-          vertices.getLast(),
-          CarpoolTreeStreetRouter.Direction.TO,
-          MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
-        );
-
-        var middleVertices = vertices.subList(1, vertices.size() - 1);
-        middleVertices.forEach(vertex -> {
-          carpoolTreeVertexRouter.addVertex(
-            vertex,
-            CarpoolTreeStreetRouter.Direction.BOTH,
-            MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
-          );
-        });
-      });
 
       var stopDuration = request.preferences().car().pickupTime();
 
-      var insertionEvaluator = new InsertionEvaluator(carpoolTreeVertexRouter, stopDuration);
+      var insertionEvaluator = new InsertionEvaluator(
+        carpoolTreeVertexRouter,
+        baselineRouter,
+        stopDuration
+      );
 
-      var candidateTripsWithViableStopsAndPositions = candidateTripsWithVertices
+      var candidateTripsWithViableStopsAndPositions = routableTrips
         .stream()
         .map(tripWithVertices -> {
           var viableSegmentInsertions = stopSnaps
@@ -579,8 +601,120 @@ public class DefaultCarpoolingService implements CarpoolingService {
     }
   }
 
+  /**
+   * Sizes the street routing tree for each leg of a driver trip from the leg's travel duration:
+   * {@code result[k]} limits the leg from waypoint {@code k} to {@code k + 1} — waypoint
+   * {@code k}'s forward tree and waypoint {@code k + 1}'s reverse tree — one entry per leg. Sizing
+   * per leg instead of to the whole {@link CarpoolTrip#startTime()}→{@link CarpoolTrip#endTime()}
+   * span keeps trees local even when consecutive waypoints are minutes apart, the dominant cost
+   * for long or multi-waypoint trips.
+   * <p>
+   * A leg's limit is its travel duration plus a small slack plus the detour
+   * allowance: the smallest deviation budget among the stops downstream of the leg. A detour on a
+   * leg delays every downstream stop, each checked against its own budget by
+   * {@link org.opentripplanner.ext.carpooling.constraints.PassengerDelayConstraints}, so the
+   * smallest downstream budget is the most a feasible detour can add — a stop beyond the tree
+   * would be rejected by the delay constraints anyway.
+   * <p>
+   * Each limit is finally capped at {@link CarpoolTrip#MAX_TRIP_DURATION}, the same bound the
+   * SIRI mapper rejects over-long trips at. A consistent trip's leg never approaches that bound, so
+   * the cap only trims the detour margin of a trip at the very edge of the accepted range; its real
+   * purpose is to keep every driver tree bounded should a trip with inconsistent geometry slip past
+   * the mapper's checks, so that no single request can expand a multi-hour tree.
+   *
+   * @param legDurations the travel duration of each leg, one entry per leg (length
+   *        {@code stops().size() - 1}). The caller passes OTP's own routed durations (see
+   *        {@link #resolveLegDurations}) so the tree is sized against the same routing model it is
+   *        built with; a leg's tree then spans its baseline whatever the SIRI schedule claimed.
+   */
+  static Duration[] driverLegTreeLimits(CarpoolTrip trip, Duration[] legDurations) {
+    var stops = trip.stops();
+    int n = stops.size();
+
+    // Small slack: a floor for zero-length legs and a guard against rounding or routing-model
+    // discrepancy. Not load-bearing — the OTP-measured leg duration plus the downstream deviation
+    // budget already span the baseline and any feasible detour.
+    var slack = Duration.ofMinutes(1);
+
+    // Detour allowance = backward running minimum of the downstream deviation budgets; the
+    // origin's budget never participates — no detour can delay the origin.
+    var legLimits = new Duration[n - 1];
+    var detourAllowance = stops.get(n - 1).getDeviationBudget();
+    for (int k = n - 2; k >= 0; k--) {
+      detourAllowance = min(detourAllowance, stops.get(k + 1).getDeviationBudget());
+      legLimits[k] = min(
+        legDurations[k].plus(slack).plus(detourAllowance),
+        CarpoolTrip.MAX_TRIP_DURATION
+      );
+    }
+    return legLimits;
+  }
+
+  /**
+   * Resolves the per-leg travel durations used to size a trip's routing trees, or {@code null}
+   * when the trip's baseline cannot be routed and the trip should be skipped.
+   * <p>
+   * The outcome is memoized on the repository
+   * ({@link CarpoolingRepository#cachedBaselineRouting}) — both success and failure — because the
+   * baseline route depends only on the trip's waypoint geometry and the static street graph, never
+   * on the passenger request: the baseline router is bounded by
+   * {@link CarpoolTrip#MAX_TRIP_DURATION}, a fixed ceiling, not by any request preference. On a
+   * cache miss every leg is routed with {@code baselineRouter}; the result — the durations if all
+   * legs route, or unroutable if any leg cannot be driven within that ceiling — is cached either
+   * way, so a trip that cannot carry a passenger is routed once and skipped cheaply thereafter. The
+   * cache validates its entry against the trip's current route points, so a re-routed trip never
+   * reads a stale verdict.
+   */
+  @Nullable
+  private Duration[] resolveLegDurations(
+    CarpoolTripWithVertices tripWithVertices,
+    CarpoolRouter baselineRouter
+  ) {
+    var trip = tripWithVertices.trip();
+    var cached = repository.cachedBaselineRouting(trip);
+    if (cached != null) {
+      return cached.legDurations();
+    }
+    var routed = routeBaselineLegDurations(tripWithVertices, baselineRouter);
+    repository.cacheBaselineRouting(trip, routed);
+    return routed;
+  }
+
+  /**
+   * Routes every leg of the trip with {@code baselineRouter} and returns OTP's travel duration for
+   * each, or {@code null} if any leg cannot be routed. {@code baselineRouter} is a goal-directed
+   * search bounded by {@link CarpoolTrip#MAX_TRIP_DURATION} — the same ceiling the trees are capped
+   * at — so a {@code null} here means the leg cannot be driven within the carpool bound: no tree
+   * could route it either, and the trip is dropped.
+   */
+  @Nullable
+  private static Duration[] routeBaselineLegDurations(
+    CarpoolTripWithVertices tripWithVertices,
+    CarpoolRouter baselineRouter
+  ) {
+    var vertices = tripWithVertices.vertices();
+    var durations = new Duration[vertices.size() - 1];
+    for (int leg = 0; leg < durations.length; leg++) {
+      var path = baselineRouter.route(vertices.get(leg), vertices.get(leg + 1));
+      if (path == null) {
+        LOG.debug(
+          "OTP could not route baseline leg {} of trip {} within the carpool bound; skipping it",
+          leg,
+          tripWithVertices.trip().getId()
+        );
+        return null;
+      }
+      durations[leg] = GraphPathUtils.durationOrZero(path);
+    }
+    return durations;
+  }
+
   private static Duration min(Duration a, Duration b) {
     return a.compareTo(b) <= 0 ? a : b;
+  }
+
+  private static Duration max(Duration a, Duration b) {
+    return a.compareTo(b) >= 0 ? a : b;
   }
 
   private void validateRequest(RouteRequest request) throws RoutingValidationException {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -147,7 +147,9 @@ public class DefaultCarpoolingService implements CarpoolingService {
     this.preFilters = TripPreFilters.defaults();
     this.postFilters = ItineraryPostFilters.defaults();
     this.itineraryMapper = new CarpoolItineraryMapper();
-    this.positionFinder = new InsertionPositionFinder(new BeelineEstimator());
+    this.positionFinder = new InsertionPositionFinder(
+      new BeelineEstimator(streetLimitationParametersService.maxCarSpeed())
+    );
     this.vertexCreationService = vertexCreationService;
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -19,7 +19,9 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.model.CarpoolStop;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
+import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetConstants;
 import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +69,9 @@ public class CarpoolSiriMapper {
    *
    * @throws IllegalArgumentException if the raw message is malformed (fewer than 2 calls
    *         before filtering, calls out of order, missing flexible areas, no departure time
-   *         on the first call or no arrival time on the last call, etc.)
+   *         on the first call or no arrival time on the last call, end time not after start
+   *         time, etc.) or if the trip span or its straight-line drive time exceeds
+   *         {@link CarpoolTrip#MAX_TRIP_DURATION}
    */
   @Nullable
   public CarpoolTrip mapSiriToCarpoolTrip(EstimatedVehicleJourney journey) {
@@ -124,6 +128,55 @@ public class CarpoolSiriMapper {
         "Trip " + tripId + ": last call has neither expected nor aimed arrival time."
       );
     }
+    if (!endTime.isAfter(startTime)) {
+      throw new IllegalArgumentException(
+        String.format(
+          "Trip %s: end time (%s) is not after start time (%s).",
+          tripId,
+          endTime,
+          startTime
+        )
+      );
+    }
+
+    // Reject over-long trips at ingestion. A malformed feed (e.g. a wrong date on one call) could
+    // otherwise create an absurdly long trip whose access/egress routing expands street search
+    // trees across the network and degrades every later request. When the destination has no
+    // latest expected arrival, its scheduled arrival plus the default deviation budget is used —
+    // the same default the destination stop itself receives when the feed omits a latest arrival.
+    var latestArrival = lastStop.getLatestExpectedArrivalTime() != null
+      ? lastStop.getLatestExpectedArrivalTime()
+      : endTime.plus(CarpoolStop.DEFAULT_DEVIATION_BUDGET);
+    var tripDuration = Duration.between(startTime, latestArrival);
+    if (tripDuration.compareTo(CarpoolTrip.MAX_TRIP_DURATION) > 0) {
+      throw new IllegalArgumentException(
+        String.format(
+          "Trip %s: duration (%s) exceeds the maximum of %s (start %s, latest arrival %s).",
+          tripId,
+          tripDuration,
+          CarpoolTrip.MAX_TRIP_DURATION,
+          startTime,
+          latestArrival
+        )
+      );
+    }
+
+    // The timetable above bounds only the claimed schedule, which says nothing about how far apart
+    // the waypoints are. Tree-expansion cost is driven by distance, so reject a trip whose
+    // waypoints cannot be reached in order within the same bound even at the maximum modelled car
+    // speed: such a trip is malformed and would expand street trees far beyond a real carpool trip.
+    var minimumDriveDuration = minimumDriveDuration(stops);
+    if (minimumDriveDuration.compareTo(CarpoolTrip.MAX_TRIP_DURATION) > 0) {
+      throw new IllegalArgumentException(
+        String.format(
+          "Trip %s: straight-line drive time (%s) exceeds the maximum of %s; its waypoints are too" +
+            " far apart to be a real carpool trip whatever the schedule claims.",
+          tripId,
+          minimumDriveDuration,
+          CarpoolTrip.MAX_TRIP_DURATION
+        )
+      );
+    }
 
     int totalCapacity = extractTotalCapacity(tripId, activeCalls);
 
@@ -145,6 +198,25 @@ public class CarpoolSiriMapper {
     }
 
     return builder.build();
+  }
+
+  /**
+   * Lower bound on the time needed to drive the trip's waypoints in order, summing the straight-
+   * line distance between consecutive stops at {@link StreetConstants#DEFAULT_MAX_CAR_SPEED}. No
+   * street route is shorter than the beeline and no car drives faster than the modelled maximum, so
+   * the real drive can only take longer; a value above {@link CarpoolTrip#MAX_TRIP_DURATION} therefore proves
+   * the trip cannot be driven within the cap whatever its claimed timetable says, with no risk of
+   * rejecting a trip that actually could.
+   */
+  private static Duration minimumDriveDuration(List<CarpoolStop> stops) {
+    var estimator = new BeelineEstimator();
+    var total = Duration.ZERO;
+    for (int i = 1; i < stops.size(); i++) {
+      total = total.plus(
+        estimator.estimateDuration(stops.get(i - 1).getCoordinate(), stops.get(i).getCoordinate())
+      );
+    }
+    return total;
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -110,13 +110,9 @@ public class CarpoolSiriMapper {
     var firstStop = stops.getFirst();
     var lastStop = stops.getLast();
 
-    var startTime = firstStop.getExpectedDepartureTime() != null
-      ? firstStop.getExpectedDepartureTime()
-      : firstStop.getAimedDepartureTime();
+    var startTime = firstStop.getScheduledDepartureTime();
 
-    var endTime = lastStop.getExpectedArrivalTime() != null
-      ? lastStop.getExpectedArrivalTime()
-      : lastStop.getAimedArrivalTime();
+    var endTime = lastStop.getScheduledArrivalTime();
 
     if (startTime == null) {
       throw new IllegalArgumentException(

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/BeelineEstimator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/BeelineEstimator.java
@@ -4,63 +4,50 @@ import java.time.Duration;
 import java.util.List;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetConstants;
 
 /**
  * Provides fast, low-resolution travel time estimates based on beeline (straight-line) distances.
  * <p>
  * Used as a heuristic to quickly reject incompatible insertion positions before
  * performing expensive A* street routing. The estimates are intentionally optimistic
- * (lower bounds) to ensure we never incorrectly reject valid insertions.
+ * (lower bounds) so that valid insertions are never incorrectly rejected.
  * <p>
- * Formula: duration = (beeline_distance × detour_factor) / average_speed (in m/s)
+ * Formula: duration = beeline_distance / speed (in m/s)
  * <p>
- * The detour factor accounts for the fact that street routes are rarely straight lines.
- * Typical values: 1.2-1.5, with 1.3 being a reasonable default for urban areas.
+ * No street route is shorter than the beeline, so dividing it by the fastest speed any street
+ * can be driven yields a guaranteed lower bound on the real drive time, whatever the road
+ * geometry.
  */
 public class BeelineEstimator {
 
   /**
-   * Default detour factor: 1.3
-   * Assumes actual street routes are ~30% longer than straight-line distance.
-   * This is conservative - works well for most urban areas.
+   * Fallback speed for the no-arg constructor when no graph-derived speed is supplied
+   * ({@link StreetConstants#DEFAULT_MAX_CAR_SPEED}, 40 m/s ≈ 144 km/h). Production passes the
+   * graph's actual maximum car speed instead — the tightest divisor that still keeps the estimate
+   * a lower bound, since dividing by anything slower would over-estimate and discard feasible
+   * insertions on fast roads.
    */
-  public static final double DEFAULT_DETOUR_FACTOR = 1.3;
+  public static final double DEFAULT_SPEED_MPS = StreetConstants.DEFAULT_MAX_CAR_SPEED;
 
-  /**
-   * Default average speed: 10 m/s (~36 km/h or ~22 mph)
-   * Typical urban carpooling speed accounting for traffic, turns, stops.
-   */
-  public static final double DEFAULT_SPEED_MPS = 10.0;
-
-  private final double detourFactor;
   private final double speed;
 
   /**
-   * Creates estimator with default parameters.
+   * Creates estimator with the default speed.
    */
   public BeelineEstimator() {
-    this(DEFAULT_DETOUR_FACTOR, DEFAULT_SPEED_MPS);
+    this(DEFAULT_SPEED_MPS);
   }
 
   /**
-   * Creates estimator with custom parameters.
-   *
-   * @param detourFactor Factor by which street routes are longer than beeline (typically 1.2-1.5)
-   * @param speed Average travel speed in meters per second
+   * @param speed Travel speed in meters per second; must be at least the fastest speed a car can
+   *        reach in the street model to preserve the lower-bound guarantee
    */
-  public BeelineEstimator(double detourFactor, double speed) {
-    if (detourFactor < 1.0) {
-      throw new IllegalArgumentException("detourFactor must be >= 1.0 (got " + detourFactor + ")");
-    }
+  public BeelineEstimator(double speed) {
     if (speed <= 0) {
-      throw new IllegalArgumentException("speedMps must be positive (got " + speed + ")");
+      throw new IllegalArgumentException("speed must be positive (got " + speed + ")");
     }
-    this.detourFactor = detourFactor;
     this.speed = speed;
-  }
-
-  public double getDetourFactor() {
-    return detourFactor;
   }
 
   public double getSpeed() {
@@ -79,8 +66,7 @@ public class BeelineEstimator {
       from.asJtsCoordinate(),
       to.asJtsCoordinate()
     );
-    double routeDistance = beelineDistance * detourFactor;
-    double seconds = routeDistance / speed;
+    double seconds = beelineDistance / speed;
     return Duration.ofSeconds((long) seconds);
   }
 


### PR DESCRIPTION
### Summary

Bounds the cost of carpool access/egress street routing: each driver leg's search tree is sized from its routed travel duration plus the feasible detour, Fixes a bug where viable passenger drop off and pickup locations were filtered out by the BeelineEstimator estimator. Put's a hard limit on the maximum length of carpooling trips of 2.5 hours because of scalability issues, this might have to be improved in the future, but for now we need some way of avoiding that bad client data poisons the entire feed. 

### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?

Yes

- Was any manual verification done?

Yes

- Any observations on changes to performance?

It solves some of the scalability problems of access/egress for carpooling. Now a single carpooling trip which is very long, either because of client errors or because it actually is very long cannot make the module churn until timeout. 

- Was the code designed so it is unit testable?

Yes

- Were any tests applied to the smallest appropriate unit?

Yes

- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

Yes

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

Yes

- Were all non-trivial public classes and methods documented with Javadoc?

Yes

- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?

no
