### PR TITLE
Fix mapping of `omitCanceled` in deprecated `plan` query

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapper.java
@@ -146,6 +146,7 @@ public class LegacyRouteRequestMapper {
         );
         callWith.argument("unpreferred.unpreferredCost", tr::withUnpreferredCostString);
         callWith.argument("ignoreRealtimeUpdates", tr::withIgnoreRealtimeUpdates);
+        callWith.argument("omitCanceled", tr::withIncludeRealtimeCancellations);
         callWith.argument("modeWeight", (Map<String, Object> modeWeights) ->
           tr.withReluctanceForMode(
             modeWeights

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1729,8 +1729,8 @@ type QueryType {
     nonpreferredTransferPenalty: Int,
     "The maximum number of itineraries to return. Default value: 3."
     numItineraries: Int = 3,
-    "When false, return itineraries using canceled trips. Default value: true."
-    omitCanceled: Boolean = true,
+    "When false, return itineraries using canceled trips. Default value: false."
+    omitCanceled: Boolean = false,
     "Optimization type for bicycling legs, e.g. prefer flat terrain. Default value: `QUICK`"
     optimize: OptimizeType,
     """

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1729,8 +1729,8 @@ type QueryType {
     nonpreferredTransferPenalty: Int,
     "The maximum number of itineraries to return. Default value: 3."
     numItineraries: Int = 3,
-    "When false, return itineraries using canceled trips. Default value: false."
-    omitCanceled: Boolean = false,
+    "When false, return itineraries using canceled trips. Default value: true."
+    omitCanceled: Boolean = true,
     "Optimization type for bicycling legs, e.g. prefer flat terrain. Default value: `QUICK`"
     optimize: OptimizeType,
     """

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.SchemaFactory;
@@ -353,6 +354,20 @@ class LegacyRouteRequestMapperTest implements PlanTestConstants {
       CONTEXT
     );
     assertEquals(List.of(), noParamsReq.listViaLocations());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void omitCanceled(boolean omitCanceled) {
+    Map<String, Object> arguments = decorateWithRequiredParams(
+      Map.of("omitCanceled", omitCanceled)
+    );
+
+    var routeRequest = LegacyRouteRequestMapper.toRouteRequest(
+      executionContext(arguments),
+      CONTEXT
+    );
+    assertEquals(omitCanceled, routeRequest.preferences().transit().includeRealtimeCancellations());
   }
 
   private static Map<String, Object> mode(String mode) {


### PR DESCRIPTION
### Summary

@alec-georgoff has reported that the field `omitCanceled` in the deprecated `plan` query does nothing.

Indeed, it is not mapped, but this PR changes that.

~~The schema defined this field to be `true` by default, but I don't think this makes sense and would be a breaking change. Therefore I set it to `false`.~~

### Issue

No issue.

### Unit tests

Added.