### PR TITLE
Report invalid line ref as DataImportIssue in NeTEx TripMapper

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -82,10 +82,6 @@ class TripMapper {
     org.opentripplanner.transit.model.network.Route route = resolveRoute(serviceJourney);
 
     if (route == null) {
-      LOG.warn(
-        "Unable to map ServiceJourney, missing serviceId. SJ id: {}",
-        serviceJourney.getId()
-      );
       return null;
     }
 
@@ -173,6 +169,7 @@ class TripMapper {
     return null;
   }
 
+  @Nullable
   private org.opentripplanner.transit.model.network.Route resolveRoute(
     ServiceJourney serviceJourney
   ) {
@@ -195,8 +192,9 @@ class TripMapper {
     );
 
     if (route == null) {
-      LOG.warn(
-        "Unable to link ServiceJourney to Route. ServiceJourney id: {}, Line ref: {}",
+      issueStore.add(
+        "InvalidLineRef",
+        "Unable to map ServiceJourney. SJ id: %s, LineRef: %s",
         serviceJourney.getId(),
         lineRef
       );

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
@@ -2,16 +2,20 @@ package org.opentripplanner.netex.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.netex.mapping.MappingSupport.ID_FACTORY;
 import static org.opentripplanner.netex.mapping.MappingSupport.createWrappedRef;
 
 import jakarta.xml.bind.JAXBElement;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
@@ -29,7 +33,7 @@ import org.rutebanken.netex.model.LineRefStructure;
 import org.rutebanken.netex.model.RouteRefStructure;
 import org.rutebanken.netex.model.ServiceJourney;
 
-public class TripMapperTest {
+class TripMapperTest {
 
   private static final String ROUTE_ID = "RUT:Route:1";
   private static final String SERVICE_JOURNEY_ID = NetexTestDataSample.SERVICE_JOURNEY_ID;
@@ -43,7 +47,7 @@ public class TripMapperTest {
   );
 
   @Test
-  public void mapTripWithWheelchairAccess() {
+  void mapTripWithWheelchairAccess() {
     var serviceJourney = createExampleServiceJourney();
     var wheelchairLimitation = LimitationStatusEnumeration.TRUE;
     var limitation = new AccessibilityLimitation();
@@ -78,7 +82,7 @@ public class TripMapperTest {
   }
 
   @Test
-  public void mapTrip() {
+  void mapTrip() {
     TransitDataImportBuilder transitBuilder = new TransitDataImportBuilder(
       new SiteRepository(),
       ISSUE_STORE
@@ -105,7 +109,7 @@ public class TripMapperTest {
   }
 
   @Test
-  public void mapTripWithRouteRefViaJourneyPattern() {
+  void mapTripWithRouteRefViaJourneyPattern() {
     TransitDataImportBuilder transitBuilder = new TransitDataImportBuilder(
       new SiteRepository(),
       ISSUE_STORE
@@ -143,6 +147,35 @@ public class TripMapperTest {
     Trip trip = tripMapper.mapServiceJourney(serviceJourney, this::headsign);
 
     assertEquals(trip.getId(), ID_FACTORY.createId("RUT:ServiceJourney:1"));
+  }
+
+  @Test
+  void mapTripWithInvalidLineRefAddsIssue() {
+    var issueStore = new DefaultDataImportIssueStore();
+    var transitBuilder = new TransitDataImportBuilder(new SiteRepository(), issueStore);
+
+    TripMapper tripMapper = new TripMapper(
+      ID_FACTORY,
+      issueStore,
+      transitBuilder.getOperatorsById(),
+      transitBuilder.getRoutes(),
+      new HierarchicalMapById<>(),
+      new HierarchicalMap<>(),
+      Map.of(SERVICE_JOURNEY_ID, SERVICE_ID)
+    );
+
+    ServiceJourney serviceJourney = createExampleServiceJourney();
+    serviceJourney.setLineRef(
+      MappingSupport.createWrappedRef("RUT:Line:NONEXISTENT", LineRefStructure.class)
+    );
+
+    Trip trip = tripMapper.mapServiceJourney(serviceJourney, this::headsign);
+
+    assertNull(trip, "trip must be null when lineRef is invalid");
+
+    List<DataImportIssue> issues = issueStore.listIssues();
+    assertEquals(1, issues.size());
+    assertEquals("InvalidLineRef", issues.getFirst().getType());
   }
 
   private ServiceJourney createExampleServiceJourney() {


### PR DESCRIPTION
### Summary

When a NeTEx `ServiceJourney` cannot be linked to a route because the `LineRef` is invalid or missing, the mapper previously logged a `WARN` message that was easy to miss. This PR replaces that log call with `issueStore.add(\"InvalidLineRef\", ...)`, which surfaces the problem in the data import issue report alongside all other mapping issues.

### Issue

No separate issue — this is a small, self-contained improvement to issue reporting consistency in the NeTEx importer.

- **Motivation:** Silent `LOG.warn` calls in the importer are harder to track down than structured `DataImportIssue` entries. Operators and developers should see these problems in the standard import report.
- **How the code works:** `TripMapper.resolveRoute` now calls `issueStore.add` instead of `LOG.warn` when the resolved OTP route is `null`. The `@Nullable` annotation is also added to the method to make the contract explicit. The redundant `LOG.warn` at the call site (which repeated the same condition) is removed.

### Unit tests

- A new test `mapTripWithInvalidLineRefAddsIssue` is added to `TripMapperTest`. It uses a real `DefaultDataImportIssueStore` (instead of the `NOOP` store used in other tests) and asserts that:
  - `mapServiceJourney` returns `null` for an invalid line ref
  - exactly one `InvalidLineRef` issue is recorded in the store

### Documentation

No new configuration options or public API changes.

### Changelog

The PR title describes the change. No `+Skip Changelog` label needed.