### PR TITLE
Add handling of no_exit/no_entry turn restrictions

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
@@ -10,6 +10,7 @@ import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
+import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -914,11 +915,25 @@ public class OsmDatabase {
         Direction.LEFT,
         relation.getId()
       );
+    } else if (relation.isTag("restriction", "no_entry")) {
+      tag = new TurnRestrictionTag(
+        via,
+        TurnRestrictionType.NO_TURN,
+        Direction.ENTRY,
+        relation.getId()
+      );
     } else if (relation.isTag("restriction", "only_u_turn")) {
       tag = new TurnRestrictionTag(
         via,
         TurnRestrictionType.ONLY_TURN,
         Direction.U,
+        relation.getId()
+      );
+    } else if (relation.isTag("restriction", "no_exit")) {
+      tag = new TurnRestrictionTag(
+        via,
+        TurnRestrictionType.NO_TURN,
+        Direction.EXIT,
         relation.getId()
       );
     } else {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmDatabase.java
@@ -10,7 +10,6 @@ import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
-import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/TurnRestrictionTag.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/TurnRestrictionTag.java
@@ -38,5 +38,7 @@ class TurnRestrictionTag {
     RIGHT,
     U,
     STRAIGHT,
+    ENTRY,
+    EXIT,
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
@@ -10,11 +10,14 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.TurnRestrictionBad;
+import org.opentripplanner.graph_builder.issues.TurnRestrictionUnknown;
 import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.osm.TestOsmProvider;
 import org.opentripplanner.osm.model.OsmNode;
 import org.opentripplanner.osm.model.RelationBuilder;
+import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
 
 /**
  * Checks that turn restrictions are processed even if they don't strictly adhere to their
@@ -41,7 +44,12 @@ class TurnRestrictionsTest {
       Arguments.of("no_straight_on", true, node05, node15, node24),
       Arguments.of("no_left_turn", true, node05, node15, node26),
       Arguments.of("no_right_turn", true, node05, node15, node24),
-      Arguments.of("no_u_turn", true, node05, node15, node16)
+      Arguments.of("no_u_turn", true, node05, node15, node16),
+      // Support no_entry & no_exit https://github.com/opentripplanner/OpenTripPlanner/issues/2731
+      Arguments.of("no_entry", false, node05, node15, node16),
+      Arguments.of("no_exit", false, node05, node15, node16),
+      // noexit is a misspelling which we don't check for
+      Arguments.of("noexit", true, node05, node15, node16)
     );
   }
 
@@ -79,7 +87,7 @@ class TurnRestrictionsTest {
       issueStore
         .listIssues()
         .stream()
-        .filter(i -> i instanceof TurnRestrictionBad)
+        .filter(i -> i instanceof TurnRestrictionBad || i instanceof TurnRestrictionUnknown)
         .toList()
     ).hasSize(shouldWarn ? 1 : 0);
   }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/TurnRestrictionsTest.java
@@ -15,9 +15,7 @@ import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.osm.TestOsmProvider;
 import org.opentripplanner.osm.model.OsmNode;
 import org.opentripplanner.osm.model.RelationBuilder;
-import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.street.graph.Graph;
 
 /**
  * Checks that turn restrictions are processed even if they don't strictly adhere to their


### PR DESCRIPTION
This PR adds handling of `no_exit` and `no_entry` turn restrictions. It fixes https://github.com/opentripplanner/OpenTripPlanner/issues/2731.

First commit adds a test case illustrating the issue, second commit adds `no_exit` and `no_entry` support.