### PR TITLE
Add tests for `WalkableAreaBuilder`

### DIFF
--- a/application/src/test-fixtures/java/org/opentripplanner/osm/TestOsmProvider.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/osm/TestOsmProvider.java
@@ -105,7 +105,10 @@ public class TestOsmProvider implements OsmProvider {
       return addAreaFromNodes(way -> way.withTag("highway", "pedestrian"), id, areaNodes);
     }
 
-    public Builder addAreaFromNodes(Consumer<OsmWayBuilder> areaBuilderConsumer, List<OsmNode> areaNodes) {
+    public Builder addAreaFromNodes(
+      Consumer<OsmWayBuilder> areaBuilderConsumer,
+      List<OsmNode> areaNodes
+    ) {
       return addAreaFromNodes(areaBuilderConsumer, counter.incrementAndGet(), areaNodes);
     }
 

--- a/application/src/test-fixtures/java/org/opentripplanner/osm/TestOsmProvider.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/osm/TestOsmProvider.java
@@ -102,15 +102,25 @@ public class TestOsmProvider implements OsmProvider {
     }
 
     public Builder addAreaFromNodes(long id, List<OsmNode> areaNodes) {
+      return addAreaFromNodes(way -> way.withTag("highway", "pedestrian"), id, areaNodes);
+    }
+
+    public Builder addAreaFromNodes(Consumer<OsmWayBuilder> areaBuilderConsumer, List<OsmNode> areaNodes) {
+      return addAreaFromNodes(areaBuilderConsumer, counter.incrementAndGet(), areaNodes);
+    }
+
+    public Builder addAreaFromNodes(
+      Consumer<OsmWayBuilder> areaBuilderConsumer,
+      long id,
+      List<OsmNode> areaNodes
+    ) {
       this.nodes.addAll(areaNodes);
       var nodeIds = areaNodes.stream().map(OsmEntity::getId).toList();
 
-      var areaBuilder = OsmWay.of()
-        .withId(id)
-        .withTag("area", "yes")
-        .withTag("highway", "pedestrian");
+      var areaBuilder = OsmWay.of().withId(id).withTag("area", "yes");
       nodeIds.forEach(areaBuilder::addNodeRef);
       areaBuilder.addNodeRef(nodeIds.getFirst());
+      areaBuilderConsumer.accept(areaBuilder);
       var area = areaBuilder.build();
 
       this.ways.add(area);

--- a/application/src/test-fixtures/java/org/opentripplanner/osm/model/RelationBuilder.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/osm/model/RelationBuilder.java
@@ -5,10 +5,7 @@ public class RelationBuilder {
   private final OsmRelationBuilder builder = OsmRelation.of();
 
   public static RelationBuilder ofMultiPolygon() {
-    var builder = new RelationBuilder();
-    builder.withTag("type", "multipolygon");
-    builder.withTag("highway", "pedestrian");
-    return builder;
+    return ofType("multipolygon");
   }
 
   public static RelationBuilder ofTurnRestriction(String restrictionType) {
@@ -32,6 +29,14 @@ public class RelationBuilder {
 
   public RelationBuilder withWayMember(long id, String role) {
     return withMember(id, role, OsmMemberType.WAY);
+  }
+
+  public RelationBuilder withOuterWay(long id) {
+    return withWayMember(id, "outer");
+  }
+
+  public RelationBuilder withInnerWay(long id) {
+    return withWayMember(id, "inner");
   }
 
   public RelationBuilder withNodeMember(long id) {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/AreaWithoutVisibilityTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/AreaWithoutVisibilityTest.java
@@ -28,13 +28,14 @@ class AreaWithoutVisibilityTest {
     var br = node(3, new WgsCoordinate(0, 0.001));
     var area = List.of(bl, tl, tr, br);
 
-    // Footway that touches corner bl — would normally make bl a startingNode,
-    // but with visibility disabled there is no visibility graph at all.
-    var outside = node(4, new WgsCoordinate(-0.001, 0));
+    // Footways that touches corner bl and tr
+    var outside1 = node(4, new WgsCoordinate(-0.001, 0));
+    var outside2 = node(5, new WgsCoordinate(0.002, 0));
 
     var provider = TestOsmProvider.of()
       .addAreaFromNodes(area)
-      .addWayFromNodes(way -> way.withTag("highway", "footway"), outside, bl)
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), outside1, bl)
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), outside2, tr)
       .build();
 
     var graph = new Graph();
@@ -50,9 +51,12 @@ class AreaWithoutVisibilityTest {
     assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
       .that(summarizer.summarizeEdges())
       .containsExactly(
-        // footway from outside to bl
+        // footway from outside1 to bl
         "(0,0) → (-0.001,0) PEDESTRIAN ♿✅",
         "(-0.001,0) → (0,0) PEDESTRIAN ♿✅",
+        // footway from outside2 to tr
+        "(0.001,0.001) → (0.002,0) PEDESTRIAN ♿✅",
+        "(0.002,0) → (0.001,0.001) PEDESTRIAN ♿✅",
         // ring: all 4 segments × 2 directions, no visibility edges added
         "(0,0) → (0.001,0) PEDESTRIAN ♿✅",
         "(0.001,0) → (0,0) PEDESTRIAN ♿✅",

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/AreaWithoutVisibilityTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/AreaWithoutVisibilityTest.java
@@ -1,0 +1,67 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Tests the {@code buildWithoutVisibility} code path, activated by {@code withAreaVisibility(false)}.
+ *
+ * <p>Without visibility computation there is no pruning: every ring segment survives. No
+ * cross-area visibility edges are ever added, so the only graph edges are the ring boundary
+ * plus any non-area ways that happen to share nodes with the area.
+ */
+class AreaWithoutVisibilityTest {
+
+  @Test
+  void ringEdgesOnlyWhenVisibilityDisabled() {
+    var bl = node(0, new WgsCoordinate(0, 0));
+    var tl = node(1, new WgsCoordinate(0.001, 0));
+    var tr = node(2, new WgsCoordinate(0.001, 0.001));
+    var br = node(3, new WgsCoordinate(0, 0.001));
+    var area = List.of(bl, tl, tr, br);
+
+    // Footway that touches corner bl — would normally make bl a startingNode,
+    // but with visibility disabled there is no visibility graph at all.
+    var outside = node(4, new WgsCoordinate(-0.001, 0));
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(area)
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), outside, bl)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(false)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly(
+        // footway from outside to bl
+        "(0,0) → (-0.001,0) PEDESTRIAN ♿✅",
+        "(-0.001,0) → (0,0) PEDESTRIAN ♿✅",
+        // ring: all 4 segments × 2 directions, no visibility edges added
+        "(0,0) → (0.001,0) PEDESTRIAN ♿✅",
+        "(0.001,0) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,0.001) PEDESTRIAN ♿✅",
+        "(0,0.001) → (0,0) PEDESTRIAN ♿✅",
+        "(0.001,0) → (0.001,0.001) PEDESTRIAN ♿✅",
+        "(0.001,0.001) → (0.001,0) PEDESTRIAN ♿✅",
+        "(0.001,0.001) → (0,0.001) PEDESTRIAN ♿✅",
+        "(0,0.001) → (0.001,0.001) PEDESTRIAN ♿✅"
+      );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcaveHoleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcaveHoleTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.osm.model.NodeBuilder.node;
 
@@ -11,6 +12,7 @@ import org.opentripplanner.osm.TestOsmProvider;
 import org.opentripplanner.osm.model.RelationBuilder;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.vertex.VertexLabel;
 
@@ -58,6 +60,7 @@ class ConcaveHoleTest {
     var holeId = 1001;
 
     var relation = RelationBuilder.ofMultiPolygon()
+      .withTag("highway", "pedestrian")
       .withWayMember(outerRingId, "outer")
       .withWayMember(holeId, "inner")
       .build();
@@ -71,18 +74,36 @@ class ConcaveHoleTest {
       .build();
 
     var graph = new Graph();
-    var osmModule = OsmModuleTestFactory.of(provider)
+
+    OsmModuleTestFactory.of(provider)
       .withGraph(graph)
       .builder()
       .withAreaVisibility(true)
       .withMaxAreaNodes(10)
-      .build();
+      .build().buildGraph();
 
-    osmModule.buildGraph();
+    var summarizer = new GraphSummarizer(graph);
 
-    assertEquals(28, graph.getEdgesOfType(AreaEdge.class).size(), "Incorrect number of edges");
-
-    var vertex = graph.getVertex(VertexLabel.osm(visibilityNodeId));
-    assertThat(vertex.getOutgoing()).hasSize(4);
+assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly(
+        // stair edges — wheelchair-inaccessible, as expected for steps
+        "(-1,2.5) → (2,2.5) PEDESTRIAN ♿❌",
+        "(2,2.5) → (-1,2.5) PEDESTRIAN ♿❌",
+        // platform ring edges (boundary of the square)
+        "(0,0) → (5,0) PEDESTRIAN ♿✅",
+        "(5,0) → (0,0) PEDESTRIAN ♿✅",
+        "(5,0) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (5,0) PEDESTRIAN ♿✅",
+        "(5,5) → (0,5) PEDESTRIAN ♿✅",
+        "(0,5) → (5,5) PEDESTRIAN ♿✅",
+        "(0,5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,5) PEDESTRIAN ♿✅",
+        // stairTop connected to visible platform corners via visibility edges
+        "(2,2.5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (2,2.5) PEDESTRIAN ♿✅",
+        "(2,2.5) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (2,2.5) PEDESTRIAN ♿✅"
+      );
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcaveHoleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcaveHoleTest.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.osm.model.NodeBuilder.node;
 
 import java.util.List;
@@ -13,8 +11,6 @@ import org.opentripplanner.osm.model.RelationBuilder;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.graph.summary.GraphSummarizer;
-import org.opentripplanner.street.model.edge.AreaEdge;
-import org.opentripplanner.street.model.vertex.VertexLabel;
 
 /**
  * Checks that concave areas of inner rings/holes in multipolygons are connected to the outer ring.
@@ -80,30 +76,51 @@ class ConcaveHoleTest {
       .builder()
       .withAreaVisibility(true)
       .withMaxAreaNodes(10)
-      .build().buildGraph();
+      .build()
+      .buildGraph();
 
     var summarizer = new GraphSummarizer(graph);
 
-assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
       .that(summarizer.summarizeEdges())
       .containsExactly(
-        // stair edges — wheelchair-inaccessible, as expected for steps
-        "(-1,2.5) → (2,2.5) PEDESTRIAN ♿❌",
-        "(2,2.5) → (-1,2.5) PEDESTRIAN ♿❌",
-        // platform ring edges (boundary of the square)
+        // connecting ways from outside into two outer-ring corners
+        "(0,0) → (-1,0) PEDESTRIAN ♿✅",
+        "(-1,0) → (0,0) PEDESTRIAN ♿✅",
+        "(5,5) → (6,5) PEDESTRIAN ♿✅",
+        "(6,5) → (5,5) PEDESTRIAN ♿✅",
+        // outer ring (4 sides × 2 directions)
         "(0,0) → (5,0) PEDESTRIAN ♿✅",
         "(5,0) → (0,0) PEDESTRIAN ♿✅",
-        "(5,0) → (5,5) PEDESTRIAN ♿✅",
-        "(5,5) → (5,0) PEDESTRIAN ♿✅",
-        "(5,5) → (0,5) PEDESTRIAN ♿✅",
-        "(0,5) → (5,5) PEDESTRIAN ♿✅",
-        "(0,5) → (0,0) PEDESTRIAN ♿✅",
         "(0,0) → (0,5) PEDESTRIAN ♿✅",
-        // stairTop connected to visible platform corners via visibility edges
-        "(2,2.5) → (0,0) PEDESTRIAN ♿✅",
-        "(0,0) → (2,2.5) PEDESTRIAN ♿✅",
-        "(2,2.5) → (5,5) PEDESTRIAN ♿✅",
-        "(5,5) → (2,2.5) PEDESTRIAN ♿✅"
+        "(0,5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,5) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (0,5) PEDESTRIAN ♿✅",
+        "(5,5) → (5,0) PEDESTRIAN ♿✅",
+        "(5,0) → (5,5) PEDESTRIAN ♿✅",
+        // concave (comb-shaped) hole ring (8 sides × 2 directions)
+        "(1,1) → (4,1) PEDESTRIAN ♿✅",
+        "(4,1) → (1,1) PEDESTRIAN ♿✅",
+        "(1,1) → (1,4) PEDESTRIAN ♿✅",
+        "(1,4) → (1,1) PEDESTRIAN ♿✅",
+        "(1,4) → (4,4) PEDESTRIAN ♿✅",
+        "(4,4) → (1,4) PEDESTRIAN ♿✅",
+        "(4,4) → (4,3) PEDESTRIAN ♿✅",
+        "(4,3) → (4,4) PEDESTRIAN ♿✅",
+        "(4,3) → (3,3) PEDESTRIAN ♿✅",
+        "(3,3) → (4,3) PEDESTRIAN ♿✅",
+        "(3,3) → (3,2) PEDESTRIAN ♿✅",
+        "(3,2) → (3,3) PEDESTRIAN ♿✅",
+        "(3,2) → (4,2) PEDESTRIAN ♿✅",
+        "(4,2) → (3,2) PEDESTRIAN ♿✅",
+        "(4,2) → (4,1) PEDESTRIAN ♿✅",
+        "(4,1) → (4,2) PEDESTRIAN ♿✅",
+        // visibility edges linking the concave hole node (4,1) to the outer ring corners,
+        // so you can route out of the concave part of the inner ring
+        "(0,0) → (4,1) PEDESTRIAN ♿✅",
+        "(4,1) → (0,0) PEDESTRIAN ♿✅",
+        "(5,5) → (4,1) PEDESTRIAN ♿✅",
+        "(4,1) → (5,5) PEDESTRIAN ♿✅"
       );
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcavePlatformWithStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcavePlatformWithStairsTest.java
@@ -25,10 +25,11 @@ import org.opentripplanner.street.graph.summary.GraphSummarizer;
  * {@code Ring.isNodeConvex(C)} returns {@code true} for a CW ring because the cross-product at
  * a re-entrant corner is positive. This adds C to {@code visibilityVertices}.
  *
- * <p>Stairs connect from outside to the top-left (A) and the bottom-right (F). A direct
- * line-of-sight from A to F exits the L-shape through the empty upper-right quadrant, so those
- * two stair entries can only reach each other via C. The SPT uses A→C and C→F visibility edges,
- * making them survive pruning.
+ * <p>Stairs connect from outside to the top-left (A) and the bottom-right (F). The direct
+ * line-of-sight from A to F grazes the re-entrant corner C exactly (the segment A–F passes
+ * through C's coordinate), so it stays inside the L-shape and is a valid visibility edge. Being
+ * shorter than the ring detour A→E→F, this direct diagonal survives the SPT pruning between the
+ * two stair entries; no separate A–C or C–F visibility edges are needed.
  */
 class ConcavePlatformWithStairsTest {
 
@@ -67,6 +68,29 @@ class ConcavePlatformWithStairsTest {
 
     assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
       .that(summarizer.summarizeEdges())
-      .containsExactly("PLACEHOLDER");
+      .containsExactly(
+        // stairs into A (wheelchair-inaccessible steps)
+        "(0.004,0) → (0.005,0) PEDESTRIAN ♿❌",
+        "(0.005,0) → (0.004,0) PEDESTRIAN ♿❌",
+        // stairs into F
+        "(0,0.004) → (0,0.005) PEDESTRIAN ♿❌",
+        "(0,0.005) → (0,0.004) PEDESTRIAN ♿❌",
+        // ring segments (6 sides × 2 directions)
+        "(0.004,0) → (0.004,0.002) PEDESTRIAN ♿✅",
+        "(0.004,0.002) → (0.004,0) PEDESTRIAN ♿✅",
+        "(0.004,0.002) → (0.002,0.002) PEDESTRIAN ♿✅",
+        "(0.002,0.002) → (0.004,0.002) PEDESTRIAN ♿✅",
+        "(0.002,0.002) → (0.002,0.004) PEDESTRIAN ♿✅",
+        "(0.002,0.004) → (0.002,0.002) PEDESTRIAN ♿✅",
+        "(0.002,0.004) → (0,0.004) PEDESTRIAN ♿✅",
+        "(0,0.004) → (0.002,0.004) PEDESTRIAN ♿✅",
+        "(0,0.004) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,0.004) PEDESTRIAN ♿✅",
+        "(0.004,0) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0.004,0) PEDESTRIAN ♿✅",
+        // visibility diagonal A↔F grazing the re-entrant corner C — the surviving shortest path
+        "(0.004,0) → (0,0.004) PEDESTRIAN ♿✅",
+        "(0,0.004) → (0.004,0) PEDESTRIAN ♿✅"
+      );
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcavePlatformWithStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/ConcavePlatformWithStairsTest.java
@@ -1,0 +1,72 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Tests that a re-entrant (concave) corner of an L-shaped platform enters the visibility vertex
+ * set via {@code isNodeConvex}, enabling the shortest path between two stair entries.
+ *
+ * <p>The platform is an L-shape made of two rectangles:
+ * <pre>
+ *   A --- B
+ *   |     C --- D
+ *   E ---------- F
+ * </pre>
+ * Corner C is the re-entrant corner (interior angle &gt; 180° in the polygon sense).
+ * {@code Ring.isNodeConvex(C)} returns {@code true} for a CW ring because the cross-product at
+ * a re-entrant corner is positive. This adds C to {@code visibilityVertices}.
+ *
+ * <p>Stairs connect from outside to the top-left (A) and the bottom-right (F). A direct
+ * line-of-sight from A to F exits the L-shape through the empty upper-right quadrant, so those
+ * two stair entries can only reach each other via C. The SPT uses A→C and C→F visibility edges,
+ * making them survive pruning.
+ */
+class ConcavePlatformWithStairsTest {
+
+  @Test
+  void reEntrantCornerEnablesShortestPath() {
+    // L-shape: left column (lat 0–0.004, lon 0–0.002) + bottom row (lat 0–0.002, lon 0–0.004)
+    var a = node(0, new WgsCoordinate(0.004, 0));
+    var b = node(1, new WgsCoordinate(0.004, 0.002));
+    var c = node(2, new WgsCoordinate(0.002, 0.002));
+    var d = node(3, new WgsCoordinate(0.002, 0.004));
+    var f = node(4, new WgsCoordinate(0, 0.004));
+    var e = node(5, new WgsCoordinate(0, 0));
+    var lShape = List.of(a, b, c, d, f, e);
+
+    // Stairs: one entering from above-left (reaches A), one from below-right (reaches F).
+    // The direct A–F line passes through the cut-out quadrant, so C is the connecting relay.
+    var stairA = node(10, new WgsCoordinate(0.005, 0));
+    var stairF = node(11, new WgsCoordinate(0, 0.005));
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), lShape)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stairA, a)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stairF, f)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(50)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly("PLACEHOLDER");
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/DiagonalStairsOnRingCornersTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/DiagonalStairsOnRingCornersTest.java
@@ -1,0 +1,58 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Tests that stair connections at two diagonally opposite ring corners produce a surviving
+ * diagonal visibility edge via the SPT pruning step.
+ *
+ * <p>Both corners are {@code isStartingNode} (shared with a stair way), so they enter
+ * {@code visibilityVertices} and {@code startingVertices}. The diagonal visibility edge between
+ * them is shorter than the two-segment ring path, so it survives the SPT pruning that
+ * retains only edges on shortest paths between starting vertices.
+ */
+class DiagonalStairsOnRingCornersTest {
+
+  @Test
+  void diagonalVisibilityEdgeSurvivesPruning() {
+    var bl = node(0, new WgsCoordinate(0, 0));
+    var tl = node(1, new WgsCoordinate(0.001, 0));
+    var tr = node(2, new WgsCoordinate(0.001, 0.001));
+    var br = node(3, new WgsCoordinate(0, 0.001));
+    var platform = List.of(bl, tl, tr, br);
+
+    // Stairs at diagonally opposite corners bl and tr.
+    var stairBL = node(10, new WgsCoordinate(-0.001, 0));
+    var stairTR = node(11, new WgsCoordinate(0.002, 0.001));
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), platform)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stairBL, bl)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stairTR, tr)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(50)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly("PLACEHOLDER");
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/DiagonalStairsOnRingCornersTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/DiagonalStairsOnRingCornersTest.java
@@ -53,6 +53,24 @@ class DiagonalStairsOnRingCornersTest {
 
     assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
       .that(summarizer.summarizeEdges())
-      .containsExactly("PLACEHOLDER");
+      .containsExactly(
+        // stairs at bl and tr (wheelchair-inaccessible steps)
+        "(0,0) → (-0.001,0) PEDESTRIAN ♿❌",
+        "(-0.001,0) → (0,0) PEDESTRIAN ♿❌",
+        "(0.001,0.001) → (0.002,0.001) PEDESTRIAN ♿❌",
+        "(0.002,0.001) → (0.001,0.001) PEDESTRIAN ♿❌",
+        // ring segments (4 sides × 2 directions)
+        "(0,0) → (0.001,0) PEDESTRIAN ♿✅",
+        "(0.001,0) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,0.001) PEDESTRIAN ♿✅",
+        "(0,0.001) → (0,0) PEDESTRIAN ♿✅",
+        "(0.001,0) → (0.001,0.001) PEDESTRIAN ♿✅",
+        "(0.001,0.001) → (0.001,0) PEDESTRIAN ♿✅",
+        "(0.001,0.001) → (0,0.001) PEDESTRIAN ♿✅",
+        "(0,0.001) → (0.001,0.001) PEDESTRIAN ♿✅",
+        // surviving diagonal visibility edge bl↔tr (shorter than the two-segment ring detour)
+        "(0,0) → (0.001,0.001) PEDESTRIAN ♿✅",
+        "(0.001,0.001) → (0,0) PEDESTRIAN ♿✅"
+      );
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/IsolatedAreaRemovedTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/IsolatedAreaRemovedTest.java
@@ -1,0 +1,51 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Tests the {@code UnconnectedArea} branch in {@code buildWithVisibility}.
+ *
+ * <p>A convex outer ring whose corners are all non-convex in the CW-ring sense
+ * ({@code isNodeConvex} returns false) and has no external way connections produces an empty
+ * {@code visibilityVertices} set. The builder then removes every ring edge it just created and
+ * records an {@code UnconnectedArea} issue, leaving the graph empty.
+ */
+class IsolatedAreaRemovedTest {
+
+  @Test
+  void isolatedPlatformProducesNoEdges() {
+    var bl = node(0, new WgsCoordinate(0, 0));
+    var tl = node(1, new WgsCoordinate(0.001, 0));
+    var tr = node(2, new WgsCoordinate(0.001, 0.001));
+    var br = node(3, new WgsCoordinate(0, 0.001));
+    var platform = List.of(bl, tl, tr, br);
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), platform)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(50)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Expected empty graph — isolated area should be fully removed")
+      .that(summarizer.summarizeEdges())
+      .isEmpty();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformRelationWithHoleAndStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformRelationWithHoleAndStairsTest.java
@@ -1,0 +1,131 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.osm.model.RelationBuilder;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Checks that a platform defined as a multipolygon relation (with an inner hole) connects
+ * correctly when entries share a node with the platform boundary.
+ *
+ * <p>The platform is a square "donut" roughly 100 m across (0.0009° ≈ 100 m at the equator): a
+ * large outer ring with a smaller square hole cut out of the middle. The inner ring's south side is
+ * split with an intermediate node (innerS) where a stairway terminates.
+ *
+ * <p>A stairway from the south terminates at innerS on the inner hole boundary. Because innerS
+ * lies on the inner hole boundary the donut polygon's strict contains() check fails, so innerS is
+ * NOT a platformLinkingPoint. However, innerS is shared with the stair way, so
+ * {@code isStartingNode} returns true, adding it to visibilityVertices.
+ *
+ * <p>A pedestrian footway from the north terminates at {@code ped}, a node on the outer ring's
+ * north side that is shared with the footway. Like innerS, ped becomes a startingNode, so it
+ * enters visibilityVertices. The SPT from {ped, innerS} finds a path via ped↔innerTR visibility
+ * edges, keeping them alive after pruning.
+ */
+class PlatformRelationWithHoleAndStairsTest {
+
+  @Test
+  void platformRelationConnectedToStairway() {
+    // Pedestrian footway from north: north is the external entry, ped is a node on the outer
+    // ring's north side. Being shared with the footway makes ped a startingNode, so it enters
+    // visibilityVertices and gets connected to the inner ring via a visibility edge.
+    var north = node(21, new WgsCoordinate(0.0011, 0.000451));
+    var ped = node(22, new WgsCoordinate(0.0009, 0.0004511));
+
+    // Outer ring: ~100 m square (0.0009° ≈ 100 m at the equator)
+    var outerBL = node(0, new WgsCoordinate(0, 0));
+    var outerTL = node(1, new WgsCoordinate(0.0009, 0));
+    var outerTR = node(2, new WgsCoordinate(0.0009, 0.0009));
+    var outerBR = node(3, new WgsCoordinate(0, 0.0009));
+    var outerRing = List.of(outerBL, outerTL, ped, outerTR, outerBR);
+
+    // Inner hole: ~33 m square centred inside the outer ring.
+    // The south side (innerBR→innerBL) is split by an intermediate node innerS at the midpoint.
+    var innerBL = node(10, new WgsCoordinate(0.0003, 0.0003));
+    var innerTL = node(11, new WgsCoordinate(0.0006, 0.0003));
+    var innerTR = node(12, new WgsCoordinate(0.0006, 0.0006));
+    var innerBR = node(13, new WgsCoordinate(0.0003, 0.0006));
+    var innerS = node(14, new WgsCoordinate(0.0003, 0.000451));
+    var innerHole = List.of(innerBL, innerTL, innerTR, innerBR, innerS);
+
+    // Stair from south: terminates at innerS on the inner hole boundary.
+    // innerS fails the donut contains() check so it is NOT a platformLinkingPoint,
+    // but isStartingNode returns true (shared with stair way) → innerS enters visibilityVertices.
+    var stairBottom = node(20, new WgsCoordinate(-0.0001, 0.000451));
+
+    long outerRingId = 1000;
+    long innerHoleId = 1001;
+
+    var relation = RelationBuilder.ofMultiPolygon()
+      .withTag("public_transport", "platform")
+      .withOuterWay(outerRingId)
+      .withInnerWay(innerHoleId)
+      .build();
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), outerRingId, outerRing)
+      .addAreaFromNodes(innerHoleId, innerHole)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stairBottom, innerS)
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), north, ped)
+      .addRelation(relation)
+      .build();
+
+    var graph = new Graph();
+
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(50)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly(
+        // outer ring (5 segments × 2 directions) — ped splits the north side into two segments
+        "(0,0) → (0.0009,0) PEDESTRIAN ♿✅",
+        "(0.0009,0) → (0,0) PEDESTRIAN ♿✅",
+        "(0.0009,0) → (0.0009,0.000451) PEDESTRIAN ♿✅",
+        "(0.0009,0.000451) → (0.0009,0) PEDESTRIAN ♿✅",
+        "(0.0009,0.000451) → (0.0009,0.0009) PEDESTRIAN ♿✅",
+        "(0.0009,0.0009) → (0.0009,0.000451) PEDESTRIAN ♿✅",
+        "(0.0009,0.0009) → (0,0.0009) PEDESTRIAN ♿✅",
+        "(0,0.0009) → (0.0009,0.0009) PEDESTRIAN ♿✅",
+        "(0,0.0009) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,0.0009) PEDESTRIAN ♿✅",
+        // inner hole (5 segments × 2 directions)
+        "(0.0003,0.0003) → (0.0006,0.0003) PEDESTRIAN ♿✅",
+        "(0.0006,0.0003) → (0.0003,0.0003) PEDESTRIAN ♿✅",
+        "(0.0006,0.0003) → (0.0006,0.0006) PEDESTRIAN ♿✅",
+        "(0.0006,0.0006) → (0.0006,0.0003) PEDESTRIAN ♿✅",
+        "(0.0006,0.0006) → (0.0003,0.0006) PEDESTRIAN ♿✅",
+        "(0.0003,0.0006) → (0.0006,0.0006) PEDESTRIAN ♿✅",
+        "(0.0003,0.0006) → (0.0003,0.000451) PEDESTRIAN ♿✅",
+        "(0.0003,0.000451) → (0.0003,0.0006) PEDESTRIAN ♿✅",
+        "(0.0003,0.000451) → (0.0003,0.0003) PEDESTRIAN ♿✅",
+        "(0.0003,0.0003) → (0.0003,0.000451) PEDESTRIAN ♿✅",
+        // visibility edges: ped ↔ innerTR (NE corner of inner hole), both directions survive.
+        // The lon offset of 0.000451 breaks the path-length tie that existed at 0.00045,
+        // so the SPT finds a unique shortest path in both directions through innerTR.
+        "(0.0009,0.000451) → (0.0006,0.0006) PEDESTRIAN ♿✅",
+        "(0.0006,0.0006) → (0.0009,0.000451) PEDESTRIAN ♿✅",
+        // stair — wheelchair-inaccessible steps
+        "(0.0003,0.000451) → (-0.0001,0.000451) PEDESTRIAN ♿❌",
+        "(-0.0001,0.000451) → (0.0003,0.000451) PEDESTRIAN ♿❌",
+        // pedestrian footway from north
+        "(0.0011,0.000451) → (0.0009,0.000451) PEDESTRIAN ♿✅",
+        "(0.0009,0.000451) → (0.0011,0.000451) PEDESTRIAN ♿✅"
+      );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformRelationWithTwoHolesAndStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformRelationWithTwoHolesAndStairsTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static org.opentripplanner.osm.model.NodeBuilder.node;
 
 import java.util.List;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.osm.TestOsmProvider;
@@ -23,72 +24,20 @@ import org.opentripplanner.street.graph.summary.GraphSummarizer;
  * <p>A pedestrian footway from the north terminates at {@code ped} on the outer ring's north side.
  * This makes ped a startingNode, giving it visibility edges into both inner holes. The SPT from
  * {ped, inner1S, inner2S} keeps the edges that connect all three across the donut.
+ *
+ * <p>The two test cases share the same OSM geometry (built by {@link #buildSummarizer}) but use a
+ * different {@code maxAreaNodes} budget. {@link #platformRelationConnectedToTwoStairways} uses a
+ * generous budget (50) and gets the full, deterministic set of visibility edges.
+ * {@link #lowMaxAreaNodes} uses a budget (5) smaller than the number of visibility-vertex
+ * candidates, forcing the builder to sample the candidate set down. The mandatory ring, footway and
+ * stair edges are unaffected by the budget; the surviving visibility cross-edges depend on the
+ * sampling order and are not asserted (see that test for details).
  */
 class PlatformRelationWithTwoHolesAndStairsTest {
 
   @Test
   void platformRelationConnectedToTwoStairways() {
-    // Outer ring: ~200 m square
-    var outerBL = node(0, new WgsCoordinate(0, 0));
-    var outerTL = node(1, new WgsCoordinate(0.002, 0));
-    var outerTR = node(2, new WgsCoordinate(0.002, 0.002));
-    var outerBR = node(3, new WgsCoordinate(0, 0.002));
-    var ped = node(4, new WgsCoordinate(0.002, 0.001));
-    var outerRing = List.of(outerBL, outerTL, ped, outerTR, outerBR);
-
-    var north = node(5, new WgsCoordinate(0.0024, 0.001));
-
-    // Inner hole 1 (west): lat 0.0007–0.0013, lon 0.0004–0.0008
-    var inner1BL = node(10, new WgsCoordinate(0.0007, 0.0004));
-    var inner1TL = node(11, new WgsCoordinate(0.0013, 0.0004));
-    var inner1TR = node(12, new WgsCoordinate(0.0013, 0.0008));
-    var inner1BR = node(13, new WgsCoordinate(0.0007, 0.0008));
-    var inner1S = node(14, new WgsCoordinate(0.0007, 0.0006));
-    var innerHole1 = List.of(inner1BL, inner1TL, inner1TR, inner1BR, inner1S);
-
-    // Inner hole 2 (east): lat 0.0007–0.0013, lon 0.0012–0.0016
-    var inner2BL = node(20, new WgsCoordinate(0.0007, 0.0012));
-    var inner2TL = node(21, new WgsCoordinate(0.0013, 0.0012));
-    var inner2TR = node(22, new WgsCoordinate(0.0013, 0.0016));
-    var inner2BR = node(23, new WgsCoordinate(0.0007, 0.0016));
-    var inner2S = node(24, new WgsCoordinate(0.0007, 0.0014));
-    var innerHole2 = List.of(inner2BL, inner2TL, inner2TR, inner2BR, inner2S);
-
-    // Stairs from south, one per hole
-    var stair1Bottom = node(30, new WgsCoordinate(-0.0003, 0.0006));
-    var stair2Bottom = node(31, new WgsCoordinate(-0.0003, 0.0014));
-
-    long outerRingId = 1000;
-    long innerHole1Id = 1001;
-    long innerHole2Id = 1002;
-
-    var relation = RelationBuilder.ofMultiPolygon()
-      .withTag("public_transport", "platform")
-      .withOuterWay(outerRingId)
-      .withInnerWay(innerHole1Id)
-      .withInnerWay(innerHole2Id)
-      .build();
-
-    var provider = TestOsmProvider.of()
-      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), outerRingId, outerRing)
-      .addAreaFromNodes(innerHole1Id, innerHole1)
-      .addAreaFromNodes(innerHole2Id, innerHole2)
-      .addWayFromNodes(way -> way.withTag("highway", "steps"), stair1Bottom, inner1S)
-      .addWayFromNodes(way -> way.withTag("highway", "steps"), stair2Bottom, inner2S)
-      .addWayFromNodes(way -> way.withTag("highway", "footway"), north, ped)
-      .addRelation(relation)
-      .build();
-
-    var graph = new Graph();
-    OsmModuleTestFactory.of(provider)
-      .withGraph(graph)
-      .builder()
-      .withAreaVisibility(true)
-      .withMaxAreaNodes(50)
-      .build()
-      .buildGraph();
-
-    var summarizer = new GraphSummarizer(graph);
+    var summarizer = buildSummarizer(50);
 
     assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
       .that(summarizer.summarizeEdges())
@@ -146,5 +95,125 @@ class PlatformRelationWithTwoHolesAndStairsTest {
         "(0.0007,0.0014) → (-0.0003,0.0014) PEDESTRIAN ♿❌",
         "(-0.0003,0.0014) → (0.0007,0.0014) PEDESTRIAN ♿❌"
       );
+  }
+
+  @Test
+  void lowMaxAreaNodes() {
+    var summarizer = buildSummarizer(5);
+    // The ring, footway and stair edges are created unconditionally, so they are always present and
+    // identical to the maxAreaNodes=50 case. The visibility (cross) edges, however, depend on which
+    // vertices the node budget samples, and that sampling follows the (identity-based) iteration
+    // order of the candidate set, which is not stable across JVM runs. We therefore only assert the
+    // deterministic mandatory edges here; the point of this case is that a budget smaller than the
+    // candidate count does not drop any of them.
+    assertWithMessage("Missing mandatory edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsAtLeast(
+        // outer ring (5 segments × 2 directions) — ped splits the north side into two segments
+        "(0,0) → (0.002,0) PEDESTRIAN ♿✅",
+        "(0.002,0) → (0,0) PEDESTRIAN ♿✅",
+        "(0.002,0) → (0.002,0.001) PEDESTRIAN ♿✅",
+        "(0.002,0.001) → (0.002,0) PEDESTRIAN ♿✅",
+        "(0.002,0.001) → (0.002,0.002) PEDESTRIAN ♿✅",
+        "(0.002,0.002) → (0.002,0.001) PEDESTRIAN ♿✅",
+        "(0.002,0.002) → (0,0.002) PEDESTRIAN ♿✅",
+        "(0,0.002) → (0.002,0.002) PEDESTRIAN ♿✅",
+        "(0,0.002) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,0.002) PEDESTRIAN ♿✅",
+        // pedestrian footway from north
+        "(0.002,0.001) → (0.0024,0.001) PEDESTRIAN ♿✅",
+        "(0.0024,0.001) → (0.002,0.001) PEDESTRIAN ♿✅",
+        // inner hole 1 (5 segments × 2 directions)
+        "(0.0007,0.0004) → (0.0013,0.0004) PEDESTRIAN ♿✅",
+        "(0.0013,0.0004) → (0.0007,0.0004) PEDESTRIAN ♿✅",
+        "(0.0013,0.0004) → (0.0013,0.0008) PEDESTRIAN ♿✅",
+        "(0.0013,0.0008) → (0.0013,0.0004) PEDESTRIAN ♿✅",
+        "(0.0013,0.0008) → (0.0007,0.0008) PEDESTRIAN ♿✅",
+        "(0.0007,0.0008) → (0.0013,0.0008) PEDESTRIAN ♿✅",
+        "(0.0007,0.0008) → (0.0007,0.0006) PEDESTRIAN ♿✅",
+        "(0.0007,0.0006) → (0.0007,0.0008) PEDESTRIAN ♿✅",
+        "(0.0007,0.0006) → (0.0007,0.0004) PEDESTRIAN ♿✅",
+        "(0.0007,0.0004) → (0.0007,0.0006) PEDESTRIAN ♿✅",
+        // inner hole 2 (5 segments × 2 directions)
+        "(0.0007,0.0012) → (0.0013,0.0012) PEDESTRIAN ♿✅",
+        "(0.0013,0.0012) → (0.0007,0.0012) PEDESTRIAN ♿✅",
+        "(0.0013,0.0012) → (0.0013,0.0016) PEDESTRIAN ♿✅",
+        "(0.0013,0.0016) → (0.0013,0.0012) PEDESTRIAN ♿✅",
+        "(0.0013,0.0016) → (0.0007,0.0016) PEDESTRIAN ♿✅",
+        "(0.0007,0.0016) → (0.0013,0.0016) PEDESTRIAN ♿✅",
+        "(0.0007,0.0016) → (0.0007,0.0014) PEDESTRIAN ♿✅",
+        "(0.0007,0.0014) → (0.0007,0.0016) PEDESTRIAN ♿✅",
+        "(0.0007,0.0014) → (0.0007,0.0012) PEDESTRIAN ♿✅",
+        "(0.0007,0.0012) → (0.0007,0.0014) PEDESTRIAN ♿✅",
+        // stairs — wheelchair-inaccessible steps, one per hole
+        "(0.0007,0.0006) → (-0.0003,0.0006) PEDESTRIAN ♿❌",
+        "(-0.0003,0.0006) → (0.0007,0.0006) PEDESTRIAN ♿❌",
+        "(0.0007,0.0014) → (-0.0003,0.0014) PEDESTRIAN ♿❌",
+        "(-0.0003,0.0014) → (0.0007,0.0014) PEDESTRIAN ♿❌"
+      );
+  }
+
+  private static @NonNull GraphSummarizer buildSummarizer(int maxAreaNodes) {
+    // Outer ring: ~200 m square
+    var outerBL = node(0, new WgsCoordinate(0, 0));
+    var outerTL = node(1, new WgsCoordinate(0.002, 0));
+    var outerTR = node(2, new WgsCoordinate(0.002, 0.002));
+    var outerBR = node(3, new WgsCoordinate(0, 0.002));
+    var ped = node(4, new WgsCoordinate(0.002, 0.001));
+    var outerRing = List.of(outerBL, outerTL, ped, outerTR, outerBR);
+
+    var north = node(5, new WgsCoordinate(0.0024, 0.001));
+
+    // Inner hole 1 (west): lat 0.0007–0.0013, lon 0.0004–0.0008
+    var inner1BL = node(10, new WgsCoordinate(0.0007, 0.0004));
+    var inner1TL = node(11, new WgsCoordinate(0.0013, 0.0004));
+    var inner1TR = node(12, new WgsCoordinate(0.0013, 0.0008));
+    var inner1BR = node(13, new WgsCoordinate(0.0007, 0.0008));
+    var inner1S = node(14, new WgsCoordinate(0.0007, 0.0006));
+    var innerHole1 = List.of(inner1BL, inner1TL, inner1TR, inner1BR, inner1S);
+
+    // Inner hole 2 (east): lat 0.0007–0.0013, lon 0.0012–0.0016
+    var inner2BL = node(20, new WgsCoordinate(0.0007, 0.0012));
+    var inner2TL = node(21, new WgsCoordinate(0.0013, 0.0012));
+    var inner2TR = node(22, new WgsCoordinate(0.0013, 0.0016));
+    var inner2BR = node(23, new WgsCoordinate(0.0007, 0.0016));
+    var inner2S = node(24, new WgsCoordinate(0.0007, 0.0014));
+    var innerHole2 = List.of(inner2BL, inner2TL, inner2TR, inner2BR, inner2S);
+
+    // Stairs from south, one per hole
+    var stair1Bottom = node(30, new WgsCoordinate(-0.0003, 0.0006));
+    var stair2Bottom = node(31, new WgsCoordinate(-0.0003, 0.0014));
+
+    long outerRingId = 1000;
+    long innerHole1Id = 1001;
+    long innerHole2Id = 1002;
+
+    var relation = RelationBuilder.ofMultiPolygon()
+      .withTag("public_transport", "platform")
+      .withOuterWay(outerRingId)
+      .withInnerWay(innerHole1Id)
+      .withInnerWay(innerHole2Id)
+      .build();
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), outerRingId, outerRing)
+      .addAreaFromNodes(innerHole1Id, innerHole1)
+      .addAreaFromNodes(innerHole2Id, innerHole2)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stair1Bottom, inner1S)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stair2Bottom, inner2S)
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), north, ped)
+      .addRelation(relation)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(maxAreaNodes)
+      .build()
+      .buildGraph();
+
+    return new GraphSummarizer(graph);
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformRelationWithTwoHolesAndStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformRelationWithTwoHolesAndStairsTest.java
@@ -1,0 +1,150 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.osm.model.RelationBuilder;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Checks that a platform with two inner holes (each connected to a stairway) produces a
+ * fully-connected graph.
+ *
+ * <p>The platform is a ~200 m square "double-donut": one outer ring with two square holes cut out
+ * side by side (west and east). Each hole's south boundary has a midpoint node (inner1S / inner2S)
+ * where a stairway from outside the platform terminates.
+ *
+ * <p>A pedestrian footway from the north terminates at {@code ped} on the outer ring's north side.
+ * This makes ped a startingNode, giving it visibility edges into both inner holes. The SPT from
+ * {ped, inner1S, inner2S} keeps the edges that connect all three across the donut.
+ */
+class PlatformRelationWithTwoHolesAndStairsTest {
+
+  @Test
+  void platformRelationConnectedToTwoStairways() {
+    // Outer ring: ~200 m square
+    var outerBL = node(0, new WgsCoordinate(0, 0));
+    var outerTL = node(1, new WgsCoordinate(0.002, 0));
+    var outerTR = node(2, new WgsCoordinate(0.002, 0.002));
+    var outerBR = node(3, new WgsCoordinate(0, 0.002));
+    var ped = node(4, new WgsCoordinate(0.002, 0.001));
+    var outerRing = List.of(outerBL, outerTL, ped, outerTR, outerBR);
+
+    var north = node(5, new WgsCoordinate(0.0024, 0.001));
+
+    // Inner hole 1 (west): lat 0.0007–0.0013, lon 0.0004–0.0008
+    var inner1BL = node(10, new WgsCoordinate(0.0007, 0.0004));
+    var inner1TL = node(11, new WgsCoordinate(0.0013, 0.0004));
+    var inner1TR = node(12, new WgsCoordinate(0.0013, 0.0008));
+    var inner1BR = node(13, new WgsCoordinate(0.0007, 0.0008));
+    var inner1S = node(14, new WgsCoordinate(0.0007, 0.0006));
+    var innerHole1 = List.of(inner1BL, inner1TL, inner1TR, inner1BR, inner1S);
+
+    // Inner hole 2 (east): lat 0.0007–0.0013, lon 0.0012–0.0016
+    var inner2BL = node(20, new WgsCoordinate(0.0007, 0.0012));
+    var inner2TL = node(21, new WgsCoordinate(0.0013, 0.0012));
+    var inner2TR = node(22, new WgsCoordinate(0.0013, 0.0016));
+    var inner2BR = node(23, new WgsCoordinate(0.0007, 0.0016));
+    var inner2S = node(24, new WgsCoordinate(0.0007, 0.0014));
+    var innerHole2 = List.of(inner2BL, inner2TL, inner2TR, inner2BR, inner2S);
+
+    // Stairs from south, one per hole
+    var stair1Bottom = node(30, new WgsCoordinate(-0.0003, 0.0006));
+    var stair2Bottom = node(31, new WgsCoordinate(-0.0003, 0.0014));
+
+    long outerRingId = 1000;
+    long innerHole1Id = 1001;
+    long innerHole2Id = 1002;
+
+    var relation = RelationBuilder.ofMultiPolygon()
+      .withTag("public_transport", "platform")
+      .withOuterWay(outerRingId)
+      .withInnerWay(innerHole1Id)
+      .withInnerWay(innerHole2Id)
+      .build();
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), outerRingId, outerRing)
+      .addAreaFromNodes(innerHole1Id, innerHole1)
+      .addAreaFromNodes(innerHole2Id, innerHole2)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stair1Bottom, inner1S)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stair2Bottom, inner2S)
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), north, ped)
+      .addRelation(relation)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(50)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly(
+        // outer ring (5 segments × 2 directions) — ped splits the north side into two segments
+        "(0,0) → (0.002,0) PEDESTRIAN ♿✅",
+        "(0.002,0) → (0,0) PEDESTRIAN ♿✅",
+        "(0.002,0) → (0.002,0.001) PEDESTRIAN ♿✅",
+        "(0.002,0.001) → (0.002,0) PEDESTRIAN ♿✅",
+        "(0.002,0.001) → (0.002,0.002) PEDESTRIAN ♿✅",
+        "(0.002,0.002) → (0.002,0.001) PEDESTRIAN ♿✅",
+        "(0.002,0.002) → (0,0.002) PEDESTRIAN ♿✅",
+        "(0,0.002) → (0.002,0.002) PEDESTRIAN ♿✅",
+        "(0,0.002) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,0.002) PEDESTRIAN ♿✅",
+        // pedestrian footway from north
+        "(0.002,0.001) → (0.0024,0.001) PEDESTRIAN ♿✅",
+        "(0.0024,0.001) → (0.002,0.001) PEDESTRIAN ♿✅",
+        // visibility edges: ped sees the innermost corner of each hole (the corner facing the
+        // platform centre, not the outer wall), since those are the only corners reachable
+        // without the line passing through the hole itself.
+        "(0.002,0.001) → (0.0007,0.0008) PEDESTRIAN ♿✅",
+        "(0.0007,0.0008) → (0.002,0.001) PEDESTRIAN ♿✅",
+        "(0.002,0.001) → (0.0007,0.0012) PEDESTRIAN ♿✅",
+        "(0.0007,0.0012) → (0.002,0.001) PEDESTRIAN ♿✅",
+        // visibility edge: inner1S ↔ inner2S directly across the gap between the two holes
+        "(0.0007,0.0006) → (0.0007,0.0014) PEDESTRIAN ♿✅",
+        "(0.0007,0.0014) → (0.0007,0.0006) PEDESTRIAN ♿✅",
+        // inner hole 1 (5 segments × 2 directions)
+        "(0.0007,0.0004) → (0.0013,0.0004) PEDESTRIAN ♿✅",
+        "(0.0013,0.0004) → (0.0007,0.0004) PEDESTRIAN ♿✅",
+        "(0.0013,0.0004) → (0.0013,0.0008) PEDESTRIAN ♿✅",
+        "(0.0013,0.0008) → (0.0013,0.0004) PEDESTRIAN ♿✅",
+        "(0.0013,0.0008) → (0.0007,0.0008) PEDESTRIAN ♿✅",
+        "(0.0007,0.0008) → (0.0013,0.0008) PEDESTRIAN ♿✅",
+        "(0.0007,0.0008) → (0.0007,0.0006) PEDESTRIAN ♿✅",
+        "(0.0007,0.0006) → (0.0007,0.0008) PEDESTRIAN ♿✅",
+        "(0.0007,0.0006) → (0.0007,0.0004) PEDESTRIAN ♿✅",
+        "(0.0007,0.0004) → (0.0007,0.0006) PEDESTRIAN ♿✅",
+        // stair 1 — wheelchair-inaccessible steps
+        "(0.0007,0.0006) → (-0.0003,0.0006) PEDESTRIAN ♿❌",
+        "(-0.0003,0.0006) → (0.0007,0.0006) PEDESTRIAN ♿❌",
+        // inner hole 2 (5 segments × 2 directions)
+        "(0.0007,0.0012) → (0.0013,0.0012) PEDESTRIAN ♿✅",
+        "(0.0013,0.0012) → (0.0007,0.0012) PEDESTRIAN ♿✅",
+        "(0.0013,0.0012) → (0.0013,0.0016) PEDESTRIAN ♿✅",
+        "(0.0013,0.0016) → (0.0013,0.0012) PEDESTRIAN ♿✅",
+        "(0.0013,0.0016) → (0.0007,0.0016) PEDESTRIAN ♿✅",
+        "(0.0007,0.0016) → (0.0013,0.0016) PEDESTRIAN ♿✅",
+        "(0.0007,0.0016) → (0.0007,0.0014) PEDESTRIAN ♿✅",
+        "(0.0007,0.0014) → (0.0007,0.0016) PEDESTRIAN ♿✅",
+        "(0.0007,0.0014) → (0.0007,0.0012) PEDESTRIAN ♿✅",
+        "(0.0007,0.0012) → (0.0007,0.0014) PEDESTRIAN ♿✅",
+        // stair 2 — wheelchair-inaccessible steps
+        "(0.0007,0.0014) → (-0.0003,0.0014) PEDESTRIAN ♿❌",
+        "(-0.0003,0.0014) → (0.0007,0.0014) PEDESTRIAN ♿❌"
+      );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformWithStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformWithStairsTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.opentripplanner.osm.model.NodeBuilder.node;
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformWithStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformWithStairsTest.java
@@ -21,12 +21,12 @@ class PlatformWithStairsTest {
   @Test
   void platformConnectedToStairway() {
     // Square platform: corners listed in order to form a closed polygon
-    var platformBottomLeft = node(0, new WgsCoordinate(0, 0));
-    var platformTopLeft = node(1, new WgsCoordinate(5, 0));
-    var platformTopRight = node(2, new WgsCoordinate(5, 5));
-    var platformBottomRight = node(3, new WgsCoordinate(0, 5));
+    var bl = node(0, new WgsCoordinate(0, 0));
+    var tl = node(1, new WgsCoordinate(5, 0));
+    var tr = node(2, new WgsCoordinate(5, 5));
+    var br = node(3, new WgsCoordinate(0, 5));
 
-    var platform = List.of(platformBottomLeft, platformTopLeft, platformTopRight, platformBottomRight);
+    var platform = List.of(bl, tl, tr, br);
 
     // Stair rises from outside and terminates inside the platform area.
     // Neither node is shared with the platform polygon.

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformWithStairsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/PlatformWithStairsTest.java
@@ -1,0 +1,76 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Checks that a platform (area) connects correctly to a stairway entering from outside.
+ * The stair rises from below and meets the bottom-left corner of a square platform.
+ */
+class PlatformWithStairsTest {
+
+  @Test
+  void platformConnectedToStairway() {
+    // Square platform: corners listed in order to form a closed polygon
+    var platformBottomLeft = node(0, new WgsCoordinate(0, 0));
+    var platformTopLeft = node(1, new WgsCoordinate(5, 0));
+    var platformTopRight = node(2, new WgsCoordinate(5, 5));
+    var platformBottomRight = node(3, new WgsCoordinate(0, 5));
+
+    var platform = List.of(platformBottomLeft, platformTopLeft, platformTopRight, platformBottomRight);
+
+    // Stair rises from outside and terminates inside the platform area.
+    // Neither node is shared with the platform polygon.
+    var stairBottom = node(4, new WgsCoordinate(-1, 2.5));
+    var stairTop = node(5, new WgsCoordinate(2, 2.5));
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), platform)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stairBottom, stairTop)
+      .build();
+
+    var graph = new Graph();
+    var osmModule = OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(10)
+      .withPlatformEntriesLinking(true)
+      .build();
+
+    osmModule.buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly(
+        // stair edges — wheelchair-inaccessible, as expected for steps
+        "(-1,2.5) → (2,2.5) PEDESTRIAN ♿❌",
+        "(2,2.5) → (-1,2.5) PEDESTRIAN ♿❌",
+        // platform ring edges (boundary of the square)
+        "(0,0) → (5,0) PEDESTRIAN ♿✅",
+        "(5,0) → (0,0) PEDESTRIAN ♿✅",
+        "(5,0) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (5,0) PEDESTRIAN ♿✅",
+        "(5,5) → (0,5) PEDESTRIAN ♿✅",
+        "(0,5) → (5,5) PEDESTRIAN ♿✅",
+        "(0,5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,5) PEDESTRIAN ♿✅",
+        // stairTop connected to visible platform corners via visibility edges
+        "(2,2.5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (2,2.5) PEDESTRIAN ♿✅",
+        "(2,2.5) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (2,2.5) PEDESTRIAN ♿✅"
+      );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/SimpleAreaTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/SimpleAreaTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.opentripplanner.osm.model.NodeBuilder.node;
 
 import java.util.List;
@@ -41,18 +40,20 @@ class SimpleAreaTest {
       .builder()
       .withAreaVisibility(true)
       .withMaxAreaNodes(10)
-      .build().buildGraph();
+      .build()
+      .buildGraph();
 
-    assertFalse(graph.getVertices().isEmpty());
     var summarizer = new GraphSummarizer(graph);
 
     assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
       .that(summarizer.summarizeEdges())
       .containsExactly(
-        // stair edges — wheelchair-inaccessible, as expected for steps
-        "(-1,2.5) → (2,2.5) PEDESTRIAN ♿❌",
-        "(2,2.5) → (-1,2.5) PEDESTRIAN ♿❌",
-        // platform ring edges (boundary of the square)
+        // connecting ways from outside into two opposite corners
+        "(0,0) → (-1,0) PEDESTRIAN ♿✅",
+        "(-1,0) → (0,0) PEDESTRIAN ♿✅",
+        "(5,5) → (6,5) PEDESTRIAN ♿✅",
+        "(6,5) → (5,5) PEDESTRIAN ♿✅",
+        // ring edges (boundary of the square)
         "(0,0) → (5,0) PEDESTRIAN ♿✅",
         "(5,0) → (0,0) PEDESTRIAN ♿✅",
         "(5,0) → (5,5) PEDESTRIAN ♿✅",
@@ -61,11 +62,9 @@ class SimpleAreaTest {
         "(0,5) → (5,5) PEDESTRIAN ♿✅",
         "(0,5) → (0,0) PEDESTRIAN ♿✅",
         "(0,0) → (0,5) PEDESTRIAN ♿✅",
-        // stairTop connected to visible platform corners via visibility edges
-        "(2,2.5) → (0,0) PEDESTRIAN ♿✅",
-        "(0,0) → (2,2.5) PEDESTRIAN ♿✅",
-        "(2,2.5) → (5,5) PEDESTRIAN ♿✅",
-        "(5,5) → (2,2.5) PEDESTRIAN ♿✅"
+        // diagonal visibility edge between the two connected corners (shortest crossing)
+        "(0,0) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (0,0) PEDESTRIAN ♿✅"
       );
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/SimpleAreaTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/SimpleAreaTest.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.opentripplanner.osm.model.NodeBuilder.node;
 
@@ -10,7 +10,7 @@ import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.osm.TestOsmProvider;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.street.model.edge.AreaEdge;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
 
 class SimpleAreaTest {
 
@@ -35,17 +35,37 @@ class SimpleAreaTest {
       .build();
 
     var graph = new Graph();
-    var osmModule = OsmModuleTestFactory.of(provider)
+
+    OsmModuleTestFactory.of(provider)
       .withGraph(graph)
       .builder()
       .withAreaVisibility(true)
       .withMaxAreaNodes(10)
-      .build();
-
-    osmModule.buildGraph();
+      .build().buildGraph();
 
     assertFalse(graph.getVertices().isEmpty());
+    var summarizer = new GraphSummarizer(graph);
 
-    assertEquals(10, graph.getEdgesOfType(AreaEdge.class).size(), "Incorrect number of edges");
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly(
+        // stair edges — wheelchair-inaccessible, as expected for steps
+        "(-1,2.5) → (2,2.5) PEDESTRIAN ♿❌",
+        "(2,2.5) → (-1,2.5) PEDESTRIAN ♿❌",
+        // platform ring edges (boundary of the square)
+        "(0,0) → (5,0) PEDESTRIAN ♿✅",
+        "(5,0) → (0,0) PEDESTRIAN ♿✅",
+        "(5,0) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (5,0) PEDESTRIAN ♿✅",
+        "(5,5) → (0,5) PEDESTRIAN ♿✅",
+        "(0,5) → (5,5) PEDESTRIAN ♿✅",
+        "(0,5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,5) PEDESTRIAN ♿✅",
+        // stairTop connected to visible platform corners via visibility edges
+        "(2,2.5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (2,2.5) PEDESTRIAN ♿✅",
+        "(2,2.5) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (2,2.5) PEDESTRIAN ♿✅"
+      );
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/StopAreaWithUnderpassAndElevatorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/StopAreaWithUnderpassAndElevatorTest.java
@@ -1,0 +1,142 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.osm.model.NodeBuilder;
+import org.opentripplanner.osm.model.RelationBuilder;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Extends the stop-area platform scene with an underpass running beneath the platform and an
+ * elevator connecting the two levels.
+ *
+ * <p>The platform (level 0) and the elevator node are both members of a
+ * {@code public_transport=stop_area} relation. The platform is reached by a stair at its bottom-left
+ * corner. The elevator is a single node in the middle of the platform. On the top level a footway
+ * runs straight north from the elevator to an extra node inserted into the northern platform edge;
+ * the underpass ({@code tunnel=yes}, level -1) shares the same elevator node from below. OTP
+ * therefore builds elevator board/alight/hop edges linking the platform (level 0) to the underpass
+ * (level -1).
+ *
+ * <p>Platform entry linking is disabled, but area visibility is enabled. Because the elevator node
+ * sits inside the walkable area and is shared with the footway, the visibility builder attaches it
+ * to the platform corners in addition to the explicit footway. The node therefore gets two level-0
+ * attachments — one from the platform area (WAY:100) and one from the footway (WAY:2) — joined by a
+ * zero-level elevator hop, and the footway to the northern edge is mirrored by a visibility edge.
+ */
+class StopAreaWithUnderpassAndElevatorTest {
+
+  @Test
+  void underpassReachesPlatformViaElevator() {
+    var bl = node(0, new WgsCoordinate(0, 0));
+    var tl = node(1, new WgsCoordinate(5, 0));
+    // extra node inserted into the northern platform edge, due north of the elevator
+    var north = node(7, new WgsCoordinate(5, 2.5));
+    var tr = node(2, new WgsCoordinate(5, 5));
+    var br = node(3, new WgsCoordinate(0, 5));
+    var platform = List.of(bl, tl, north, tr, br);
+
+    // Stair rises from outside to the bottom-left corner.
+    var stairBottom = node(4, new WgsCoordinate(-1, 0));
+
+    // Elevator is a single node in the middle of the platform, shared with the underpass below.
+    var elevator = NodeBuilder.of(5, new WgsCoordinate(2.5, 2.5))
+      .withTag("highway", "elevator")
+      .withTag("wheelchair", "yes")
+      .build();
+
+    // Underpass runs beneath the platform and surfaces outside it.
+    var underpassEnd = node(6, new WgsCoordinate(2.5, 7));
+
+    var platformId = 100;
+    var stopArea = RelationBuilder.ofStopArea()
+      .withWayMember(platformId, "platform")
+      .withNodeMember(elevator.getId())
+      .build();
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(way -> way.withTag("public_transport", "platform"), platformId, platform)
+      .addWayFromNodes(way -> way.withTag("highway", "steps"), stairBottom, bl)
+      // top-level footway running straight north from the elevator to the northern platform edge
+      .addWayFromNodes(
+        way -> way.withTag("highway", "footway").withTag("level", "0"),
+        elevator,
+        north
+      )
+      // underpass one level below, sharing the elevator node
+      .addWayFromNodes(
+        way -> way.withTag("highway", "footway").withTag("tunnel", "yes").withTag("level", "-1"),
+        elevator,
+        underpassEnd
+      )
+      .addRelation(stopArea)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(true)
+      .withMaxAreaNodes(10)
+      .withPlatformEntriesLinking(false)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly(
+        // stair meeting the bottom-left corner (wheelchair-inaccessible steps)
+        "(0,0) → (-1,0) PEDESTRIAN ♿❌",
+        "(-1,0) → (0,0) PEDESTRIAN ♿❌",
+        // platform ring (5 sides × 2 directions; the northern side is split by the north node)
+        "(0,0) → (5,0) PEDESTRIAN ♿✅",
+        "(5,0) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (0,5) PEDESTRIAN ♿✅",
+        "(0,5) → (0,0) PEDESTRIAN ♿✅",
+        "(5,0) → (5,2.5) PEDESTRIAN ♿✅",
+        "(5,2.5) → (5,0) PEDESTRIAN ♿✅",
+        "(5,5) → (5,2.5) PEDESTRIAN ♿✅",
+        "(5,2.5) → (5,5) PEDESTRIAN ♿✅",
+        "(5,5) → (0,5) PEDESTRIAN ♿✅",
+        "(0,5) → (5,5) PEDESTRIAN ♿✅",
+        // visibility edges from the platform corners to the interior nodes they can see
+        "(0,0) → (5,2.5) PEDESTRIAN ♿✅",
+        "(5,2.5) → (0,0) PEDESTRIAN ♿✅",
+        "(0,0) → (2.5,2.5) PEDESTRIAN ♿✅",
+        "(2.5,2.5) → (0,0) PEDESTRIAN ♿✅",
+        "(5,5) → (2.5,2.5) PEDESTRIAN ♿✅",
+        "(2.5,2.5) → (5,5) PEDESTRIAN ♿✅",
+        // north-node-to-elevator connection: the explicit level-0 footway plus a mirroring
+        // visibility edge, so each direction appears twice
+        "(5,2.5) → (2.5,2.5) PEDESTRIAN ♿✅",
+        "(5,2.5) → (2.5,2.5) PEDESTRIAN ♿✅",
+        "(2.5,2.5) → (5,2.5) PEDESTRIAN ♿✅",
+        "(2.5,2.5) → (5,2.5) PEDESTRIAN ♿✅",
+        // underpass (tunnel, level -1) surfacing outside the platform
+        "(2.5,7) → (2.5,2.5) PEDESTRIAN ♿✅",
+        "(2.5,2.5) → (2.5,7) PEDESTRIAN ♿✅",
+        // elevator level 0: the node is attached both by the platform area (WAY:100) and the footway
+        // (WAY:2), joined by a zero-level hop
+        "osm:node:5:WAY:100 → elevator/osm:node:5:WAY:100 ELEVATOR board",
+        "elevator/osm:node:5:WAY:100 → osm:node:5:WAY:100 ELEVATOR alight",
+        "elevator/osm:node:5:WAY:100 → elevator/osm:node:5:WAY:2 ELEVATOR hop levels=0 ♿✅",
+        "elevator/osm:node:5:WAY:2 → elevator/osm:node:5:WAY:100 ELEVATOR hop levels=0 ♿✅",
+        // elevator between the footway (level 0) and the underpass (WAY:3, level -1)
+        "osm:node:5:WAY:2 → elevator/osm:node:5:WAY:2 ELEVATOR board",
+        "elevator/osm:node:5:WAY:2 → osm:node:5:WAY:2 ELEVATOR alight",
+        "osm:node:5:WAY:3 → elevator/osm:node:5:WAY:3 ELEVATOR board",
+        "elevator/osm:node:5:WAY:3 → osm:node:5:WAY:3 ELEVATOR alight",
+        "elevator/osm:node:5:WAY:2 → elevator/osm:node:5:WAY:3 ELEVATOR hop levels=1 ♿✅",
+        "elevator/osm:node:5:WAY:3 → elevator/osm:node:5:WAY:2 ELEVATOR hop levels=1 ♿✅"
+      );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/WheelchairInaccessibleAreaTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/WheelchairInaccessibleAreaTest.java
@@ -53,6 +53,19 @@ class WheelchairInaccessibleAreaTest {
 
     assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
       .that(summarizer.summarizeEdges())
-      .containsExactly("PLACEHOLDER");
+      .containsExactly(
+        // connecting footway stays accessible
+        "(0,0) → (-0.001,0) PEDESTRIAN ♿✅",
+        "(-0.001,0) → (0,0) PEDESTRIAN ♿✅",
+        // all ring edges inherit wheelchair=no from the area
+        "(0,0) → (0.001,0) PEDESTRIAN ♿❌",
+        "(0.001,0) → (0,0) PEDESTRIAN ♿❌",
+        "(0,0) → (0,0.001) PEDESTRIAN ♿❌",
+        "(0,0.001) → (0,0) PEDESTRIAN ♿❌",
+        "(0.001,0) → (0.001,0.001) PEDESTRIAN ♿❌",
+        "(0.001,0.001) → (0.001,0) PEDESTRIAN ♿❌",
+        "(0.001,0.001) → (0,0.001) PEDESTRIAN ♿❌",
+        "(0,0.001) → (0.001,0.001) PEDESTRIAN ♿❌"
+      );
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/WheelchairInaccessibleAreaTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/WheelchairInaccessibleAreaTest.java
@@ -1,0 +1,58 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.walkablearea;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+
+/**
+ * Tests that {@code wheelchair=no} on an area propagates to all generated ring edges.
+ *
+ * <p>The accessibility flag is set in {@code createSegments} from
+ * {@code parent.isWheelchairAccessible()}, so every AreaEdge produced for a
+ * {@code wheelchair=no} area should carry {@code ♿❌}.
+ *
+ * <p>Visibility is disabled so the expected edges are simply the four ring segments.
+ * The connecting footway is accessible and retains {@code ♿✅}.
+ */
+class WheelchairInaccessibleAreaTest {
+
+  @Test
+  void areaEdgesInheritWheelchairInaccessibility() {
+    var bl = node(0, new WgsCoordinate(0, 0));
+    var tl = node(1, new WgsCoordinate(0.001, 0));
+    var tr = node(2, new WgsCoordinate(0.001, 0.001));
+    var br = node(3, new WgsCoordinate(0, 0.001));
+    var area = List.of(bl, tl, tr, br);
+
+    var outside = node(4, new WgsCoordinate(-0.001, 0));
+
+    var provider = TestOsmProvider.of()
+      .addAreaFromNodes(
+        way -> way.withTag("highway", "pedestrian").withTag("wheelchair", "no"),
+        area
+      )
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), outside, bl)
+      .build();
+
+    var graph = new Graph();
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withAreaVisibility(false)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Unexpected edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(summarizer.summarizeEdges())
+      .containsExactly("PLACEHOLDER");
+  }
+}

--- a/street/src/main/java/org/opentripplanner/street/graph/summary/StreetSummarizer.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/summary/StreetSummarizer.java
@@ -7,6 +7,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.street.model.edge.Edge;
+import org.opentripplanner.street.model.edge.ElevatorAlightEdge;
+import org.opentripplanner.street.model.edge.ElevatorBoardEdge;
+import org.opentripplanner.street.model.edge.ElevatorHopEdge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.edge.StreetTransitEntityLink;
 import org.opentripplanner.street.model.edge.TemporaryFreeEdge;
@@ -46,6 +49,25 @@ class StreetSummarizer {
         "Parking %s → %s",
         summarizeVertex(p.getFromVertex()),
         summarizeVertex(p.getToVertex())
+      );
+      // Elevator vertices all share the elevator node's coordinate, so their labels (which encode
+      // the connected entity and level) identify them rather than the coordinate.
+      case ElevatorBoardEdge board -> String.format(
+        "%s → %s ELEVATOR board",
+        board.getFromVertex().getLabelString(),
+        board.getToVertex().getLabelString()
+      );
+      case ElevatorAlightEdge alight -> String.format(
+        "%s → %s ELEVATOR alight",
+        alight.getFromVertex().getLabelString(),
+        alight.getToVertex().getLabelString()
+      );
+      case ElevatorHopEdge hop -> String.format(
+        "%s → %s ELEVATOR hop levels=%s ♿%s",
+        hop.getFromVertex().getLabelString(),
+        hop.getToVertex().getLabelString(),
+        DECIMAL_FORMAT.format(hop.getLevels()),
+        summarizeBoolean(hop.isWheelchairAccessible())
       );
       default -> throw new NotImplementedException(
         "No summary for edge " + e.getClass().getSimpleName()


### PR DESCRIPTION
### Summary

This is a **test-only** PR: it adds a suite of module-level characterization tests for the OSM
`WalkableAreaBuilder`. There are **no production changes**.

`WalkableAreaBuilder` is complex and, until now, thinly covered. Several refactorings are planned to
simplify and speed it up (deduplicating the ring traversal and edge construction, collapsing
redundant data structures, clarifying the `maxAreaNodes` sampling, making better use of prepared
geometries, etc.). Before touching that code, this PR locks in its current observable behaviour so
that the upcoming refactors can be verified to be behaviour-preserving — i.e. **this PR exists to
prevent regressions in the refactoring work that follows.**

The tests exercise:

- simple areas, with and without visibility computation (`withAreaVisibility`)
- multipolygon platforms with one and with two inner holes
- concave outer rings and concave (comb-shaped) holes
- stairs and footways connecting into areas, and platform-entry linking (`platformEntriesLinking`)
- wheelchair-inaccessible areas propagating to their edges
- an elevator/underpass connecting a stop-area platform across levels
- isolated (unconnected) areas being removed
- the `maxAreaNodes` budget reducing the visibility graph

Each test asserts the **exact** set of generated area/visibility edges (and their permissions and
wheelchair flags) via `GraphSummarizer`, so any change to the produced street graph is caught
immediately.

### Unit tests

This PR is entirely tests. They live in
`application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/walkablearea/`
and use the in-memory `TestOsmProvider` + `GraphSummarizer` harness, so a failure prints a
human-readable edge list plus a geojson.io link to inspect the graph. All tests pass in CI.

One caveat worth noting: `PlatformRelationWithTwoHolesAndStairsTest#lowMaxAreaNodes` asserts only the
mandatory (ring / footway / stair) edges with `containsAtLeast`, because under a `maxAreaNodes`
budget smaller than the candidate count the surviving visibility cross-edges depend on candidate
iteration order, which is not stable across JVM runs. Making that fully deterministic is one of the
follow-up refactorings.

### Documentation

Every test class carries Javadoc describing the geometry it sets up and the behaviour it locks in.

### Changelog

Test-only, so this should be excluded from the changelog — please add the `+Skip Changelog` label.
