### PR TITLE
Do not re-enable boarding at a cancelled SIRI call

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/PickDropChange.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/PickDropChange.java
@@ -52,8 +52,8 @@ public final class PickDropChange {
    * @return the mapped {@link PickDrop} type, empty if routability is not changed
    */
   public Optional<PickDrop> applyTo(PickDrop scheduled) {
-    if (!scheduled.isNotRoutable() && cancelled) {
-      return Optional.of(CANCELLED);
+    if (cancelled) {
+      return scheduled.isNotRoutable() ? Optional.empty() : Optional.of(CANCELLED);
     }
     return switch (activity) {
       case UNSPECIFIED -> Optional.empty();

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/CallWrapperPickDropTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/CallWrapperPickDropTest.java
@@ -231,4 +231,34 @@ class CallWrapperPickDropTest {
       "There is no change in routability - dropoff should be changed"
     );
   }
+
+  @Test
+  public void testCancellationWithNoPlannedBoardingButBoardingActivity() {
+    var originalPickUpType = PickDrop.NONE;
+    TestCall call = TestCall.of()
+      .withCancellation(Boolean.TRUE)
+      .withDepartureBoardingActivity(BOARDING)
+      .build();
+    var testResult = call.pickUp().applyTo(originalPickUpType);
+
+    assertTrue(
+      testResult.isEmpty(),
+      "A cancelled call must not re-enable boarding that was not routable in the schedule"
+    );
+  }
+
+  @Test
+  public void testCancellationWithNoPlannedAlightingButAlightingActivity() {
+    var originalDropOffType = PickDrop.NONE;
+    TestCall call = TestCall.of()
+      .withCancellation(Boolean.TRUE)
+      .withArrivalBoardingActivity(ALIGHTING)
+      .build();
+    var testResult = call.dropOff().applyTo(originalDropOffType);
+
+    assertTrue(
+      testResult.isEmpty(),
+      "A cancelled call must not re-enable alighting that was not routable in the schedule"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up from the SIRI-ET updater refactoring (#7783 review, spotted by @MaxGosau): fix a pre-existing bug in `PickDropChange.applyTo(...)` where a cancelled call could re-enable boarding/alighting.

When a call was cancelled but carried an explicit boarding/alighting activity (`BOARDING`/`ALIGHTING`) **and** the scheduled pick/drop was already not routable, the cancellation guard was skipped and execution fell through to `case ALLOWED`, which returned `Optional.of(SCHEDULED)` — re-enabling boarding at a cancelled call.

### Fix

Hoist the `cancelled` check to the top so a cancelled call is never overridden by the boarding-activity switch:

```java
if (cancelled) {
  return scheduled.isNotRoutable() ? Optional.empty() : Optional.of(CANCELLED);
}
```

This preserves the "only change the value when routability changes" contract: cancelled + already-not-routable → empty (unchanged); cancelled + routable → `CANCELLED`.

### Tests

Added two cases to `CallWrapperPickDropTest` .