### PR TITLE
Move alert service away from transit service

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
@@ -43,6 +43,8 @@ class RealtimeResolverTest {
   private final RegularStop stop2 = testModel.stop("stop2", 2, 1).build();
   private final RegularStop stop3 = testModel.stop("stop3", 3, 1).build();
 
+  private final TransitAlertService transitAlertService = new TransitAlertServiceImpl();
+
   @Test
   void testPopulateLegsWithRealtime() {
     var itinerary = newItinerary(Place.forStop(stop1), time("11:00"))
@@ -61,11 +63,12 @@ class RealtimeResolverTest {
       .addEntity(new EntitySelector.StopAndRoute(stop3.getId(), route2.getId()))
       .addTimePeriod(new TimePeriod(0, 0))
       .build();
-    transitService.getTransitAlertService().setAlerts(List.of(alert));
+    transitAlertService.setAlerts(List.of(alert));
 
     var itinerariesWithRealtime = RealtimeResolver.populateLegsWithRealtime(
       List.of(itinerary),
-      transitService
+      transitService,
+      transitAlertService
     );
 
     assertFalse(itinerariesWithRealtime.isEmpty());
@@ -98,7 +101,11 @@ class RealtimeResolverTest {
     var transitService = new DefaultTransitService(model);
 
     var itineraries = List.of(itinerary);
-    itineraries = RealtimeResolver.populateLegsWithRealtime(itineraries, transitService);
+    itineraries = RealtimeResolver.populateLegsWithRealtime(
+      itineraries,
+      transitService,
+      transitAlertService
+    );
 
     assertEquals(1, itineraries.size());
 
@@ -120,7 +127,11 @@ class RealtimeResolverTest {
     var transitService = makeTransitService(patterns, serviceDate);
 
     var itineraries = List.of(staySeatedItinerary);
-    itineraries = RealtimeResolver.populateLegsWithRealtime(itineraries, transitService);
+    itineraries = RealtimeResolver.populateLegsWithRealtime(
+      itineraries,
+      transitService,
+      transitAlertService
+    );
 
     assertEquals(1, itineraries.size());
 
@@ -179,13 +190,6 @@ class RealtimeResolverTest {
     transitRepository.updateCalendarServiceData(calendarServiceData);
     transitRepository.index();
 
-    return new DefaultTransitService(transitRepository) {
-      final TransitAlertService alertService = new TransitAlertServiceImpl(transitRepository);
-
-      @Override
-      public TransitAlertService getTransitAlertService() {
-        return alertService;
-      }
-    };
+    return new DefaultTransitService(transitRepository);
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
@@ -21,7 +21,6 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -43,8 +42,6 @@ class RealtimeResolverTest {
   private final RegularStop stop2 = testModel.stop("stop2", 2, 1).build();
   private final RegularStop stop3 = testModel.stop("stop3", 3, 1).build();
 
-  private final TransitAlertService transitAlertService = new TransitAlertServiceImpl();
-
   @Test
   void testPopulateLegsWithRealtime() {
     var itinerary = newItinerary(Place.forStop(stop1), time("11:00"))
@@ -59,6 +56,7 @@ class RealtimeResolverTest {
     var transitService = makeTransitService(List.of(delayedPattern, patterns.get(1)), serviceDate);
 
     // Put an alert on stop3
+    var transitAlertService = new TransitAlertServiceImpl();
     var alert = TransitAlert.of(stop3.getId())
       .addEntity(new EntitySelector.StopAndRoute(stop3.getId(), route2.getId()))
       .addTimePeriod(new TimePeriod(0, 0))
@@ -104,7 +102,7 @@ class RealtimeResolverTest {
     itineraries = RealtimeResolver.populateLegsWithRealtime(
       itineraries,
       transitService,
-      transitAlertService
+      new TransitAlertServiceImpl()
     );
 
     assertEquals(1, itineraries.size());
@@ -130,7 +128,7 @@ class RealtimeResolverTest {
     itineraries = RealtimeResolver.populateLegsWithRealtime(
       itineraries,
       transitService,
-      transitAlertService
+      new TransitAlertServiceImpl()
     );
 
     assertEquals(1, itineraries.size());

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -21,7 +21,6 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -56,17 +55,11 @@ public class RealtimeStopsLayerTest {
 
   @Test
   void realtimeStopLayer() {
-    var transitRepository = new TransitRepository(new SiteRepository());
-    transitRepository.initTimeZone(ZoneIds.HELSINKI);
-    transitRepository.index();
-    var transitService = new DefaultTransitService(transitRepository) {
-      final TransitAlertService alertService = new TransitAlertServiceImpl(transitRepository);
-
-      @Override
-      public TransitAlertService getTransitAlertService() {
-        return alertService;
-      }
-    };
+    var timetableRepository = new TransitRepository(new SiteRepository());
+    timetableRepository.initTimeZone(ZoneIds.HELSINKI);
+    timetableRepository.index();
+    var transitService = new DefaultTransitService(timetableRepository);
+    var transitAlertService = new TransitAlertServiceImpl();
 
     Route route = TransitRepositoryForTest.route("route").build();
     var itinerary = newItinerary(Place.forStop(stop), time("11:00"))
@@ -79,14 +72,19 @@ public class RealtimeStopsLayerTest {
       .addTimePeriod(new TimePeriod(startDate, endDate))
       .withEffect(AlertEffect.NO_SERVICE)
       .build();
-    transitService.getTransitAlertService().setAlerts(List.of(alert));
+    transitAlertService.setAlerts(List.of(alert));
 
     // TODO Why is these 2 lines here - the test works without them?
     var itineraries = List.of(itinerary);
-    itineraries = RealtimeResolver.populateLegsWithRealtime(itineraries, transitService);
+    itineraries = RealtimeResolver.populateLegsWithRealtime(
+      itineraries,
+      transitService,
+      transitAlertService
+    );
 
     DigitransitRealtimeStopPropertyMapper mapper = new DigitransitRealtimeStopPropertyMapper(
       transitService,
+      transitAlertService,
       new Locale("en-US")
     );
 

--- a/application/src/ext/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolver.java
+++ b/application/src/ext/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolver.java
@@ -5,14 +5,17 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.TransitService;
 
 public class RealtimeResolver {
 
   private final TransitService transitService;
+  private final TransitAlertService transitAlertService;
 
-  public RealtimeResolver(TransitService transitService) {
+  public RealtimeResolver(TransitService transitService, TransitAlertService transitAlertService) {
     this.transitService = transitService;
+    this.transitAlertService = transitAlertService;
   }
 
   /**
@@ -20,9 +23,10 @@ public class RealtimeResolver {
    */
   public static List<Itinerary> populateLegsWithRealtime(
     List<Itinerary> itineraries,
-    TransitService transitService
+    TransitService transitService,
+    TransitAlertService transitAlertService
   ) {
-    return new RealtimeResolver(transitService).addRealtimeInfo(itineraries);
+    return new RealtimeResolver(transitService, transitAlertService).addRealtimeInfo(itineraries);
   }
 
   private List<Itinerary> addRealtimeInfo(List<Itinerary> itineraries) {
@@ -47,7 +51,7 @@ public class RealtimeResolver {
     if (!(leg.isScheduledTransitLeg())) {
       return leg;
     }
-    var realTimeLeg = ref.getLeg(transitService);
+    var realTimeLeg = ref.getLeg(transitService, transitAlertService);
     if (realTimeLeg == null) {
       return leg;
     }

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -5,7 +5,6 @@ import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.siri.SiriAlertsUpdateHandler;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.opentripplanner.updater.trip.siri.SiriFuzzyTripMatcherCache;
@@ -23,10 +22,9 @@ public class SiriAzureSXUpdater implements SiriAzureMessageHandler {
 
   public SiriAzureSXUpdater(
     SiriAzureSXUpdaterParameters config,
-    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache
   ) {
-    this.transitAlertService = new TransitAlertServiceImpl(transitRepository);
+    this.transitAlertService = new TransitAlertServiceImpl();
     this.updateHandler = new SiriAlertsUpdateHandler(
       config.feedId(),
       transitAlertService,

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
@@ -34,7 +34,6 @@ import org.opentripplanner.framework.retry.OtpRetry;
 import org.opentripplanner.framework.retry.OtpRetryBuilder;
 import org.opentripplanner.framework.retry.OtpRetryException;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -134,14 +133,9 @@ public class SiriAzureUpdater implements GraphUpdater {
 
   public static SiriAzureUpdater createSXUpdater(
     SiriAzureSXUpdaterParameters config,
-    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache
   ) {
-    var messageHandler = new SiriAzureSXUpdater(
-      config,
-      transitRepository,
-      siriFuzzyTripMatcherCache
-    );
+    var messageHandler = new SiriAzureSXUpdater(config, siriFuzzyTripMatcherCache);
     return new SxWrapper(config, messageHandler);
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -124,7 +124,12 @@ public class VectorTilesResource {
     OtpServerRequestContext context
   ) {
     return switch (layerParameters.type()) {
-      case Stop -> new StopsLayerBuilder(context.transitService(), layerParameters, locale);
+      case Stop -> new StopsLayerBuilder(
+        context.transitService(),
+        context.transitAlertService(),
+        layerParameters,
+        locale
+      );
       case Station -> new StationsLayerBuilder(context.transitService(), layerParameters, locale);
       case AreaStop -> new AreaStopsLayerBuilder(context.transitService(), layerParameters, locale);
       case VehicleRental -> new VehicleRentalPlacesLayerBuilder(

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
 import org.opentripplanner.core.model.i18n.I18NStringMapper;
 import org.opentripplanner.inspector.vector.KeyValue;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.ArrivalDeparture;
 import org.opentripplanner.transit.service.TransitService;
@@ -19,23 +20,25 @@ import org.opentripplanner.utils.collection.ListUtils;
 public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<RegularStop> {
 
   private final TransitService transitService;
+  private final TransitAlertService transitAlertService;
   private final I18NStringMapper i18NStringMapper;
 
-  public DigitransitRealtimeStopPropertyMapper(TransitService transitService, Locale locale) {
+  public DigitransitRealtimeStopPropertyMapper(
+    TransitService transitService,
+    TransitAlertService transitAlertService,
+    Locale locale
+  ) {
     this.transitService = transitService;
+    this.transitAlertService = transitAlertService;
     this.i18NStringMapper = new I18NStringMapper(locale);
   }
 
   @Override
   protected Collection<KeyValue> map(RegularStop stop) {
     Instant currentTime = Instant.now();
-    var stopAlerts = new HashSet<>(
-      transitService.getTransitAlertService().getStopAlerts(stop.getId())
-    );
+    var stopAlerts = new HashSet<>(transitAlertService.getStopAlerts(stop.getId()));
     if (stop.isPartOfStation()) {
-      stopAlerts.addAll(
-        transitService.getTransitAlertService().getStopAlerts(stop.getParentStation().getId())
-      );
+      stopAlerts.addAll(transitAlertService.getStopAlerts(stop.getParentStation().getId()));
     }
     boolean noServiceAlert = stopAlerts.stream().anyMatch(alert -> alert.noServiceAt(currentTime));
 

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPr
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
@@ -36,10 +35,7 @@ public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<Regula
   @Override
   protected Collection<KeyValue> map(RegularStop stop) {
     Instant currentTime = Instant.now();
-    var stopAlerts = new HashSet<>(transitAlertService.getStopAlerts(stop.getId()));
-    if (stop.isPartOfStation()) {
-      stopAlerts.addAll(transitAlertService.getStopAlerts(stop.getParentStation().getId()));
-    }
+    var stopAlerts = transitAlertService.getStopLocationsAlerts(stop.getIdAndParentStationId());
     boolean noServiceAlert = stopAlerts.stream().anyMatch(alert -> alert.noServiceAt(currentTime));
 
     var serviceDate = LocalDate.now(transitService.getTimeZone());

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitRealtimeStopPropertyMapper.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPr
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
@@ -28,11 +29,15 @@ public class DigitransitRealtimeStopPropertyMapper extends PropertyMapper<Regula
   @Override
   protected Collection<KeyValue> map(RegularStop stop) {
     Instant currentTime = Instant.now();
-    boolean noServiceAlert = transitService
-      .getTransitAlertService()
-      .getStopAlerts(stop.getId())
-      .stream()
-      .anyMatch(alert -> alert.noServiceAt(currentTime));
+    var stopAlerts = new HashSet<>(
+      transitService.getTransitAlertService().getStopAlerts(stop.getId())
+    );
+    if (stop.isPartOfStation()) {
+      stopAlerts.addAll(
+        transitService.getTransitAlertService().getStopAlerts(stop.getParentStation().getId())
+      );
+    }
+    boolean noServiceAlert = stopAlerts.stream().anyMatch(alert -> alert.noServiceAt(currentTime));
 
     var serviceDate = LocalDate.now(transitService.getTimeZone());
     boolean stopTimesExist = transitService

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
@@ -12,6 +12,7 @@ import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.ext.vectortiles.layers.LayerFilters;
 import org.opentripplanner.inspector.vector.LayerBuilder;
 import org.opentripplanner.inspector.vector.LayerParameters;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -22,6 +23,7 @@ public class StopsLayerBuilder extends LayerBuilder<RegularStop> {
 
   public StopsLayerBuilder(
     TransitService transitService,
+    TransitAlertService transitAlertService,
     LayerParameters<VectorTilesResource.LayerType> layerParameters,
     Locale locale
   ) {
@@ -30,7 +32,7 @@ public class StopsLayerBuilder extends LayerBuilder<RegularStop> {
         entry(MapperType.Digitransit, new DigitransitStopPropertyMapper(transitService, locale)),
         entry(
           MapperType.DigitransitRealtime,
-          new DigitransitRealtimeStopPropertyMapper(transitService, locale)
+          new DigitransitRealtimeStopPropertyMapper(transitService, transitAlertService, locale)
         )
       ).get(MapperType.valueOf(layerParameters.mapper())),
       layerParameters.name(),

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/GraphQLRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/GraphQLRequestContext.java
@@ -6,6 +6,7 @@ import org.opentripplanner.place.NearbyStopFinder;
 import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -16,6 +17,7 @@ import org.opentripplanner.transit.service.TransitService;
 public record GraphQLRequestContext(
   RoutingService routingService,
   TransitService transitService,
+  TransitAlertService transitAlertService,
   RegularTransferService transferService,
   FareService fareService,
   VehicleRentalService vehicleRentalService,
@@ -30,6 +32,7 @@ public record GraphQLRequestContext(
     return new GraphQLRequestContext(
       context.routingService(),
       context.transitService(),
+      context.transitAlertService(),
       context.transferService(),
       context.fareService(),
       context.vehicleRentalService(),

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AgencyImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AgencyImpl.java
@@ -22,7 +22,7 @@ public class AgencyImpl implements GraphQLDataFetchers.GraphQLAgency {
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitAlertService(environment);
       var args = new GraphQLTypes.GraphQLAgencyAlertsArgs(environment.getArguments());
       List<GraphQLTypes.GraphQLAgencyAlertType> types = args.getGraphQLTypes();
       if (types != null) {
@@ -116,6 +116,10 @@ public class AgencyImpl implements GraphQLDataFetchers.GraphQLAgency {
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().transitService();
+  }
+
+  private TransitAlertService getTransitAlertService(DataFetchingEnvironment environment) {
+    return environment.<GraphQLRequestContext>getContext().transitAlertService();
   }
 
   private Agency getSource(DataFetchingEnvironment environment) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/FeedImpl.java
@@ -26,7 +26,7 @@ public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitAlertService(environment);
       var args = new GraphQLTypes.GraphQLFeedAlertsArgs(environment.getArguments());
       List<GraphQLTypes.GraphQLFeedAlertType> types = args.getGraphQLTypes();
       if (types != null) {
@@ -94,6 +94,10 @@ public class FeedImpl implements GraphQLDataFetchers.GraphQLFeed {
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().transitService();
+  }
+
+  private TransitAlertService getTransitAlertService(DataFetchingEnvironment environment) {
+    return environment.<GraphQLRequestContext>getContext().transitAlertService();
   }
 
   private String getSource(DataFetchingEnvironment environment) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
@@ -99,10 +99,9 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
               getSource(environment)
                 .getStops()
                 .forEach(stop -> {
-                  alerts.addAll(alertService.getStopAlerts(stop.getId()));
-                  if (stop.isPartOfStation()) {
-                    alerts.addAll(alertService.getStopAlerts(stop.getParentStation().getId()));
-                  }
+                  alerts.addAll(
+                    alertService.getStopLocationsAlerts(stop.getIdAndParentStationId())
+                  );
                 });
               break;
             case STOPS_ON_TRIPS:

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
@@ -42,7 +42,7 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitAlertService(environment);
       var args = new GraphQLTypes.GraphQLPatternAlertsArgs(environment.getArguments());
       List<GraphQLTypes.GraphQLPatternAlertType> types = args.getGraphQLTypes();
       if (types != null) {
@@ -297,6 +297,10 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().transitService();
+  }
+
+  private TransitAlertService getTransitAlertService(DataFetchingEnvironment environment) {
+    return environment.<GraphQLRequestContext>getContext().transitAlertService();
   }
 
   private TripPattern getSource(DataFetchingEnvironment environment) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
@@ -20,7 +20,6 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLPatternTripsO
 import org.opentripplanner.apis.gtfs.service.ApiTransitService;
 import org.opentripplanner.apis.gtfs.support.time.LocalDateRangeUtil;
 import org.opentripplanner.apis.support.SemanticHash;
-import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
@@ -100,8 +99,10 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
               getSource(environment)
                 .getStops()
                 .forEach(stop -> {
-                  FeedScopedId stopId = stop.getId();
-                  alerts.addAll(alertService.getStopAlerts(stopId));
+                  alerts.addAll(alertService.getStopAlerts(stop.getId()));
+                  if (stop.isPartOfStation()) {
+                    alerts.addAll(alertService.getStopAlerts(stop.getParentStation().getId()));
+                  }
                 });
               break;
             case STOPS_ON_TRIPS:

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
@@ -63,6 +63,7 @@ import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.error.RoutingValidationException;
 import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehicleparking.model.VehicleParking;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -110,9 +111,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      Collection<TransitAlert> alerts = getTransitService(environment)
-        .getTransitAlertService()
-        .getAllAlerts();
+      Collection<TransitAlert> alerts = getTransitAlertService(environment).getAllAlerts();
       var args = new GraphQLTypes.GraphQLQueryTypeAlertsArgs(environment.getArguments());
       return filterAlerts(alerts, args);
     };
@@ -378,7 +377,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
       if (ref == null) {
         return null;
       }
-      return ref.getLeg(transitService);
+      return ref.getLeg(transitService, getTransitAlertService(environment));
     };
   }
 
@@ -397,7 +396,7 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
         case "Agency":
           return transitService.getAgency(FeedScopedId.parseStrict(id));
         case "Alert":
-          return transitService.getTransitAlertService().getAlertById(FeedScopedId.parseStrict(id));
+          return getTransitAlertService(environment).getAlertById(FeedScopedId.parseStrict(id));
         case "BikePark":
           var bikeParkId = FeedScopedId.parseStrict(id);
           return vehicleParkingService == null
@@ -999,6 +998,10 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().transitService();
+  }
+
+  private TransitAlertService getTransitAlertService(DataFetchingEnvironment environment) {
+    return environment.<GraphQLRequestContext>getContext().transitAlertService();
   }
 
   private FareService getFareService(DataFetchingEnvironment environment) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
@@ -89,9 +89,15 @@ public class RouteImpl implements GraphQLDataFetchers.GraphQLRoute {
                   )
                   .toList()
               );
-              getStops(environment).forEach(stop ->
-                alerts.addAll(alertService.getStopAlerts(((StopLocation) stop).getId()))
-              );
+              getStops(environment).forEach(stop -> {
+                StopLocation stopLocation = (StopLocation) stop;
+                alerts.addAll(alertService.getStopAlerts(stopLocation.getId()));
+                if (stopLocation.isPartOfStation()) {
+                  alerts.addAll(
+                    alertService.getStopAlerts(stopLocation.getParentStation().getId())
+                  );
+                }
+              });
               break;
             case STOPS_ON_TRIPS:
               Iterable<Trip> trips = getTrips(environment);

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
@@ -91,12 +91,9 @@ public class RouteImpl implements GraphQLDataFetchers.GraphQLRoute {
               );
               getStops(environment).forEach(stop -> {
                 StopLocation stopLocation = (StopLocation) stop;
-                alerts.addAll(alertService.getStopAlerts(stopLocation.getId()));
-                if (stopLocation.isPartOfStation()) {
-                  alerts.addAll(
-                    alertService.getStopAlerts(stopLocation.getParentStation().getId())
-                  );
-                }
+                alerts.addAll(
+                  alertService.getStopLocationsAlerts(stopLocation.getIdAndParentStationId())
+                );
               });
               break;
             case STOPS_ON_TRIPS:

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/RouteImpl.java
@@ -278,7 +278,7 @@ public class RouteImpl implements GraphQLDataFetchers.GraphQLRoute {
   }
 
   private TransitAlertService getAlertService(DataFetchingEnvironment environment) {
-    return getTransitService(environment).getTransitAlertService();
+    return environment.<GraphQLRequestContext>getContext().transitAlertService();
   }
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -50,7 +50,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitAlertService(environment);
       var args = new GraphQLTypes.GraphQLStopAlertsArgs(environment.getArguments());
       List<GraphQLTypes.GraphQLStopAlertType> types = args.getGraphQLTypes();
       FeedScopedId id = getValue(environment, StopLocation::getId, AbstractTransitEntity::getId);
@@ -582,6 +582,10 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().transitService();
+  }
+
+  private TransitAlertService getTransitAlertService(DataFetchingEnvironment environment) {
+    return environment.<GraphQLRequestContext>getContext().transitAlertService();
   }
 
   private static <T> T getValue(

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -54,24 +53,15 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
       var args = new GraphQLTypes.GraphQLStopAlertsArgs(environment.getArguments());
       List<GraphQLTypes.GraphQLStopAlertType> types = args.getGraphQLTypes();
       FeedScopedId id = getValue(environment, StopLocation::getId, AbstractTransitEntity::getId);
+      List<FeedScopedId> ids = getValue(
+        environment,
+        StopLocation::getIdAndParentStationId,
+        station -> List.of(station.getId())
+      );
       if (types != null) {
         Collection<TransitAlert> alerts = new ArrayList<>();
         if (types.contains(GraphQLTypes.GraphQLStopAlertType.STOP)) {
-          alerts.addAll(
-            getValue(
-              environment,
-              stop -> {
-                Collection<TransitAlert> stopAlerts = new HashSet<>(
-                  alertService.getStopAlerts(stop.getId())
-                );
-                if (stop.isPartOfStation()) {
-                  stopAlerts.addAll(alertService.getStopAlerts(stop.getParentStation().getId()));
-                }
-                return stopAlerts;
-              },
-              station -> alertService.getStopAlerts(station.getId())
-            )
-          );
+          alerts.addAll(alertService.getStopLocationsAlerts(ids));
         }
         if (
           types.contains(GraphQLTypes.GraphQLStopAlertType.STOP_ON_ROUTES) ||
@@ -139,19 +129,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
         }
         return alerts.stream().distinct().collect(Collectors.toList());
       } else {
-        return getValue(
-          environment,
-          stop -> {
-            Collection<TransitAlert> stopAlerts = new HashSet<>(
-              alertService.getStopAlerts(stop.getId())
-            );
-            if (stop.isPartOfStation()) {
-              stopAlerts.addAll(alertService.getStopAlerts(stop.getParentStation().getId()));
-            }
-            return stopAlerts;
-          },
-          station -> alertService.getStopAlerts(station.getId())
-        );
+        return alertService.getStopLocationsAlerts(ids);
       }
     };
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -56,7 +57,21 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
       if (types != null) {
         Collection<TransitAlert> alerts = new ArrayList<>();
         if (types.contains(GraphQLTypes.GraphQLStopAlertType.STOP)) {
-          alerts.addAll(alertService.getStopAlerts(id));
+          alerts.addAll(
+            getValue(
+              environment,
+              stop -> {
+                Collection<TransitAlert> stopAlerts = new HashSet<>(
+                  alertService.getStopAlerts(stop.getId())
+                );
+                if (stop.isPartOfStation()) {
+                  stopAlerts.addAll(alertService.getStopAlerts(stop.getParentStation().getId()));
+                }
+                return stopAlerts;
+              },
+              station -> alertService.getStopAlerts(station.getId())
+            )
+          );
         }
         if (
           types.contains(GraphQLTypes.GraphQLStopAlertType.STOP_ON_ROUTES) ||
@@ -124,7 +139,19 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
         }
         return alerts.stream().distinct().collect(Collectors.toList());
       } else {
-        return alertService.getStopAlerts(id);
+        return getValue(
+          environment,
+          stop -> {
+            Collection<TransitAlert> stopAlerts = new HashSet<>(
+              alertService.getStopAlerts(stop.getId())
+            );
+            if (stop.isPartOfStation()) {
+              stopAlerts.addAll(alertService.getStopAlerts(stop.getParentStation().getId()));
+            }
+            return stopAlerts;
+          },
+          station -> alertService.getStopAlerts(station.getId())
+        );
       }
     };
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
@@ -118,8 +118,13 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
                   .toList()
               );
               getStops(environment).forEach(stop -> {
-                FeedScopedId stopId = ((StopLocation) stop).getId();
-                alerts.addAll(alertService.getStopAlerts(stopId));
+                StopLocation stopLocation = (StopLocation) stop;
+                alerts.addAll(alertService.getStopAlerts(stopLocation.getId()));
+                if (stopLocation.isPartOfStation()) {
+                  alerts.addAll(
+                    alertService.getStopAlerts(stopLocation.getParentStation().getId())
+                  );
+                }
               });
               break;
           }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
@@ -119,12 +119,9 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
               );
               getStops(environment).forEach(stop -> {
                 StopLocation stopLocation = (StopLocation) stop;
-                alerts.addAll(alertService.getStopAlerts(stopLocation.getId()));
-                if (stopLocation.isPartOfStation()) {
-                  alerts.addAll(
-                    alertService.getStopAlerts(stopLocation.getParentStation().getId())
-                  );
-                }
+                alerts.addAll(
+                  alertService.getStopLocationsAlerts(stopLocation.getIdAndParentStationId())
+                );
               });
               break;
           }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
@@ -62,7 +62,7 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitAlertService(environment);
       var args = new GraphQLTypes.GraphQLTripAlertsArgs(environment.getArguments());
       List<GraphQLTypes.GraphQLTripAlertType> types = args.getGraphQLTypes();
       if (types != null) {
@@ -447,6 +447,10 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {
     return environment.<GraphQLRequestContext>getContext().transitService();
+  }
+
+  private TransitAlertService getTransitAlertService(DataFetchingEnvironment environment) {
+    return environment.<GraphQLRequestContext>getContext().transitAlertService();
   }
 
   private RealtimeVehicleService getRealtimeVehiclesService(DataFetchingEnvironment environment) {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchemaFactory.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchemaFactory.java
@@ -1455,9 +1455,9 @@ public class TransmodelGraphQLSchemaFactory {
               .build()
           )
           .dataFetcher(environment -> {
-            Collection<TransitAlert> alerts = GqlUtil.getTransitService(environment)
-              .getTransitAlertService()
-              .getAllAlerts();
+            Collection<TransitAlert> alerts = GqlUtil.getTransitAlertService(
+              environment
+            ).getAllAlerts();
 
             Set<String> codespaces = new HashSet<>();
 
@@ -1510,9 +1510,9 @@ public class TransmodelGraphQLSchemaFactory {
             if (situationNumber.isBlank()) {
               return null;
             }
-            return GqlUtil.getTransitService(environment)
-              .getTransitAlertService()
-              .getAlertById(idMapper.parseNullSafe(situationNumber).orElse(null));
+            return GqlUtil.getTransitAlertService(environment).getAlertById(
+              idMapper.parseNullSafe(situationNumber).orElse(null)
+            );
           })
           .build()
       )
@@ -1537,7 +1537,10 @@ public class TransmodelGraphQLSchemaFactory {
             if (ref == null) {
               return null;
             }
-            return ref.getLeg(GqlUtil.getTransitService(environment));
+            return ref.getLeg(
+              GqlUtil.getTransitService(environment),
+              GqlUtil.getTransitAlertService(environment)
+            );
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelRequestContext.java
@@ -3,6 +3,7 @@ package org.opentripplanner.apis.transmodel;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.empiricaldelay.EmpiricalDelayService;
 import org.opentripplanner.routing.api.RoutingService;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.utils.lang.Sandbox;
@@ -36,6 +37,10 @@ public class TransmodelRequestContext {
 
   public TransitService getTransitService() {
     return transitService;
+  }
+
+  public TransitAlertService getTransitAlertService() {
+    return serverContext.transitAlertService();
   }
 
   @Nullable

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/AuthorityType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/AuthorityType.java
@@ -83,9 +83,9 @@ public class AuthorityType {
           .description("Get all situations active for the authority.")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(environment ->
-            getTransitService(environment)
-              .getTransitAlertService()
-              .getAgencyAlerts(((Agency) environment.getSource()).getId())
+            GqlUtil.getTransitAlertService(environment).getAgencyAlerts(
+              ((Agency) environment.getSource()).getId()
+            )
           )
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/network/JourneyPatternType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/network/JourneyPatternType.java
@@ -144,12 +144,10 @@ public class JourneyPatternType {
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(environment -> {
             TripPattern tripPattern = environment.getSource();
-            return GqlUtil.getTransitService(environment)
-              .getTransitAlertService()
-              .getDirectionAndRouteAlerts(
-                tripPattern.getDirection(),
-                tripPattern.getRoute().getId()
-              );
+            return GqlUtil.getTransitAlertService(environment).getDirectionAndRouteAlerts(
+              tripPattern.getDirection(),
+              tripPattern.getRoute().getId()
+            );
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/network/LineType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/network/LineType.java
@@ -190,9 +190,9 @@ public class LineType {
           .description("Get all situations active for the line.")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(environment ->
-            GqlUtil.getTransitService(environment)
-              .getTransitAlertService()
-              .getRouteAlerts((getSource(environment)).getId())
+            GqlUtil.getTransitAlertService(environment).getRouteAlerts(
+              (getSource(environment)).getId()
+            )
           )
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
@@ -34,7 +34,6 @@ import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
-import org.opentripplanner.transit.service.TransitService;
 
 public class EstimatedCallType {
 
@@ -288,7 +287,9 @@ public class EstimatedCallType {
           .withDirective(TransmodelDirectives.TIMING_DATA)
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .description("Get all relevant situations for this EstimatedCall.")
-          .dataFetcher(env -> getAllRelevantAlerts(env.getSource(), GqlUtil.getTransitService(env)))
+          .dataFetcher(env ->
+            getAllRelevantAlerts(env.getSource(), GqlUtil.getTransitAlertService(env))
+          )
           .build()
       )
       .field(
@@ -347,7 +348,7 @@ public class EstimatedCallType {
    */
   private static Collection<TransitAlert> getAllRelevantAlerts(
     TripTimeOnDate tripTimeOnDate,
-    TransitService transitService
+    TransitAlertService alertPatchService
   ) {
     Trip trip = tripTimeOnDate.getTrip();
     FeedScopedId tripId = trip.getId();
@@ -357,8 +358,6 @@ public class EstimatedCallType {
     FeedScopedId stopId = stop.getId();
 
     Collection<TransitAlert> allAlerts = new HashSet<>();
-
-    TransitAlertService alertPatchService = transitService.getTransitAlertService();
 
     final LocalDate serviceDate = tripTimeOnDate.getServiceDay();
 

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
@@ -360,7 +360,7 @@ public class QuayType {
           .description("Get all situations active for the quay.")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(env -> {
-            var alertService = GqlUtil.getTransitService(env).getTransitAlertService();
+            var alertService = GqlUtil.getTransitAlertService(env);
             var quay = (StopLocation) env.getSource();
             var alerts = new HashSet<TransitAlert>(alertService.getStopAlerts(quay.getId()));
             if (quay.isPartOfStation()) {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,6 +31,7 @@ import org.opentripplanner.apis.transmodel.model.scalars.GeoJSONCoordinatesScala
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
+import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.transit.api.request.CancellationPolicy;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -357,11 +359,15 @@ public class QuayType {
           .name("situations")
           .description("Get all situations active for the quay.")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
-          .dataFetcher(env ->
-            GqlUtil.getTransitService(env)
-              .getTransitAlertService()
-              .getStopAlerts(((StopLocation) env.getSource()).getId())
-          )
+          .dataFetcher(env -> {
+            var alertService = GqlUtil.getTransitService(env).getTransitAlertService();
+            var quay = (StopLocation) env.getSource();
+            var alerts = new HashSet<TransitAlert>(alertService.getStopAlerts(quay.getId()));
+            if (quay.isPartOfStation()) {
+              alerts.addAll(alertService.getStopAlerts(quay.getParentStation().getId()));
+            }
+            return alerts;
+          })
           .build()
       )
       .field(

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/QuayType.java
@@ -16,7 +16,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,7 +30,6 @@ import org.opentripplanner.apis.transmodel.model.scalars.GeoJSONCoordinatesScala
 import org.opentripplanner.apis.transmodel.support.GqlUtil;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
-import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.transit.api.request.CancellationPolicy;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -362,11 +360,7 @@ public class QuayType {
           .dataFetcher(env -> {
             var alertService = GqlUtil.getTransitAlertService(env);
             var quay = (StopLocation) env.getSource();
-            var alerts = new HashSet<TransitAlert>(alertService.getStopAlerts(quay.getId()));
-            if (quay.isPartOfStation()) {
-              alerts.addAll(alertService.getStopAlerts(quay.getParentStation().getId()));
-            }
-            return alerts;
+            return alertService.getStopLocationsAlerts(quay.getIdAndParentStationId());
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/stop/StopPlaceType.java
@@ -423,9 +423,9 @@ public class StopPlaceType {
           )
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(env ->
-            GqlUtil.getTransitService(env)
-              .getTransitAlertService()
-              .getStopAlerts(((MonoOrMultiModalStation) env.getSource()).getId())
+            GqlUtil.getTransitAlertService(env).getStopAlerts(
+              ((MonoOrMultiModalStation) env.getSource()).getId()
+            )
           )
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/timetable/ServiceJourneyType.java
@@ -295,9 +295,7 @@ public class ServiceJourneyType {
           .description("Get all situations active for the service journey.")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(environment ->
-            GqlUtil.getTransitService(environment)
-              .getTransitAlertService()
-              .getTripAlerts(trip(environment).getId())
+            GqlUtil.getTransitAlertService(environment).getTripAlerts(trip(environment).getId())
           )
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/support/GqlUtil.java
@@ -18,6 +18,7 @@ import org.opentripplanner.apis.transmodel.TransmodelRequestContext;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.place.NearbyPlaceFinder;
 import org.opentripplanner.place.NearbyStopFinder;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
@@ -34,6 +35,10 @@ public class GqlUtil {
 
   public static TransitService getTransitService(DataFetchingEnvironment environment) {
     return ((TransmodelRequestContext) environment.getContext()).getTransitService();
+  }
+
+  public static TransitAlertService getTransitAlertService(DataFetchingEnvironment environment) {
+    return ((TransmodelRequestContext) environment.getContext()).getTransitAlertService();
   }
 
   public static VehicleRentalService getVehicleRentalService(DataFetchingEnvironment environment) {

--- a/application/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model.plan.legreference;
 
 import javax.annotation.Nullable;
 import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -9,5 +10,5 @@ import org.opentripplanner.transit.service.TransitService;
  */
 public interface LegReference {
   @Nullable
-  Leg getLeg(TransitService transitService);
+  Leg getLeg(TransitService transitService, TransitAlertService transitAlertService);
 }

--- a/application/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/application/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -9,6 +9,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
 import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Timetable;
@@ -82,7 +83,10 @@ public record ScheduledTransitLegReference(
    */
   @Override
   @Nullable
-  public ScheduledTransitLeg getLeg(TransitService transitService) {
+  public ScheduledTransitLeg getLeg(
+    TransitService transitService,
+    TransitAlertService transitAlertService
+  ) {
     Trip trip;
     TripOnServiceDate tripOnServiceDate = null;
 
@@ -216,7 +220,7 @@ public record ScheduledTransitLegReference(
       .build();
 
     return (ScheduledTransitLeg) new AlertToLegMapper(
-      transitService.getTransitAlertService(),
+      transitAlertService,
       transitService::findMultiModalStation
     ).decorateWithAlerts(leg, false);
   }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -167,6 +167,7 @@ public class RoutingWorker {
       result.errors(),
       debugTimingAggregator,
       serverContext.transitService(),
+      serverContext.transitAlertService(),
       pagingService
     );
   }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -90,7 +90,7 @@ public class RouteRequestToFilterChainMapper {
         params.removeItinerariesWithSameRoutesAndStops()
       )
       .withTransitAlerts(
-        context.transitService().getTransitAlertService(),
+        context.transitAlertService(),
         context.transitService()::findMultiModalStation
       )
       .withSearchWindow(earliestDepartureTimeUsed, searchWindowUsed)

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
@@ -11,6 +11,7 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.response.RoutingError;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.framework.DebugTimingAggregator;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.paging.PagingService;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ public class RoutingResponseMapper {
     Set<RoutingError> routingErrors,
     DebugTimingAggregator debugTimingAggregator,
     TransitService transitService,
+    TransitAlertService transitAlertService,
     PagingService pagingService
   ) {
     // Search is performed without realtime, but we still want to
@@ -33,7 +35,7 @@ public class RoutingResponseMapper {
     if (
       request.preferences().transit().ignoreRealtimeUpdates() && OTPFeature.RealtimeResolver.isOn()
     ) {
-      itineraries = populateLegsWithRealtime(itineraries, transitService);
+      itineraries = populateLegsWithRealtime(itineraries, transitService, transitAlertService);
     }
 
     // Create response

--- a/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -1,46 +1,42 @@
 package org.opentripplanner.routing.impl;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.timetable.Direction;
-import org.opentripplanner.updater.alert.TransitAlertProvider;
-import org.opentripplanner.updater.spi.GraphUpdater;
 
 /**
  * This class is used to combine alerts from multiple {@link TransitAlertService}s. Each
- * {@link TransitAlertProvider} has its own service, and all need to be queried in order to fetch
- * all alerts.
+ * {@link org.opentripplanner.updater.alert.TransitAlertProvider} has its own service, and all need
+ * to be queried in order to fetch all alerts.
  *
  * Concretely: every realtime updater receiving GTFS Alerts or SIRI Situation Exchange (SX)
  * messages currently maintains its own private index of alerts separately from all other updaters.
  * To make the set of all alerts from all updaters available in a single operation and associate it
- * with the graph as a whole, the various indexes are merged in such a way as to have the same
+ * with the application as a whole, the various indexes are merged in such a way as to have the same
  * index as each individual index.
+ *
+ * <p>Instances are registered with {@link #addDelegate(TransitAlertService)} when the updaters are
+ * configured. This class is an application-wide singleton, so registration and reads may happen
+ * concurrently; a {@link CopyOnWriteArrayList} is used to keep reads lock-free.
  */
 public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
 
-  private final ArrayList<TransitAlertService> transitAlertServices = new ArrayList<>();
+  private final List<TransitAlertService> transitAlertServices = new CopyOnWriteArrayList<>();
 
   /**
-   * Constructor which scans over all existing GraphUpdaters associated with a TransitRepository
-   * instance and retains references to all their TransitAlertService instances.
-   * This implies that these instances are expected to remain in use indefinitely (not be replaced
-   * with new instances or taken out of service over time).
+   * Register a delegate service, typically owned by a single realtime updater.
    */
-  public DelegatingTransitAlertServiceImpl(Iterable<GraphUpdater> updaters) {
-    for (GraphUpdater updater : updaters) {
-      if (updater instanceof TransitAlertProvider alertProvider) {
-        transitAlertServices.add(alertProvider.getTransitAlertService());
-      }
-    }
+  public void addDelegate(TransitAlertService transitAlertService) {
+    transitAlertServices.add(transitAlertService);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -78,6 +78,15 @@ public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
   }
 
   @Override
+  public Set<TransitAlert> getStopLocationsAlerts(List<FeedScopedId> stopLocationIds) {
+    return transitAlertServices
+      .stream()
+      .map(transitAlertService -> transitAlertService.getStopLocationsAlerts(stopLocationIds))
+      .flatMap(Collection::stream)
+      .collect(Collectors.toSet());
+  }
+
+  @Override
   public Collection<TransitAlert> getRouteAlerts(FeedScopedId route) {
     return transitAlertServices
       .stream()

--- a/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -5,7 +5,9 @@ import com.google.common.collect.Multimap;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.alertpatch.EntityKey;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
@@ -70,6 +72,16 @@ public class TransitAlertServiceImpl implements TransitAlertService {
     Set<StopCondition> stopConditions
   ) {
     return findMatchingAlerts(new EntitySelector.Stop(stopId, stopConditions));
+  }
+
+  @Override
+  public Set<TransitAlert> getStopLocationsAlerts(List<FeedScopedId> stopLocationIds) {
+    return stopLocationIds
+      .stream()
+      .flatMap(stopLocationId ->
+        findMatchingAlerts(new EntitySelector.Stop(stopLocationId)).stream()
+      )
+      .collect(Collectors.toSet());
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -13,7 +13,6 @@ import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.timetable.Direction;
-import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This is the primary implementation of TransitAlertService, which actually retains its own set
@@ -32,13 +31,7 @@ import org.opentripplanner.transit.service.TransitRepository;
  */
 public class TransitAlertServiceImpl implements TransitAlertService {
 
-  private final TransitRepository transitRepository;
-
   private Multimap<EntityKey, TransitAlert> alerts = HashMultimap.create();
-
-  public TransitAlertServiceImpl(TransitRepository transitRepository) {
-    this.transitRepository = transitRepository;
-  }
 
   @Override
   public void setAlerts(Collection<TransitAlert> alerts) {

--- a/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Multimap;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.alertpatch.EntityKey;
@@ -77,22 +76,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
     FeedScopedId stopId,
     Set<StopCondition> stopConditions
   ) {
-    EntitySelector.Stop entitySelector = new EntitySelector.Stop(stopId, stopConditions);
-    var result = findMatchingAlerts(entitySelector);
-    var stop = transitRepository.getSiteRepository().getStopLocation(stopId);
-
-    if (stop != null && stop.isPartOfStation()) {
-      // Add alerts for parent-station
-      result.addAll(
-        findMatchingAlerts(
-          new EntitySelector.Stop(
-            Objects.requireNonNull(stop.getParentStation()).getId(),
-            stopConditions
-          )
-        )
-      );
-    }
-    return result;
+    return findMatchingAlerts(new EntitySelector.Stop(stopId, stopConditions));
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/routing/refetch/RefetchItineraryService.java
+++ b/application/src/main/java/org/opentripplanner/routing/refetch/RefetchItineraryService.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.via.ViaLocation;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.internal.VertexCreationService;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
@@ -51,6 +52,7 @@ public class RefetchItineraryService {
   private static final Logger LOG = LoggerFactory.getLogger(RefetchItineraryService.class);
 
   private final TransitService transitService;
+  private final TransitAlertService transitAlertService;
   private final RegularTransferService transferService;
   private final Graph graph;
   private final LinkingContextFactory linkingContextFactory;
@@ -61,6 +63,7 @@ public class RefetchItineraryService {
     this(
       serverContext.graph(),
       serverContext.transitService(),
+      serverContext.transitAlertService(),
       serverContext.transferService(),
       serverContext.streetDetailsService(),
       serverContext.linkingContextFactory(),
@@ -71,12 +74,14 @@ public class RefetchItineraryService {
   public RefetchItineraryService(
     Graph graph,
     TransitService transitService,
+    TransitAlertService transitAlertService,
     RegularTransferService transferService,
     StreetDetailsService streetDetailsService,
     LinkingContextFactory linkingContextFactory,
     StreetLimitationParametersService streetLimitationParametersService
   ) {
     this.transitService = transitService;
+    this.transitAlertService = transitAlertService;
     this.transferService = transferService;
     this.linkingContextFactory = linkingContextFactory;
     this.graph = graph;
@@ -161,7 +166,7 @@ public class RefetchItineraryService {
     var transitLegs = new ArrayList<ScheduledTransitLeg>(legReferences.size());
     for (LegReference legReference : legReferences) {
       if (legReference instanceof ScheduledTransitLegReference scheduledTransitLeg) {
-        var transitLeg = scheduledTransitLeg.getLeg(transitService);
+        var transitLeg = scheduledTransitLeg.getLeg(transitService, transitAlertService);
         if (transitLeg == null) {
           throw new RefetchItineraryException("Could not find leg " + scheduledTransitLeg);
         }

--- a/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
+++ b/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
@@ -37,6 +37,10 @@ public interface TransitAlertService {
     return getStopAlerts(stop, Set.of());
   }
 
+  /**
+   * Returns the alerts for the exact stop only. Alerts on the parent station (or any other related
+   * stop) are not included; call this method again with the parent station id to obtain those.
+   */
   Collection<TransitAlert> getStopAlerts(FeedScopedId stop, Set<StopCondition> stopConditions);
 
   Collection<TransitAlert> getRouteAlerts(FeedScopedId route);

--- a/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
+++ b/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.services;
 
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.alertpatch.StopCondition;
@@ -39,9 +40,15 @@ public interface TransitAlertService {
 
   /**
    * Returns the alerts for the exact stop only. Alerts on the parent station (or any other related
-   * stop) are not included; call this method again with the parent station id to obtain those.
+   * stop) are not included; use {@link #getStopLocationsAlerts} to get alerts for multiple
+   * locations at once.
    */
   Collection<TransitAlert> getStopAlerts(FeedScopedId stop, Set<StopCondition> stopConditions);
+
+  /**
+   * Returns the alerts for the stop locations.
+   */
+  Set<TransitAlert> getStopLocationsAlerts(List<FeedScopedId> stopLocationIds);
 
   Collection<TransitAlert> getRouteAlerts(FeedScopedId route);
 

--- a/application/src/main/java/org/opentripplanner/routing/services/configure/TransitAlertServiceModule.java
+++ b/application/src/main/java/org/opentripplanner/routing/services/configure/TransitAlertServiceModule.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.routing.services.configure;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+import jakarta.inject.Singleton;
+import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
+import org.opentripplanner.routing.services.TransitAlertService;
+
+/**
+ * Wires up the application-wide {@link TransitAlertService}. The service is a delegating aggregator
+ * that combines the alerts from all realtime updaters. The concrete type is exposed so that the
+ * updater configuration can register the per-updater services into it.
+ */
+@Module
+public abstract class TransitAlertServiceModule {
+
+  @Binds
+  abstract TransitAlertService bindTransitAlertService(DelegatingTransitAlertServiceImpl service);
+
+  @Provides
+  @Singleton
+  static DelegatingTransitAlertServiceImpl transitAlertService() {
+    return new DelegatingTransitAlertServiceImpl();
+  }
+}

--- a/application/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
@@ -34,6 +34,7 @@ import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -100,6 +101,12 @@ public interface OtpServerRequestContext {
 
   @HttpRequestScoped
   TransitService transitService();
+
+  /**
+   * The application-wide alert service. Unlike {@link #transitService()} this is a long-lived
+   * singleton and is not tied to the transit snapshot of the request.
+   */
+  TransitAlertService transitAlertService();
 
   /**
    * Get a request-scoped {@link RoutingService} valid for one HTTP request. It guarantees that

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -218,6 +218,7 @@ public class ConstructApplication {
       carpoolTripVertexResolver(),
       factory.updateManager(),
       factory.timetableRepositoryHandle(),
+      factory.transitAlertService(),
       routerConfig().updaterConfig()
     );
 

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
@@ -36,8 +36,10 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransit
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareServiceFactory;
+import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.configure.LinkingServiceModule;
+import org.opentripplanner.routing.services.configure.TransitAlertServiceModule;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
 import org.opentripplanner.routing.via.configure.ViaModule;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
@@ -100,6 +102,7 @@ import org.opentripplanner.warmup.configure.WarmupModule;
     StopConsolidationServiceModule.class,
     StreetLimitationParametersServiceModule.class,
     TransitModule.class,
+    TransitAlertServiceModule.class,
     TransferServiceModule.class,
     VehicleParkingServiceModule.class,
     VehicleRentalRepositoryModule.class,
@@ -150,6 +153,12 @@ public interface ConstructApplicationFactory {
   TransitService transitService();
 
   RequestScopedFactory.Builder requestScopedFactoryBuilder();
+
+  /**
+   * The application-wide alert service aggregator. Exposed as the concrete type so that the updater
+   * configuration can register the per-updater alert services into it.
+   */
+  DelegatingTransitAlertServiceImpl transitAlertService();
 
   MetricsLogging metricsLogging();
 

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -25,6 +25,7 @@ import org.opentripplanner.routing.algorithm.filterchain.framework.spi.Itinerary
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -82,6 +83,7 @@ public class RequestScopedModule {
     VertexLinker vertexLinker,
     TransactionScope transactionScope,
     TransitService transitService,
+    TransitAlertService transitAlertService,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -130,6 +132,7 @@ public class RequestScopedModule {
       transactionScope,
       transitRoutingConfig,
       transitService,
+      transitAlertService,
       triasApiParameters,
       gtfsApiConfig,
       vectorTileConfig,

--- a/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -29,6 +29,7 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.service.DefaultRoutingService;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleService;
@@ -69,6 +70,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   private final RegularTransferService transferService;
   private final TransitRoutingConfig transitRoutingConfig;
   private final TransitService transitService;
+  private final TransitAlertService transitAlertService;
   private final VectorTileConfig vectorTileConfig;
   private final VehicleParkingService vehicleParkingService;
   private final VehicleRentalService vehicleRentalService;
@@ -142,6 +144,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     TransactionScope transactionScope,
     TransitRoutingConfig transitRoutingConfig,
     TransitService transitService,
+    TransitAlertService transitAlertService,
     TriasApiParameters triasApiParameters,
     GtfsApiParameters gtfsApiParameters,
     VectorTileConfig vectorTileConfig,
@@ -178,6 +181,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     this.transactionScope = transactionScope;
     this.transitRoutingConfig = transitRoutingConfig;
     this.transitService = transitService;
+    this.transitAlertService = transitAlertService;
     this.transmodelSchema = transmodelSchema;
     this.triasApiParameters = triasApiParameters;
     this.gtfsApiParameters = gtfsApiParameters;
@@ -229,6 +233,11 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
   @Override
   public TransitService transitService() {
     return transitService;
+  }
+
+  @Override
+  public TransitAlertService transitAlertService() {
+    return transitAlertService;
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
@@ -24,6 +24,7 @@ import org.opentripplanner.framework.transaction.UpdateManager;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueSummary;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.TransitRepository;
 
 /**
@@ -37,7 +38,8 @@ public class MetricsLogging {
     TransitRepository transitRepository,
     RaptorConfig<TripSchedule> raptorConfig,
     DataImportIssueSummary issueSummary,
-    UpdateManager updateManager
+    UpdateManager updateManager,
+    TransitAlertService transitAlertService
   ) {
     new ClassLoaderMetrics().bindTo(Metrics.globalRegistry);
     new FileDescriptorMetrics().bindTo(Metrics.globalRegistry);
@@ -51,7 +53,7 @@ public class MetricsLogging {
     new ProcessorMetrics().bindTo(Metrics.globalRegistry);
     new UptimeMetrics().bindTo(Metrics.globalRegistry);
     if (OTPFeature.AlertMetrics.isOn()) {
-      new AlertMetrics(transitRepository::getTransitAlertService).bindTo(Metrics.globalRegistry);
+      new AlertMetrics(() -> transitAlertService).bindTo(Metrics.globalRegistry);
     }
 
     if (transitRepository.getRaptorTransitData() != null) {

--- a/application/src/main/java/org/opentripplanner/transit/model/site/AreaStop.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/site/AreaStop.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.model.site;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.IntSupplier;
@@ -56,6 +57,11 @@ public class AreaStop
 
   public static AreaStopBuilder of(FeedScopedId id, IntSupplier indexCounter) {
     return new AreaStopBuilder(id, indexCounter);
+  }
+
+  @Override
+  public List<FeedScopedId> getIdAndParentStationId() {
+    return List.of(getId());
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
@@ -43,6 +43,11 @@ public class GroupStop
   }
 
   @Override
+  public List<FeedScopedId> getIdAndParentStationId() {
+    return List.of(getId());
+  }
+
+  @Override
   public int getIndex() {
     return index;
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/site/StationElement.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/site/StationElement.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.transit.model.site;
 
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 
@@ -47,6 +49,10 @@ public abstract class StationElement<
     this.description = builder.description();
     this.level = builder.level();
     this.parentStation = builder.parentStation();
+  }
+
+  public List<FeedScopedId> getIdAndParentStationId() {
+    return isPartOfStation() ? List.of(getId(), getParentStation().getId()) : List.of(getId());
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
@@ -25,6 +25,12 @@ public interface StopLocation extends LogInfo {
   FeedScopedId getId();
 
   /**
+   * The IDs for the StopLocation and its parent station (if the location is part of a station). The
+   * location's id comes first and the station is the second id in the list.
+   */
+  List<FeedScopedId> getIdAndParentStationId();
+
+  /**
    * This is the OTP internal <em>synthetic key</em>, used to reference a StopLocation inside OTP.  This is used
    * to optimize routing, we do not access the stop instance only keep the {code index}. The index will not change.
    * <p>

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -29,7 +29,6 @@ import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.StopTimesInPattern;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitData;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transfer.constrained.ConstrainedTransferService;
 import org.opentripplanner.transit.api.request.FindRegularStopsByBoundingBoxRequest;
 import org.opentripplanner.transit.api.request.FindRoutesRequest;
@@ -673,12 +672,6 @@ public class DefaultTransitService implements TransitEditorService {
     return this.transitRepository.getTimeZone();
   }
 
-  @Override
-  public TransitAlertService getTransitAlertService() {
-    return this.transitRepository.getTransitAlertService();
-  }
-
-  @Override
   public FlexIndex getFlexIndex() {
     return this.transitRepositoryIndex.getFlexIndex();
   }

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitRepository.java
@@ -31,8 +31,6 @@ import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitData;
-import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transfer.constrained.ConstrainedTransferService;
 import org.opentripplanner.transfer.constrained.internal.DefaultConstrainedTransferService;
 import org.opentripplanner.transit.model.basic.Notice;
@@ -116,8 +114,6 @@ public class TransitRepository implements Serializable {
     ArrayListMultimap.create();
 
   private final Map<FeedScopedId, FlexTrip<?, ?>> flexTripsById = new HashMap<>();
-
-  private transient TransitAlertService transitAlertService;
 
   private final Map<FeedScopedId, RegularStop> stopsByScheduledStopPointRefs = new HashMap<>();
 
@@ -356,19 +352,6 @@ public class TransitRepository implements Serializable {
     this.noticesByElement.putAll(noticesByElement);
   }
 
-  /**
-   * Returns the alert service. If no updaters are configured an empty instance is returned.
-   * See  {@link TransitRepository#initUpdaterManager(GraphUpdaterManager)}.
-   */
-  public TransitAlertService getTransitAlertService() {
-    if (transitAlertService == null) {
-      transitAlertService = new DelegatingTransitAlertServiceImpl(
-        this.updaterManager == null ? List.of() : this.updaterManager.getUpdaterList()
-      );
-    }
-    return transitAlertService;
-  }
-
   public TripPattern getTripPatternForId(FeedScopedId id) {
     return tripPatternForId.get(id);
   }
@@ -459,7 +442,6 @@ public class TransitRepository implements Serializable {
       this.updaterManager,
       updaterManager
     );
-    this.transitAlertService = null;
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -18,7 +18,6 @@ import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.StopTimesInPattern;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitData;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transfer.constrained.ConstrainedTransferService;
 import org.opentripplanner.transit.api.request.FindRegularStopsByBoundingBoxRequest;
 import org.opentripplanner.transit.api.request.FindRoutesRequest;
@@ -350,8 +349,6 @@ public interface TransitService {
   TripCalendars getTripCalendars();
 
   ZoneId getTimeZone();
-
-  TransitAlertService getTransitAlertService();
 
   FlexIndex getFlexIndex();
 

--- a/application/src/main/java/org/opentripplanner/updater/alert/gtfs/GtfsRealtimeAlertsUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/gtfs/GtfsRealtimeAlertsUpdater.java
@@ -8,7 +8,6 @@ import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -29,14 +28,11 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
   private final OtpHttpClient otpHttpClient;
   private Long lastTimestamp = Long.MIN_VALUE;
 
-  public GtfsRealtimeAlertsUpdater(
-    GtfsRealtimeAlertsUpdaterParameters config,
-    TransitRepository transitRepository
-  ) {
+  public GtfsRealtimeAlertsUpdater(GtfsRealtimeAlertsUpdaterParameters config) {
     super(config);
     this.url = config.url();
     this.headers = HttpHeaders.of().acceptProtobuf().add(config.headers()).build();
-    TransitAlertService transitAlertService = new TransitAlertServiceImpl(transitRepository);
+    TransitAlertService transitAlertService = new TransitAlertServiceImpl();
 
     this.transitAlertService = transitAlertService;
 

--- a/application/src/main/java/org/opentripplanner/updater/alert/siri/SiriSXUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/siri/SiriSXUpdater.java
@@ -10,7 +10,6 @@ import org.opentripplanner.framework.retry.OtpRetry;
 import org.opentripplanner.framework.retry.OtpRetryBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.PollingGraphUpdaterParameters;
@@ -48,7 +47,6 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
 
   public SiriSXUpdater(
     Parameters config,
-    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache,
     SiriLoader siriLoader
   ) {
@@ -63,7 +61,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
     //Keeping original requestorRef use as base for updated requestorRef to be used in retries
     this.originalRequestorRef = requestorRef;
     this.blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
-    this.transitAlertService = new TransitAlertServiceImpl(transitRepository);
+    this.transitAlertService = new TransitAlertServiceImpl();
     this.updateHandler = new SiriAlertsUpdateHandler(
       config.feedId(),
       transitAlertService,

--- a/application/src/main/java/org/opentripplanner/updater/configure/SiriUpdaterModule.java
+++ b/application/src/main/java/org/opentripplanner/updater/configure/SiriUpdaterModule.java
@@ -2,7 +2,6 @@ package org.opentripplanner.updater.configure;
 
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
-import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.siri.SiriSXUpdater;
 import org.opentripplanner.updater.alert.siri.SiriSXUpdaterParameters;
 import org.opentripplanner.updater.alert.siri.lite.SiriLiteHttpLoader;
@@ -36,15 +35,9 @@ public class SiriUpdaterModule {
 
   public static SiriSXUpdater createSiriSXUpdater(
     SiriSXUpdater.Parameters params,
-    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache
   ) {
-    return new SiriSXUpdater(
-      params,
-      transitRepository,
-      siriFuzzyTripMatcherCache,
-      createLoader(params)
-    );
+    return new SiriSXUpdater(params, siriFuzzyTripMatcherCache, createLoader(params));
   }
 
   private static EstimatedTimetableSource createSource(SiriETUpdaterParameters params) {

--- a/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -158,11 +158,11 @@ public class UpdaterConfigurator {
 
     // Register the alert service of each updater that provides one into the application-wide
     // aggregating alert service.
-    updaters
-      .stream()
-      .filter(TransitAlertProvider.class::isInstance)
-      .map(TransitAlertProvider.class::cast)
-      .forEach(provider -> transitAlertService.addDelegate(provider.getTransitAlertService()));
+    for (var it : updaters) {
+      if (it instanceof TransitAlertProvider provider) {
+        transitAlertService.addDelegate(provider.getTransitAlertService());
+      }
+    }
 
     var graphWriterService = new GraphWriterService(
       updateManager,

--- a/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -16,6 +16,7 @@ import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.framework.transaction.UpdateManager;
 import org.opentripplanner.framework.transaction.api.RepositoryHandle;
+import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.vehicleparking.VehicleParkingRepository;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
@@ -28,6 +29,7 @@ import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterService;
 import org.opentripplanner.updater.UpdatersParameters;
+import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.alert.gtfs.GtfsRealtimeAlertsUpdater;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.trip.gtfs.GtfsRealTimeTripUpdateAdapter;
@@ -75,6 +77,7 @@ public class UpdaterConfigurator {
     TimetableRepositorySnapshot,
     TimetableRepository
   > timetableRepositoryHandle;
+  private final DelegatingTransitAlertServiceImpl transitAlertService;
 
   @Nullable
   private SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache;
@@ -91,6 +94,7 @@ public class UpdaterConfigurator {
     @Nullable CarpoolTripVertexResolver carpoolTripVertexResolver,
     UpdateManager updateManager,
     RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableRepositoryHandle,
+    DelegatingTransitAlertServiceImpl transitAlertService,
     UpdatersParameters updatersParameters
   ) {
     this.graph = graph;
@@ -105,6 +109,7 @@ public class UpdaterConfigurator {
     this.timetableRepositoryHandle = timetableRepositoryHandle;
     this.carpoolingRepository = carpoolingRepository;
     this.carpoolTripVertexResolver = carpoolTripVertexResolver;
+    this.transitAlertService = transitAlertService;
   }
 
   public static void configure(
@@ -119,6 +124,7 @@ public class UpdaterConfigurator {
     @Nullable CarpoolTripVertexResolver carpoolTripVertexResolver,
     UpdateManager updateManager,
     RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableRepositoryHandle,
+    DelegatingTransitAlertServiceImpl transitAlertService,
     UpdatersParameters updatersParameters
   ) {
     new UpdaterConfigurator(
@@ -133,6 +139,7 @@ public class UpdaterConfigurator {
       carpoolTripVertexResolver,
       updateManager,
       timetableRepositoryHandle,
+      transitAlertService,
       updatersParameters
     ).configure();
   }
@@ -148,6 +155,14 @@ public class UpdaterConfigurator {
         updatersParameters.getVehicleRentalServiceDirectoryFetcherParameters()
       )
     );
+
+    // Register the alert service of each updater that provides one into the application-wide
+    // aggregating alert service.
+    updaters
+      .stream()
+      .filter(TransitAlertProvider.class::isInstance)
+      .map(TransitAlertProvider.class::cast)
+      .forEach(provider -> transitAlertService.addDelegate(provider.getTransitAlertService()));
 
     var graphWriterService = new GraphWriterService(
       updateManager,
@@ -219,7 +234,7 @@ public class UpdaterConfigurator {
       }
     }
     for (var configItem : updatersParameters.getGtfsRealtimeAlertsUpdaterParameters()) {
-      updaters.add(new GtfsRealtimeAlertsUpdater(configItem, transitRepository));
+      updaters.add(new GtfsRealtimeAlertsUpdater(configItem));
     }
     for (var configItem : updatersParameters.getPollingStoptimeUpdaterParameters()) {
       updaters.add(new PollingTripUpdater(configItem, provideGtfsAdapter()));
@@ -259,22 +274,10 @@ public class UpdaterConfigurator {
       );
     }
     for (var configItem : updatersParameters.getSiriSXUpdaterParameters()) {
-      updaters.add(
-        SiriUpdaterModule.createSiriSXUpdater(
-          configItem,
-          transitRepository,
-          siriFuzzyTripMatcherCache()
-        )
-      );
+      updaters.add(SiriUpdaterModule.createSiriSXUpdater(configItem, siriFuzzyTripMatcherCache()));
     }
     for (var configItem : updatersParameters.getSiriSXLiteUpdaterParameters()) {
-      updaters.add(
-        SiriUpdaterModule.createSiriSXUpdater(
-          configItem,
-          transitRepository,
-          siriFuzzyTripMatcherCache()
-        )
-      );
+      updaters.add(SiriUpdaterModule.createSiriSXUpdater(configItem, siriFuzzyTripMatcherCache()));
     }
     for (var configItem : updatersParameters.getMqttGtfsRealtimeUpdaterParameters()) {
       updaters.add(new MqttGtfsRealtimeUpdater(configItem, provideGtfsAdapter()));
@@ -305,9 +308,7 @@ public class UpdaterConfigurator {
       );
     }
     for (var configItem : updatersParameters.getSiriAzureSXUpdaterParameters()) {
-      updaters.add(
-        SiriAzureUpdater.createSXUpdater(configItem, transitRepository, siriFuzzyTripMatcherCache())
-      );
+      updaters.add(SiriAzureUpdater.createSXUpdater(configItem, siriFuzzyTripMatcherCache()));
     }
     for (var configItem : updatersParameters.getMqttSiriETUpdaterParameters()) {
       updaters.add(

--- a/application/src/test-fixtures/java/org/opentripplanner/apis/support/graphql/DataFetchingSupport.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/apis/support/graphql/DataFetchingSupport.java
@@ -56,6 +56,7 @@ public class DataFetchingSupport {
           null,
           null,
           null,
+          null,
           null
         )
       )

--- a/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
@@ -21,6 +21,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RaptorTransitDataMapper;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.routing.linking.internal.VertexCreationService;
@@ -207,6 +208,7 @@ public class TestServerContext {
       transactionScope,
       routerConfig.transitTuningConfig(),
       transitService,
+      new TransitAlertServiceImpl(),
       routerConfig.triasApiParameters(),
       routerConfig.gtfsApiParameters(),
       routerConfig.vectorTileConfig(),

--- a/application/src/test-fixtures/java/org/opentripplanner/transit/model/site/TestStopLocation.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/transit/model/site/TestStopLocation.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.model.site;
 
+import java.util.List;
 import org.apache.commons.lang3.NotImplementedException;
 import org.jetbrains.annotations.Nullable;
 import org.locationtech.jts.geom.Geometry;
@@ -13,6 +14,11 @@ public class TestStopLocation implements StopLocation {
 
   public TestStopLocation(FeedScopedId id) {
     this.id = id;
+  }
+
+  @Override
+  public List<FeedScopedId> getIdAndParentStationId() {
+    return List.of(getId());
   }
 
   @Override

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -247,7 +247,7 @@ public abstract class GtfsTest {
       new Deduplicator(),
       LocalDate::now
     );
-    alertPatchServiceImpl = new TransitAlertServiceImpl(transitRepository);
+    alertPatchServiceImpl = new TransitAlertServiceImpl();
     alertsUpdateHandler.setTransitAlertService(alertPatchServiceImpl);
     alertsUpdateHandler.setFeedId(FEED_ID);
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -78,7 +78,6 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransit
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleRepository;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleService;
 import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
@@ -376,18 +375,9 @@ class GraphQLIntegrationTest {
     var snapshot = timetableSnapshot.commit();
 
     TransitEditorService transitService = new DefaultTransitService(transitRepository, snapshot) {
-      private final TransitAlertService alertService = new TransitAlertServiceImpl(
-        transitRepository
-      );
-
       @Override
       public List<TransitMode> findTransitModes(StopLocation stop) {
         return List.of(BUS, FERRY);
-      }
-
-      @Override
-      public TransitAlertService getTransitAlertService() {
-        return alertService;
       }
 
       @Override
@@ -521,7 +511,8 @@ class GraphQLIntegrationTest {
     i1 = i1.copyOf().withEmissionPerPerson(emission).build();
 
     var alerts = ListUtils.combine(List.of(alert, stationAlert), getTransitAlert(entitySelector));
-    transitService.getTransitAlertService().setAlerts(alerts);
+    var transitAlertService = new TransitAlertServiceImpl();
+    transitAlertService.setAlerts(alerts);
 
     var realtimeVehicleRepository = new DefaultRealtimeVehicleRepository();
     var realtimeVehicleService = new DefaultRealtimeVehicleService(
@@ -561,6 +552,7 @@ class GraphQLIntegrationTest {
     context = new GraphQLRequestContext(
       new TestRoutingService(List.of(i1)),
       transitService,
+      transitAlertService,
       TransferServiceTestFactory.defaultTransferService(),
       fareService,
       defaultVehicleRentalService,

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
@@ -39,6 +39,7 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.TimeSlopeSafetyTriangle;
 import org.opentripplanner.routing.api.request.preference.TransferPreferences;
 import org.opentripplanner.routing.api.request.preference.VehicleParkingPreferences;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.routing.linking.internal.VertexCreationService;
@@ -85,6 +86,7 @@ class LegacyRouteRequestMapperTest implements PlanTestConstants {
     CONTEXT = new GraphQLRequestContext(
       new TestRoutingService(List.of()),
       transitService,
+      new TransitAlertServiceImpl(),
       transferService,
       new DefaultFareService(),
       new DefaultVehicleRentalService(),

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
@@ -20,6 +20,7 @@ import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareService;
 import org.opentripplanner.place.nearbystopfinder.StreetNearbyStopFinder;
 import org.opentripplanner.place.placefinder.StreetNearbyPlaceFinder;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.routing.linking.internal.VertexCreationService;
@@ -77,6 +78,7 @@ class _RouteRequestTestContext {
     this.context = new GraphQLRequestContext(
       new TestRoutingService(List.of()),
       transitService,
+      new TransitAlertServiceImpl(),
       transferService,
       new DefaultFareService(),
       new DefaultVehicleRentalService(),

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/StopMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/StopMapperTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.gtfs.mapping;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
@@ -95,6 +97,7 @@ public class StopMapperTest {
     assertNull(result.getDescription());
     assertEquals(NAME, result.getName().toString());
     assertNull(result.getParentStation());
+    assertThat(result.getIdAndParentStationId()).containsExactly(result.getId());
     assertNull(result.getCode());
     assertNull(result.getUrl());
     // Skip getting coordinate, it will throw an exception
@@ -162,6 +165,9 @@ public class StopMapperTest {
 
     assertNotNull(result.getParentStation());
     assertEquals(parentStation, result.getParentStation());
+    assertThat(result.getIdAndParentStationId()).containsExactlyElementsIn(
+      List.of(result.getId(), result.getParentStation().getId())
+    );
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -16,7 +16,6 @@ import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -46,7 +45,6 @@ class ScheduledTransitLegReferenceTest {
   public static final FeedScopedId STOP_3_A_ID = id("STOP3A");
   public static final FeedScopedId STOP_3_B_ID = id("STOP3B");
   private static TransitService transitService;
-  private static final TransitAlertService TRANSIT_ALERT_SERVICE = new TransitAlertServiceImpl();
   private static final FeedScopedId SIMPLE_TRIP_ID = id("trip");
   private static final FeedScopedId TRIP_ID_WITH_MULTIPLE_CALLS = id("multiple_calls");
   private static final FeedScopedId LOOP_TRIP_ID = id("loop");
@@ -137,7 +135,7 @@ class ScheduledTransitLegReferenceTest {
     );
     ScheduledTransitLeg leg = scheduledTransitLegReference.getLeg(
       transitService,
-      TRANSIT_ALERT_SERVICE
+      new TransitAlertServiceImpl()
     );
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
@@ -157,7 +155,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl()));
   }
 
   @Test
@@ -171,7 +169,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl()));
   }
 
   @Test
@@ -185,7 +183,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl()));
   }
 
   @Test
@@ -201,7 +199,9 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    assertNotNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
+    assertNotNull(
+      scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl())
+    );
   }
 
   @Test
@@ -215,7 +215,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(TRIP_ID_WITH_MULTIPLE_CALLS, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -236,7 +236,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(LOOP_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -257,7 +257,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_A_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -276,7 +276,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -295,7 +295,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -314,7 +314,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_1_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl()));
   }
 
   @Test
@@ -329,7 +329,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -379,7 +379,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       TRIP_ON_SERVICE_DATE_ID
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl()));
   }
 
   @Test
@@ -393,7 +393,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       FeedScopedIdForTestFactory.id("unknown trip on date id")
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl()));
   }
 
   @Test
@@ -409,7 +409,7 @@ class ScheduledTransitLegReferenceTest {
     );
     ScheduledTransitLeg leg = scheduledTransitLegReference.getLeg(
       transitService,
-      TRANSIT_ALERT_SERVICE
+      new TransitAlertServiceImpl()
     );
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
@@ -432,7 +432,7 @@ class ScheduledTransitLegReferenceTest {
       null
     );
     // Should handle gracefully by finding the closest matching stops, not throw ArrayIndexOutOfBoundsException
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(0, leg.boardStopPosInPattern());
     assertEquals(1, leg.alightStopPosInPattern());
@@ -453,7 +453,7 @@ class ScheduledTransitLegReferenceTest {
       null
     );
     // Should handle gracefully by finding the closest matching stop, or return null
-    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
+    var leg = scheduledTransitLegReference.getLeg(transitService, new TransitAlertServiceImpl());
     assertNotNull(leg);
     assertEquals(0, leg.boardStopPosInPattern());
     assertEquals(1, leg.alightStopPosInPattern());

--- a/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -15,6 +15,8 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -44,6 +46,7 @@ class ScheduledTransitLegReferenceTest {
   public static final FeedScopedId STOP_3_A_ID = id("STOP3A");
   public static final FeedScopedId STOP_3_B_ID = id("STOP3B");
   private static TransitService transitService;
+  private static final TransitAlertService TRANSIT_ALERT_SERVICE = new TransitAlertServiceImpl();
   private static final FeedScopedId SIMPLE_TRIP_ID = id("trip");
   private static final FeedScopedId TRIP_ID_WITH_MULTIPLE_CALLS = id("multiple_calls");
   private static final FeedScopedId LOOP_TRIP_ID = id("loop");
@@ -132,7 +135,10 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    ScheduledTransitLeg leg = scheduledTransitLegReference.getLeg(transitService);
+    ScheduledTransitLeg leg = scheduledTransitLegReference.getLeg(
+      transitService,
+      TRANSIT_ALERT_SERVICE
+    );
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -151,7 +157,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
   }
 
   @Test
@@ -165,7 +171,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
   }
 
   @Test
@@ -179,7 +185,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
   }
 
   @Test
@@ -195,7 +201,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    assertNotNull(scheduledTransitLegReference.getLeg(transitService));
+    assertNotNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
   }
 
   @Test
@@ -209,7 +215,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(TRIP_ID_WITH_MULTIPLE_CALLS, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -230,7 +236,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(LOOP_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -251,7 +257,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_A_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -270,7 +276,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_3_B_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -289,7 +295,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -308,7 +314,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_1_ID,
       null
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
   }
 
   @Test
@@ -323,7 +329,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       null
     );
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -373,7 +379,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       TRIP_ON_SERVICE_DATE_ID
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
   }
 
   @Test
@@ -387,7 +393,7 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       FeedScopedIdForTestFactory.id("unknown trip on date id")
     );
-    assertNull(scheduledTransitLegReference.getLeg(transitService));
+    assertNull(scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE));
   }
 
   @Test
@@ -401,7 +407,10 @@ class ScheduledTransitLegReferenceTest {
       STOP_2_ID,
       TRIP_ON_SERVICE_DATE_ID
     );
-    ScheduledTransitLeg leg = scheduledTransitLegReference.getLeg(transitService);
+    ScheduledTransitLeg leg = scheduledTransitLegReference.getLeg(
+      transitService,
+      TRANSIT_ALERT_SERVICE
+    );
     assertNotNull(leg);
     assertEquals(SIMPLE_TRIP_ID, leg.trip().getId());
     assertEquals(SERVICE_DATE, leg.serviceDate());
@@ -423,7 +432,7 @@ class ScheduledTransitLegReferenceTest {
       null
     );
     // Should handle gracefully by finding the closest matching stops, not throw ArrayIndexOutOfBoundsException
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(0, leg.boardStopPosInPattern());
     assertEquals(1, leg.alightStopPosInPattern());
@@ -444,7 +453,7 @@ class ScheduledTransitLegReferenceTest {
       null
     );
     // Should handle gracefully by finding the closest matching stop, or return null
-    var leg = scheduledTransitLegReference.getLeg(transitService);
+    var leg = scheduledTransitLegReference.getLeg(transitService, TRANSIT_ALERT_SERVICE);
     assertNotNull(leg);
     assertEquals(0, leg.boardStopPosInPattern());
     assertEquals(1, leg.alightStopPosInPattern());

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/DecorateTransitAlertTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/DecorateTransitAlertTest.java
@@ -14,7 +14,6 @@ import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.alertpatch.TransitAlertBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.transit.service.TransitRepository;
 
 class DecorateTransitAlertTest implements PlanTestConstants {
 
@@ -62,7 +61,7 @@ class DecorateTransitAlertTest implements PlanTestConstants {
   @Test
   void testSkipsLegRebuildWhenNoAlertsMatch() {
     // Alert service with no alerts at all — nothing can match.
-    var transitAlertService = new TransitAlertServiceImpl(new TransitRepository());
+    var transitAlertService = new TransitAlertServiceImpl();
     var decorator = new DecorateTransitAlert(transitAlertService, ignore -> null);
 
     var i1 = newItinerary(A).bus(31, 0, 30, E).build();
@@ -81,7 +80,7 @@ class DecorateTransitAlertTest implements PlanTestConstants {
   }
 
   private static TransitAlertServiceImpl buildService(TransitAlertBuilder builder) {
-    var transitAlertService = new TransitAlertServiceImpl(new TransitRepository());
+    var transitAlertService = new TransitAlertServiceImpl();
     transitAlertService.setAlerts(
       List.of(builder.addTimePeriod(new TimePeriod(0, TimePeriod.OPEN_ENDED)).build())
     );

--- a/application/src/test/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImplTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImplTest.java
@@ -1,0 +1,69 @@
+package org.opentripplanner.routing.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.routing.alertpatch.EntitySelector;
+import org.opentripplanner.routing.alertpatch.TransitAlert;
+
+/**
+ * Tests that the delegating service merges the alerts of all registered delegates.
+ */
+class DelegatingTransitAlertServiceImplTest {
+
+  private static final String FEED_ID = "GB";
+  private static final String STATION_ID = "910GSTPX";
+  private static final String STOP_ID = "9100STPX1";
+
+  private static final TransitAlert STATION_ALERT = TransitAlert.of(id("station_alert"))
+    .addEntity(new EntitySelector.Stop(id(STATION_ID)))
+    .build();
+  private static final TransitAlert STOP_ALERT = TransitAlert.of(id("stop_alert"))
+    .addEntity(new EntitySelector.Stop(id(STOP_ID)))
+    .build();
+
+  @Test
+  void getStopLocationsAlertsCombinesAlertsOfAllDelegates() {
+    // each updater keeps its own service, here one holds the stop alert, the other the station one
+    var iut = delegatingService(List.of(STOP_ALERT), List.of(STATION_ALERT));
+
+    assertThat(iut.getStopLocationsAlerts(List.of(id(STOP_ID), id(STATION_ID)))).containsExactly(
+      STOP_ALERT,
+      STATION_ALERT
+    );
+  }
+
+  @Test
+  void getStopLocationsAlertsDeduplicatesAlertsFromMultipleDelegates() {
+    // the same alert is present in two delegates, it must only be returned once
+    var iut = delegatingService(List.of(STOP_ALERT), List.of(STOP_ALERT));
+
+    assertThat(iut.getStopLocationsAlerts(List.of(id(STOP_ID)))).containsExactly(STOP_ALERT);
+  }
+
+  @Test
+  void getStopLocationsAlertsWithoutDelegates() {
+    assertThat(
+      new DelegatingTransitAlertServiceImpl().getStopLocationsAlerts(List.of(id(STOP_ID)))
+    ).isEmpty();
+  }
+
+  @SafeVarargs
+  private static DelegatingTransitAlertServiceImpl delegatingService(
+    List<TransitAlert>... alertsPerDelegate
+  ) {
+    var service = new DelegatingTransitAlertServiceImpl();
+    for (var alerts : alertsPerDelegate) {
+      var delegate = new TransitAlertServiceImpl();
+      delegate.setAlerts(alerts);
+      service.addDelegate(delegate);
+    }
+    return service;
+  }
+
+  private static FeedScopedId id(String id) {
+    return new FeedScopedId(FEED_ID, id);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
@@ -54,7 +54,7 @@ class TransitAlertServiceImplTest {
 
   @Test
   void getStopAlerts() {
-    var iut = new TransitAlertServiceImpl(TIMETABLE_REPOSITORY);
+    var iut = new TransitAlertServiceImpl();
     var railStationAlert = TransitAlert.of(id("rail_station_alert"))
       .addEntity(new EntitySelector.Stop(id(RAIL_STATION_ID)))
       .build();

--- a/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.impl;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -34,6 +35,16 @@ class TransitAlertServiceImplTest {
     .withCoordinate(51.5306090, -0.1239491)
     .build();
 
+  private static final TransitAlert RAIL_STATION_ALERT = TransitAlert.of(id("rail_station_alert"))
+    .addEntity(new EntitySelector.Stop(id(RAIL_STATION_ID)))
+    .build();
+  private static final TransitAlert RAIL_STOP_ALERT = TransitAlert.of(id("rail_stop_alert"))
+    .addEntity(new EntitySelector.Stop(id(RAIL_P1_ID)))
+    .build();
+  private static final TransitAlert BUS_STOP_ALERT = TransitAlert.of(id("bus_stop_alert"))
+    .addEntity(new EntitySelector.Stop(id(BUS_STOP_ID)))
+    .build();
+
   private static final TransitRepository TIMETABLE_REPOSITORY = new TransitRepository(
     getSiteRepository()
   );
@@ -54,25 +65,81 @@ class TransitAlertServiceImplTest {
 
   @Test
   void getStopAlerts() {
-    var iut = new TransitAlertServiceImpl();
-    var railStationAlert = TransitAlert.of(id("rail_station_alert"))
-      .addEntity(new EntitySelector.Stop(id(RAIL_STATION_ID)))
-      .build();
-    var railStopAlert = TransitAlert.of(id("rail_stop_alert"))
-      .addEntity(new EntitySelector.Stop(id(RAIL_P1_ID)))
-      .build();
-    var busStopAlert = TransitAlert.of(id("bus_stop_alert"))
-      .addEntity(new EntitySelector.Stop(id(BUS_STOP_ID)))
-      .build();
-    iut.setAlerts(List.of(railStationAlert, railStopAlert, busStopAlert));
+    var iut = serviceWithStopAlerts();
 
     // getStopAlerts only returns alerts for the exact stop - parent stations are not included.
-    assertEquals(Set.of(railStationAlert), Set.copyOf(iut.getStopAlerts(id(RAIL_STATION_ID))));
-    assertEquals(Set.of(railStopAlert), Set.copyOf(iut.getStopAlerts(id(RAIL_P1_ID))));
+    assertEquals(Set.of(RAIL_STATION_ALERT), Set.copyOf(iut.getStopAlerts(id(RAIL_STATION_ID))));
+    assertEquals(Set.of(RAIL_STOP_ALERT), Set.copyOf(iut.getStopAlerts(id(RAIL_P1_ID))));
     assertEquals(Set.of(), Set.copyOf(iut.getStopAlerts(id(RAIL_PA_ID))));
     assertEquals(Set.of(), Set.copyOf(iut.getStopAlerts(id(METRO_STATION_ID))));
     assertEquals(Set.of(), Set.copyOf(iut.getStopAlerts(id(METRO_P1_ID))));
-    assertEquals(Set.of(busStopAlert), Set.copyOf(iut.getStopAlerts(id(BUS_STOP_ID))));
+    assertEquals(Set.of(BUS_STOP_ALERT), Set.copyOf(iut.getStopAlerts(id(BUS_STOP_ID))));
+  }
+
+  @Test
+  void getStopLocationsAlertsIncludesAlertsForAllIds() {
+    var iut = serviceWithStopAlerts();
+
+    // unlike getStopAlerts, both the stop's own alert and the parent station alert are returned
+    assertThat(
+      iut.getStopLocationsAlerts(List.of(id(RAIL_P1_ID), id(RAIL_STATION_ID)))
+    ).containsExactly(RAIL_STOP_ALERT, RAIL_STATION_ALERT);
+  }
+
+  @Test
+  void getStopLocationsAlertsForSingleId() {
+    var iut = serviceWithStopAlerts();
+
+    assertThat(iut.getStopLocationsAlerts(List.of(id(BUS_STOP_ID)))).containsExactly(
+      BUS_STOP_ALERT
+    );
+  }
+
+  @Test
+  void getStopLocationsAlertsForStopWithoutOwnAlert() {
+    var iut = serviceWithStopAlerts();
+
+    // the stop itself has no alert, so only the parent station alert is returned
+    assertThat(
+      iut.getStopLocationsAlerts(List.of(id(RAIL_PA_ID), id(RAIL_STATION_ID)))
+    ).containsExactly(RAIL_STATION_ALERT);
+  }
+
+  @Test
+  void getStopLocationsAlertsDeduplicatesAlerts() {
+    var iut = new TransitAlertServiceImpl();
+    var alert = TransitAlert.of(id("multi_stop_alert"))
+      .addEntity(new EntitySelector.Stop(id(RAIL_P1_ID)))
+      .addEntity(new EntitySelector.Stop(id(RAIL_STATION_ID)))
+      .build();
+    iut.setAlerts(List.of(alert));
+
+    // the same alert matches both ids, but it is returned only once
+    assertThat(
+      iut.getStopLocationsAlerts(List.of(id(RAIL_P1_ID), id(RAIL_STATION_ID)))
+    ).containsExactly(alert);
+  }
+
+  @Test
+  void getStopLocationsAlertsIgnoresUnrelatedAndUnknownIds() {
+    var iut = serviceWithStopAlerts();
+
+    assertThat(
+      iut.getStopLocationsAlerts(List.of(id(METRO_P1_ID), id(METRO_STATION_ID), id("unknown")))
+    ).isEmpty();
+  }
+
+  @Test
+  void getStopLocationsAlertsWithEmptyIdList() {
+    var iut = serviceWithStopAlerts();
+
+    assertThat(iut.getStopLocationsAlerts(List.of())).isEmpty();
+  }
+
+  private static TransitAlertServiceImpl serviceWithStopAlerts() {
+    var service = new TransitAlertServiceImpl();
+    service.setAlerts(List.of(RAIL_STATION_ALERT, RAIL_STOP_ALERT, BUS_STOP_ALERT));
+    return service;
   }
 
   private static FeedScopedId id(String id) {

--- a/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
@@ -66,12 +66,10 @@ class TransitAlertServiceImplTest {
       .build();
     iut.setAlerts(List.of(railStationAlert, railStopAlert, busStopAlert));
 
+    // getStopAlerts only returns alerts for the exact stop - parent stations are not included.
     assertEquals(Set.of(railStationAlert), Set.copyOf(iut.getStopAlerts(id(RAIL_STATION_ID))));
-    assertEquals(
-      Set.of(railStationAlert, railStopAlert),
-      Set.copyOf(iut.getStopAlerts(id(RAIL_P1_ID)))
-    );
-    assertEquals(Set.of(railStationAlert), Set.copyOf(iut.getStopAlerts(id(RAIL_PA_ID))));
+    assertEquals(Set.of(railStopAlert), Set.copyOf(iut.getStopAlerts(id(RAIL_P1_ID))));
+    assertEquals(Set.of(), Set.copyOf(iut.getStopAlerts(id(RAIL_PA_ID))));
     assertEquals(Set.of(), Set.copyOf(iut.getStopAlerts(id(METRO_STATION_ID))));
     assertEquals(Set.of(), Set.copyOf(iut.getStopAlerts(id(METRO_P1_ID))));
     assertEquals(Set.of(busStopAlert), Set.copyOf(iut.getStopAlerts(id(BUS_STOP_ID))));

--- a/application/src/test/java/org/opentripplanner/routing/refetch/RefetchItineraryServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/refetch/RefetchItineraryServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.internal.VertexCreationService;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -335,6 +336,7 @@ class RefetchItineraryServiceTest {
     return new RefetchItineraryService(
       GRAPH,
       TRANSIT_ENV.transitService(),
+      new TransitAlertServiceImpl(),
       TRANSFER_SERVICE,
       streetDetailsService,
       linkingContextFactory,

--- a/application/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
@@ -15,6 +15,7 @@ import org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference;
 import org.opentripplanner.routing.alternativelegs.AlternativeLegs;
 import org.opentripplanner.routing.alternativelegs.AlternativeLegsFilter;
 import org.opentripplanner.routing.alternativelegs.NavigationDirection;
+import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.transit.service.DefaultTransitService;
 
 /**
@@ -45,7 +46,7 @@ class AlternativeLegsTest extends GtfsTest {
       STOP_ID_B,
       STOP_ID_C,
       null
-    ).getLeg(transitService);
+    ).getLeg(transitService, new TransitAlertServiceImpl());
 
     final List<ScheduledTransitLeg> alternativeLegs = AlternativeLegs.getAlternativeLegs(
       originalLeg,
@@ -78,7 +79,7 @@ class AlternativeLegsTest extends GtfsTest {
       STOP_ID_B,
       STOP_ID_C,
       null
-    ).getLeg(transitService);
+    ).getLeg(transitService, new TransitAlertServiceImpl());
 
     final List<ScheduledTransitLeg> alternativeLegs = AlternativeLegs.getAlternativeLegs(
       originalLeg,
@@ -111,7 +112,7 @@ class AlternativeLegsTest extends GtfsTest {
       STOP_ID_X,
       STOP_ID_Y,
       null
-    ).getLeg(transitService);
+    ).getLeg(transitService, new TransitAlertServiceImpl());
 
     final List<ScheduledTransitLeg> alternativeLegs = AlternativeLegs.getAlternativeLegs(
       originalLeg,
@@ -138,7 +139,7 @@ class AlternativeLegsTest extends GtfsTest {
       STOP_ID_X,
       STOP_ID_B,
       null
-    ).getLeg(transitService);
+    ).getLeg(transitService, new TransitAlertServiceImpl());
 
     final List<ScheduledTransitLeg> alternativeLegs = AlternativeLegs.getAlternativeLegs(
       originalLeg,

--- a/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
@@ -34,6 +34,7 @@ import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
+import org.opentripplanner.routing.services.configure.TransitAlertServiceModule;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleRepository;
@@ -169,7 +170,7 @@ class RequestScopedFactoryTest {
   }
 
   @Singleton
-  @Component(modules = ConstructApplicationModule.class)
+  @Component(modules = { ConstructApplicationModule.class, TransitAlertServiceModule.class })
   interface TestFactory {
     RequestScopedFactory.Builder requestScopedFactoryBuilder();
 

--- a/application/src/test/java/org/opentripplanner/standalone/server/AlertMetricsTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/server/AlertMetricsTest.java
@@ -13,7 +13,6 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.alertpatch.TransitAlertBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.transit.service.TransitRepository;
 
 class AlertMetricsTest {
 
@@ -32,7 +31,7 @@ class AlertMetricsTest {
   void registerMultiGauge() {
     var alert1 = alertBuilder("1").withSeverity(INFO).build();
     var alert2 = alertBuilder("2").withEffect(DETOUR).build();
-    var service = new TransitAlertServiceImpl(new TransitRepository());
+    var service = new TransitAlertServiceImpl();
     service.setAlerts(List.of(alert1, alert2));
 
     var binder = new AlertMetrics(() -> service);

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -26,6 +26,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.RaptorTransitDataMapper;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.framework.DebugTimingAggregator;
+import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
@@ -158,6 +159,7 @@ public class SpeedTest {
       null,
       updateManager,
       timetableHandle,
+      new DelegatingTransitAlertServiceImpl(),
       routerConfig.updaterConfig()
     );
     if (transitRepository.getUpdaterManager() != null) {
@@ -194,6 +196,7 @@ public class SpeedTest {
         transitRepository,
         timetableHandle.repositorySnapshot(registry.scope())
       ),
+      new DelegatingTransitAlertServiceImpl(),
       null,
       null,
       VectorTileConfig.DEFAULT,

--- a/application/src/test/java/org/opentripplanner/updater/alert/gtfs/AlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/gtfs/AlertsUpdateHandlerTest.java
@@ -25,13 +25,12 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TransitRepository;
 
 public class AlertsUpdateHandlerTest {
 
   private AlertsUpdateHandler handler;
 
-  private final TransitAlertService service = new TransitAlertServiceImpl(new TransitRepository());
+  private final TransitAlertService service = new TransitAlertServiceImpl();
 
   @BeforeEach
   public void setUp() {

--- a/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
@@ -88,7 +88,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       transitAlertService.getAllAlerts().clear();
     }
     if (alertsUpdateHandler == null) {
-      transitAlertService = new TransitAlertServiceImpl(transitRepository);
+      transitAlertService = new TransitAlertServiceImpl();
       alertsUpdateHandler = new SiriAlertsUpdateHandler(
         FEED_ID,
         transitAlertService,


### PR DESCRIPTION
### Summary

This pr makes the delegating alert service live in the server context as a separate entity, not as part of the transit service. Alert service does not need to be request scoped. This also changes the alert service interface for fetching stops so it no longer returns alerts for the parent station for a stop.

### Issue

Relates to https://github.com/opentripplanner/OpenTripPlanner/issues/7499, but not strictly required by it.

### Unit tests

Updated tests

### Documentation

Just javadoc

### Changelog

Skipped
