### PR TITLE
Add extra/new trips to RAPTOR even when original pattern is not scheduled on the new service date

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitData.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitData.java
@@ -180,7 +180,11 @@ public class RaptorTransitData {
     LocalDate date,
     List<TripPatternForDate> tripPatternForDates
   ) {
-    this.tripPatternsRunningOnDate.replace(date, tripPatternForDates);
+    if (tripPatternForDates.isEmpty()) {
+      this.tripPatternsRunningOnDate.remove(date);
+    } else {
+      this.tripPatternsRunningOnDate.put(date, tripPatternForDates);
+    }
   }
 
   public void setConstrainedTransfers(ConstrainedTransfersForPatterns constrainedTransfers) {

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedOnServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedOnServiceDateTest.java
@@ -63,8 +63,7 @@ class AddedOnServiceDateTest implements RealtimeTestConstants {
     var dates = env.transitService().getTripCalendars().listServiceDates(trip.getServiceId());
     assertThat(dates).containsExactly(date);
 
-    // this currently doesn't work because of a bug in RaptorTransitData
-    // assertThat(env.raptorData(date).summarizePatterns()).contains("F:AddedTrip::001:RT[A U]");
+    assertThat(env.raptorData(date).summarizePatterns()).contains("F:AddedTrip::001:RT[A U]");
   }
 
   private static List<LocalDate> outsidePeriod() {

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancelAfterPatternChangeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancelAfterPatternChangeTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.updater.trip.gtfs.moduletests.cancellation;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -85,5 +86,7 @@ class CancelAfterPatternChangeTest implements RealtimeTestConstants {
       "C U | A 0:01 0:01:01 | B 0:01:10 0:01:11 | C 0:01:20 0:01:21",
       tripData.showTimetable()
     );
+
+    assertThat(env.raptorData().summarizePatterns()).containsExactly("F:Pattern1[C U]");
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CanceledTripTest.java
@@ -39,5 +39,7 @@ public class CanceledTripTest implements RealtimeTestConstants {
     var trip = canceled.getFirst();
     assertEquals(id(TRIP_1_ID), trip.getTrip().getId());
     assertEquals(env.defaultServiceDate(), trip.getServiceDate());
+
+    assertThat(env.raptorData().summarizePatterns()).containsExactly("F:Pattern1[C U]");
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyOnServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyOnServiceDateTest.java
@@ -7,7 +7,6 @@ import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSucce
 
 import java.time.LocalDate;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model.TransitTestEnvironment;
 import org.opentripplanner.transit.model.TransitTestEnvironmentBuilder;
@@ -21,8 +20,6 @@ import org.opentripplanner.updater.trip.siri.SiriTestHelper;
 import uk.org.siri.siri21.EstimatedTimetableDeliveryStructure;
 
 /// This test adds an extra journey on a service date where the original pattern is not running.
-/// It correctly ends up in the API queries but the RAPTOR transit data drops it.
-@Disabled("Not supported right now but should be fixed")
 class ExtraJourneyOnServiceDateTest implements RealtimeTestConstants {
 
   private static final LocalDate SERVICE_DATE = LocalDate.of(2026, 6, 23);


### PR DESCRIPTION
### Summary

`RaptorTransitData.replaceTripPatternsForDate()` used `Map.replace()`, which is a no-op
when the key doesn't exist. So extra journeys / added trips for service dates where the
original pattern has no scheduled runs were silently discarded from the Raptor index,
making them invisible to routing even though the `TimetableSnapshot` and departure board
APIs reflected them correctly.

Fix: use `put()` instead (removes the entry when the list is empty, to keep the map clean).

Closes #7755

### Unit tests

- Re-enabled `ExtraJourneyOnServiceDateTest` (SIRI extra journey on a date the pattern
  doesn't run) — was previously `@Disabled` with the note "Not supported right now but
  should be fixed".
- Re-enabled the `ADDED_DATE` case in `AddedOnServiceDateTest` (GTFS-RT NEW trip on a
  date between the pattern's start and end dates where it has no service).

Both tests now pass.

### Documentation

No public API or configuration changes.