### PR TITLE
Ignore trip segments when mapping GTFS notices

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -288,7 +288,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>14.0.0</version>
+            <version>14.2.0</version>
         </dependency>
         <!-- Used in DegreeGridNEDTileSource to fetch tiles from Amazon S3 -->
         <dependency>

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
@@ -79,6 +79,7 @@ class NoticeAssignmentMapper {
     AbstractTransitEntity entity = switch (assignment.getTableName()) {
       case routes -> routes.get(recordId);
       case trips -> trips.get(recordId);
+      case trip_segments -> null;
     };
 
     if (entity == null) {


### PR DESCRIPTION
### Summary

This is a very small PR that fixes the parsing of experimental GTFS notices. It doesn't actually map them to an internal data structure but simply ignores them. Before this PR they would break the graph build process.

I will add the mapping in a follow up.