### PR TITLE
Allow http protocol for remote sources

### DIFF
--- a/application/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/application/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -50,7 +50,7 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   /* private methods */
 
   private static boolean skipUri(URI uri) {
-    return !"https".equals(uri.getScheme());
+    return !"http".equals(uri.getScheme()) && !"https".equals(uri.getScheme());
   }
 
   private DataSource createSource(URI uri, FileType type) {


### PR DESCRIPTION
### Summary

Allow http protocol on remote sources after further discussions in developer meeting. On the previous PR, t2gran states:

> HTTP/HTTPS The protocol should be part of the uri source config paramter. If set to "https:...", then a secure connection must be used. If set to "http:..." **using http** or redirect to https is ok.

I decided leaving everything as is and just allowing http would be the most minimal way to implement this change. I was considering the name of the `HttpsDataSourceRepository` class as well as the description (perhaps rename to indicate https & http? ) but this does not seem to have been conversed about so I'm assuming it is not important.

See [previous PR](https://github.com/opentripplanner/OpenTripPlanner/pull/7718) for details. 

### Issue

The issue below has requested the ability to include http sources with http **and** non-existent .zip extension  but only allowing a source with http will be resolved. Again see [previous PR (https://github.com/opentripplanner/OpenTripPlanner/pull/7718) for details

Partially resolves: https://github.com/opentripplanner/OpenTripPlanner/issues/7512






### Unit tests

Write a few words on how the new code is tested.

- Were unit tests added/updated?
No - the change is minimal enough where I thought it was okay to exclude them.


- Was any manual verification done?
I verified locally that the program still ran successfully with a url that had http

- Any observations on changes to performance?
- Nothing noticeable
