### PR TITLE
Remove dependency on TimetableSnapshot lookup from TripPatternCache

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
@@ -56,10 +56,7 @@ public class GtfsRealTimeTripUpdateAdapter {
       snapshotManager.getTimetableSnapshotBuffer()
     );
     var tripTimesUpdater = new TripTimesUpdater(timetableRepository.getTimeZone(), deduplicator);
-    var tripPatternCache = new TripPatternCache(
-      new TripPatternIdGenerator(),
-      transitEditorService::findPattern
-    );
+    var tripPatternCache = new TripPatternCache(new TripPatternIdGenerator());
 
     this.scheduledTripHandler = new ScheduledTripHandler(
       transitEditorService,

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/NewTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/NewTripHandler.java
@@ -152,7 +152,11 @@ class NewTripHandler {
     Trip trip = tripTimes.getTrip();
 
     final StopPattern stopPattern = tripTimesWithStopPattern.stopPattern();
-    final TripPattern pattern = tripPatternCache.getOrCreateTripPattern(stopPattern, trip);
+    final TripPattern pattern = tripPatternCache.getOrCreateTripPattern(
+      stopPattern,
+      trip,
+      transitEditorService.findPattern(trip)
+    );
 
     TripPattern hideTripInScheduledPattern = null;
     if (modified) {

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
@@ -98,7 +98,11 @@ class ScheduledTripHandler {
         .build();
 
       final Trip trip = transitEditorService.getTrip(tripUpdate.tripId());
-      final TripPattern newPattern = tripPatternCache.getOrCreateTripPattern(newStopPattern, trip);
+      final TripPattern newPattern = tripPatternCache.getOrCreateTripPattern(
+        newStopPattern,
+        trip,
+        pattern
+      );
 
       return snapshotManager.updateBuffer(
         RealTimeTripUpdate.of(newPattern, updatedTripTimes, tripUpdate.serviceDate())

--- a/application/src/main/java/org/opentripplanner/updater/trip/patterncache/TripPatternCache.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/patterncache/TripPatternCache.java
@@ -2,7 +2,7 @@ package org.opentripplanner.updater.trip.patterncache;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -41,35 +41,33 @@ public class TripPatternCache {
 
   private final TripPatternIdGenerator tripPatternIdGenerator;
 
-  private final Function<Trip, TripPattern> getPatternForTrip;
-
-  /**
-   * @param getPatternForTrip TripPatternCache needs only this one feature of TransitService, so we retain
-   *                          only this function reference to effectively narrow the interface. This should also facilitate
-   *                          testing.
-   */
-  public TripPatternCache(
-    TripPatternIdGenerator tripPatternIdGenerator,
-    Function<Trip, TripPattern> getPatternForTrip
-  ) {
+  public TripPatternCache(TripPatternIdGenerator tripPatternIdGenerator) {
     this.tripPatternIdGenerator = tripPatternIdGenerator;
-    this.getPatternForTrip = getPatternForTrip;
   }
 
   /**
    * Get cached trip pattern or create one if it doesn't exist yet.
+   * <p>
+   * If {@code originalTripPattern} is non-null and its stop pattern matches {@code stopPattern},
+   * the original pattern is returned as-is — no new RT pattern is created. Otherwise the cache is
+   * checked by stop pattern; if no entry exists, a new realtime-modified pattern is created,
+   * stored, and returned.
+   * <p>
+   * The caller is responsible for resolving {@code originalTripPattern} before calling this method.
    *
-   * @param stopPattern stop pattern to retrieve/create trip pattern
-   * @param trip        Trip containing route of new trip pattern in case a new trip pattern will be
-   *                    created
-   * @return cached or newly created trip pattern
+   * @param stopPattern         stop pattern to retrieve/create a trip pattern for
+   * @param trip                trip whose route, mode, and submode are copied when a new pattern is
+   *                            created; also used to generate the new pattern's id
+   * @param originalTripPattern the current pattern for {@code trip} — either the static scheduled
+   *                            pattern, or a previously RT-modified pattern if the trip was already
+   *                            updated. {@code null} for genuinely new added trips.
+   * @return the original, cached, or newly created trip pattern
    */
   public synchronized TripPattern getOrCreateTripPattern(
     final StopPattern stopPattern,
-    final Trip trip
+    final Trip trip,
+    @Nullable final TripPattern originalTripPattern
   ) {
-    TripPattern originalTripPattern = getPatternForTrip.apply(trip);
-
     if (originalTripPattern != null && originalTripPattern.getStopPattern().equals(stopPattern)) {
       return originalTripPattern;
     }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -74,10 +74,7 @@ public class SiriRealTimeTripUpdateAdapter {
       timetableRepository,
       snapshotManager.getTimetableSnapshotBuffer()
     );
-    this.tripPatternCache = new TripPatternCache(
-      tripPatternIdGenerator,
-      transitEditorService::findPattern
-    );
+    this.tripPatternCache = new TripPatternCache(tripPatternIdGenerator);
   }
 
   /**
@@ -339,7 +336,11 @@ public class SiriRealTimeTripUpdateAdapter {
       pattern = tripUpdate.addedTripPattern();
     } else {
       // Get cached trip pattern or create one if it doesn't exist yet
-      pattern = tripPatternCache.getOrCreateTripPattern(tripUpdate.stopPattern(), trip);
+      pattern = tripPatternCache.getOrCreateTripPattern(
+        tripUpdate.stopPattern(),
+        trip,
+        transitEditorService.findPattern(trip)
+      );
     }
 
     // Revert for TRIP_UPDATE and EXTRA_CALL, but NOT for REPLACEMENT_DEPARTURE (new trips)


### PR DESCRIPTION
### Summary

This PR delegates the responsibility of looking up the current trip pattern for a trip to the caller of the `TripPatternCache`. This makes the `TripPatternCache` independent from any `TimetableSnapshot` associated look up functions and enables us to make the `TransitEditorService` update scoped instead of application scoped.

### Issue

This is a prerequisite for #7689 

### Unit tests

No functional changes, pure refactoring
