### PR TITLE
Make TransitGroupPriority an official feature

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/TripQuery.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/TripQuery.java
@@ -330,8 +330,6 @@ public class TripQuery {
 
             - The `ratio` must be greater or equal to 1.0 and less then 1.2.
             - The `constant` must be greater or equal to '0s' and less then '1h'.
-
-            THIS IS STILL AN EXPERIMENTAL FEATURE - IT MAY CHANGE WITHOUT ANY NOTICE!
             """.stripIndent()
           )
           .type(RelaxCostType.INPUT_TYPE)

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/TransitGroupPriorityConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/TransitGroupPriorityConfig.java
@@ -30,7 +30,6 @@ public class TransitGroupPriorityConfig {
         Unmatched patterns are put in the BASE priority-group.
         """
       )
-      .experimentalFeature()
       .asObject();
 
     transit.withPriorityGroupsByAgency(

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -946,8 +946,6 @@ type QueryType {
     
     - The `ratio` must be greater or equal to 1.0 and less then 1.2.
     - The `constant` must be greater or equal to '0s' and less then '1h'.
-    
-    THIS IS STILL AN EXPERIMENTAL FEATURE - IT MAY CHANGE WITHOUT ANY NOTICE!
     """
     relaxTransitGroupPriority: RelaxCostInput = null,
     "Scooter routing preferences. If not provided, default values from the server configuration will be used."

--- a/doc/user/RouteRequest.md
+++ b/doc/user/RouteRequest.md
@@ -1171,8 +1171,6 @@ only available in the TransmodelAPI for now.
 Unmatched patterns are put in the BASE priority-group.
 
 
-**THIS IS STILL AN EXPERIMENTAL FEATURE - IT MAY CHANGE WITHOUT ANY NOTICE!**
-
 <h3 id="rd_transitReluctanceForMode">transitReluctanceForMode</h3>
 
 **Since version:** `2.1` ∙ **Type:** `enum map of double` ∙ **Cardinality:** `Optional`   


### PR DESCRIPTION
### Summary

Promotes **TransitGroupPriority** from experimental to an official feature by removing all
experimental-feature warnings and the `.experimentalFeature()` config flag.

### Issue

The feature has been in use at Entur in production for some time and is stable. This PR removes the
remaining markers that warned API consumers and operators it might change without notice.

### Unit tests

🟥 No logic changes — documentation/annotation-only cleanup, no new tests needed.

### Documentation

✅ Both user doc and graphql doc is updated.

### Changelog

✅ Promoting TransitGroupPriority to official — include in changelog.

### Bumping the serialization version id

🟥 No serialized classes changed.
