### PR TITLE
Introduce EstimatedVehicleJourneyWrapper for the SIRI-ET updater

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
@@ -1,12 +1,10 @@
 package org.opentripplanner.updater.trip.siri;
 
-import static java.lang.Boolean.TRUE;
 import static org.opentripplanner.updater.alert.siri.mapping.SiriTransportModeMapper.mapTransitMainMode;
 import static org.opentripplanner.updater.spi.UpdateErrorType.CANNOT_RESOLVE_AGENCY;
 import static org.opentripplanner.updater.spi.UpdateErrorType.NO_START_DATE;
 import static org.opentripplanner.updater.spi.UpdateErrorType.TOO_FEW_STOPS;
 import static org.opentripplanner.updater.spi.UpdateErrorType.UNKNOWN_STOP;
-import static org.opentripplanner.updater.trip.siri.support.NaturalLanguageStringHelper.getFirstStringFromList;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -38,10 +36,7 @@ import org.rutebanken.netex.model.BusSubmodeEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.org.siri.siri21.EstimatedVehicleJourney;
 import uk.org.siri.siri21.OccupancyEnumeration;
-import uk.org.siri.siri21.VehicleJourneyRef;
-import uk.org.siri.siri21.VehicleModesEnumeration;
 
 class AddedTripBuilder {
 
@@ -70,60 +65,54 @@ class AddedTripBuilder {
   private final DeduplicatorService deduplicator;
 
   AddedTripBuilder(
-    EstimatedVehicleJourney estimatedVehicleJourney,
+    EstimatedVehicleJourneyWrapper journey,
     TransitEditorService transitService,
     DeduplicatorService deduplicator,
     EntityResolver entityResolver,
-    Function<Trip, FeedScopedId> getTripPatternId,
-    List<CallWrapper> calls
+    Function<Trip, FeedScopedId> getTripPatternId
   ) {
     this.deduplicator = deduplicator;
     // Verifying values required in SIRI Profile
     // Added ServiceJourneyId
-    String estimatedVehicleJourneyCode = estimatedVehicleJourney.getEstimatedVehicleJourneyCode();
+    String estimatedVehicleJourneyCode = journey.estimatedVehicleJourneyCode();
     Objects.requireNonNull(estimatedVehicleJourneyCode, "EstimatedVehicleJourneyCode is required");
     var codeAdapter = new EstimatedVehicleJourneyCodeAdapter(estimatedVehicleJourneyCode);
     tripId = entityResolver.resolveId(codeAdapter.getServiceJourneyId());
     tripOnServiceDateId = entityResolver.resolveId(codeAdapter.getDatedServiceJourneyId());
 
     // OperatorRef of added trip
-    Objects.requireNonNull(estimatedVehicleJourney.getOperatorRef(), "OperatorRef is required");
-    String operatorRef = estimatedVehicleJourney.getOperatorRef().getValue();
+    String operatorRef = Objects.requireNonNull(journey.operatorRef(), "OperatorRef is required");
     operator = entityResolver.resolveOperator(operatorRef);
 
     // DataSource of added trip
-    dataSource = estimatedVehicleJourney.getDataSource();
+    dataSource = journey.dataSource();
 
     // LineRef of added trip
-    Objects.requireNonNull(estimatedVehicleJourney.getLineRef(), "LineRef is required");
-    lineRef = estimatedVehicleJourney.getLineRef().getValue();
+    lineRef = Objects.requireNonNull(journey.lineRef(), "LineRef is required");
 
-    String externalLineRef = estimatedVehicleJourney.getExternalLineRef() != null
-      ? estimatedVehicleJourney.getExternalLineRef().getValue()
-      : lineRef;
+    String externalLineRef = Objects.requireNonNullElse(journey.externalLineRef(), lineRef);
     replacedRoute = entityResolver.resolveRoute(externalLineRef);
 
-    serviceDate = entityResolver.resolveServiceDate(estimatedVehicleJourney, calls);
+    serviceDate = entityResolver.resolveServiceDate(journey);
 
-    shortName = getFirstStringFromList(estimatedVehicleJourney.getPublishedLineNames());
+    shortName = journey.publishedLineName();
 
-    List<VehicleModesEnumeration> vehicleModes = estimatedVehicleJourney.getVehicleModes();
-    transitMode = mapTransitMainMode(vehicleModes);
+    transitMode = mapTransitMainMode(journey.vehicleModes());
     transitSubMode = resolveTransitSubMode(transitMode, replacedRoute);
 
-    isJourneyPredictionInaccurate = TRUE.equals(estimatedVehicleJourney.isPredictionInaccurate());
-    occupancy = estimatedVehicleJourney.getOccupancy();
-    cancellation = TRUE.equals(estimatedVehicleJourney.isCancellation());
-    headsign = getFirstStringFromList(estimatedVehicleJourney.getDestinationNames());
+    isJourneyPredictionInaccurate = journey.isPredictionInaccurate();
+    occupancy = journey.occupancy();
+    cancellation = journey.isCancellation();
+    headsign = journey.destinationName();
 
-    this.calls = calls;
+    this.calls = journey.calls();
 
     this.transitService = transitService;
     this.entityResolver = entityResolver;
     this.getTripPatternId = getTripPatternId;
     timeZone = transitService.getTimeZone();
 
-    replacedTrips = getReplacedVehicleJourneys(estimatedVehicleJourney);
+    replacedTrips = getReplacedVehicleJourneys(journey);
     stopTimesMapper = new StopTimesMapper(entityResolver, timeZone);
   }
 
@@ -369,15 +358,14 @@ class AddedTripBuilder {
   }
 
   private List<TripOnServiceDate> getReplacedVehicleJourneys(
-    EstimatedVehicleJourney estimatedVehicleJourney
+    EstimatedVehicleJourneyWrapper journey
   ) {
     List<TripOnServiceDate> listOfReplacedVehicleJourneys = new ArrayList<>();
 
-    // VehicleJourneyRef is the reference to the serviceJourney being replaced.
-    VehicleJourneyRef vehicleJourneyRef = estimatedVehicleJourney.getVehicleJourneyRef();
-    if (vehicleJourneyRef != null) {
+    String replacedDatedVehicleJourneyRef = journey.replacedDatedVehicleJourneyRef();
+    if (replacedDatedVehicleJourneyRef != null) {
       var replacedDatedServiceJourney = entityResolver.resolveTripOnServiceDate(
-        vehicleJourneyRef.getValue()
+        replacedDatedVehicleJourneyRef
       );
       if (replacedDatedServiceJourney != null) {
         listOfReplacedVehicleJourneys.add(replacedDatedServiceJourney);
@@ -385,8 +373,8 @@ class AddedTripBuilder {
     }
 
     // Add additional replaced service journeys if present.
-    estimatedVehicleJourney
-      .getAdditionalVehicleJourneyReves()
+    journey
+      .additionalReplacedDatedVehicleJourneyRefs()
       .stream()
       .map(entityResolver::resolveTripOnServiceDate)
       .filter(Objects::nonNull)

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -16,8 +15,6 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.org.siri.siri21.DatedVehicleJourneyRef;
-import uk.org.siri.siri21.EstimatedVehicleJourney;
 import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
 import uk.org.siri.siri21.MonitoredVehicleJourneyStructure;
 
@@ -43,20 +40,23 @@ public class EntityResolver {
   }
 
   /**
-   * Resolve a {@link Trip} either by resolving a service journey id from EstimatedVehicleJourney ->
-   * FramedVehicleJourneyRef -> DatedVehicleJourneyRef or a dated service journey id from
-   * EstimatedVehicleJourney -> DatedVehicleJourneyRef.
+   * Resolve a {@link Trip} either by resolving a service journey id from the journey's
+   * FramedVehicleJourneyRef -> DatedVehicleJourneyRef, from its DatedVehicleJourneyRef, or from its
+   * EstimatedVehicleJourneyCode (for a trip that was previously added by a real-time message).
    */
-  public Trip resolveTrip(EstimatedVehicleJourney journey) {
-    Trip trip = resolveTrip(journey.getFramedVehicleJourneyRef());
-    if (trip != null) {
-      return trip;
+  @Nullable
+  public Trip resolveTrip(EstimatedVehicleJourneyWrapper journey) {
+    var vehicleJourneyIdAndServiceDate = journey.vehicleJourneyIdAndServiceDate();
+    if (vehicleJourneyIdAndServiceDate != null) {
+      Trip trip = resolveTrip(vehicleJourneyIdAndServiceDate.vehicleJourneyId());
+      if (trip != null) {
+        return trip;
+      }
     }
 
-    if (journey.getDatedVehicleJourneyRef() != null) {
-      String datedServiceJourneyId = journey.getDatedVehicleJourneyRef().getValue();
+    if (journey.datedVehicleJourneyRef() != null) {
       TripOnServiceDate tripOnServiceDate = transitService.getTripOnServiceDate(
-        resolveId(datedServiceJourneyId)
+        resolveId(journey.datedVehicleJourneyRef())
       );
 
       if (tripOnServiceDate != null) {
@@ -65,10 +65,8 @@ public class EntityResolver {
     }
 
     // It is possible that the trip has previously been added, resolve the added trip
-    if (journey.getEstimatedVehicleJourneyCode() != null) {
-      var adapter = new EstimatedVehicleJourneyCodeAdapter(
-        journey.getEstimatedVehicleJourneyCode()
-      );
+    if (journey.estimatedVehicleJourneyCode() != null) {
+      var adapter = new EstimatedVehicleJourneyCodeAdapter(journey.estimatedVehicleJourneyCode());
       var addedTrip = transitService.getTrip(resolveId(adapter.getServiceJourneyId()));
       if (addedTrip != null) {
         return addedTrip;
@@ -86,16 +84,6 @@ public class EntityResolver {
     return resolveTrip(journey.getFramedVehicleJourneyRef());
   }
 
-  public TripOnServiceDate resolveTripOnServiceDate(
-    EstimatedVehicleJourney estimatedVehicleJourney
-  ) {
-    FeedScopedId datedServiceJourneyId = resolveDatedServiceJourneyId(estimatedVehicleJourney);
-    if (datedServiceJourneyId != null) {
-      return resolveTripOnServiceDate(datedServiceJourneyId);
-    }
-    return resolveTripOnServiceDate(estimatedVehicleJourney.getFramedVehicleJourneyRef());
-  }
-
   public TripOnServiceDate resolveTripOnServiceDate(String datedServiceJourneyId) {
     return resolveTripOnServiceDate(resolveId(datedServiceJourneyId));
   }
@@ -106,6 +94,16 @@ public class EntityResolver {
     return resolveTripOnServiceDate(
       framedVehicleJourney.getDatedVehicleJourneyRef(),
       resolveServiceDate(framedVehicleJourney)
+    );
+  }
+
+  @Nullable
+  public TripOnServiceDate resolveTripOnServiceDate(
+    VehicleJourneyIdAndServiceDate vehicleJourneyIdAndServiceDate
+  ) {
+    return resolveTripOnServiceDate(
+      vehicleJourneyIdAndServiceDate.vehicleJourneyId(),
+      parseServiceDate(vehicleJourneyIdAndServiceDate.serviceDate())
     );
   }
 
@@ -127,34 +125,38 @@ public class EntityResolver {
     return transitService.getTripOnServiceDate(datedServiceJourneyId);
   }
 
-  public FeedScopedId resolveDatedServiceJourneyId(
-    EstimatedVehicleJourney estimatedVehicleJourney
-  ) {
-    DatedVehicleJourneyRef datedVehicleJourneyRef =
-      estimatedVehicleJourney.getDatedVehicleJourneyRef();
-    if (datedVehicleJourneyRef != null) {
-      return resolveId(datedVehicleJourneyRef.getValue());
+  public FeedScopedId resolveDatedServiceJourneyId(EstimatedVehicleJourneyWrapper journey) {
+    if (journey.datedVehicleJourneyRef() != null) {
+      return resolveId(journey.datedVehicleJourneyRef());
     }
 
-    if (estimatedVehicleJourney.getEstimatedVehicleJourneyCode() != null) {
-      return resolveId(estimatedVehicleJourney.getEstimatedVehicleJourneyCode());
+    if (journey.estimatedVehicleJourneyCode() != null) {
+      return resolveId(journey.estimatedVehicleJourneyCode());
     }
 
     return null;
   }
 
   public LocalDate resolveServiceDate(FramedVehicleJourneyRefStructure vehicleJourneyRefStructure) {
-    if (vehicleJourneyRefStructure.getDataFrameRef() != null) {
-      var dataFrame = vehicleJourneyRefStructure.getDataFrameRef();
-      if (dataFrame != null) {
-        try {
-          return LocalDate.parse(dataFrame.getValue());
-        } catch (DateTimeParseException ignored) {
-          LOG.warn("Invalid dataFrame format: {}", dataFrame.getValue());
-        }
-      }
+    var dataFrame = vehicleJourneyRefStructure.getDataFrameRef();
+    return parseServiceDate(dataFrame != null ? dataFrame.getValue() : null);
+  }
+
+  /**
+   * Parse a SIRI data frame ref (an ISO-8601 date) into a service date, returning {@code null} if it
+   * is missing or malformed.
+   */
+  @Nullable
+  private LocalDate parseServiceDate(@Nullable String dataFrameRef) {
+    if (dataFrameRef == null) {
+      return null;
     }
-    return null;
+    try {
+      return LocalDate.parse(dataFrameRef);
+    } catch (DateTimeParseException ignored) {
+      LOG.warn("Invalid dataFrame format: {}", dataFrameRef);
+      return null;
+    }
   }
 
   /**
@@ -215,22 +217,16 @@ public class EntityResolver {
   }
 
   @Nullable
-  public LocalDate resolveServiceDate(
-    EstimatedVehicleJourney vehicleJourney,
-    List<CallWrapper> calls
-  ) {
-    if (vehicleJourney.getFramedVehicleJourneyRef() != null) {
-      var dataFrame = vehicleJourney.getFramedVehicleJourneyRef().getDataFrameRef();
-      if (dataFrame != null) {
-        try {
-          return LocalDate.parse(dataFrame.getValue());
-        } catch (DateTimeParseException ignored) {
-          LOG.warn("Invalid dataFrame format: {}", dataFrame.getValue());
-        }
+  public LocalDate resolveServiceDate(EstimatedVehicleJourneyWrapper journey) {
+    var vehicleJourneyIdAndServiceDate = journey.vehicleJourneyIdAndServiceDate();
+    if (vehicleJourneyIdAndServiceDate != null) {
+      var serviceDate = parseServiceDate(vehicleJourneyIdAndServiceDate.serviceDate());
+      if (serviceDate != null) {
+        return serviceDate;
       }
     }
 
-    FeedScopedId datedServiceJourneyId = resolveDatedServiceJourneyId(vehicleJourney);
+    FeedScopedId datedServiceJourneyId = resolveDatedServiceJourneyId(journey);
     if (datedServiceJourneyId != null) {
       var datedServiceJourney = resolveTripOnServiceDate(datedServiceJourneyId);
       if (datedServiceJourney != null) {
@@ -238,6 +234,7 @@ public class EntityResolver {
       }
     }
 
+    var calls = journey.calls();
     if (calls.isEmpty()) {
       return null;
     }
@@ -247,7 +244,7 @@ public class EntityResolver {
       return null;
     }
 
-    var daysOffset = calculateDayOffset(vehicleJourney);
+    var daysOffset = calculateDayOffset(journey);
 
     return departureTime.toLocalDate().minusDays(daysOffset);
   }
@@ -255,8 +252,8 @@ public class EntityResolver {
   /**
    * Calculate the difference in days between the service date and the departure at the first stop.
    */
-  private int calculateDayOffset(EstimatedVehicleJourney vehicleJourney) {
-    Trip trip = resolveTrip(vehicleJourney);
+  private int calculateDayOffset(EstimatedVehicleJourneyWrapper journey) {
+    Trip trip = resolveTrip(journey);
     if (trip == null) {
       return 0;
     }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapper.java
@@ -173,12 +173,16 @@ final class EstimatedVehicleJourneyWrapper {
 
   /* Descriptive information */
 
-  @Nullable
+  /**
+   * The published line name, or an empty string if not set.
+   */
   String publishedLineName() {
     return getFirstStringFromList(journey.getPublishedLineNames());
   }
 
-  @Nullable
+  /**
+   * The destination name (headsign), or an empty string if not set.
+   */
   String destinationName() {
     return getFirstStringFromList(journey.getDestinationNames());
   }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapper.java
@@ -1,0 +1,202 @@
+package org.opentripplanner.updater.trip.siri;
+
+import static java.lang.Boolean.TRUE;
+import static org.opentripplanner.updater.trip.siri.support.NaturalLanguageStringHelper.getFirstStringFromList;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.opentripplanner.updater.spi.UpdateErrorType;
+import org.opentripplanner.updater.spi.UpdateException;
+import uk.org.siri.siri21.EstimatedVehicleJourney;
+import uk.org.siri.siri21.OccupancyEnumeration;
+import uk.org.siri.siri21.VehicleModesEnumeration;
+
+/**
+ * A wrapper around a JAXB {@link EstimatedVehicleJourney} that also owns the parsed and validated
+ * {@link CallWrapper}s for that journey.
+ */
+final class EstimatedVehicleJourneyWrapper {
+
+  private final EstimatedVehicleJourney journey;
+  private final List<CallWrapper> calls;
+
+  private EstimatedVehicleJourneyWrapper(EstimatedVehicleJourney journey, List<CallWrapper> calls) {
+    this.journey = journey;
+    this.calls = calls;
+  }
+
+  /* Construction and validation */
+
+  static EstimatedVehicleJourneyWrapper of(EstimatedVehicleJourney journey) throws UpdateException {
+    var wrapper = new EstimatedVehicleJourneyWrapper(journey, CallWrapper.of(journey));
+    wrapper.validate();
+    return wrapper;
+  }
+
+  private void validate() throws UpdateException {
+    if (mustBeRejectedAsUnmonitored()) {
+      throw UpdateException.of(UpdateErrorType.NOT_MONITORED);
+    }
+  }
+
+  /**
+   * Whether this journey must be rejected because it is not monitored.
+   * <p>
+   * A journey reported as not monitored is normally rejected, but the not-monitored flag is ignored
+   * when the journey is a cancellation: a cancelled journey is no longer monitored, yet must still
+   * be processed so that the cancellation is applied.
+   */
+  private boolean mustBeRejectedAsUnmonitored() {
+    return !isMonitored() && !isCancellation();
+  }
+
+  /* Calls */
+
+  List<CallWrapper> calls() {
+    return calls;
+  }
+
+  /**
+   * Whether at least one call of this journey is an extra (unplanned) call.
+   */
+  boolean hasExtraCall() {
+    return calls.stream().anyMatch(CallWrapper::isExtraCall);
+  }
+
+  /* Journey status */
+
+  boolean isMonitored() {
+    return TRUE.equals(journey.isMonitored());
+  }
+
+  boolean isCancellation() {
+    return TRUE.equals(journey.isCancellation());
+  }
+
+  boolean isExtraJourney() {
+    return TRUE.equals(journey.isExtraJourney());
+  }
+
+  boolean isPredictionInaccurate() {
+    return TRUE.equals(journey.isPredictionInaccurate());
+  }
+
+  /* Trip identification */
+
+  /**
+   * A code used to build the id of an extra-journey.
+   */
+  @Nullable
+  String estimatedVehicleJourneyCode() {
+    return journey.getEstimatedVehicleJourneyCode();
+  }
+
+  /**
+   * The dated vehicle journey identified by unique id.
+   */
+  @Nullable
+  String datedVehicleJourneyRef() {
+    return journey.getDatedVehicleJourneyRef() != null
+      ? journey.getDatedVehicleJourneyRef().getValue()
+      : null;
+  }
+
+  /**
+   * The dated vehicle journey identified by the pair (service journey id, service date).
+   */
+  @Nullable
+  VehicleJourneyIdAndServiceDate vehicleJourneyIdAndServiceDate() {
+    return VehicleJourneyIdAndServiceDate.of(journey.getFramedVehicleJourneyRef());
+  }
+
+  /**
+   * An internal (private) id used for fuzzy matching.
+   */
+  @Nullable
+  String internalPlanningCode() {
+    return journey.getVehicleRef() != null ? journey.getVehicleRef().getValue() : null;
+  }
+
+  /* Replaced trips */
+
+  /**
+   * The dated vehicle journey this journey replaces.
+   */
+  @Nullable
+  String replacedDatedVehicleJourneyRef() {
+    return journey.getVehicleJourneyRef() != null
+      ? journey.getVehicleJourneyRef().getValue()
+      : null;
+  }
+
+  /**
+   * Additional dated vehicle journeys this journey replaces (beyond {@link #replacedDatedVehicleJourneyRef()}).
+   */
+  List<VehicleJourneyIdAndServiceDate> additionalReplacedDatedVehicleJourneyRefs() {
+    return journey
+      .getAdditionalVehicleJourneyReves()
+      .stream()
+      .map(VehicleJourneyIdAndServiceDate::of)
+      .toList();
+  }
+
+  /**
+   * In case of a replacement departure, the line of the replaced vehicle journey.
+   */
+  @Nullable
+  String externalLineRef() {
+    return journey.getExternalLineRef() != null ? journey.getExternalLineRef().getValue() : null;
+  }
+
+  /* Line, operator and mode */
+
+  @Nullable
+  String lineRef() {
+    return journey.getLineRef() != null ? journey.getLineRef().getValue() : null;
+  }
+
+  @Nullable
+  String operatorRef() {
+    return journey.getOperatorRef() != null ? journey.getOperatorRef().getValue() : null;
+  }
+
+  /**
+   * Whether this journey is operated by rail.
+   */
+  boolean isRail() {
+    return journey.getVehicleModes().contains(VehicleModesEnumeration.RAIL);
+  }
+
+  List<VehicleModesEnumeration> vehicleModes() {
+    return journey.getVehicleModes();
+  }
+
+  /* Descriptive information */
+
+  @Nullable
+  String publishedLineName() {
+    return getFirstStringFromList(journey.getPublishedLineNames());
+  }
+
+  @Nullable
+  String destinationName() {
+    return getFirstStringFromList(journey.getDestinationNames());
+  }
+
+  @Nullable
+  OccupancyEnumeration occupancy() {
+    return journey.getOccupancy();
+  }
+
+  @Nullable
+  String dataSource() {
+    return journey.getDataSource();
+  }
+
+  /**
+   * A human-readable, single-line description of this journey for debug logging.
+   */
+  String debugString() {
+    return DebugString.of(journey);
+  }
+}

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.trip.siri;
 
-import static java.lang.Boolean.TRUE;
 import static org.opentripplanner.updater.spi.UpdateErrorType.INVALID_STOP_SEQUENCE;
 import static org.opentripplanner.updater.spi.UpdateErrorType.NO_START_DATE;
 import static org.opentripplanner.updater.spi.UpdateErrorType.STOP_MISMATCH;
@@ -26,7 +25,6 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.UpdateException;
-import uk.org.siri.siri21.EstimatedVehicleJourney;
 import uk.org.siri.siri21.OccupancyEnumeration;
 
 class ExtraCallTripBuilder {
@@ -46,28 +44,27 @@ class ExtraCallTripBuilder {
   private final DeduplicatorService deduplicator;
 
   ExtraCallTripBuilder(
-    EstimatedVehicleJourney estimatedVehicleJourney,
+    EstimatedVehicleJourneyWrapper journey,
     TransitEditorService transitService,
     DeduplicatorService deduplicator,
     EntityResolver entityResolver,
     Function<Trip, FeedScopedId> generateTripPatternId,
-    Trip trip,
-    List<CallWrapper> calls
+    Trip trip
   ) {
     this.trip = Objects.requireNonNull(trip);
 
     this.deduplicator = deduplicator;
     // DataSource of added trip
-    dataSource = estimatedVehicleJourney.getDataSource();
+    dataSource = journey.dataSource();
 
-    serviceDate = entityResolver.resolveServiceDate(estimatedVehicleJourney, calls);
+    serviceDate = entityResolver.resolveServiceDate(journey);
 
-    isJourneyPredictionInaccurate = TRUE.equals(estimatedVehicleJourney.isPredictionInaccurate());
-    occupancy = estimatedVehicleJourney.getOccupancy();
-    cancellation = TRUE.equals(estimatedVehicleJourney.isCancellation());
-    added = TRUE.equals(estimatedVehicleJourney.isExtraJourney());
+    isJourneyPredictionInaccurate = journey.isPredictionInaccurate();
+    occupancy = journey.occupancy();
+    cancellation = journey.isCancellation();
+    added = journey.isExtraJourney();
 
-    this.calls = calls;
+    this.calls = journey.calls();
 
     this.transitService = transitService;
     this.generateTripPatternId = generateTripPatternId;

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.trip.siri;
 
-import static java.lang.Boolean.TRUE;
 import static org.opentripplanner.updater.spi.UpdateErrorType.STOP_MISMATCH;
 import static org.opentripplanner.updater.spi.UpdateErrorType.TOO_FEW_STOPS;
 import static org.opentripplanner.updater.spi.UpdateErrorType.TOO_MANY_STOPS;
@@ -23,7 +22,6 @@ import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.updater.trip.siri.mapping.PickDropMapper;
 import org.opentripplanner.utils.time.ServiceDateUtils;
-import uk.org.siri.siri21.EstimatedVehicleJourney;
 import uk.org.siri.siri21.OccupancyEnumeration;
 
 /**
@@ -47,11 +45,10 @@ class ModifiedTripBuilder {
   public ModifiedTripBuilder(
     TripTimes existingTripTimes,
     TripPattern pattern,
-    EstimatedVehicleJourney journey,
+    EstimatedVehicleJourneyWrapper journey,
     LocalDate serviceDate,
     ZoneId zoneId,
-    EntityResolver entityResolver,
-    List<CallWrapper> calls
+    EntityResolver entityResolver
   ) {
     this.existingTripTimes = existingTripTimes;
     this.pattern = pattern;
@@ -59,12 +56,12 @@ class ModifiedTripBuilder {
     this.zoneId = zoneId;
     this.entityResolver = entityResolver;
 
-    this.calls = calls;
-    cancellation = TRUE.equals(journey.isCancellation());
-    added = TRUE.equals(journey.isExtraJourney());
-    predictionInaccurate = TRUE.equals(journey.isPredictionInaccurate());
-    occupancy = journey.getOccupancy();
-    dataSource = journey.getDataSource();
+    this.calls = journey.calls();
+    cancellation = journey.isCancellation();
+    added = journey.isExtraJourney();
+    predictionInaccurate = journey.isPredictionInaccurate();
+    occupancy = journey.occupancy();
+    dataSource = journey.dataSource();
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcher.java
@@ -30,8 +30,6 @@ import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.org.siri.siri21.EstimatedVehicleJourney;
-import uk.org.siri.siri21.VehicleModesEnumeration;
 
 /**
  * This class is used for matching TripDescriptors without trip_ids to scheduled GTFS data and to
@@ -63,12 +61,12 @@ public class SiriFuzzyTripMatcher {
    * Matches EstimatedVehicleJourney to a set of possible Trips based on tripId
    */
   public TripAndPattern match(
-    EstimatedVehicleJourney journey,
-    List<CallWrapper> calls,
+    EstimatedVehicleJourneyWrapper journeyWrapper,
     EntityResolver entityResolver,
     BiFunction<TripPattern, LocalDate, Timetable> getCurrentTimetable,
     BiFunction<FeedScopedId, LocalDate, TripPattern> getNewTripPatternForModifiedTrip
   ) throws UpdateException {
+    var calls = journeyWrapper.calls();
     if (calls.isEmpty()) {
       throw UpdateException.of(NO_VALID_STOPS);
     }
@@ -78,11 +76,8 @@ public class SiriFuzzyTripMatcher {
     }
 
     Set<Trip> trips = null;
-    if (
-      journey.getVehicleRef() != null &&
-      journey.getVehicleModes().contains(VehicleModesEnumeration.RAIL)
-    ) {
-      trips = getCachedTripsByInternalPlanningCode(journey.getVehicleRef().getValue());
+    if (journeyWrapper.internalPlanningCode() != null && journeyWrapper.isRail()) {
+      trips = getCachedTripsByInternalPlanningCode(journeyWrapper.internalPlanningCode());
     }
 
     if (trips == null || trips.isEmpty()) {
@@ -105,8 +100,8 @@ public class SiriFuzzyTripMatcher {
       throw UpdateException.of(NO_FUZZY_TRIP_MATCH);
     }
 
-    if (journey.getLineRef() != null) {
-      var lineRef = journey.getLineRef().getValue();
+    String lineRef = journeyWrapper.lineRef();
+    if (lineRef != null) {
       Route route = entityResolver.resolveRoute(lineRef);
       if (route != null) {
         trips = trips

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.updater.trip.siri;
 
-import static java.lang.Boolean.TRUE;
-import static org.opentripplanner.updater.spi.UpdateErrorType.NOT_MONITORED;
 import static org.opentripplanner.updater.spi.UpdateErrorType.NO_START_DATE;
 import static org.opentripplanner.updater.spi.UpdateErrorType.TRIP_NOT_FOUND;
 import static org.opentripplanner.updater.spi.UpdateErrorType.TRIP_NOT_FOUND_IN_PATTERN;
@@ -135,21 +133,20 @@ public class SiriRealTimeTripUpdateAdapter {
     @Nullable SiriFuzzyTripMatcher fuzzyTripMatcher,
     EntityResolver entityResolver
   ) throws UpdateException {
-    List<CallWrapper> calls = CallWrapper.of(journey);
+    var journeyWrapper = EstimatedVehicleJourneyWrapper.of(journey);
     SiriUpdateType siriUpdateType = null;
     try {
-      siriUpdateType = updateType(journey, calls, entityResolver);
+      siriUpdateType = updateType(journeyWrapper, entityResolver);
       TripUpdate result = switch (siriUpdateType) {
         case REPLACEMENT_DEPARTURE -> new AddedTripBuilder(
-          journey,
+          journeyWrapper,
           transitService,
           deduplicator,
           entityResolver,
-          tripPatternIdGenerator::generateUniqueTripPatternId,
-          calls
+          tripPatternIdGenerator::generateUniqueTripPatternId
         ).build();
-        case EXTRA_CALL -> handleExtraCall(fuzzyTripMatcher, entityResolver, journey, calls);
-        case TRIP_UPDATE -> handleModifiedTrip(fuzzyTripMatcher, entityResolver, journey, calls);
+        case EXTRA_CALL -> handleExtraCall(fuzzyTripMatcher, entityResolver, journeyWrapper);
+        case TRIP_UPDATE -> handleModifiedTrip(fuzzyTripMatcher, entityResolver, journeyWrapper);
       };
 
       /* commit */
@@ -159,7 +156,7 @@ public class SiriRealTimeTripUpdateAdapter {
     } catch (DataValidationException e) {
       throw DataValidationExceptionMapper.map(e);
     } catch (Exception e) {
-      LOG.warn("{} EstimatedJourney {} failed.", siriUpdateType, DebugString.of(journey), e);
+      LOG.warn("{} EstimatedJourney {} failed.", siriUpdateType, journeyWrapper.debugString(), e);
       throw UpdateException.noTripId(UNKNOWN);
     }
   }
@@ -191,20 +188,16 @@ public class SiriRealTimeTripUpdateAdapter {
    * {@code added=true} and {@code canceled=true} at the same time for a SIRI source.
    */
   private SiriUpdateType updateType(
-    EstimatedVehicleJourney vehicleJourney,
-    List<CallWrapper> callWrappers,
+    EstimatedVehicleJourneyWrapper journey,
     EntityResolver entityResolver
   ) {
     // Extra call if at least one of the call is an extra call
-    if (callWrappers.stream().anyMatch(CallWrapper::isExtraCall)) {
+    if (journey.hasExtraCall()) {
       return SiriUpdateType.EXTRA_CALL;
     }
 
     // Replacement departure if the trip is marked as extra journey, and it has not been added before
-    if (
-      TRUE.equals(vehicleJourney.isExtraJourney()) &&
-      entityResolver.resolveTrip(vehicleJourney) == null
-    ) {
+    if (journey.isExtraJourney() && entityResolver.resolveTrip(journey) == null) {
       return SiriUpdateType.REPLACEMENT_DEPARTURE;
     }
 
@@ -224,21 +217,11 @@ public class SiriRealTimeTripUpdateAdapter {
   private TripUpdate handleModifiedTrip(
     @Nullable SiriFuzzyTripMatcher fuzzyTripMatcher,
     EntityResolver entityResolver,
-    EstimatedVehicleJourney estimatedVehicleJourney,
-    List<CallWrapper> calls
+    EstimatedVehicleJourneyWrapper journey
   ) throws UpdateException {
-    Trip trip = entityResolver.resolveTrip(estimatedVehicleJourney);
+    Trip trip = entityResolver.resolveTrip(journey);
 
-    // Check if EstimatedVehicleJourney is reported as NOT monitored, ignore the notMonitored-flag
-    // if the journey is NOT monitored because it has been cancelled
-    if (
-      !TRUE.equals(estimatedVehicleJourney.isMonitored()) &&
-      !TRUE.equals(estimatedVehicleJourney.isCancellation())
-    ) {
-      throw UpdateException.of(trip != null ? trip.getId() : null, NOT_MONITORED);
-    }
-
-    LocalDate serviceDate = entityResolver.resolveServiceDate(estimatedVehicleJourney, calls);
+    LocalDate serviceDate = entityResolver.resolveServiceDate(journey);
 
     if (serviceDate == null) {
       throw UpdateException.of(trip != null ? trip.getId() : null, NO_START_DATE);
@@ -252,8 +235,7 @@ public class SiriRealTimeTripUpdateAdapter {
     } else if (fuzzyTripMatcher != null) {
       // No exact match found - search for trips based on arrival-times/stop-patterns
       var tripAndPattern = fuzzyTripMatcher.match(
-        estimatedVehicleJourney,
-        calls,
+        journey,
         entityResolver,
         this::getCurrentTimetable,
         snapshotManager::getNewTripPatternForModifiedTrip
@@ -273,11 +255,10 @@ public class SiriRealTimeTripUpdateAdapter {
     var tripUpdate = new ModifiedTripBuilder(
       existingTripTimes,
       pattern,
-      estimatedVehicleJourney,
+      journey,
       serviceDate,
       transitEditorService.getTimeZone(),
-      entityResolver,
-      calls
+      entityResolver
     ).build();
 
     TripPattern deleteFrom = !tripUpdate.stopPattern().equals(pattern.getStopPattern())
@@ -290,21 +271,11 @@ public class SiriRealTimeTripUpdateAdapter {
   private TripUpdate handleExtraCall(
     @Nullable SiriFuzzyTripMatcher fuzzyTripMatcher,
     EntityResolver entityResolver,
-    EstimatedVehicleJourney estimatedVehicleJourney,
-    List<CallWrapper> calls
+    EstimatedVehicleJourneyWrapper journey
   ) throws UpdateException {
-    Trip trip = entityResolver.resolveTrip(estimatedVehicleJourney);
+    Trip trip = entityResolver.resolveTrip(journey);
 
-    // Check if EstimatedVehicleJourney is reported as NOT monitored, ignore the notMonitored-flag
-    // if the journey is NOT monitored because it has been cancelled
-    if (
-      !TRUE.equals(estimatedVehicleJourney.isMonitored()) &&
-      !TRUE.equals(estimatedVehicleJourney.isCancellation())
-    ) {
-      throw UpdateException.of(trip != null ? trip.getId() : null, NOT_MONITORED);
-    }
-
-    LocalDate serviceDate = entityResolver.resolveServiceDate(estimatedVehicleJourney, calls);
+    LocalDate serviceDate = entityResolver.resolveServiceDate(journey);
 
     if (serviceDate == null) {
       throw UpdateException.of(trip != null ? trip.getId() : null, NO_START_DATE);
@@ -318,8 +289,7 @@ public class SiriRealTimeTripUpdateAdapter {
     } else if (fuzzyTripMatcher != null) {
       // No exact match found - search for trips based on arrival-times/stop-patterns
       var tripAndPattern = fuzzyTripMatcher.match(
-        estimatedVehicleJourney,
-        calls,
+        journey,
         entityResolver,
         this::getCurrentTimetable,
         snapshotManager::getNewTripPatternForModifiedTrip
@@ -338,13 +308,12 @@ public class SiriRealTimeTripUpdateAdapter {
       throw UpdateException.of(trip.getId(), TRIP_NOT_FOUND_IN_PATTERN);
     }
     var tripUpdate = new ExtraCallTripBuilder(
-      estimatedVehicleJourney,
+      journey,
       transitEditorService,
       deduplicator,
       entityResolver,
       tripPatternIdGenerator::generateUniqueTripPatternId,
-      trip,
-      calls
+      trip
     ).build();
 
     TripPattern deleteFrom = !tripUpdate.stopPattern().equals(pattern.getStopPattern())

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/VehicleJourneyIdAndServiceDate.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/VehicleJourneyIdAndServiceDate.java
@@ -1,0 +1,24 @@
+package org.opentripplanner.updater.trip.siri;
+
+import javax.annotation.Nullable;
+import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
+
+/**
+ * A pair of vehicle journey id and service date used to uniquely identify a DatedVehicleJourney.
+ */
+record VehicleJourneyIdAndServiceDate(
+  @Nullable String vehicleJourneyId,
+  @Nullable String serviceDate
+) {
+  @Nullable
+  static VehicleJourneyIdAndServiceDate of(@Nullable FramedVehicleJourneyRefStructure ref) {
+    if (ref == null) {
+      return null;
+    }
+    var dataFrameRef = ref.getDataFrameRef();
+    return new VehicleJourneyIdAndServiceDate(
+      ref.getDatedVehicleJourneyRef(),
+      dataFrameRef != null ? dataFrameRef.getValue() : null
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapperTest.java
@@ -1,0 +1,265 @@
+package org.opentripplanner.updater.trip.siri;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.LocalTimeParser;
+import org.opentripplanner.updater.spi.UpdateErrorType;
+import uk.org.siri.siri21.OccupancyEnumeration;
+import uk.org.siri.siri21.VehicleModesEnumeration;
+
+class EstimatedVehicleJourneyWrapperTest {
+
+  private static final LocalTimeParser TIME_PARSER = new LocalTimeParser(
+    ZoneId.of("Europe/Paris"),
+    LocalDate.of(2024, 5, 7)
+  );
+
+  /* Construction and validation */
+
+  @Test
+  void rejectUnmonitoredJourney() {
+    var journey = builder().withMonitored(false).buildEstimatedVehicleJourney();
+
+    assertFailure(UpdateErrorType.NOT_MONITORED, () -> EstimatedVehicleJourneyWrapper.of(journey));
+  }
+
+  @Test
+  void acceptUnmonitoredCancellation() {
+    var journey = builder()
+      .withMonitored(false)
+      .withCancellation(true)
+      .buildEstimatedVehicleJourney();
+
+    var wrapper = EstimatedVehicleJourneyWrapper.of(journey);
+
+    assertFalse(wrapper.isMonitored());
+    assertTrue(wrapper.isCancellation());
+  }
+
+  @Test
+  void propagateInvalidCallFailure() {
+    var journey = builder()
+      .withEstimatedCalls(calls -> calls.call("STOP_A").clearOrder())
+      .buildEstimatedVehicleJourney();
+
+    assertFailure(UpdateErrorType.MISSING_CALL_ORDER, () ->
+      EstimatedVehicleJourneyWrapper.of(journey)
+    );
+  }
+
+  /* Calls */
+
+  @Test
+  void calls() {
+    var journey = builder()
+      .withEstimatedCalls(calls -> calls.call("STOP_A").call("STOP_B"))
+      .buildEstimatedVehicleJourney();
+
+    var wrapper = EstimatedVehicleJourneyWrapper.of(journey);
+
+    assertEquals(
+      List.of("STOP_A", "STOP_B"),
+      wrapper.calls().stream().map(CallWrapper::getStopPointRef).toList()
+    );
+  }
+
+  @Test
+  void hasExtraCall() {
+    var withExtraCall = builder()
+      .withEstimatedCalls(calls -> calls.call("STOP_A").call("STOP_B").withIsExtraCall(true))
+      .buildEstimatedVehicleJourney();
+    assertTrue(EstimatedVehicleJourneyWrapper.of(withExtraCall).hasExtraCall());
+
+    var withoutExtraCall = builder()
+      .withEstimatedCalls(calls -> calls.call("STOP_A").call("STOP_B"))
+      .buildEstimatedVehicleJourney();
+    assertFalse(EstimatedVehicleJourneyWrapper.of(withoutExtraCall).hasExtraCall());
+  }
+
+  /* Journey status */
+
+  @Test
+  void journeyStatusFlags() {
+    var journey = builder()
+      .withCancellation(true)
+      .withIsExtraJourney(true)
+      .withPredictionInaccurate(true)
+      .buildEstimatedVehicleJourney();
+
+    var wrapper = EstimatedVehicleJourneyWrapper.of(journey);
+
+    assertTrue(wrapper.isMonitored());
+    assertTrue(wrapper.isCancellation());
+    assertTrue(wrapper.isExtraJourney());
+    assertTrue(wrapper.isPredictionInaccurate());
+  }
+
+  @Test
+  void journeyStatusFlagsDefaultToFalse() {
+    var wrapper = EstimatedVehicleJourneyWrapper.of(builder().buildEstimatedVehicleJourney());
+
+    assertFalse(wrapper.isCancellation());
+    assertFalse(wrapper.isExtraJourney());
+    assertFalse(wrapper.isPredictionInaccurate());
+  }
+
+  /* Trip identification */
+
+  @Test
+  void datedVehicleJourneyRef() {
+    var journey = builder().withDatedVehicleJourneyRef("DSJ:1").buildEstimatedVehicleJourney();
+
+    assertEquals("DSJ:1", EstimatedVehicleJourneyWrapper.of(journey).datedVehicleJourneyRef());
+  }
+
+  @Test
+  void estimatedVehicleJourneyCode() {
+    var journey = builder().withEstimatedVehicleJourneyCode("EVJ:1").buildEstimatedVehicleJourney();
+
+    assertEquals("EVJ:1", EstimatedVehicleJourneyWrapper.of(journey).estimatedVehicleJourneyCode());
+  }
+
+  @Test
+  void vehicleJourneyIdAndServiceDate() {
+    var journey = builder()
+      .withFramedVehicleJourneyRef(ref ->
+        ref.withVehicleJourneyRef("SJ:1").withServiceDate(LocalDate.of(2024, 5, 7))
+      )
+      .buildEstimatedVehicleJourney();
+
+    var result = EstimatedVehicleJourneyWrapper.of(journey).vehicleJourneyIdAndServiceDate();
+
+    assertEquals("SJ:1", result.vehicleJourneyId());
+    assertEquals("2024-05-07", result.serviceDate());
+  }
+
+  @Test
+  void internalPlanningCode() {
+    var journey = builder().withVehicleRef("VEHICLE:1").buildEstimatedVehicleJourney();
+
+    assertEquals("VEHICLE:1", EstimatedVehicleJourneyWrapper.of(journey).internalPlanningCode());
+  }
+
+  /* Replaced trips */
+
+  @Test
+  void replacedDatedVehicleJourneyRef() {
+    var journey = builder().withVehicleJourneyRef("REPLACED:1").buildEstimatedVehicleJourney();
+
+    assertEquals(
+      "REPLACED:1",
+      EstimatedVehicleJourneyWrapper.of(journey).replacedDatedVehicleJourneyRef()
+    );
+  }
+
+  @Test
+  void additionalReplacedDatedVehicleJourneyRefs() {
+    var journey = builder().buildEstimatedVehicleJourney();
+    journey
+      .getAdditionalVehicleJourneyReves()
+      .add(
+        new SiriEtBuilder.FramedVehicleRefBuilder()
+          .withVehicleJourneyRef("REPLACED:2")
+          .withServiceDate(LocalDate.of(2024, 5, 7))
+          .build()
+      );
+
+    var result = EstimatedVehicleJourneyWrapper.of(
+      journey
+    ).additionalReplacedDatedVehicleJourneyRefs();
+
+    assertEquals(1, result.size());
+    assertEquals("REPLACED:2", result.getFirst().vehicleJourneyId());
+    assertEquals("2024-05-07", result.getFirst().serviceDate());
+  }
+
+  @Test
+  void externalLineRef() {
+    var journey = builder().withExternalLineRef("LINE:ext").buildEstimatedVehicleJourney();
+
+    assertEquals("LINE:ext", EstimatedVehicleJourneyWrapper.of(journey).externalLineRef());
+  }
+
+  /* Line, operator and mode */
+
+  @Test
+  void lineAndOperatorRef() {
+    var journey = builder()
+      .withLineRef("LINE:1")
+      .withOperatorRef("OPERATOR:1")
+      .buildEstimatedVehicleJourney();
+
+    var wrapper = EstimatedVehicleJourneyWrapper.of(journey);
+
+    assertEquals("LINE:1", wrapper.lineRef());
+    assertEquals("OPERATOR:1", wrapper.operatorRef());
+  }
+
+  @Test
+  void vehicleModes() {
+    var rail = builder()
+      .withVehicleMode(VehicleModesEnumeration.RAIL)
+      .buildEstimatedVehicleJourney();
+    var railWrapper = EstimatedVehicleJourneyWrapper.of(rail);
+    assertTrue(railWrapper.isRail());
+    assertEquals(List.of(VehicleModesEnumeration.RAIL), railWrapper.vehicleModes());
+
+    var bus = builder().withVehicleMode(VehicleModesEnumeration.BUS).buildEstimatedVehicleJourney();
+    assertFalse(EstimatedVehicleJourneyWrapper.of(bus).isRail());
+  }
+
+  /* Descriptive information */
+
+  @Test
+  void descriptiveInformation() {
+    var journey = builder()
+      .withPublishedLineName("Line 1")
+      .withDestinationName("Central Station")
+      .withOccupancy(OccupancyEnumeration.FULL)
+      .buildEstimatedVehicleJourney();
+
+    var wrapper = EstimatedVehicleJourneyWrapper.of(journey);
+
+    assertEquals("Line 1", wrapper.publishedLineName());
+    assertEquals("Central Station", wrapper.destinationName());
+    assertEquals(OccupancyEnumeration.FULL, wrapper.occupancy());
+    assertEquals("DATASOURCE", wrapper.dataSource());
+  }
+
+  /* Null-safety of optional references */
+
+  @Test
+  void accessorsAreNullSafeOnMinimalJourney() {
+    var wrapper = EstimatedVehicleJourneyWrapper.of(builder().buildEstimatedVehicleJourney());
+
+    assertNull(wrapper.lineRef());
+    assertNull(wrapper.operatorRef());
+    assertNull(wrapper.datedVehicleJourneyRef());
+    assertNull(wrapper.estimatedVehicleJourneyCode());
+    assertNull(wrapper.vehicleJourneyIdAndServiceDate());
+    assertNull(wrapper.internalPlanningCode());
+    assertNull(wrapper.replacedDatedVehicleJourneyRef());
+    assertNull(wrapper.externalLineRef());
+    assertNull(wrapper.occupancy());
+    // Natural-language accessors default to an empty string rather than null.
+    assertEquals("", wrapper.publishedLineName());
+    assertEquals("", wrapper.destinationName());
+    assertTrue(wrapper.calls().isEmpty());
+    assertFalse(wrapper.hasExtraCall());
+    assertTrue(wrapper.additionalReplacedDatedVehicleJourneyRefs().isEmpty());
+    assertTrue(wrapper.vehicleModes().isEmpty());
+    assertFalse(wrapper.isRail());
+  }
+
+  private static SiriEtBuilder builder() {
+    return new SiriEtBuilder(TIME_PARSER);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
@@ -110,10 +110,8 @@ class SiriFuzzyTripMatcherTest implements RealtimeTestConstants {
     throws UpdateException {
     var transitService = env.transitService();
     var fuzzyMatcher = new SiriFuzzyTripMatcher(transitService);
-    var calls = CallWrapper.of(evj);
     return fuzzyMatcher.match(
-      evj,
-      calls,
+      EstimatedVehicleJourneyWrapper.of(evj),
       new EntityResolver(transitService, env.feedId()),
       transitService::findTimetable,
       transitService::findNewTripPatternForModifiedTrip

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -208,7 +208,7 @@ class ExtraJourneyTest implements RealtimeTestConstants {
 
     var result = siri.applyEstimatedTimetable(updates);
 
-    assertEquals(0, result.successful());
+    assertSuccess(result);
     assertFailure(UpdateErrorType.NOT_MONITORED, result);
     assertNull(
       env.transitService().getTrip(id(ADDED_TRIP_ID)),

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
@@ -194,6 +195,49 @@ class ExtraJourneyTest implements RealtimeTestConstants {
     var result = siri.applyEstimatedTimetable(createExtraJourney);
     assertEquals(0, result.successful());
     assertFailure(UpdateErrorType.NEGATIVE_HOP_TIME, result);
+  }
+
+  @Test
+  void testRejectUnmonitoredExtraJourney() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = createValidAddedJourney(siri)
+      .withMonitored(false)
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertEquals(0, result.successful());
+    assertFailure(UpdateErrorType.NOT_MONITORED, result);
+    assertNull(
+      env.transitService().getTrip(id(ADDED_TRIP_ID)),
+      "An unmonitored extra journey must not be added"
+    );
+  }
+
+  /**
+   * The not-monitored validation is overridden for cancellations: an extra journey reported as not
+   * monitored but cancelled is still processed, so the trip is added (in cancelled state) rather
+   * than rejected. This is the counterpart to {@link #testRejectUnmonitoredExtraJourney()}.
+   */
+  @Test
+  void testAcceptUnmonitoredCancelledExtraJourney() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = createValidAddedJourney(siri)
+      .withMonitored(false)
+      .withCancellation(true)
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertSuccess(result);
+    assertNotNull(
+      env.transitService().getTrip(id(ADDED_TRIP_ID)),
+      "An unmonitored but cancelled extra journey must still be added"
+    );
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -208,7 +208,6 @@ class ExtraJourneyTest implements RealtimeTestConstants {
 
     var result = siri.applyEstimatedTimetable(updates);
 
-    assertSuccess(result);
     assertFailure(UpdateErrorType.NOT_MONITORED, result);
     assertNull(
       env.transitService().getTrip(id(ADDED_TRIP_ID)),


### PR DESCRIPTION
## Summary

Introduces `EstimatedVehicleJourneyWrapper`, a wrapper around the JAXB `EstimatedVehicleJourney`
that also owns its parsed and validated `CallWrapper`s, for the SIRI-ET real-time trip updater.

This change:

- Collapses the pair of parameters `(journey, calls)` into a single object, mirroring the existing
  `CallWrapper` pattern (private constructor + static `of` factory, immutable, validation at
  construction).
- **Moves journey behaviour and JAXB navigation into the wrapper**. The raw `EstimatedVehicleJourney` is never handed out
- **Encapsulates `FramedVehicleJourneyRef`** behind a small `VehicleJourneyIdAndServiceDate` value
  type (it carries two values: the service journey id and the service date).
- **Validates the not-monitored invariant at construction**, mirroring `CallWrapper.of`, so an
  unmonitored journey (that is not a cancellation) can no longer be wrapped.

### Behaviour

This is a structural refactor. One intentional behavioural nuance: the not-monitored rejection
previously lived in the `TRIP_UPDATE` and `EXTRA_CALL` handlers; moving it to construction means it
now applies uniformly (including the replacement-departure path) and the resulting `NOT_MONITORED`
error no longer carries the resolved trip id (it is raised before the trip is resolved). The error
type and rejection outcome are unchanged.


## Issue

No

## Unit tests

Added

## Documentation
No

## Changelog
skip

## Follow-up

- Both CallWrapper and EstimatedVehicleJourneyWrapper expose JAXB enumerations. The JAXB enumerations should be encapsulated in the wrappers, and the wrappers should expose OTP enumerations.
- EstimatedVehicleJourneyCodeAdapter should be encapsulated in EstimatedVehicleJourneyWrapper #7775
- UpdateError should be extended to support, in addition to tripID, other types of trip identification, since tripId may not be available when validation is performed early (same issue with CallWrapper validation) #7773