### PR TITLE
test: cover default transit service lookups

### DIFF
--- a/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
@@ -11,6 +11,7 @@ import static org.opentripplanner.transit.model.basic.TransitMode.FERRY;
 import static org.opentripplanner.transit.model.basic.TransitMode.RAIL;
 import static org.opentripplanner.transit.model.basic.TransitMode.TRAM;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collection;
@@ -20,6 +21,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.TripTimeOnDate;
@@ -424,5 +426,42 @@ class DefaultTransitServiceTest {
   void groupOfStationsChildIds() {
     var res = service.findStopOrChildIds(GO_STATIONS.getId());
     assertThat(res).containsExactly(STOP_A.getId(), STOP_B.getId());
+  }
+
+  private static Instant startOfService(LocalDate serviceDate) {
+    return ServiceDateUtils.asStartOfService(serviceDate, service.getTimeZone()).toInstant();
+  }
+
+  @Test
+  void findTripTimesOnDateForPatternAtStop() {
+    var tripTimes = service.findTripTimesOnDate(
+      STOP_A,
+      REAL_TIME_PATTERN,
+      startOfService(SERVICE_DATE),
+      Duration.ofMinutes(3),
+      10,
+      ArrivalDeparture.DEPARTURES,
+      false
+    );
+
+    assertThat(tripTimes.stream().map(TripTimeOnDate::getTrip).toList()).containsExactly(
+      TRIP,
+      ADDED_TRIP
+    );
+    assertThat(tripTimes.stream().map(TripTimeOnDate::getStop).toList()).containsExactly(
+      STOP_A,
+      STOP_A
+    );
+    assertThat(
+      tripTimes.stream().map(TripTimeOnDate::getRealtimeDeparture).toList()
+    ).containsExactly(DELAY, 10);
+  }
+
+  @Test
+  void findRegularStopsByBoundingBox() {
+    var stops = service.findRegularStopsByBoundingBox(new Envelope(9.9, 10.1, 59.9, 60.1));
+
+    assertThat(stops).containsAtLeast(STOP_A, STOP_B, STOP_C, STOP_ONE);
+    assertThat(service.findRegularStopsByBoundingBox(new Envelope(170, 180, 80, 90))).isEmpty();
   }
 }


### PR DESCRIPTION
Hi,

### Summary

This PR adds two focused regression tests for `DefaultTransitService` lookup behavior: realtime trip times for a stop and pattern, and regular stop lookup by bounding box.

### Issue

These service paths were only lightly covered before. The tests exercise the direct delegation to the stop-times helper and site repository, including [DefaultTransitService.java:475-476](https://github.com/amirdeljouyi/OpenTripPlanner/blob/86ce8fb01873bb56841a7a2674598101228c0edf/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java#L475-L476) and [DefaultTransitService.java:690-691](https://github.com/amirdeljouyi/OpenTripPlanner/blob/86ce8fb01873bb56841a7a2674598101228c0edf/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java#L690-L691). Line coverage for `DefaultTransitService` increases by about 4%.

### Unit tests

Added unit coverage in `DefaultTransitServiceTest`; the focused tests pass locally.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir