### PR TITLE
test: add regression tests for VertexLinker

### DIFF
--- a/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironment.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironment.java
@@ -5,23 +5,16 @@ import static org.opentripplanner.street.linking.VisibilityMode.COMPUTE_AREA_VIS
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.service.vehiclerental.GeofencingZoneService;
-import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.graph.summary.DisposableEdgeDataFetcher;
 import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.street.model.StreetConstants;
-import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.street.model.edge.Area;
-import org.opentripplanner.street.model.edge.AreaEdgeBuilder;
-import org.opentripplanner.street.model.edge.AreaGroup;
 import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
-import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -39,6 +32,10 @@ public class LinkingEnvironment {
 
   @Nullable
   private DisposableEdgeCollection disposable;
+
+  public static LinkingEnvironmentBuilder of() {
+    return new LinkingEnvironmentBuilder();
+  }
 
   public LinkingEnvironment(Vertex... vertices) {
     var graph = new Graph();
@@ -112,77 +109,5 @@ public class LinkingEnvironment {
 
   public VertexLinker linker() {
     return linker;
-  }
-
-  public AreaGroupBuilder areaGroup(IntersectionVertex... boundaryVertices) {
-    return new AreaGroupBuilder(List.of(boundaryVertices));
-  }
-
-  public final class AreaGroupBuilder {
-
-    private final List<IntersectionVertex> boundaryVertices;
-    private Set<IntersectionVertex> visibilityVertices = Set.of();
-
-    private AreaGroupBuilder(List<IntersectionVertex> boundaryVertices) {
-      if (boundaryVertices.size() < 3) {
-        throw new IllegalArgumentException("An area must have at least three boundary vertices.");
-      }
-      this.boundaryVertices = boundaryVertices;
-    }
-
-    public AreaGroupBuilder withVisibilityVertices(IntersectionVertex... visibilityVertices) {
-      this.visibilityVertices = Set.of(visibilityVertices);
-      return this;
-    }
-
-    public AreaGroup build() {
-      var coordinates = new Coordinate[boundaryVertices.size() + 1];
-      for (int i = 0; i < boundaryVertices.size(); i++) {
-        coordinates[i] = boundaryVertices.get(i).getCoordinate();
-      }
-      coordinates[boundaryVertices.size()] = coordinates[0];
-
-      var polygon = GeometryUtils.getGeometryFactory().createPolygon(coordinates);
-      var areaGroup = new AreaGroup(polygon);
-      areaGroup.addVisibilityVertices(visibilityVertices);
-
-      var area = new Area();
-      area.setName(I18NString.of("test area"));
-      area.setWalkSafety(0.5f);
-      area.setBicycleSafety(0.5f);
-      area.setPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-      area.setGeometry(polygon);
-      areaGroup.addArea(area);
-
-      for (int i = 0; i < boundaryVertices.size(); i++) {
-        var from = boundaryVertices.get(i);
-        var to = boundaryVertices.get((i + 1) % boundaryVertices.size());
-        connectAreaEdge(from, to, areaGroup, false);
-        connectAreaEdge(to, from, areaGroup, true);
-      }
-
-      graphFetcher.graph().index();
-      return areaGroup;
-    }
-
-    private void connectAreaEdge(
-      IntersectionVertex from,
-      IntersectionVertex to,
-      AreaGroup areaGroup,
-      boolean back
-    ) {
-      var geometry = GeometryUtils.getGeometryFactory().createLineString(
-        new Coordinate[] { from.getCoordinate(), to.getCoordinate() }
-      );
-      new AreaEdgeBuilder()
-        .withFromVertex(from)
-        .withToVertex(to)
-        .withGeometry(geometry)
-        .withName(I18NString.of("area boundary"))
-        .withPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE)
-        .withBack(back)
-        .withArea(areaGroup)
-        .buildAndConnect();
-    }
   }
 }

--- a/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironment.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironment.java
@@ -5,16 +5,23 @@ import static org.opentripplanner.street.linking.VisibilityMode.COMPUTE_AREA_VIS
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.service.vehiclerental.GeofencingZoneService;
+import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.graph.summary.DisposableEdgeDataFetcher;
 import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.street.model.StreetConstants;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.edge.Area;
+import org.opentripplanner.street.model.edge.AreaEdgeBuilder;
+import org.opentripplanner.street.model.edge.AreaGroup;
 import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -105,5 +112,77 @@ public class LinkingEnvironment {
 
   public VertexLinker linker() {
     return linker;
+  }
+
+  public AreaGroupBuilder areaGroup(IntersectionVertex... boundaryVertices) {
+    return new AreaGroupBuilder(List.of(boundaryVertices));
+  }
+
+  public final class AreaGroupBuilder {
+
+    private final List<IntersectionVertex> boundaryVertices;
+    private Set<IntersectionVertex> visibilityVertices = Set.of();
+
+    private AreaGroupBuilder(List<IntersectionVertex> boundaryVertices) {
+      if (boundaryVertices.size() < 3) {
+        throw new IllegalArgumentException("An area must have at least three boundary vertices.");
+      }
+      this.boundaryVertices = boundaryVertices;
+    }
+
+    public AreaGroupBuilder withVisibilityVertices(IntersectionVertex... visibilityVertices) {
+      this.visibilityVertices = Set.of(visibilityVertices);
+      return this;
+    }
+
+    public AreaGroup build() {
+      var coordinates = new Coordinate[boundaryVertices.size() + 1];
+      for (int i = 0; i < boundaryVertices.size(); i++) {
+        coordinates[i] = boundaryVertices.get(i).getCoordinate();
+      }
+      coordinates[boundaryVertices.size()] = coordinates[0];
+
+      var polygon = GeometryUtils.getGeometryFactory().createPolygon(coordinates);
+      var areaGroup = new AreaGroup(polygon);
+      areaGroup.addVisibilityVertices(visibilityVertices);
+
+      var area = new Area();
+      area.setName(I18NString.of("test area"));
+      area.setWalkSafety(0.5f);
+      area.setBicycleSafety(0.5f);
+      area.setPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+      area.setGeometry(polygon);
+      areaGroup.addArea(area);
+
+      for (int i = 0; i < boundaryVertices.size(); i++) {
+        var from = boundaryVertices.get(i);
+        var to = boundaryVertices.get((i + 1) % boundaryVertices.size());
+        connectAreaEdge(from, to, areaGroup, false);
+        connectAreaEdge(to, from, areaGroup, true);
+      }
+
+      graphFetcher.graph().index();
+      return areaGroup;
+    }
+
+    private void connectAreaEdge(
+      IntersectionVertex from,
+      IntersectionVertex to,
+      AreaGroup areaGroup,
+      boolean back
+    ) {
+      var geometry = GeometryUtils.getGeometryFactory().createLineString(
+        new Coordinate[] { from.getCoordinate(), to.getCoordinate() }
+      );
+      new AreaEdgeBuilder()
+        .withFromVertex(from)
+        .withToVertex(to)
+        .withGeometry(geometry)
+        .withName(I18NString.of("area boundary"))
+        .withPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE)
+        .withBack(back)
+        .withArea(areaGroup)
+        .buildAndConnect();
+    }
   }
 }

--- a/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironmentBuilder.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/linking/LinkingEnvironmentBuilder.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.street.linking;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.opentripplanner.street.model.vertex.Vertex;
+
+public class LinkingEnvironmentBuilder {
+
+  private final List<Vertex> vertices = new ArrayList<>();
+
+  public LinkingEnvironmentBuilder addVertices(Vertex... vertices) {
+    this.vertices.addAll(List.of(vertices));
+    return this;
+  }
+
+  public LinkingEnvironment build() {
+    return new LinkingEnvironment(vertices.toArray(Vertex[]::new));
+  }
+}

--- a/street/src/test-fixtures/java/org/opentripplanner/street/model/StreetModelFactory.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/model/StreetModelFactory.java
@@ -19,6 +19,7 @@ import org.opentripplanner.street.model.edge.AreaGroup;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.edge.TemporaryPartialStreetEdgeBuilder;
+import org.opentripplanner.street.model.edge.TestAreaGroupBuilder;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.LabelledIntersectionVertex;
 import org.opentripplanner.street.model.vertex.StreetVertex;
@@ -44,6 +45,10 @@ public class StreetModelFactory {
 
   public static IntersectionVertex intersectionVertex(String label, double lat, double lon) {
     return new LabelledIntersectionVertex(label, lon, lat, false, false);
+  }
+
+  public static TestAreaGroupBuilder areaGroup(IntersectionVertex... boundaryVertices) {
+    return new TestAreaGroupBuilder(boundaryVertices);
   }
 
   public static TransitEntranceVertex transitEntranceVertex(String id, double lat, double lon) {

--- a/street/src/test-fixtures/java/org/opentripplanner/street/model/edge/TestAreaGroupBuilder.java
+++ b/street/src/test-fixtures/java/org/opentripplanner/street/model/edge/TestAreaGroupBuilder.java
@@ -1,0 +1,75 @@
+package org.opentripplanner.street.model.edge;
+
+import java.util.List;
+import java.util.Set;
+import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.model.StreetTraversalPermission;
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
+
+public class TestAreaGroupBuilder {
+
+  private final List<IntersectionVertex> boundaryVertices;
+  private Set<IntersectionVertex> visibilityVertices = Set.of();
+
+  public TestAreaGroupBuilder(IntersectionVertex... boundaryVertices) {
+    if (boundaryVertices.length < 3) {
+      throw new IllegalArgumentException("An area must have at least three boundary vertices.");
+    }
+    this.boundaryVertices = List.of(boundaryVertices);
+  }
+
+  public TestAreaGroupBuilder withVisibilityVertices(IntersectionVertex... visibilityVertices) {
+    this.visibilityVertices = Set.of(visibilityVertices);
+    return this;
+  }
+
+  public AreaGroup build() {
+    var coordinates = new Coordinate[boundaryVertices.size() + 1];
+    for (int i = 0; i < boundaryVertices.size(); i++) {
+      coordinates[i] = boundaryVertices.get(i).getCoordinate();
+    }
+    coordinates[boundaryVertices.size()] = coordinates[0];
+
+    var polygon = GeometryUtils.getGeometryFactory().createPolygon(coordinates);
+    var areaGroup = new AreaGroup(polygon);
+    areaGroup.addVisibilityVertices(visibilityVertices);
+
+    var area = new Area();
+    area.setName(I18NString.of("test area"));
+    area.setWalkSafety(0.5f);
+    area.setBicycleSafety(0.5f);
+    area.setPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+    area.setGeometry(polygon);
+    areaGroup.addArea(area);
+
+    for (int i = 0; i < boundaryVertices.size(); i++) {
+      var from = boundaryVertices.get(i);
+      var to = boundaryVertices.get((i + 1) % boundaryVertices.size());
+      connectAreaEdge(from, to, areaGroup, false);
+      connectAreaEdge(to, from, areaGroup, true);
+    }
+    return areaGroup;
+  }
+
+  private static void connectAreaEdge(
+    IntersectionVertex from,
+    IntersectionVertex to,
+    AreaGroup areaGroup,
+    boolean back
+  ) {
+    var geometry = GeometryUtils.getGeometryFactory().createLineString(
+      new Coordinate[] { from.getCoordinate(), to.getCoordinate() }
+    );
+    new AreaEdgeBuilder()
+      .withFromVertex(from)
+      .withToVertex(to)
+      .withGeometry(geometry)
+      .withName(I18NString.of("area boundary"))
+      .withPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE)
+      .withBack(back)
+      .withArea(areaGroup)
+      .buildAndConnect();
+  }
+}

--- a/street/src/test/java/org/opentripplanner/street/linking/PermanentAreaVertexLinkingTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/PermanentAreaVertexLinkingTest.java
@@ -2,47 +2,71 @@ package org.opentripplanner.street.linking;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.street.model.StreetModelFactory.areaGroup;
 import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests the forced-link fallback in {@code addPermanentAreaVertex}. The fallback is used when a
+ * normal visibility link cannot be created, including when the only visibility vertex overlaps the
+ * new vertex and is initially filtered out as a duplicate.
+ */
 class PermanentAreaVertexLinkingTest {
-
-  private static final String FORWARD_LINK = "(0.1,-0.1) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅";
-  private static final String REVERSE_LINK = "(0,0) → (0.1,-0.1) PEDESTRIAN_AND_BICYCLE ♿✅";
-  private static final String OVERLAPPING_LINK = "(0,0) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅";
 
   @Test
   void outsideAreaVertexLinksToNearestVisibilityVertex() {
-    var v0 = intersectionVertex("0", 0, 0);
-    var v1 = intersectionVertex("1", 0, 1);
-    var v2 = intersectionVertex("2", 1, 1);
-    var v3 = intersectionVertex("3", 1, 0);
-    var env = new LinkingEnvironment(v0, v1, v2, v3);
-    var areaGroup = env.areaGroup(v0, v1, v2, v3).withVisibilityVertices(v0, v2).build();
-    var boardingLocation = intersectionVertex("boarding-location", 0.1, -0.1);
+    var v0 = intersectionVertex(0, 0);
+    var v1 = intersectionVertex(0, 1);
+    var v2 = intersectionVertex(1, 1);
+    var v3 = intersectionVertex(1, 0);
+    var areaGroup = areaGroup(v0, v1, v2, v3).withVisibilityVertices(v0, v2).build();
+    var env = LinkingEnvironment.of().addVertices(v0, v1, v2, v3).build();
+    var boardingLocation = intersectionVertex(0.1, -0.1);
 
     assertThat(env.linker().addPermanentAreaVertex(boardingLocation, areaGroup)).isTrue();
 
     assertWithMessage("Inspect graph at %s", env.graph().geoJsonUrl())
       .that(env.graph().summarizeEdges())
-      .containsAtLeast(FORWARD_LINK, REVERSE_LINK);
+      .containsExactly(
+        "(0,0) → (0,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,1) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,1) → (1,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,1) → (0,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,1) → (1,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,0) → (1,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,0) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,0) → (1,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0.1,-0.1) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,0) → (0.1,-0.1) PEDESTRIAN_AND_BICYCLE ♿✅"
+      );
   }
 
   @Test
   void vertexAtVisibilityPointStillGetsAreaLink() {
-    var v0 = intersectionVertex("0", 0, 0);
-    var v1 = intersectionVertex("1", 0, 1);
-    var v2 = intersectionVertex("2", 1, 1);
-    var v3 = intersectionVertex("3", 1, 0);
-    var env = new LinkingEnvironment(v0, v1, v2, v3);
-    var areaGroup = env.areaGroup(v0, v1, v2, v3).withVisibilityVertices(v0).build();
-    var boardingLocation = intersectionVertex("boarding-location", 0, 0);
+    var v0 = intersectionVertex(0, 0);
+    var v1 = intersectionVertex(0, 1);
+    var v2 = intersectionVertex(1, 1);
+    var v3 = intersectionVertex(1, 0);
+    var areaGroup = areaGroup(v0, v1, v2, v3).withVisibilityVertices(v0).build();
+    var env = LinkingEnvironment.of().addVertices(v0, v1, v2, v3).build();
+    var boardingLocation = intersectionVertex(0, 0);
 
     assertThat(env.linker().addPermanentAreaVertex(boardingLocation, areaGroup)).isTrue();
 
     assertWithMessage("Inspect graph at %s", env.graph().geoJsonUrl())
       .that(env.graph().summarizeEdges())
-      .containsAtLeast(OVERLAPPING_LINK, OVERLAPPING_LINK);
+      .containsExactly(
+        "(0,0) → (0,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,1) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,1) → (1,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,1) → (0,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,1) → (1,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,0) → (1,1) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(1,0) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,0) → (1,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,0) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅",
+        "(0,0) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅"
+      );
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/linking/PermanentAreaVertexLinkingTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/PermanentAreaVertexLinkingTest.java
@@ -1,0 +1,48 @@
+package org.opentripplanner.street.linking;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
+
+import org.junit.jupiter.api.Test;
+
+class PermanentAreaVertexLinkingTest {
+
+  private static final String FORWARD_LINK = "(0.1,-0.1) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅";
+  private static final String REVERSE_LINK = "(0,0) → (0.1,-0.1) PEDESTRIAN_AND_BICYCLE ♿✅";
+  private static final String OVERLAPPING_LINK = "(0,0) → (0,0) PEDESTRIAN_AND_BICYCLE ♿✅";
+
+  @Test
+  void outsideAreaVertexLinksToNearestVisibilityVertex() {
+    var v0 = intersectionVertex("0", 0, 0);
+    var v1 = intersectionVertex("1", 0, 1);
+    var v2 = intersectionVertex("2", 1, 1);
+    var v3 = intersectionVertex("3", 1, 0);
+    var env = new LinkingEnvironment(v0, v1, v2, v3);
+    var areaGroup = env.areaGroup(v0, v1, v2, v3).withVisibilityVertices(v0, v2).build();
+    var boardingLocation = intersectionVertex("boarding-location", 0.1, -0.1);
+
+    assertThat(env.linker().addPermanentAreaVertex(boardingLocation, areaGroup)).isTrue();
+
+    assertWithMessage("Inspect graph at %s", env.graph().geoJsonUrl())
+      .that(env.graph().summarizeEdges())
+      .containsAtLeast(FORWARD_LINK, REVERSE_LINK);
+  }
+
+  @Test
+  void vertexAtVisibilityPointStillGetsAreaLink() {
+    var v0 = intersectionVertex("0", 0, 0);
+    var v1 = intersectionVertex("1", 0, 1);
+    var v2 = intersectionVertex("2", 1, 1);
+    var v3 = intersectionVertex("3", 1, 0);
+    var env = new LinkingEnvironment(v0, v1, v2, v3);
+    var areaGroup = env.areaGroup(v0, v1, v2, v3).withVisibilityVertices(v0).build();
+    var boardingLocation = intersectionVertex("boarding-location", 0, 0);
+
+    assertThat(env.linker().addPermanentAreaVertex(boardingLocation, areaGroup)).isTrue();
+
+    assertWithMessage("Inspect graph at %s", env.graph().geoJsonUrl())
+      .that(env.graph().summarizeEdges())
+      .containsAtLeast(OVERLAPPING_LINK, OVERLAPPING_LINK);
+  }
+}


### PR DESCRIPTION
### Summary

This adds two focused regression tests for permanent area-vertex linking. They cover linking an outside boarding location to the nearest visibility vertex and the fallback used when the visibility vertex overlaps the boarding location.

The tests use `LinkingEnvironment` and assert against the graph's summarized edge list. `LinkingEnvironment` now also provides a small reusable builder for area groups and their visibility vertices.

### Issue

No linked issue; this is a focused test-only change for existing behavior that was not directly covered.

### Unit tests

The new tests exercise the forced-linking branches in `VertexLinker.addPermanentAreaVertex`. The focused tests and the complete street-linking test package pass locally.

### Documentation

No documentation changes are required because this only adds test fixtures and regression coverage.

### Changelog

The `+Skip Changelog` label is applied because this is a test-only change.
