### PR TITLE
Fix ArrayIndexOutOfBoundsException in pass-through via chaining

### DIFF
--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -168,13 +168,17 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
       boardStopArrival.stop()
     );
     if (boardingStopPos == -1) {
-      LOG.warn(
-        "Unexpected board stop position missing for trip {} at stop {} after {}.",
-        trip.pattern().debugInfo(),
-        boardStopArrival.stop(),
-        TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
-      );
-      return;
+      // In case of a constrained transfer, the boarding arrivalTime could be after the trip
+      // departure time, which is valid. We use the first depature time of the boarded trip
+      // here to find a valid bearding. This is slightly incorrect and may fail to find the
+      // correct departure for circular lines. There is not a good simple fix for this. A Fix would
+      // need to look up the constrained transfers and apply the logic done by the routing lgorithm.
+      // This logic is fragmented, so a larger refactoring is needed.
+      boardingStopPos = trip.findDepartureStopPosition(trip.departure(0), boardStopArrival.stop());
+      if (boardingStopPos == -1) {
+        logUnexpectedStopPosition("board", trip, boardStopArrival);
+        return;
+      }
     }
 
     int startRoutingAtStopPosition = trip.findArrivalStopPosition(
@@ -183,12 +187,7 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     );
 
     if (startRoutingAtStopPosition == -1) {
-      LOG.warn(
-        "Unexpected alight stop position missing for trip {} at stop {} after {}.",
-        trip.pattern().debugInfo(),
-        alightArrival.stop(),
-        TimeUtils.timeToStrLong(alightArrival.arrivalTime())
-      );
+      logUnexpectedStopPosition("alight", trip, alightArrival);
       return;
     }
 
@@ -231,5 +230,19 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     int arrivalTime = from.arrivalTime() + via.durationInSeconds();
     var to = stopArrivalFactory.createTransferStopArrival(from, via.transfer(), arrivalTime);
     transfersCache.add(to);
+  }
+
+  private static void logUnexpectedStopPosition(
+    String event,
+    RaptorTripSchedule trip,
+    ArrivalView<?> boardStopArrival
+  ) {
+    LOG.warn(
+      "Unexpected {} stop position missing for trip {} at stop {} after {}.",
+      event,
+      trip.pattern().debugInfo(),
+      boardStopArrival.stop(),
+      TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
+    );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -170,9 +170,9 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     if (boardingStopPos == -1) {
       // In case of a constrained transfer, the boarding arrivalTime could be after the trip
       // departure time, which is valid. We use the first depature time of the boarded trip
-      // here to find a valid bearding. This is slightly incorrect and may fail to find the
-      // correct departure for circular lines. There is not a good simple fix for this. A Fix would
-      // need to look up the constrained transfers and apply the logic done by the routing lgorithm.
+      // here to find a valid boarding. This is slightly incorrect and may fail to find the
+      // correct departure for circular lines. There is not a good simple fix for this. A fix would
+      // need to look up the constrained transfers and apply the logic done by the routing algorithm.
       // This logic is fragmented, so a larger refactoring is needed.
       boardingStopPos = trip.findDepartureStopPosition(trip.departure(0), boardStopArrival.stop());
       if (boardingStopPos == -1) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -23,6 +23,9 @@ import org.opentripplanner.raptor.rangeraptor.transit.ViaConnections;
 import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 import org.opentripplanner.raptor.spi.RaptorTripScheduleReference;
 import org.opentripplanner.raptor.util.paretoset.ParetoSetEventListener;
+import org.opentripplanner.utils.time.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to listen for stop arrivals in one Raptor state and then copy
@@ -43,6 +46,10 @@ import org.opentripplanner.raptor.util.paretoset.ParetoSetEventListener;
  */
 public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSchedule>
   implements ParetoSetEventListener<ArrivalView<T>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+    ViaConnectionStopArrivalEventListener.class
+  );
 
   private final McStopArrivalFactory<T> stopArrivalFactory;
   private final List<ViaConnection> connections;
@@ -154,24 +161,45 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     }
     var transitPath = alightArrival.transitPath();
     T trip = transitPath.trip();
-    var info = tripInfoProvider.apply(trip);
 
-    var arrivalAtBoardStop = alightArrival.previous();
+    var boardStopArrival = alightArrival.previous();
     int boardingStopPos = trip.findDepartureStopPosition(
-      arrivalAtBoardStop.arrivalTime(),
-      transitPath.boardStop()
+      boardStopArrival.arrivalTime(),
+      boardStopArrival.stop()
     );
+    if (boardingStopPos == -1) {
+      LOG.warn(
+        "Unexpected board stop position missing for trip {} at stop {} after {}.",
+        trip.pattern().debugInfo(),
+        boardStopArrival.stop(),
+        TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
+      );
+      return;
+    }
+
     int startRoutingAtStopPosition = trip.findArrivalStopPosition(
       alightArrival.arrivalTime(),
       alightArrival.stop()
     );
+
+    if (startRoutingAtStopPosition == -1) {
+      LOG.warn(
+        "Unexpected alight stop position missing for trip {} at stop {} after {}.",
+        trip.pattern().debugInfo(),
+        alightArrival.stop(),
+        TimeUtils.timeToStrLong(alightArrival.arrivalTime())
+      );
+      return;
+    }
+
+    var info = tripInfoProvider.apply(trip);
     var boardingConstraint = new RaptorTripScheduleStopPosition(
       info.routeIndex(),
       info.tripScheduleIndex(),
       boardingStopPos
     );
     next.addOnBoardTripArrival(
-      arrivalAtBoardStop,
+      boardStopArrival,
       alightArrival.stop(),
       startRoutingAtStopPosition,
       boardingConstraint

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -235,14 +235,14 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
   private static void logUnexpectedStopPosition(
     String event,
     RaptorTripSchedule trip,
-    ArrivalView<?> boardStopArrival
+    ArrivalView<?> stopArrival
   ) {
     LOG.warn(
       "Unexpected {} stop position missing for trip {} at stop {} after {}.",
       event,
       trip.pattern().debugInfo(),
-      boardStopArrival.stop(),
-      TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
+      stopArrival.stop(),
+      TimeUtils.timeToStrLong(stopArrival.arrivalTime())
     );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorPathConstrainedTransferSearch.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorPathConstrainedTransferSearch.java
@@ -3,7 +3,7 @@ package org.opentripplanner.raptor.spi;
 import javax.annotation.Nullable;
 
 /**
- * This interface is used by Raptor to create a path from the Raptor state. We do not keep
+ * Raptor uses this interface to create a path from the Raptor state. We do not keep
  * constraints during the search, so we need to look it up when building the path.
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J08_PassThroughWithConstrainedTransferTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J08_PassThroughWithConstrainedTransferTest.java
@@ -1,0 +1,132 @@
+package org.opentripplanner.raptor.moduletests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
+import static org.opentripplanner.raptor._data.transit.TestTransfer.transfer;
+import static org.opentripplanner.raptor.api.request.via.RaptorViaLocation.passThrough;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.raptor.RaptorService;
+import org.opentripplanner.raptor._data.RaptorTestConstants;
+import org.opentripplanner.raptor._data.transit.TestTransferConstraint;
+import org.opentripplanner.raptor._data.transit.TestTransitData;
+import org.opentripplanner.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.raptor.api.request.RaptorProfile;
+import org.opentripplanner.raptor.configure.RaptorTestFactory;
+import org.opentripplanner.raptor.spi.TestSlackProvider;
+
+/**
+ * FEATURE UNDER TEST
+ * <p>
+ * When a trip passes through a pass-through via point and the boarding was via a constrained
+ * transfer (stay-seated or guaranteed), {@code continueOnSameTripInNextSegment} must correctly
+ * reconstruct the boarding stop position for the trip in the next Raptor segment.
+ * <p>
+ * For a <b>guaranteed (walk) transfer</b>, the walk-arrival time at the boarding stop may exceed
+ * the trip's scheduled departure (the train is held), so a time-based stop-position search fails.
+ * The fallback must find the stop position without relying on the walk-arrival time.
+ */
+class J08_PassThroughWithConstrainedTransferTest implements RaptorTestConstants {
+
+  private final TestTransitData data = new TestTransitData();
+  private final RaptorService<TestTripSchedule> raptorService = RaptorTestFactory.raptorService();
+
+  /**
+   * Stay-seated pass-through: a feeder trip (R1) connects via a stay-seated transfer to a main
+   * trip (R2). The main trip passes through the via point C before reaching the destination D.
+   */
+  @Test
+  void staySeatedTransferWithPassThrough() {
+    data
+      .access("Walk 30s ~ A")
+      .withTimetables(
+        """
+        -- R1
+        A     B
+        0:02  0:05
+        -- R2
+              B     C     D
+              0:05  0:08  0:12
+        """
+      )
+      .egress("D ~ Walk 30s");
+
+    var tripR1 = data.getRoute(0).getTripSchedule(0);
+    var tripR2 = data.getRoute(1).getTripSchedule(0);
+
+    data.withConstrainedTransfer(
+      tripR1,
+      STOP_B,
+      tripR2,
+      STOP_B,
+      TestTransferConstraint.staySeated()
+    );
+    data.withSlackProvider(new TestSlackProvider(D30_s, D20_s, D10_s));
+
+    var requestBuilder = data.requestBuilder();
+    requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).clearOptimizations();
+    requestBuilder
+      .searchParams()
+      .constrainedTransfers(true)
+      .earliestDepartureTime(T00_00)
+      .latestArrivalTime(T00_30)
+      .searchWindow(Duration.ofMinutes(15))
+      .timetable(true)
+      .addViaLocation(passThrough("C").addStop(STOP_C).build());
+
+    assertEquals(
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R2 0:05 0:12 ~ D ~ Walk 30s [0:01:10 0:12:40 11m30s Tₙ0 C₁1_350]",
+      pathsToString(raptorService.route(requestBuilder.build(), data))
+    );
+  }
+
+  /**
+   * Guaranteed walk transfer with pass-through: a feeder bus (R1) connects via a guaranteed
+   * interchange with a 30s walk to the main train (R2). The walk arrival at the boarding stop
+   * exceeds R2's scheduled departure — the constrained transfer holds the train. R2 then passes
+   * through the via point D before reaching the destination E.
+   * <p>
+   * Without the fix, {@code findDepartureStopPosition(walkArrivalTime=330s, C)} fails because
+   * R2 departed C at 300s — causing the pass-through continuation to be silently dropped.
+   */
+  @Test
+  void guaranteedWalkTransferWithPassThrough() {
+    data
+      .access("Walk 30s ~ A")
+      .withTimetables(
+        """
+        -- R1
+        A     B
+        0:02  0:05
+        -- R2
+        C     D     E
+        0:05  0:08  0:12
+        """
+      )
+      .egress("E ~ Walk 30s");
+
+    var tripR1 = data.getRoute(0).getTripSchedule(0);
+    var tripR2 = data.getRoute(1).getTripSchedule(0);
+
+    data.withGuaranteedTransfer(tripR1, STOP_B, tripR2, STOP_C);
+    data.withTransfer(STOP_B, transfer(STOP_C, D30_s));
+    data.withSlackProvider(new TestSlackProvider(D30_s, D20_s, D10_s));
+
+    var requestBuilder = data.requestBuilder();
+    requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).clearOptimizations();
+    requestBuilder
+      .searchParams()
+      .constrainedTransfers(true)
+      .earliestDepartureTime(T00_00)
+      .latestArrivalTime(T00_30)
+      .searchWindow(Duration.ofMinutes(15))
+      .timetable(true)
+      .addViaLocation(passThrough("D").addStop(STOP_D).build());
+
+    assertEquals(
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ Walk 30s ~ C ~ BUS R2 0:05 0:12 ~ E ~ Walk 30s [0:01:10 0:12:40 11m30s Tₙ1 C₁1_380]",
+      pathsToString(raptorService.route(requestBuilder.build(), data))
+    );
+  }
+}


### PR DESCRIPTION
### Summary

`via.passThrough` queries that involve a guaranteed (constrained) NeTEx interchange crash Raptor
with an `ArrayIndexOutOfBoundsException` in `TripPatternForDates.departureTime`.

Addresses [#7743](https://github.com/opentripplanner/OpenTripPlanner/issues/7743).

### Root cause

When a trip passes through a pass-through via point,
`ViaConnectionStopArrivalEventListener.continueOnSameTripInNextSegment` reconstructs where on
the trip the rider boarded by calling `findDepartureStopPosition(boardStopArrival.arrivalTime(),
boardStop)`. For a **guaranteed interchange** the train is held at the platform, so the walk
arrival at the boarding stop can be slightly *after* the scheduled departure (in production: 9 s).
`findDepartureStopPosition` requires `departure >= arrivalTime`, so it returns -1. That -1 was
passed unchecked into `RaptorTripScheduleStopPosition` and eventually reached
`TripPatternForDates.departureTime`, which indexes a flat array as
`stopPositionInPattern * numberOfTripSchedules + tripIndex` with no bounds check — a negative
stop position produces a negative index and throws `ArrayIndexOutOfBoundsException`.

**Production evidence:** NeTEx interchange `VYG:ServiceJourneyInterchange:942` (Vy) links a bus
to RE11 at Arendal station with a 2 m 9 s platform walk. RE11 departs at 16:54:00; the walk
arrives at 16:54:09 — a 9 s gap. The guaranteed interchange holds the train, so the boarding is
valid, but the time-based stop-position search fails.

### Fix

`continueOnSameTripInNextSegment` now performs a two-step lookup for the boarding stop position:

1. **Tight search** — `findDepartureStopPosition(boardStopArrival.arrivalTime(), boardStop)`.
   This is the original constraint and works correctly for all regular boardings.
2. **Fallback** — if step 1 returns -1, retry with `trip.departure(0)` as the time floor.
   The first stop's departure is always ≤ any en-route departure, so the boarding stop is
   reliably found. 
   
> **Note!** For a circular trip pattern the above fix may still fail if the boarding stop is not the first 
>                  visit to the stop. A larger refactoring is requiered to fix this, and we think this is rare 
>                  case.

If both searches return -1 a warning is logged and the pass-through continuation is dropped,
which is preferable to crashing the request.

### Tests

`J08_PassThroughWithConstrainedTransferTest` adds two module tests:

- **`staySeatedTransferWithPassThrough`** — a feeder trip stay-seated transfers to a main trip
  that passes through the via point; verifies the normal case continues to work.
- **`guaranteedWalkTransferWithPassThrough`** — reproduces the bug: a 30 s guaranteed walk
  transfer causes the walk arrival to exceed the train's scheduled departure, and the fallback
  search must find the boarding stop correctly.

### Documentation

🟥 No public API or configuration changes.

### Changelog

✅ Bug fix — include in changelog.

### Bumping the serialization version id

🟥 No changes to serialized graph fields.