### PR TITLE
Remove "safest streets" vehicle routing optimization and deprecate its API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/OptimizationTypeMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/OptimizationTypeMapper.java
@@ -10,7 +10,7 @@ public final class OptimizationTypeMapper {
       case QUICK -> VehicleRoutingOptimizeType.SHORTEST_DURATION;
       case FLAT -> VehicleRoutingOptimizeType.FLAT_STREETS;
       case SAFE -> VehicleRoutingOptimizeType.SAFE_STREETS;
-      case GREENWAYS -> VehicleRoutingOptimizeType.SAFEST_STREETS;
+      case GREENWAYS -> VehicleRoutingOptimizeType.SAFE_STREETS;
       case TRIANGLE -> VehicleRoutingOptimizeType.TRIANGLE;
     };
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/VehicleOptimizationTypeMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/VehicleOptimizationTypeMapper.java
@@ -13,8 +13,7 @@ public class VehicleOptimizationTypeMapper {
     return switch (type) {
       case SHORTEST_DURATION -> VehicleRoutingOptimizeType.SHORTEST_DURATION;
       case FLAT_STREETS -> VehicleRoutingOptimizeType.FLAT_STREETS;
-      case SAFE_STREETS -> VehicleRoutingOptimizeType.SAFE_STREETS;
-      case SAFEST_STREETS -> VehicleRoutingOptimizeType.SAFEST_STREETS;
+      case SAFE_STREETS, SAFEST_STREETS -> VehicleRoutingOptimizeType.SAFE_STREETS;
     };
   }
 
@@ -22,8 +21,7 @@ public class VehicleOptimizationTypeMapper {
     return switch (type) {
       case SHORTEST_DURATION -> VehicleRoutingOptimizeType.SHORTEST_DURATION;
       case FLAT_STREETS -> VehicleRoutingOptimizeType.FLAT_STREETS;
-      case SAFE_STREETS -> VehicleRoutingOptimizeType.SAFE_STREETS;
-      case SAFEST_STREETS -> VehicleRoutingOptimizeType.SAFEST_STREETS;
+      case SAFE_STREETS, SAFEST_STREETS -> VehicleRoutingOptimizeType.SAFE_STREETS;
     };
   }
 
@@ -35,7 +33,6 @@ public class VehicleOptimizationTypeMapper {
       case SHORTEST_DURATION -> GraphQLTypes.GraphQLCyclingOptimizationType.SHORTEST_DURATION;
       case FLAT_STREETS -> GraphQLTypes.GraphQLCyclingOptimizationType.FLAT_STREETS;
       case SAFE_STREETS -> GraphQLTypes.GraphQLCyclingOptimizationType.SAFE_STREETS;
-      case SAFEST_STREETS -> GraphQLTypes.GraphQLCyclingOptimizationType.SAFEST_STREETS;
       case TRIANGLE -> null;
     };
   }
@@ -48,7 +45,6 @@ public class VehicleOptimizationTypeMapper {
       case SHORTEST_DURATION -> GraphQLTypes.GraphQLScooterOptimizationType.SHORTEST_DURATION;
       case FLAT_STREETS -> GraphQLTypes.GraphQLScooterOptimizationType.FLAT_STREETS;
       case SAFE_STREETS -> GraphQLTypes.GraphQLScooterOptimizationType.SAFE_STREETS;
-      case SAFEST_STREETS -> GraphQLTypes.GraphQLScooterOptimizationType.SAFEST_STREETS;
       case TRIANGLE -> null;
     };
   }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -77,7 +77,7 @@ public class EnumTypes {
     .value("quick", VehicleRoutingOptimizeType.SHORTEST_DURATION)
     .value("safe", VehicleRoutingOptimizeType.SAFE_STREETS)
     .value("flat", VehicleRoutingOptimizeType.FLAT_STREETS)
-    .value("greenways", VehicleRoutingOptimizeType.SAFEST_STREETS)
+    .value("greenways", VehicleRoutingOptimizeType.SAFE_STREETS)
     .value("triangle", VehicleRoutingOptimizeType.TRIANGLE)
     .build();
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -364,9 +364,8 @@ public class RouteRequestConfig {
           )
           .description(
             """
-            If the optimization is set to `safe-streets` or `safest-streets`, or if `safety` is non-zero
-            in the triangle, the actual effect will further be affected by the safety of the cycle
-            route.
+            If the optimization is set to `safe-streets`, or if `safety` is non-zero in the triangle,
+            the actual effect will further be affected by the safety of the cycle route.
 
             The effect of safety has changed between versions 2.9 and 2.10 by the removal of the
             safety normalizer. Before the change, all the safety values were multiplied such that

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -3334,13 +3334,7 @@ one can use the triangle factors.
 enum CyclingOptimizationType {
   "Emphasize flatness over safety or duration of the route. This option was previously called `FLAT`."
   FLAT_STREETS
-  """
-  Completely ignore the elevation differences and prefer the streets, that are evaluated
-  to be the safest, even more than with the `SAFE_STREETS` option.
-  Safety can also include other concerns such as convenience and general cyclist preferences
-  by taking into account road surface etc. This option was previously called `GREENWAYS`.
-  """
-  SAFEST_STREETS
+  SAFEST_STREETS @deprecated(reason : "Use SAFE_STREETS instead")
   """
   Emphasize cycling safety over flatness or duration of the route. Safety can also include other
   concerns such as convenience and general cyclist preferences by taking into account
@@ -4008,15 +4002,7 @@ one can use the triangle factors.
 enum ScooterOptimizationType {
   "Emphasize flatness over safety or duration of the route. This option was previously called `FLAT`."
   FLAT_STREETS
-  """
-  Completely ignore the elevation differences and prefer the streets, that are evaluated
-  to be safest for scooters, even more than with the `SAFE_STREETS` option.
-  Safety can also include other concerns such as convenience and general preferences by taking
-  into account road surface etc.  Note, currently the same criteria is used both for cycling and
-  scooter travel to determine how safe streets are for cycling or scooter.
-  This option was previously called `GREENWAYS`.
-  """
-  SAFEST_STREETS
+  SAFEST_STREETS @deprecated(reason : "Use SAFE_STREETS instead")
   """
   Emphasize scooter safety over flatness or duration of the route. Safety can also include other
   concerns such as convenience and general preferences by taking into account road surface etc.

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperBicycleTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperBicycleTest.java
@@ -150,7 +150,7 @@ class RouteRequestMapperBicycleTest {
           Map.ofEntries(
             entry(
               "bicycle",
-              Map.ofEntries(entry("optimization", Map.ofEntries(entry("type", "SAFEST_STREETS"))))
+              Map.ofEntries(entry("optimization", Map.ofEntries(entry("type", "SAFE_STREETS"))))
             )
           )
         )
@@ -159,7 +159,7 @@ class RouteRequestMapperBicycleTest {
     var env = testCtx.executionContext(bicycleArgs);
     var routeRequest = RouteRequestMapper.toRouteRequest(env, testCtx.context());
     var bikePreferences = routeRequest.preferences().bike();
-    assertEquals(VehicleRoutingOptimizeType.SAFEST_STREETS, bikePreferences.optimizeType());
+    assertEquals(VehicleRoutingOptimizeType.SAFE_STREETS, bikePreferences.optimizeType());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperScooterTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperScooterTest.java
@@ -94,7 +94,7 @@ class RouteRequestMapperScooterTest {
           Map.ofEntries(
             entry(
               "scooter",
-              Map.ofEntries(entry("optimization", Map.ofEntries(entry("type", "SAFEST_STREETS"))))
+              Map.ofEntries(entry("optimization", Map.ofEntries(entry("type", "SAFE_STREETS"))))
             )
           )
         )
@@ -103,7 +103,7 @@ class RouteRequestMapperScooterTest {
     var env = testCtx.executionContext(scooterArgs);
     var routeRequest = RouteRequestMapper.toRouteRequest(env, testCtx.context());
     var scooterPreferences = routeRequest.preferences().scooter();
-    assertEquals(VehicleRoutingOptimizeType.SAFEST_STREETS, scooterPreferences.optimizeType());
+    assertEquals(VehicleRoutingOptimizeType.SAFE_STREETS, scooterPreferences.optimizeType());
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/preferences/BikePreferencesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/preferences/BikePreferencesMapperTest.java
@@ -83,10 +83,10 @@ class BikePreferencesMapperTest {
     var preferences = BikePreferences.of();
     var callWith = TestDataFetcherDecorator.of(
       "bikePreferences",
-      Map.of("optimisationMethod", VehicleRoutingOptimizeType.SAFEST_STREETS)
+      Map.of("optimisationMethod", VehicleRoutingOptimizeType.SAFE_STREETS)
     );
     mapBikePreferences(preferences, callWith);
-    assertEquals(VehicleRoutingOptimizeType.SAFEST_STREETS, preferences.build().optimizeType());
+    assertEquals(VehicleRoutingOptimizeType.SAFE_STREETS, preferences.build().optimizeType());
   }
 
   @Test
@@ -200,7 +200,7 @@ class BikePreferencesMapperTest {
         "bikeSpeed",
         11.0,
         "bicycleOptimisationMethod",
-        VehicleRoutingOptimizeType.SAFEST_STREETS,
+        VehicleRoutingOptimizeType.SAFE_STREETS,
         "triangleFactors",
         Map.of("time", 0.6, "slope", 0.2, "safety", 0.1),
         // Wrapper takes precedence

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/preferences/ScooterPreferencesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/preferences/ScooterPreferencesMapperTest.java
@@ -48,10 +48,10 @@ class ScooterPreferencesMapperTest {
     var preferences = ScooterPreferences.of();
     var callWith = TestDataFetcherDecorator.of(
       "scooterPreferences",
-      Map.of("optimisationMethod", VehicleRoutingOptimizeType.SAFEST_STREETS)
+      Map.of("optimisationMethod", VehicleRoutingOptimizeType.SAFE_STREETS)
     );
     mapScooterPreferences(preferences, callWith);
-    assertEquals(VehicleRoutingOptimizeType.SAFEST_STREETS, preferences.build().optimizeType());
+    assertEquals(VehicleRoutingOptimizeType.SAFE_STREETS, preferences.build().optimizeType());
   }
 
   @Test

--- a/doc/user/RouteRequest.md
+++ b/doc/user/RouteRequest.md
@@ -496,7 +496,7 @@ This is the cost that is used when boarding while cycling. This is usually highe
 
 **Since version:** `2.0` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"safe-streets"`   
 **Path:** /routingDefaults/bicycle   
-**Enum values:** `shortest-duration` | `safe-streets` | `flat-streets` | `safest-streets` | `triangle`
+**Enum values:** `shortest-duration` | `safe-streets` | `flat-streets` | `triangle`
 
 The set of characteristics that the user wants to optimize for.
 
@@ -509,9 +509,8 @@ If the triangle optimization is used, it's enough to just define the triangle pa
 
 A multiplier for how bad cycling is, compared to being in transit for equal lengths of time.
 
-If the optimization is set to `safe-streets` or `safest-streets`, or if `safety` is non-zero
-in the triangle, the actual effect will further be affected by the safety of the cycle
-route.
+If the optimization is set to `safe-streets`, or if `safety` is non-zero in the triangle,
+the actual effect will further be affected by the safety of the cycle route.
 
 The effect of safety has changed between versions 2.9 and 2.10 by the removal of the
 safety normalizer. Before the change, all the safety values were multiplied such that
@@ -1015,7 +1014,7 @@ done because some street modes searches are much more resource intensive than ot
 
 **Since version:** `2.0` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"safe-streets"`   
 **Path:** /routingDefaults/scooter   
-**Enum values:** `shortest-duration` | `safe-streets` | `flat-streets` | `safest-streets` | `triangle`
+**Enum values:** `shortest-duration` | `safe-streets` | `flat-streets` | `triangle`
 
 The set of characteristics that the user wants to optimize for.
 

--- a/street/src/main/java/org/opentripplanner/street/model/VehicleRoutingOptimizeType.java
+++ b/street/src/main/java/org/opentripplanner/street/model/VehicleRoutingOptimizeType.java
@@ -15,8 +15,6 @@ public enum VehicleRoutingOptimizeType {
   SAFE_STREETS,
   /** This was previously called FLAT. Needs a rewrite. */
   FLAT_STREETS,
-  /** This was previously called GREENWAYS. */
-  SAFEST_STREETS,
   TRIANGLE;
 
   private static final Set<VehicleRoutingOptimizeType> NON_TRIANGLE_VALUES =

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -940,13 +940,6 @@ public class StreetEdge
       ? req.bike().optimizeType()
       : req.scooter().optimizeType();
     switch (optimizeType) {
-      case SAFEST_STREETS -> {
-        weight = (bicycleSafetyFactor * getDistanceMeters()) / speed;
-        if (bicycleSafetyFactor <= SAFEST_STREETS_SAFETY_FACTOR) {
-          // safest streets are treated as even safer than they really are
-          weight *= 0.66;
-        }
-      }
       case SAFE_STREETS -> weight = getEffectiveBicycleSafetyDistance() / speed;
       case FLAT_STREETS ->
         /* see notes in StreetVertex on speed overhead */ weight =

--- a/street/src/main/java/org/opentripplanner/street/search/EuclideanRemainingWeightHeuristic.java
+++ b/street/src/main/java/org/opentripplanner/street/search/EuclideanRemainingWeightHeuristic.java
@@ -157,7 +157,6 @@ public class EuclideanRemainingWeightHeuristic implements RemainingWeightHeurist
       case SHORTEST_DURATION -> 1.0;
       case SAFE_STREETS -> safety;
       case FLAT_STREETS -> 1.0;
-      case SAFEST_STREETS -> safety;
       case TRIANGLE -> scaleSafety(
         safety,
         Objects.requireNonNull(

--- a/street/src/test/java/org/opentripplanner/street/search/EuclideanRemainingWeightHeuristicTest.java
+++ b/street/src/test/java/org/opentripplanner/street/search/EuclideanRemainingWeightHeuristicTest.java
@@ -115,16 +115,6 @@ class EuclideanRemainingWeightHeuristicTest {
           .build(),
         28
       ),
-      // safest bike
-      Arguments.argumentSet(
-        "safest bike",
-        safeStreets,
-        StreetSearchRequest.of()
-          .withMode(StreetMode.BIKE)
-          .withBike(b -> b.withOptimizeType(VehicleRoutingOptimizeType.SAFEST_STREETS))
-          .build(),
-        24
-      ),
       // a slow car
       Arguments.argumentSet(
         "slow car",

--- a/test/performance/helsinki/router-config.json
+++ b/test/performance/helsinki/router-config.json
@@ -10,7 +10,7 @@
       "speed": 5.55,
       "reluctance": 1.7,
       "boardCost": 120,
-      "optimization": "safest-streets"
+      "optimization": "safe-streets"
     },
     "car": {
       "reluctance": 10.0


### PR DESCRIPTION
### Summary

Remove "safest streets" vehicle routing optimization and deprecate its API, falling back to "safe streets" instead.

### Issue

This is a follow up to #6785 . After discussion, we have found out that there is no longer a valid use case of the "safest streets" optimization option, and it currently performs little different from "safe streets".

### Unit tests

Updated to replace all references of "SAFEST_STREETS" to "SAFE_STREETS"

### Documentation

Updated GraphQL documentation to add deprecation notice

### Changelog

May not be needed

### Bumping the serialization version id

Not needed