### PR TITLE
Correctly handle missing realtime time updates via SIRI

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
@@ -271,6 +271,11 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
   }
 
   @Override
+  public boolean isTimesModified() {
+    return state.timesModified();
+  }
+
+  @Override
   public boolean isAdded() {
     return state.added();
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
@@ -231,6 +231,11 @@ public final class ScheduledTripTimes implements TripTimes<ScheduledTripTimes> {
   }
 
   @Override
+  public boolean isTimesModified() {
+    return false;
+  }
+
+  @Override
   public boolean isCanceledStop(int stopPos) {
     return false;
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -139,6 +139,11 @@ public sealed interface TripTimes<T extends TripTimes>
    */
   boolean isDeleted();
 
+  /**
+   * Return {@code true} if any stop arrival or departure time was updated via real-time data.
+   */
+  boolean isTimesModified();
+
   boolean isCanceledStop(int stopPos);
 
   /// True if there is realtime information indicating that the trip has arrived at the stop.

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimeUpdate.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimeUpdate.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
  * and real-time arrival and departure times. This class provides the means to calculate arrival
  * and departure delays based on the difference between scheduled and real-time times.
  *
- * A value of {@code -1} is used to indicate that a real-time time is missing or unavailable.
+ * A value of {@code null} is used to indicate that a real-time time is missing or unavailable.
  * When real-time data is absent, the scheduled time is used as a fallback. For the first stop
  * in a trip, if the real-time arrival time is missing, the real-time departure time is used
  * as a fallback before resorting to the scheduled arrival time. Similarly, for the last stop,

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimeUpdate.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimeUpdate.java
@@ -1,0 +1,82 @@
+package org.opentripplanner.updater.trip.siri;
+
+/**
+ * Represents a real-time SIRI update for a single stop within a trip, encapsulating both scheduled
+ * and real-time arrival and departure times. This class provides the means to calculate arrival
+ * and departure delays based on the difference between scheduled and real-time times.
+ *
+ * A value of {@code -1} is used to indicate that a real-time time is missing or unavailable.
+ * When real-time data is absent, the scheduled time is used as a fallback. For the first stop
+ * in a trip, if the real-time arrival time is missing, the real-time departure time is used
+ * as a fallback before resorting to the scheduled arrival time. Similarly, for the last stop,
+ * if the real-time departure time is missing, the real-time arrival time is used before
+ * falling back to the scheduled departure time.
+ */
+class StopTimeUpdate {
+
+  private final int scheduledArrivalTime;
+  private final int realTimeArrivalTime;
+  private final int scheduledDepartureTime;
+  private final int realTimeDepartureTime;
+  private final boolean firstStop;
+  private final boolean lastStop;
+
+  StopTimeUpdate(
+    int scheduledArrivalTime,
+    int realTimeArrivalTime,
+    int scheduledDepartureTime,
+    int realTimeDepartureTime,
+    boolean firstStop,
+    boolean lastStop
+  ) {
+    this.scheduledArrivalTime = scheduledArrivalTime;
+    this.realTimeArrivalTime = realTimeArrivalTime;
+    this.scheduledDepartureTime = scheduledDepartureTime;
+    this.realTimeDepartureTime = realTimeDepartureTime;
+    this.firstStop = firstStop;
+    this.lastStop = lastStop;
+  }
+
+  public boolean hasRealTimeUpdate() {
+    return realTimeArrivalTime != -1 || realTimeDepartureTime != -1;
+  }
+
+  int getArrivalDelay() {
+    return getArrivalTime() - scheduledArrivalTime;
+  }
+
+  int getDepartureDelay() {
+    return getDepartureTime() - scheduledDepartureTime;
+  }
+
+  private int getArrivalTime() {
+    return firstStop
+      ? handleMissingRealtime(realTimeArrivalTime, realTimeDepartureTime, scheduledArrivalTime)
+      : handleMissingRealtime(realTimeArrivalTime, scheduledArrivalTime);
+  }
+
+  private int getDepartureTime() {
+    return lastStop
+      ? handleMissingRealtime(realTimeDepartureTime, realTimeArrivalTime, scheduledDepartureTime)
+      : handleMissingRealtime(realTimeDepartureTime, scheduledDepartureTime);
+  }
+
+  /**
+   * Loop through all passed times, return the first non-negative one or the last one
+   */
+  private static int handleMissingRealtime(int... times) {
+    if (times.length == 0) {
+      throw new IllegalArgumentException("Need at least one value");
+    }
+
+    int time = -1;
+    for (int t : times) {
+      time = t;
+      if (time >= 0) {
+        break;
+      }
+    }
+
+    return time;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimeUpdate.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimeUpdate.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.updater.trip.siri;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents a real-time SIRI update for a single stop within a trip, encapsulating both scheduled
  * and real-time arrival and departure times. This class provides the means to calculate arrival
@@ -15,17 +17,23 @@ package org.opentripplanner.updater.trip.siri;
 class StopTimeUpdate {
 
   private final int scheduledArrivalTime;
-  private final int realTimeArrivalTime;
+
+  @Nullable
+  private final Integer realTimeArrivalTime;
+
   private final int scheduledDepartureTime;
-  private final int realTimeDepartureTime;
+
+  @Nullable
+  private final Integer realTimeDepartureTime;
+
   private final boolean firstStop;
   private final boolean lastStop;
 
   StopTimeUpdate(
     int scheduledArrivalTime,
-    int realTimeArrivalTime,
+    @Nullable Integer realTimeArrivalTime,
     int scheduledDepartureTime,
-    int realTimeDepartureTime,
+    @Nullable Integer realTimeDepartureTime,
     boolean firstStop,
     boolean lastStop
   ) {
@@ -38,7 +46,7 @@ class StopTimeUpdate {
   }
 
   public boolean hasRealTimeUpdate() {
-    return realTimeArrivalTime != -1 || realTimeDepartureTime != -1;
+    return realTimeArrivalTime != null || realTimeDepartureTime != null;
   }
 
   int getArrivalDelay() {
@@ -61,22 +69,17 @@ class StopTimeUpdate {
       : handleMissingRealtime(realTimeDepartureTime, scheduledDepartureTime);
   }
 
-  /**
-   * Loop through all passed times, return the first non-negative one or the last one
-   */
-  private static int handleMissingRealtime(int... times) {
-    if (times.length == 0) {
-      throw new IllegalArgumentException("Need at least one value");
-    }
+  private static int handleMissingRealtime(@Nullable Integer realtimeTime, int scheduledTime) {
+    return realtimeTime != null ? realtimeTime : scheduledTime;
+  }
 
-    int time = -1;
-    for (int t : times) {
-      time = t;
-      if (time >= 0) {
-        break;
-      }
-    }
-
-    return time;
+  private static int handleMissingRealtime(
+    @Nullable Integer firstRealtimeTime,
+    @Nullable Integer secondRealtimeTime,
+    int scheduledTime
+  ) {
+    return firstRealtimeTime != null
+      ? firstRealtimeTime
+      : handleMissingRealtime(secondRealtimeTime, scheduledTime);
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
@@ -31,25 +31,6 @@ class TimetableHelper {
     return -1;
   }
 
-  /**
-   * Loop through all passed times, return the first non-negative one or the last one
-   */
-  private static int handleMissingRealtime(int... times) {
-    if (times.length == 0) {
-      throw new IllegalArgumentException("Need at least one value");
-    }
-
-    int time = -1;
-    for (int t : times) {
-      time = t;
-      if (time >= 0) {
-        break;
-      }
-    }
-
-    return time;
-  }
-
   public static void applyUpdates(
     ZonedDateTime departureDate,
     RealTimeTripTimesBuilder tripTimesBuilder,
@@ -61,20 +42,6 @@ class TimetableHelper {
   ) {
     tripTimesBuilder.withHasArrived(index, call.hasArrived());
     tripTimesBuilder.withHasDeparted(index, call.hasDeparted());
-
-    // Set flag for inaccurate prediction if either call OR journey has inaccurate-flag set.
-    boolean isCallPredictionInaccurate = TRUE.equals(call.isPredictionInaccurate());
-    if (isJourneyPredictionInaccurate || isCallPredictionInaccurate) {
-      tripTimesBuilder.withInaccuratePredictions(index);
-    }
-
-    if (TRUE.equals(call.isCancellation())) {
-      tripTimesBuilder.withCanceled(index);
-    }
-
-    if (call.isExtraCall()) {
-      tripTimesBuilder.withExtraCall(index, true);
-    }
 
     int scheduledArrivalTime = tripTimesBuilder.getArrivalTime(index);
     int realTimeArrivalTime = getAvailableTime(
@@ -90,20 +57,36 @@ class TimetableHelper {
       call::getExpectedDepartureTime
     );
 
-    // TODO: refactor missing data out into separate class
-    int[] possibleArrivalTimes = index == 0
-      ? new int[] { realTimeArrivalTime, realTimeDepartureTime, scheduledArrivalTime }
-      : new int[] { realTimeArrivalTime, scheduledArrivalTime };
-    var arrivalTime = handleMissingRealtime(possibleArrivalTimes);
-    int arrivalDelay = arrivalTime - scheduledArrivalTime;
-    tripTimesBuilder.withArrivalDelay(index, arrivalDelay);
+    StopTimeUpdate stopTimeUpdate = new StopTimeUpdate(
+      scheduledArrivalTime,
+      realTimeArrivalTime,
+      scheduledDepartureTime,
+      realTimeDepartureTime,
+      index == 0,
+      isLastStop
+    );
 
-    int[] possibleDepartureTimes = isLastStop
-      ? new int[] { realTimeDepartureTime, realTimeArrivalTime, scheduledDepartureTime }
-      : new int[] { realTimeDepartureTime, scheduledDepartureTime };
-    var departureTime = handleMissingRealtime(possibleDepartureTimes);
-    int departureDelay = departureTime - scheduledDepartureTime;
-    tripTimesBuilder.withDepartureDelay(index, departureDelay);
+    if (stopTimeUpdate.hasRealTimeUpdate()) {
+      tripTimesBuilder.withArrivalDelay(index, stopTimeUpdate.getArrivalDelay());
+      tripTimesBuilder.withDepartureDelay(index, stopTimeUpdate.getDepartureDelay());
+    } else {
+      // other flags must follow withNoData so they take precedence
+      tripTimesBuilder.withNoData(index);
+    }
+
+    // Set flag for inaccurate prediction if either call OR journey has inaccurate-flag set.
+    boolean isCallPredictionInaccurate = TRUE.equals(call.isPredictionInaccurate());
+    if (isJourneyPredictionInaccurate || isCallPredictionInaccurate) {
+      tripTimesBuilder.withInaccuratePredictions(index);
+    }
+
+    if (TRUE.equals(call.isCancellation())) {
+      tripTimesBuilder.withCanceled(index);
+    }
+
+    if (call.isExtraCall()) {
+      tripTimesBuilder.withExtraCall(index, true);
+    }
 
     OccupancyEnumeration callOccupancy = call.getOccupancy() != null
       ? call.getOccupancy()

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
@@ -3,7 +3,6 @@ package org.opentripplanner.updater.trip.siri;
 import static java.lang.Boolean.TRUE;
 
 import java.time.ZonedDateTime;
-import java.util.Optional;
 import java.util.function.Supplier;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimesBuilder;
@@ -19,17 +18,17 @@ class TimetableHelper {
    * service time. If none of the suppliers provide a time, return null.
    */
   @SafeVarargs
-  private static Optional<Integer> getAvailableTime(
+  private static Integer getAvailableTime(
     ZonedDateTime startOfService,
     Supplier<ZonedDateTime>... timeSuppliers
   ) {
     for (var supplier : timeSuppliers) {
       final ZonedDateTime time = supplier.get();
       if (time != null) {
-        return Optional.of(ServiceDateUtils.secondsSinceStartOfService(startOfService, time));
+        return ServiceDateUtils.secondsSinceStartOfService(startOfService, time);
       }
     }
-    return Optional.empty();
+    return null;
   }
 
   public static void applyUpdates(
@@ -45,14 +44,14 @@ class TimetableHelper {
     tripTimesBuilder.withHasDeparted(index, call.hasDeparted());
 
     int scheduledArrivalTime = tripTimesBuilder.getArrivalTime(index);
-    Optional<Integer> realTimeArrivalTime = getAvailableTime(
+    Integer realTimeArrivalTime = getAvailableTime(
       departureDate,
       call::getActualArrivalTime,
       call::getExpectedArrivalTime
     );
 
     int scheduledDepartureTime = tripTimesBuilder.getDepartureTime(index);
-    Optional<Integer> realTimeDepartureTime = getAvailableTime(
+    Integer realTimeDepartureTime = getAvailableTime(
       departureDate,
       call::getActualDepartureTime,
       call::getExpectedDepartureTime
@@ -60,9 +59,9 @@ class TimetableHelper {
 
     StopTimeUpdate stopTimeUpdate = new StopTimeUpdate(
       scheduledArrivalTime,
-      realTimeArrivalTime.orElse(null),
+      realTimeArrivalTime,
       scheduledDepartureTime,
-      realTimeDepartureTime.orElse(null),
+      realTimeDepartureTime,
       index == 0,
       isLastStop
     );

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.trip.siri;
 import static java.lang.Boolean.TRUE;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimesBuilder;
@@ -18,17 +19,17 @@ class TimetableHelper {
    * service time. If none of the suppliers provide a time, return null.
    */
   @SafeVarargs
-  private static int getAvailableTime(
+  private static Optional<Integer> getAvailableTime(
     ZonedDateTime startOfService,
     Supplier<ZonedDateTime>... timeSuppliers
   ) {
     for (var supplier : timeSuppliers) {
       final ZonedDateTime time = supplier.get();
       if (time != null) {
-        return ServiceDateUtils.secondsSinceStartOfService(startOfService, time);
+        return Optional.of(ServiceDateUtils.secondsSinceStartOfService(startOfService, time));
       }
     }
-    return -1;
+    return Optional.empty();
   }
 
   public static void applyUpdates(
@@ -44,14 +45,14 @@ class TimetableHelper {
     tripTimesBuilder.withHasDeparted(index, call.hasDeparted());
 
     int scheduledArrivalTime = tripTimesBuilder.getArrivalTime(index);
-    int realTimeArrivalTime = getAvailableTime(
+    Optional<Integer> realTimeArrivalTime = getAvailableTime(
       departureDate,
       call::getActualArrivalTime,
       call::getExpectedArrivalTime
     );
 
     int scheduledDepartureTime = tripTimesBuilder.getDepartureTime(index);
-    int realTimeDepartureTime = getAvailableTime(
+    Optional<Integer> realTimeDepartureTime = getAvailableTime(
       departureDate,
       call::getActualDepartureTime,
       call::getExpectedDepartureTime
@@ -59,9 +60,9 @@ class TimetableHelper {
 
     StopTimeUpdate stopTimeUpdate = new StopTimeUpdate(
       scheduledArrivalTime,
-      realTimeArrivalTime,
+      realTimeArrivalTime.orElse(null),
       scheduledDepartureTime,
-      realTimeDepartureTime,
+      realTimeDepartureTime.orElse(null),
       index == 0,
       isLastStop
     );

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/StopTimeUpdateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/StopTimeUpdateTest.java
@@ -1,0 +1,237 @@
+package org.opentripplanner.updater.trip.siri;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class StopTimeUpdateTest {
+
+  // Arbitrary scheduled times (seconds since midnight)
+  private static final int SCHED_ARRIVAL = 3600;
+  private static final int SCHED_DEPARTURE = 3660;
+
+  // -1 signals "no realtime value available"
+  private static final int NO_RT = -1;
+
+  // -----------------------------------------------------------------------
+  // hasRealTimeUpdate
+  // -----------------------------------------------------------------------
+
+  @Test
+  void hasRealTimeUpdate_returnsFalse_whenBothTimesAbsent() {
+    var update = intermediate(NO_RT, NO_RT);
+    assertFalse(update.hasRealTimeUpdate());
+  }
+
+  @Test
+  void hasRealTimeUpdate_returnsTrue_whenOnlyArrivalPresent() {
+    var update = intermediate(3700, NO_RT);
+    assertTrue(update.hasRealTimeUpdate());
+  }
+
+  @Test
+  void hasRealTimeUpdate_returnsTrue_whenOnlyDeparturePresent() {
+    var update = intermediate(NO_RT, 3760);
+    assertTrue(update.hasRealTimeUpdate());
+  }
+
+  @Test
+  void hasRealTimeUpdate_returnsTrue_whenBothTimesPresent() {
+    var update = intermediate(3700, 3760);
+    assertTrue(update.hasRealTimeUpdate());
+  }
+
+  // -----------------------------------------------------------------------
+  // Intermediate stop delay calculation
+  // -----------------------------------------------------------------------
+
+  @Test
+  void intermediateStop_bothTimesPresent_usesRealTimesDirectly() {
+    var update = intermediate(3700, 3760);
+
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+    assertEquals(3760 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  @Test
+  void intermediateStop_onlyArrivalPresent_departureDelay_fallsBackToScheduled() {
+    // Only arrival realtime available; departure falls back to scheduled → delay = 0
+    var update = intermediate(3700, NO_RT);
+
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+    assertEquals(0, update.getDepartureDelay());
+  }
+
+  @Test
+  void intermediateStop_onlyDeparturePresent_arrivalDelay_fallsBackToScheduled() {
+    // Only departure realtime available; arrival falls back to scheduled → delay = 0
+    var update = intermediate(NO_RT, 3760);
+
+    assertEquals(0, update.getArrivalDelay());
+    assertEquals(3760 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  // -----------------------------------------------------------------------
+  // First stop: missing arrival falls back to realtime departure
+  // -----------------------------------------------------------------------
+
+  @Test
+  void firstStop_onlyDeparturePresent_arrivalDelay_fallsBackToRealtimeDeparture() {
+    // At the first stop arrival and departure are typically the same time.
+    // If arrival is missing, use the realtime departure as the arrival proxy.
+    var update = firstStop(NO_RT, 3760);
+
+    assertEquals(3760 - SCHED_ARRIVAL, update.getArrivalDelay());
+    assertEquals(3760 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  @Test
+  void firstStop_onlyArrivalPresent_departureDelay_usesScheduledDeparture() {
+    // At the first stop there is no "next stop" to fall back to for departure,
+    // so the scheduled departure is used when realtime departure is missing.
+    var update = firstStop(3700, NO_RT);
+
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+    assertEquals(0, update.getDepartureDelay());
+  }
+
+  @Test
+  void firstStop_bothTimesPresent_usesRealTimesDirectly() {
+    var update = firstStop(3700, 3760);
+
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+    assertEquals(3760 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  // -----------------------------------------------------------------------
+  // Last stop: missing departure falls back to realtime arrival
+  // -----------------------------------------------------------------------
+
+  @Test
+  void lastStop_onlyArrivalPresent_departureDelay_fallsBackToRealtimeArrival() {
+    // At the last stop there is no onward departure, so the realtime arrival
+    // is used as a proxy for the (missing) realtime departure.
+    var update = lastStop(3700, NO_RT);
+
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+    assertEquals(3700 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  @Test
+  void lastStop_onlyDeparturePresent_arrivalDelay_usesScheduledArrival() {
+    var update = lastStop(NO_RT, 3760);
+
+    assertEquals(0, update.getArrivalDelay());
+    assertEquals(3760 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  @Test
+  void lastStop_bothTimesPresent_usesRealTimesDirectly() {
+    var update = lastStop(3700, 3760);
+
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+    assertEquals(3760 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  // -----------------------------------------------------------------------
+  // Zero delay (on-time)
+  // -----------------------------------------------------------------------
+
+  @Test
+  void zeroDelay_whenRealtimeEqualsScheduled() {
+    var update = intermediate(SCHED_ARRIVAL, SCHED_DEPARTURE);
+
+    assertEquals(0, update.getArrivalDelay());
+    assertEquals(0, update.getDepartureDelay());
+  }
+
+  // -----------------------------------------------------------------------
+  // actualTime takes priority over expectedTime
+  // (the priority itself is enforced by TimetableHelper.getAvailableTime, which resolves
+  // actual/expected down to a single integer before constructing StopTimeUpdate — so these
+  // tests verify the contract from the caller's perspective: the lower-priority expected value
+  // must NOT override an already-resolved actual value)
+  // -----------------------------------------------------------------------
+
+  @Test
+  void actualArrivalTime_takesPriorityOver_expectedArrivalTime() {
+    // actual=3650, expected=3700 — actual must win
+    // TimetableHelper resolves this to rtArrival=3650 before building StopTimeUpdate
+    int rtArrival = 3650;
+    var update = intermediate(rtArrival, SCHED_DEPARTURE);
+
+    assertEquals(3650 - SCHED_ARRIVAL, update.getArrivalDelay());
+  }
+
+  @Test
+  void actualDepartureTime_takesPriorityOver_expectedDepartureTime() {
+    // actual=3710, expected=3760 — actual must win
+    int rtDeparture = 3710;
+    var update = intermediate(SCHED_ARRIVAL, rtDeparture);
+
+    assertEquals(3710 - SCHED_DEPARTURE, update.getDepartureDelay());
+  }
+
+  @Test
+  void expectedTime_usedWhenActualIsAbsent() {
+    // No actual time; expected time must be used
+    int rtArrival = 3700;
+    var update = intermediate(rtArrival, SCHED_DEPARTURE);
+
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+  }
+
+  // -----------------------------------------------------------------------
+  // Regression: the old && condition silently dropped one-sided updates
+  // -----------------------------------------------------------------------
+
+  /**
+   * Before the fix, {@code hasRealTimeUpdate()} used {@code &&} instead of {@code ||}.
+   * With {@code &&}, a stop that only received one of the two times (a common SIRI pattern,
+   * especially for first/last stops) was incorrectly treated as NO_DATA and its realtime
+   * information was discarded entirely.
+   *
+   * <p>This test documents the old broken contract so the regression is explicit: if the
+   * condition were reverted to {@code &&}, exactly these two cases would silently return
+   * {@code false} and the caller would call {@code withNoData(stop)} instead of applying delays.
+   */
+  @Test
+  void regression_oldAndCondition_wouldHaveDiscardedArrivalOnlyUpdate() {
+    // Only arrival present — with &&, hasRealTimeUpdate() would return false (BUG)
+    var update = intermediate(3700, NO_RT);
+
+    // Current correct behaviour: returns true, delay is applied
+    assertTrue(update.hasRealTimeUpdate());
+    assertEquals(3700 - SCHED_ARRIVAL, update.getArrivalDelay());
+    // If the && bug were present: hasRealTimUpdate() == false → stop marked NO_DATA → delay lost
+  }
+
+  @Test
+  void regression_oldAndCondition_wouldHaveDiscardedDepartureOnlyUpdate() {
+    // Only departure present — with &&, hasRealTimeUpdate() would return false (BUG)
+    var update = intermediate(NO_RT, 3760);
+
+    // Current correct behaviour: returns true, delay is applied
+    assertTrue(update.hasRealTimeUpdate());
+    assertEquals(3760 - SCHED_DEPARTURE, update.getDepartureDelay());
+    // If the && bug were present: hasRealTimUpdate() == false → stop marked NO_DATA → delay lost
+  }
+
+  // -----------------------------------------------------------------------
+  // Factories
+  // -----------------------------------------------------------------------
+
+  private static StopTimeUpdate intermediate(int rtArrival, int rtDeparture) {
+    return new StopTimeUpdate(SCHED_ARRIVAL, rtArrival, SCHED_DEPARTURE, rtDeparture, false, false);
+  }
+
+  private static StopTimeUpdate firstStop(int rtArrival, int rtDeparture) {
+    return new StopTimeUpdate(SCHED_ARRIVAL, rtArrival, SCHED_DEPARTURE, rtDeparture, true, false);
+  }
+
+  private static StopTimeUpdate lastStop(int rtArrival, int rtDeparture) {
+    return new StopTimeUpdate(SCHED_ARRIVAL, rtArrival, SCHED_DEPARTURE, rtDeparture, false, true);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/StopTimeUpdateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/StopTimeUpdateTest.java
@@ -13,7 +13,7 @@ class StopTimeUpdateTest {
   private static final int SCHED_DEPARTURE = 3660;
 
   // -1 signals "no realtime value available"
-  private static final int NO_RT = -1;
+  private static final Integer NO_RT = null;
 
   // -----------------------------------------------------------------------
   // hasRealTimeUpdate
@@ -223,15 +223,15 @@ class StopTimeUpdateTest {
   // Factories
   // -----------------------------------------------------------------------
 
-  private static StopTimeUpdate intermediate(int rtArrival, int rtDeparture) {
+  private static StopTimeUpdate intermediate(Integer rtArrival, Integer rtDeparture) {
     return new StopTimeUpdate(SCHED_ARRIVAL, rtArrival, SCHED_DEPARTURE, rtDeparture, false, false);
   }
 
-  private static StopTimeUpdate firstStop(int rtArrival, int rtDeparture) {
+  private static StopTimeUpdate firstStop(Integer rtArrival, Integer rtDeparture) {
     return new StopTimeUpdate(SCHED_ARRIVAL, rtArrival, SCHED_DEPARTURE, rtDeparture, true, false);
   }
 
-  private static StopTimeUpdate lastStop(int rtArrival, int rtDeparture) {
+  private static StopTimeUpdate lastStop(Integer rtArrival, Integer rtDeparture) {
     return new StopTimeUpdate(SCHED_ARRIVAL, rtArrival, SCHED_DEPARTURE, rtDeparture, false, true);
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/StopTimeUpdateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/StopTimeUpdateTest.java
@@ -12,7 +12,7 @@ class StopTimeUpdateTest {
   private static final int SCHED_ARRIVAL = 3600;
   private static final int SCHED_DEPARTURE = 3660;
 
-  // -1 signals "no realtime value available"
+  // null signals "no realtime value available"
   private static final Integer NO_RT = null;
 
   // -----------------------------------------------------------------------

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/TimetableHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/TimetableHelperTest.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.updater.trip.siri;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -57,6 +59,8 @@ public class TimetableHelperTest {
       .build();
 
     var stopTime = new StopTime();
+    stopTime.setArrivalTime(3600);
+    stopTime.setDepartureTime(3660);
     RegularStop stop = SiteRepository.of()
       .regularStop(SCOPED_STOP_ID)
       .withCoordinate(0.0, 0.0)
@@ -238,6 +242,116 @@ public class TimetableHelperTest {
 
     assertEquals(
       "Occupancy:NO_DATA_AVAILABLE Cancelled:false Extra:true Arrived:false Departed:false Inaccurate:false",
+      showStatuses(0)
+    );
+  }
+
+  @Test
+  public void testApplyUpdates_NoRealtime_setsNoDataOnStop() {
+    // A call with no realtime times at all should mark the stop as NO_DATA
+    // and must NOT set timesModified (so hasAnyUpdates stays false).
+    CallWrapper callWithNoTimes = TestCall.of().withStopPointRef(STOP_ID).build();
+
+    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, callWithNoTimes, null);
+
+    RealTimeTripTimes tripTimes = builder.build();
+    assertTrue(
+      tripTimes.isNoDataStop(0),
+      "Stop should be marked NO_DATA when no realtime times provided"
+    );
+    assertFalse(
+      tripTimes.isTimesModified(),
+      "timesModified must remain false when only NO_DATA stops"
+    );
+    assertFalse(
+      tripTimes.hasAnyUpdates(),
+      "hasAnyUpdates must be false when no times were modified"
+    );
+  }
+
+  @Test
+  public void testApplyUpdates_OnlyExpectedDeparture_doesNotSetNoData() {
+    // A call with only a departure time (no arrival) must still be treated as a real-time update
+    // and must NOT mark the stop as NO_DATA.
+    ZonedDateTime expectedDeparture = START_OF_SERVICE.plus(Duration.ofHours(1));
+    CallWrapper callWithOnlyDeparture = TestCall.of()
+      .withStopPointRef(STOP_ID)
+      .withExpectedDepartureTime(expectedDeparture)
+      .build();
+
+    TimetableHelper.applyUpdates(
+      START_OF_SERVICE,
+      builder,
+      0,
+      false,
+      false,
+      callWithOnlyDeparture,
+      null
+    );
+
+    RealTimeTripTimes tripTimes = builder.build();
+    assertFalse(
+      tripTimes.isNoDataStop(0),
+      "Stop must NOT be NO_DATA when a departure time is provided"
+    );
+    assertTrue(
+      tripTimes.isTimesModified(),
+      "timesModified must be true when a realtime departure is applied"
+    );
+  }
+
+  @Test
+  public void testApplyUpdates_OnlyExpectedArrival_doesNotSetNoData() {
+    // A call with only an arrival time (no departure) must still be treated as a real-time update.
+    // The arrival must be ≤ scheduled departure (3660s) to avoid a negative dwell time.
+    ZonedDateTime expectedArrival = START_OF_SERVICE.plus(Duration.ofSeconds(3620));
+    CallWrapper callWithOnlyArrival = TestCall.of()
+      .withStopPointRef(STOP_ID)
+      .withExpectedArrivalTime(expectedArrival)
+      .build();
+
+    TimetableHelper.applyUpdates(
+      START_OF_SERVICE,
+      builder,
+      0,
+      false,
+      false,
+      callWithOnlyArrival,
+      null
+    );
+
+    RealTimeTripTimes tripTimes = builder.build();
+    assertFalse(
+      tripTimes.isNoDataStop(0),
+      "Stop must NOT be NO_DATA when an arrival time is provided"
+    );
+    assertTrue(
+      tripTimes.isTimesModified(),
+      "timesModified must be true when a realtime arrival is applied"
+    );
+  }
+
+  @Test
+  public void testApplyUpdates_NoDataStop_doesNotPreventCancellationFromBeingApplied() {
+    // A cancelled stop with no realtime times: cancellation must still be set
+    // even though the times are NO_DATA.
+    CallWrapper cancelledNoTimesCall = TestCall.of()
+      .withStopPointRef(STOP_ID)
+      .withCancellation(true)
+      .build();
+
+    TimetableHelper.applyUpdates(
+      START_OF_SERVICE,
+      builder,
+      0,
+      false,
+      false,
+      cancelledNoTimesCall,
+      null
+    );
+
+    assertEquals(
+      "Occupancy:NO_DATA_AVAILABLE Cancelled:true Extra:false Arrived:false Departed:false Inaccurate:false",
       showStatuses(0)
     );
   }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MissingRealtimeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MissingRealtimeTest.java
@@ -1,0 +1,266 @@
+package org.opentripplanner.updater.trip.siri.moduletests.update;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.SiriTestHelper;
+
+/**
+ * Tests for the handling of SIRI ET updates where realtime times are partially or fully absent
+ * for stops in a trip.
+ *
+ * <p>The key behaviours under test:
+ * <ul>
+ *   <li>A stop that receives only one of arrival/departure time must NOT be marked NO_DATA.</li>
+ *   <li>A stop with no realtime times at all must be marked NO_DATA.</li>
+ *   <li>A trip where every stop is NO_DATA must have {@code timesModified = false}, so
+ *       {@code hasAnyUpdates()} returns {@code false} and the trip prefix is "S" (scheduled).</li>
+ * </ul>
+ */
+class MissingRealtimeTest implements RealtimeTestConstants {
+
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
+  private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
+  private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
+  private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);
+
+  private final TripInput TWO_STOP_TRIP = TripInput.of(TRIP_1_ID)
+    .withWithTripOnServiceDate(TRIP_1_ID)
+    .addStop(STOP_A, "0:00:10", "0:00:11")
+    .addStop(STOP_B, "0:00:20", "0:00:21");
+
+  private final TripInput THREE_STOP_TRIP = TripInput.of(TRIP_1_ID)
+    .withWithTripOnServiceDate(TRIP_1_ID)
+    .addStop(STOP_A, "0:00:10", "0:00:11")
+    .addStop(STOP_B, "0:00:20", "0:00:21")
+    .addStop(STOP_C, "0:00:30", "0:00:31");
+
+  /**
+   * An intermediate stop that provides only a departure time (no arrival) must be treated as a
+   * real-time update, not NO_DATA. The missing arrival falls back to the scheduled arrival
+   * (delay = 0), while the departure carries the provided delay.
+   */
+  @Test
+  void intermediateStop_withOnlyDepartureTime_isNotNoData() {
+    var env = ENV_BUILDER.addTrip(THREE_STOP_TRIP).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          // departure only – arrival falls back to scheduled
+          .departAimedExpected("00:00:21", "00:00:26")
+          .call(STOP_C)
+          .arriveAimedExpected("00:00:30", "00:00:35")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+    assertSuccess(result);
+
+    // Stop B: arrival = scheduled (0:00:20, delay 0), departure = realtime (0:00:26, +5s)
+    assertEquals(
+      "U | A 0:00:15 0:00:15 | B 0:00:20 0:00:26 | C 0:00:35 0:00:35",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * An intermediate stop that provides only an arrival time (no departure) must be treated as a
+   * real-time update. The missing departure falls back to the scheduled departure (delay = 0).
+   * The realtime arrival must not exceed the scheduled departure to avoid a negative dwell time.
+   */
+  @Test
+  void intermediateStop_withOnlyArrivalTime_isNotNoData() {
+    var env = ENV_BUILDER.addTrip(THREE_STOP_TRIP).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          // arrival only – departure falls back to scheduled
+          .arriveAimedExpected("00:00:20", "00:00:20")
+          .call(STOP_C)
+          .arriveAimedExpected("00:00:30", "00:00:35")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+    assertSuccess(result);
+
+    // Stop B: arrival = realtime (0:00:20, delay 0), departure = scheduled (0:00:21, delay 0)
+    assertEquals(
+      "U | A 0:00:15 0:00:15 | B 0:00:20 0:00:21 | C 0:00:35 0:00:35",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * A stop with no realtime times at all must be marked NO_DATA and display the scheduled times.
+   * The other stops in the same trip have valid updates, so the trip prefix is "U" (updated).
+   */
+  @Test
+  void oneStopWithNoTimes_isMarkedNoData_tripStillUpdated() {
+    var env = ENV_BUILDER.addTrip(THREE_STOP_TRIP).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          // no times → NO_DATA, scheduled times shown
+          .call(STOP_B)
+          .call(STOP_C)
+          .arriveAimedExpected("00:00:30", "00:00:35")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+    assertSuccess(result);
+
+    assertEquals(
+      "U | A 0:00:15 0:00:15 | B [ND] 0:00:20 0:00:21 | C 0:00:35 0:00:35",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * When every stop in the update has no realtime times, all stops are marked NO_DATA and
+   * {@code timesModified} remains {@code false}. The trip prefix must be "S" (scheduled), not "U"
+   * (updated), because no times were actually modified.
+   */
+  @Test
+  void allStopsWithNoTimes_timesModifiedIsFalse_tripAppearsScheduled() {
+    var env = ENV_BUILDER.addTrip(TWO_STOP_TRIP).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder -> builder.call(STOP_A).call(STOP_B))
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+    assertSuccess(result);
+
+    // "S" prefix: hasAnyUpdates() = false (timesModified = false, no cancellation/added/etc.)
+    assertEquals(
+      "S | A [ND] 0:00:10 0:00:11 | B [ND] 0:00:20 0:00:21",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * The first stop of a trip typically only provides a departure time (no arrival). This must be
+   * treated as a valid update. The missing arrival falls back to the realtime departure time
+   * (first-stop rule), so both arrival and departure show the same realtime value.
+   */
+  @Test
+  void firstStop_withOnlyDepartureTime_isNotNoData() {
+    var env = ENV_BUILDER.addTrip(TWO_STOP_TRIP).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:25")
+          .departAimedExpected("00:00:21", "00:00:26")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+    assertSuccess(result);
+
+    // Stop A: missing arrival falls back to realtime departure (0:00:15) → both show 0:00:15
+    assertEquals(
+      "U | A 0:00:15 0:00:15 | B 0:00:25 0:00:26",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * The last stop of a trip typically only provides an arrival time (no departure). This must be
+   * treated as a valid update. The missing departure falls back to the realtime arrival time
+   * (last-stop rule), so both arrival and departure show the same realtime value.
+   */
+  @Test
+  void lastStop_withOnlyArrivalTime_isNotNoData() {
+    var env = ENV_BUILDER.addTrip(TWO_STOP_TRIP).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:00:11", "00:00:15")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:25")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+    assertSuccess(result);
+
+    // Stop B: missing departure falls back to realtime arrival (0:00:25) → both show 0:00:25
+    assertEquals(
+      "U | A 0:00:15 0:00:15 | B 0:00:25 0:00:25",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+
+  /**
+   * A journey-level cancellation with no stop times provided must set {@code isCanceled = true}
+   * and leave {@code timesModified = false}. The trip is "updated" because it is cancelled
+   * (prefix "C U"), but no time modifications were made, so the scheduled times are shown.
+   *
+   * <p>This verifies that {@code hasAnyUpdates()} is driven by the cancellation flag alone and
+   * does not require {@code timesModified} to be {@code true}.
+   */
+  @Test
+  void journeyLevelCancellation_withNoTimes_isCanceled_butTimesNotModified() {
+    var env = ENV_BUILDER.addTrip(TWO_STOP_TRIP).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withCancellation(true)
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+    assertSuccess(result);
+
+    // "C U": cancelled (C) and has any updates (U) due to the cancellation flag alone;
+    // scheduled times are preserved unchanged because no time modifications were applied.
+    assertEquals(
+      "C U | A 0:00:10 0:00:11 | B 0:00:20 0:00:21",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MissingRealtimeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MissingRealtimeTest.java
@@ -12,13 +12,13 @@ import org.opentripplanner.updater.trip.RealtimeTestConstants;
 import org.opentripplanner.updater.trip.SiriTestHelper;
 
 /**
- * Tests for the handling of SIRI ET updates where realtime times are partially or fully absent
+ * Tests for the handling of SIRI ET updates where real-time times are partially or fully absent
  * for stops in a trip.
  *
  * <p>The key behaviours under test:
  * <ul>
  *   <li>A stop that receives only one of arrival/departure time must NOT be marked NO_DATA.</li>
- *   <li>A stop with no realtime times at all must be marked NO_DATA.</li>
+ *   <li>A stop with no real-time times at all must be marked NO_DATA.</li>
  *   <li>A trip where every stop is NO_DATA must have {@code timesModified = false}, so
  *       {@code hasAnyUpdates()} returns {@code false} and the trip prefix is "S" (scheduled).</li>
  * </ul>
@@ -69,7 +69,7 @@ class MissingRealtimeTest implements RealtimeTestConstants {
     var result = siri.applyEstimatedTimetable(updates);
     assertSuccess(result);
 
-    // Stop B: arrival = scheduled (0:00:20, delay 0), departure = realtime (0:00:26, +5s)
+    // Stop B: arrival = scheduled (0:00:20, delay 0), departure = real-time (0:00:26, +5s)
     assertEquals(
       "U | A 0:00:15 0:00:15 | B 0:00:20 0:00:26 | C 0:00:35 0:00:35",
       env.tripData(TRIP_1_ID).showTimetable()
@@ -79,7 +79,7 @@ class MissingRealtimeTest implements RealtimeTestConstants {
   /**
    * An intermediate stop that provides only an arrival time (no departure) must be treated as a
    * real-time update. The missing departure falls back to the scheduled departure (delay = 0).
-   * The realtime arrival must not exceed the scheduled departure to avoid a negative dwell time.
+   * The real-time arrival must not exceed the scheduled departure to avoid a negative dwell time.
    */
   @Test
   void intermediateStop_withOnlyArrivalTime_isNotNoData() {
@@ -104,7 +104,7 @@ class MissingRealtimeTest implements RealtimeTestConstants {
     var result = siri.applyEstimatedTimetable(updates);
     assertSuccess(result);
 
-    // Stop B: arrival = realtime (0:00:20, delay 0), departure = scheduled (0:00:21, delay 0)
+    // Stop B: arrival = real-time (0:00:20, delay 0), departure = scheduled (0:00:21, delay 0)
     assertEquals(
       "U | A 0:00:15 0:00:15 | B 0:00:20 0:00:21 | C 0:00:35 0:00:35",
       env.tripData(TRIP_1_ID).showTimetable()
@@ -112,7 +112,7 @@ class MissingRealtimeTest implements RealtimeTestConstants {
   }
 
   /**
-   * A stop with no realtime times at all must be marked NO_DATA and display the scheduled times.
+   * A stop with no real-time times at all must be marked NO_DATA and display the scheduled times.
    * The other stops in the same trip have valid updates, so the trip prefix is "U" (updated).
    */
   @Test
@@ -144,7 +144,7 @@ class MissingRealtimeTest implements RealtimeTestConstants {
   }
 
   /**
-   * When every stop in the update has no realtime times, all stops are marked NO_DATA and
+   * When every stop in the update has no real-time times, all stops are marked NO_DATA and
    * {@code timesModified} remains {@code false}. The trip prefix must be "S" (scheduled), not "U"
    * (updated), because no times were actually modified.
    */
@@ -171,8 +171,8 @@ class MissingRealtimeTest implements RealtimeTestConstants {
 
   /**
    * The first stop of a trip typically only provides a departure time (no arrival). This must be
-   * treated as a valid update. The missing arrival falls back to the realtime departure time
-   * (first-stop rule), so both arrival and departure show the same realtime value.
+   * treated as a valid update. The missing arrival falls back to the real-time departure time
+   * (first-stop rule), so both arrival and departure show the same real-time value.
    */
   @Test
   void firstStop_withOnlyDepartureTime_isNotNoData() {
@@ -195,7 +195,7 @@ class MissingRealtimeTest implements RealtimeTestConstants {
     var result = siri.applyEstimatedTimetable(updates);
     assertSuccess(result);
 
-    // Stop A: missing arrival falls back to realtime departure (0:00:15) → both show 0:00:15
+    // Stop A: missing arrival falls back to real-time departure (0:00:15) → both show 0:00:15
     assertEquals(
       "U | A 0:00:15 0:00:15 | B 0:00:25 0:00:26",
       env.tripData(TRIP_1_ID).showTimetable()
@@ -204,8 +204,8 @@ class MissingRealtimeTest implements RealtimeTestConstants {
 
   /**
    * The last stop of a trip typically only provides an arrival time (no departure). This must be
-   * treated as a valid update. The missing departure falls back to the realtime arrival time
-   * (last-stop rule), so both arrival and departure show the same realtime value.
+   * treated as a valid update. The missing departure falls back to the real-time arrival time
+   * (last-stop rule), so both arrival and departure show the same real-time value.
    */
   @Test
   void lastStop_withOnlyArrivalTime_isNotNoData() {
@@ -227,7 +227,7 @@ class MissingRealtimeTest implements RealtimeTestConstants {
     var result = siri.applyEstimatedTimetable(updates);
     assertSuccess(result);
 
-    // Stop B: missing departure falls back to realtime arrival (0:00:25) → both show 0:00:25
+    // Stop B: missing departure falls back to real-time arrival (0:00:25) → both show 0:00:25
     assertEquals(
       "U | A 0:00:15 0:00:15 | B 0:00:25 0:00:25",
       env.tripData(TRIP_1_ID).showTimetable()

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MissingRealtimeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/MissingRealtimeTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TransitTestEnvironment;
-import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
-import org.opentripplanner.transit.model._data.TripInput;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model.TripInput;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.updater.trip.RealtimeTestConstants;
-import org.opentripplanner.updater.trip.SiriTestHelper;
+import org.opentripplanner.updater.trip.siri.SiriTestHelper;
 
 /**
  * Tests for the handling of SIRI ET updates where real-time times are partially or fully absent


### PR DESCRIPTION

### Summary

Intended to handle missing realtime on SIRI-ET Trip Updates correctly.
Old behaviour:
When there were no realtime updates on departure/ arrival it was exposed as having been updated and having a delay of 0 minutes
New Behaviour:
When there is no realtime update on a single departure/ arrival the stops realtime state gets set to "NO_DATA", when there is no realtime update on any of the stops in a trips, the trips realtime state gets set to "timesUpdated = false".

### Issue
part of https://github.com/opentripplanner/OpenTripPlanner/issues/7513

exposing this to the API will happen in: https://github.com/opentripplanner/OpenTripPlanner/pull/7748

### Unit tests

- Added unit tests for the new encapsulated StipTimeUpdate
- Added unit tests for the new behaviour in TimeTableHelper

### Documentation

- comment about flag presedence added to TimeTableHelper
