### PR TITLE
Skip GBFS vehicle types with missing form_factor or propulsion_type

### DIFF
--- a/application/src/main/java/org/opentripplanner/gbfs/v2/GbfsFeedMapper.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/v2/GbfsFeedMapper.java
@@ -153,6 +153,7 @@ public class GbfsFeedMapper implements org.opentripplanner.gbfs.GbfsFeedMapper {
     return gbfsVehicleTypes
       .stream()
       .map(vehicleTypeMapper::mapRentalVehicleType)
+      .filter(Objects::nonNull)
       .distinct()
       .collect(Collectors.toMap(v -> v.id().getId(), Function.identity()));
   }

--- a/application/src/main/java/org/opentripplanner/gbfs/v2/GbfsVehicleTypeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/v2/GbfsVehicleTypeMapper.java
@@ -1,12 +1,19 @@
 package org.opentripplanner.gbfs.v2;
 
+import javax.annotation.Nullable;
 import org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.street.model.RentalFormFactor;
+import org.opentripplanner.utils.logging.Throttle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class GbfsVehicleTypeMapper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GbfsVehicleTypeMapper.class);
+  private static final Throttle LOG_THROTTLE = Throttle.ofOneMinute();
 
   private final String systemId;
 
@@ -14,13 +21,44 @@ class GbfsVehicleTypeMapper {
     this.systemId = systemId;
   }
 
+  /**
+   * Maps a GBFS vehicle type to the OTP model, or returns {@code null} when it cannot be mapped and
+   * should be ignored.
+   * <p>
+   * {@code form_factor} and {@code propulsion_type} are required by the GBFS specification. When a
+   * feed omits one, or sends a value the GBFS model does not recognize, it is deserialized to
+   * {@code null}. Rather than guess a substitute we skip the vehicle type so that a single malformed
+   * entry does not abort the whole feed update. Downstream consumers already treat an unknown vehicle
+   * type id as either filtered out (stations) or the system default (free-floating vehicles).
+   */
+  @Nullable
   public RentalVehicleType mapRentalVehicleType(GBFSVehicleType vehicleType) {
+    if (vehicleType.getFormFactor() == null) {
+      logIgnoredVehicleType(vehicleType, "form_factor");
+      return null;
+    }
+    if (vehicleType.getPropulsionType() == null) {
+      logIgnoredVehicleType(vehicleType, "propulsion_type");
+      return null;
+    }
     return new RentalVehicleType(
       new FeedScopedId(systemId, vehicleType.getVehicleTypeId()),
       NonLocalizedString.ofNullable(vehicleType.getName()),
       fromGbfs(vehicleType.getFormFactor()),
       fromGbfs(vehicleType.getPropulsionType()),
       vehicleType.getMaxRangeMeters()
+    );
+  }
+
+  private void logIgnoredVehicleType(GBFSVehicleType vehicleType, String field) {
+    LOG_THROTTLE.throttle(() ->
+      LOG.info(
+        "Ignoring rental vehicle type '{}' in feed '{}': missing or unrecognized {}. {}",
+        vehicleType.getVehicleTypeId(),
+        systemId,
+        field,
+        LOG_THROTTLE.setupInfo()
+      )
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/gbfs/v3/GbfsFeedMapper.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/v3/GbfsFeedMapper.java
@@ -150,6 +150,7 @@ public class GbfsFeedMapper implements org.opentripplanner.gbfs.GbfsFeedMapper {
     return gbfsVehicleTypes
       .stream()
       .map(vehicleTypeMapper::mapRentalVehicleType)
+      .filter(Objects::nonNull)
       .distinct()
       .collect(Collectors.toMap(v -> v.id().getId(), Function.identity()));
   }

--- a/application/src/main/java/org/opentripplanner/gbfs/v3/GbfsVehicleTypeMapper.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/v3/GbfsVehicleTypeMapper.java
@@ -2,13 +2,20 @@ package org.opentripplanner.gbfs.v3;
 
 import static org.opentripplanner.gbfs.v3.GbfsFeedMapper.optionalLocalizedString;
 
+import javax.annotation.Nullable;
 import org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSName;
 import org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleType;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.service.vehiclerental.model.RentalVehicleType;
 import org.opentripplanner.street.model.RentalFormFactor;
+import org.opentripplanner.utils.logging.Throttle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class GbfsVehicleTypeMapper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GbfsVehicleTypeMapper.class);
+  private static final Throttle LOG_THROTTLE = Throttle.ofOneMinute();
 
   private final String systemId;
 
@@ -16,13 +23,44 @@ class GbfsVehicleTypeMapper {
     this.systemId = systemId;
   }
 
+  /**
+   * Maps a GBFS vehicle type to the OTP model, or returns {@code null} when it cannot be mapped and
+   * should be ignored.
+   * <p>
+   * {@code form_factor} and {@code propulsion_type} are required by the GBFS specification. When a
+   * feed omits one, or sends a value the GBFS model does not recognize, it is deserialized to
+   * {@code null}. Rather than guess a substitute we skip the vehicle type so that a single malformed
+   * entry does not abort the whole feed update. Downstream consumers already treat an unknown vehicle
+   * type id as either filtered out (stations) or the system default (free-floating vehicles).
+   */
+  @Nullable
   public RentalVehicleType mapRentalVehicleType(GBFSVehicleType vehicleType) {
+    if (vehicleType.getFormFactor() == null) {
+      logIgnoredVehicleType(vehicleType, "form_factor");
+      return null;
+    }
+    if (vehicleType.getPropulsionType() == null) {
+      logIgnoredVehicleType(vehicleType, "propulsion_type");
+      return null;
+    }
     return new RentalVehicleType(
       new FeedScopedId(systemId, vehicleType.getVehicleTypeId()),
       optionalLocalizedString(vehicleType.getName(), GBFSName::getLanguage, GBFSName::getText),
       fromGbfs(vehicleType.getFormFactor()),
       fromGbfs(vehicleType.getPropulsionType()),
       vehicleType.getMaxRangeMeters()
+    );
+  }
+
+  private void logIgnoredVehicleType(GBFSVehicleType vehicleType, String field) {
+    LOG_THROTTLE.throttle(() ->
+      LOG.info(
+        "Ignoring rental vehicle type '{}' in feed '{}': missing or unrecognized {}. {}",
+        vehicleType.getVehicleTypeId(),
+        systemId,
+        field,
+        LOG_THROTTLE.setupInfo()
+      )
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/gbfs/v2/GbfsFeedMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/v2/GbfsFeedMapperTest.java
@@ -375,6 +375,41 @@ class GbfsFeedMapperTest {
     assertEquals(10, duplicateStation.vehiclesAvailable());
   }
 
+  @Test
+  void vehicleTypesWithMissingFormFactorOrPropulsionAreSkippedWithoutThrowing() {
+    GbfsVehicleTypeMapper vehicleTypeMapper = new GbfsVehicleTypeMapper("systemID");
+
+    GBFSVehicleType valid = new GBFSVehicleType();
+    valid.setVehicleTypeId("valid");
+    valid.setFormFactor(GBFSVehicleType.FormFactor.BICYCLE);
+    valid.setPropulsionType(GBFSVehicleType.PropulsionType.ELECTRIC);
+
+    // A feed that omits the required form_factor / propulsion_type (or sends an unrecognized value
+    // that Jackson deserializes to null) must not abort the whole feed update with a NPE. The
+    // malformed vehicle types are skipped; the valid one survives.
+    GBFSVehicleType missingFormFactor = new GBFSVehicleType();
+    missingFormFactor.setVehicleTypeId("missingFormFactor");
+    missingFormFactor.setFormFactor(null);
+    missingFormFactor.setPropulsionType(GBFSVehicleType.PropulsionType.ELECTRIC);
+
+    GBFSVehicleType missingPropulsion = new GBFSVehicleType();
+    missingPropulsion.setVehicleTypeId("missingPropulsion");
+    missingPropulsion.setFormFactor(GBFSVehicleType.FormFactor.BICYCLE);
+    missingPropulsion.setPropulsionType(null);
+
+    Map<String, RentalVehicleType> vehicleTypes = assertDoesNotThrow(() ->
+      GbfsFeedMapper.mapVehicleTypes(
+        vehicleTypeMapper,
+        List.of(valid, missingFormFactor, missingPropulsion)
+      )
+    );
+
+    assertEquals(1, vehicleTypes.size());
+    assertTrue(vehicleTypes.containsKey("valid"));
+    assertFalse(vehicleTypes.containsKey("missingFormFactor"));
+    assertFalse(vehicleTypes.containsKey("missingPropulsion"));
+  }
+
   private static List<GBFSVehicleType> getDuplicatedGbfsVehicleTypes() {
     GBFSVehicleType gbfsVehicleType1 = new GBFSVehicleType();
     gbfsVehicleType1.setVehicleTypeId("sameId");

--- a/application/src/test/java/org/opentripplanner/gbfs/v3/GbfsFeedMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/v3/GbfsFeedMapperTest.java
@@ -265,6 +265,41 @@ class GbfsFeedMapperTest {
     assertEquals(10, duplicateStation.vehiclesAvailable());
   }
 
+  @Test
+  void vehicleTypesWithMissingFormFactorOrPropulsionAreSkippedWithoutThrowing() {
+    GbfsVehicleTypeMapper vehicleTypeMapper = new GbfsVehicleTypeMapper("systemID");
+
+    GBFSVehicleType valid = new GBFSVehicleType();
+    valid.setVehicleTypeId("valid");
+    valid.setFormFactor(GBFSVehicleType.FormFactor.BICYCLE);
+    valid.setPropulsionType(GBFSVehicleType.PropulsionType.ELECTRIC);
+
+    // A feed that omits the required form_factor / propulsion_type (or sends an unrecognized value
+    // that Jackson deserializes to null) must not abort the whole feed update with a NPE. The
+    // malformed vehicle types are skipped; the valid one survives.
+    GBFSVehicleType missingFormFactor = new GBFSVehicleType();
+    missingFormFactor.setVehicleTypeId("missingFormFactor");
+    missingFormFactor.setFormFactor(null);
+    missingFormFactor.setPropulsionType(GBFSVehicleType.PropulsionType.ELECTRIC);
+
+    GBFSVehicleType missingPropulsion = new GBFSVehicleType();
+    missingPropulsion.setVehicleTypeId("missingPropulsion");
+    missingPropulsion.setFormFactor(GBFSVehicleType.FormFactor.BICYCLE);
+    missingPropulsion.setPropulsionType(null);
+
+    Map<String, RentalVehicleType> vehicleTypes = assertDoesNotThrow(() ->
+      GbfsFeedMapper.mapVehicleTypes(
+        vehicleTypeMapper,
+        List.of(valid, missingFormFactor, missingPropulsion)
+      )
+    );
+
+    assertEquals(1, vehicleTypes.size());
+    assertTrue(vehicleTypes.containsKey("valid"));
+    assertFalse(vehicleTypes.containsKey("missingFormFactor"));
+    assertFalse(vehicleTypes.containsKey("missingPropulsion"));
+  }
+
   private static List<GBFSVehicleType> getDuplicatedGbfsVehicleTypes() {
     GBFSVehicleType gbfsVehicleType1 = new GBFSVehicleType();
     gbfsVehicleType1.setVehicleTypeId("sameId");

--- a/application/src/test/java/org/opentripplanner/gbfs/v3/GbfsFeedMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/v3/GbfsFeedMapperTest.java
@@ -271,7 +271,7 @@ class GbfsFeedMapperTest {
 
     GBFSVehicleType valid = new GBFSVehicleType();
     valid.setVehicleTypeId("valid");
-    valid.setFormFactor(GBFSVehicleType.FormFactor.BICYCLE);
+    valid.setFormFactor(GBFSVehicleType.FormFactor.SCOOTER_STANDING);
     valid.setPropulsionType(GBFSVehicleType.PropulsionType.ELECTRIC);
 
     // A feed that omits the required form_factor / propulsion_type (or sends an unrecognized value
@@ -284,7 +284,7 @@ class GbfsFeedMapperTest {
 
     GBFSVehicleType missingPropulsion = new GBFSVehicleType();
     missingPropulsion.setVehicleTypeId("missingPropulsion");
-    missingPropulsion.setFormFactor(GBFSVehicleType.FormFactor.BICYCLE);
+    missingPropulsion.setFormFactor(GBFSVehicleType.FormFactor.SCOOTER_STANDING);
     missingPropulsion.setPropulsionType(null);
 
     Map<String, RentalVehicleType> vehicleTypes = assertDoesNotThrow(() ->


### PR DESCRIPTION
## Summary

A GBFS vehicle type whose required `form_factor` (or `propulsion_type`) is omitted — or carries a value the GBFS model does not recognize — is deserialized to `null` by Jackson. The exhaustive `switch` in `GbfsVehicleTypeMapper` then threw a `NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke
"...GBFSVehicleType$FormFactor.ordinal()" because "formFactor" is null
  at org.opentripplanner.gbfs.v3.GbfsVehicleTypeMapper.fromGbfs(GbfsVehicleTypeMapper.java:45)
  at ...GbfsFeedMapper.mapVehicleTypes(...)
  at ...VehicleRentalUpdater.runPolling(...)
```

Because the mapping uses a stream `collect`, a single malformed vehicle type aborts the **whole feed's** `vehicle_types` mapping, so every poll of that rental updater fails and all of the operator's vehicles disappear.

## Changes

- `GbfsVehicleTypeMapper.mapRentalVehicleType` (v2 and v3) now returns `@Nullable`: when `form_factor` or `propulsion_type` is null/unrecognized it logs a **throttled INFO** message identifying the feed and vehicle type, and returns `null`.
- `GbfsFeedMapper.mapVehicleTypes` (v2 and v3) filters out the `null`s.
- The `fromGbfs(...)` switches remain exhaustive (no `default`), so adding a new form factor / propulsion type in the GBFS model is still a compile-time decision.

A single malformed entry no longer drops the entire feed. This is consistent with how downstream consumers already treat an unknown `vehicle_type_id`: filtered out at stations (`GbfsStationStatusMapper` / `UnknownVehicleTypeFilter`), and the system default type for free-floating vehicles (`GbfsVehicleStatusMapper`).

## Testing

Added `vehicleTypesWithMissingFormFactorOrPropulsionAreSkippedWithoutThrowing` to both the v2 and v3 `GbfsFeedMapperTest`: a valid vehicle type alongside one missing `form_factor` and one missing `propulsion_type` maps without throwing, and only the valid type survives.