### PR TITLE
Map GTFS notice assignments on trip segments to individual stop times

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToTransitDataImportMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToTransitDataImportMapper.java
@@ -234,7 +234,7 @@ public class GTFSToTransitDataImportMapper {
       .addAll(fareTransferRuleMapper.map(data.getAllFareTransferRules()));
     fareRulesBuilder.stopAreas().putAll(stopAreaMapper.map(data.getAllStopAreaElements()));
 
-    tripSegmentMapper.map(data.getAllTripSegments(), data);
+    tripSegmentMapper.map(data.getAllTripSegments(), builder.getStopTimesSortedByTrip());
     noticeMapper.map(data.getAllNotices());
     builder
       .getNoticeAssignments()

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToTransitDataImportMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToTransitDataImportMapper.java
@@ -61,6 +61,8 @@ public class GTFSToTransitDataImportMapper {
 
   private final TripMapper tripMapper;
 
+  private final TripSegmentMapper tripSegmentMapper;
+
   private final BookingRuleMapper bookingRuleMapper;
 
   private final StopTimeMapper stopTimeMapper;
@@ -148,6 +150,7 @@ public class GTFSToTransitDataImportMapper {
     );
     directionMapper = new DirectionMapper(issueStore);
     tripMapper = new TripMapper(idFactory, routeMapper, directionMapper, translationHelper);
+    tripSegmentMapper = new TripSegmentMapper(idFactory);
     bookingRuleMapper = new BookingRuleMapper();
     stopTimeMapper = new StopTimeMapper(
       stopMapper,
@@ -176,7 +179,8 @@ public class GTFSToTransitDataImportMapper {
       issueStore,
       noticeMapper,
       tripMapper,
-      routeMapper
+      routeMapper,
+      tripSegmentMapper
     );
   }
 
@@ -230,6 +234,7 @@ public class GTFSToTransitDataImportMapper {
       .addAll(fareTransferRuleMapper.map(data.getAllFareTransferRules()));
     fareRulesBuilder.stopAreas().putAll(stopAreaMapper.map(data.getAllStopAreaElements()));
 
+    tripSegmentMapper.map(data.getAllTripSegments(), data);
     noticeMapper.map(data.getAllNotices());
     builder
       .getNoticeAssignments()

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
@@ -2,7 +2,6 @@ package org.opentripplanner.gtfs.mapping;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -56,14 +55,12 @@ class NoticeAssignmentMapper {
       .collect(Collectors.toMap(Trip::getId, Function.identity()));
     var routes = routeMapper.mappedRoutes();
     for (var assignment : assignments) {
-      for (var entry : mapOne(assignment, notices, trips, routes)) {
-        result.put(entry.getKey(), entry.getValue());
-      }
+      map(assignment, notices, trips, routes).forEach(e -> result.put(e.getKey(), e.getValue()));
     }
     return result;
   }
 
-  private List<Map.Entry<AbstractTransitEntity, Notice>> mapOne(
+  private Iterable<Map.Entry<AbstractTransitEntity, Notice>> map(
     NoticeAssignment assignment,
     Map<FeedScopedId, Notice> notices,
     Map<FeedScopedId, Trip> trips,
@@ -86,7 +83,7 @@ class NoticeAssignmentMapper {
     List<AbstractTransitEntity> entities = switch (assignment.getTableName()) {
       case routes -> ListUtils.ofNullable(routes.get(recordId));
       case trips -> ListUtils.ofNullable(trips.get(recordId));
-      case trip_segments -> new ArrayList<>(tripSegmentMapper.getStopTimeKeys(recordId));
+      case trip_segments -> List.copyOf(tripSegmentMapper.getStopTimeKeys(recordId));
     };
 
     if (entities.isEmpty()) {
@@ -100,9 +97,10 @@ class NoticeAssignmentMapper {
       return List.of();
     }
 
-    return entities
-      .stream()
-      .map(entity -> Map.entry(entity, notice))
-      .toList();
+    return () ->
+      entities
+        .stream()
+        .map(entity -> Map.entry(entity, notice))
+        .iterator();
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
@@ -2,9 +2,10 @@ package org.opentripplanner.gtfs.mapping;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.onebusaway.gtfs.model.NoticeAssignment;
@@ -14,10 +15,12 @@ import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.utils.collection.ListUtils;
 
 /**
  * Maps GTFS notice_assignments.txt entries to OTP notice assignments, connecting each
- * {@link Notice} to its target {@link Route} or {@link Trip}.
+ * {@link Notice} to its target {@link Route}, {@link Trip} or trip segment. A trip segment is
+ * expanded to one entry per stop time it covers.
  */
 class NoticeAssignmentMapper {
 
@@ -26,37 +29,41 @@ class NoticeAssignmentMapper {
   private final NoticeMapper noticeMapper;
   private final RouteMapper routeMapper;
   private final TripMapper tripMapper;
+  private final TripSegmentMapper tripSegmentMapper;
 
   NoticeAssignmentMapper(
     IdFactory idFactory,
     DataImportIssueStore issueStore,
     NoticeMapper noticeMapper,
     TripMapper tripMapper,
-    RouteMapper routeMapper
+    RouteMapper routeMapper,
+    TripSegmentMapper tripSegmentMapper
   ) {
     this.idFactory = idFactory;
     this.issueStore = issueStore;
     this.noticeMapper = noticeMapper;
     this.routeMapper = routeMapper;
     this.tripMapper = tripMapper;
+    this.tripSegmentMapper = tripSegmentMapper;
   }
 
   Multimap<AbstractTransitEntity, Notice> map(Collection<NoticeAssignment> assignments) {
     Multimap<AbstractTransitEntity, Notice> result = ArrayListMultimap.create();
+    var notices = noticeMapper.mappedNotices();
     var trips = tripMapper
       .getMappedTrips()
       .stream()
       .collect(Collectors.toMap(Trip::getId, Function.identity()));
     var routes = routeMapper.mappedRoutes();
     for (var assignment : assignments) {
-      mapOne(assignment, noticeMapper.mappedNotices(), trips, routes).ifPresent(entry ->
-        result.put(entry.getKey(), entry.getValue())
-      );
+      for (var entry : mapOne(assignment, notices, trips, routes)) {
+        result.put(entry.getKey(), entry.getValue());
+      }
     }
     return result;
   }
 
-  private Optional<Map.Entry<AbstractTransitEntity, Notice>> mapOne(
+  private List<Map.Entry<AbstractTransitEntity, Notice>> mapOne(
     NoticeAssignment assignment,
     Map<FeedScopedId, Notice> notices,
     Map<FeedScopedId, Trip> trips,
@@ -71,18 +78,18 @@ class NoticeAssignmentMapper {
         "Notice in notice assignment is missing for assignment %s",
         assignment
       );
-      return Optional.empty();
+      return List.of();
     }
 
     var recordId = idFactory.createId(assignment.getRecordId(), "NoticeAssignment.recordId");
 
-    AbstractTransitEntity entity = switch (assignment.getTableName()) {
-      case routes -> routes.get(recordId);
-      case trips -> trips.get(recordId);
-      case trip_segments -> null;
+    List<AbstractTransitEntity> entities = switch (assignment.getTableName()) {
+      case routes -> ListUtils.ofNullable(routes.get(recordId));
+      case trips -> ListUtils.ofNullable(trips.get(recordId));
+      case trip_segments -> new ArrayList<>(tripSegmentMapper.getStopTimeKeys(recordId));
     };
 
-    if (entity == null) {
+    if (entities.isEmpty()) {
       issueStore.add(
         "NoticeAssignmentWithUnknownEntity",
         "Could not map notice assignment %s for %s with id %s",
@@ -90,9 +97,12 @@ class NoticeAssignmentMapper {
         assignment.getTableName(),
         assignment.getRecordId()
       );
-      return Optional.empty();
+      return List.of();
     }
 
-    return Optional.of(Map.entry(entity, notice));
+    return entities
+      .stream()
+      .map(entity -> Map.entry(entity, notice))
+      .toList();
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapper.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.onebusaway.gtfs.model.NoticeAssignment;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -60,7 +61,7 @@ class NoticeAssignmentMapper {
     return result;
   }
 
-  private Iterable<Map.Entry<AbstractTransitEntity, Notice>> map(
+  private Stream<Map.Entry<AbstractTransitEntity, Notice>> map(
     NoticeAssignment assignment,
     Map<FeedScopedId, Notice> notices,
     Map<FeedScopedId, Trip> trips,
@@ -75,7 +76,7 @@ class NoticeAssignmentMapper {
         "Notice in notice assignment is missing for assignment %s",
         assignment
       );
-      return List.of();
+      return Stream.of();
     }
 
     var recordId = idFactory.createId(assignment.getRecordId(), "NoticeAssignment.recordId");
@@ -94,13 +95,9 @@ class NoticeAssignmentMapper {
         assignment.getTableName(),
         assignment.getRecordId()
       );
-      return List.of();
+      return Stream.of();
     }
 
-    return () ->
-      entities
-        .stream()
-        .map(entity -> Map.entry(entity, notice))
-        .iterator();
+    return entities.stream().map(entity -> Map.entry(entity, notice));
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TripSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TripSegmentMapper.java
@@ -6,8 +6,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.onebusaway.gtfs.model.TripSegment;
-import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.transit.model.timetable.StopTimeKey;
 
 /**
@@ -27,11 +28,15 @@ class TripSegmentMapper {
     this.idFactory = idFactory;
   }
 
-  void map(Collection<TripSegment> segments, GtfsRelationalDao data) {
+  void map(Collection<TripSegment> segments, TripStopTimes stopTimesByTrip) {
+    var stopTimesByTripId = new HashMap<FeedScopedId, List<StopTime>>();
+    for (var trip : stopTimesByTrip.keys()) {
+      stopTimesByTripId.put(trip.getId(), stopTimesByTrip.get(trip));
+    }
     for (var segment : segments) {
       mappedTripSegments.put(
         idFactory.createId(segment.getId(), "trip_segment_id"),
-        mapStopTimeKeys(segment, data)
+        mapStopTimeKeys(segment, stopTimesByTripId)
       );
     }
   }
@@ -50,13 +55,12 @@ class TripSegmentMapper {
    * index in the (sequence-ordered) list of the trip's stop times, not the GTFS
    * {@code stop_sequence}, to match how {@link StopTimeKey}s are referenced elsewhere in OTP.
    */
-  private List<StopTimeKey> mapStopTimeKeys(TripSegment segment, GtfsRelationalDao data) {
-    var trip = data.getTripForId(segment.getTripId());
-    if (trip == null) {
-      return List.of();
-    }
+  private List<StopTimeKey> mapStopTimeKeys(
+    TripSegment segment,
+    Map<FeedScopedId, List<StopTime>> stopTimesByTripId
+  ) {
     var tripId = idFactory.createId(segment.getTripId(), "trip_id in trip segment");
-    var stopTimes = data.getStopTimesForTrip(trip);
+    var stopTimes = stopTimesByTripId.getOrDefault(tripId, List.of());
     var result = new ArrayList<StopTimeKey>();
     for (int i = 0; i < stopTimes.size(); i++) {
       var stopSequence = stopTimes.get(i).getStopSequence();

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TripSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TripSegmentMapper.java
@@ -1,0 +1,67 @@
+package org.opentripplanner.gtfs.mapping;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.onebusaway.gtfs.model.TripSegment;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.StopTimeKey;
+
+/**
+ * Maps a GTFS trip segment - a range of stops on a single trip - to the {@link StopTimeKey}s of
+ * every stop within that range. This allows a notice assigned to a trip segment to be attached to
+ * each of the individual stop times the segment covers.
+ * <p>
+ * The mapped result is stored keyed by {@code trip_segment_id} so that
+ * {@link NoticeAssignmentMapper} can look it up when resolving notice assignments.
+ */
+class TripSegmentMapper {
+
+  private final IdFactory idFactory;
+  private final Map<FeedScopedId, List<StopTimeKey>> mappedTripSegments = new HashMap<>();
+
+  TripSegmentMapper(IdFactory idFactory) {
+    this.idFactory = idFactory;
+  }
+
+  void map(Collection<TripSegment> segments, GtfsRelationalDao data) {
+    for (var segment : segments) {
+      mappedTripSegments.put(
+        idFactory.createId(segment.getId(), "trip_segment_id"),
+        mapStopTimeKeys(segment, data)
+      );
+    }
+  }
+
+  /**
+   * The {@link StopTimeKey}s for the stops covered by the given {@code trip_segment_id}, or an empty
+   * list if no such trip segment was mapped.
+   */
+  List<StopTimeKey> getStopTimeKeys(FeedScopedId tripSegmentId) {
+    return mappedTripSegments.getOrDefault(tripSegmentId, List.of());
+  }
+
+  /**
+   * Returns a {@link StopTimeKey} for each of the trip's stop times whose stop sequence lies within
+   * the segment's {@code [fromStopSequence, toStopSequence]} range.
+   */
+  private List<StopTimeKey> mapStopTimeKeys(TripSegment segment, GtfsRelationalDao data) {
+    var trip = data.getTripForId(segment.getTripId());
+    if (trip == null) {
+      return List.of();
+    }
+    var tripId = idFactory.createId(segment.getTripId(), "trip_id in trip segment");
+    return data
+      .getStopTimesForTrip(trip)
+      .stream()
+      .filter(
+        st ->
+          st.getStopSequence() >= segment.getFromStopSequence() &&
+          st.getStopSequence() <= segment.getToStopSequence()
+      )
+      .map(st -> StopTimeKey.of(tripId, st.getStopSequence()).build())
+      .toList();
+  }
+}

--- a/application/src/main/java/org/opentripplanner/gtfs/mapping/TripSegmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/mapping/TripSegmentMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.gtfs.mapping;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +46,9 @@ class TripSegmentMapper {
 
   /**
    * Returns a {@link StopTimeKey} for each of the trip's stop times whose stop sequence lies within
-   * the segment's {@code [fromStopSequence, toStopSequence]} range.
+   * the segment's {@code [fromStopSequence, toStopSequence]} range. The key uses the stop time's
+   * index in the (sequence-ordered) list of the trip's stop times, not the GTFS
+   * {@code stop_sequence}, to match how {@link StopTimeKey}s are referenced elsewhere in OTP.
    */
   private List<StopTimeKey> mapStopTimeKeys(TripSegment segment, GtfsRelationalDao data) {
     var trip = data.getTripForId(segment.getTripId());
@@ -53,15 +56,16 @@ class TripSegmentMapper {
       return List.of();
     }
     var tripId = idFactory.createId(segment.getTripId(), "trip_id in trip segment");
-    return data
-      .getStopTimesForTrip(trip)
-      .stream()
-      .filter(
-        st ->
-          st.getStopSequence() >= segment.getFromStopSequence() &&
-          st.getStopSequence() <= segment.getToStopSequence()
-      )
-      .map(st -> StopTimeKey.of(tripId, st.getStopSequence()).build())
-      .toList();
+    var stopTimes = data.getStopTimesForTrip(trip);
+    var result = new ArrayList<StopTimeKey>();
+    for (int i = 0; i < stopTimes.size(); i++) {
+      var stopSequence = stopTimes.get(i).getStopSequence();
+      if (
+        stopSequence >= segment.getFromStopSequence() && stopSequence <= segment.getToStopSequence()
+      ) {
+        result.add(StopTimeKey.of(tripId, i).build());
+      }
+    }
+    return result;
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/StopTimeKey.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/StopTimeKey.java
@@ -15,9 +15,13 @@ public class StopTimeKey extends AbstractTransitEntity<StopTimeKey, StopTimeKeyB
     super(builder.getId());
   }
 
-  public static StopTimeKeyBuilder of(FeedScopedId tripId, int stopSequenceNumber) {
+  /**
+   * @param tripId
+   * @param stopPositionInPattern the 0 based position in the trip pattern, not GTFS stop_sequence
+   */
+  public static StopTimeKeyBuilder of(FeedScopedId tripId, int stopPositionInPattern) {
     return new StopTimeKeyBuilder(
-      new FeedScopedId(tripId.getFeedId(), tripId.getId() + "_#" + stopSequenceNumber)
+      new FeedScopedId(tripId.getFeedId(), tripId.getId() + "_#" + stopPositionInPattern)
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -37,57 +37,6 @@ class NoticeAssignmentMapperTest {
     GTFS_NOTICE.setDisplayText(NOTICE_TEXT);
   }
 
-  private static RouteMapper createRouteMapper() {
-    return new RouteMapper(
-      ID_FACTORY,
-      new AgencyMapper(ID_FACTORY),
-      new RouteNetworkAssignmentMapper(ID_FACTORY),
-      DataImportIssueStore.NOOP,
-      new TranslationHelper()
-    );
-  }
-
-  private static TripMapper createTripMapper(RouteMapper routeMapper) {
-    return new TripMapper(
-      ID_FACTORY,
-      routeMapper,
-      new DirectionMapper(DataImportIssueStore.NOOP),
-      new TranslationHelper()
-    );
-  }
-
-  private static NoticeAssignmentMapper createMapper(
-    DataImportIssueStore issueStore,
-    NoticeMapper noticeMapper,
-    TripMapper tripMapper,
-    RouteMapper routeMapper,
-    TripSegmentMapper tripSegmentMapper
-  ) {
-    return new NoticeAssignmentMapper(
-      ID_FACTORY,
-      issueStore,
-      noticeMapper,
-      tripMapper,
-      routeMapper,
-      tripSegmentMapper
-    );
-  }
-
-  private static NoticeAssignmentMapper createMapper(
-    DataImportIssueStore issueStore,
-    NoticeMapper noticeMapper,
-    TripMapper tripMapper,
-    RouteMapper routeMapper
-  ) {
-    return createMapper(
-      issueStore,
-      noticeMapper,
-      tripMapper,
-      routeMapper,
-      new TripSegmentMapper(ID_FACTORY)
-    );
-  }
-
   @Test
   void mapNoticeAssignmentOnRoute() {
     var routeMapper = createRouteMapper();
@@ -311,5 +260,56 @@ class NoticeAssignmentMapperTest {
     assertEquals(2, result.size());
     assertEquals(1, result.get(route).size());
     assertEquals(1, result.get(trip).size());
+  }
+
+  private static RouteMapper createRouteMapper() {
+    return new RouteMapper(
+      ID_FACTORY,
+      new AgencyMapper(ID_FACTORY),
+      new RouteNetworkAssignmentMapper(ID_FACTORY),
+      DataImportIssueStore.NOOP,
+      new TranslationHelper()
+    );
+  }
+
+  private static TripMapper createTripMapper(RouteMapper routeMapper) {
+    return new TripMapper(
+      ID_FACTORY,
+      routeMapper,
+      new DirectionMapper(DataImportIssueStore.NOOP),
+      new TranslationHelper()
+    );
+  }
+
+  private static NoticeAssignmentMapper createMapper(
+    DataImportIssueStore issueStore,
+    NoticeMapper noticeMapper,
+    TripMapper tripMapper,
+    RouteMapper routeMapper,
+    TripSegmentMapper tripSegmentMapper
+  ) {
+    return new NoticeAssignmentMapper(
+      ID_FACTORY,
+      issueStore,
+      noticeMapper,
+      tripMapper,
+      routeMapper,
+      tripSegmentMapper
+    );
+  }
+
+  private static NoticeAssignmentMapper createMapper(
+    DataImportIssueStore issueStore,
+    NoticeMapper noticeMapper,
+    TripMapper tripMapper,
+    RouteMapper routeMapper
+  ) {
+    return createMapper(
+      issueStore,
+      noticeMapper,
+      tripMapper,
+      routeMapper,
+      new TripSegmentMapper(ID_FACTORY)
+    );
   }
 }

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -6,7 +6,10 @@ import static org.onebusaway.gtfs.model.AgencyAndIdFactory.obaId;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
 import org.onebusaway.gtfs.model.NoticeAssignment;
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.model.TripSegment;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
@@ -49,6 +52,38 @@ class NoticeAssignmentMapperTest {
     );
   }
 
+  private static NoticeAssignmentMapper createMapper(
+    DataImportIssueStore issueStore,
+    NoticeMapper noticeMapper,
+    TripMapper tripMapper,
+    RouteMapper routeMapper,
+    TripSegmentMapper tripSegmentMapper
+  ) {
+    return new NoticeAssignmentMapper(
+      ID_FACTORY,
+      issueStore,
+      noticeMapper,
+      tripMapper,
+      routeMapper,
+      tripSegmentMapper
+    );
+  }
+
+  private static NoticeAssignmentMapper createMapper(
+    DataImportIssueStore issueStore,
+    NoticeMapper noticeMapper,
+    TripMapper tripMapper,
+    RouteMapper routeMapper
+  ) {
+    return createMapper(
+      issueStore,
+      noticeMapper,
+      tripMapper,
+      routeMapper,
+      new TripSegmentMapper(ID_FACTORY)
+    );
+  }
+
   @Test
   void mapNoticeAssignmentOnRoute() {
     var routeMapper = createRouteMapper();
@@ -57,8 +92,7 @@ class NoticeAssignmentMapperTest {
     var noticeMapper = new NoticeMapper(ID_FACTORY);
     noticeMapper.map(GTFS_NOTICE);
 
-    var mapper = new NoticeAssignmentMapper(
-      ID_FACTORY,
+    var mapper = createMapper(
       DataImportIssueStore.NOOP,
       noticeMapper,
       createTripMapper(routeMapper),
@@ -87,13 +121,7 @@ class NoticeAssignmentMapperTest {
     var noticeMapper = new NoticeMapper(ID_FACTORY);
     noticeMapper.map(GTFS_NOTICE);
 
-    var mapper = new NoticeAssignmentMapper(
-      ID_FACTORY,
-      DataImportIssueStore.NOOP,
-      noticeMapper,
-      tripMapper,
-      routeMapper
-    );
+    var mapper = createMapper(DataImportIssueStore.NOOP, noticeMapper, tripMapper, routeMapper);
 
     var assignment = new NoticeAssignment();
     assignment.setNoticeId(obaId(NOTICE_ID));
@@ -108,18 +136,66 @@ class NoticeAssignmentMapperTest {
   }
 
   @Test
+  void mapNoticeAssignmentOnTripSegment() {
+    var routeMapper = createRouteMapper();
+    var tripMapper = createTripMapper(routeMapper);
+
+    var noticeMapper = new NoticeMapper(ID_FACTORY);
+    noticeMapper.map(GTFS_NOTICE);
+
+    var segment = new TripSegment();
+    segment.setId(obaId("SEG1"));
+    segment.setTripId(DATA.trip.getId());
+    segment.setFromStopSequence(2);
+    segment.setToStopSequence(4);
+
+    var dao = new GtfsRelationalDaoImpl();
+    dao.saveEntity(DATA.trip);
+    for (int seq = 1; seq <= 5; seq++) {
+      var stopTime = new StopTime();
+      stopTime.setId(seq);
+      stopTime.setTrip(DATA.trip);
+      stopTime.setStop(DATA.stop);
+      stopTime.setStopSequence(seq);
+      dao.saveEntity(stopTime);
+    }
+
+    var tripSegmentMapper = new TripSegmentMapper(ID_FACTORY);
+    tripSegmentMapper.map(List.of(segment), dao);
+
+    var mapper = createMapper(
+      DataImportIssueStore.NOOP,
+      noticeMapper,
+      tripMapper,
+      routeMapper,
+      tripSegmentMapper
+    );
+
+    var assignment = new NoticeAssignment();
+    assignment.setNoticeId(obaId(NOTICE_ID));
+    assignment.setTableName(NoticeAssignment.TableName.trip_segments);
+    assignment.setRecordId(obaId("SEG1"));
+
+    var result = mapper.map(List.of(assignment));
+
+    // Stop sequences 2, 3 and 4 are within the segment's [from, to] range
+    assertEquals(3, result.size());
+    var stopTimeKeyIds = result
+      .keySet()
+      .stream()
+      .map(e -> e.getId().getId())
+      .sorted()
+      .toList();
+    assertThat(stopTimeKeyIds).containsExactly("T1_#2", "T1_#3", "T1_#4");
+  }
+
+  @Test
   void missingNoticeLogsIssue() {
     var issues = new DefaultDataImportIssueStore();
     var noticeMapper = new NoticeMapper(ID_FACTORY);
     var routeMapper = createRouteMapper();
 
-    var mapper = new NoticeAssignmentMapper(
-      ID_FACTORY,
-      issues,
-      noticeMapper,
-      createTripMapper(routeMapper),
-      routeMapper
-    );
+    var mapper = createMapper(issues, noticeMapper, createTripMapper(routeMapper), routeMapper);
 
     var assignment = new NoticeAssignment();
     assignment.setNoticeId(obaId("NONEXISTENT"));
@@ -141,13 +217,7 @@ class NoticeAssignmentMapperTest {
     noticeMapper.map(GTFS_NOTICE);
     var routeMapper = createRouteMapper();
 
-    var mapper = new NoticeAssignmentMapper(
-      ID_FACTORY,
-      issues,
-      noticeMapper,
-      createTripMapper(routeMapper),
-      routeMapper
-    );
+    var mapper = createMapper(issues, noticeMapper, createTripMapper(routeMapper), routeMapper);
 
     var assignment = new NoticeAssignment();
     assignment.setNoticeId(obaId(NOTICE_ID));
@@ -169,13 +239,7 @@ class NoticeAssignmentMapperTest {
     noticeMapper.map(GTFS_NOTICE);
     var routeMapper = createRouteMapper();
 
-    var mapper = new NoticeAssignmentMapper(
-      ID_FACTORY,
-      issues,
-      noticeMapper,
-      createTripMapper(routeMapper),
-      routeMapper
-    );
+    var mapper = createMapper(issues, noticeMapper, createTripMapper(routeMapper), routeMapper);
 
     var assignment = new NoticeAssignment();
     assignment.setNoticeId(obaId(NOTICE_ID));
@@ -201,13 +265,7 @@ class NoticeAssignmentMapperTest {
     var noticeMapper = new NoticeMapper(ID_FACTORY);
     noticeMapper.map(GTFS_NOTICE);
 
-    var mapper = new NoticeAssignmentMapper(
-      ID_FACTORY,
-      DataImportIssueStore.NOOP,
-      noticeMapper,
-      tripMapper,
-      routeMapper
-    );
+    var mapper = createMapper(DataImportIssueStore.NOOP, noticeMapper, tripMapper, routeMapper);
 
     var routeAssignment = new NoticeAssignment();
     routeAssignment.setNoticeId(obaId(NOTICE_ID));

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -4,16 +4,20 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.onebusaway.gtfs.model.AgencyAndIdFactory.obaId;
 
+import com.google.common.collect.Multimap;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
 import org.onebusaway.gtfs.model.NoticeAssignment;
-import org.onebusaway.gtfs.model.StopTime;
 import org.onebusaway.gtfs.model.TripSegment;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model.basic.Notice;
+import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 
 class NoticeAssignmentMapperTest {
 
@@ -137,8 +141,35 @@ class NoticeAssignmentMapperTest {
 
   @Test
   void mapNoticeAssignmentOnTripSegment() {
+    // Stop sequences 20, 30 and 40 are within the segment's [from, to] range; their list indices
+    // 1, 2 and 3 are used as the StopTimeKey sequence, not the GTFS stop_sequence.
+    var result = mapTripSegment(20, 40);
+
+    assertEquals(3, result.size());
+    assertThat(sortedStopTimeKeyIds(result)).containsExactly("T1_#1", "T1_#2", "T1_#3");
+  }
+
+  @Test
+  void mapNoticeAssignmentOnSingleStopTripSegment() {
+    // A segment with the same from and to stop sequence covers a single stop time (index 2).
+    var result = mapTripSegment(30, 30);
+
+    assertEquals(1, result.size());
+    assertThat(sortedStopTimeKeyIds(result)).containsExactly("T1_#2");
+  }
+
+  /**
+   * Maps a notice assignment onto a trip segment spanning the given
+   * {@code [fromStopSequence, toStopSequence]} range. The trip has non-contiguous stop sequences
+   * 10, 20, 30, 40, 50 at list indices 0, 1, 2, 3, 4.
+   */
+  private static Multimap<AbstractTransitEntity, Notice> mapTripSegment(
+    int fromStopSequence,
+    int toStopSequence
+  ) {
     var routeMapper = createRouteMapper();
     var tripMapper = createTripMapper(routeMapper);
+    var trip = tripMapper.map(DATA.trip);
 
     var noticeMapper = new NoticeMapper(ID_FACTORY);
     noticeMapper.map(GTFS_NOTICE);
@@ -146,24 +177,21 @@ class NoticeAssignmentMapperTest {
     var segment = new TripSegment();
     segment.setId(obaId("SEG1"));
     segment.setTripId(DATA.trip.getId());
-    segment.setFromStopSequence(20);
-    segment.setToStopSequence(40);
+    segment.setFromStopSequence(fromStopSequence);
+    segment.setToStopSequence(toStopSequence);
 
-    // Non-contiguous stop sequences: 10, 20, 30, 40, 50 at list indices 0, 1, 2, 3, 4
-    var dao = new GtfsRelationalDaoImpl();
-    dao.saveEntity(DATA.trip);
-    var stopSequences = new int[] { 10, 20, 30, 40, 50 };
-    for (int i = 0; i < stopSequences.length; i++) {
+    var stopTimes = new ArrayList<StopTime>();
+    for (int stopSequence : new int[] { 10, 20, 30, 40, 50 }) {
       var stopTime = new StopTime();
-      stopTime.setId(i + 1);
-      stopTime.setTrip(DATA.trip);
-      stopTime.setStop(DATA.stop);
-      stopTime.setStopSequence(stopSequences[i]);
-      dao.saveEntity(stopTime);
+      stopTime.setTrip(trip);
+      stopTime.setStopSequence(stopSequence);
+      stopTimes.add(stopTime);
     }
+    var stopTimesByTrip = new TripStopTimes();
+    stopTimesByTrip.addAll(stopTimes);
 
     var tripSegmentMapper = new TripSegmentMapper(ID_FACTORY);
-    tripSegmentMapper.map(List.of(segment), dao);
+    tripSegmentMapper.map(List.of(segment), stopTimesByTrip);
 
     var mapper = createMapper(
       DataImportIssueStore.NOOP,
@@ -178,18 +206,16 @@ class NoticeAssignmentMapperTest {
     assignment.setTableName(NoticeAssignment.TableName.trip_segments);
     assignment.setRecordId(obaId("SEG1"));
 
-    var result = mapper.map(List.of(assignment));
+    return mapper.map(List.of(assignment));
+  }
 
-    // Stop sequences 20, 30 and 40 are within the segment's [from, to] range; their list indices
-    // 1, 2 and 3 are used as the StopTimeKey sequence, not the GTFS stop_sequence.
-    assertEquals(3, result.size());
-    var stopTimeKeyIds = result
+  private static List<String> sortedStopTimeKeyIds(Multimap<AbstractTransitEntity, Notice> result) {
+    return result
       .keySet()
       .stream()
       .map(e -> e.getId().getId())
       .sorted()
       .toList();
-    assertThat(stopTimeKeyIds).containsExactly("T1_#1", "T1_#2", "T1_#3");
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -146,17 +146,19 @@ class NoticeAssignmentMapperTest {
     var segment = new TripSegment();
     segment.setId(obaId("SEG1"));
     segment.setTripId(DATA.trip.getId());
-    segment.setFromStopSequence(2);
-    segment.setToStopSequence(4);
+    segment.setFromStopSequence(20);
+    segment.setToStopSequence(40);
 
+    // Non-contiguous stop sequences: 10, 20, 30, 40, 50 at list indices 0, 1, 2, 3, 4
     var dao = new GtfsRelationalDaoImpl();
     dao.saveEntity(DATA.trip);
-    for (int seq = 1; seq <= 5; seq++) {
+    var stopSequences = new int[] { 10, 20, 30, 40, 50 };
+    for (int i = 0; i < stopSequences.length; i++) {
       var stopTime = new StopTime();
-      stopTime.setId(seq);
+      stopTime.setId(i + 1);
       stopTime.setTrip(DATA.trip);
       stopTime.setStop(DATA.stop);
-      stopTime.setStopSequence(seq);
+      stopTime.setStopSequence(stopSequences[i]);
       dao.saveEntity(stopTime);
     }
 
@@ -178,7 +180,8 @@ class NoticeAssignmentMapperTest {
 
     var result = mapper.map(List.of(assignment));
 
-    // Stop sequences 2, 3 and 4 are within the segment's [from, to] range
+    // Stop sequences 20, 30 and 40 are within the segment's [from, to] range; their list indices
+    // 1, 2 and 3 are used as the StopTimeKey sequence, not the GTFS stop_sequence.
     assertEquals(3, result.size());
     var stopTimeKeyIds = result
       .keySet()
@@ -186,7 +189,7 @@ class NoticeAssignmentMapperTest {
       .map(e -> e.getId().getId())
       .sorted()
       .toList();
-    assertThat(stopTimeKeyIds).containsExactly("T1_#2", "T1_#3", "T1_#4");
+    assertThat(stopTimeKeyIds).containsExactly("T1_#1", "T1_#2", "T1_#3");
   }
 
   @Test


### PR DESCRIPTION
### Summary

Adds support for GTFS `notice_assignments.txt` entries that target `trip_segments`. A trip segment (a `[from_stop_sequence, to_stop_sequence]` range on a trip) is now expanded so that the referenced notice is attached to every stop time the segment covers, instead of being ignored.

### Issue

This builds on #7801, which added the `trip_segments` table to the GTFS parser but ignored it when mapping notices (the `trip_segments` case previously returned `null`). Trip segments are part of the experimental GTFS proposal [google/transit#638](https://github.com/google/transit/pull/638).

How the code works:

- A new `TripSegmentMapper` resolves each `trip_segment_id` to the `StopTimeKey`s of the stops within the segment's range. It uses the trip's sequence-ordered stop times (`TripStopTimes`) and includes every stop time whose GTFS `stop_sequence` falls within `[from_stop_sequence, to_stop_sequence]`.
- The `StopTimeKey` is built from the **0-based stop position in the pattern**, not the raw GTFS `stop_sequence`, to match how `StopTimeKey`s are referenced elsewhere in OTP. The `StopTimeKey.of(...)` Javadoc was clarified accordingly.
- The mapped keys are stored by `trip_segment_id`, and `NoticeAssignmentMapper` looks them up when resolving assignments, emitting one notice assignment per covered stop time. Assignments referencing an unknown record continue to be reported as data-import issues.

### Unit tests

Unit tests were added to `NoticeAssignmentMapperTest` covering trip-segment notice assignments:

- a multi-stop segment range that resolves to several stop times,
- a single-stop segment (`from_stop_sequence == to_stop_sequence`),
- verification that the stop's position in the pattern, rather than the GTFS `stop_sequence`, is used to build the key (using non-contiguous stop sequences).

The mapping logic is tested at the mapper level with no need for a full graph build.

### Documentation

- Added Javadoc to `TripSegmentMapper` describing its purpose and the stored result.
- Clarified the `StopTimeKey.of(...)` parameter documentation to state that the position is the 0-based stop position in the pattern rather than the GTFS `stop_sequence`.
