### PR TITLE
Clamp street access/egress/transfer cost to prevent Raptor int overflow

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgress.java
@@ -8,8 +8,8 @@ import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.raptor.spi.RaptorConstants;
-import org.opentripplanner.raptor.spi.RaptorCostConverter;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RoutingAccessEgress;
+import org.opentripplanner.routing.cost.CostLimit;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
@@ -104,7 +104,7 @@ public class CarpoolAccessEgress implements RoutingAccessEgress {
     double walkWeight =
       GraphPathUtils.weightOrZero(walkToPickup) + GraphPathUtils.weightOrZero(walkFromDropoff);
     double totalWeight = walkWeight + insertionCandidate.getPassengerRideWeight(carpoolReluctance);
-    this.c1 = RaptorCostConverter.toRaptorCost(totalWeight) + penalty.cost().toCentiSeconds();
+    this.c1 = CostLimit.toRaptorCost(totalWeight) + penalty.cost().toCentiSeconds();
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgress.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgress.java
@@ -3,7 +3,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 import java.util.Objects;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.raptor.spi.RaptorConstants;
-import org.opentripplanner.raptor.spi.RaptorCostConverter;
+import org.opentripplanner.routing.cost.CostLimit;
 import org.opentripplanner.street.search.state.State;
 
 /**
@@ -54,7 +54,7 @@ public class DefaultAccessEgress implements RoutingAccessEgress {
     this(
       stop,
       (int) finalState.getElapsedTimeSeconds(),
-      RaptorCostConverter.toRaptorCost(finalState.getWeight()),
+      CostLimit.toRaptorCost(finalState.getWeight()),
       TimeAndCost.ZERO,
       finalState
     );

--- a/application/src/main/java/org/opentripplanner/routing/cost/CostLimit.java
+++ b/application/src/main/java/org/opentripplanner/routing/cost/CostLimit.java
@@ -1,0 +1,81 @@
+package org.opentripplanner.routing.cost;
+
+import org.opentripplanner.raptor.spi.RaptorConstants;
+import org.opentripplanner.raptor.spi.RaptorCostConverter;
+import org.opentripplanner.utils.logging.Throttle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Converts a street-search-derived generalized cost — the cost of an access, egress or transfer
+ * leg — into a Raptor internal cost, clamping it to a sane maximum first.
+ * <p>
+ * These costs are produced by an A* search (or, for an edge-less transfer, a straight-line distance
+ * estimate) and are not bounded by Raptor's own pruning. A leg over, for example, a steep,
+ * wheelchair-inaccessible stairway can accumulate an extremely high generalized cost. Casting such a
+ * cost straight to Raptor's 32-bit {@code int} representation overflows and wraps to a negative
+ * value, which then makes the whole request fail (a negative cost is rejected when the path is
+ * mapped back to an itinerary) and can corrupt the pareto search by making a path look artificially
+ * cheap.
+ * <p>
+ * The limit is high enough — several days of transit-equivalent cost — that no legitimate journey
+ * is affected, but far enough below {@link RaptorConstants#UNREACHED_HIGH} that summing a handful
+ * of capped legs still cannot overflow. A capped leg ends up with a large-but-finite cost and is
+ * dropped by the itinerary filters, so valid alternatives are returned instead of an error.
+ * <p>
+ * Transfers were the first place this overflow was observed and fixed
+ * (<a href="https://github.com/opentripplanner/OpenTripPlanner/issues/5509">#5509</a>); access and
+ * egress legs are the unguarded sibling
+ * (<a href="https://github.com/opentripplanner/OpenTripPlanner/issues/7679">#7679</a>). This helper
+ * holds the single shared definition used by both.
+ *
+ * @see RaptorCostConverter
+ */
+public final class CostLimit {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CostLimit.class);
+  private static final Throttle THROTTLE_COST_EXCEEDED = Throttle.ofOneSecond();
+
+  /**
+   * The maximum street generalized cost, in transit-seconds, that is converted to Raptor. This is
+   * roughly 23 days and converts to a Raptor cost of 2&times;10<sup>8</sup>, an order of magnitude
+   * below {@link RaptorConstants#UNREACHED_HIGH}.
+   */
+  public static final int MAX_COST = 2_000_000;
+
+  private CostLimit() {}
+
+  /**
+   * Convert a street generalized cost (transit-seconds) to a Raptor cost, capping it at
+   * {@link #MAX_COST} so the conversion cannot overflow Raptor's {@code int} cost. A negative input
+   * (which only happens if the cost has already overflowed upstream) is treated as the worst case
+   * and capped as well, never as a "free" leg.
+   */
+  public static int toRaptorCost(double generalizedCost) {
+    return RaptorCostConverter.toRaptorCost(sanityLimit(generalizedCost));
+  }
+
+  /**
+   * Like {@link #toRaptorCost(double)} but truncates the cost to whole transit-seconds first. This
+   * preserves the historical resolution of transfer costs — a side effect of the original integer
+   * sanity-check in #5509 — so routing results are unchanged. New callers should normally use
+   * {@link #toRaptorCost(double)}, which keeps centi-second precision.
+   */
+  public static int toRaptorCostWholeSeconds(double generalizedCost) {
+    return RaptorCostConverter.toRaptorCost((int) sanityLimit(generalizedCost));
+  }
+
+  private static double sanityLimit(double cost) {
+    if (cost >= 0 && cost <= MAX_COST) {
+      return cost;
+    }
+    THROTTLE_COST_EXCEEDED.throttle(() ->
+      LOG.warn(
+        "Generalized cost {} for a street access, egress or transfer leg exceeded the maximum of {} and was capped. Please consider changing the cost calculation. More information: https://github.com/opentripplanner/OpenTripPlanner/pull/5516#issuecomment-1819138078",
+        cost,
+        MAX_COST
+      )
+    );
+    return MAX_COST;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/routing/via/model/ViaCoordinateTransfer.java
+++ b/application/src/main/java/org/opentripplanner/routing/via/model/ViaCoordinateTransfer.java
@@ -2,8 +2,8 @@ package org.opentripplanner.routing.via.model;
 
 import java.util.List;
 import org.opentripplanner.raptor.api.model.RaptorValueType;
-import org.opentripplanner.raptor.spi.RaptorCostConverter;
 import org.opentripplanner.raptor.spi.RaptorTransfer;
+import org.opentripplanner.routing.cost.CostLimit;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.utils.time.DurationUtils;
@@ -55,7 +55,7 @@ public class ViaCoordinateTransfer implements RaptorTransfer {
     this.fromEdges = fromEdges;
     this.toEdges = toEdges;
     this.durationInSeconds = durationInSeconds;
-    this.raptorCost = RaptorCostConverter.toRaptorCost(generalizedCostInSeconds);
+    this.raptorCost = CostLimit.toRaptorCost(generalizedCostInSeconds);
   }
 
   public WgsCoordinate coordinate() {

--- a/application/src/main/java/org/opentripplanner/transfer/regular/model/PathTransfer.java
+++ b/application/src/main/java/org/opentripplanner/transfer/regular/model/PathTransfer.java
@@ -5,7 +5,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.raptor.spi.RaptorCostConverter;
+import org.opentripplanner.routing.cost.CostLimit;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.Edge;
@@ -15,10 +15,7 @@ import org.opentripplanner.street.search.state.EdgeTraverser;
 import org.opentripplanner.street.search.state.StateEditor;
 import org.opentripplanner.transfer.constrained.model.ConstrainedTransfer;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.utils.logging.Throttle;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents a transfer for a set of modes between stops with the street network path attached to it.
@@ -31,8 +28,6 @@ import org.slf4j.LoggerFactory;
  */
 public class PathTransfer implements Serializable {
 
-  private static final Logger LOG = LoggerFactory.getLogger(PathTransfer.class);
-
   public final StopLocation from;
 
   public final StopLocation to;
@@ -42,10 +37,6 @@ public class PathTransfer implements Serializable {
   private final List<Edge> edges;
 
   private final EnumSet<StreetMode> modes;
-
-  private static final Throttle THROTTLE_COST_EXCEEDED = Throttle.ofOneSecond();
-
-  protected static final int MAX_TRANSFER_COST = 2_000_000;
 
   public PathTransfer(
     StopLocation from,
@@ -97,12 +88,11 @@ public class PathTransfer implements Serializable {
     if (edges == null || edges.isEmpty()) {
       WalkRequest walkReq = request.walk();
       double durationSeconds = distanceMeters / walkReq.speed();
-      final double domainCost = costLimitSanityCheck(durationSeconds * walkReq.reluctance());
       return Optional.of(
         new DefaultRaptorTransfer(
           to.getIndex(),
           (int) Math.ceil(durationSeconds),
-          RaptorCostConverter.toRaptorCost(domainCost),
+          CostLimit.toRaptorCostWholeSeconds(durationSeconds * walkReq.reluctance()),
           this
         )
       );
@@ -117,7 +107,7 @@ public class PathTransfer implements Serializable {
       new DefaultRaptorTransfer(
         to.getIndex(),
         (int) s.getElapsedTimeSeconds(),
-        RaptorCostConverter.toRaptorCost(costLimitSanityCheck(s.getWeight())),
+        CostLimit.toRaptorCostWholeSeconds(s.getWeight()),
         this
       )
     );
@@ -132,34 +122,5 @@ public class PathTransfer implements Serializable {
       .addColSize("edges", edges)
       .addColSize("modes", modes)
       .toString();
-  }
-
-  /**
-   * Since transfer costs are not computed through a full A* with pruning they can incur an
-   * absurdly high cost that overflows the integer cost inside RAPTOR
-   * (https://github.com/opentripplanner/OpenTripPlanner/issues/5509).
-   * <p>
-   * An example would be a transfer using lots of stairs being used on a wheelchair when no
-   * wheelchair-specific one has been generated.
-   * (see https://docs.opentripplanner.org/en/dev-2.x/Accessibility/).
-   * <p>
-   * For this reason there is this sanity limit that makes sure that the transfer cost stays below a
-   * limit that is still very high (several days of transit-equivalent cost) but far away from the
-   * integer overflow.
-   *
-   * @see EdgeTraverser
-   * @see RaptorCostConverter
-   */
-  private int costLimitSanityCheck(double cost) {
-    if (cost >= 0 && cost <= MAX_TRANSFER_COST) {
-      return (int) cost;
-    } else {
-      THROTTLE_COST_EXCEEDED.throttle(() ->
-        LOG.warn(
-          "Transfer exceeded maximum cost. Please consider changing the transfer cost calculation. More information: https://github.com/opentripplanner/OpenTripPlanner/pull/5516#issuecomment-1819138078"
-        )
-      );
-      return MAX_TRANSFER_COST;
-    }
   }
 }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgressTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/DefaultAccessEgressTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.basic.Cost;
 import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.raptor.spi.RaptorConstants;
+import org.opentripplanner.raptor.spi.RaptorCostConverter;
+import org.opentripplanner.routing.cost.CostLimit;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.TestStateBuilder;
 
@@ -59,6 +61,32 @@ class DefaultAccessEgressTest {
   @Test
   void hasOpeningHours() {
     assertFalse(subject.hasOpeningHours());
+  }
+
+  /**
+   * A long access leg — e.g. a walk over steep, wheelchair-inaccessible stairs — can accumulate a
+   * generalized cost so large that converting it straight to Raptor's {@code int} cost overflows to
+   * a negative value, crashing the whole request (issue #7679). The cost must instead be capped to
+   * {@link CostLimit#MAX_COST} so a valid (finite, non-negative) cost is produced.
+   */
+  @Test
+  void generalizedCostDoesNotOverflow() {
+    var builder = TestStateBuilder.ofWalking();
+    for (int i = 0; i < 20; i++) {
+      builder.streetEdge();
+    }
+    var state = builder.build();
+
+    // Precondition: the raw weight must exceed the cap, otherwise this test proves nothing.
+    assertTrue(
+      state.getWeight() > CostLimit.MAX_COST,
+      () -> "test fixture weight " + state.getWeight() + " must exceed the cap to be meaningful"
+    );
+
+    var subject = new DefaultAccessEgress(STOP, state);
+
+    assertEquals(RaptorCostConverter.toRaptorCost((double) CostLimit.MAX_COST), subject.c1());
+    assertTrue(subject.c1() > 0, "capped access cost must stay positive");
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/routing/cost/CostLimitTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/cost/CostLimitTest.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.routing.cost;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.raptor.spi.RaptorConstants;
+import org.opentripplanner.raptor.spi.RaptorCostConverter;
+
+class CostLimitTest {
+
+  private static final int MAX_RAPTOR_COST = RaptorCostConverter.toRaptorCost(
+    (double) CostLimit.MAX_COST
+  );
+
+  @Test
+  void costBelowLimitIsConvertedUnchanged() {
+    // A normal access/egress/transfer cost is converted exactly like the plain converter.
+    assertEquals(RaptorCostConverter.toRaptorCost(123.45), CostLimit.toRaptorCost(123.45));
+    assertEquals(RaptorCostConverter.toRaptorCost(0.0), CostLimit.toRaptorCost(0.0));
+  }
+
+  @Test
+  void costAtLimitIsConvertedUnchanged() {
+    assertEquals(MAX_RAPTOR_COST, CostLimit.toRaptorCost(CostLimit.MAX_COST));
+  }
+
+  @Test
+  void costAboveLimitIsCapped() {
+    assertEquals(MAX_RAPTOR_COST, CostLimit.toRaptorCost(CostLimit.MAX_COST + 1.0));
+  }
+
+  @Test
+  void negativeCostIsCappedNotTreatedAsFree() {
+    // A negative input means the cost already overflowed upstream; treat it as the worst case.
+    assertEquals(MAX_RAPTOR_COST, CostLimit.toRaptorCost(-5.0));
+  }
+
+  @Test
+  void wholeSecondsVariantTruncatesSubSecondCost() {
+    // Transfers historically truncate the cost to whole transit-seconds before converting;
+    // toRaptorCostWholeSeconds preserves that, while toRaptorCost keeps centi-second precision.
+    assertEquals(12_300, CostLimit.toRaptorCostWholeSeconds(123.99));
+    assertEquals(12_399, CostLimit.toRaptorCost(123.99));
+  }
+
+  @Test
+  void wholeSecondsVariantCapsLargeAndNegativeCosts() {
+    assertEquals(MAX_RAPTOR_COST, CostLimit.toRaptorCostWholeSeconds(22_778_951.0));
+    assertEquals(MAX_RAPTOR_COST, CostLimit.toRaptorCostWholeSeconds(-5.0));
+  }
+
+  @Test
+  void cappedCostLeavesHeadroomForSummingSeveralLegs() {
+    // access + egress + a transfer, all capped, must still be well below the int sentinels so the
+    // path cost sum cannot overflow.
+    long threeCappedLegs = 3L * MAX_RAPTOR_COST;
+    assertTrue(threeCappedLegs < RaptorConstants.UNREACHED_HIGH);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/transfer/regular/model/PathTransferTest.java
+++ b/application/src/test/java/org/opentripplanner/transfer/regular/model/PathTransferTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.geometry.Coordinates;
 import org.opentripplanner.raptor.spi.RaptorCostConverter;
 import org.opentripplanner.raptor.spi.RaptorTransfer;
+import org.opentripplanner.routing.cost.CostLimit;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.StreetModelForTest;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
@@ -27,7 +28,7 @@ class PathTransferTest {
   );
   private static final IntersectionVertex BOSTON_V = intersectionVertex(Coordinates.BOSTON);
   private static final int MAX_RAPTOR_TRANSFER_C1 = RaptorCostConverter.toRaptorCost(
-    PathTransfer.MAX_TRANSFER_COST
+    (double) CostLimit.MAX_COST
   );
 
   private static final RegularStop S1 = RegularStop.of(id("Stop1"), () -> 1).build();


### PR DESCRIPTION
## Summary

Fixes #7679.

A street **access, egress or transfer** leg over a steep, wheelchair-inaccessible stairway can accumulate a generalized cost so large that converting it to Raptor's 32-bit `int` cost overflows and wraps to a negative value. The negative cost is then rejected when the path is mapped back to an itinerary (`Cost.costOfCentiSeconds(path.c1())` → `IntUtils.requireNotNegative`), so the **whole `/trip` request fails** with `Negative value not expected for value: -2017081832` instead of returning the other valid itineraries.

Transfers were already guarded against exactly this in #5509 / #5516 .

 This PR extracts the transfer sanity-clamp into a small shared `CostLimit` helper and applies it to every street-derived Raptor cost conversion.

