### PR TITLE
Small sandbox refactoring changes to `Emission` and `EmpiricalDelay`

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/emission/configure/EmissionGraphBuilderModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/configure/EmissionGraphBuilderModule.java
@@ -6,6 +6,7 @@ import jakarta.inject.Singleton;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.emission.EmissionRepository;
 import org.opentripplanner.ext.emission.internal.graphbuilder.EmissionGraphBuilder;
+import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.GraphBuilderDataSources;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.standalone.config.BuildConfig;
@@ -24,7 +25,7 @@ public class EmissionGraphBuilderModule {
     TimetableRepository timetableRepository,
     DataImportIssueStore issueStore
   ) {
-    if (emissionRepository == null) {
+    if (OTPFeature.Emission.isOff() || emissionRepository == null) {
       return null;
     }
 

--- a/application/src/ext/java/org/opentripplanner/ext/emission/configure/EmissionServiceModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/configure/EmissionServiceModule.java
@@ -2,9 +2,11 @@ package org.opentripplanner.ext.emission.configure;
 
 import dagger.Module;
 import dagger.Provides;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.emission.EmissionRepository;
 import org.opentripplanner.ext.emission.internal.DefaultEmissionService;
 import org.opentripplanner.ext.emission.internal.itinerary.EmissionItineraryDecorator;
+import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.routing.algorithm.filterchain.ext.EmissionDecorator;
 import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
 
@@ -16,8 +18,14 @@ import org.opentripplanner.routing.algorithm.filterchain.framework.spi.Itinerary
 public class EmissionServiceModule {
 
   @Provides
+  @Nullable
   @EmissionDecorator
-  public ItineraryDecorator provideEmissionService(EmissionRepository emissionRepository) {
+  public ItineraryDecorator provideEmissionItineraryDecorator(
+    EmissionRepository emissionRepository
+  ) {
+    if (OTPFeature.Emission.isOff() || emissionRepository == null) {
+      return null;
+    }
     return new EmissionItineraryDecorator(new DefaultEmissionService(emissionRepository));
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/empiricaldelay/config/EmpiricalDelayConfig.java
+++ b/application/src/ext/java/org/opentripplanner/ext/empiricaldelay/config/EmpiricalDelayConfig.java
@@ -12,7 +12,7 @@ import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
  */
 public class EmpiricalDelayConfig {
 
-  public static EmpiricalDelayParameters mapEmissionsConfig(
+  public static EmpiricalDelayParameters mapEmpiricalDelayConfig(
     String parameterName,
     NodeAdapter root
   ) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
@@ -100,7 +100,7 @@ public class ItineraryListFilterChainBuilder {
 
   @Sandbox
   @Nullable
-  private ItineraryDecorator emissionDecorator;
+  private ItineraryDecorator emissionItineraryDecorator;
 
   @Sandbox
   private ItineraryListFilter rideHailingDecorator;
@@ -344,10 +344,10 @@ public class ItineraryListFilterChainBuilder {
     return this;
   }
 
-  public ItineraryListFilterChainBuilder withEmissions(
-    @Nullable ItineraryDecorator emissionDecorator
+  public ItineraryListFilterChainBuilder withEmissionItineraryDecorator(
+    @Nullable ItineraryDecorator emissionItineraryDecorator
   ) {
-    this.emissionDecorator = emissionDecorator;
+    this.emissionItineraryDecorator = emissionItineraryDecorator;
     return this;
   }
 
@@ -527,8 +527,8 @@ public class ItineraryListFilterChainBuilder {
         addDecorateFilter(filters, new DecorateWithAccessibilityScore(wheelchairMaxSlope));
       }
 
-      if (emissionDecorator != null) {
-        addDecorateFilter(filters, emissionDecorator);
+      if (emissionItineraryDecorator != null) {
+        addDecorateFilter(filters, emissionItineraryDecorator);
       }
 
       if (rideHailingDecorator != null) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.opentripplanner.ext.ridehailing.DecorateWithRideHailing;
 import org.opentripplanner.ext.stopconsolidation.DecorateConsolidatedStopNames;
-import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.model.plan.paging.cursor.PageCursorInput;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChain;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChainBuilder;
@@ -110,7 +109,7 @@ public class RouteRequestToFilterChainMapper {
       );
     }
 
-    if (OTPFeature.Emission.isOn()) {
+    if (context.emissionItineraryDecorator() != null) {
       builder.withEmissions(context.emissionItineraryDecorator());
     }
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -110,7 +110,7 @@ public class RouteRequestToFilterChainMapper {
     }
 
     if (context.emissionItineraryDecorator() != null) {
-      builder.withEmissions(context.emissionItineraryDecorator());
+      builder.withEmissionItineraryDecorator(context.emissionItineraryDecorator());
     }
 
     if (

--- a/application/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -90,7 +90,7 @@ public class SerializedGraphObject implements Serializable {
   public final DataImportIssueSummary issueSummary;
   public final StopConsolidationRepository stopConsolidationRepository;
   private final int routingTripPatternCounter;
-  public final EmissionRepository emissionRepository;
+  public final @Nullable EmissionRepository emissionRepository;
   public final @Nullable EmpiricalDelayRepository empiricalDelayRepository;
   public final FareServiceFactory fareServiceFactory;
   public final StreetRepository streetRepository;
@@ -108,7 +108,7 @@ public class SerializedGraphObject implements Serializable {
     BuildConfig buildConfig,
     RouterConfig routerConfig,
     DataImportIssueSummary issueSummary,
-    EmissionRepository emissionRepository,
+    @Nullable EmissionRepository emissionRepository,
     @Nullable EmpiricalDelayRepository empiricalDelayRepository,
     StopConsolidationRepository stopConsolidationRepository,
     FareServiceFactory fareServiceFactory

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -572,7 +572,7 @@ public class BuildConfig implements OtpDataStoreConfig {
     demDefaults = DemConfig.mapDemDefaultsConfig(root, "demDefaults");
     dem = DemConfig.mapDemConfig(root, "dem", demDefaults);
     emission = EmissionConfig.mapEmissionsConfig("emission", root);
-    empiricalDelay = EmpiricalDelayConfig.mapEmissionsConfig("empiricalDelay", root);
+    empiricalDelay = EmpiricalDelayConfig.mapEmpiricalDelayConfig("empiricalDelay", root);
     netexDefaults = NetexConfig.mapNetexDefaultParameters(root, "netexDefaults");
     gtfsDefaults = GtfsConfig.mapGtfsDefaultParameters(root, "gtfsDefaults");
     transitFeeds = TransitFeedConfig.mapTransitFeeds(

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -90,7 +90,7 @@ public class ConstructApplication {
     ConfigModel config,
     GraphBuilderDataSources graphBuilderDataSources,
     DataImportIssueSummary issueSummary,
-    EmissionRepository emissionRepository,
+    @Nullable EmissionRepository emissionRepository,
     @Nullable EmpiricalDelayRepository empiricalDelayRepository,
     VehicleParkingRepository vehicleParkingRepository,
     @Nullable StopConsolidationRepository stopConsolidationRepository,
@@ -367,6 +367,7 @@ public class ConstructApplication {
     factory.metricsLogging();
   }
 
+  @Nullable
   public EmissionRepository emissionRepository() {
     return factory.emissionRepository();
   }

--- a/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -20,6 +20,7 @@ import org.opentripplanner.ext.sorlandsbanen.SorlandsbanenNorwayService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.raptor.api.request.RaptorTuningParameters;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.routing.algorithm.filterchain.ext.EmissionDecorator;
 import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitTuningParameters;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
@@ -147,7 +148,7 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
     WorldEnvelopeService worldEnvelopeService,
     @Nullable CarpoolingService carpoolingService,
     @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
-    @Nullable ItineraryDecorator emissionItineraryDecorator,
+    @Nullable @EmissionDecorator ItineraryDecorator emissionItineraryDecorator,
     StreetDetailsService streetDetailsService,
     @Nullable EmpiricalDelayService empiricalDelayService,
     @Nullable LuceneIndex luceneIndex,

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
@@ -314,12 +314,12 @@ class ItineraryListFilterChainTest implements PlanTestConstants {
   @Test
   void makeSureEmissionDecoratorIsAddedToTheFilterChainTest() {
     final Box<String> state = Box.of("I");
-    ItineraryDecorator emissionDecorator = it -> {
+    ItineraryDecorator emissionItineraryDecorator = it -> {
       state.modify(v -> v + "+C");
       return it;
     };
     createBuilder(false, false, 10)
-      .withEmissions(emissionDecorator)
+      .withEmissionItineraryDecorator(emissionItineraryDecorator)
       .build()
       .filter(List.of(i1, i2));
     assertEquals("I+C+C", state.get());


### PR DESCRIPTION
### Summary

This PR fixes some small issues I found with sandbox extensions:
- Consistent emissions `@Nullable` use (this goes against the soon-to-be developer decision record that requires non-null sandbox repostories, however, this makes the use of `@Nullable` consistent for now and lessens confusion when someone refactors it in the future)
- Consistent emission feature flag use 
For example, the `@Nullable` annotation on this was incorrect before the changes in this PR:
`@Nullable @EmissionDecorator ItineraryDecorator emissionItineraryDecorator`
- `mapEmpiricalDelayConfig` was named `mapEmissionsConfig`

No functional changes. I tested building and running with the `OTPFeature.Emission` feature flag on and off.

### Issue

no

### Unit tests

no

### Documentation

no