### PR TITLE
Log a trip identifier for SIRI realtime errors raised before trip resolution

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/spi/UpdateError.java
+++ b/application/src/main/java/org/opentripplanner/updater/spi/UpdateError.java
@@ -11,15 +11,23 @@ public record UpdateError(
   @Nullable FeedScopedId tripId,
   UpdateErrorType errorType,
   @Nullable Integer stopIndex,
-  @Nullable String producer
+  @Nullable String producer,
+  /**
+   * A best-effort, human-readable trip identifier used for logging when the trip could not be
+   * resolved to a {@link FeedScopedId}, for example because the failure was raised during parsing
+   * or validation, before the trip was resolved. It typically holds the raw reference carried by
+   * the realtime message.
+   */
+  @Nullable String tripReference
 ) {
   public String debugId() {
-    if (tripId == null) {
+    var id = tripId != null ? tripId.toString() : tripReference;
+    if (id == null) {
       return "no trip id";
     } else if (stopIndex == null) {
-      return tripId.toString();
+      return id;
     } else {
-      return "%s{stopIndex=%s}".formatted(tripId, stopIndex);
+      return "%s{stopIndex=%s}".formatted(id, stopIndex);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/spi/UpdateException.java
+++ b/application/src/main/java/org/opentripplanner/updater/spi/UpdateException.java
@@ -15,30 +15,36 @@ public class UpdateException extends RuntimeException {
   @Nullable
   private final Integer stopIndex;
 
+  /// A best-effort trip identifier used for logging when no resolved [FeedScopedId] is available.
+  @Nullable
+  private final String tripReference;
+
   private UpdateException(
     @Nullable FeedScopedId tripId,
     UpdateErrorType errorType,
-    @Nullable Integer stopIndex
+    @Nullable Integer stopIndex,
+    @Nullable String tripReference
   ) {
     this.tripId = tripId;
     this.errorType = errorType;
     this.stopIndex = stopIndex;
+    this.tripReference = tripReference;
   }
 
   public static UpdateException of(@Nullable FeedScopedId tripId, UpdateErrorType errorType) {
-    return new UpdateException(tripId, errorType, null);
+    return new UpdateException(tripId, errorType, null, null);
   }
 
   public static UpdateException ofStopIndex(UpdateErrorType updateErrorType, int stopIndex) {
-    return new UpdateException(null, updateErrorType, stopIndex);
+    return new UpdateException(null, updateErrorType, stopIndex, null);
   }
 
   public static UpdateException noTripId(UpdateErrorType errorType) {
-    return new UpdateException(null, errorType, null);
+    return new UpdateException(null, errorType, null, null);
   }
 
   public static UpdateException of(UpdateErrorType updateErrorType) {
-    return new UpdateException(null, updateErrorType, null);
+    return new UpdateException(null, updateErrorType, null, null);
   }
 
   public static UpdateException of(
@@ -46,12 +52,18 @@ public class UpdateException extends RuntimeException {
     UpdateErrorType updateErrorType,
     int stopIndex
   ) {
-    return new UpdateException(tripId, updateErrorType, stopIndex);
+    return new UpdateException(tripId, updateErrorType, stopIndex, null);
   }
 
   /// Gives an updated exception with the specified tripId
   public UpdateException withTripId(FeedScopedId tripId) {
-    return new UpdateException(tripId, this.errorType, this.stopIndex);
+    return new UpdateException(tripId, this.errorType, this.stopIndex, this.tripReference);
+  }
+
+  /// Gives an updated exception with a best-effort trip identifier for logging, used when the trip
+  /// could not be resolved to a [FeedScopedId].
+  public UpdateException withTripReference(@Nullable String tripReference) {
+    return new UpdateException(this.tripId, this.errorType, this.stopIndex, tripReference);
   }
 
   /// The index of the GTFS-RT stop time update or SIRI call in the list of updates, which
@@ -66,10 +78,10 @@ public class UpdateException extends RuntimeException {
   }
 
   public UpdateError toError() {
-    return new UpdateError(tripId, errorType, stopIndex, null);
+    return new UpdateError(tripId, errorType, stopIndex, null, tripReference);
   }
 
   public UpdateError toError(String producer) {
-    return new UpdateError(tripId, errorType, stopIndex, producer);
+    return new UpdateError(tripId, errorType, stopIndex, producer, tripReference);
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/DebugString.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/DebugString.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.updater.trip.siri;
 
+import javax.annotation.Nullable;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 import uk.org.siri.siri21.DataFrameRefStructure;
 import uk.org.siri.siri21.DatedVehicleJourneyRef;
 import uk.org.siri.siri21.EstimatedVehicleJourney;
+import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
 import uk.org.siri.siri21.LineRef;
 import uk.org.siri.siri21.OperatorRefStructure;
 import uk.org.siri.siri21.VehicleRef;
@@ -12,6 +14,40 @@ import uk.org.siri.siri21.VehicleRef;
  * Create pretty strings for various SIRI elements, which is useful for debug printing.
  */
 public class DebugString {
+
+  /**
+   * A compact, best-effort identifier of the trip a journey refers to, used for logging when the
+   * trip could not be resolved to an internal id (for example because the failure was raised before
+   * resolution). It mirrors the reference chain that {@code EntityResolver} uses to resolve the
+   * trip: the framed vehicle journey (service journey id and service date), the dated vehicle
+   * journey, the estimated vehicle journey code (added trips), and finally the vehicle ref (used as
+   * the fuzzy matching key).
+   *
+   * @return the identifier, or {@code null} if the journey carries no usable reference
+   */
+  @Nullable
+  static String tripReference(EstimatedVehicleJourney journey) {
+    if (journey == null) {
+      return null;
+    }
+    FramedVehicleJourneyRefStructure framed = journey.getFramedVehicleJourneyRef();
+    if (framed != null && framed.getDatedVehicleJourneyRef() != null) {
+      var dataFrameRef = framed.getDataFrameRef();
+      return dataFrameRef != null
+        ? "%s (%s)".formatted(framed.getDatedVehicleJourneyRef(), dataFrameRef.getValue())
+        : framed.getDatedVehicleJourneyRef();
+    }
+    if (journey.getDatedVehicleJourneyRef() != null) {
+      return journey.getDatedVehicleJourneyRef().getValue();
+    }
+    if (journey.getEstimatedVehicleJourneyCode() != null) {
+      return journey.getEstimatedVehicleJourneyCode();
+    }
+    if (journey.getVehicleRef() != null) {
+      return journey.getVehicleRef().getValue();
+    }
+    return null;
+  }
 
   static String of(EstimatedVehicleJourney estimatedVehicleJourney) {
     if (estimatedVehicleJourney == null) {

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -118,7 +118,11 @@ public class SiriRealTimeTripUpdateAdapter {
           try {
             successes.add(apply(journey, transitEditorService, fuzzyTripMatcher, entityResolver));
           } catch (UpdateException e) {
-            errors.add(e.toError(journey.getDataSource()));
+            errors.add(
+              e
+                .withTripReference(DebugString.tripReference(journey))
+                .toError(journey.getDataSource())
+            );
           }
         }
       }

--- a/application/src/test/java/org/opentripplanner/updater/spi/UpdateErrorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/spi/UpdateErrorTest.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.updater.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+
+class UpdateErrorTest {
+
+  private static final FeedScopedId TRIP_ID = new FeedScopedId("F", "Trip1");
+
+  @Test
+  void resolvedTripIdIsPreferred() {
+    var error = new UpdateError(TRIP_ID, UpdateErrorType.TRIP_NOT_FOUND, null, null, "ignored-ref");
+    assertEquals("F:Trip1", error.debugId());
+  }
+
+  @Test
+  void fallBackToTripReferenceWhenTripIdIsMissing() {
+    var error = new UpdateError(
+      null,
+      UpdateErrorType.NOT_MONITORED,
+      null,
+      null,
+      "SJ:1 (2026-06-29)"
+    );
+    assertEquals("SJ:1 (2026-06-29)", error.debugId());
+  }
+
+  @Test
+  void noTripIdWhenNeitherIsAvailable() {
+    var error = new UpdateError(null, UpdateErrorType.NOT_MONITORED, null, null, null);
+    assertEquals("no trip id", error.debugId());
+  }
+
+  @Test
+  void stopIndexIsAppendedToResolvedTripId() {
+    var error = new UpdateError(TRIP_ID, UpdateErrorType.INVALID_ARRIVAL_TIME, 3, null, null);
+    assertEquals("F:Trip1{stopIndex=3}", error.debugId());
+  }
+
+  @Test
+  void stopIndexIsAppendedToTripReference() {
+    var error = new UpdateError(null, UpdateErrorType.INVALID_ARRIVAL_TIME, 3, null, "SJ:1");
+    assertEquals("SJ:1{stopIndex=3}", error.debugId());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/DebugStringTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/DebugStringTest.java
@@ -1,0 +1,79 @@
+package org.opentripplanner.updater.trip.siri;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.org.siri.siri21.DataFrameRefStructure;
+import uk.org.siri.siri21.DatedVehicleJourneyRef;
+import uk.org.siri.siri21.EstimatedVehicleJourney;
+import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
+import uk.org.siri.siri21.VehicleRef;
+
+class DebugStringTest {
+
+  @Test
+  void framedVehicleJourneyRefWithServiceDateIsPreferred() {
+    var journey = new EstimatedVehicleJourney();
+    journey.setFramedVehicleJourneyRef(framed("SJ:1", "2026-06-29"));
+    journey.setDatedVehicleJourneyRef(datedRef("DSJ:1"));
+    assertEquals("SJ:1 (2026-06-29)", DebugString.tripReference(journey));
+  }
+
+  @Test
+  void framedVehicleJourneyRefWithoutServiceDate() {
+    var journey = new EstimatedVehicleJourney();
+    journey.setFramedVehicleJourneyRef(framed("SJ:1", null));
+    assertEquals("SJ:1", DebugString.tripReference(journey));
+  }
+
+  @Test
+  void fallBackToDatedVehicleJourneyRef() {
+    var journey = new EstimatedVehicleJourney();
+    journey.setDatedVehicleJourneyRef(datedRef("DSJ:1"));
+    assertEquals("DSJ:1", DebugString.tripReference(journey));
+  }
+
+  @Test
+  void fallBackToEstimatedVehicleJourneyCode() {
+    var journey = new EstimatedVehicleJourney();
+    journey.setEstimatedVehicleJourneyCode("EVJ:1");
+    assertEquals("EVJ:1", DebugString.tripReference(journey));
+  }
+
+  @Test
+  void fallBackToVehicleRef() {
+    var journey = new EstimatedVehicleJourney();
+    journey.setVehicleRef(vehicleRef("2051"));
+    assertEquals("2051", DebugString.tripReference(journey));
+  }
+
+  @Test
+  void noReferenceAtAll() {
+    assertNull(DebugString.tripReference(new EstimatedVehicleJourney()));
+    assertNull(DebugString.tripReference(null));
+  }
+
+  private static FramedVehicleJourneyRefStructure framed(String vehicleJourneyRef, String date) {
+    var framed = new FramedVehicleJourneyRefStructure();
+    framed.setDatedVehicleJourneyRef(vehicleJourneyRef);
+    if (date != null) {
+      var dataFrameRef = new DataFrameRefStructure();
+      dataFrameRef.setValue(date);
+      framed.setDataFrameRef(dataFrameRef);
+    }
+    return framed;
+  }
+
+  private static DatedVehicleJourneyRef datedRef(String value) {
+    var ref = new DatedVehicleJourneyRef();
+    ref.setValue(value);
+    return ref;
+  }
+
+  private static VehicleRef vehicleRef(String value) {
+    var ref = new VehicleRef();
+    ref.setValue(value);
+    return ref;
+  }
+}


### PR DESCRIPTION
## Summary

Several SIRI-ET realtime update errors are raised _before_ the trip is resolved to a
`FeedScopedId` — the `CallWrapper` parse/validation errors (`EMPTY_STOP_POINT_REF`,
`MISSING_CALL_ORDER`, `MIXED_CALL_ORDER_AND_VISIT_NUMBER`), the fuzzy-match failures, and
`TRIP_NOT_FOUND`. These were logged with `no trip id` in the per-feed error summary
(`ResultLogger`), even though the SIRI message itself carries a usable reference.

This change lets `UpdateError` carry that reference:

- Adds an optional, best-effort `tripReference` to `UpdateError`; `debugId()` now falls back to it,
  with precedence **resolved `tripId` → `tripReference` → `no trip id`**.
- Adds `UpdateException#withTripReference(String)`, mirroring the existing
  `withTripId(FeedScopedId)`.
- Adds `DebugString#tripReference(EstimatedVehicleJourney)`, a compact identifier following the same
  chain `EntityResolver` uses to resolve the trip: framed vehicle journey (service journey id +
  service date) → dated vehicle journey → estimated vehicle journey code → vehicle ref.
- Attaches the reference once, centrally, in the SIRI adapter's `catch`, so the resolved id still
  wins when present and the fix applies uniformly to every error raised for a journey.

### Behaviour

Error logging only. Per-feed error summaries that previously read `[... TRIP_NOT_FOUND]: [no trip
id]` now read e.g. `[... TRIP_NOT_FOUND]: [ENTUR:ServiceJourney:1 (2026-06-29)]`. The error types
and rejection outcomes are unchanged.

## Issue

No

## Unit tests

Added `UpdateErrorTest` (`debugId()` precedence) and `DebugStringTest` (the reference chain).

## Documentation

No

## Changelog

skip