### PR TITLE
Resolve pattern headsign and originalTripPattern in the API layer

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
@@ -158,8 +158,21 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
 
   @Override
   public DataFetcher<String> headsign() {
-    return environment ->
-      GraphQLUtils.getTranslation(getSource(environment).getTripHeadsign(), environment);
+    return environment -> {
+      var pattern = getSource(environment);
+      var headsign = pattern.getTripHeadsign();
+      // A pattern created by a real-time update has no scheduled trip times, so its headsign is
+      // resolved from a trip currently running on it in the timetable snapshot.
+      if (headsign == null && pattern.isRealTimeTripPattern()) {
+        headsign = getTransitService(environment)
+          .listTrips(pattern)
+          .stream()
+          .findFirst()
+          .map(Trip::getHeadsign)
+          .orElse(null);
+      }
+      return GraphQLUtils.getTranslation(headsign, environment);
+    };
   }
 
   @Override
@@ -175,7 +188,23 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
 
   @Override
   public DataFetcher<TripPattern> originalTripPattern() {
-    return environment -> getSource(environment).getOriginalTripPattern();
+    return environment -> {
+      var pattern = getSource(environment);
+      // Only real-time patterns with a modified stop sequence have a scheduled "original".
+      if (!pattern.isStopPatternModifiedInRealTime()) {
+        return null;
+      }
+      var transitService = getTransitService(environment);
+      // The pattern's "original" is a per-trip relationship, so resolve it from a trip currently
+      // running on the pattern. This picks the first such trip deterministically.
+      return transitService
+        .listTrips(pattern)
+        .stream()
+        .findFirst()
+        .map(transitService::findPattern)
+        .filter(original -> !original.equals(pattern))
+        .orElse(null);
+    };
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -463,17 +463,16 @@ public final class TripPattern
   }
 
   /**
-   * Returns trip headsign from the scheduled timetables or from the original pattern's scheduled
-   * timetables if this pattern is added by realtime and the stop sequence has not changed apart
-   * from pickup/dropoff values.
+   * Returns the trip headsign from the scheduled timetable, or {@code null} when this pattern has
+   * no scheduled trip times (a pattern created by a real-time update). The real-time headsign
+   * fallback for such patterns is resolved in the API layer, which has access to the timetable
+   * snapshot.
    *
    * @return trip headsign
    */
   public I18NString getTripHeadsign() {
     var tripTimes = scheduledTimetable.getRepresentativeTripTimes();
-    return tripTimes == null
-      ? getTripHeadsignFromOriginalPattern()
-      : getTripHeadSignFromTripTimes(tripTimes);
+    return tripTimes == null ? null : tripTimes.getTripHeadsign();
   }
 
   public TripPattern clone() {
@@ -533,31 +532,5 @@ public final class TripPattern
       Objects.equals(this.stopPattern, other.stopPattern) &&
       Objects.equals(this.scheduledTimetable, other.scheduledTimetable)
     );
-  }
-
-  /**
-   * Checks if the stops in this trip pattern are the same as in the original pattern (if this trip
-   * is added through a realtime update. The pickup and dropoff values don't have to be the same.
-   */
-  private boolean containsSameStopsAsOriginalPattern() {
-    return isModified() && getStops().equals(originalTripPattern.getStops());
-  }
-
-  /**
-   * Helper method for getting the trip headsign from the {@link TripTimes}.
-   */
-  private I18NString getTripHeadSignFromTripTimes(TripTimes tripTimes) {
-    return tripTimes != null ? tripTimes.getTripHeadsign() : null;
-  }
-
-  /**
-   * Returns trip headsign from the original pattern if one exists.
-   */
-  private I18NString getTripHeadsignFromOriginalPattern() {
-    if (containsSameStopsAsOriginalPattern()) {
-      var tripTimes = originalTripPattern.getScheduledTimetable().getRepresentativeTripTimes();
-      return getTripHeadSignFromTripTimes(tripTimes);
-    }
-    return null;
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableSnapshot.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableSnapshot.java
@@ -245,6 +245,25 @@ public class TimetableSnapshot {
   }
 
   /**
+   * Return the distinct trips that have real-time trip times on the given pattern in this
+   * snapshot, over all service dates. For a trip pattern created by a real-time update — whose
+   * scheduled timetable is empty — this is the only way to navigate from the pattern to its
+   * trips. A trip is not returned anymore if a later update has moved it to another pattern.
+   */
+  public List<Trip> listTrips(TripPattern pattern) {
+    SortedSet<Timetable> sortedTimetables = timetables.get(pattern.getId());
+    if (sortedTimetables == null) {
+      return List.of();
+    }
+    return sortedTimetables
+      .stream()
+      .flatMap(timetable -> timetable.getTripTimes().stream())
+      .map(TripTimes::getTrip)
+      .distinct()
+      .toList();
+  }
+
+  /**
    * @return if any trip patterns were modified
    */
   public boolean hasNewTripPatternsForModifiedTrips() {

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -423,6 +423,14 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
+  public List<Trip> listTrips(TripPattern pattern) {
+    if (pattern.isRealTimeTripPattern()) {
+      return timetableSnapshot != null ? timetableSnapshot.listTrips(pattern) : List.of();
+    }
+    return pattern.scheduledTripsAsStream().toList();
+  }
+
+  @Override
   public MultiModalStation findMultiModalStation(Station station) {
     return this.timetableRepository.getSiteRepository().getMultiModalStationForStation(station);
   }

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -227,6 +227,15 @@ public interface TransitService {
    */
   Collection<TripPattern> findPatterns(Route route);
 
+  /**
+   * Return the trips running on the given pattern. For a scheduled pattern this is the trips of
+   * its scheduled timetable, regardless of real-time modifications. For a pattern created by a
+   * real-time update — whose scheduled timetable is empty — the trips are looked up in the
+   * current timetable snapshot: a trip is not listed anymore if a later update has moved it to
+   * another pattern.
+   */
+  List<Trip> listTrips(TripPattern pattern);
+
   MultiModalStation findMultiModalStation(Station station);
 
   /**

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1144,7 +1144,7 @@ type Pattern implements Node {
   """
   name: String
   "Original Trip pattern for changed patterns"
-  originalTripPattern: Pattern
+  originalTripPattern: Pattern @deprecated(reason : "The \"original\" pattern is a per-trip relationship, but this field is resolved per-pattern from a single, arbitrarily picked trip currently running on this pattern. It is best-effort only: it can differ between trips sharing this pattern and returns null once the pattern no longer has any running trips. This field is scheduled for removal.")
   "Coordinates of the route of this pattern in Google polyline encoded format"
   patternGeometry: Geometry
   "The route this pattern runs on"

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImplTest.java
@@ -1,0 +1,134 @@
+package org.opentripplanner.apis.gtfs.datafetchers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.support.graphql.DataFetchingSupport;
+import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model.TripInput;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.siri.SiriTestHelper;
+
+/**
+ * Verifies that {@link PatternImpl} resolves the headsign and the "original" pattern of a
+ * real-time modified pattern from the timetable snapshot, instead of relying on
+ * {@code TripPattern.originalTripPattern}.
+ */
+class PatternImplTest implements RealtimeTestConstants {
+
+  private static final I18NString HEADSIGN = I18NString.of("To Downtown");
+
+  private final TransitTestEnvironmentBuilder envBuilder = TransitTestEnvironment.of();
+  private final RegularStop stopA = envBuilder.stop(STOP_A_ID);
+  private final RegularStop stopB = envBuilder.stop(STOP_B_ID);
+  private final RegularStop stopD = envBuilder.stop(STOP_D_ID);
+
+  private final TripInput tripInput = TripInput.of(TRIP_1_ID)
+    .withWithTripOnServiceDate(TRIP_1_ID)
+    .withHeadsign(HEADSIGN)
+    .addStop(stopA, "0:01:00", "0:01:01")
+    .addStop(stopB, "0:01:10", "0:01:11")
+    .addStop(stopD, "0:01:20", "0:01:21");
+
+  private final PatternImpl subject = new PatternImpl();
+
+  @Test
+  void originalTripPatternResolvesScheduledPatternForModifiedRealTimePattern() throws Exception {
+    var env = buildEnvironmentWithModifiedPattern();
+    var transitService = env.transitService();
+    var trip = transitService.getTrip(id(TRIP_1_ID));
+    var scheduledPattern = transitService.findPattern(trip);
+    var realTimePattern = transitService.findPattern(trip, env.defaultServiceDate());
+
+    var original = subject
+      .originalTripPattern()
+      .get(dataFetchingEnvironment(realTimePattern, transitService));
+
+    assertSame(scheduledPattern, original);
+  }
+
+  @Test
+  void originalTripPatternIsNullForScheduledPattern() throws Exception {
+    var env = buildEnvironmentWithModifiedPattern();
+    var transitService = env.transitService();
+    var trip = transitService.getTrip(id(TRIP_1_ID));
+    var scheduledPattern = transitService.findPattern(trip);
+
+    var original = subject
+      .originalTripPattern()
+      .get(dataFetchingEnvironment(scheduledPattern, transitService));
+
+    assertNull(original);
+  }
+
+  @Test
+  void headsignFallsBackToRealTimeTripForModifiedRealTimePattern() throws Exception {
+    var env = buildEnvironmentWithModifiedPattern();
+    var transitService = env.transitService();
+    var trip = transitService.getTrip(id(TRIP_1_ID));
+    var realTimePattern = transitService.findPattern(trip, env.defaultServiceDate());
+
+    // The real-time pattern has no scheduled trip times of its own.
+    assertNull(realTimePattern.getTripHeadsign());
+
+    var headsign = subject.headsign().get(dataFetchingEnvironment(realTimePattern, transitService));
+
+    assertEquals(HEADSIGN.toString(), headsign);
+  }
+
+  @Test
+  void headsignIsReadDirectlyFromScheduledPattern() throws Exception {
+    var env = buildEnvironmentWithModifiedPattern();
+    var transitService = env.transitService();
+    var trip = transitService.getTrip(id(TRIP_1_ID));
+    var scheduledPattern = transitService.findPattern(trip);
+
+    var headsign = subject
+      .headsign()
+      .get(dataFetchingEnvironment(scheduledPattern, transitService));
+
+    assertEquals(HEADSIGN.toString(), headsign);
+  }
+
+  /**
+   * Build a transit network with a single scheduled trip and cancel one of its stops through a
+   * SIRI update, which creates a real-time pattern with a modified stop sequence.
+   */
+  private TransitTestEnvironment buildEnvironmentWithModifiedPattern() {
+    var env = envBuilder.addTrip(tripInput).build();
+    var siri = SiriTestHelper.of(env);
+    var update = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(stopA)
+          .departAimedExpected("00:01:01", "00:01:01")
+          .call(stopB)
+          .withIsCancellation(true)
+          .call(stopD)
+          .arriveAimedExpected("00:01:20", "00:01:20")
+      )
+      .buildEstimatedTimetableDeliveries();
+    assertSuccess(siri.applyEstimatedTimetable(update));
+    return env;
+  }
+
+  private static DataFetchingEnvironment dataFetchingEnvironment(
+    TripPattern pattern,
+    TransitService transitService
+  ) {
+    return DataFetchingSupport.dataFetchingEnvironment(pattern, Map.of(), transitService);
+  }
+}


### PR DESCRIPTION
## Summary

Moves the two GTFS GraphQL consumers of `TripPattern.originalTripPattern` off the field, so it can later be removed from the domain entity. This is a preparation step — **the field itself is not removed here** (no serialization version bump), only its API-layer consumers are rewritten to navigate per-trip instead of relying on the per-pattern (and cross-contaminated) reference.

### Why `originalTripPattern` is unsafe
It is set once per `StopPattern`-keyed cache entry from the *first* trip that created it, so a shared cached pattern can point at an unrelated route's pattern, and for real-time-added trips the stored "original" is itself a real-time pattern. "Original" is a **per-trip** relationship stored **per-pattern**.

### Changes
- Add a `listTrips(TripPattern)` navigation primitive to `TransitService` / `TimetableSnapshot` to go from a real-time pattern to its trips (a trip drops out once a later update moves it elsewhere).
- `TripPattern.getTripHeadsign()` no longer falls back to the original pattern; it returns `null` for real-time patterns. The fallback now lives in `PatternImpl.headsign()`, reading the headsign from a trip currently running on the pattern (the RT trip's own headsign, not another pattern's).
- Reimplement `PatternImpl.originalTripPattern()` via navigation: for a stop-modified real-time pattern, resolve the scheduled pattern from a trip on it (`findPattern(trip)`), with a `result != pattern` guard. Returns `null` for scheduled and RT-added patterns, as before.
- Deprecate the GraphQL `Pattern.originalTripPattern` field: it is inherently a per-trip answer served per-pattern, so the reimplementation is best-effort (first running trip, arbitrary among trips sharing the pattern; `null` once no trips run on it). Behaviour is identical in the normal single-origin case.

### Notes for review
- **Public API:** the `@deprecated` note on `Pattern.originalTripPattern` is a public-schema change and should get a community discussion / issue.
- **Depends on** the `listTrips` primitive introduced in the vehicle-service PR (earlier step of this epic). It is duplicated here so the branch builds standalone off `dev-2.x`; the duplicate resolves trivially once that PR lands.
- **Behaviour choices**: reimplement-via-navigation (not deprecate-to-null), and RT-trip headsign fallback (not navigate-to-scheduled-pattern).

### Testing
New `PatternImplTest` covers RT-modified original resolution, scheduled→null, RT headsign fallback, and scheduled headsign. `CancelledStopCrossPatternTest`, `DestinationDisplayTest`, `DefaultTransitServiceTest` still pass.
