### PR TITLE
Base realtime stop-pattern updates on the trip's planned pattern

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModule.java
@@ -65,7 +65,7 @@ public class StopConsolidationModule implements GraphBuilderModule {
     TripPattern pattern,
     List<StopReplacement> replacements
   ) {
-    var updatedStopPattern = pattern.copyPlannedStopPattern();
+    var updatedStopPattern = pattern.copyStopPattern();
     replacements.forEach(r -> updatedStopPattern.replaceStop(r.secondary(), r.primary()));
     return pattern.copy().withStopPattern(updatedStopPattern.build()).build();
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
@@ -88,14 +88,15 @@ public final class StopPattern implements Serializable {
 
   /**
    * This has package local access since a StopPattern is a part of a TripPattern. To change it
-   * use the {@link TripPattern#copyPlannedStopPattern()} method.
+   * use the {@link TripPattern#copyStopPattern()} or
+   * {@link TripPattern#copyPlannedStopPattern(StopPattern)} method.
    */
   StopPatternBuilder copyOf() {
     return new StopPatternBuilder(this, null);
   }
 
   StopPatternBuilder copyOf(StopPattern realTime) {
-    return new StopPatternBuilder(this, realTime);
+    return new StopPatternBuilder(this, Objects.requireNonNull(realTime));
   }
 
   public int hashCode() {

--- a/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -213,17 +213,28 @@ public final class TripPattern
   }
 
   /**
-   * Return the "original"/planned stop pattern as a builder. This is used when a realtime-update
-   * contains a full set of stops/pickup/dropoff for a pattern. This will wipe out any changes
-   * to the stop-pattern from previous updates.
-   * <p>
-   * Be aware, if the same update is applied twice, then the first instance will be reused to avoid
-   * unnecessary objects creation and gc.
+   * Return a copy of this pattern's stop pattern as a builder, to create a modified version of it.
    */
-  public StopPattern.StopPatternBuilder copyPlannedStopPattern() {
-    return isModified()
-      ? originalTripPattern.stopPattern.copyOf(stopPattern)
-      : stopPattern.copyOf();
+  public StopPattern.StopPatternBuilder copyStopPattern() {
+    return stopPattern.copyOf();
+  }
+
+  /**
+   * Return this pattern's stop pattern as a builder, to apply a real-time update to it. This must
+   * be called on the trip's planned pattern: a real-time update contains the full set of
+   * stops/pickup/dropoff for a trip, and basing the copy on the planned stop pattern wipes out any
+   * changes to the stop-pattern from previous updates.
+   * <p>
+   * Be aware, if the same update is applied twice, then the {@code currentRealTime} instance will
+   * be reused to avoid unnecessary objects creation and gc.
+   * <p>
+   * Use {@link #copyStopPattern()} instead if there is no current realtime stop pattern.
+   *
+   * @param currentRealTime the stop pattern of the pattern the trip is currently running on, used
+   *                        for instance reuse only
+   */
+  public StopPattern.StopPatternBuilder copyPlannedStopPattern(StopPattern currentRealTime) {
+    return stopPattern.copyOf(Objects.requireNonNull(currentRealTime));
   }
 
   /**
@@ -372,7 +383,7 @@ public final class TripPattern
    */
   public boolean isModifiedFromTripPatternWithEqualStops(TripPattern other) {
     return (
-      isModified() &&
+      originalTripPattern != null &&
       originalTripPattern.equals(other) &&
       getStopPattern().stopsEqual(other.getStopPattern())
     );
@@ -454,15 +465,6 @@ public final class TripPattern
   }
 
   /**
-   * @deprecated This method is not clearly defined. Use {@link #isStopPatternModifiedInRealTime()}
-   * or {@link #isRealTimeTripPattern()} if possible, or clarify what this is needed for.
-   */
-  @Deprecated
-  public boolean isModified() {
-    return originalTripPattern != null;
-  }
-
-  /**
    * Returns trip headsign from the scheduled timetables or from the original pattern's scheduled
    * timetables if this pattern is added by realtime and the stop sequence has not changed apart
    * from pickup/dropoff values.
@@ -540,7 +542,7 @@ public final class TripPattern
    * is added through a realtime update. The pickup and dropoff values don't have to be the same.
    */
   private boolean containsSameStopsAsOriginalPattern() {
-    return isModified() && getStops().equals(originalTripPattern.getStops());
+    return originalTripPattern != null && getStops().equals(originalTripPattern.getStops());
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
@@ -91,7 +91,7 @@ class ScheduledTripHandler {
     // If there are stops with different pickup / drop off, or replaced stops, we need to change the pattern from the scheduled one
     if (!updatedPickup.isEmpty() || !updatedDropoff.isEmpty() || !newStops.isEmpty()) {
       StopPattern newStopPattern = pattern
-        .copyPlannedStopPattern()
+        .copyStopPattern()
         .updatePickups(updatedPickup)
         .updateDropoffs(updatedDropoff)
         .replaceStops(newStops)

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
@@ -31,7 +31,13 @@ import uk.org.siri.siri21.OccupancyEnumeration;
 class ModifiedTripBuilder {
 
   private final TripTimes existingTripTimes;
+
+  /** The pattern the trip is currently running on, possibly a real-time-modified pattern. */
   private final TripPattern pattern;
+
+  /** The trip's planned pattern, on which the real-time modifications are based. */
+  private final TripPattern plannedPattern;
+
   private final LocalDate serviceDate;
   private final ZoneId zoneId;
   private final EntityResolver entityResolver;
@@ -45,6 +51,7 @@ class ModifiedTripBuilder {
   public ModifiedTripBuilder(
     TripTimes existingTripTimes,
     TripPattern pattern,
+    TripPattern plannedPattern,
     EstimatedVehicleJourneyWrapper journey,
     LocalDate serviceDate,
     ZoneId zoneId,
@@ -52,6 +59,7 @@ class ModifiedTripBuilder {
   ) {
     this.existingTripTimes = existingTripTimes;
     this.pattern = pattern;
+    this.plannedPattern = plannedPattern;
     this.serviceDate = serviceDate;
     this.zoneId = zoneId;
     this.entityResolver = entityResolver;
@@ -70,6 +78,7 @@ class ModifiedTripBuilder {
   public ModifiedTripBuilder(
     TripTimes existingTripTimes,
     TripPattern pattern,
+    TripPattern plannedPattern,
     LocalDate serviceDate,
     ZoneId zoneId,
     EntityResolver entityResolver,
@@ -82,6 +91,7 @@ class ModifiedTripBuilder {
   ) {
     this.existingTripTimes = existingTripTimes;
     this.pattern = pattern;
+    this.plannedPattern = plannedPattern;
     this.serviceDate = serviceDate;
     this.zoneId = zoneId;
     this.entityResolver = entityResolver;
@@ -118,7 +128,12 @@ class ModifiedTripBuilder {
 
     StopPattern stopPattern;
     try {
-      stopPattern = createStopPattern(pattern, calls, entityResolver);
+      stopPattern = createStopPattern(
+        plannedPattern,
+        pattern.getStopPattern(),
+        calls,
+        entityResolver
+      );
     } catch (UpdateException e) {
       throw e.withTripId(existingTripTimes.getTrip().getId());
     }
@@ -129,7 +144,7 @@ class ModifiedTripBuilder {
 
     applyUpdates(builder);
 
-    if (!pattern.getStopPattern().equals(stopPattern)) {
+    if (!plannedPattern.getStopPattern().equals(stopPattern)) {
       builder.withModifiedTripPattern();
     }
 
@@ -206,19 +221,21 @@ class ModifiedTripBuilder {
   }
 
   /**
-   * Creates a new StopPattern, based on an existing pattern, and list of calls. The stops can be
-   * replaced with stops belonging to the same Station/StopPlace. The PickDrop values are updated
-   * as well.
+   * Creates a new StopPattern, based on the trip's planned pattern, and list of calls. The stops
+   * can be replaced with stops belonging to the same Station/StopPlace. The PickDrop values are
+   * updated as well. If the resulting stop pattern is equal to {@code currentStopPattern} (the
+   * stop pattern of the pattern the trip is currently running on), that instance is reused.
    * Precondition: the number of calls is equal to the number of stops in the pattern (this is
    * verified before calling this method).
    */
   static StopPattern createStopPattern(
-    TripPattern pattern,
+    TripPattern plannedPattern,
+    StopPattern currentStopPattern,
     List<CallWrapper> calls,
     EntityResolver entityResolver
   ) throws UpdateException {
-    int numberOfStops = pattern.numberOfStops();
-    var builder = pattern.copyPlannedStopPattern();
+    int numberOfStops = plannedPattern.numberOfStops();
+    var builder = plannedPattern.copyPlannedStopPattern(currentStopPattern);
 
     Set<CallWrapper> alreadyVisited = new HashSet<>();
     // modify updated stop-times
@@ -261,9 +278,6 @@ class ModifiedTripBuilder {
         throw UpdateException.ofStopIndex(STOP_MISMATCH, i);
       }
     }
-    var newStopPattern = builder.build();
-    return (pattern.isModified() && pattern.getStopPattern().equals(newStopPattern))
-      ? pattern.getStopPattern()
-      : newStopPattern;
+    return builder.build();
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -231,11 +231,19 @@ public class SiriRealTimeTripUpdateAdapter {
       throw UpdateException.of(trip != null ? trip.getId() : null, NO_START_DATE);
     }
 
+    // The pattern the trip is currently running on, possibly a realtime-modified pattern
     TripPattern pattern;
+    // The trip's planned pattern: the scheduled pattern for scheduled trips, or the pattern
+    // created together with the trip for realtime-added trips. The realtime modifications of a
+    // trip are based on its planned pattern, not on the pattern the trip is currently running
+    // on: an update contains the full set of stops/pickup/dropoff for the trip and must wipe
+    // out changes from previous updates.
+    TripPattern plannedPattern;
 
     if (trip != null) {
       // Found exact match
       pattern = transitEditorService.findPattern(trip);
+      plannedPattern = pattern;
     } else if (fuzzyTripMatcher != null) {
       // No exact match found - search for trips based on arrival-times/stop-patterns
       var tripAndPattern = fuzzyTripMatcher.match(
@@ -246,6 +254,7 @@ public class SiriRealTimeTripUpdateAdapter {
       );
       trip = tripAndPattern.trip();
       pattern = tripAndPattern.tripPattern();
+      plannedPattern = transitEditorService.findPattern(trip);
     } else {
       throw UpdateException.of(null, TRIP_NOT_FOUND);
     }
@@ -259,6 +268,7 @@ public class SiriRealTimeTripUpdateAdapter {
     var tripUpdate = new ModifiedTripBuilder(
       existingTripTimes,
       pattern,
+      plannedPattern,
       journey,
       serviceDate,
       transitEditorService.getTimeZone(),

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilderTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.updater.trip.siri;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 
@@ -153,6 +154,7 @@ class ModifiedTripBuilderTest {
     var result = new ModifiedTripBuilder(
       TRIP_TIMES,
       PATTERN,
+      PATTERN,
       SERVICE_DATE,
       timetableRepository.getTimeZone(),
       entityResolver,
@@ -171,6 +173,7 @@ class ModifiedTripBuilderTest {
   void testUpdateCancellation() {
     var tripUpdate = new ModifiedTripBuilder(
       TRIP_TIMES,
+      PATTERN,
       PATTERN,
       SERVICE_DATE,
       timetableRepository.getTimeZone(),
@@ -210,6 +213,7 @@ class ModifiedTripBuilderTest {
   void testUpdateSameStops() {
     var tripUpdate = new ModifiedTripBuilder(
       TRIP_TIMES,
+      PATTERN,
       PATTERN,
       SERVICE_DATE,
       timetableRepository.getTimeZone(),
@@ -256,6 +260,7 @@ class ModifiedTripBuilderTest {
     var tripUpdate = new ModifiedTripBuilder(
       TRIP_TIMES,
       PATTERN,
+      PATTERN,
       SERVICE_DATE,
       timetableRepository.getTimeZone(),
       entityResolver,
@@ -297,6 +302,7 @@ class ModifiedTripBuilderTest {
   void testUpdateSameStopsDepartEarly() {
     var tripUpdate = new ModifiedTripBuilder(
       TRIP_TIMES,
+      PATTERN,
       PATTERN,
       SERVICE_DATE,
       timetableRepository.getTimeZone(),
@@ -342,6 +348,7 @@ class ModifiedTripBuilderTest {
   void testUpdateUpdatedStop() {
     var tripUpdate = new ModifiedTripBuilder(
       TRIP_TIMES,
+      PATTERN,
       PATTERN,
       SERVICE_DATE,
       timetableRepository.getTimeZone(),
@@ -393,6 +400,7 @@ class ModifiedTripBuilderTest {
     // No change in stops should result in original pattern
     var result = ModifiedTripBuilder.createStopPattern(
       PATTERN,
+      PATTERN.getStopPattern(),
       List.of(
         TestCall.of().withStopPointRef(STOP_A_1.getId().getId()).build(),
         TestCall.of().withStopPointRef(STOP_B_1.getId().getId()).build(),
@@ -409,6 +417,7 @@ class ModifiedTripBuilderTest {
     // Change in stations should result in new pattern
     var result = ModifiedTripBuilder.createStopPattern(
       PATTERN,
+      PATTERN.getStopPattern(),
       List.of(
         TestCall.of().withStopPointRef(STOP_A_2.getId().getId()).build(),
         TestCall.of().withStopPointRef(STOP_B_1.getId().getId()).build(),
@@ -438,6 +447,7 @@ class ModifiedTripBuilderTest {
     assertFailure(UpdateErrorType.STOP_MISMATCH, () ->
       ModifiedTripBuilder.createStopPattern(
         PATTERN,
+        PATTERN.getStopPattern(),
         List.of(
           TestCall.of().withStopPointRef(STOP_A_1.getId().getId()).build(),
           TestCall.of().withStopPointRef(STOP_D.getId().getId()).build(),
@@ -453,6 +463,7 @@ class ModifiedTripBuilderTest {
     // Cancellation of a call should be reflected in PickDrop
     var result = ModifiedTripBuilder.createStopPattern(
       PATTERN,
+      PATTERN.getStopPattern(),
       List.of(
         TestCall.of().withStopPointRef(STOP_A_1.getId().getId()).build(),
         TestCall.of().withStopPointRef(STOP_B_1.getId().getId()).build(),
@@ -484,6 +495,7 @@ class ModifiedTripBuilderTest {
     // Cancellation of a call should be reflected in PickDrop
     var result = ModifiedTripBuilder.createStopPattern(
       PATTERN,
+      PATTERN.getStopPattern(),
       List.of(
         TestCall.of().withStopPointRef(STOP_A_1.getId().getId()).build(),
         TestCall.of()
@@ -511,6 +523,62 @@ class ModifiedTripBuilderTest {
 
     assertEquals(PickDrop.SCHEDULED, newPattern.getAlightType(2));
     assertEquals(PickDrop.SCHEDULED, newPattern.getBoardType(2));
+  }
+
+  @Test
+  void testCreateStopPatternRebasedOnPlannedPattern() {
+    // A first update cancels a call and moves the trip to a realtime stop pattern
+    var cancelledStopPattern = ModifiedTripBuilder.createStopPattern(
+      PATTERN,
+      PATTERN.getStopPattern(),
+      List.of(
+        TestCall.of().withStopPointRef(STOP_A_1.getId().getId()).build(),
+        TestCall.of().withStopPointRef(STOP_B_1.getId().getId()).build(),
+        TestCall.of().withStopPointRef(STOP_C_1.getId().getId()).withCancellation(true).build()
+      ),
+      entityResolver
+    );
+
+    // A second update without the cancellation is based on the planned pattern, not on the
+    // current realtime stop pattern, and reverts the trip to the planned stop pattern
+    var revertedStopPattern = ModifiedTripBuilder.createStopPattern(
+      PATTERN,
+      cancelledStopPattern,
+      List.of(
+        TestCall.of().withStopPointRef(STOP_A_1.getId().getId()).build(),
+        TestCall.of().withStopPointRef(STOP_B_1.getId().getId()).build(),
+        TestCall.of().withStopPointRef(STOP_C_1.getId().getId()).build()
+      ),
+      entityResolver
+    );
+
+    assertSame(PATTERN.getStopPattern(), revertedStopPattern);
+  }
+
+  @Test
+  void testCreateStopPatternReusesCurrentRealTimeInstance() {
+    List<CallWrapper> calls = List.of(
+      TestCall.of().withStopPointRef(STOP_A_1.getId().getId()).build(),
+      TestCall.of().withStopPointRef(STOP_B_1.getId().getId()).build(),
+      TestCall.of().withStopPointRef(STOP_C_1.getId().getId()).withCancellation(true).build()
+    );
+    var cancelledStopPattern = ModifiedTripBuilder.createStopPattern(
+      PATTERN,
+      PATTERN.getStopPattern(),
+      calls,
+      entityResolver
+    );
+
+    // Applying the same update twice reuses the current realtime stop pattern instance
+    // to avoid unnecessary object creation
+    var repeatedStopPattern = ModifiedTripBuilder.createStopPattern(
+      PATTERN,
+      cancelledStopPattern,
+      calls,
+      entityResolver
+    );
+
+    assertSame(cancelledStopPattern, repeatedStopPattern);
   }
 
   private static ZonedDateTime zonedDateTime(int hour, int minute) {

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/PlannedPatternRebaseTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/PlannedPatternRebaseTest.java
@@ -1,0 +1,121 @@
+package org.opentripplanner.updater.trip.siri.moduletests.update;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.PickDrop;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model.TripInput;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.siri.SiriTestHelper;
+
+/**
+ * Test that a real-time update is based on the trip's own planned pattern, also when the trip is
+ * currently running on a realtime pattern shared with a trip of another route.
+ * <p>
+ * TripPatternCache caches realtime patterns keyed by StopPattern only. When trips of two routes
+ * produce the same modified StopPattern (here: the same stop cancelled on trips with the same
+ * stops), they share one cached realtime pattern, and the shared pattern's originalTripPattern
+ * belongs to the first route. A later update to the second trip must be based on the planned
+ * pattern of that trip: basing it on the shared pattern's originalTripPattern would apply the
+ * first route's planned pickup/dropoff values to the second route's trip.
+ */
+class PlannedPatternRebaseTest implements RealtimeTestConstants {
+
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
+  private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
+  private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
+  private final RegularStop STOP_D = ENV_BUILDER.stop(STOP_D_ID);
+
+  private final TripInput TRIP_1_INPUT = TripInput.of(TRIP_1_ID)
+    .withRoute(ENV_BUILDER.route("Route1"))
+    .withWithTripOnServiceDate(TRIP_1_ID)
+    .addStop(STOP_A, "0:01:00", "0:01:01")
+    .addStop(STOP_B, "0:01:10", "0:01:11")
+    .addStop(STOP_D, "0:01:20", "0:01:21");
+
+  // Same stops as TRIP_1, but boarding at stop B is planned with a different pickup type
+  private final TripInput TRIP_2_INPUT = TripInput.of(TRIP_2_ID)
+    .withRoute(ENV_BUILDER.route("Route2"))
+    .withWithTripOnServiceDate(TRIP_2_ID)
+    .addStop(STOP_A, "0:02:00", "0:02:01")
+    .addStop(STOP_B, "0:02:10", "0:02:11", PickDrop.CALL_AGENCY, PickDrop.SCHEDULED)
+    .addStop(STOP_D, "0:02:20", "0:02:21");
+
+  @Test
+  void updateIsRebasedOnPlannedPatternOfTheTripsOwnRoute() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).addTrip(TRIP_2_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    // Batch 1: Cancel stop B on TRIP_1 — creates the TripPatternCache entry
+    var batch1 = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:01:01", "00:01:01")
+          .call(STOP_B)
+          .withIsCancellation(true)
+          .call(STOP_D)
+          .arriveAimedExpected("00:01:20", "00:01:20")
+      )
+      .buildEstimatedTimetableDeliveries();
+    assertSuccess(siri.applyEstimatedTimetable(batch1));
+
+    // Batch 2: Cancel stop B on TRIP_2 — the cancellation masks the different planned pickup at
+    // stop B, so both trips end up on the same cached realtime pattern
+    var batch2 = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_2_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:02:01", "00:02:01")
+          .call(STOP_B)
+          .withIsCancellation(true)
+          .call(STOP_D)
+          .arriveAimedExpected("00:02:20", "00:02:20")
+      )
+      .buildEstimatedTimetableDeliveries();
+    assertSuccess(siri.applyEstimatedTimetable(batch2));
+    assertSame(
+      env.tripData(TRIP_1_ID).tripPattern(),
+      env.tripData(TRIP_2_ID).tripPattern(),
+      "Precondition: both trips share the same cached realtime pattern"
+    );
+
+    // Batch 3: Update TRIP_2 without the cancellation, resolved through fuzzy matching (the
+    // only path that resolves the realtime pattern for the trip). The update is based on the
+    // planned pattern of TRIP_2's own route and reverts the trip to its scheduled pattern.
+    var batch3 = siri
+      .etBuilder()
+      .withFramedVehicleJourneyRef(builder ->
+        builder.withServiceDate(env.defaultServiceDate()).withVehicleJourneyRef("XXX")
+      )
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_A)
+          .departAimedExpected("00:02:01", "00:02:02")
+          .call(STOP_B)
+          .arriveAimedExpected("00:02:10", "00:02:12")
+          .departAimedExpected("00:02:11", "00:02:13")
+          .call(STOP_D)
+          .arriveAimedExpected("00:02:20", "00:02:25")
+      )
+      .buildEstimatedTimetableDeliveries();
+    assertSuccess(siri.applyEstimatedTimetableWithFuzzyMatcher(batch3));
+
+    var trip2Data = env.tripData(TRIP_2_ID);
+    assertSame(trip2Data.scheduledTripPattern(), trip2Data.tripPattern());
+    assertEquals(PickDrop.CALL_AGENCY, trip2Data.tripPattern().getBoardType(1));
+    assertEquals(
+      "U | A 0:02:02 0:02:02 | B 0:02:12 0:02:13 | D 0:02:25 0:02:25",
+      trip2Data.showTimetable()
+    );
+  }
+}


### PR DESCRIPTION
## Summary

When a SIRI-ET update modifies a trip, `ModifiedTripBuilder` builds the new `StopPattern` from
the trip's *planned* stop pattern (an update contains the full set of stops/pickup/dropoff for
the journey, so it must wipe out changes from previous updates, not accumulate on top of them).
The planned pattern was resolved through `TripPattern.copyPlannedStopPattern()`, which navigates
the `originalTripPattern` field when called on a realtime pattern.

That field is unreliable: realtime patterns are cached in `TripPatternCache` keyed by
`StopPattern` only, and `originalTripPattern` is set from the **first** trip that created the
cache entry. When trips of *different* routes produce the same modified stop pattern, they share
one cached realtime pattern whose `originalTripPattern` points at the first trip's route. A
subsequent update to the second trip resolved through fuzzy matching (the only path where the
current pattern handed to `ModifiedTripBuilder` is a realtime pattern) is then re-based on the
*first* route's planned stop pattern, resurrecting that route's planned pickup/dropoff values on
the second route's trip. In the reverting case the trip ends up stranded on a bogus realtime
pattern instead of returning to its scheduled pattern.

This PR makes the caller resolve the planned pattern per trip instead:

- `SiriRealTimeTripUpdateAdapter` resolves the trip's planned pattern
  (`TransitEditorService.findPattern(trip)`: the scheduled pattern, or the creation pattern for
  realtime-added trips) and passes it to `ModifiedTripBuilder` alongside the current pattern.
- `TripPattern.copyPlannedStopPattern()` no longer navigates `originalTripPattern`. It must now
  be called on the planned pattern and takes the current realtime `StopPattern` as an argument,
  used only for instance reuse when an identical update is applied twice. The now-redundant
  instance-reuse ternary at the end of `ModifiedTripBuilder.createStopPattern()`
  (`StopPatternBuilder.build()` already returns the reused instance) is removed.
- The `PATTERN_MODIFIED` flag on the updated trip times is now computed against the *planned*
  stop pattern instead of the current one. This is the correct definition, and the exact-match
  path already behaved this way (the current pattern is the planned pattern there); on the
  fuzzy-match path the old comparison was wrong in both directions (a reverting update kept the
  flag, a repeated identical update lost it).
- The GTFS path (`ScheduledTripHandler`) and the stop-consolidation module always operate on a
  planned pattern, so they only need a plain copy: new method `TripPattern.copyStopPattern()`.
- `TripPattern.isModified()` (deprecated, defined as `originalTripPattern != null`) is deleted;
  the two remaining internal usages inline the null-check.

This removes another set of `TripPattern.originalTripPattern` usages, whose per-pattern storage
of a per-trip relationship is the root cause of this class of bugs (see #7794 and #7795 for the
other usages; this PR is independent of both).

## Unit tests

- `PlannedPatternRebaseTest` (new) reproduces the cross-route scenario end to end: two routes
  with the same stops but different planned pickup at one stop, the same stop cancelled on both
  (single shared cached realtime pattern), then a fuzzy-matched update reverting the second
  trip. With the old logic the trip ends up on a realtime pattern carrying the first route's
  planned pickup values; with this change it returns to its own scheduled pattern. Verified to
  fail against the previous implementation.
- `ModifiedTripBuilderTest`: two new tests pin the re-basing contract of
  `createStopPattern` and the instance-reuse behaviour that previously relied on the removed
  ternary.

## Documentation

JavaDoc on the new/changed methods. No user-facing configuration or API schema changes.
