### PR TITLE
Identify realtime-modified patterns by stop sequence instead of originalTripPattern

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
@@ -144,7 +144,8 @@ public class ApiTransitService {
       .filter(
         tripPattern ->
           tripPattern != null &&
-          tripPattern.isModifiedFromTripPatternWithEqualStops(originalPattern)
+          tripPattern.isStopPatternModifiedInRealTime() &&
+          tripPattern.containsSameStopsAs(originalPattern)
       );
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
@@ -133,6 +133,13 @@ public class ApiTransitService {
   /**
    * Get a stream of {@link TripPattern} that were created real-time based of the provided pattern.
    * Only patterns that don't have removed (stops can still be skipped) or added stops are included.
+   * <p>
+   * Note: the real-time pattern cache is keyed by stop pattern only (see
+   * {@link org.opentripplanner.updater.trip.patterncache.TripPatternCache}), so trips of different
+   * routes that end up with the same modified stop pattern share a single real-time pattern. A
+   * returned pattern may therefore also carry trips of other routes, which then show up in the
+   * caller's departure list (cross-route over-inclusion). This is accepted as the lesser evil over
+   * the previous behavior, which hid the modified trips of all but one of the sharing routes.
    */
   private Stream<TripPattern> getRealtimeAddedPatternsAsStream(
     TripPattern originalPattern,

--- a/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -367,15 +367,11 @@ public final class TripPattern
   /* METHODS THAT DELEGATE TO THE SCHEDULED TIMETABLE */
 
   /**
-   * Checks that this is TripPattern is based off the provided TripPattern and contains the same stops
+   * Checks that this TripPattern contains the same stops as the provided TripPattern
    * (but not necessarily with same pickup and dropoff values).
    */
-  public boolean isModifiedFromTripPatternWithEqualStops(TripPattern other) {
-    return (
-      isModified() &&
-      originalTripPattern.equals(other) &&
-      getStopPattern().stopsEqual(other.getStopPattern())
-    );
+  public boolean containsSameStopsAs(TripPattern other) {
+    return getStopPattern().stopsEqual(other.getStopPattern());
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -135,6 +135,10 @@ class ApiTransitServiceTest {
    * pattern cache (keyed by stop pattern only), whose originalTripPattern belongs to the first
    * trip's route. Matching real-time patterns by that field instead of by stop sequence used to
    * hide the second trip.
+   * <p>
+   * Because the two routes share one real-time pattern, querying either route's pattern returns
+   * both trips. This cross-route over-inclusion is a known limitation of the shared pattern cache
+   * (keyed by stop pattern only) and is asserted explicitly here to pin the behavior.
    */
   @Test
   void skipStopInTripsFromDifferentRoutesWithSameStops() {
@@ -177,7 +181,10 @@ class ApiTransitServiceTest {
       .stream()
       .map(t -> t.getTrip().getId().getId())
       .toList();
-    assertThat(tripIds).contains(TRIP_2_ID);
+    // TRIP_2 is the trip under test; TRIP_1 (the other route) is also present because both routes
+    // share the same real-time pattern (see the class comment on cross-route over-inclusion). They
+    // are ordered by departure time at STOP_A (TRIP_1 at 12:00, TRIP_2 at 12:10).
+    assertEquals(List.of(TRIP_1_ID, TRIP_2_ID), tripIds);
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -129,6 +129,57 @@ class ApiTransitServiceTest {
     assertEquals(List.of(TRIP_1_ID, TRIP_2_ID), tripIds);
   }
 
+  /**
+   * Tests that a trip with a skipped stop is returned when its route shares the modified stop
+   * pattern with a trip of another route. The two trips get the same real-time pattern from the
+   * pattern cache (keyed by stop pattern only), whose originalTripPattern belongs to the first
+   * trip's route. Matching real-time patterns by that field instead of by stop sequence used to
+   * hide the second trip.
+   */
+  @Test
+  void skipStopInTripsFromDifferentRoutesWithSameStops() {
+    var trip1Input = TripInput.of(TRIP_1_ID)
+      .withRoute(envBuilder.route("Route1"))
+      .addStop(STOP_A, "12:00:00", "12:00:00")
+      .addStop(STOP_B, "12:30:00", "12:30:00")
+      .addStop(STOP_C, "13:00:00", "13:00:00");
+    var trip2Input = TripInput.of(TRIP_2_ID)
+      .withRoute(envBuilder.route("Route2"))
+      .addStop(STOP_A, "12:10:00", "12:10:00")
+      .addStop(STOP_B, "12:40:00", "12:40:00")
+      .addStop(STOP_C, "13:10:00", "13:10:00");
+    var env = envBuilder.addTrip(trip1Input).addTrip(trip2Input).build();
+    var rt = GtfsRtTestHelper.of(env);
+
+    var res = rt.applyTripUpdates(
+      List.of(
+        skipSecondStop(rt.tripUpdateScheduled(TRIP_1_ID)),
+        skipSecondStop(rt.tripUpdateScheduled(TRIP_2_ID))
+      ),
+      FULL_DATASET
+    );
+    assertSuccess(res);
+    var transitService = env.transitService();
+    var service = new ApiTransitService(transitService);
+
+    var trip2 = transitService.getTrip(id(TRIP_2_ID));
+    var scheduledPattern2 = transitService.findPattern(trip2);
+    var calls = service.getTripTimeOnDatesForPatternAtStopIncludingTripsWithSkippedStops(
+      STOP_A,
+      scheduledPattern2,
+      T11_59,
+      Duration.ofHours(2),
+      Integer.MAX_VALUE,
+      ArrivalDeparture.BOTH
+    );
+
+    var tripIds = calls
+      .stream()
+      .map(t -> t.getTrip().getId().getId())
+      .toList();
+    assertThat(tripIds).contains(TRIP_2_ID);
+  }
+
   @Test
   void transitLegCalls() {
     var env = envBuilder.addTrip(TRIP1_INPUT).build();

--- a/application/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
@@ -138,6 +138,23 @@ class TripPatternTest {
   }
 
   @Test
+  void containsSameStopsAs() {
+    assertTrue(SUBJECT.containsSameStopsAs(SUBJECT.copy().build()));
+
+    var sameStopsOtherRoute = TripPattern.of(id("other-route-pattern"))
+      .withRoute(TimetableRepositoryForTest.route("anotherId").build())
+      .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A, STOP_B, STOP_C))
+      .build();
+    assertTrue(SUBJECT.containsSameStopsAs(sameStopsOtherRoute));
+
+    var otherStops = TripPattern.of(id("other-stops-pattern"))
+      .withRoute(ROUTE)
+      .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A, STOP_B))
+      .build();
+    assertFalse(SUBJECT.containsSameStopsAs(otherStops));
+  }
+
+  @Test
   void containsAnyStopId() {
     assertFalse(SUBJECT.containsAnyStopId(List.of()));
     assertFalse(SUBJECT.containsAnyStopId(List.of(id("not-in-pattern"))));

--- a/application/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -146,6 +147,25 @@ class TripPatternTest {
       .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A, STOP_B, STOP_C))
       .build();
     assertTrue(SUBJECT.containsSameStopsAs(sameStopsOtherRoute));
+
+    // Same stop sequence but different pickup/dropoff values (STOP_B skipped) still counts as the
+    // same stops - this is the real-time-modified case the method exists to identify, and it guards
+    // against comparing full stop patterns (which would also compare pickup/dropoff) by mistake.
+    var skippedStop = StopPattern.create(3);
+    skippedStop.stops.with(0, STOP_A);
+    skippedStop.stops.with(1, STOP_B);
+    skippedStop.stops.with(2, STOP_C);
+    skippedStop.pickups.with(0, PickDrop.SCHEDULED);
+    skippedStop.dropoffs.with(0, PickDrop.SCHEDULED);
+    skippedStop.pickups.with(1, PickDrop.NONE);
+    skippedStop.dropoffs.with(1, PickDrop.NONE);
+    skippedStop.pickups.with(2, PickDrop.SCHEDULED);
+    skippedStop.dropoffs.with(2, PickDrop.SCHEDULED);
+    var sameStopsStopSkipped = TripPattern.of(id("skipped-stop-pattern"))
+      .withRoute(ROUTE)
+      .withStopPattern(skippedStop.build())
+      .build();
+    assertTrue(SUBJECT.containsSameStopsAs(sameStopsStopSkipped));
 
     var otherStops = TripPattern.of(id("other-stops-pattern"))
       .withRoute(ROUTE)


### PR DESCRIPTION
## Summary

When listing stop times for a pattern including trips with skipped stops
(`stop.stopTimesForPattern` in the GTFS GraphQL API), `ApiTransitService` identified the
realtime-modified patterns derived from the queried pattern with
`TripPattern.isModifiedFromTripPatternWithEqualStops()`, which compares the
`originalTripPattern` field.

That field is unreliable: realtime patterns are cached in `TripPatternCache` keyed by
`StopPattern` only, and `originalTripPattern` is set from the **first** trip that created the
cache entry. When trips of *different* routes produce the same modified stop pattern (for
example the same stop skipped on two routes serving the same stops), they share one cached
realtime pattern whose `originalTripPattern` points at the first trip's route. Querying the
second route's pattern then failed the field comparison, the realtime pattern was filtered
out, and the second trip disappeared from the departure list entirely (its scheduled
timetable rows are deleted for that service date once it moves to the realtime pattern).

The realtime pattern is resolved per trip of the queried pattern
(`findNewTripPatternForModifiedTrip`), so "is based off the queried pattern" is already
guaranteed by construction. The field check is therefore replaced with
`isStopPatternModifiedInRealTime()` plus a stop-sequence comparison
(`TripPattern.containsSameStopsAs()`), and `isModifiedFromTripPatternWithEqualStops()` is
removed from `TripPattern`.

This removes one of the remaining usages of `TripPattern.originalTripPattern`, whose
per-pattern storage of a per-trip relationship is the root cause of this class of bugs
(see #7794 for the realtime-vehicle usage).

## Unit tests

- `ApiTransitServiceTest.skipStopInTripsFromDifferentRoutesWithSameStops` reproduces the
  cross-route scenario: it fails on the previous implementation (the second route's trip is
  missing from the result) and passes with this change.
- `TripPatternTest.containsSameStopsAs` covers the new comparison method.

The scenario was also reproduced against a full Norway graph with a live OTP instance:
skipping the same stop on two trips of two routes with identical stop patterns produced a
single shared realtime pattern, and `stopTimesForPattern` on the second route's pattern
returned its trip only with this fix.

## Documentation

JavaDoc on the new method. No user-facing configuration or API schema changes.
