### PR TITLE
Carpool beeline delay lower bound

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolTripTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolTripTestData.java
@@ -8,6 +8,9 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.model.CarpoolStop;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
+import org.opentripplanner.ext.carpooling.routing.CarpoolTripWithVertices;
+import org.opentripplanner.ext.carpooling.routing.RoutedCarpoolTrip;
+import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 
 /**
@@ -254,6 +257,17 @@ public class CarpoolTripTestData {
       .withOnboardCount(1)
       .withDeviationBudget(deviationBudget)
       .build();
+  }
+
+  /** A graph-free stand-in for the routed baseline: each leg's beeline duration. */
+  public static RoutedCarpoolTrip beelineRoutedTrip(CarpoolTripWithVertices tripWithVertices) {
+    var estimator = new BeelineEstimator();
+    var points = tripWithVertices.vertexCoordinates();
+    var durations = new Duration[points.size() - 1];
+    for (int i = 0; i < durations.length; i++) {
+      durations[i] = estimator.estimateDuration(points.get(i), points.get(i + 1));
+    }
+    return new RoutedCarpoolTrip(tripWithVertices, durations);
   }
 
   private static CarpoolTrip buildTrip(

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolRouterEquivalenceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolRouterEquivalenceTest.java
@@ -1,0 +1,135 @@
+package org.opentripplanner.ext.carpooling.routing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
+import org.opentripplanner.street.model.vertex.Vertex;
+import org.opentripplanner.street.service.StreetLimitationParametersService;
+
+/**
+ * Both {@link CarpoolRouter} implementations must report the same duration for the same vertex pair,
+ * since {@link InsertionEvaluator} validates an insertion against durations from one and emits
+ * geometry from the other. The fixture's two routes differ in speed, length and edge count, so a
+ * cost charged per edge or per intersection would make the two dominance functions disagree.
+ */
+class CarpoolRouterEquivalenceTest extends GraphRoutingTest {
+
+  private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
+
+  /** A 40 m/s ceiling, above every car speed in the fixture, so the heuristic stays admissible. */
+  private static final StreetLimitationParametersService STREET_LIMITATION_PARAMETERS =
+    StreetLimitationParametersService.DEFAULT;
+
+  /** Far larger than any route through the fixture, so the tree is never the binding constraint. */
+  private static final Duration GENEROUS_LIMIT = Duration.ofMinutes(30);
+
+  private IntersectionVertex vertexA;
+  private IntersectionVertex vertexZ;
+
+  private CarpoolStreetRouter goalDirectedRouter;
+  private CarpoolTreeStreetRouter treeRouter;
+
+  @BeforeEach
+  void setUp() {
+    modelOf(
+      new Builder() {
+        @Override
+        public void build() {
+          var a = intersection("A", ORIGIN);
+          var z = intersection("Z", ORIGIN.moveEastMeters(1000));
+          // Every declared length exceeds the straight line between its endpoints, keeping the
+          // Euclidean heuristic admissible.
+          var fast1 = intersection("F1", ORIGIN.moveEastMeters(333).moveNorthMeters(600));
+          var fast2 = intersection("F2", ORIGIN.moveEastMeters(667).moveNorthMeters(600));
+
+          // Slow road: one 1000 m edge at 5 m/s = 200 s, drivable both ways.
+          street(a, z, 1000, StreetTraversalPermission.ALL, 5f);
+          street(z, a, 1000, StreetTraversalPermission.ALL, 5f);
+
+          // Fast road: three edges, 1800 m at 30 m/s = 60 s, drivable towards Z only.
+          street(a, fast1, 700, StreetTraversalPermission.ALL, 30f);
+          street(fast1, fast2, 400, StreetTraversalPermission.ALL, 30f);
+          street(fast2, z, 700, StreetTraversalPermission.ALL, 30f);
+
+          vertexA = a;
+          vertexZ = z;
+        }
+      }
+    );
+
+    goalDirectedRouter = new CarpoolStreetRouter(STREET_LIMITATION_PARAMETERS);
+    treeRouter = new CarpoolTreeStreetRouter();
+  }
+
+  @Test
+  void forwardTreeMatchesGoalDirectedRouter() {
+    treeRouter.addVertex(vertexA, CarpoolTreeStreetRouter.Direction.FROM, GENEROUS_LIMIT);
+
+    assertEquals(
+      routedDuration(goalDirectedRouter, vertexA, vertexZ),
+      routedDuration(treeRouter, vertexA, vertexZ)
+    );
+  }
+
+  @Test
+  void reverseTreeMatchesGoalDirectedRouter() {
+    treeRouter.addVertex(vertexZ, CarpoolTreeStreetRouter.Direction.TO, GENEROUS_LIMIT);
+
+    assertEquals(
+      routedDuration(goalDirectedRouter, vertexA, vertexZ),
+      routedDuration(treeRouter, vertexA, vertexZ)
+    );
+  }
+
+  /** The fast road is one-way, so the return leg must fall back on the slow road in both routers. */
+  @Test
+  void oneWayReturnLegMatchesGoalDirectedRouter() {
+    treeRouter.addVertex(vertexZ, CarpoolTreeStreetRouter.Direction.FROM, GENEROUS_LIMIT);
+
+    assertEquals(
+      routedDuration(goalDirectedRouter, vertexZ, vertexA),
+      routedDuration(treeRouter, vertexZ, vertexA)
+    );
+  }
+
+  /**
+   * The quicker route must also be the cheaper one, or the two dominance functions would rank the
+   * pair differently. Its higher edge count is what makes a per-edge cost term visible here.
+   */
+  @Test
+  void theQuickerRouteIsAlsoTheCheaperOne() {
+    var outbound = goalDirectedRouter.route(vertexA, vertexZ);
+    var returnLeg = goalDirectedRouter.route(vertexZ, vertexA);
+    assertNotNull(outbound);
+    assertNotNull(returnLeg);
+
+    assertTrue(
+      GraphPathUtils.durationOrZero(outbound).compareTo(GraphPathUtils.durationOrZero(returnLeg)) <
+        0,
+      "the outbound leg takes the fast road and must be quicker than the slow return leg"
+    );
+    assertTrue(
+      outbound.getWeight() < returnLeg.getWeight(),
+      "the quicker route must also weigh less, or the two dominance functions would disagree"
+    );
+    assertTrue(
+      outbound.edges.size() > returnLeg.edges.size(),
+      "the quicker route must not also be the one with the fewest edges"
+    );
+  }
+
+  private static Duration routedDuration(CarpoolRouter router, Vertex from, Vertex to) {
+    var path = router.route(from, to);
+    assertNotNull(path, "no path found from " + from + " to " + to);
+    return GraphPathUtils.durationOrZero(path);
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouterTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.TestOtpModel;
+import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
 import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
@@ -196,6 +197,23 @@ class CarpoolTreeStreetRouterTest extends GraphRoutingTest {
 
     var farPath = router.route(vertexA, vertexD);
     assertNull(farPath, "Should not find far vertex D within short search limit");
+  }
+
+  /**
+   * The search limit is inclusive, so a tree sized to exactly the leg's routed duration still spans
+   * it — the floor case of {@code DefaultCarpoolingService.driverLegTreeLimits}.
+   */
+  @Test
+  void treeSizedToTheRoutedDurationStillSpansTheLeg() {
+    router.addVertex(vertexA, CarpoolTreeStreetRouter.Direction.FROM, SEARCH_LIMIT);
+    var routed = GraphPathUtils.durationOrZero(router.route(vertexA, vertexD));
+
+    var exactlySizedRouter = new CarpoolTreeStreetRouter();
+    exactlySizedRouter.addVertex(vertexA, CarpoolTreeStreetRouter.Direction.FROM, routed);
+
+    var path = exactlySizedRouter.route(vertexA, vertexD);
+    assertNotNull(path, "a tree sized to the routed duration must still reach the leg's end");
+    assertEquals(routed, GraphPathUtils.durationOrZero(path));
   }
 
   @Test

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
@@ -14,6 +14,7 @@ import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NOR
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTHEAST;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_SOUTH;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_WEST;
+import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.beelineRoutedTrip;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createSimpleTrip;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createStopAt;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createTripWithDeviationBudget;
@@ -76,12 +77,10 @@ class InsertionEvaluatorTest {
   }
 
   private WgsCoordinate getCoordinate(Vertex vertex) {
-    return new WgsCoordinate(vertex.getCoordinate().y, vertex.getCoordinate().x);
+    return vertex.toWgsCoordinate();
   }
 
-  /**
-   * Runs position finding followed by evaluation and returns the best insertion.
-   */
+  /** Runs position finding followed by evaluation. */
   private InsertionCandidate findOptimalInsertion(
     CarpoolTrip trip,
     WgsCoordinate passengerPickup,
@@ -89,8 +88,15 @@ class InsertionEvaluatorTest {
     CarpoolRouter carpoolRouter
   ) {
     var tripWithVertices = createTripWithVertices(trip);
+    // A trip whose baseline cannot be routed cannot carry a passenger. The same durations feed the
+    // finder and the evaluator.
+    var legDurations = carpoolRouter.routeLegDurations(tripWithVertices.vertices());
+    if (legDurations == null) {
+      return null;
+    }
+    var routedTrip = new RoutedCarpoolTrip(tripWithVertices, legDurations);
     List<InsertionPosition> viablePositions = positionFinder.findViablePositions(
-      trip,
+      routedTrip,
       passengerPickup,
       passengerDropoff,
       Duration.ZERO
@@ -102,7 +108,7 @@ class InsertionEvaluatorTest {
 
     var evaluator = new InsertionEvaluator(carpoolRouter, Duration.ZERO);
     return evaluator.findBestInsertion(
-      tripWithVertices,
+      routedTrip,
       viablePositions,
       new PassengerSnap(vertexMap.get(passengerPickup), vertexMap.get(passengerDropoff), null, null)
     );
@@ -296,7 +302,10 @@ class InsertionEvaluatorTest {
 
     var evaluator = new InsertionEvaluator(routingFunction, Duration.ZERO);
     var result = evaluator.findBestInsertion(
-      tripWithVertices,
+      new RoutedCarpoolTrip(
+        tripWithVertices,
+        routingFunction.routeLegDurations(tripWithVertices.vertices())
+      ),
       viablePositions,
       new PassengerSnap(vertexMap.get(OSLO_EAST), vertexMap.get(OSLO_WEST), null, null)
     );

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluatorTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
+import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressType;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.SimpleVertex;
@@ -251,6 +252,174 @@ class InsertionEvaluatorTest {
     var result = findOptimalInsertion(trip, OSLO_EAST, OSLO_WEST, routingFunction);
 
     assertNull(result);
+  }
+
+  /**
+   * No baseline leg may be routed when no insertion is valid, through either entry point. The router
+   * throws if asked for a leg between two driver waypoints.
+   */
+  @Test
+  void doesNotRouteBaselineWhenNoInsertionIsValid() {
+    var trip = createTripWithDeviationBudget(Duration.ofMinutes(5), OSLO_CENTER, OSLO_NORTH);
+    var tripWithVertices = createTripWithVertices(trip);
+
+    var centerVertex = vertexMap.get(OSLO_CENTER);
+    var northVertex = vertexMap.get(OSLO_NORTH);
+    var slowDetour = createGraphPath(Duration.ofMinutes(30));
+    CarpoolRouter routingFunction = (from, to) -> {
+      boolean baselineLeg =
+        (from == centerVertex || from == northVertex) && (to == centerVertex || to == northVertex);
+      if (baselineLeg) {
+        throw new AssertionError(
+          "baseline routed though no insertion is valid: " + from + " → " + to
+        );
+      }
+      return slowDetour;
+    };
+    var evaluator = new InsertionEvaluator(routingFunction, Duration.ZERO);
+
+    var routedTrip = beelineRoutedTrip(tripWithVertices);
+    var viablePositions = finderPositions(routedTrip, OSLO_EAST, OSLO_WEST);
+    assertFalse(viablePositions.isEmpty(), "beeline pre-filter should admit the position");
+
+    assertNull(
+      evaluator.findBestInsertion(
+        routedTrip,
+        viablePositions,
+        new PassengerSnap(vertexMap.get(OSLO_EAST), vertexMap.get(OSLO_WEST), null, null)
+      ),
+      "findBestInsertion must reject the position"
+    );
+
+    var candidates = evaluator.findBestInsertions(
+      new TripWithViableAccessEgress(
+        routedTrip,
+        List.of(accessAtEastEndingAt(OSLO_WEST), accessAtEastEndingAt(OSLO_MIDPOINT_NORTH))
+      )
+    );
+    assertTrue(candidates.isEmpty(), "findBestInsertions must yield no candidate for any stop");
+  }
+
+  private List<InsertionPosition> finderPositions(
+    RoutedCarpoolTrip routedTrip,
+    WgsCoordinate pickup,
+    WgsCoordinate dropoff
+  ) {
+    return positionFinder.findViablePositions(routedTrip, pickup, dropoff, Duration.ZERO);
+  }
+
+  /** A two-stop trip's only baseline leg is replaced by the insertion, so it is never routed. */
+  @Test
+  void findBestInsertions_doesNotRouteBaselineLegsTheInsertionReplaces() {
+    var trip = createTripWithDeviationBudget(Duration.ofMinutes(20), OSLO_CENTER, OSLO_NORTH);
+    var tripWithVertices = createTripWithVertices(trip);
+
+    var pathsMap = Map.of(
+      // Both stops share the leg from the driver's origin to the passenger.
+      new Pair<>(OSLO_CENTER, OSLO_EAST),
+      createGraphPath(Duration.ofMinutes(3)),
+      // Stop served at OSLO_WEST: 3 + 4 + 5 = 12 min.
+      new Pair<>(OSLO_EAST, OSLO_WEST),
+      createGraphPath(Duration.ofMinutes(4)),
+      new Pair<>(OSLO_WEST, OSLO_NORTH),
+      createGraphPath(Duration.ofMinutes(5)),
+      // Stop served at OSLO_MIDPOINT_NORTH: 3 + 2 + 1 = 6 min.
+      new Pair<>(OSLO_EAST, OSLO_MIDPOINT_NORTH),
+      createGraphPath(Duration.ofMinutes(2)),
+      new Pair<>(OSLO_MIDPOINT_NORTH, OSLO_NORTH),
+      createGraphPath(Duration.ofMinutes(1))
+    );
+
+    final int[] baselineLegCalls = { 0 };
+    CarpoolRouter routingFunction = (from, to) -> {
+      if (from == vertexMap.get(OSLO_CENTER) && to == vertexMap.get(OSLO_NORTH)) {
+        baselineLegCalls[0]++;
+      }
+      return pathsMap.get(new Pair<>(getCoordinate(from), getCoordinate(to)));
+    };
+
+    var evaluator = new InsertionEvaluator(routingFunction, Duration.ZERO);
+    var candidates = evaluator.findBestInsertions(
+      new TripWithViableAccessEgress(
+        new RoutedCarpoolTrip(tripWithVertices, new Duration[] { Duration.ofMinutes(10) }),
+        List.of(accessAtEastEndingAt(OSLO_WEST), accessAtEastEndingAt(OSLO_MIDPOINT_NORTH))
+      )
+    );
+
+    assertEquals(0, baselineLegCalls[0], "the replaced baseline leg must never be routed");
+    assertEquals(
+      List.of(Duration.ofMinutes(12), Duration.ofMinutes(6)),
+      candidates.stream().map(InsertionCandidate::totalTripDuration).toList()
+    );
+  }
+
+  /** A leg that survives the insertion is routed once and shared by every winning stop. */
+  @Test
+  void findBestInsertions_routesAReusedBaselineLegOnceForAllWinningStops() {
+    var budget = Duration.ofMinutes(20);
+    var trip = createTripWithStops(
+      OSLO_CENTER,
+      List.of(createStopAt(OSLO_NORTHEAST, budget)),
+      OSLO_NORTH,
+      budget
+    );
+    var tripWithVertices = createTripWithVertices(trip);
+
+    var pathsMap = Map.of(
+      new Pair<>(OSLO_CENTER, OSLO_EAST),
+      createGraphPath(Duration.ofMinutes(3)),
+      // Stop served at OSLO_WEST: 3 + 4 + 5 + reused 5 = 17 min.
+      new Pair<>(OSLO_EAST, OSLO_WEST),
+      createGraphPath(Duration.ofMinutes(4)),
+      new Pair<>(OSLO_WEST, OSLO_NORTHEAST),
+      createGraphPath(Duration.ofMinutes(5)),
+      // Stop served at OSLO_MIDPOINT_NORTH: 3 + 2 + 1 + reused 5 = 11 min.
+      new Pair<>(OSLO_EAST, OSLO_MIDPOINT_NORTH),
+      createGraphPath(Duration.ofMinutes(2)),
+      new Pair<>(OSLO_MIDPOINT_NORTH, OSLO_NORTHEAST),
+      createGraphPath(Duration.ofMinutes(1)),
+      // The surviving second leg.
+      new Pair<>(OSLO_NORTHEAST, OSLO_NORTH),
+      createGraphPath(Duration.ofMinutes(5))
+    );
+
+    final int[] reusedLegCalls = { 0 };
+    CarpoolRouter routingFunction = (from, to) -> {
+      if (from == vertexMap.get(OSLO_NORTHEAST) && to == vertexMap.get(OSLO_NORTH)) {
+        reusedLegCalls[0]++;
+      }
+      return pathsMap.get(new Pair<>(getCoordinate(from), getCoordinate(to)));
+    };
+
+    var evaluator = new InsertionEvaluator(routingFunction, Duration.ZERO);
+    var candidates = evaluator.findBestInsertions(
+      new TripWithViableAccessEgress(
+        new RoutedCarpoolTrip(
+          tripWithVertices,
+          new Duration[] { Duration.ofMinutes(10), Duration.ofMinutes(5) }
+        ),
+        List.of(accessAtEastEndingAt(OSLO_WEST), accessAtEastEndingAt(OSLO_MIDPOINT_NORTH))
+      )
+    );
+
+    assertEquals(1, reusedLegCalls[0], "the reused leg must be routed once for both winning stops");
+    assertEquals(
+      List.of(Duration.ofMinutes(17), Duration.ofMinutes(11)),
+      candidates.stream().map(InsertionCandidate::totalTripDuration).toList()
+    );
+  }
+
+  /** An access candidate from {@code OSLO_EAST} to {@code transitCoordinate} at position (1, 2). */
+  private ViableAccessEgress accessAtEastEndingAt(WgsCoordinate transitCoordinate) {
+    return new ViableAccessEgress(
+      null,
+      vertexMap.get(transitCoordinate),
+      vertexMap.get(OSLO_EAST),
+      AccessEgressType.ACCESS,
+      List.of(new InsertionPosition(1, 2)),
+      null,
+      null
+    );
   }
 
   /**

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionPositionFinderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/InsertionPositionFinderTest.java
@@ -8,17 +8,23 @@ import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_EAS
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_SOUTH;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_WEST;
+import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.beelineRoutedTrip;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createDestinationStop;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createOriginStop;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createSimpleTrip;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createStopAt;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createTripWithCapacity;
+import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createTripWithDeviationBudget;
 import static org.opentripplanner.ext.carpooling.CarpoolTripTestData.createTripWithStops;
 
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.vertex.SimpleVertex;
+import org.opentripplanner.street.model.vertex.Vertex;
 
 /**
  * Tests for {@link InsertionPositionFinder}.
@@ -38,7 +44,12 @@ class InsertionPositionFinderTest {
     var trip = createSimpleTrip(OSLO_CENTER, OSLO_NORTH);
 
     // Passenger picked up east of route, dropped off at destination — small compatible detour
-    var viablePositions = finder.findViablePositions(trip, OSLO_EAST, OSLO_NORTH, Duration.ZERO);
+    var viablePositions = finder.findViablePositions(
+      beelineRoutedTrip(onRoutePoints(trip)),
+      OSLO_EAST,
+      OSLO_NORTH,
+      Duration.ZERO
+    );
 
     assertFalse(viablePositions.isEmpty());
   }
@@ -49,7 +60,12 @@ class InsertionPositionFinderTest {
     var stops = List.of(createOriginStop(OSLO_CENTER), createDestinationStop(OSLO_NORTH));
     var trip = createTripWithCapacity(0, stops);
 
-    var viablePositions = finder.findViablePositions(trip, OSLO_EAST, OSLO_WEST, Duration.ZERO);
+    var viablePositions = finder.findViablePositions(
+      beelineRoutedTrip(onRoutePoints(trip)),
+      OSLO_EAST,
+      OSLO_WEST,
+      Duration.ZERO
+    );
 
     // Should reject all positions due to capacity
     assertTrue(viablePositions.isEmpty());
@@ -67,7 +83,12 @@ class InsertionPositionFinderTest {
     );
 
     // Passenger going opposite direction (WEST→SOUTH) with 1s budget — all positions should be rejected
-    var viablePositions = finder.findViablePositions(trip, OSLO_WEST, OSLO_SOUTH, Duration.ZERO);
+    var viablePositions = finder.findViablePositions(
+      beelineRoutedTrip(onRoutePoints(trip)),
+      OSLO_WEST,
+      OSLO_SOUTH,
+      Duration.ZERO
+    );
 
     assertTrue(viablePositions.isEmpty());
   }
@@ -78,10 +99,88 @@ class InsertionPositionFinderTest {
     var stop2 = createStopAt(OSLO_WEST);
     var trip = createTripWithStops(OSLO_CENTER, List.of(stop1, stop2), OSLO_NORTH);
 
-    var viablePositions = finder.findViablePositions(trip, OSLO_SOUTH, OSLO_NORTH, Duration.ZERO);
+    var viablePositions = finder.findViablePositions(
+      beelineRoutedTrip(onRoutePoints(trip)),
+      OSLO_SOUTH,
+      OSLO_NORTH,
+      Duration.ZERO
+    );
 
     // Should evaluate multiple pickup/dropoff combinations
     // Exact count depends on beeline filtering
     assertNotNull(viablePositions);
+  }
+
+  /**
+   * Delay is a difference against the baseline, so the baseline must carry the leg's routed duration:
+   * a winding leg leaves an off-line detour adding almost nothing on top of it.
+   */
+  @Test
+  void findViablePositions_windingBaselineLeg_keepsNearOnRouteInsertion() {
+    // Tight budget the straight-line detour estimate on its own would exceed.
+    var tightBudget = Duration.ofSeconds(30);
+    var trip = createTripWithDeviationBudget(tightBudget, OSLO_CENTER, OSLO_NORTH);
+
+    // The lone CENTER→NORTH leg takes an hour to drive (a winding road), far longer than the
+    // straight line between its endpoints, so the detour via EAST/WEST adds little beyond it.
+    var windingBaseline = new RoutedCarpoolTrip(
+      onRoutePoints(trip),
+      new Duration[] { Duration.ofHours(1) }
+    );
+
+    var viablePositions = finder.findViablePositions(
+      windingBaseline,
+      OSLO_EAST,
+      OSLO_WEST,
+      Duration.ZERO
+    );
+
+    assertFalse(
+      viablePositions.isEmpty(),
+      "measuring the detour against the real (longer) baseline must keep the feasible insertion"
+    );
+  }
+
+  /**
+   * The detour is measured from the resolved vertices, not the declared route points. The passenger
+   * waits on the driver's actual route, so the tightest budget still admits the insertion.
+   */
+  @Test
+  void findViablePositions_routePointResolvedFarFromItsVertex_measuresDetourFromTheVertex() {
+    var trip = createTripWithDeviationBudget(Duration.ofSeconds(1), OSLO_CENTER, OSLO_NORTH);
+    var tripWithVertices = new CarpoolTripWithVertices(
+      trip,
+      List.of(vertexAt(OSLO_EAST), vertexAt(OSLO_NORTH))
+    );
+
+    // The baseline is driven between the resolved vertices, so its lone leg runs EAST → NORTH.
+    var viablePositions = finder.findViablePositions(
+      beelineRoutedTrip(tripWithVertices),
+      OSLO_EAST,
+      OSLO_NORTH,
+      Duration.ZERO
+    );
+
+    assertFalse(
+      viablePositions.isEmpty(),
+      "a passenger waiting on the driver's actual route adds no delay and must not be rejected"
+    );
+  }
+
+  /** A vertex sitting exactly on the given coordinate. */
+  private static Vertex vertexAt(WgsCoordinate coordinate) {
+    return new SimpleVertex(
+      "vertex-" + coordinate.latitude() + "-" + coordinate.longitude(),
+      coordinate.latitude(),
+      coordinate.longitude()
+    );
+  }
+
+  /** The trip resolved to vertices sitting exactly on its route points — nothing was snapped. */
+  private static CarpoolTripWithVertices onRoutePoints(CarpoolTrip trip) {
+    return new CarpoolTripWithVertices(
+      trip,
+      trip.routePoints().stream().map(InsertionPositionFinderTest::vertexAt).toList()
+    );
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/BeelineEstimatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/BeelineEstimatorTest.java
@@ -1,14 +1,11 @@
 package org.opentripplanner.ext.carpooling.util;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
-import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_EAST;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
 
 import java.time.Duration;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 
@@ -42,31 +39,5 @@ class BeelineEstimatorTest {
   void constructorRejectsNonPositiveSpeed() {
     assertThrows(IllegalArgumentException.class, () -> new BeelineEstimator(0.0));
     assertThrows(IllegalArgumentException.class, () -> new BeelineEstimator(-5.0));
-  }
-
-  @Test
-  void calculateCumulativeTimesIsEmptyForNoPoints() {
-    assertEquals(
-      0,
-      new BeelineEstimator().calculateCumulativeTimes(List.of(), Duration.ZERO).length
-    );
-  }
-
-  @Test
-  void calculateCumulativeTimesAccumulatesPerSegmentEstimates() {
-    var estimator = new BeelineEstimator();
-    var stop = Duration.ofMinutes(1);
-
-    Duration[] times = estimator.calculateCumulativeTimes(
-      List.of(OSLO_CENTER, OSLO_EAST, OSLO_NORTH),
-      stop
-    );
-
-    Duration firstLeg = estimator.estimateDuration(OSLO_CENTER, OSLO_EAST);
-    Duration secondLeg = estimator.estimateDuration(OSLO_EAST, OSLO_NORTH);
-    assertArrayEquals(
-      new Duration[] { Duration.ZERO, firstLeg, firstLeg.plus(stop).plus(secondLeg) },
-      times
-    );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/README.md
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/README.md
@@ -32,7 +32,7 @@ The carpooling extension enables OpenTripPlanner to find carpool trip options by
 ┌────────────────────────────────────────────┐
 │ DefaultCarpoolingService                   │
 │                                            │
-│  1. Filter Phase (TripPreFilters)         │
+│  1. Filter Phase (TripPreFilters)          │
 │     - Time window check                    │
 │     - Distance check                       │
 │     - Direction check                      │
@@ -40,15 +40,16 @@ The carpooling extension enables OpenTripPlanner to find carpool trip options by
 │  2. Insertion Phase                        │
 │     2a. Position Pre-screening             │
 │         (InsertionPositionFinder)          │
+│         - Needs routed baseline (memoized) │
 │         - Capacity check                   │
 │         - Beeline delay heuristic          │
 │                                            │
 │     2b. Routing & Selection                │
 │         (InsertionEvaluator)               │
-│         - Route baseline segments (cached) │
-│         - Route viable positions           │
-│         - Endpoint-matching segment reuse  │
+│         - Route each position's detours    │
 │         - Select minimum additional time   │
+│         - Route baseline once, lazily,     │
+│           to build the winning geometry    │
 │                                            │
 └────────┬───────────────────────────────────┘
          │
@@ -122,9 +123,13 @@ For trips that pass filtering, computes optimal pickup/dropoff positions using a
 
 #### Stage 1: Position Pre-screening (InsertionPositionFinder)
 
-Fast heuristic checks eliminate impossible positions **before any A* routing**:
+Fast heuristic checks eliminate impossible positions **before any per-position A\* routing**. They
+are not routing-free, though: the checks measure each detour against the trip's routed baseline,
+which must therefore be routed first.
 
 ```
+Once per trip: route the driver's baseline legs, keeping each leg's duration.
+
 For each remaining trip:
   1. Generate all position combinations (pickup, dropoff) where:
      - Pickup: between any two consecutive stops (0-based index in modified route)
@@ -132,41 +137,42 @@ For each remaining trip:
 
   2. For each position pair, check:
      a. Capacity: Does insertion exceed vehicle capacity at any point?
-     b. Beeline delay: Do straight-line estimates exceed delay threshold?
+     b. Beeline delay: beeline only the new detour segments, reuse the trip's
+        routed baseline durations for every untouched leg, and reject if the
+        resulting delay exceeds a stop's budget.
 
   3. Return only "viable" positions that pass all checks
 ```
 
 **Key optimizations**:
 - **Capacity validation**: Uses `CarpoolTrip.hasCapacityForInsertion()` to check entire journey range
-- **Beeline heuristic**: Optimistic straight-line estimates eliminate positions early
-- **No routing yet**: All checks use geometric calculations only
+- **Guaranteed lower bound**: The detour is beelined and untouched legs keep their routed duration, so the estimated delay never exceeds the routed delay — no feasible insertion is lost
+- **Measured from the resolved vertices**: The beeline runs between the vertices the route points snapped to (`CarpoolTripWithVertices.vertexCoordinates()`), which is where the driver is actually routed
+- **Baseline routed per trip, not per position**: Memoized on the repository until the trip's route points change, so the cost falls once per trip rather than once per request
 
 #### Stage 2: Routing and Selection (InsertionEvaluator)
 
-For viable positions from Stage 1, perform A* routing to find the optimal insertion:
+For viable positions from Stage 1, route each candidate's detour and select the best insertion. Baseline geometry is routed **lazily** — only for the legs a winner actually reuses:
 
 ```
 For each trip with viable positions:
-  1. Route baseline segments (driver's original route) and cache results
+  1. For each viable position:
+     a. Build the modified route with the passenger inserted
+     b. Route only the detour segments around the inserted pickup/dropoff
+     c. Take each untouched leg's duration from the routed baseline durations
+     d. Reject the position if any stop's delay exceeds its deviation budget
 
-  2. For each viable position:
-     a. Build modified route with passenger inserted
-     b. Route only segments with changed endpoints
-     c. Reuse cached segments where endpoints match exactly
-     d. Calculate total duration and additional time vs. baseline
-     e. Check passenger delay constraints
+  2. Select the surviving insertion with the minimum total trip duration
 
-  3. Select insertion with minimum additional time
-  4. Ensure additional time ≤ driver's deviation budget
+  3. Route the baseline legs the winners reuse, and stitch them into the
+     selected detour segments to build the leg geometry
 ```
 
-**Critical optimization - Endpoint-matching segment reuse**:
-- Baseline segments are cached after first routing
-- For modified routes, segments are reused **only if both endpoints match exactly**
-- Endpoint matching uses `WgsCoordinate.equals()` with 7-decimal precision (~1cm)
-- Only segments with changed endpoints are re-routed
-- Prevents incorrect reuse when passenger insertion splits existing segments
+**Critical optimization - lazy baseline, durations-first selection**:
+- Selection routes only each position's detour segments; untouched legs reuse the routed baseline durations
+- A trip whose every position fails the delay constraints costs **no** baseline-geometry routing
+- Only the baseline legs some winner reuses are routed, once each and shared across winners. An insertion replaces the legs around its pickup and dropoff, so a two-stop trip reuses none at all
+- `InsertionPosition.baselineSegmentIndex` maps a modified segment to its baseline leg, or `-1` for the (at most four) new detour segments
 
 ## Usage Examples
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolRouter.java
@@ -1,5 +1,10 @@
 package org.opentripplanner.ext.carpooling.routing;
 
+import static org.opentripplanner.ext.carpooling.util.GraphPathUtils.durationOrZero;
+
+import java.time.Duration;
+import java.util.List;
+import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -11,4 +16,36 @@ import org.opentripplanner.street.search.state.State;
 @FunctionalInterface
 public interface CarpoolRouter {
   GraphPath<State, Edge, Vertex> route(Vertex from, Vertex to);
+
+  /**
+   * Routes each consecutive leg between {@code waypoints}, or returns {@code null} as soon as one
+   * cannot be routed.
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable
+  default GraphPath<State, Edge, Vertex>[] routeLegs(List<Vertex> waypoints) {
+    GraphPath<State, Edge, Vertex>[] legs = new GraphPath[waypoints.size() - 1];
+    for (int i = 0; i < legs.length; i++) {
+      var leg = route(waypoints.get(i), waypoints.get(i + 1));
+      if (leg == null) {
+        return null;
+      }
+      legs[i] = leg;
+    }
+    return legs;
+  }
+
+  /** The travel duration of each leg between {@code waypoints}, or {@code null} if any fails. */
+  @Nullable
+  default Duration[] routeLegDurations(List<Vertex> waypoints) {
+    var legs = routeLegs(waypoints);
+    if (legs == null) {
+      return null;
+    }
+    var durations = new Duration[legs.length];
+    for (int i = 0; i < legs.length; i++) {
+      durations[i] = durationOrZero(legs[i]);
+    }
+    return durations;
+  }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
@@ -1,17 +1,19 @@
 package org.opentripplanner.ext.carpooling.routing;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
-import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.ext.carpooling.util.CarpoolStreetSearch;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.EuclideanRemainingWeightHeuristic;
 import org.opentripplanner.street.search.StreetSearchBuilder;
-import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.strategy.DominanceFunctions;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.utils.collection.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +33,10 @@ import org.slf4j.LoggerFactory;
  *   <li><strong>Error Handling:</strong> Returns null on routing failure (logged as warning)</li>
  * </ul>
  *
+ * <p>
+ * Results are memoized per {@code (from, to)} pair, including {@code null}. The cache is unbounded
+ * but request-scoped, and not thread-safe.
+ *
  * @see InsertionEvaluator for usage in insertion evaluation
  */
 public class CarpoolStreetRouter implements CarpoolRouter {
@@ -38,6 +44,7 @@ public class CarpoolStreetRouter implements CarpoolRouter {
   private static final Logger LOG = LoggerFactory.getLogger(CarpoolStreetRouter.class);
 
   private final StreetLimitationParametersService streetLimitationParametersService;
+  private final Map<Pair<Vertex>, GraphPath<State, Edge, Vertex>> pathCache = new HashMap<>();
 
   /**
    * Creates a new carpool street router.
@@ -50,12 +57,19 @@ public class CarpoolStreetRouter implements CarpoolRouter {
 
   @Override
   public GraphPath<State, Edge, Vertex> route(Vertex from, Vertex to) {
+    var key = new Pair<>(from, to);
+    if (pathCache.containsKey(key)) {
+      return pathCache.get(key);
+    }
+    GraphPath<State, Edge, Vertex> path;
     try {
-      return carpoolRouting(from, to);
+      path = carpoolRouting(from, to);
     } catch (Exception e) {
       LOG.warn("Routing failed from {} to {}: {}", from, to, e.getMessage());
-      return null;
+      path = null;
     }
+    pathCache.put(key, path);
+    return path;
   }
 
   /**
@@ -73,7 +87,7 @@ public class CarpoolStreetRouter implements CarpoolRouter {
    * @return the first (best) path found, or null if no paths exist
    */
   private GraphPath<State, Edge, Vertex> carpoolRouting(Vertex fromVertex, Vertex toVertex) {
-    var request = StreetSearchRequest.of().withMode(StreetMode.CAR).build();
+    var request = CarpoolStreetSearch.carRequest(false);
     var streetSearch = StreetSearchBuilder.of()
       .withHeuristic(new EuclideanRemainingWeightHeuristic(streetLimitationParametersService))
       // Bound the search at the carpool trip ceiling rather than the passenger request's

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouter.java
@@ -6,11 +6,10 @@ import java.util.Map;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
-import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.ext.carpooling.util.CarpoolStreetSearch;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.StreetSearchBuilder;
-import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.strategy.DominanceFunctions;
 import org.opentripplanner.utils.collection.Pair;
@@ -66,9 +65,7 @@ public class CarpoolTreeStreetRouter implements CarpoolRouter {
     boolean reverse,
     Duration searchLimit
   ) {
-    var streetSearchRequest = reverse
-      ? StreetSearchRequest.of().withMode(StreetMode.CAR).withArriveBy(true).build()
-      : StreetSearchRequest.of().withMode(StreetMode.CAR).build();
+    var streetSearchRequest = CarpoolStreetSearch.carRequest(reverse);
     var builder = StreetSearchBuilder.of()
       .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(searchLimit))
       .withDominanceFunction(new DominanceFunctions.EarliestArrival())

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTripWithVertices.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTripWithVertices.java
@@ -2,14 +2,20 @@ package org.opentripplanner.ext.carpooling.routing;
 
 import java.util.List;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.vertex.Vertex;
 
 /**
  * Pairs a {@link CarpoolTrip} with the permanent street vertices its route points resolve to, one
  * per route point, in route order.
  */
-public record CarpoolTripWithVertices(CarpoolTrip trip, List<Vertex> vertices) {
-  public CarpoolTripWithVertices {
+public final class CarpoolTripWithVertices {
+
+  private final CarpoolTrip trip;
+  private final List<Vertex> vertices;
+  private final List<WgsCoordinate> vertexCoordinates;
+
+  public CarpoolTripWithVertices(CarpoolTrip trip, List<Vertex> vertices) {
     if (vertices.size() != trip.stops().size()) {
       throw new IllegalArgumentException(
         "Number of vertices (%d) does not match number of stops (%d)".formatted(
@@ -18,6 +24,24 @@ public record CarpoolTripWithVertices(CarpoolTrip trip, List<Vertex> vertices) {
         )
       );
     }
-    vertices = List.copyOf(vertices);
+    this.trip = trip;
+    this.vertices = List.copyOf(vertices);
+    this.vertexCoordinates = this.vertices.stream().map(Vertex::toWgsCoordinate).toList();
+  }
+
+  public CarpoolTrip trip() {
+    return trip;
+  }
+
+  public List<Vertex> vertices() {
+    return vertices;
+  }
+
+  /**
+   * Where the driver is actually routed from and to, which can differ from
+   * {@link CarpoolTrip#routePoints()} when a point did not sit on the drivable network.
+   */
+  public List<WgsCoordinate> vertexCoordinates() {
+    return vertexCoordinates;
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.carpooling.routing;
 
 import static org.opentripplanner.ext.carpooling.util.GraphPathUtils.calculateCumulativeDurations;
+import static org.opentripplanner.ext.carpooling.util.GraphPathUtils.durationOrZero;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -18,139 +19,73 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Evaluates pre-filtered insertion positions using A* routing.
- * <p>
- * This class is a pure evaluator that takes positions identified by heuristic
- * filtering and evaluates them using expensive A* street routing. It selects
- * the insertion that minimizes additional travel time while satisfying
- * passenger delay constraints.
- * <p>
- * This follows the established OTP pattern of separating candidate generation
- * from evaluation, similar to {@code TransferGenerator} and {@code OptimizePathDomainService}.
+ * Selects the best insertion among pre-screened positions, routing the detour around each candidate
+ * pickup/dropoff and reusing the trip's baseline legs elsewhere.
  */
 public class InsertionEvaluator {
 
   private static final Logger LOG = LoggerFactory.getLogger(InsertionEvaluator.class);
 
-  private final CarpoolRouter carpoolRouter;
-
-  @Nullable
-  private final CarpoolRouter baselineFallbackRouter;
-
+  private final CarpoolRouter router;
   private final Duration stopDuration;
 
   /**
-   * @param carpoolRouter routes a single street segment between two vertices in the candidate
-   *        carpool route — used both to build the baseline route and to re-route only the
-   *        segments that change when a passenger pickup/dropoff is inserted.
-   * @param stopDuration duration added at each intermediate stop (from the car {@code pickupTime}
-   *        preference); applied between consecutive segments when computing total trip and
-   *        passenger-ride durations.
+   * @param stopDuration dwell time at each intermediate stop, from the car {@code pickupTime}
+   *        preference.
    */
-  public InsertionEvaluator(CarpoolRouter carpoolRouter, Duration stopDuration) {
-    this(carpoolRouter, null, stopDuration);
-  }
-
-  /**
-   * @param carpoolRouter routes a single street segment between two vertices in the candidate
-   *        carpool route — used both to build the baseline route and to re-route only the
-   *        segments that change when a passenger pickup/dropoff is inserted.
-   * @param baselineFallbackRouter re-routes a baseline leg that {@code carpoolRouter} could not,
-   *        or {@code null} for no fallback. Only the baseline route falls back. When
-   *        {@code carpoolRouter} is a tree router whose per-leg trees are sized to a bounded
-   *        per-leg limit, an underestimate of that limit would leave a waypoint outside its tree
-   *        and drop the whole trip; a goal-directed fallback re-routes just that leg instead.
-   *        Inserted passenger
-   *        segments deliberately do not fall back — a segment that cannot be routed within the
-   *        tree is an insertion the delay constraints reject anyway, so failing fast there is
-   *        correct and avoids a goal-directed search per nearby stop.
-   * @param stopDuration duration added at each intermediate stop (from the car {@code pickupTime}
-   *        preference); applied between consecutive segments when computing total trip and
-   *        passenger-ride durations.
-   */
-  public InsertionEvaluator(
-    CarpoolRouter carpoolRouter,
-    @Nullable CarpoolRouter baselineFallbackRouter,
-    Duration stopDuration
-  ) {
-    this.carpoolRouter = carpoolRouter;
-    this.baselineFallbackRouter = baselineFallbackRouter;
+  public InsertionEvaluator(CarpoolRouter router, Duration stopDuration) {
+    this.router = router;
     this.stopDuration = stopDuration;
   }
 
-  /**
-   * Routes all segments of routePoints
-   *
-   * @return Array of routed segments, or null if any segment fails to route
-   */
-  @SuppressWarnings("unchecked")
-  private GraphPath<State, Edge, Vertex>[] routeSegments(List<Vertex> routePoints) {
-    GraphPath<State, Edge, Vertex>[] segments = new GraphPath[routePoints.size() - 1];
-
-    for (int i = 0; i < routePoints.size() - 1; i++) {
-      var from = routePoints.get(i);
-      var to = routePoints.get(i + 1);
-
-      GraphPath<State, Edge, Vertex> segment = carpoolRouter.route(from, to);
-      if (segment == null && baselineFallbackRouter != null) {
-        segment = baselineFallbackRouter.route(from, to);
-        if (segment != null) {
-          LOG.debug("Baseline segment {} → {} routed by the fallback router", i, i + 1);
-        }
-      }
-      if (segment == null) {
-        LOG.debug("Baseline routing failed for segment {} → {}", i, i + 1);
-        return null;
-      }
-
-      segments[i] = segment;
-    }
-
-    return segments;
-  }
-
-  /**
-   * @return A list containing the best insertion that can be found for every NearbyStop in
-   * the list tripWithViableAccessEgress.viableAccessEgress. If there are no valid insertions
-   * for a NearbyStop, then no candidate for that stop will be returned.
-   */
+  /** One candidate per nearby stop that has a valid insertion. */
   public List<InsertionCandidate> findBestInsertions(
     TripWithViableAccessEgress tripWithViableAccessEgress
   ) {
-    var tripWithVertices = tripWithViableAccessEgress.tripWithVertices();
-
-    // No nearby stop produced a viable insertion position for this trip, so there is nothing to
-    // evaluate. Return before routing the baseline: that routing builds the trip's street trees,
-    // which are expensive for long trips — wasted work for a trip that cannot yield an
-    // access/egress leg.
-    if (tripWithViableAccessEgress.viableAccessEgress().isEmpty()) {
-      return List.of();
-    }
-
-    GraphPath<State, Edge, Vertex>[] baselineSegments = routeSegments(tripWithVertices.vertices());
+    var routedTrip = tripWithViableAccessEgress.routedTrip();
+    var baselineSegments = routeBaseline(routedTrip);
     if (baselineSegments == null) {
-      LOG.error("Could not route baseline segments for trip {}", tripWithVertices.trip().getId());
       return List.of();
     }
-
-    Duration[] cumulativeDurations = calculateCumulativeDurations(baselineSegments, stopDuration);
-
     return tripWithViableAccessEgress
       .viableAccessEgress()
       .stream()
-      .map(viableAccessEgress -> {
-        var snap = toPassengerSnap(viableAccessEgress);
-        return findBestInsertion(
-          tripWithVertices,
+      .map(viableAccessEgress ->
+        selectBestPosition(
+          routedTrip,
           viableAccessEgress.insertionPositions(),
-          snap,
+          toPassengerSnap(viableAccessEgress),
           baselineSegments,
-          cumulativeDurations,
           viableAccessEgress.transitStop()
-        );
-      })
+        )
+      )
       .filter(Objects::nonNull)
       .toList();
+  }
+
+  /**
+   * @param snap pickup/dropoff vertices, already snapped, plus the walk paths bracketing the ride.
+   */
+  @Nullable
+  public InsertionCandidate findBestInsertion(
+    RoutedCarpoolTrip routedTrip,
+    List<InsertionPosition> viablePositions,
+    PassengerSnap snap
+  ) {
+    var baselineSegments = routeBaseline(routedTrip);
+    if (baselineSegments == null) {
+      return null;
+    }
+    return selectBestPosition(routedTrip, viablePositions, snap, baselineSegments, null);
+  }
+
+  @Nullable
+  private GraphPath<State, Edge, Vertex>[] routeBaseline(RoutedCarpoolTrip routedTrip) {
+    var baselineSegments = router.routeLegs(routedTrip.vertices());
+    if (baselineSegments == null) {
+      LOG.warn("Could not route baseline for trip {}", routedTrip.trip().getId());
+    }
+    return baselineSegments;
   }
 
   private static PassengerSnap toPassengerSnap(ViableAccessEgress viableAccessEgress) {
@@ -169,75 +104,31 @@ public class InsertionEvaluator {
     );
   }
 
-  /**
-   * Evaluates pre-filtered insertion positions using A* routing.
-   * <p>
-   * This method assumes the provided positions have already passed heuristic
-   * validation (capacity, direction, beeline delay). It performs expensive
-   * A* routing for each position and selects the one with minimum additional
-   * duration that satisfies delay constraints.
-   *
-   * @param tripWithVertices The carpool trip with resolved vertices
-   * @param viablePositions Positions that passed heuristic checks (from InsertionPositionFinder)
-   * @param snap Pickup/dropoff vertices (already snapped to car-reachable vertices by the
-   *        caller) and the optional walk paths bracketing the carpool ride
-   * @return The best insertion candidate, or null if none are viable after routing
-   */
+  /** The valid position with the smallest total trip duration. */
   @Nullable
-  public InsertionCandidate findBestInsertion(
-    CarpoolTripWithVertices tripWithVertices,
-    List<InsertionPosition> viablePositions,
-    PassengerSnap snap
-  ) {
-    GraphPath<State, Edge, Vertex>[] baselineSegments = routeSegments(tripWithVertices.vertices());
-    if (baselineSegments == null) {
-      LOG.warn("Could not route baseline for trip {}", tripWithVertices.trip().getId());
-      return null;
-    }
-
-    Duration[] cumulativeDurations = calculateCumulativeDurations(baselineSegments, stopDuration);
-
-    return findBestInsertion(
-      tripWithVertices,
-      viablePositions,
-      snap,
-      baselineSegments,
-      cumulativeDurations,
-      null
-    );
-  }
-
-  @Nullable
-  private InsertionCandidate findBestInsertion(
-    CarpoolTripWithVertices tripWithVertices,
+  private InsertionCandidate selectBestPosition(
+    RoutedCarpoolTrip routedTrip,
     List<InsertionPosition> viablePositions,
     PassengerSnap snap,
     GraphPath<State, Edge, Vertex>[] baselineSegments,
-    Duration[] cumulativeDurations,
-    NearbyStop transitStop
+    @Nullable NearbyStop transitStop
   ) {
-    InsertionCandidate bestCandidate = null;
-
+    Duration[] baselineCumulative = routedTrip.cumulativeArrivals(stopDuration);
+    InsertionCandidate best = null;
     for (InsertionPosition position : viablePositions) {
-      InsertionCandidate candidate = evaluateInsertion(
-        tripWithVertices,
-        position.pickupPos(),
-        position.dropoffPos(),
+      var candidate = evaluatePosition(
+        routedTrip,
+        position,
         snap,
         baselineSegments,
-        cumulativeDurations,
+        baselineCumulative,
         transitStop
       );
-
       if (candidate == null) {
         continue;
       }
-
-      if (
-        bestCandidate == null ||
-        candidate.totalTripDuration().compareTo(bestCandidate.totalTripDuration()) < 0
-      ) {
-        bestCandidate = candidate;
+      if (best == null || candidate.totalTripDuration().compareTo(best.totalTripDuration()) < 0) {
+        best = candidate;
         LOG.debug(
           "New best insertion: pickup@{}, dropoff@{}, duration={}s",
           position.pickupPos(),
@@ -246,140 +137,71 @@ public class InsertionEvaluator {
         );
       }
     }
-
-    return bestCandidate;
+    return best;
   }
 
   /**
-   * Evaluates a specific insertion configuration.
-   * Reuses cached baseline segments and only routes new segments involving the passenger.
+   * Routes the detour segments around the inserted pickup/dropoff and reuses the baseline legs
+   * elsewhere. {@code null} if a detour cannot be routed or the delay constraints are exceeded.
    */
-  private InsertionCandidate evaluateInsertion(
-    CarpoolTripWithVertices tripWithVertices,
-    int pickupPos,
-    int dropoffPos,
+  @Nullable
+  private InsertionCandidate evaluatePosition(
+    RoutedCarpoolTrip routedTrip,
+    InsertionPosition position,
     PassengerSnap snap,
     GraphPath<State, Edge, Vertex>[] baselineSegments,
-    Duration[] originalCumulativeDurations,
-    NearbyStop transitStop
+    Duration[] baselineCumulative,
+    @Nullable NearbyStop transitStop
   ) {
-    List<GraphPath<State, Edge, Vertex>> modifiedSegments = buildModifiedSegments(
-      tripWithVertices.vertices(),
-      baselineSegments,
-      pickupPos,
-      dropoffPos,
-      snap.pickupVertex(),
-      snap.dropoffVertex()
-    );
+    List<Vertex> modifiedPoints = new ArrayList<>(routedTrip.vertices());
+    modifiedPoints.add(position.pickupPos(), snap.pickupVertex());
+    modifiedPoints.add(position.dropoffPos(), snap.dropoffVertex());
 
-    if (modifiedSegments == null) {
-      return null;
+    List<GraphPath<State, Edge, Vertex>> modifiedSegments = new ArrayList<>();
+    Duration[] modifiedDurations = new Duration[modifiedPoints.size() - 1];
+    for (int i = 0; i < modifiedDurations.length; i++) {
+      int baselineIndex = position.baselineSegmentIndex(i);
+      GraphPath<State, Edge, Vertex> segment;
+      if (baselineIndex >= 0) {
+        segment = baselineSegments[baselineIndex];
+      } else {
+        segment = router.route(modifiedPoints.get(i), modifiedPoints.get(i + 1));
+        if (segment == null) {
+          LOG.trace("Routing failed for new segment {} → {}", i, i + 1);
+          return null;
+        }
+      }
+      modifiedSegments.add(segment);
+      modifiedDurations[i] = durationOrZero(segment);
     }
 
-    Duration[] modifiedCumulativeDurations = calculateCumulativeDurations(
-      modifiedSegments.toArray(new GraphPath[modifiedSegments.size()]),
-      stopDuration
-    );
+    Duration[] modifiedCumulative = calculateCumulativeDurations(modifiedDurations, stopDuration);
     if (
       !PassengerDelayConstraints.satisfiesConstraints(
-        originalCumulativeDurations,
-        modifiedCumulativeDurations,
-        pickupPos,
-        dropoffPos,
-        tripWithVertices.trip().stops()
+        baselineCumulative,
+        modifiedCumulative,
+        position.pickupPos(),
+        position.dropoffPos(),
+        routedTrip.trip().stops()
       )
     ) {
       LOG.trace(
         "Insertion at pickup={}, dropoff={} rejected by delay constraints",
-        pickupPos,
-        dropoffPos
+        position.pickupPos(),
+        position.dropoffPos()
       );
       return null;
     }
 
     return new InsertionCandidate(
-      tripWithVertices.trip(),
-      pickupPos,
-      dropoffPos,
+      routedTrip.trip(),
+      position.pickupPos(),
+      position.dropoffPos(),
       modifiedSegments,
       stopDuration,
       transitStop,
       snap.walkToPickup(),
       snap.walkFromDropoff()
     );
-  }
-
-  private List<GraphPath<State, Edge, Vertex>> buildModifiedSegments(
-    List<Vertex> originalPoints,
-    GraphPath<State, Edge, Vertex>[] baselineSegments,
-    int pickupPos,
-    int dropoffPos,
-    Vertex passengerPickup,
-    Vertex passengerDropoff
-  ) {
-    List<GraphPath<State, Edge, Vertex>> segments = new ArrayList<>();
-
-    List<Vertex> modifiedPoints = new ArrayList<>(originalPoints);
-    modifiedPoints.add(pickupPos, passengerPickup);
-    modifiedPoints.add(dropoffPos, passengerDropoff);
-
-    for (int i = 0; i < modifiedPoints.size() - 1; i++) {
-      GraphPath<State, Edge, Vertex> segment;
-
-      int baselineIndex = baselineSegmentIndex(i, pickupPos, dropoffPos);
-      if (baselineIndex >= 0 && baselineIndex < baselineSegments.length) {
-        segment = baselineSegments[baselineIndex];
-        LOG.trace("Reusing baseline segment {} for modified position {}", baselineIndex, i);
-      } else {
-        var fromVertex = modifiedPoints.get(i);
-        var toVertex = modifiedPoints.get(i + 1);
-
-        segment = this.carpoolRouter.route(fromVertex, toVertex);
-        if (segment == null) {
-          LOG.trace("Routing failed for new segment {} → {}", i, i + 1);
-          return null;
-        }
-        LOG.trace("Routed new segment for modified position {}", i);
-      }
-
-      segments.add(segment);
-    }
-
-    return segments;
-  }
-
-  /**
-   * Maps a modified-route segment index to the corresponding baseline segment index, or
-   * {@code -1} if the modified segment touches the inserted pickup or dropoff and so cannot be
-   * reused.
-   * <p>
-   * The modified route is the original route with two insertions: pickup at {@code pickupPos}
-   * and dropoff at {@code dropoffPos} (List.add semantics, dropoffPos interpreted after the
-   * pickup insertion). A modified segment {@code [i, i+1)} either reuses an original segment
-   * (when both endpoints fall in original points) or is one of the four newly created segments
-   * around the inserted points.
-   * <p>
-   * Requires {@code pickupPos < dropoffPos} — the shift arithmetic depends on the pickup being
-   * strictly before the dropoff, otherwise the result would silently describe a route with the
-   * dropoff before the pickup. Throws {@link IllegalArgumentException} if the precondition is
-   * violated.
-   */
-  private static int baselineSegmentIndex(int modifiedIndex, int pickupPos, int dropoffPos) {
-    if (pickupPos >= dropoffPos) {
-      throw new IllegalArgumentException(
-        "pickupPos (" + pickupPos + ") must be < dropoffPos (" + dropoffPos + ")"
-      );
-    }
-    int i = modifiedIndex;
-    if (i == pickupPos - 1 || i == pickupPos || i == dropoffPos - 1 || i == dropoffPos) {
-      return -1;
-    }
-    if (i < pickupPos) {
-      return i;
-    }
-    if (i < dropoffPos) {
-      return i - 1;
-    }
-    return i - 2;
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Selects the best insertion among pre-screened positions, routing the detour around each candidate
- * pickup/dropoff and reusing the trip's baseline legs elsewhere.
+ * pickup/dropoff and the baseline legs the winner reuses.
  */
 public class InsertionEvaluator {
 
@@ -43,50 +43,29 @@ public class InsertionEvaluator {
     TripWithViableAccessEgress tripWithViableAccessEgress
   ) {
     var routedTrip = tripWithViableAccessEgress.routedTrip();
-    var baselineSegments = routeBaseline(routedTrip);
-    if (baselineSegments == null) {
-      return List.of();
-    }
-    return tripWithViableAccessEgress
+
+    List<StopInsertion> winners = tripWithViableAccessEgress
       .viableAccessEgress()
       .stream()
-      .map(viableAccessEgress ->
-        selectBestPosition(
-          routedTrip,
-          viableAccessEgress.insertionPositions(),
-          toPassengerSnap(viableAccessEgress),
-          baselineSegments,
-          viableAccessEgress.transitStop()
-        )
-      )
+      .map(viableAccessEgress -> {
+        var snap = toPassengerSnap(viableAccessEgress);
+        var best = selectBestPosition(routedTrip, viableAccessEgress.insertionPositions(), snap);
+        return best == null
+          ? null
+          : new StopInsertion(snap, best, viableAccessEgress.transitStop());
+      })
       .filter(Objects::nonNull)
       .toList();
+
+    return materializeWinners(routedTrip, winners);
   }
 
-  /**
-   * @param snap pickup/dropoff vertices, already snapped, plus the walk paths bracketing the ride.
-   */
-  @Nullable
-  public InsertionCandidate findBestInsertion(
-    RoutedCarpoolTrip routedTrip,
-    List<InsertionPosition> viablePositions,
-    PassengerSnap snap
-  ) {
-    var baselineSegments = routeBaseline(routedTrip);
-    if (baselineSegments == null) {
-      return null;
-    }
-    return selectBestPosition(routedTrip, viablePositions, snap, baselineSegments, null);
-  }
-
-  @Nullable
-  private GraphPath<State, Edge, Vertex>[] routeBaseline(RoutedCarpoolTrip routedTrip) {
-    var baselineSegments = router.routeLegs(routedTrip.vertices());
-    if (baselineSegments == null) {
-      LOG.warn("Could not route baseline for trip {}", routedTrip.trip().getId());
-    }
-    return baselineSegments;
-  }
+  /** A chosen insertion awaiting the baseline legs it reuses. */
+  private record StopInsertion(
+    PassengerSnap snap,
+    SelectedPosition selected,
+    @Nullable NearbyStop transitStop
+  ) {}
 
   private static PassengerSnap toPassengerSnap(ViableAccessEgress viableAccessEgress) {
     boolean isAccess = viableAccessEgress.accessEgress() == AccessEgressType.ACCESS;
@@ -104,75 +83,140 @@ public class InsertionEvaluator {
     );
   }
 
-  /** The valid position with the smallest total trip duration. */
+  /**
+   * @param snap pickup/dropoff vertices, already snapped, plus the walk paths bracketing the ride.
+   */
   @Nullable
-  private InsertionCandidate selectBestPosition(
+  public InsertionCandidate findBestInsertion(
     RoutedCarpoolTrip routedTrip,
     List<InsertionPosition> viablePositions,
-    PassengerSnap snap,
-    GraphPath<State, Edge, Vertex>[] baselineSegments,
-    @Nullable NearbyStop transitStop
+    PassengerSnap snap
   ) {
-    Duration[] baselineCumulative = routedTrip.cumulativeArrivals(stopDuration);
-    InsertionCandidate best = null;
-    for (InsertionPosition position : viablePositions) {
-      var candidate = evaluatePosition(
-        routedTrip,
-        position,
-        snap,
-        baselineSegments,
-        baselineCumulative,
-        transitStop
-      );
-      if (candidate == null) {
+    var best = selectBestPosition(routedTrip, viablePositions, snap);
+    if (best == null) {
+      return null;
+    }
+    var candidates = materializeWinners(routedTrip, List.of(new StopInsertion(snap, best, null)));
+    return candidates.isEmpty() ? null : candidates.getFirst();
+  }
+
+  /** Routes the baseline legs the winners reuse and stitches each winner's geometry together. */
+  private List<InsertionCandidate> materializeWinners(
+    RoutedCarpoolTrip routedTrip,
+    List<StopInsertion> winners
+  ) {
+    if (winners.isEmpty()) {
+      return List.of();
+    }
+    var baselineLegs = routeReusedBaselineLegs(routedTrip, winners);
+    if (baselineLegs == null) {
+      return List.of();
+    }
+    return winners
+      .stream()
+      .map(winner ->
+        materialize(
+          routedTrip,
+          winner.selected(),
+          winner.snap(),
+          baselineLegs,
+          winner.transitStop()
+        )
+      )
+      .toList();
+  }
+
+  /**
+   * Routes only the baseline legs some winner reuses, leaving the rest {@code null}. An insertion
+   * replaces the legs around its pickup and dropoff, so a short trip reuses none at all.
+   */
+  @Nullable
+  @SuppressWarnings("unchecked")
+  private GraphPath<State, Edge, Vertex>[] routeReusedBaselineLegs(
+    RoutedCarpoolTrip routedTrip,
+    List<StopInsertion> winners
+  ) {
+    var vertices = routedTrip.vertices();
+    GraphPath<State, Edge, Vertex>[] legs = new GraphPath[vertices.size() - 1];
+    var reused = new boolean[legs.length];
+    for (var winner : winners) {
+      var detours = winner.selected().detourSegments();
+      for (int i = 0; i < detours.length; i++) {
+        if (detours[i] == null) {
+          reused[winner.selected().position().baselineSegmentIndex(i)] = true;
+        }
+      }
+    }
+    for (int leg = 0; leg < legs.length; leg++) {
+      if (!reused[leg]) {
         continue;
       }
-      if (best == null || candidate.totalTripDuration().compareTo(best.totalTripDuration()) < 0) {
-        best = candidate;
+      var path = router.route(vertices.get(leg), vertices.get(leg + 1));
+      if (path == null) {
+        LOG.warn("Could not route baseline leg {} of trip {}", leg, routedTrip.trip().getId());
+        return null;
+      }
+      legs[leg] = path;
+    }
+    return legs;
+  }
+
+  /** The valid position with the smallest total trip duration. Only detours are routed. */
+  @Nullable
+  private SelectedPosition selectBestPosition(
+    RoutedCarpoolTrip routedTrip,
+    List<InsertionPosition> viablePositions,
+    PassengerSnap snap
+  ) {
+    Duration[] baselineCumulative = routedTrip.cumulativeArrivals(stopDuration);
+    SelectedPosition best = null;
+    for (InsertionPosition position : viablePositions) {
+      var evaluated = evaluatePosition(routedTrip, position, snap, baselineCumulative);
+      if (evaluated == null) {
+        continue;
+      }
+      if (best == null || evaluated.totalTripDuration().compareTo(best.totalTripDuration()) < 0) {
+        best = evaluated;
         LOG.debug(
           "New best insertion: pickup@{}, dropoff@{}, duration={}s",
           position.pickupPos(),
           position.dropoffPos(),
-          candidate.totalTripDuration().getSeconds()
+          evaluated.totalTripDuration().getSeconds()
         );
       }
     }
     return best;
   }
 
-  /**
-   * Routes the detour segments around the inserted pickup/dropoff and reuses the baseline legs
-   * elsewhere. {@code null} if a detour cannot be routed or the delay constraints are exceeded.
-   */
+  /** {@code null} if a detour cannot be routed or the delay constraints are exceeded. */
   @Nullable
-  private InsertionCandidate evaluatePosition(
+  @SuppressWarnings("unchecked")
+  private SelectedPosition evaluatePosition(
     RoutedCarpoolTrip routedTrip,
     InsertionPosition position,
     PassengerSnap snap,
-    GraphPath<State, Edge, Vertex>[] baselineSegments,
-    Duration[] baselineCumulative,
-    @Nullable NearbyStop transitStop
+    Duration[] baselineCumulative
   ) {
     List<Vertex> modifiedPoints = new ArrayList<>(routedTrip.vertices());
     modifiedPoints.add(position.pickupPos(), snap.pickupVertex());
     modifiedPoints.add(position.dropoffPos(), snap.dropoffVertex());
 
-    List<GraphPath<State, Edge, Vertex>> modifiedSegments = new ArrayList<>();
-    Duration[] modifiedDurations = new Duration[modifiedPoints.size() - 1];
-    for (int i = 0; i < modifiedDurations.length; i++) {
+    // Detour segments are routed and kept; reused legs stay null and are filled in by materialize().
+    GraphPath<State, Edge, Vertex>[] detourSegments = new GraphPath[modifiedPoints.size() - 1];
+    Duration[] modifiedDurations = new Duration[detourSegments.length];
+    for (int i = 0; i < detourSegments.length; i++) {
       int baselineIndex = position.baselineSegmentIndex(i);
-      GraphPath<State, Edge, Vertex> segment;
       if (baselineIndex >= 0) {
-        segment = baselineSegments[baselineIndex];
+        modifiedDurations[i] = routedTrip.legDurations()[baselineIndex];
       } else {
-        segment = router.route(modifiedPoints.get(i), modifiedPoints.get(i + 1));
+        var segment = router.route(modifiedPoints.get(i), modifiedPoints.get(i + 1));
         if (segment == null) {
           LOG.trace("Routing failed for new segment {} → {}", i, i + 1);
           return null;
         }
+        detourSegments[i] = segment;
+        modifiedDurations[i] = durationOrZero(segment);
       }
-      modifiedSegments.add(segment);
-      modifiedDurations[i] = durationOrZero(segment);
     }
 
     Duration[] modifiedCumulative = calculateCumulativeDurations(modifiedDurations, stopDuration);
@@ -193,10 +237,35 @@ public class InsertionEvaluator {
       return null;
     }
 
+    return new SelectedPosition(
+      position,
+      detourSegments,
+      modifiedCumulative[modifiedCumulative.length - 1]
+    );
+  }
+
+  /** Stitches the routed baseline legs into the detour segments to build the final candidate. */
+  private InsertionCandidate materialize(
+    RoutedCarpoolTrip routedTrip,
+    SelectedPosition selected,
+    PassengerSnap snap,
+    GraphPath<State, Edge, Vertex>[] baselineLegs,
+    @Nullable NearbyStop transitStop
+  ) {
+    var detourSegments = selected.detourSegments();
+    List<GraphPath<State, Edge, Vertex>> modifiedSegments = new ArrayList<>(detourSegments.length);
+    for (int i = 0; i < detourSegments.length; i++) {
+      modifiedSegments.add(
+        detourSegments[i] != null
+          ? detourSegments[i]
+          : baselineLegs[selected.position().baselineSegmentIndex(i)]
+      );
+    }
+
     return new InsertionCandidate(
       routedTrip.trip(),
-      position.pickupPos(),
-      position.dropoffPos(),
+      selected.position().pickupPos(),
+      selected.position().dropoffPos(),
       modifiedSegments,
       stopDuration,
       transitStop,
@@ -204,4 +273,11 @@ public class InsertionEvaluator {
       snap.walkFromDropoff()
     );
   }
+
+  /** Detour segments carry a {@code null} in every slot that reuses a baseline leg. */
+  private record SelectedPosition(
+    InsertionPosition position,
+    GraphPath<State, Edge, Vertex>[] detourSegments,
+    Duration totalTripDuration
+  ) {}
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionPosition.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionPosition.java
@@ -63,4 +63,22 @@ public class InsertionPosition {
 
     return modifiedIndex;
   }
+
+  /**
+   * The baseline leg the modified-route segment {@code [i, i+1)} corresponds to, or {@code -1} when
+   * it touches the inserted pickup or dropoff and so is one of the four new detour segments.
+   */
+  public int baselineSegmentIndex(int modifiedIndex) {
+    int i = modifiedIndex;
+    if (i == pickupPos - 1 || i == pickupPos || i == dropOffPos - 1 || i == dropOffPos) {
+      return -1;
+    }
+    if (i < pickupPos) {
+      return i;
+    }
+    if (i < dropOffPos) {
+      return i - 1;
+    }
+    return i - 2;
+  }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionPositionFinder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionPositionFinder.java
@@ -6,22 +6,14 @@ import java.util.List;
 import org.opentripplanner.ext.carpooling.constraints.PassengerDelayConstraints;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
+import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Finds viable insertion positions for a passenger in a carpool trip using fast heuristics.
- * <p>
- * This class performs early-stage filtering to identify pickup/dropoff position pairs that
- * are worth evaluating with expensive A* routing. It validates positions using:
- * <ul>
- *   <li>Capacity constraints - ensures available seats throughout the journey</li>
- *   <li>Beeline delay heuristic - optimistic straight-line time estimates</li>
- * </ul>
- * <p>
- * This follows the established OTP pattern of separating candidate generation from evaluation,
- * similar to {@code TransferGenerator} and {@code StreetNearbyStopFinder}.
+ * Screens pickup/dropoff position pairs on capacity and a beeline delay heuristic, so only positions
+ * worth routing reach {@link InsertionEvaluator}.
  */
 public class InsertionPositionFinder {
 
@@ -29,50 +21,39 @@ public class InsertionPositionFinder {
 
   private final BeelineEstimator beelineEstimator;
 
-  /**
-   * Creates a finder with default estimator.
-   */
   public InsertionPositionFinder() {
     this(new BeelineEstimator());
   }
 
-  /**
-   * Creates a finder with specified estimator.
-   *
-   * @param beelineEstimator Estimator for beeline travel times
-   */
   public InsertionPositionFinder(BeelineEstimator beelineEstimator) {
     this.beelineEstimator = beelineEstimator;
   }
 
   /**
-   * Finds insertion positions that pass validation and beeline checks.
-   * This is done BEFORE any expensive routing to eliminate positions early.
+   * The positions that pass capacity and the beeline delay check, which is a lower bound on the
+   * routed delay — so no feasible insertion is lost. The bound holds because the detour is beelined
+   * between the resolved vertices the driver is actually routed between, not the trip's declared
+   * route points.
    *
-   * @param trip The carpool trip being evaluated
-   * @param passengerPickup Passenger's pickup location
-   * @param passengerDropoff Passenger's dropoff location
-   * @param stopDuration Dwell time added at each intermediate stop; used by the beeline delay
-   *                     heuristic so its cumulative-time estimates match the per-stop budget
-   *                     check used downstream
-   * @return List of viable insertion positions (may be empty)
+   * @param passengerPickup already snapped to a car-accessible vertex.
+   * @param passengerDropoff already snapped to a car-accessible vertex.
+   * @param stopDuration dwell time at each intermediate stop.
    */
   public List<InsertionPosition> findViablePositions(
-    CarpoolTrip trip,
+    RoutedCarpoolTrip routedTrip,
     WgsCoordinate passengerPickup,
     WgsCoordinate passengerDropoff,
     Duration stopDuration
   ) {
-    List<WgsCoordinate> routePoints = trip.routePoints();
-
-    Duration[] beelineTimes = beelineEstimator.calculateCumulativeTimes(routePoints, stopDuration);
+    CarpoolTrip trip = routedTrip.trip();
+    List<WgsCoordinate> routePoints = routedTrip.vertexCoordinates();
+    Duration[] baselineCumulative = routedTrip.cumulativeArrivals(stopDuration);
 
     List<InsertionPosition> viable = new ArrayList<>();
 
-    // pickupPos/dropoffPos are 0-based indices of the passenger's stops in the modified route.
-    // Pickup cannot be at index 0 (that's the driver's origin).
+    // 0-based indices in the modified route: pickup cannot be the driver's origin, and dropoff must
+    // follow it.
     for (int pickupPos = 1; pickupPos < routePoints.size(); pickupPos++) {
-      // Dropoff must be after pickup. Max is routePoints.size() (appended after all original stops except the last).
       for (int dropoffPos = pickupPos + 1; dropoffPos <= routePoints.size(); dropoffPos++) {
         if (!trip.hasCapacityForInsertion(pickupPos, dropoffPos, 1)) {
           LOG.trace(
@@ -83,15 +64,14 @@ public class InsertionPositionFinder {
           continue;
         }
 
+        var position = new InsertionPosition(pickupPos, dropoffPos);
         if (
           !passesBeelineDelayCheck(
-            routePoints,
-            beelineTimes,
+            routedTrip,
+            position,
+            baselineCumulative,
             passengerPickup,
             passengerDropoff,
-            pickupPos,
-            dropoffPos,
-            trip,
             stopDuration
           )
         ) {
@@ -103,7 +83,7 @@ public class InsertionPositionFinder {
           continue;
         }
 
-        viable.add(new InsertionPosition(pickupPos, dropoffPos));
+        viable.add(position);
       }
     }
 
@@ -111,48 +91,40 @@ public class InsertionPositionFinder {
   }
 
   /**
-   * Checks if an insertion position passes the beeline delay heuristic.
-   * This is a fast, optimistic check using straight-line distance estimates.
-   * If this check fails, we know the actual A* routing will also fail, so we
-   * can skip the expensive routing calculation.
-   *
-   * @param originalCoords Original route coordinates
-   * @param originalBeelineTimes Beeline cumulative times for original route
-   * @param passengerPickup Passenger pickup location
-   * @param passengerDropoff Passenger dropoff location
-   * @param pickupPos 0-based index of the passenger's pickup in the modified route
-   * @param dropoffPos 0-based index of the passenger's dropoff in the modified route
-   * @param trip The carpool trip being evaluated
-   * @return true if insertion might satisfy delay constraints (proceed with A* routing)
+   * True if the insertion might satisfy the delay constraints. Untouched legs keep their baseline
+   * duration; only the detour segments around the inserted points are beelined.
    */
   private boolean passesBeelineDelayCheck(
-    List<WgsCoordinate> originalCoords,
-    Duration[] originalBeelineTimes,
+    RoutedCarpoolTrip routedTrip,
+    InsertionPosition position,
+    Duration[] baselineCumulative,
     WgsCoordinate passengerPickup,
     WgsCoordinate passengerDropoff,
-    int pickupPos,
-    int dropoffPos,
-    CarpoolTrip trip,
     Duration stopDuration
   ) {
-    // Build modified coordinate list with passenger stops inserted
-    List<WgsCoordinate> modifiedCoords = new ArrayList<>(originalCoords);
-    modifiedCoords.add(pickupPos, passengerPickup);
-    modifiedCoords.add(dropoffPos, passengerDropoff);
+    List<WgsCoordinate> modifiedCoords = new ArrayList<>(routedTrip.vertexCoordinates());
+    modifiedCoords.add(position.pickupPos(), passengerPickup);
+    modifiedCoords.add(position.dropoffPos(), passengerDropoff);
 
-    // Calculate beeline times for modified route
-    Duration[] modifiedBeelineTimes = beelineEstimator.calculateCumulativeTimes(
-      modifiedCoords,
+    Duration[] modifiedSegmentDurations = new Duration[modifiedCoords.size() - 1];
+    for (int i = 0; i < modifiedSegmentDurations.length; i++) {
+      int baselineIndex = position.baselineSegmentIndex(i);
+      modifiedSegmentDurations[i] = baselineIndex >= 0
+        ? routedTrip.legDurations()[baselineIndex]
+        : beelineEstimator.estimateDuration(modifiedCoords.get(i), modifiedCoords.get(i + 1));
+    }
+
+    Duration[] modifiedCumulative = GraphPathUtils.calculateCumulativeDurations(
+      modifiedSegmentDurations,
       stopDuration
     );
 
-    // If even the optimistic beeline estimate exceeds a stop's budget, actual routing will too
     return PassengerDelayConstraints.satisfiesConstraints(
-      originalBeelineTimes,
-      modifiedBeelineTimes,
-      pickupPos,
-      dropoffPos,
-      trip.stops()
+      baselineCumulative,
+      modifiedCumulative,
+      position.pickupPos(),
+      position.dropoffPos(),
+      routedTrip.trip().stops()
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/RoutedCarpoolTrip.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/RoutedCarpoolTrip.java
@@ -1,0 +1,43 @@
+package org.opentripplanner.ext.carpooling.routing;
+
+import java.time.Duration;
+import java.util.List;
+import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.ext.carpooling.util.GraphPathUtils;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.vertex.Vertex;
+
+/**
+ * A carpool trip together with OTP's routed travel duration for each of its baseline legs, one per
+ * leg.
+ */
+public record RoutedCarpoolTrip(CarpoolTripWithVertices tripWithVertices, Duration[] legDurations) {
+  public RoutedCarpoolTrip {
+    int legs = tripWithVertices.vertices().size() - 1;
+    if (legDurations.length != legs) {
+      throw new IllegalArgumentException(
+        "legDurations length (%d) must equal the number of legs (%d)".formatted(
+          legDurations.length,
+          legs
+        )
+      );
+    }
+  }
+
+  public CarpoolTrip trip() {
+    return tripWithVertices.trip();
+  }
+
+  public List<Vertex> vertices() {
+    return tripWithVertices.vertices();
+  }
+
+  public List<WgsCoordinate> vertexCoordinates() {
+    return tripWithVertices.vertexCoordinates();
+  }
+
+  /** Cumulative arrival time at each route point, with {@code stopDuration} at every stop. */
+  public Duration[] cumulativeArrivals(Duration stopDuration) {
+    return GraphPathUtils.calculateCumulativeDurations(legDurations, stopDuration);
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/TripWithViableAccessEgress.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/TripWithViableAccessEgress.java
@@ -3,14 +3,10 @@ package org.opentripplanner.ext.carpooling.routing;
 import java.util.List;
 
 /**
- * Associates a {@link CarpoolTripWithVertices} with the list of {@link ViableAccessEgress}
- * entries that passed heuristic filtering for that trip. Each viable access/egress
- * represents a transit stop that can potentially be served by this carpool trip.
- *
- * @param tripWithVertices the carpool trip with its resolved street graph vertices
- * @param viableAccessEgress the access/egress candidates that passed filtering for this trip
+ * A routed carpool trip paired with the access/egress candidates that passed filtering for it. Each
+ * {@link ViableAccessEgress} represents a transit stop this trip can potentially serve.
  */
 public record TripWithViableAccessEgress(
-  CarpoolTripWithVertices tripWithVertices,
+  RoutedCarpoolTrip routedTrip,
   List<ViableAccessEgress> viableAccessEgress
 ) {}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -29,6 +29,7 @@ import org.opentripplanner.ext.carpooling.routing.InsertionEvaluator;
 import org.opentripplanner.ext.carpooling.routing.InsertionPosition;
 import org.opentripplanner.ext.carpooling.routing.InsertionPositionFinder;
 import org.opentripplanner.ext.carpooling.routing.PassengerSnap;
+import org.opentripplanner.ext.carpooling.routing.RoutedCarpoolTrip;
 import org.opentripplanner.ext.carpooling.routing.TripWithViableAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.ViableAccessEgress;
 import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
@@ -282,15 +283,27 @@ public class DefaultCarpoolingService implements CarpoolingService {
         .stream()
         .map(tripWithVertices -> {
           var trip = tripWithVertices.trip();
+
+          // The delay heuristic measures each detour against the routed baseline, resolved here.
+          var baselineLegDurations = resolveLegDurations(tripWithVertices, router);
+          if (baselineLegDurations == null) {
+            LOG.debug("Baseline for trip {} is unroutable; skipping", trip.getId());
+            return null;
+          }
+          var routedTrip = new RoutedCarpoolTrip(tripWithVertices, baselineLegDurations);
+
           List<InsertionPosition> viablePositions = positionFinder.findViablePositions(
-            trip,
+            routedTrip,
             snappedPickup,
             snappedDropoff,
             stopDuration
           );
 
           if (viablePositions.isEmpty()) {
-            LOG.debug("No viable positions found for trip {} (avoided all routing!)", trip.getId());
+            LOG.debug(
+              "No viable positions found for trip {} (avoided per-position routing)",
+              trip.getId()
+            );
             return null;
           }
 
@@ -301,7 +314,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
           );
 
           return insertionEvaluator.findBestInsertion(
-            tripWithVertices,
+            routedTrip,
             viablePositions,
             new PassengerSnap(
               pickupSnap.vertex(),
@@ -498,19 +511,17 @@ public class DefaultCarpoolingService implements CarpoolingService {
         }
       }
 
-      // Sizes each leg's tree from OTP's own routed leg durations (cached per trip) and re-routes
-      // any baseline leg the tree misses — see resolveLegDurations and the InsertionEvaluator
-      // fallback below.
+      // Computes only the per-leg durations that size each trip's trees; the geometry comes from
+      // those trees.
       var baselineRouter = new CarpoolStreetRouter(streetLimitationParametersService);
 
       // Each waypoint's tree only has to span its own leg plus the feasible insertion detour —
       // see driverLegTreeLimits.
-      var routableTrips = new ArrayList<CarpoolTripWithVertices>(candidateTrips.size());
+      var routableTrips = new ArrayList<RoutedCarpoolTrip>(candidateTrips.size());
       var passengerTreeLimit = Duration.ZERO;
       for (var tripWithVertices : candidateTrips) {
         var legDurations = resolveLegDurations(tripWithVertices, baselineRouter);
-        // A trip whose baseline cannot be routed within the carpool bound cannot carry a passenger:
-        // skip it before sizing and building trees its baseline would fail to route in anyway.
+        // A trip whose baseline cannot be routed cannot carry a passenger.
         if (legDurations == null) {
           continue;
         }
@@ -529,7 +540,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
           );
           passengerTreeLimit = max(passengerTreeLimit, legLimits[leg]);
         }
-        routableTrips.add(tripWithVertices);
+        routableTrips.add(new RoutedCarpoolTrip(tripWithVertices, legDurations));
       }
       // Every passenger segment lies on a single leg of some candidate trip, so the largest leg
       // limit bounds them all. A smaller cap would silently drop feasible insertions: route()
@@ -542,15 +553,17 @@ public class DefaultCarpoolingService implements CarpoolingService {
 
       var stopDuration = request.preferences().car().pickupTime();
 
-      var insertionEvaluator = new InsertionEvaluator(
-        carpoolTreeVertexRouter,
-        baselineRouter,
-        stopDuration
-      );
+      var insertionEvaluator = new InsertionEvaluator(carpoolTreeVertexRouter, stopDuration);
+
+      // The snapped coordinates are the same for every candidate trip, so wrap them once rather
+      // than once per (trip, stop) pair.
+      var passengerCoordinate = passengerSnap.vertex().toWgsCoordinate();
+      var stopCoordinates = new HashMap<NearbyStop, WgsCoordinate>();
+      stopSnaps.forEach((stop, snap) -> stopCoordinates.put(stop, snap.vertex().toWgsCoordinate()));
 
       var candidateTripsWithViableStopsAndPositions = routableTrips
         .stream()
-        .map(tripWithVertices -> {
+        .map(routedTrip -> {
           var viableSegmentInsertions = stopSnaps
             .entrySet()
             .stream()
@@ -559,11 +572,12 @@ public class DefaultCarpoolingService implements CarpoolingService {
               var stopSnap = entry.getValue();
               var pickupSide = accessOrEgress.isAccess() ? passengerSnap : stopSnap;
               var dropoffSide = accessOrEgress.isAccess() ? stopSnap : passengerSnap;
+              var stopCoordinate = stopCoordinates.get(nearbyStop);
 
               var viablePositions = positionFinder.findViablePositions(
-                tripWithVertices.trip(),
-                new WgsCoordinate(pickupSide.vertex().getCoordinate()),
-                new WgsCoordinate(dropoffSide.vertex().getCoordinate()),
+                routedTrip,
+                accessOrEgress.isAccess() ? passengerCoordinate : stopCoordinate,
+                accessOrEgress.isAccess() ? stopCoordinate : passengerCoordinate,
                 stopDuration
               );
               return new ViableAccessEgress(
@@ -578,7 +592,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
             })
             .filter(it -> !it.insertionPositions().isEmpty())
             .toList();
-          return new TripWithViableAccessEgress(tripWithVertices, viableSegmentInsertions);
+          return new TripWithViableAccessEgress(routedTrip, viableSegmentInsertions);
         })
         .toList();
 
@@ -697,19 +711,12 @@ public class DefaultCarpoolingService implements CarpoolingService {
     CarpoolTripWithVertices tripWithVertices,
     CarpoolRouter baselineRouter
   ) {
-    var vertices = tripWithVertices.vertices();
-    var durations = new Duration[vertices.size() - 1];
-    for (int leg = 0; leg < durations.length; leg++) {
-      var path = baselineRouter.route(vertices.get(leg), vertices.get(leg + 1));
-      if (path == null) {
-        LOG.debug(
-          "OTP could not route baseline leg {} of trip {} within the carpool bound; skipping it",
-          leg,
-          tripWithVertices.trip().getId()
-        );
-        return null;
-      }
-      durations[leg] = GraphPathUtils.durationOrZero(path);
+    var durations = baselineRouter.routeLegDurations(tripWithVertices.vertices());
+    if (durations == null) {
+      LOG.debug(
+        "OTP could not route the baseline of trip {} within the carpool bound; skipping it",
+        tripWithVertices.trip().getId()
+      );
     }
     return durations;
   }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/BeelineEstimator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/BeelineEstimator.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.ext.carpooling.util;
 
 import java.time.Duration;
-import java.util.List;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.StreetConstants;
@@ -68,25 +67,5 @@ public class BeelineEstimator {
     );
     double seconds = beelineDistance / speed;
     return Duration.ofSeconds((long) seconds);
-  }
-
-  /**
-   * Calculates cumulative travel times to each point in a route, including stop duration
-   * at each intermediate point.
-   *
-   * @param points Route points in order
-   * @param stopDuration Duration added at each intermediate stop (not at the first point)
-   * @return Array of cumulative durations (first element is always Duration.ZERO)
-   */
-  public Duration[] calculateCumulativeTimes(List<WgsCoordinate> points, Duration stopDuration) {
-    if (points.isEmpty()) {
-      return new Duration[0];
-    }
-
-    Duration[] segmentDurations = new Duration[points.size() - 1];
-    for (int i = 0; i < segmentDurations.length; i++) {
-      segmentDurations[i] = estimateDuration(points.get(i), points.get(i + 1));
-    }
-    return GraphPathUtils.calculateCumulativeDurations(segmentDurations, stopDuration);
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarReachableVertexSnapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarReachableVertexSnapper.java
@@ -48,12 +48,8 @@ public final class CarReachableVertexSnapper {
    */
   private static final double DEFAULT_MIN_CAR_ESCAPE_METERS = 500;
 
-  private static final StreetSearchRequest CAR_DEPART = StreetSearchRequest.of()
-    .withMode(StreetMode.CAR)
-    .build();
-  private static final StreetSearchRequest CAR_ARRIVE = StreetSearchRequest.copyOf(CAR_DEPART)
-    .withArriveBy(true)
-    .build();
+  private static final StreetSearchRequest CAR_DEPART = CarpoolStreetSearch.carRequest(false);
+  private static final StreetSearchRequest CAR_ARRIVE = CarpoolStreetSearch.carRequest(true);
 
   private final double minCarEscapeMeters;
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarpoolStreetSearch.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarpoolStreetSearch.java
@@ -1,0 +1,14 @@
+package org.opentripplanner.ext.carpooling.util;
+
+import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.search.request.StreetSearchRequest;
+
+/** The street search request every carpool car search uses, so they all rank paths alike. */
+public final class CarpoolStreetSearch {
+
+  private CarpoolStreetSearch() {}
+
+  public static StreetSearchRequest carRequest(boolean arriveBy) {
+    return StreetSearchRequest.of().withMode(StreetMode.CAR).withArriveBy(arriveBy).build();
+  }
+}


### PR DESCRIPTION
### Summary

Makes the carpool insertion pre-screen's delay estimate a guaranteed lower bound on the routed delay: it now beelines only the new detour segments and measures them against OTP's routed baseline leg durations (routed once per trip and cached) instead of beelining the whole route. Fixes viable pickup/dropoff positions being wrongly filtered out before any routing.

### Unit tests

- Were unit tests added/updated?

Yes

- Was any manual verification done?

Yes

- Any observations on changes to performance?

No

- Was the code designed so it is unit testable?

Yes

- Were any tests applied to the smallest appropriate unit?

yes

- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

Yes

### Documentation

- Have you added documentation in code covering design and rationale behind the code?

Yes

- Were all non-trivial public classes and methods documented with Javadoc?

Yes

- Were any new configuration options added? If so were the tables in
  the [configuration documentation](Configuration.md) updated?

No
