### PR TITLE
Replace raptor stop index with position

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripStopTime.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripStopTime.java
@@ -24,21 +24,8 @@ public final class TripStopTime<T extends RaptorTripSchedule> implements StopTim
     return new TripStopTime<>(trip, stopPosition, false);
   }
 
-  public static <T extends RaptorTripSchedule> TripStopTime<T> arrival(T trip, StopTime stopTime) {
-    int stopPosition = trip.findArrivalStopPosition(stopTime.time(), stopTime.stop());
-    return arrival(trip, stopPosition);
-  }
-
   public static <T extends RaptorTripSchedule> TripStopTime<T> departure(T trip, int stopPosition) {
     return new TripStopTime<>(trip, stopPosition, true);
-  }
-
-  public static <T extends RaptorTripSchedule> TripStopTime<T> departure(
-    T trip,
-    StopTime stopTime
-  ) {
-    int stopPosition = trip.findDepartureStopPosition(stopTime.time(), stopTime.stop());
-    return departure(trip, stopPosition);
   }
 
   public T trip() {

--- a/application/src/test/java/org/opentripplanner/raptorlegacy/_data/api/TestPathBuilder.java
+++ b/application/src/test/java/org/opentripplanner/raptorlegacy/_data/api/TestPathBuilder.java
@@ -97,7 +97,9 @@ public class TestPathBuilder implements RaptorTestConstants {
     // testing routes visiting the same stop more than once. Create a new factory
     // method if this happens.
     int boardStopPosition = trip.findDepartureStopPosition(startTime, boardStop);
-    int alightStopPosition = trip.pattern().findStopPositionAfter(boardStopPosition, alightStop);
+    int alightStopPosition = trip
+      .pattern()
+      .findAlightStopPositionAfter(boardStopPosition, alightStop);
     var baTime = new BoardAndAlightTime(trip, boardStopPosition, alightStopPosition);
     builder.transit(trip, baTime);
     return this;

--- a/application/src/test/java/org/opentripplanner/raptorlegacy/_data/api/TestPathBuilder.java
+++ b/application/src/test/java/org/opentripplanner/raptorlegacy/_data/api/TestPathBuilder.java
@@ -1,11 +1,10 @@
 package org.opentripplanner.raptorlegacy._data.api;
 
-import static org.opentripplanner.raptor.rangeraptor.transit.TripTimesSearch.findTripTimes;
-
 import javax.annotation.Nullable;
 import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.api.path.RaptorPath;
 import org.opentripplanner.raptor.path.PathBuilder;
+import org.opentripplanner.raptor.spi.BoardAndAlightTime;
 import org.opentripplanner.raptor.spi.RaptorConstants;
 import org.opentripplanner.raptor.spi.RaptorCostCalculator;
 import org.opentripplanner.raptor.spi.RaptorSlackProvider;
@@ -19,11 +18,11 @@ import org.opentripplanner.raptorlegacy._data.transit.TestTripSchedule;
 
 /**
  * Utility to help build paths for testing. The path builder is "reusable", every time the {@code
- * access(...)} methods are called the builder reset it self.
+ * access(...)} methods are called the builder reset itself.
  * <p>
  * If the {@code costCalculator} is null, paths will not include cost.
  *
- * @deprecated This was earlier part of Raptor and should not be used outside the Raptor
+ * @deprecated This was an earlier part of Raptor and should not be used outside the Raptor
  *             module. Use the OTP model entities instead.
  */
 @Deprecated
@@ -97,7 +96,9 @@ public class TestPathBuilder implements RaptorTestConstants {
     // We use the startTime as earliest-board-time, this may cause problems for
     // testing routes visiting the same stop more than once. Create a new factory
     // method if this happens.
-    var baTime = findTripTimes(trip, boardStop, alightStop, startTime);
+    int boardStopPosition = trip.findDepartureStopPosition(startTime, boardStop);
+    int alightStopPosition = trip.pattern().findStopPositionAfter(boardStopPosition, alightStop);
+    var baTime = new BoardAndAlightTime(trip, boardStopPosition, alightStopPosition);
     builder.transit(trip, baTime);
     return this;
   }

--- a/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTransitData.java
+++ b/application/src/test/java/org/opentripplanner/raptorlegacy/_data/transit/TestTransitData.java
@@ -258,8 +258,8 @@ public class TestTransitData
     int toStop,
     TransferConstraint constraint
   ) {
-    int fromStopPos = fromTrip.pattern().findStopPositionAfter(0, fromStop);
-    int toStopPos = toTrip.pattern().findStopPositionAfter(0, toStop);
+    int fromStopPos = fromTrip.pattern().findAlightStopPositionAfter(0, fromStop);
+    int toStopPos = toTrip.pattern().findBoardStopPositionAfter(0, toStop);
 
     for (TestRoute route : routes) {
       route.addTransferConstraint(fromTrip, fromStopPos, toTrip, toStopPos, constraint);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/BasicPathTestCase.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/BasicPathTestCase.java
@@ -85,6 +85,9 @@ public class BasicPathTestCase implements RaptorTestConstants {
   /** Stop cost for stop NA, A, C, E .. H is zero(0), B: 30s, and D: 60s. ?=0, A=1 .. H=8 */
   private static final int[] STOP_C1_S = { 0, 0, 3_000, 0, 6_000, 0, 0, 0, 0, 0 };
 
+  private static final int STOP_POS_0 = 0;
+  private static final int STOP_POS_1 = 1;
+
   // Some times which should not have eny effect on tests
   private static final int VERY_EARLY = time("00:00");
   private static final int VERY_LATE = time("23:59");
@@ -219,8 +222,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
       TRIP_3,
       L31_START,
       L31_END,
-      TRIP_3.findDepartureStopPosition(L31_START, STOP_D),
-      TRIP_3.findArrivalStopPosition(L31_END, STOP_E),
+      STOP_POS_0,
+      STOP_POS_1,
       EMPTY_CONSTRAINTS,
       LINE_31_C1,
       leg6
@@ -229,8 +232,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
       TRIP_2,
       L21_START,
       L21_END,
-      TRIP_2.findDepartureStopPosition(L21_START, STOP_C),
-      TRIP_2.findArrivalStopPosition(L21_END, STOP_D),
+      STOP_POS_0,
+      STOP_POS_1,
       EMPTY_CONSTRAINTS,
       LINE_21_C1,
       leg5
@@ -248,8 +251,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
       TRIP_1,
       L11_START,
       L11_END,
-      TRIP_1.findDepartureStopPosition(L11_START, STOP_A),
-      TRIP_1.findArrivalStopPosition(L11_END, STOP_B),
+      STOP_POS_0,
+      STOP_POS_1,
       EMPTY_CONSTRAINTS,
       LINE_11_C1,
       leg3
@@ -279,8 +282,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
       TRIP_1,
       L11_START,
       L11_END,
-      TRIP_1.findDepartureStopPosition(L11_START, STOP_A),
-      TRIP_1.findArrivalStopPosition(L11_END, STOP_B),
+      STOP_POS_0,
+      STOP_POS_1,
       EMPTY_CONSTRAINTS,
       LINE_11_C1,
       leg3

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripStopTimeTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripStopTimeTest.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.routing.algorithm.transferoptimization.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.routing.algorithm.transferoptimization.model.StopTime.stopTime;
-import static org.opentripplanner.utils.time.TimeUtils.time;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.raptorlegacy._data.transit.TestTripPattern;
@@ -62,32 +60,6 @@ public class TripStopTimeTest {
   public void testToString() {
     assertEquals("[2 10:01 BUS L31]", departureStop1.toString());
     assertEquals("[7 10:20 BUS L31]", arrivalStop3.toString());
-  }
-
-  @Test
-  public void createArrival() {
-    // Arrival at the first stop is not valid (cannot alight where the trip originates)
-    assertEquals(
-      "[5 10:05 BUS L31]",
-      TripStopTime.arrival(trip, stopTime(STOP_2, time("10:05"))).toString()
-    );
-    assertEquals(
-      "[7 10:20 BUS L31]",
-      TripStopTime.arrival(trip, stopTime(STOP_3, time("10:20"))).toString()
-    );
-  }
-
-  @Test
-  public void createDeparture() {
-    assertEquals(
-      "[2 10:01 BUS L31]",
-      TripStopTime.departure(trip, stopTime(STOP_1, time("10:01"))).toString()
-    );
-    assertEquals(
-      "[5 10:06 BUS L31]",
-      TripStopTime.departure(trip, stopTime(STOP_2, time("10:06"))).toString()
-    );
-    // Departure at the last stop is not valid (cannot board where the trip terminates)
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
@@ -289,8 +289,6 @@ public class OptimizePathDomainServiceTest implements RaptorTestConstants {
 
     var transfers = dummyTransferGenerator(
       List.of(
-        tx(trip1, STOP_A, trip2, STOP_B).walk(D10_s).build(),
-        tx(trip1, STOP_A, trip2, STOP_C).walk(D10_s).build(),
         tx(trip1, STOP_B, trip2).build(),
         tx(trip1, STOP_B, trip2, STOP_C).walk(D10_s).build(),
         tx(trip1, STOP_C, trip2, STOP_B).walk(D10_s).build(),

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
@@ -145,8 +145,8 @@ public class TestTransferBuilder<T extends RaptorTripSchedule> {
       : TestTransfers.transfer(toStopIndex, walkDurationSec);
 
     return new TripToTripTransfer<>(
-      departure(fromTrip, fromStopIndex),
-      arrival(toTrip, toStopIndex),
+      arrival(fromTrip, fromStopIndex),
+      departure(toTrip, toStopIndex),
       pathTransfer,
       buildConstrainedTransfer()
     );
@@ -163,8 +163,8 @@ public class TestTransferBuilder<T extends RaptorTripSchedule> {
     if (constraint == null) {
       return null;
     }
-    int fromStopPos = fromTrip.pattern().findStopPositionAfter(0, fromStopIndex);
-    int toStopPos = toTrip.pattern().findStopPositionAfter(0, toStopIndex);
+    int fromStopPos = fromTrip.pattern().findAlightStopPositionAfter(0, fromStopIndex);
+    int toStopPos = toTrip.pattern().findBoardStopPositionAfter(0, toStopIndex);
 
     return new ConstrainedTransfer(
       null,
@@ -175,11 +175,13 @@ public class TestTransferBuilder<T extends RaptorTripSchedule> {
   }
 
   private static <T extends RaptorTripSchedule> TripStopTime<T> departure(T trip, int stopIndex) {
-    return TripStopTime.departure(trip, trip.pattern().findStopPositionAfter(0, stopIndex));
+    int boardStopPos = trip.pattern().findBoardStopPositionAfter(0, stopIndex);
+    return TripStopTime.departure(trip, boardStopPos);
   }
 
   private static <T extends RaptorTripSchedule> TripStopTime<T> arrival(T trip, int stopIndex) {
-    return TripStopTime.arrival(trip, trip.pattern().findStopPositionAfter(0, stopIndex));
+    int alightStopPos = trip.pattern().findAlightStopPositionAfter(0, stopIndex);
+    return TripStopTime.arrival(trip, alightStopPos);
   }
 
   private void validateFromTo() {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelectorTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelectorTest.java
@@ -111,14 +111,14 @@ public class TransitPathLegSelectorTest implements RaptorTestConstants {
   private TransitPathLeg<TestTripSchedule> transitLeg(int egressStop) {
     var walk = TestAccessEgress.walk(egressStop, EGRESS_END - EGRESS_START);
     var egress = new EgressPathLeg<TestTripSchedule>(walk, EGRESS_START, EGRESS_END, walk.c1());
-    int toTime = TRIP.arrival(TRIP.findArrivalStopPosition(Integer.MAX_VALUE, egressStop));
+    int toTime = TRIP.arrival(TRIP.pattern().findAlightStopPositionAfter(0, egressStop));
     int cost = 100 * (STOP_TIME_THREE - STOP_TIME_ONE);
     return new TransitPathLeg<>(
       TRIP,
       STOP_TIME_ONE,
       toTime,
-      TRIP.findDepartureStopPosition(STOP_TIME_ONE, STOP_A),
-      TRIP.findArrivalStopPosition(toTime, egressStop),
+      STOP_POS_ONE,
+      TRIP.pattern().findAlightStopPositionAfter(STOP_POS_ONE, egressStop),
       null,
       cost,
       egress

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/TestCaseDefinition.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/model/testcase/TestCaseDefinition.java
@@ -27,14 +27,21 @@ public record TestCaseDefinition(
 ) {
   @Override
   public String toString() {
+    var viaLoc = "";
+    var viaCoordinate = "";
+    if (viaLocation != null) {
+      viaLoc = " - via " + viaLocation.label();
+      viaCoordinate = " - via " + coordinateString(viaLocation.coordinateLocation());
+    }
+
     return String.format(
-      "#%s %s - via:%s - %s, %s - via:%s - %s, %s-%s(%s)",
+      "#%s %s%s - %s, %s%s - %s, %s-%s(%s)",
       id,
       fromPlace.label(),
-      viaLocation != null ? viaLocation.label() : null,
+      viaLoc,
       toPlace.label(),
       coordinateString(fromPlace),
-      viaLocation != null ? coordinateString(viaLocation.coordinateLocation()) : null,
+      viaCoordinate,
       coordinateString(toPlace),
       TimeUtils.timeToStrCompact(departureTime, TestCase.NOT_SET),
       TimeUtils.timeToStrCompact(arrivalTime, TestCase.NOT_SET),

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/request/RaptorProfile.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/request/RaptorProfile.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.raptor.api.request;
 
 import java.util.stream.Stream;
-import org.opentripplanner.raptor.rangeraptor.standard.MinTravelDurationRoutingStrategy;
 
 /**
  * Several implementation are implemented - with different behaviour. Use the one that suites your

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/request/RaptorProfile.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/request/RaptorProfile.java
@@ -26,10 +26,10 @@ public enum RaptorProfile {
   BEST_TIME("StdBestTime", false),
 
   /**
-   * Used by Raptor to find the shortest travel duration ignoring wait-time. It also finds number
-   * transfers. This profile can only be used with one Raptor iteration - no {code searchWindow}.
-   * The path is not kept, because this potentially creates paths which is not possible; Hence,
-   * can not be constructed.
+   * Used by Raptor to find the shortest travel duration ignoring wait-time. It also finds the
+   * number of transfers. This profile can only be used with one Raptor iteration - no
+   * {code searchWindow}. The path is not kept because this potentially creates paths, which are
+   * not possible; Hence, cannot be constructed.
    */
   MIN_TRAVEL_DURATION("MinTravelDuration", true);
 
@@ -56,15 +56,6 @@ public enum RaptorProfile {
 
   public boolean isOneOf(RaptorProfile... candidates) {
     return Stream.of(candidates).anyMatch(this::is);
-  }
-
-  /**
-   * The {@link MinTravelDurationRoutingStrategy} will time-shift the arrival-times, so we need to
-   * use the approximate trip-times search in path construction. The BEST_TIME state should not have
-   * path construction, but we include it here anyway.
-   */
-  public boolean useApproximateTripSearch() {
-    return is(MIN_TRAVEL_DURATION);
   }
 
   public boolean producesGeneralizedCost() {

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/view/PatternRideView.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/view/PatternRideView.java
@@ -11,7 +11,12 @@ import org.opentripplanner.raptor.spi.RaptorTripSchedule;
  */
 public interface PatternRideView<T extends RaptorTripSchedule, A extends ArrivalView<T>> {
   A prevArrival();
-  int boardStopIndex();
+  int boardStopPosition();
+
+  default int boardStopIndex() {
+    return trip().pattern().stopIndex(boardStopPosition());
+  }
+
   int boardTime();
   T trip();
   int relativeC1();

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/view/TransitPathView.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/view/TransitPathView.java
@@ -4,11 +4,6 @@ import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 
 public interface TransitPathView<T extends RaptorTripSchedule> {
   /**
-   * Stop index where the transit path was boarded.
-   */
-  int boardStopIndex();
-
-  /**
    * Stop position in the pattern where the transit path was boarded.
    */
   int boardStopPosition();

--- a/raptor/src/main/java/org/opentripplanner/raptor/api/view/TransitPathView.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/api/view/TransitPathView.java
@@ -6,7 +6,12 @@ public interface TransitPathView<T extends RaptorTripSchedule> {
   /**
    * Stop index where the transit path was boarded.
    */
-  int boardStop();
+  int boardStopIndex();
+
+  /**
+   * Stop position in the pattern where the transit path was boarded.
+   */
+  int boardStopPosition();
 
   /**
    * Trip used for transit.

--- a/raptor/src/main/java/org/opentripplanner/raptor/extensions/direct/service/DirectTransitSearch.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/extensions/direct/service/DirectTransitSearch.java
@@ -85,16 +85,16 @@ public class DirectTransitSearch<T extends RaptorTripSchedule> {
 
     for (var access : accesses) {
       var pattern = route.pattern();
-      int boardPos = pattern.findStopPositionAfter(0, access.stop());
+      int boardPos = pattern.findBoardStopPositionAfter(0, access.stop());
 
-      if (boardPos == -1 || !pattern.boardingPossibleAt(boardPos)) {
+      if (boardPos == -1) {
         continue;
       }
 
       for (var egress : egresses) {
-        int alightPos = pattern.findStopPositionAfter(boardPos + 1, egress.stop());
+        int alightPos = pattern.findAlightStopPositionAfter(boardPos, egress.stop());
 
-        if (alightPos == -1 || !pattern.alightingPossibleAt(alightPos)) {
+        if (alightPos == -1) {
           continue;
         }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/SystemErrDebugLogger.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/SystemErrDebugLogger.java
@@ -229,12 +229,12 @@ public class SystemErrDebugLogger implements DebugLogger {
       case TRANSIT -> {
         String tripInfo = a.transitPath().trip().pattern().debugInfo();
         if (forwardSearch) {
-          var t = TripTimesSearch.findTripForwardSearchApproximateTime(a);
+          var t = TripTimesSearch.findTripForwardSearch(a);
           buf.transit(tripInfo, t.boardTime(), t.alightTime());
         }
         // reverse search
         else {
-          var t = TripTimesSearch.findTripReverseSearchApproximateTime(a);
+          var t = TripTimesSearch.findTripReverseSearch(a);
           buf.transit(tripInfo, t.alightTime(), t.boardTime());
         }
       }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/AbstractDebugHandlerAdapter.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/AbstractDebugHandlerAdapter.java
@@ -74,7 +74,7 @@ abstract class AbstractDebugHandlerAdapter<T> implements DebugHandler<T> {
   /**
    * Returns {@link RaptorConstants#NOT_FOUND} not supported.
    */
-  protected abstract int stop(T arrival);
+  protected abstract int stopIndex(T arrival);
 
   protected abstract Iterable<Integer> stopsVisited(T arrival);
 
@@ -92,11 +92,11 @@ abstract class AbstractDebugHandlerAdapter<T> implements DebugHandler<T> {
   }
 
   private boolean isDebugStopOrTripPath(T arrival) {
-    return stops.contains(stop(arrival)) || isDebugTripPath(arrival);
+    return stops.contains(stopIndex(arrival)) || isDebugTripPath(arrival);
   }
 
   private boolean isDebugTripPath(T arrival) {
-    if (!isDebugTrip(stop(arrival))) {
+    if (!isDebugTrip(stopIndex(arrival))) {
       return false;
     }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/DebugHandlerPathAdapter.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/DebugHandlerPathAdapter.java
@@ -14,7 +14,7 @@ final class DebugHandlerPathAdapter extends AbstractDebugHandlerAdapter<RaptorPa
   }
 
   @Override
-  protected int stop(RaptorPath<?> path) {
+  protected int stopIndex(RaptorPath<?> path) {
     EgressPathLeg<?> egressPathLeg = path.egressLeg();
     return egressPathLeg != null ? egressPathLeg.fromStop() : RaptorConstants.NOT_FOUND;
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/DebugHandlerPatternRideAdapter.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/DebugHandlerPatternRideAdapter.java
@@ -14,7 +14,7 @@ final class DebugHandlerPatternRideAdapter
   }
 
   @Override
-  protected int stop(PatternRideView<?, ?> ride) {
+  protected int stopIndex(PatternRideView<?, ?> ride) {
     return ride.boardStopIndex();
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/DebugHandlerStopArrivalAdapter.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/debug/DebugHandlerStopArrivalAdapter.java
@@ -12,7 +12,7 @@ final class DebugHandlerStopArrivalAdapter extends AbstractDebugHandlerAdapter<A
   }
 
   @Override
-  protected int stop(ArrivalView<?> arrival) {
+  protected int stopIndex(ArrivalView<?> arrival) {
     return arrival.stop();
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
@@ -190,7 +190,6 @@ public class MultiCriteriaRoutingStrategy<
 
     var ride = patternRideFactory.createPatternRide(
       prevArrival,
-      stopIndex,
       boarding.stopPositionInPattern(),
       boardTime,
       boardC1,

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -168,13 +168,17 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
       boardStopArrival.stop()
     );
     if (boardingStopPos == -1) {
-      LOG.warn(
-        "Unexpected board stop position missing for trip {} at stop {} after {}.",
-        trip.pattern().debugInfo(),
-        boardStopArrival.stop(),
-        TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
-      );
-      return;
+      // In case of a constrained transfer, the boarding arrivalTime could be after the trip
+      // departure time, which is valid. We use the first depature time of the boarded trip
+      // here to find a valid bearding. This is slightly incorrect and may fail to find the
+      // correct departure for circular lines. There is not a good simple fix for this. A Fix would
+      // need to look up the constrained transfers and apply the logic done by the routing lgorithm.
+      // This logic is fragmented, so a larger refactoring is needed.
+      boardingStopPos = trip.findDepartureStopPosition(trip.departure(0), boardStopArrival.stop());
+      if (boardingStopPos == -1) {
+        logUnexpectedStopPosition("board", trip, boardStopArrival);
+        return;
+      }
     }
 
     int startRoutingAtStopPosition = trip.findArrivalStopPosition(
@@ -183,12 +187,7 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     );
 
     if (startRoutingAtStopPosition == -1) {
-      LOG.warn(
-        "Unexpected alight stop position missing for trip {} at stop {} after {}.",
-        trip.pattern().debugInfo(),
-        alightArrival.stop(),
-        TimeUtils.timeToStrLong(alightArrival.arrivalTime())
-      );
+      logUnexpectedStopPosition("alight", trip, alightArrival);
       return;
     }
 
@@ -231,5 +230,19 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     int arrivalTime = from.arrivalTime() + via.durationInSeconds();
     var to = stopArrivalFactory.createTransferStopArrival(from, via.transfer(), arrivalTime);
     transfersCache.add(to);
+  }
+
+  private static void logUnexpectedStopPosition(
+    String event,
+    RaptorTripSchedule trip,
+    ArrivalView<?> boardStopArrival
+  ) {
+    LOG.warn(
+      "Unexpected {} stop position missing for trip {} at stop {} after {}.",
+      event,
+      trip.pattern().debugInfo(),
+      boardStopArrival.stop(),
+      TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
+    );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -170,9 +170,9 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     if (boardingStopPos == -1) {
       // In case of a constrained transfer, the boarding arrivalTime could be after the trip
       // departure time, which is valid. We use the first depature time of the boarded trip
-      // here to find a valid bearding. This is slightly incorrect and may fail to find the
-      // correct departure for circular lines. There is not a good simple fix for this. A Fix would
-      // need to look up the constrained transfers and apply the logic done by the routing lgorithm.
+      // here to find a valid boarding. This is slightly incorrect and may fail to find the
+      // correct departure for circular lines. There is not a good simple fix for this. A fix would
+      // need to look up the constrained transfers and apply the logic done by the routing algorithm.
       // This logic is fragmented, so a larger refactoring is needed.
       boardingStopPos = trip.findDepartureStopPosition(trip.departure(0), boardStopArrival.stop());
       if (boardingStopPos == -1) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -23,6 +23,9 @@ import org.opentripplanner.raptor.rangeraptor.transit.ViaConnections;
 import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 import org.opentripplanner.raptor.spi.RaptorTripScheduleReference;
 import org.opentripplanner.raptor.util.paretoset.ParetoSetEventListener;
+import org.opentripplanner.utils.time.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to listen for stop arrivals in one Raptor state and then copy
@@ -43,6 +46,10 @@ import org.opentripplanner.raptor.util.paretoset.ParetoSetEventListener;
  */
 public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSchedule>
   implements ParetoSetEventListener<ArrivalView<T>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+    ViaConnectionStopArrivalEventListener.class
+  );
 
   private final McStopArrivalFactory<T> stopArrivalFactory;
   private final List<ViaConnection> connections;
@@ -154,24 +161,45 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     }
     var transitPath = alightArrival.transitPath();
     T trip = transitPath.trip();
-    var info = tripInfoProvider.apply(trip);
 
-    var arrivalAtBoardStop = alightArrival.previous();
+    var boardStopArrival = alightArrival.previous();
     int boardingStopPos = trip.findDepartureStopPosition(
-      arrivalAtBoardStop.arrivalTime(),
-      transitPath.boardStop()
+      boardStopArrival.arrivalTime(),
+      boardStopArrival.stop()
     );
+    if (boardingStopPos == -1) {
+      LOG.warn(
+        "Unexpected board stop position missing for trip {} at stop {} after {}.",
+        trip.pattern().debugInfo(),
+        boardStopArrival.stop(),
+        TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
+      );
+      return;
+    }
+
     int startRoutingAtStopPosition = trip.findArrivalStopPosition(
       alightArrival.arrivalTime(),
       alightArrival.stop()
     );
+
+    if (startRoutingAtStopPosition == -1) {
+      LOG.warn(
+        "Unexpected alight stop position missing for trip {} at stop {} after {}.",
+        trip.pattern().debugInfo(),
+        alightArrival.stop(),
+        TimeUtils.timeToStrLong(alightArrival.arrivalTime())
+      );
+      return;
+    }
+
+    var info = tripInfoProvider.apply(trip);
     var boardingConstraint = new RaptorTripScheduleStopPosition(
       info.routeIndex(),
       info.tripScheduleIndex(),
       boardingStopPos
     );
     next.addOnBoardTripArrival(
-      arrivalAtBoardStop,
+      boardStopArrival,
       alightArrival.stop(),
       startRoutingAtStopPosition,
       boardingConstraint

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -163,22 +163,12 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
     T trip = transitPath.trip();
 
     var boardStopArrival = alightArrival.previous();
-    int boardingStopPos = trip.findDepartureStopPosition(
-      boardStopArrival.arrivalTime(),
-      boardStopArrival.stop()
-    );
+
+    int boardingStopPos = transitPath.boardStopPosition();
+
     if (boardingStopPos == -1) {
-      // In case of a constrained transfer, the boarding arrivalTime could be after the trip
-      // departure time, which is valid. We use the first depature time of the boarded trip
-      // here to find a valid boarding. This is slightly incorrect and may fail to find the
-      // correct departure for circular lines. There is not a good simple fix for this. A fix would
-      // need to look up the constrained transfers and apply the logic done by the routing algorithm.
-      // This logic is fragmented, so a larger refactoring is needed.
-      boardingStopPos = trip.findDepartureStopPosition(trip.departure(0), boardStopArrival.stop());
-      if (boardingStopPos == -1) {
-        logUnexpectedStopPosition("board", trip, boardStopArrival);
-        return;
-      }
+      logUnexpectedStopPosition("board", trip, boardStopArrival);
+      return;
     }
 
     int startRoutingAtStopPosition = trip.findArrivalStopPosition(

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ViaConnectionStopArrivalEventListener.java
@@ -235,14 +235,14 @@ public final class ViaConnectionStopArrivalEventListener<T extends RaptorTripSch
   private static void logUnexpectedStopPosition(
     String event,
     RaptorTripSchedule trip,
-    ArrivalView<?> boardStopArrival
+    ArrivalView<?> stopArrival
   ) {
     LOG.warn(
       "Unexpected {} stop position missing for trip {} at stop {} after {}.",
       event,
       trip.pattern().debugInfo(),
-      boardStopArrival.stop(),
-      TimeUtils.timeToStrLong(boardStopArrival.arrivalTime())
+      stopArrival.stop(),
+      TimeUtils.timeToStrLong(stopArrival.arrivalTime())
     );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/McStopArrival.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/McStopArrival.java
@@ -107,11 +107,4 @@ public abstract sealed class McStopArrival<T extends RaptorTripSchedule>
   public String toString() {
     return asString();
   }
-
-  /**
-   * @return previous state or throw a NPE if no previousArrival exist.
-   */
-  protected final int previousStop() {
-    return previous.stop;
-  }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC1.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC1.java
@@ -30,6 +30,7 @@ public class StopArrivalFactoryC1<T extends RaptorTripSchedule> implements McSto
       alightStop,
       stopArrivalTime,
       c1,
+      ride.boardStopPosition(),
       ride.trip()
     );
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC2.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC2.java
@@ -31,6 +31,7 @@ public class StopArrivalFactoryC2<T extends RaptorTripSchedule> implements McSto
       stopArrivalTime,
       c1,
       ride.c2(),
+      ride.boardStopPosition(),
       ride.trip()
     );
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrival.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrival.java
@@ -37,11 +37,6 @@ final class TransitStopArrival<T extends RaptorTripSchedule>
   }
 
   @Override
-  public int boardStopIndex() {
-    return trip.pattern().stopIndex(boardStopPosition);
-  }
-
-  @Override
   public int boardStopPosition() {
     return boardStopPosition;
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrival.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrival.java
@@ -16,15 +16,18 @@ final class TransitStopArrival<T extends RaptorTripSchedule>
   implements TransitPathView<T>, TransitArrival<T> {
 
   private final T trip;
+  private final int boardStopPosition;
 
   TransitStopArrival(
     McStopArrival<T> previousState,
     int stopIndex,
     int arrivalTime,
     int totalCost,
+    int boardStopPosition,
     T trip
   ) {
     super(previousState, previousState.round() + 1, stopIndex, arrivalTime, totalCost);
+    this.boardStopPosition = boardStopPosition;
     this.trip = trip;
   }
 
@@ -34,8 +37,13 @@ final class TransitStopArrival<T extends RaptorTripSchedule>
   }
 
   @Override
-  public int boardStop() {
-    return previousStop();
+  public int boardStopIndex() {
+    return trip.pattern().stopIndex(boardStopPosition);
+  }
+
+  @Override
+  public int boardStopPosition() {
+    return boardStopPosition;
   }
 
   @Override
@@ -65,6 +73,13 @@ final class TransitStopArrival<T extends RaptorTripSchedule>
 
   @Override
   public McStopArrival<T> addSlackToArrivalTime(int slack) {
-    return new TransitStopArrival<>(previous(), stop(), arrivalTime() + slack, c1(), trip);
+    return new TransitStopArrival<>(
+      previous(),
+      stop(),
+      arrivalTime() + slack,
+      c1(),
+      boardStopPosition,
+      trip
+    );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2.java
@@ -32,11 +32,6 @@ final class TransitStopArrivalC2<T extends RaptorTripSchedule>
   }
 
   @Override
-  public int boardStopIndex() {
-    return trip.pattern().stopIndex(boardStopPosition);
-  }
-
-  @Override
   public int boardStopPosition() {
     return boardStopPosition;
   }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2.java
@@ -15,6 +15,7 @@ final class TransitStopArrivalC2<T extends RaptorTripSchedule>
   implements TransitPathView<T>, TransitArrival<T> {
 
   private final T trip;
+  private final int boardStopPosition;
 
   TransitStopArrivalC2(
     McStopArrival<T> previous,
@@ -22,15 +23,22 @@ final class TransitStopArrivalC2<T extends RaptorTripSchedule>
     int arrivalTime,
     int c1,
     int c2,
+    int boardStopPosition,
     T trip
   ) {
     super(previous, previous.round() + 1, stopIndex, arrivalTime, c1, c2);
+    this.boardStopPosition = boardStopPosition;
     this.trip = trip;
   }
 
   @Override
-  public int boardStop() {
-    return previousStop();
+  public int boardStopIndex() {
+    return trip.pattern().stopIndex(boardStopPosition);
+  }
+
+  @Override
+  public int boardStopPosition() {
+    return boardStopPosition;
   }
 
   @Override
@@ -60,6 +68,14 @@ final class TransitStopArrivalC2<T extends RaptorTripSchedule>
 
   @Override
   public McStopArrival<T> addSlackToArrivalTime(int slack) {
-    return new TransitStopArrivalC2<>(previous(), stop(), arrivalTime() + slack, c1(), c2(), trip);
+    return new TransitStopArrivalC2<>(
+      previous(),
+      stop(),
+      arrivalTime() + slack,
+      c1(),
+      c2(),
+      boardStopPosition,
+      trip
+    );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/AbstractPatternRide.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/AbstractPatternRide.java
@@ -66,8 +66,7 @@ public abstract sealed class AbstractPatternRide<T extends RaptorTripSchedule>
   permits PatternRideC1, PatternRideC2 {
 
   private final McStopArrival<T> prevArrival;
-  private final int boardStopIndex;
-  private final int boardPos;
+  private final int boardStopPosition;
   private final int boardTime;
   private final int boardC1;
   private final int relativeC1;
@@ -76,7 +75,6 @@ public abstract sealed class AbstractPatternRide<T extends RaptorTripSchedule>
 
   public AbstractPatternRide(
     McStopArrival<T> prevArrival,
-    int boardStopIndex,
     int boardPos,
     int boardTime,
     int boardC1,
@@ -85,8 +83,7 @@ public abstract sealed class AbstractPatternRide<T extends RaptorTripSchedule>
     T trip
   ) {
     this.prevArrival = prevArrival;
-    this.boardStopIndex = boardStopIndex;
-    this.boardPos = boardPos;
+    this.boardStopPosition = boardPos;
     this.boardTime = boardTime;
     this.boardC1 = boardC1;
     this.relativeC1 = relativeC1;
@@ -94,26 +91,27 @@ public abstract sealed class AbstractPatternRide<T extends RaptorTripSchedule>
     this.trip = trip;
   }
 
+  @Override
   public McStopArrival<T> prevArrival() {
     return prevArrival;
   }
 
-  public final int boardStopIndex() {
-    return boardStopIndex;
+  @Override
+  public final int boardStopPosition() {
+    return boardStopPosition;
   }
 
-  public final int boardPos() {
-    return boardPos;
-  }
-
+  @Override
   public final int boardTime() {
     return boardTime;
   }
 
+  @Override
   public final int boardC1() {
     return boardC1;
   }
 
+  @Override
   public final int relativeC1() {
     return relativeC1;
   }
@@ -122,6 +120,7 @@ public abstract sealed class AbstractPatternRide<T extends RaptorTripSchedule>
     return tripSortIndex;
   }
 
+  @Override
   public final T trip() {
     return trip;
   }
@@ -129,8 +128,7 @@ public abstract sealed class AbstractPatternRide<T extends RaptorTripSchedule>
   protected String toString(ToStringBuilder builder, @Nullable Consumer<ToStringBuilder> addC2) {
     builder
       .addNum("prevArrival", prevArrival.stop())
-      .addNum("boardStop", boardStopIndex)
-      .addNum("boardPos", boardPos)
+      .addNum("boardStopPosition", boardStopPosition)
       .addServiceTime("boardTime", boardTime)
       .addNum("boardC1", boardC1)
       .addNum("relativeC1", relativeC1);

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1.java
@@ -15,24 +15,14 @@ public final class PatternRideC1<T extends RaptorTripSchedule> extends AbstractP
 
   public PatternRideC1(
     McStopArrival<T> prevArrival,
-    int boardStopIndex,
-    int boardPos,
+    int boardStopPosition,
     int boardTime,
     int boardC1,
     int relativeC1,
     int tripSortIndex,
     T trip
   ) {
-    super(
-      prevArrival,
-      boardStopIndex,
-      boardPos,
-      boardTime,
-      boardC1,
-      relativeC1,
-      tripSortIndex,
-      trip
-    );
+    super(prevArrival, boardStopPosition, boardTime, boardC1, relativeC1, tripSortIndex, trip);
   }
 
   public static <T extends RaptorTripSchedule> PatternRideFactory<T, PatternRideC1<T>> factory() {
@@ -40,8 +30,7 @@ public final class PatternRideC1<T extends RaptorTripSchedule> extends AbstractP
       @Override
       public PatternRideC1<T> createPatternRide(
         McStopArrival<T> prevArrival,
-        int boardStopIndex,
-        int boardPos,
+        int boardStopPosition,
         int boardTime,
         int boardCost1,
         int relativeCost1,
@@ -49,8 +38,7 @@ public final class PatternRideC1<T extends RaptorTripSchedule> extends AbstractP
       ) {
         return new PatternRideC1<>(
           prevArrival,
-          boardStopIndex,
-          boardPos,
+          boardStopPosition,
           boardTime,
           boardCost1,
           relativeCost1,

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2.java
@@ -16,8 +16,7 @@ public final class PatternRideC2<T extends RaptorTripSchedule> extends AbstractP
 
   public PatternRideC2(
     McStopArrival<T> prevArrival,
-    int boardStopIndex,
-    int boardPos,
+    int boardStopPosition,
     int boardTime,
     int boardC1,
     int relativeC1,
@@ -25,16 +24,7 @@ public final class PatternRideC2<T extends RaptorTripSchedule> extends AbstractP
     int tripSortIndex,
     T trip
   ) {
-    super(
-      prevArrival,
-      boardStopIndex,
-      boardPos,
-      boardTime,
-      boardC1,
-      relativeC1,
-      tripSortIndex,
-      trip
-    );
+    super(prevArrival, boardStopPosition, boardTime, boardC1, relativeC1, tripSortIndex, trip);
     this.c2 = c2;
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideFactory.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideFactory.java
@@ -10,8 +10,7 @@ public interface PatternRideFactory<
 > {
   R createPatternRide(
     McStopArrival<T> prevArrival,
-    int boardStopIndex,
-    int boardPos,
+    int boardStopPosition,
     int boardTime,
     int boardCost1,
     int relativeCost1,

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/TransitGroupPriorityRideFactory.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/TransitGroupPriorityRideFactory.java
@@ -24,8 +24,7 @@ public class TransitGroupPriorityRideFactory<T extends RaptorTripSchedule>
   @Override
   public PatternRideC2<T> createPatternRide(
     McStopArrival<T> prevArrival,
-    int boardStopIndex,
-    int boardPos,
+    int boardStopPosition,
     int boardTime,
     int boardCost1,
     int relativeC1,
@@ -33,8 +32,7 @@ public class TransitGroupPriorityRideFactory<T extends RaptorTripSchedule>
   ) {
     return new PatternRideC2<>(
       prevArrival,
-      boardStopIndex,
-      boardPos,
+      boardStopPosition,
       boardTime,
       boardCost1,
       relativeC1,

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -20,7 +20,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
   private final RaptorSlackProvider slackProvider;
   private final RaptorCostCalculator<T> costCalculator;
   private final RaptorStopNameResolver stopNameResolver;
-  private final BoardAndAlightTimeSearch tripSearch;
+  private final org.opentripplanner.raptor.rangeraptor.path.BoardAndAlightTimeSearch tripSearch;
   private final RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch;
 
   private int iterationDepartureTime = -1;

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -36,7 +36,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
     this.slackProvider = slackProvider;
     this.costCalculator = costCalculator;
     this.stopNameResolver = stopNameResolver;
-    this.tripSearch = forwardSearch(useApproximateTripTimesSearch);
+    this.tripSearch = TripTimesSearch::findTripForwardSearch;
     this.transferConstraintsSearch = transferConstraintsSearch;
     lifeCycle.onSetupIteration(this::setRangeRaptorIterationDepartureTime);
   }
@@ -72,12 +72,6 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
     pathBuilder.c2(destinationArrival.c2());
 
     return pathBuilder.build();
-  }
-
-  private static BoardAndAlightTimeSearch forwardSearch(boolean useApproximateTimeSearch) {
-    return useApproximateTimeSearch
-      ? TripTimesSearch::findTripForwardSearchApproximateTime
-      : TripTimesSearch::findTripForwardSearch;
   }
 
   private void setRangeRaptorIterationDepartureTime(int iterationDepartureTime) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -20,7 +20,6 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
   private final RaptorSlackProvider slackProvider;
   private final RaptorCostCalculator<T> costCalculator;
   private final RaptorStopNameResolver stopNameResolver;
-  private final org.opentripplanner.raptor.rangeraptor.path.BoardAndAlightTimeSearch tripSearch;
   private final RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch;
 
   private int iterationDepartureTime = -1;
@@ -30,13 +29,11 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
     RaptorCostCalculator<T> costCalculator,
     RaptorStopNameResolver stopNameResolver,
     RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
-    WorkerLifeCycle lifeCycle,
-    boolean useApproximateTripTimesSearch
+    WorkerLifeCycle lifeCycle
   ) {
     this.slackProvider = slackProvider;
     this.costCalculator = costCalculator;
     this.stopNameResolver = stopNameResolver;
-    this.tripSearch = TripTimesSearch::findTripForwardSearch;
     this.transferConstraintsSearch = transferConstraintsSearch;
     lifeCycle.onSetupIteration(this::setRangeRaptorIterationDepartureTime);
   }
@@ -57,7 +54,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
     while (arrival != null) {
       switch (arrival.arrivedBy()) {
         case TRANSIT -> {
-          var times = tripSearch.find(arrival);
+          var times = TripTimesSearch.findTripForwardSearch(arrival);
           pathBuilder.transit(arrival.transitPath().trip(), times);
         }
         case TRANSFER -> pathBuilder.transfer(arrival.transfer(), arrival.stop());

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ReversePathMapper.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ReversePathMapper.java
@@ -40,7 +40,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
     this.costCalculator = costCalculator;
     this.stopNameResolver = stopNameResolver;
     this.transferConstraintsSearch = transferConstraintsSearch;
-    this.tripSearch = tripTimesSearch(useApproximateTripTimesSearch);
+    this.tripSearch = TripTimesSearch::findTripReverseSearch;
   }
 
   @Override
@@ -77,11 +77,5 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
       }
       arrival = arrival.previous();
     }
-  }
-
-  private static BoardAndAlightTimeSearch tripTimesSearch(boolean useApproximateTimeSearch) {
-    return useApproximateTimeSearch
-      ? TripTimesSearch::findTripReverseSearchApproximateTime
-      : TripTimesSearch::findTripReverseSearch;
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ReversePathMapper.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/ReversePathMapper.java
@@ -26,21 +26,18 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
   private final RaptorSlackProvider slackProvider;
   private final RaptorCostCalculator<T> costCalculator;
   private final RaptorStopNameResolver stopNameResolver;
-  private final BoardAndAlightTimeSearch tripSearch;
   private final RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch;
 
   public ReversePathMapper(
     RaptorSlackProvider slackProvider,
     RaptorCostCalculator<T> costCalculator,
     RaptorStopNameResolver stopNameResolver,
-    RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
-    boolean useApproximateTripTimesSearch
+    RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch
   ) {
     this.slackProvider = slackProvider;
     this.costCalculator = costCalculator;
     this.stopNameResolver = stopNameResolver;
     this.transferConstraintsSearch = transferConstraintsSearch;
-    this.tripSearch = TripTimesSearch::findTripReverseSearch;
   }
 
   @Override
@@ -65,7 +62,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
 
           return pathBuilder.build();
         case TRANSIT:
-          var times = tripSearch.find(arrival);
+          var times = TripTimesSearch.findTripReverseSearch(arrival);
           var transit = arrival.transitPath();
           pathBuilder.transit(transit.trip(), times);
           break;

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/configure/PathConfig.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/path/configure/PathConfig.java
@@ -4,7 +4,6 @@ import static org.opentripplanner.raptor.rangeraptor.path.PathParetoSetComparato
 
 import org.opentripplanner.raptor.api.model.DominanceFunction;
 import org.opentripplanner.raptor.api.path.RaptorPath;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.rangeraptor.context.SearchContext;
 import org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetCost;
 import org.opentripplanner.raptor.rangeraptor.internalapi.ParetoSetTime;
@@ -88,7 +87,6 @@ public class PathConfig<T extends RaptorTripSchedule> {
 
   private PathMapper<T> createPathMapper(boolean includeCost) {
     return createPathMapper(
-      ctx.profile(),
       ctx.searchDirection(),
       ctx.raptorSlackProvider(),
       includeCost ? ctx.costCalculator() : null,
@@ -99,7 +97,6 @@ public class PathConfig<T extends RaptorTripSchedule> {
   }
 
   private static <S extends RaptorTripSchedule> PathMapper<S> createPathMapper(
-    RaptorProfile profile,
     SearchDirection searchDirection,
     RaptorSlackProvider slackProvider,
     RaptorCostCalculator<S> costCalculator,
@@ -113,15 +110,13 @@ public class PathConfig<T extends RaptorTripSchedule> {
           costCalculator,
           stopNameResolver,
           txConstraintsSearch,
-          lifeCycle,
-          profile.useApproximateTripSearch()
+          lifeCycle
         )
       : new ReversePathMapper<>(
           slackProvider,
           costCalculator,
           stopNameResolver,
-          txConstraintsSearch,
-          profile.useApproximateTripSearch()
+          txConstraintsSearch
         );
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/ArrivalTimeRoutingStrategy.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/ArrivalTimeRoutingStrategy.java
@@ -40,7 +40,7 @@ public final class ArrivalTimeRoutingStrategy<T extends RaptorTripSchedule>
   private int logCount = 0;
   private int onTripIndex;
   private int onTripBoardTime;
-  private int onTripBoardStop;
+  private int onTripBoardStopPosition;
   private T onTrip;
 
   public ArrivalTimeRoutingStrategy(
@@ -63,7 +63,7 @@ public final class ArrivalTimeRoutingStrategy<T extends RaptorTripSchedule>
     boardingSupport.prepareForTransitWith(route.timetable());
     this.onTripIndex = UNBOUNDED_TRIP_INDEX;
     this.onTripBoardTime = NOT_SET;
-    this.onTripBoardStop = NOT_SET;
+    this.onTripBoardStopPosition = NOT_SET;
     this.onTrip = null;
   }
 
@@ -72,12 +72,12 @@ public final class ArrivalTimeRoutingStrategy<T extends RaptorTripSchedule>
     if (onTripIndex != UNBOUNDED_TRIP_INDEX) {
       final int stopArrivalTime = calculator.stopArrivalTime(onTrip, stopPos, alightSlack);
 
-      // TODO: Make sure that the TimeTables can not have negative trip times, then
+      // TODO: Make sure that the TimeTables cannot have negative trip times, then
       //       this check can be removed.
       if (calculator.isBefore(stopArrivalTime, onTripBoardTime)) {
         logInvalidAlightTime(stopPos, stopArrivalTime);
       } else {
-        state.transitToStop(stopIndex, stopArrivalTime, onTripBoardStop, onTripBoardTime, onTrip);
+        state.transitToStop(stopIndex, stopArrivalTime, onTripBoardStopPosition, onTrip);
       }
     }
   }
@@ -99,7 +99,7 @@ public final class ArrivalTimeRoutingStrategy<T extends RaptorTripSchedule>
       onTripIndex
     );
     if (!boarding.empty()) {
-      board(stopIndex, boarding);
+      board(boarding);
     }
   }
 
@@ -119,15 +119,15 @@ public final class ArrivalTimeRoutingStrategy<T extends RaptorTripSchedule>
     if (boarding.empty()) {
       boardWithRegularTransfer(stopIndex, stopPos, boardSlack);
     } else if (!boarding.transferConstraint().isNotAllowed()) {
-      board(stopIndex, boarding);
+      board(boarding);
     }
   }
 
-  private void board(int stopIndex, RaptorBoardOrAlightEvent<T> boarding) {
+  private void board(RaptorBoardOrAlightEvent<T> boarding) {
     onTripIndex = boarding.tripScheduleIndex();
     onTrip = boarding.trip();
     onTripBoardTime = boarding.time();
-    onTripBoardStop = stopIndex;
+    onTripBoardStopPosition = boarding.stopPositionInPattern();
   }
 
   private int prevArrivalTime(int stopIndex) {
@@ -143,7 +143,7 @@ public final class ArrivalTimeRoutingStrategy<T extends RaptorTripSchedule>
       ++logCount;
       LOG.error(
         "Traveling back in time is not allowed. Board stop pos: {}, alight stop pos: {}, stop arrival time: {}, trip: {}.",
-        onTrip.findDepartureStopPosition(onTripBoardTime, onTripBoardStop),
+        onTripBoardStopPosition,
         stopPos,
         stopArrivalTime,
         onTrip

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/MinTravelDurationRoutingStrategy.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/MinTravelDurationRoutingStrategy.java
@@ -42,7 +42,7 @@ public final class MinTravelDurationRoutingStrategy<T extends RaptorTripSchedule
   private int logCount = 0;
   private int onTripIndex;
   private int onTripBoardTime;
-  private int onTripBoardStop;
+  private int onTripBoardStopPosition = NOT_SET;
   private T onTrip;
   private int onTripTimeShift;
   private int iterationDepartureTime;
@@ -69,7 +69,7 @@ public final class MinTravelDurationRoutingStrategy<T extends RaptorTripSchedule
     this.boardingSupport.prepareForTransitWith(route.timetable());
     this.onTripIndex = UNBOUNDED_TRIP_INDEX;
     this.onTripBoardTime = NOT_SET;
-    this.onTripBoardStop = NOT_SET;
+    this.onTripBoardStopPosition = NOT_SET;
     this.onTrip = null;
     this.onTripTimeShift = NOT_SET;
   }
@@ -96,9 +96,9 @@ public final class MinTravelDurationRoutingStrategy<T extends RaptorTripSchedule
       onTripIndex
     );
     if (boarding.empty()) {
-      boardSameTrip(boarding.earliestBoardTime(), stopPos, stopIndex);
+      boardSameTrip(boarding.earliestBoardTime(), stopPos);
     } else {
-      board(stopIndex, boarding);
+      board(boarding);
     }
   }
 
@@ -131,16 +131,16 @@ public final class MinTravelDurationRoutingStrategy<T extends RaptorTripSchedule
       if (calculator.isBefore(stopArrivalTime, onTripBoardTime)) {
         logInvalidAlightTime(stopPos, stopArrivalTime);
       } else {
-        state.transitToStop(stopIndex, stopArrivalTime, onTripBoardStop, onTripBoardTime, onTrip);
+        state.transitToStop(stopIndex, stopArrivalTime, onTripBoardStopPosition, onTrip);
       }
     }
   }
 
-  private void board(int stopIndex, RaptorBoardOrAlightEvent<T> boarding) {
+  private void board(RaptorBoardOrAlightEvent<T> boarding) {
     onTripIndex = boarding.tripScheduleIndex();
     onTrip = boarding.trip();
     onTripBoardTime = boarding.earliestBoardTime();
-    onTripBoardStop = stopIndex;
+    onTripBoardStopPosition = boarding.stopPositionInPattern();
     // Calculate the time-shift, the time-shift will be a positive duration in a
     // forward-search, and a negative value in case of a reverse-search.
     onTripTimeShift = boarding.time() - onTripBoardTime;
@@ -154,7 +154,7 @@ public final class MinTravelDurationRoutingStrategy<T extends RaptorTripSchedule
    * @param stopPos           - the pattern stop position
    * @param stopIndex         - the global stop index
    */
-  private void boardSameTrip(int earliestBoardTime, int stopPos, int stopIndex) {
+  private void boardSameTrip(int earliestBoardTime, int stopPos) {
     // If not boarded, return
     if (onTripIndex == UNBOUNDED_TRIP_INDEX) {
       return;
@@ -176,7 +176,7 @@ public final class MinTravelDurationRoutingStrategy<T extends RaptorTripSchedule
     }
 
     onTripBoardTime = earliestBoardTime;
-    onTripBoardStop = stopIndex;
+    onTripBoardStopPosition = stopPos;
     onTripTimeShift = tripTimeShift;
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -167,7 +167,7 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
    * transitTime.
    */
   @Override
-  public void transitToStop(int stop, int arrivalTime, int boardStop, int boardTime, T trip) {
+  public void transitToStop(int stop, int arrivalTime, int boardStopPosition, T trip) {
     if (exceedsTimeLimit(arrivalTime)) {
       return;
     }
@@ -178,13 +178,12 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
       stopArrivalsState.setNewBestTransitTime(
         stop,
         arrivalTime,
+        boardStopPosition,
         trip,
-        boardStop,
-        boardTime,
         newOverallBestTime
       );
     } else {
-      stopArrivalsState.rejectNewBestTransitTime(stop, arrivalTime, trip, boardStop, boardTime);
+      stopArrivalsState.rejectNewBestTransitTime(stop, arrivalTime, boardStopPosition, trip);
     }
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdWorkerState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/StdWorkerState.java
@@ -30,7 +30,7 @@ public interface StdWorkerState<T extends RaptorTripSchedule> extends RaptorWork
    * Set the time at a transit stop iff it is optimal. This sets both the bestTime and the
    * transitTime
    */
-  void transitToStop(int alightStop, int alightTime, int boardStop, int boardTime, T trip);
+  void transitToStop(int alightStop, int alightTime, int boardStopPosition, T trip);
 
   TransitArrival<T> previousTransit(int boardStopIndex);
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/besttimes/BestTimesOnlyStopArrivalsState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/besttimes/BestTimesOnlyStopArrivalsState.java
@@ -66,9 +66,8 @@ public class BestTimesOnlyStopArrivalsState<T extends RaptorTripSchedule>
   public void setNewBestTransitTime(
     int stop,
     int alightTime,
+    int boardStopPosition,
     T trip,
-    int boardStop,
-    int boardTime,
     boolean newBestOverall
   ) {
     bestNumberOfTransfers.arriveAtStop(stop);

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/debug/DebugStopArrivalsState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/debug/DebugStopArrivalsState.java
@@ -58,26 +58,19 @@ public final class DebugStopArrivalsState<T extends RaptorTripSchedule>
   public void setNewBestTransitTime(
     int stop,
     int alightTime,
+    int boardStopPosition,
     T trip,
-    int boardStop,
-    int boardTime,
     boolean newBestOverall
   ) {
     debug.dropOldStateAndAcceptNewOnBoardArrival(stop, newBestOverall, () ->
-      delegate.setNewBestTransitTime(stop, alightTime, trip, boardStop, boardTime, newBestOverall)
+      delegate.setNewBestTransitTime(stop, alightTime, boardStopPosition, trip, newBestOverall)
     );
   }
 
   @Override
-  public void rejectNewBestTransitTime(
-    int stop,
-    int alightTime,
-    T trip,
-    int boardStop,
-    int boardTime
-  ) {
-    debug.rejectTransit(stop, alightTime, trip, boardStop, boardTime);
-    delegate.rejectNewBestTransitTime(stop, alightTime, trip, boardStop, boardTime);
+  public void rejectNewBestTransitTime(int stop, int alightTime, int boardStopPosition, T trip) {
+    debug.rejectTransit(stop, alightTime, boardStopPosition, trip);
+    delegate.rejectNewBestTransitTime(stop, alightTime, boardStopPosition, trip);
   }
 
   @Override

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/debug/StateDebugger.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/debug/StateDebugger.java
@@ -59,9 +59,9 @@ class StateDebugger<T extends RaptorTripSchedule> {
     }
   }
 
-  void rejectTransit(int alightStop, int alightTime, T trip, int boardStop, int boardTime) {
+  void rejectTransit(int alightStop, int alightTime, int boardStopPosition, T trip) {
     if (isDebug(alightStop)) {
-      reject(cursor.fictiveTransit(round, alightStop, alightTime, trip, boardStop, boardTime));
+      reject(cursor.fictiveTransit(round, alightStop, alightTime, boardStopPosition, trip));
     }
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/internalapi/StopArrivalsState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/internalapi/StopArrivalsState.java
@@ -33,18 +33,16 @@ public interface StopArrivalsState<T extends RaptorTripSchedule> {
   void setNewBestTransitTime(
     int alightStop,
     int alightTime,
+    int boardStopPosition,
     T trip,
-    int boardStop,
-    int boardTime,
     boolean newBestOverall
   );
 
   default void rejectNewBestTransitTime(
     int alightStop,
     int alightTime,
-    T trip,
-    int boardStop,
-    int boardTime
+    int boardStopPosition,
+    T trip
   ) {}
 
   void setNewBestTransferTime(int fromStop, int arrivalTime, RaptorTransfer transfer);

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
@@ -84,14 +84,14 @@ public final class AccessStopArrivalState<T extends RaptorTripSchedule>
   }
 
   @Override
-  public int boardStop() {
-    return delegate.boardStop();
+  public int boardStopPosition() {
+    return delegate.boardStopPosition();
   }
 
   @Override
-  public void arriveByTransit(int arrivalTime, int boardStop, int boardTime, T trip) {
+  public void arriveByTransit(int arrivalTime, int boardStopPosition, T trip) {
     accessArriveOnBoard = null;
-    delegate.arriveByTransit(arrivalTime, boardStop, boardTime, trip);
+    delegate.arriveByTransit(arrivalTime, boardStopPosition, trip);
   }
 
   @Override

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/DefaultStopArrivalState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/DefaultStopArrivalState.java
@@ -28,7 +28,7 @@ sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
   permits EgressStopArrivalState {
 
   /**
-   * Used to initialize all none time based attributes.
+   * Used to initialize all none-time-based attributes.
    */
   static final int NOT_SET = -1;
 
@@ -110,8 +110,8 @@ sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
   @Override
   public void arriveByTransit(int arrivalTime, int boardStopPosition, T trip) {
     this.onBoardArrivalTime = arrivalTime;
-    this.trip = trip;
     this.boardStopPosition = boardStopPosition;
+    this.trip = trip;
   }
 
   @Override

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/DefaultStopArrivalState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/DefaultStopArrivalState.java
@@ -3,6 +3,7 @@ package org.opentripplanner.raptor.rangeraptor.standard.stoparrivals;
 import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.spi.RaptorTransfer;
 import org.opentripplanner.raptor.spi.RaptorTripSchedule;
+import org.opentripplanner.utils.time.TimeUtils;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
@@ -11,12 +12,12 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
  * garbage collect.
  * <p/>
  * This class holds both the best transit and the best transfer to a stop if they exist for a given
- * round and stop. The normal case is that this class represent either a transit arrival or a
+ * round and stop. The normal case is that this class represents either a transit arrival or a
  * transfer arrival. We only keep both if the transfer is better, arriving before the transit.
  * <p/>
  * The reason we need to keep both the best transfer and the best transit for a given stop and round
  * is that we may arrive at a stop by transit, then in the same or later round we may arrive by
- * transit. If the transfer arrival is better then the transit arrival it might be tempting to
+ * transit. If the transfer arrival is better than the transit arrival, it might be tempting to
  * remove the transit arrival, but this transit might be the best way (or only way) to get to
  * another stop by transfer.
  *
@@ -39,8 +40,7 @@ sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
 
   // Transit
   private T trip = null;
-  private int boardTime = NOT_SET;
-  private int boardStop = NOT_SET;
+  private int boardStopPosition = NOT_SET;
 
   // Transfer
   private int transferFromStop = NOT_SET;
@@ -89,7 +89,7 @@ sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
 
   @Override
   public boolean arrivedByTransit() {
-    return boardStop != NOT_SET;
+    return boardStopPosition != NOT_SET;
   }
 
   @Override
@@ -99,20 +99,19 @@ sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
 
   @Override
   public final int boardTime() {
-    return boardTime;
+    return trip.departure(boardStopPosition);
   }
 
   @Override
-  public final int boardStop() {
-    return boardStop;
+  public final int boardStopPosition() {
+    return boardStopPosition;
   }
 
   @Override
-  public void arriveByTransit(int arrivalTime, int boardStop, int boardTime, T trip) {
+  public void arriveByTransit(int arrivalTime, int boardStopPosition, T trip) {
     this.onBoardArrivalTime = arrivalTime;
     this.trip = trip;
-    this.boardTime = boardTime;
-    this.boardStop = boardStop;
+    this.boardStopPosition = boardStopPosition;
   }
 
   @Override
@@ -158,9 +157,8 @@ sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
     builder
       .addServiceTime("arrivalTime", bestArrivalTime, NOT_SET)
       .addServiceTime("onBoardArrivalTime", onBoardArrivalTime, NOT_SET)
-      .addNum("boardStop", boardStop, NOT_SET)
-      .addServiceTime("boardTime", boardTime, NOT_SET)
-      .addObj("trip", trip == null ? null : trip.pattern().debugInfo())
+      .addNum("boardStopPosition", boardStopPosition, NOT_SET)
+      .addObj("trip", tripInfo())
       .addNum("transferFromStop", transferFromStop, NOT_SET);
 
     if (transferPath != null) {
@@ -180,8 +178,15 @@ sealed class DefaultStopArrivalState<T extends RaptorTripSchedule>
       this.onBoardArrivalTime = time;
       // Clear transit to avoid mistakes
       this.trip = null;
-      this.boardTime = NOT_SET;
-      this.boardStop = NOT_SET;
+      this.boardStopPosition = NOT_SET;
     }
+  }
+
+  private String tripInfo() {
+    return boardStopPosition == NOT_SET
+      ? null
+      : trip.pattern().debugInfo() +
+        " @" +
+        TimeUtils.timeToStrCompact(trip.departure(boardStopPosition));
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/EgressStopArrivalState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/EgressStopArrivalState.java
@@ -35,8 +35,8 @@ final class EgressStopArrivalState<T extends RaptorTripSchedule>
   }
 
   @Override
-  public void arriveByTransit(int arrivalTime, int boardStop, int boardTime, T trip) {
-    super.arriveByTransit(arrivalTime, boardStop, boardTime, trip);
+  public void arriveByTransit(int arrivalTime, int boardStopPosition, T trip) {
+    super.arriveByTransit(arrivalTime, boardStopPosition, trip);
     for (RaptorAccessEgress egressPath : egressPaths) {
       callback.newDestinationArrival(round, arrivalTime, true, egressPath);
     }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/StdStopArrivals.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/StdStopArrivals.java
@@ -100,10 +100,10 @@ public final class StdStopArrivals<T extends RaptorTripSchedule> implements Best
     state.transferToStop(fromStop, arrivalTime, transfer);
   }
 
-  void transitToStop(int stop, int time, int boardStop, int boardTime, T trip, boolean bestTime) {
+  void transitToStop(int stop, int time, int boardStopPosition, T trip, boolean bestTime) {
     var state = getOrCreateStopIndex(round, stop);
 
-    state.arriveByTransit(time, boardStop, boardTime, trip);
+    state.arriveByTransit(time, boardStopPosition, trip);
 
     if (bestTime) {
       state.setBestTimeTransit(time);

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/StdStopArrivalsState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/StdStopArrivalsState.java
@@ -45,12 +45,11 @@ public final class StdStopArrivalsState<T extends RaptorTripSchedule>
   public void setNewBestTransitTime(
     int stop,
     int alightTime,
+    int boardStopPosition,
     T trip,
-    int boardStop,
-    int boardTime,
     boolean newBestOverall
   ) {
-    stops.transitToStop(stop, alightTime, boardStop, boardTime, trip, newBestOverall);
+    stops.transitToStop(stop, alightTime, boardStopPosition, trip, newBestOverall);
   }
 
   @Override

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/StopArrivalState.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/StopArrivalState.java
@@ -53,9 +53,9 @@ public interface StopArrivalState<T extends RaptorTripSchedule> {
 
   int boardTime();
 
-  int boardStop();
+  int boardStopPosition();
 
-  void arriveByTransit(int arrivalTime, int boardStop, int boardTime, T trip);
+  void arriveByTransit(int arrivalTime, int boardStopPosition, T trip);
 
   /* Transfer */
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/view/StopsCursor.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/view/StopsCursor.java
@@ -82,12 +82,11 @@ public class StopsCursor<T extends RaptorTripSchedule> {
     int round,
     int alightStop,
     int alightTime,
-    T trip,
-    int boardStop,
-    int boardTime
+    int boardStopPosition,
+    T trip
   ) {
     StopArrivalState<T> arrival = StopArrivalState.create();
-    arrival.arriveByTransit(alightTime, boardStop, boardTime, trip);
+    arrival.arriveByTransit(alightTime, boardStopPosition, trip);
     return new Transit<>(round, alightStop, arrival, this);
   }
 

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/view/Transit.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/view/Transit.java
@@ -40,7 +40,7 @@ final class Transit<T extends RaptorTripSchedule>
 
   @Override
   public ArrivalView<T> previous() {
-    return cursor.stop(round() - 1, boardStop(), this);
+    return cursor.stop(round() - 1, boardStopIndex(), this);
   }
 
   @Override
@@ -54,8 +54,13 @@ final class Transit<T extends RaptorTripSchedule>
   }
 
   @Override
-  public int boardStop() {
-    return arrival.boardStop();
+  public int boardStopIndex() {
+    return arrival.trip().pattern().stopIndex(boardStopPosition());
+  }
+
+  @Override
+  public int boardStopPosition() {
+    return arrival.boardStopPosition();
   }
 
   @Override

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/view/Transit.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/standard/stoparrivals/view/Transit.java
@@ -54,11 +54,6 @@ final class Transit<T extends RaptorTripSchedule>
   }
 
   @Override
-  public int boardStopIndex() {
-    return arrival.trip().pattern().stopIndex(boardStopPosition());
-  }
-
-  @Override
   public int boardStopPosition() {
     return arrival.boardStopPosition();
   }
@@ -75,5 +70,9 @@ final class Transit<T extends RaptorTripSchedule>
   @Override
   public boolean arrivedOnBoard() {
     return true;
+  }
+
+  private int boardStopIndex() {
+    return arrival.trip().pattern().stopIndex(boardStopPosition());
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/TripTimesSearch.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/TripTimesSearch.java
@@ -37,7 +37,7 @@ public class TripTimesSearch<T extends RaptorTripSchedule> {
     ArrivalView<S> arrival
   ) {
     var transit = arrival.transitPath();
-    var search = new TripTimesSearch<>(transit.trip(), transit.boardStop(), arrival.stop());
+    var search = new TripTimesSearch<>(transit.trip(), transit.boardStopIndex(), arrival.stop());
     return search.findTripTimesBefore(arrival.arrivalTime());
   }
 
@@ -49,7 +49,7 @@ public class TripTimesSearch<T extends RaptorTripSchedule> {
     ArrivalView<S> arrival
   ) {
     var transit = arrival.transitPath();
-    var search = new TripTimesSearch<>(transit.trip(), arrival.stop(), transit.boardStop());
+    var search = new TripTimesSearch<>(transit.trip(), arrival.stop(), transit.boardStopIndex());
     return search.findTripTimesAfter(arrival.arrivalTime());
   }
 
@@ -64,7 +64,7 @@ public class TripTimesSearch<T extends RaptorTripSchedule> {
     S extends RaptorTripSchedule
   > BoardAndAlightTime findTripForwardSearchApproximateTime(ArrivalView<S> arrival) {
     var t = arrival.transitPath();
-    return findTripTimes(t.trip(), t.boardStop(), arrival.stop(), arrival.arrivalTime());
+    return findTripTimes(t.trip(), t.boardStopIndex(), arrival.stop(), arrival.arrivalTime());
   }
 
   /**
@@ -78,7 +78,7 @@ public class TripTimesSearch<T extends RaptorTripSchedule> {
     S extends RaptorTripSchedule
   > BoardAndAlightTime findTripReverseSearchApproximateTime(ArrivalView<S> arrival) {
     var t = arrival.transitPath();
-    return findTripTimes(t.trip(), arrival.stop(), t.boardStop(), arrival.arrivalTime());
+    return findTripTimes(t.trip(), arrival.stop(), t.boardStopIndex(), arrival.arrivalTime());
   }
 
   /**

--- a/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/TripTimesSearch.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/rangeraptor/transit/TripTimesSearch.java
@@ -2,32 +2,22 @@ package org.opentripplanner.raptor.rangeraptor.transit;
 
 import org.opentripplanner.raptor.api.view.ArrivalView;
 import org.opentripplanner.raptor.spi.BoardAndAlightTime;
-import org.opentripplanner.raptor.spi.RaptorTripPattern;
 import org.opentripplanner.raptor.spi.RaptorTripSchedule;
-import org.opentripplanner.utils.time.TimeUtils;
 
 /**
  * This class is used to find the board and alight time for a known trip, where you now the
- * board-stop and the alight-stop. You must also specify either a earliest-board-time or a
+ * board-stop and the alight-stop. You must also specify either an earliest-board-time or a
  * latest-alight-time - this is done to avoid boarding at the correct stop, but at the wrong time.
- * This can happen for patterns goes in a loop, visit the same stop more than once.
+ * This can happen, for patterns go in a loop, visit the same stop more than once.
  * <p>
  * This class is used to find board- and alight-times for transfer paths when mapping stop-arrivals
  * to paths. The board and alight times are not stored in the stop-arrival state to save memory and
  * to speed up the search. Searching for this after the search is done to create paths is ok, since
- * the number of paths are a very small number compared to stop-arrivals during the search.
+ * the number of paths is a very small number compared to stop-arrivals during the search.
  */
-public class TripTimesSearch<T extends RaptorTripSchedule> {
+public final class TripTimesSearch<T extends RaptorTripSchedule> {
 
-  private final T schedule;
-  private final int fromStop;
-  private final int toStop;
-
-  private TripTimesSearch(T schedule, int fromStop, int toStop) {
-    this.schedule = schedule;
-    this.fromStop = fromStop;
-    this.toStop = toStop;
-  }
+  private TripTimesSearch() {}
 
   /**
    * Search for board- and alight-times for the trip matching the given stop-arrival when searching
@@ -37,8 +27,26 @@ public class TripTimesSearch<T extends RaptorTripSchedule> {
     ArrivalView<S> arrival
   ) {
     var transit = arrival.transitPath();
-    var search = new TripTimesSearch<>(transit.trip(), transit.boardStopIndex(), arrival.stop());
-    return search.findTripTimesBefore(arrival.arrivalTime());
+    var trip = transit.trip();
+    int boardStopPos = transit.boardStopPosition();
+    int alightStopPosition = trip
+      .pattern()
+      .findAlightStopPositionAfter(boardStopPos, arrival.stop());
+
+    if (alightStopPosition == -1) {
+      throw new IllegalStateException(
+        "Alight stop position not found: " +
+          " boardStopPosition: " +
+          boardStopPos +
+          ", arrival.stop: " +
+          arrival.stop() +
+          ", pattern: " +
+          trip.pattern().debugInfo() +
+          "]"
+      );
+    }
+
+    return new BoardAndAlightTime(trip, boardStopPos, alightStopPosition);
   }
 
   /**
@@ -49,204 +57,25 @@ public class TripTimesSearch<T extends RaptorTripSchedule> {
     ArrivalView<S> arrival
   ) {
     var transit = arrival.transitPath();
-    var search = new TripTimesSearch<>(transit.trip(), arrival.stop(), transit.boardStopIndex());
-    return search.findTripTimesAfter(arrival.arrivalTime());
-  }
+    var trip = transit.trip();
+    int alightStopPosition = transit.boardStopPosition();
+    int boardStopPos = trip
+      .pattern()
+      .findBoardStopPositionBefore(alightStopPosition, arrival.stop());
 
-  /**
-   * Search for board- and alight-times for the trip matching the given stop-arrival when searching
-   * FORWARD. Hence, searching in the same direction as the trip travel direction.
-   * <p>
-   * This uses the approximate-time search, see {@link #findTripTimes(RaptorTripSchedule, int, int,
-   * int)}.
-   */
-  public static <
-    S extends RaptorTripSchedule
-  > BoardAndAlightTime findTripForwardSearchApproximateTime(ArrivalView<S> arrival) {
-    var t = arrival.transitPath();
-    return findTripTimes(t.trip(), t.boardStopIndex(), arrival.stop(), arrival.arrivalTime());
-  }
-
-  /**
-   * Search for board- and alight-times for the trip matching the given stop-arrival when searching
-   * in REVERSE. Hence, searching in the opposite direction of the trip travel direction.
-   * <p>
-   * This uses the approximate-time search, see {@link #findTripTimes(RaptorTripSchedule, int, int,
-   * int)}.
-   */
-  public static <
-    S extends RaptorTripSchedule
-  > BoardAndAlightTime findTripReverseSearchApproximateTime(ArrivalView<S> arrival) {
-    var t = arrival.transitPath();
-    return findTripTimes(t.trip(), arrival.stop(), t.boardStopIndex(), arrival.arrivalTime());
-  }
-
-  /**
-   * Search for board- and alight-times for the trip matching the given {@code approximateTime}.
-   * This is slower than the more specific methods and not as correct - it is possible to construct
-   * cases with looping patterns where this method may find the wrong trip. But, it is safe - it
-   * will always find a trip if it exists. Can be used in tests, logging and debugging, but avoid
-   * using it in path mapping.
-   */
-  public static <S extends RaptorTripSchedule> BoardAndAlightTime findTripTimes(
-    S trip,
-    int fromStop,
-    int toStop,
-    int approximateTime
-  ) {
-    var search = new TripTimesSearch<>(trip, fromStop, toStop);
-    return search.findTripByApproximateTime(approximateTime);
-  }
-
-  /* private methods */
-
-  private BoardAndAlightTime findTripTimesAfter(final int earliestDepartureTime) {
-    RaptorTripPattern p = schedule.pattern();
-    final int size = p.numberOfStopsInPattern();
-
-    int i = schedule.findDepartureStopPosition(earliestDepartureTime, fromStop);
-
-    if (i < 0) {
-      throw notFoundException(
-        "No stops matching 'fromStop'",
-        "earliestDepartureTime",
-        earliestDepartureTime
+    if (boardStopPos == -1) {
+      throw new IllegalStateException(
+        "Board stop position not found: " +
+          " alightStopPosition: " +
+          alightStopPosition +
+          ", arrival.stop: " +
+          arrival.stop() +
+          ", pattern: " +
+          trip.pattern().debugInfo() +
+          "]"
       );
     }
 
-    int boardStopPos = i;
-
-    // Goto next stop, boarding and alighting can not happen on the same stop
-    ++i;
-
-    // Search for arrival
-    while (i < size && p.stopIndex(i) != toStop) {
-      ++i;
-    }
-
-    if (i == size) {
-      throw notFoundException(
-        "No stops matching 'toStop'",
-        "earliestDepartureTime",
-        earliestDepartureTime
-      );
-    }
-    return new BoardAndAlightTime(schedule, boardStopPos, i);
-  }
-
-  private BoardAndAlightTime findTripTimesBefore(int latestArrivalTime) {
-    RaptorTripPattern p = schedule.pattern();
-    int i = schedule.findArrivalStopPosition(latestArrivalTime, toStop);
-
-    if (i < 0) {
-      throw notFoundException("No stops matching 'toStop'", "latestArrivalTime", latestArrivalTime);
-    }
-
-    int alightStopPos = i;
-
-    // Goto next stop, boarding and alighting can not happen on the same stop
-    --i;
-
-    // Search for departure
-    while (i >= 0 && p.stopIndex(i) != fromStop) {
-      --i;
-    }
-
-    if (i < 0) {
-      throw notFoundException(
-        "No stops matching 'fromStop'",
-        "latestArrivalTime",
-        latestArrivalTime
-      );
-    }
-    return new BoardAndAlightTime(schedule, i, alightStopPos);
-  }
-
-  /**
-   * Find the trip that is closest in time to the given {@code approximateTime}.
-   * <p>
-   * If the approximate time is closer to the next trip, then the total time will be larger the 4
-   * times the approximate time:
-   * <ul>
-   *   <li>Let the current trip board and alight times be: {@code a & b}</li>
-   *   <li>Let the next trip board and alight times be: {@code c & d}</li>
-   *   <li>Let approximate-time be: {@code T}</li>
-   * </ul>
-   * Then T is closer to [a,b] then [c,d] if:
-   * <pre>
-   *   x - (a+b)/2  < (c+d)/2 + x
-   *   2x < (c+d)/2 + (a+b)/2
-   *   4x <  (a+b+c+d)
-   * </pre>
-   */
-  private BoardAndAlightTime findTripByApproximateTime(int approximateTime) {
-    RaptorTripPattern p = schedule.pattern();
-
-    int fromPos = stopPosAfter(p, 0, fromStop, approximateTime);
-    int toPos = stopPosAfter(p, fromPos + 1, toStop, approximateTime);
-    // Step back to find the closest departure stop in case there are more than one
-    fromPos = stopPosBefore(p, toPos - 1, fromStop, approximateTime);
-
-    try {
-      while (true) {
-        // Try to find next possible trip [if pattern runs in a loop]
-        int nextFromPos = stopPosAfter(p, fromPos + 1, fromStop, approximateTime);
-        int nextToPos = stopPosAfter(p, nextFromPos + 1, toStop, approximateTime);
-        nextFromPos = stopPosBefore(p, nextToPos - 1, fromStop, approximateTime);
-
-        int totTime =
-          schedule.departure(fromPos) +
-          schedule.arrival(toPos) +
-          schedule.departure(nextFromPos) +
-          schedule.arrival(nextToPos);
-
-        if (totTime >= 4 * approximateTime) {
-          break;
-        }
-
-        fromPos = nextFromPos;
-        toPos = nextToPos;
-      }
-    } catch (IllegalStateException _) {
-      /* No more times/loop exist */
-    }
-
-    return new BoardAndAlightTime(schedule, fromPos, toPos);
-  }
-
-  private int stopPosAfter(RaptorTripPattern p, int startPos, int stopIndex, int time) {
-    int stopPos = p.findStopPositionAfter(startPos, stopIndex);
-    return stopPosExist(stopPos, stopIndex, time);
-  }
-
-  private int stopPosBefore(RaptorTripPattern p, int startPos, int stopIndex, int time) {
-    int stopPos = p.findStopPositionBefore(startPos, stopIndex);
-    return stopPosExist(stopPos, stopIndex, time);
-  }
-
-  private int stopPosExist(int pos, int stop, int time) {
-    if (pos < 0) {
-      throw notFoundException("No stop matching " + stop, "approximateTime", time);
-    }
-    return pos;
-  }
-
-  private IllegalStateException notFoundException(String hint, String lbl, int time) {
-    return new IllegalStateException(
-      "Trip not found: " +
-        hint +
-        ". " +
-        " [FromStop: " +
-        fromStop +
-        ", toStop: " +
-        toStop +
-        ", " +
-        lbl +
-        ": " +
-        TimeUtils.timeToStrLong(time) +
-        ", pattern: " +
-        schedule.pattern().debugInfo() +
-        "]"
-    );
+    return new BoardAndAlightTime(trip, boardStopPos, alightStopPosition);
   }
 }

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorPathConstrainedTransferSearch.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorPathConstrainedTransferSearch.java
@@ -3,7 +3,7 @@ package org.opentripplanner.raptor.spi;
 import javax.annotation.Nullable;
 
 /**
- * This interface is used by Raptor to create a path from the Raptor state. We do not keep
+ * Raptor uses this interface to create a path from the Raptor state. We do not keep
  * constraints during the search, so we need to look it up when building the path.
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripPattern.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripPattern.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.raptor.spi;
 
 /**
- * This interface represent a trip pattern. A trip-pattern in the raptor context is just a list of
+ * This interface represents a trip pattern. A trip-pattern in the raptor context is just a list of
  * stops visited by ALL trips in the pattern. The stops must be ordered in the same sequence, with
  * no gaps, as the trips visit the stops.
  */
@@ -16,7 +16,7 @@ public interface RaptorTripPattern {
   /**
    * The stop index
    *
-   * @param stopPositionInPattern stop position number in pattern, starting at 0.
+   * @param stopPositionInPattern stop position number in the pattern, starting at 0.
    */
   int stopIndex(int stopPositionInPattern);
 
@@ -25,14 +25,14 @@ public interface RaptorTripPattern {
    * include checks like: Does the pattern allow boarding at the given stop? Is this accessible to
    * wheelchairs (if requested).
    *
-   * @param stopPositionInPattern stop position number in pattern, starting at 0.
+   * @param stopPositionInPattern stop position number in the pattern, starting at 0.
    */
   boolean boardingPossibleAt(int stopPositionInPattern);
 
   /**
    * Same as {@link #boardingPossibleAt(int)}, but for getting off a trip.
    *
-   * @param stopPositionInPattern stop position number in pattern, starting at 0.
+   * @param stopPositionInPattern stop position number in the pattern, starting at 0.
    */
   boolean alightingPossibleAt(int stopPositionInPattern);
 
@@ -50,9 +50,9 @@ public interface RaptorTripPattern {
   int priorityGroupId();
 
   /**
-   * Pattern debug info, return transit mode and route name. This is  used for debugging purposes
+   * Pattern debug info, return transit mode and route name. This is used for debugging purposes
    * only. The implementation should provide a short description with enough information for humans
-   * to identify the the trip/route. This is is used in a context where information about agency and
+   * to identify the trip/route. This is used in a context where information about agency and
    * stop is known, so there is no need to include agency or geographical region information.
    * <p/>
    * The recommended string to return is: {@code [MODE] [SHORT_ROUTE_DESCRIPTION]}.
@@ -61,16 +61,19 @@ public interface RaptorTripPattern {
 
   /**
    * Return the first occurrence of the stop position for the given stop index after the given
-   * startPosition(inclusive). Note that the returned value might not be the only occurrence, if the
+   * startPosition(inclusive). Note that the returned value might not be the only occurrence if the
    * pattern goes in a loop.
    * <p>
    * {@code -1} is returned if not found.
    *
    * @param startPos  the stop position in pattern to start the search (inclusive)
    * @param stopIndex the stopIndex to find
+   *
+   * @deprecated
    */
+  @Deprecated
   default int findStopPositionAfter(int startPos, int stopIndex) {
-    for (int i = startPos; i < numberOfStopsInPattern(); i++) {
+    for (int i = startPos; i < numberOfStopsInPattern(); ++i) {
       if (stopIndex == stopIndex(i)) {
         return i;
       }
@@ -80,12 +83,12 @@ public interface RaptorTripPattern {
 
   /**
    * Return the first occurrence of the stop position for the given stop index before the given
-   * stopPosition. Note that the returned value might not be the only occurrence, if the pattern
+   * stopPosition. Note that the returned value might not be the only occurrence if the pattern
    * goes in a loop.
    * <p>
    * {@code -1} is returned if not found.
    *
-   * @param startPos  the stop position in pattern to start the search (inclusive)
+   * @param startPos  the stop position in the pattern to start the search (inclusive)
    * @param stopIndex the stopIndex to find
    */
   default int findStopPositionBefore(int startPos, int stopIndex) {

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripPattern.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripPattern.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.raptor.spi;
 
+import org.opentripplanner.utils.lang.IntUtils;
+
 /**
  * This interface represents a trip pattern. A trip-pattern in the raptor context is just a list of
  * stops visited by ALL trips in the pattern. The stops must be ordered in the same sequence, with
@@ -82,9 +84,50 @@ public interface RaptorTripPattern {
   }
 
   /**
+   * Return the first occurrence of the stop position for the given stop index after the given
+   * startPosition(exclusive) where alighting is possible.
+   * <p>
+   * {@code -1} is returned if not found.
+   *
+   * @param startPos  the stop position in the pattern to start the search (exclusive). Note! Only
+   *                  defined for range {@code [0..N]}  (N = number of stops in the pattern).
+   * @param alightStopIndex the stopIndex to find
+   */
+  default int findAlightStopPositionBefore(int startPos, int alightStopIndex) {
+    IntUtils.requireInRange(startPos, 0, numberOfStopsInPattern(), "startPos");
+    for (int i = startPos - 1; i > 0; --i) {
+      if (alightStopIndex == stopIndex(i) && alightingPossibleAt(i)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Return the first occurrence of the stop position for the given stop index after the given
+   * startPos(exclusive) where alighting is possible. Note that the returned value might not be the
+   * only occurrence if the pattern goes in a loop.
+   * <p>
+   * {@code -1} is returned if not found.
+   *
+   * @param startPos  the stop position in the pattern to start the search (exclusive). Note! Only
+   *                  defined for range {@code [0..N-1]} (N = number of stops in the pattern).
+   * @param alightStopIndex the stopIndex to find
+   */
+  default int findAlightStopPositionAfter(int startPos, int alightStopIndex) {
+    IntUtils.requireInRange(startPos, 0, numberOfStopsInPattern() - 1, "startPos");
+    for (int i = startPos + 1; i < numberOfStopsInPattern(); ++i) {
+      if (alightStopIndex == stopIndex(i) && alightingPossibleAt(i)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
    * Return the first occurrence of the stop position for the given stop index before the given
-   * stopPosition. Note that the returned value might not be the only occurrence if the pattern
-   * goes in a loop.
+   * startPos(inclusive). Note that the returned value might not be the only occurrence if the
+   * pattern goes in a loop.
    * <p>
    * {@code -1} is returned if not found.
    *
@@ -94,6 +137,48 @@ public interface RaptorTripPattern {
   default int findStopPositionBefore(int startPos, int stopIndex) {
     for (int i = startPos; i >= 0; i--) {
       if (stopIndex == stopIndex(i)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Return the first occurrence of the stop position for the given stop index before the given
+   * startPos(exclusive). Note that the returned value might not be the only occurrence if the
+   * pattern goes in a loop.
+   * <p>
+   * {@code -1} is returned if not found.
+   *
+   * @param startPos  the stop position in the pattern to start the search (exclusive). Note! Only
+   *                  defined for range {@code [0..N-1]} (N = number of stops in the pattern).
+   * @param boardStopIndex the stopIndex to find
+   */
+  default int findBoardStopPositionBefore(int startPos, int boardStopIndex) {
+    IntUtils.requireInRange(startPos, 0, numberOfStopsInPattern() - 1, "startPos");
+    for (int i = startPos - 1; i >= 0; --i) {
+      if (boardStopIndex == stopIndex(i) && boardingPossibleAt(i)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Return the first occurrence of the stop position for the given stop index at or after the
+   * given startPos(inclusive). Note that the returned value might not be the only occurrence if
+   * the pattern goes in a loop.
+   * <p>
+   * {@code -1} is returned if not found.
+   *
+   * @param startPos the stop position in the pattern to start the search (inclusive). Note! Only
+   *    *            defined for range {@code [0..N-1]} (N = number of stops in the pattern).
+   * @param boardStopIndex the stopIndex to find
+   */
+  default int findBoardStopPositionAfter(int startPos, int boardStopIndex) {
+    IntUtils.requireInRange(startPos, 0, numberOfStopsInPattern() - 1, "startPos");
+    for (int i = startPos; i < numberOfStopsInPattern() - 1; ++i) {
+      if (boardStopIndex == stopIndex(i) && boardingPossibleAt(i)) {
         return i;
       }
     }

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripPattern.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripPattern.java
@@ -63,28 +63,6 @@ public interface RaptorTripPattern {
 
   /**
    * Return the first occurrence of the stop position for the given stop index after the given
-   * startPosition(inclusive). Note that the returned value might not be the only occurrence if the
-   * pattern goes in a loop.
-   * <p>
-   * {@code -1} is returned if not found.
-   *
-   * @param startPos  the stop position in pattern to start the search (inclusive)
-   * @param stopIndex the stopIndex to find
-   *
-   * @deprecated
-   */
-  @Deprecated
-  default int findStopPositionAfter(int startPos, int stopIndex) {
-    for (int i = startPos; i < numberOfStopsInPattern(); ++i) {
-      if (stopIndex == stopIndex(i)) {
-        return i;
-      }
-    }
-    return -1;
-  }
-
-  /**
-   * Return the first occurrence of the stop position for the given stop index after the given
    * startPosition(exclusive) where alighting is possible.
    * <p>
    * {@code -1} is returned if not found.

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
@@ -25,36 +25,12 @@ public interface RaptorTripSchedule {
   int arrival(int stopPosInPattern);
 
   /**
-   * Search for the arrival time for the given stopIndex. This is not optimized for performance.
-   *
-   * @param startStopPos the stop position in pattern to start the search (inclusive).
-   * @param stopIndex    the stop index to find the arrival time for.
-   * @return the arrival time in seconds at the given stop
-   * @throws IndexOutOfBoundsException if {@code stopIndex} is not found
-   */
-  default int arrival(int startStopPos, int stopIndex) {
-    return arrival(pattern().findStopPositionAfter(startStopPos, stopIndex));
-  }
-
-  /**
    * The departure time at the given stop position in pattern.
    *
    * @param stopPosInPattern the stop position.
    * @return the departure time in seconds at the given stop
    */
   int departure(int stopPosInPattern);
-
-  /**
-   * Search for the departure time for the given stopIndex. This is not optimized for performance.
-   *
-   * @param startStopPos the stop position in pattern to start the search (inclusive).
-   * @param stopIndex    the stop index to find the departure time for.
-   * @return the departure time in seconds at the given stop
-   * @throws IndexOutOfBoundsException if stopIndex is not found
-   */
-  default int departure(int startStopPos, int stopIndex) {
-    return departure(pattern().findStopPositionAfter(startStopPos, stopIndex));
-  }
 
   /// The relative-travel-duration is a proxy for time spent on transit from the boarding stop to
   /// the alight stop. We do not know the alight stop, so it is impossible to calculate the

--- a/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
+++ b/raptor/src/main/java/org/opentripplanner/raptor/spi/RaptorTripSchedule.java
@@ -57,49 +57,53 @@ public interface RaptorTripSchedule {
   RaptorTripPattern pattern();
 
   /**
-   * Search for the arrival stop position for the given trip, latest arrival time, and stop index.
-   * We need the time in addition to the stop in cases where the trip pattern visits the same stop
-   * twice. Also, the time alone is not sufficient, since more than one stop could have the exact
+   * Search for the arrival stop position for the latest arrival time and stop index. We need the
+   * time in addition to the stop in cases where the trip pattern loops, visits the same stop
+   * twice. Also, the time alone is not enough, since more than one stop could have the exact
    * same arrival time.
    * <p>
-   * Raptor saves memory by NOT storing board/alight stop positions in the pattern; therefore, we
-   * need this method when mapping to an itinerary or Raptor path.
-   * <p>
-   * Avoid using this during routing, as it is not optimized for performance.
+   * Consider using position-based methods in {@link RaptorTripPattern} if possible.
    *
    * @return the stop position in the trip pattern if found; otherwise, -1
    */
   default int findArrivalStopPosition(int latestArrivalTime, int stop) {
-    RaptorTripPattern p = pattern();
+    var p = pattern();
+    int i = p.findAlightStopPositionBefore(p.numberOfStopsInPattern(), stop);
 
-    int end = p.numberOfStopsInPattern() - 1;
-    // Skip position 0 — cannot alight where the trip originates
-    for (int i = end; i > 0; i--) {
-      if (!p.alightingPossibleAt(i) || arrival(i) > latestArrivalTime) {
-        continue;
-      }
-      if (p.stopIndex(i) == stop) {
-        return i;
-      }
+    while (i != -1 && arrival(i) > latestArrivalTime) {
+      i = p.findAlightStopPositionBefore(i, stop);
     }
-    return -1;
+    return i;
   }
 
   /**
-   * Search for the departure stop position for the given trip, earliest departure time, and stop
-   * index. We need the time in addition to the stop in cases where the trip pattern visits the
-   * same stop twice. Also, the time alone is not sufficient, since more than one stop could have
-   * the exact same departure time.
-   * <p>
-   * Raptor saves memory by NOT storing board/alight stop positions in the pattern; therefore, we
-   * need this method when mapping to an itinerary or Raptor path.
-   * <p>
-   * Avoid using this during routing, as it is not optimized for performance.
-   *
-   * @return the stop position in the trip pattern if found; otherwise, -1
+   * Same as {@code #findDepartureStopPosition(0, earliestDepartureTime, stop)}.
+   * @see #findDepartureStopPosition(int, int, int)
    */
   default int findDepartureStopPosition(int earliestDepartureTime, int stop) {
     return findDepartureStopPosition(0, earliestDepartureTime, stop);
+  }
+
+  /**
+   * Find the departure stop position for a stop index after the given earliest departure time
+   * (inclusive), starting the search at the given start stop position. This method returns the
+   * first stop position found, or -1 if no stop position is found.
+   * <p>
+   * Consider using position-based methods in {@link RaptorTripPattern} if possible.
+   *
+   * @param startStopPos the start stop position to search from
+   * @param earliestDepartureTime the earliest departure time to search for (inclusive)
+   * @param stop the stop index to search for
+   * @return the stop position in the trip pattern if found; otherwise, -1
+   */
+  default int findDepartureStopPosition(int startStopPos, int earliestDepartureTime, int stop) {
+    var p = pattern();
+    int i = p.findBoardStopPositionAfter(startStopPos, stop);
+
+    while (i != -1 && departure(i) < earliestDepartureTime) {
+      i = p.findBoardStopPositionAfter(i + 1, stop);
+    }
+    return i;
   }
 
   /**
@@ -129,32 +133,5 @@ public interface RaptorTripSchedule {
       i = findDepartureStopPosition(i + 1, earliestDepartureTime, stop);
     } while (i != -1);
     return IntIterators.of(stops);
-  }
-
-  /**
-   * Find the departure stop position for a stop index after the given earliest departure time
-   * (inclusive), starting the search at the given start stop position. This method returns the
-   * first stop position found, or -1 if no stop position is found.
-   *
-   * @param startStopPos the start stop position to search from
-   * @param earliestDepartureTime the earliest departure time to search for (inclusive)
-   * @param stop the stop index to search for
-   * @return the stop position in the trip pattern if found; otherwise, -1
-   */
-  default int findDepartureStopPosition(int startStopPos, int earliestDepartureTime, int stop) {
-    var p = pattern();
-
-    // Skip last stop position — cannot board at the trip destination
-    final int end = p.numberOfStopsInPattern() - 1;
-
-    for (int i = startStopPos; i < end; i++) {
-      if (!p.boardingPossibleAt(i) || departure(i) < earliestDepartureTime) {
-        continue;
-      }
-      if (p.stopIndex(i) == stop) {
-        return i;
-      }
-    }
-    return -1;
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
@@ -85,7 +85,7 @@ public class TestPathBuilder implements RaptorTestConstants {
     int boardStop = currentStop();
     // We use the last leg arrival-time as the earliest-board-time; this may cause problems for
     // testing circular routes. Create a new factory method if this happens.
-    int boardStopPosition = trip.findDepartureStopPosition(0, currentArrivalTime(), boardStop);
+    int boardStopPosition = trip.findDepartureStopPosition(currentArrivalTime(), boardStop);
     int alighttStopPosition = trip.pattern().findStopPositionAfter(boardStopPosition, alightStop);
     var baTime = new BoardAndAlightTime(trip, boardStopPosition, alighttStopPosition);
     builder.transit(trip, baTime);

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.raptor._data.api;
 
-import static org.opentripplanner.raptor.rangeraptor.transit.TripTimesSearch.findTripTimes;
-
 import javax.annotation.Nullable;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
@@ -10,6 +8,7 @@ import org.opentripplanner.raptor._data.transit.TestTripPattern;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.path.RaptorPath;
 import org.opentripplanner.raptor.path.PathBuilder;
+import org.opentripplanner.raptor.spi.BoardAndAlightTime;
 import org.opentripplanner.raptor.spi.RaptorConstants;
 import org.opentripplanner.raptor.spi.RaptorCostCalculator;
 import org.opentripplanner.raptor.spi.RaptorSlackProvider;
@@ -18,7 +17,7 @@ import org.opentripplanner.raptor.spi.TestSlackProvider;
 
 /**
  * Utility to help build paths for testing. The path builder is "reusable", every time the {@code
- * access(...)} methods are called the builder reset it self.
+ * access(...)} methods are called the builder reset itself.
  * <p>
  * If the {@code costCalculator} is null, paths will not include cost.
  */
@@ -84,10 +83,11 @@ public class TestPathBuilder implements RaptorTestConstants {
 
   public TestPathBuilder bus(TestTripSchedule trip, int alightStop) {
     int boardStop = currentStop();
-    // We use the startTime as earliest-board-time, this may cause problems for
-    // testing routes visiting the same stop more than once. Create a new factory
-    // method if this happens.
-    var baTime = findTripTimes(trip, boardStop, alightStop, startTime);
+    // We use the last leg arrival-time as the earliest-board-time; this may cause problems for
+    // testing circular routes. Create a new factory method if this happens.
+    int boardStopPosition = trip.findDepartureStopPosition(0, currentArrivalTime(), boardStop);
+    int alighttStopPosition = trip.pattern().findStopPositionAfter(boardStopPosition, alightStop);
+    var baTime = new BoardAndAlightTime(trip, boardStopPosition, alighttStopPosition);
     builder.transit(trip, baTime);
     return this;
   }
@@ -124,6 +124,10 @@ public class TestPathBuilder implements RaptorTestConstants {
 
   int currentStop() {
     return builder.tail().toStop();
+  }
+
+  int currentArrivalTime() {
+    return builder.tail().toTime();
   }
 
   private void reset(int startTime) {

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
@@ -86,7 +86,9 @@ public class TestPathBuilder implements RaptorTestConstants {
     // We use the last leg arrival-time as the earliest-board-time; this may cause problems for
     // testing circular routes. Create a new factory method if this happens.
     int boardStopPosition = trip.findDepartureStopPosition(currentArrivalTime(), boardStop);
-    int alightStopPosition = trip.pattern().findStopPositionAfter(boardStopPosition, alightStop);
+    int alightStopPosition = trip
+      .pattern()
+      .findAlightStopPositionAfter(boardStopPosition, alightStop);
     var baTime = new BoardAndAlightTime(trip, boardStopPosition, alightStopPosition);
     builder.transit(trip, baTime);
     return this;

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/api/TestPathBuilder.java
@@ -86,8 +86,8 @@ public class TestPathBuilder implements RaptorTestConstants {
     // We use the last leg arrival-time as the earliest-board-time; this may cause problems for
     // testing circular routes. Create a new factory method if this happens.
     int boardStopPosition = trip.findDepartureStopPosition(currentArrivalTime(), boardStop);
-    int alighttStopPosition = trip.pattern().findStopPositionAfter(boardStopPosition, alightStop);
-    var baTime = new BoardAndAlightTime(trip, boardStopPosition, alighttStopPosition);
+    int alightStopPosition = trip.pattern().findStopPositionAfter(boardStopPosition, alightStop);
+    var baTime = new BoardAndAlightTime(trip, boardStopPosition, alightStopPosition);
     builder.transit(trip, baTime);
     return this;
   }

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/AccessAndEgressWithOpeningHoursPathTestCase.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/AccessAndEgressWithOpeningHoursPathTestCase.java
@@ -3,6 +3,7 @@ package org.opentripplanner.raptor._data.stoparrival;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.access;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.bus;
+import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.busReverseSearch;
 import static org.opentripplanner.raptor.api.model.RaptorValueType.C1;
 import static org.opentripplanner.raptor.spi.RaptorCostConverter.toRaptorCost;
 import static org.opentripplanner.utils.time.DurationUtils.durationInSeconds;
@@ -337,7 +338,7 @@ public class AccessAndEgressWithOpeningHoursPathTestCase implements RaptorTestCo
       prevArrival = access(egressPath.stop(), arrivalTime, egressPath);
 
       cost = costL1ReverseIncWait(prevArrival.arrivalTime());
-      prevArrival = bus(2, STOP_A, L1_STOP_ARR_TIME_REV, cost, 0, TRIP_A, prevArrival);
+      prevArrival = busReverseSearch(2, STOP_A, L1_STOP_ARR_TIME_REV, cost, 0, TRIP_A, prevArrival);
     } else {
       arrivalTime = L1_END + ALIGHT_SLACK + TX2_DURATION + TRANSFER_SLACK;
       arrivalTime = egressPath.earliestDepartureTime(arrivalTime);
@@ -345,7 +346,7 @@ public class AccessAndEgressWithOpeningHoursPathTestCase implements RaptorTestCo
       arrivalTime = prevArrival.arrivalTime() - TX2_DURATION;
       prevArrival = new Transfer(1, arrivalTime, TX2_TRANSFER_REV, prevArrival);
       cost = costL1ReverseIncWait(prevArrival.arrivalTime());
-      prevArrival = bus(2, STOP_B, L1_STOP_ARR_TIME_REV, cost, 0, TRIP_B, prevArrival);
+      prevArrival = busReverseSearch(2, STOP_B, L1_STOP_ARR_TIME_REV, cost, 0, TRIP_B, prevArrival);
       arrivalTime = prevArrival.arrivalTime() - TX1_DURATION;
       prevArrival = new Transfer(2, arrivalTime, TX1_TRANSFER_REV, prevArrival);
     }

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/BasicPathTestCase.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/BasicPathTestCase.java
@@ -3,6 +3,7 @@ package org.opentripplanner.raptor._data.stoparrival;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.access;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.bus;
+import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.busReverseSearch;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.egress;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.transfer;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
@@ -240,10 +241,34 @@ public class BasicPathTestCase implements RaptorTestConstants {
     ArrivalView<TestTripSchedule> nextArrival, egress;
     nextArrival = access(STOP_E, EGRESS_END, EGRESS_START, EGRESS_C1, EGRESS_C2);
     // Board slack is subtracted from the arrival time to get the latest possible
-    nextArrival = bus(1, STOP_D, L31_START, LINE_31_C1, LINE_31_C2, TRIP_3, nextArrival);
-    nextArrival = bus(2, STOP_C, L21_START, LINE_21_C1, LINE_21_C2, TRIP_2, nextArrival);
+    nextArrival = busReverseSearch(
+      1,
+      STOP_D,
+      L31_START,
+      LINE_31_C1,
+      LINE_31_C2,
+      TRIP_3,
+      nextArrival
+    );
+    nextArrival = busReverseSearch(
+      2,
+      STOP_C,
+      L21_START,
+      LINE_21_C1,
+      LINE_21_C2,
+      TRIP_2,
+      nextArrival
+    );
     nextArrival = transfer(2, STOP_B, TX_END, TX_START, TX_C1, nextArrival);
-    nextArrival = bus(3, STOP_A, L11_START, LINE_11_C1, LINE_11_C2, TRIP_1, nextArrival);
+    nextArrival = busReverseSearch(
+      3,
+      STOP_A,
+      L11_START,
+      LINE_11_C1,
+      LINE_11_C2,
+      TRIP_1,
+      nextArrival
+    );
     egress = egress(ACCESS_END, ACCESS_START, ACCESS_C1, ACCESS_C2, nextArrival);
     return new DestinationArrival<>(
       egress.egressPath().egress(),

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/BasicPathTestCase.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/BasicPathTestCase.java
@@ -294,8 +294,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
       TRIP_3,
       L31_START,
       L31_END,
-      TRIP_3.findDepartureStopPosition(L31_START, STOP_D),
-      TRIP_3.findArrivalStopPosition(L31_END, STOP_E),
+      STOP_POS_0,
+      STOP_POS_1,
       EMPTY_CONSTRAINTS,
       LINE_31_C1,
       leg6
@@ -304,8 +304,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
       TRIP_2,
       L21_START,
       L21_END,
-      TRIP_2.findDepartureStopPosition(L21_START, STOP_C),
-      TRIP_2.findArrivalStopPosition(L21_END, STOP_D),
+      STOP_POS_0,
+      STOP_POS_1,
       EMPTY_CONSTRAINTS,
       LINE_21_C1,
       leg5
@@ -323,8 +323,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
       TRIP_1,
       L11_START,
       L11_END,
-      TRIP_1.findDepartureStopPosition(L11_START, STOP_A),
-      TRIP_1.findArrivalStopPosition(L11_END, STOP_B),
+      STOP_POS_0,
+      STOP_POS_1,
       EMPTY_CONSTRAINTS,
       LINE_11_C1,
       leg3

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/TestArrivals.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/TestArrivals.java
@@ -67,6 +67,9 @@ public class TestArrivals {
     );
   }
 
+  /// This finds the first boarding after the previous arrival. This might not be correct.
+  /// A none zero board-slack or constrained transfer could cause problems, if needed, add andother
+  /// factory method.
   public static ArrivalView<TestTripSchedule> bus(
     int round,
     int stop,
@@ -76,7 +79,8 @@ public class TestArrivals {
     TestTripSchedule trip,
     ArrivalView<TestTripSchedule> previous
   ) {
-    return new Transit(round, stop, arrivalTime, c1, c2, trip, previous);
+    int boardStopPosition = trip.findDepartureStopPosition(previous.arrivalTime(), previous.stop());
+    return new Transit(round, stop, arrivalTime, c1, c2, boardStopPosition, trip, previous);
   }
 
   public static ArrivalView<TestTripSchedule> egress(

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/TestArrivals.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/TestArrivals.java
@@ -83,6 +83,21 @@ public class TestArrivals {
     return new Transit(round, stop, arrivalTime, c1, c2, boardStopPosition, trip, previous);
   }
 
+  /// For reverse search: finds the alight stop position using the previous stop's arrival time.
+  /// The previous stop is the alight stop in the real (forward) direction.
+  public static ArrivalView<TestTripSchedule> busReverseSearch(
+    int round,
+    int stop,
+    int arrivalTime,
+    int c1,
+    int c2,
+    TestTripSchedule trip,
+    ArrivalView<TestTripSchedule> previous
+  ) {
+    int alightStopPosition = trip.findArrivalStopPosition(previous.arrivalTime(), previous.stop());
+    return new Transit(round, stop, arrivalTime, c1, c2, alightStopPosition, trip, previous);
+  }
+
   public static ArrivalView<TestTripSchedule> egress(
     int departureTime,
     int arrivalTime,

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/Transit.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/Transit.java
@@ -38,11 +38,6 @@ class Transit extends AbstractStopArrival implements TransitPathView<TestTripSch
   }
 
   @Override
-  public int boardStopIndex() {
-    return previous().stop();
-  }
-
-  @Override
   public int boardStopPosition() {
     return boardStopPosition;
   }

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/Transit.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/stoparrival/Transit.java
@@ -9,6 +9,7 @@ import org.opentripplanner.raptor.api.view.TransitPathView;
 
 class Transit extends AbstractStopArrival implements TransitPathView<TestTripSchedule> {
 
+  private final int boardStopPosition;
   private final TestTripSchedule trip;
 
   Transit(
@@ -17,10 +18,12 @@ class Transit extends AbstractStopArrival implements TransitPathView<TestTripSch
     int arrivalTime,
     int c1,
     int c2,
+    int boardStopPosition,
     TestTripSchedule trip,
     ArrivalView<TestTripSchedule> previous
   ) {
     super(round, stop, arrivalTime, c1, c2, previous);
+    this.boardStopPosition = boardStopPosition;
     this.trip = trip;
   }
 
@@ -35,8 +38,13 @@ class Transit extends AbstractStopArrival implements TransitPathView<TestTripSch
   }
 
   @Override
-  public int boardStop() {
+  public int boardStopIndex() {
     return previous().stop();
+  }
+
+  @Override
+  public int boardStopPosition() {
+    return boardStopPosition;
   }
 
   @Override

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestConstrainedBoardingSearch.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestConstrainedBoardingSearch.java
@@ -106,8 +106,8 @@ public class TestConstrainedBoardingSearch
         sourceTrip,
         sourceStopPos,
         targetTrip,
-        targetTripIndex,
         targetStopPos,
+        targetTripIndex,
         targetTime
       )
     );

--- a/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/_data/transit/TestTransitData.java
@@ -318,8 +318,8 @@ public class TestTransitData
     int toStop,
     TestTransferConstraint constraint
   ) {
-    int fromStopPos = fromTrip.pattern().findStopPositionAfter(0, fromStop);
-    int toStopPos = toTrip.pattern().findStopPositionAfter(0, toStop);
+    int fromStopPos = fromTrip.pattern().findAlightStopPositionAfter(0, fromStop);
+    int toStopPos = toTrip.pattern().findBoardStopPositionAfter(0, toStop);
 
     for (TestRoute route : routes) {
       route.addTransferConstraint(fromTrip, fromStopPos, toTrip, toStopPos, constraint);

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J08_PassThroughWithConstrainedTransferTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J08_PassThroughWithConstrainedTransferTest.java
@@ -1,0 +1,132 @@
+package org.opentripplanner.raptor.moduletests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
+import static org.opentripplanner.raptor._data.transit.TestTransfer.transfer;
+import static org.opentripplanner.raptor.api.request.via.RaptorViaLocation.passThrough;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.raptor.RaptorService;
+import org.opentripplanner.raptor._data.RaptorTestConstants;
+import org.opentripplanner.raptor._data.transit.TestTransferConstraint;
+import org.opentripplanner.raptor._data.transit.TestTransitData;
+import org.opentripplanner.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.raptor.api.request.RaptorProfile;
+import org.opentripplanner.raptor.configure.RaptorTestFactory;
+import org.opentripplanner.raptor.spi.TestSlackProvider;
+
+/**
+ * FEATURE UNDER TEST
+ * <p>
+ * When a trip passes through a pass-through via point and the boarding was via a constrained
+ * transfer (stay-seated or guaranteed), {@code continueOnSameTripInNextSegment} must correctly
+ * reconstruct the boarding stop position for the trip in the next Raptor segment.
+ * <p>
+ * For a <b>guaranteed (walk) transfer</b>, the walk-arrival time at the boarding stop may exceed
+ * the trip's scheduled departure (the train is held), so a time-based stop-position search fails.
+ * The fallback must find the stop position without relying on the walk-arrival time.
+ */
+class J08_PassThroughWithConstrainedTransferTest implements RaptorTestConstants {
+
+  private final TestTransitData data = new TestTransitData();
+  private final RaptorService<TestTripSchedule> raptorService = RaptorTestFactory.raptorService();
+
+  /**
+   * Stay-seated pass-through: a feeder trip (R1) connects via a stay-seated transfer to a main
+   * trip (R2). The main trip passes through the via point C before reaching the destination D.
+   */
+  @Test
+  void staySeatedTransferWithPassThrough() {
+    data
+      .access("Walk 30s ~ A")
+      .withTimetables(
+        """
+        -- R1
+        A     B
+        0:02  0:05
+        -- R2
+              B     C     D
+              0:05  0:08  0:12
+        """
+      )
+      .egress("D ~ Walk 30s");
+
+    var tripR1 = data.getRoute(0).getTripSchedule(0);
+    var tripR2 = data.getRoute(1).getTripSchedule(0);
+
+    data.withConstrainedTransfer(
+      tripR1,
+      STOP_B,
+      tripR2,
+      STOP_B,
+      TestTransferConstraint.staySeated()
+    );
+    data.withSlackProvider(new TestSlackProvider(D30_s, D20_s, D10_s));
+
+    var requestBuilder = data.requestBuilder();
+    requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).clearOptimizations();
+    requestBuilder
+      .searchParams()
+      .constrainedTransfers(true)
+      .earliestDepartureTime(T00_00)
+      .latestArrivalTime(T00_30)
+      .searchWindow(Duration.ofMinutes(15))
+      .timetable(true)
+      .addViaLocation(passThrough("C").addStop(STOP_C).build());
+
+    assertEquals(
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ BUS R2 0:05 0:12 ~ D ~ Walk 30s [0:01:10 0:12:40 11m30s Tₙ0 C₁1_350]",
+      pathsToString(raptorService.route(requestBuilder.build(), data))
+    );
+  }
+
+  /**
+   * Guaranteed walk transfer with pass-through: a feeder bus (R1) connects via a guaranteed
+   * interchange with a 30s walk to the main train (R2). The walk arrival at the boarding stop
+   * exceeds R2's scheduled departure — the constrained transfer holds the train. R2 then passes
+   * through the via point D before reaching the destination E.
+   * <p>
+   * Without the fix, {@code findDepartureStopPosition(walkArrivalTime=330s, C)} fails because
+   * R2 departed C at 300s — causing the pass-through continuation to be silently dropped.
+   */
+  @Test
+  void guaranteedWalkTransferWithPassThrough() {
+    data
+      .access("Walk 30s ~ A")
+      .withTimetables(
+        """
+        -- R1
+        A     B
+        0:02  0:05
+        -- R2
+        C     D     E
+        0:05  0:08  0:12
+        """
+      )
+      .egress("E ~ Walk 30s");
+
+    var tripR1 = data.getRoute(0).getTripSchedule(0);
+    var tripR2 = data.getRoute(1).getTripSchedule(0);
+
+    data.withGuaranteedTransfer(tripR1, STOP_B, tripR2, STOP_C);
+    data.withTransfer(STOP_B, transfer(STOP_C, D30_s));
+    data.withSlackProvider(new TestSlackProvider(D30_s, D20_s, D10_s));
+
+    var requestBuilder = data.requestBuilder();
+    requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).clearOptimizations();
+    requestBuilder
+      .searchParams()
+      .constrainedTransfers(true)
+      .earliestDepartureTime(T00_00)
+      .latestArrivalTime(T00_30)
+      .searchWindow(Duration.ofMinutes(15))
+      .timetable(true)
+      .addViaLocation(passThrough("D").addStop(STOP_D).build());
+
+    assertEquals(
+      "Walk 30s ~ A ~ BUS R1 0:02 0:05 ~ B ~ Walk 30s ~ C ~ BUS R2 0:05 0:12 ~ E ~ Walk 30s [0:01:10 0:12:40 11m30s Tₙ1 C₁1_380]",
+      pathsToString(raptorService.route(requestBuilder.build(), data))
+    );
+  }
+}

--- a/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J08_PassThroughWithConstrainedTransferTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/moduletests/J08_PassThroughWithConstrainedTransferTest.java
@@ -87,8 +87,8 @@ class J08_PassThroughWithConstrainedTransferTest implements RaptorTestConstants 
    * exceeds R2's scheduled departure — the constrained transfer holds the train. R2 then passes
    * through the via point D before reaching the destination E.
    * <p>
-   * Without the fix, {@code findDepartureStopPosition(walkArrivalTime=330s, C)} fails because
-   * R2 departed C at 300s — causing the pass-through continuation to be silently dropped.
+   * This verifies that the via pass-though boarding pick up the boarding stop psition correctly,
+   * ignoting the regular transfer walk duration.
    */
   @Test
   void guaranteedWalkTransferWithPassThrough() {

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/StopArrivalStateParetoSetTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/StopArrivalStateParetoSetTest.java
@@ -139,7 +139,7 @@ public class StopArrivalStateParetoSetTest {
     int cost
   ) {
     var prev = prev(round);
-    var anyRide = new PatternRideC1<>(prev, ANY, ANY, ANY, ANY, ANY, ANY, ANY_TRIP);
+    var anyRide = new PatternRideC1<>(prev, ANY, ANY, ANY, ANY, ANY, ANY_TRIP);
     return STOP_ARRIVAL_FACTORY.createTransitStopArrival(anyRide, stop, arrivalTime, cost);
   }
 

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC1Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC1Test.java
@@ -43,7 +43,6 @@ public class StopArrivalFactoryC1Test {
   private McStopArrival<TestTripSchedule> transitArrival() {
     PatternRideView<TestTripSchedule, McStopArrival<TestTripSchedule>> ride = new PatternRideC1<>(
       accessArrival(),
-      STOP_A,
       0,
       TRIP.departure(0),
       ANY,

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC2Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/StopArrivalFactoryC2Test.java
@@ -44,7 +44,6 @@ public class StopArrivalFactoryC2Test {
   private McStopArrival<TestTripSchedule> transitArrival() {
     PatternRideView<TestTripSchedule, McStopArrival<TestTripSchedule>> ride = new PatternRideC2<>(
       accessArrival(),
-      STOP_A,
       0,
       TRIP.departure(0),
       ANY,

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TestStopArivalFactory.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TestStopArivalFactory.java
@@ -108,7 +108,6 @@ public class TestStopArivalFactory {
       .build();
     var ride = new PatternRideC2<>(
       previous,
-      fromStop,
       0,
       trip.departure(0),
       ANY,

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransferStopArrivalC2Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransferStopArrivalC2Test.java
@@ -3,10 +3,13 @@ package org.opentripplanner.raptor.rangeraptor.multicriteria.arrivals.stop;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.raptor._data.RaptorTestConstants.STOP_B;
+import static org.opentripplanner.raptor._data.RaptorTestConstants.STOP_C;
 import static org.opentripplanner.raptor.api.view.PathLegType.TRANSFER;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
+import org.opentripplanner.raptor._data.transit.TestRoute;
 import org.opentripplanner.raptor._data.transit.TestTransfer;
 import org.opentripplanner.raptor.spi.RaptorTripSchedule;
 
@@ -28,7 +31,9 @@ class TransferStopArrivalC2Test {
   private static final int TRANSIT_LEG_DURATION = 1200;
   private static final int TRANSIT_ALIGHT_TIME = TRANSIT_BOARD_TIME + TRANSIT_LEG_DURATION;
   private static final int TRANSIT_C1 = 128000;
-  private static final RaptorTripSchedule TRANSIT_TRIP = null;
+  private static final RaptorTripSchedule TRANSIT_TRIP = TestRoute.route("R1", STOP_C, STOP_B)
+    .withTimetable("10:00 11:00")
+    .getTripSchedule(0);
   private static final int ROUND = 1;
 
   private static final int TRANSFER_TO_STOP = 102;
@@ -54,6 +59,7 @@ class TransferStopArrivalC2Test {
       TRANSIT_ALIGHT_TIME,
       ACCESS_ARRIVAL.c1() + TRANSIT_C1,
       TRANSIT_C2,
+      0,
       TRANSIT_TRIP
     );
 

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransferStopArrivalTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransferStopArrivalTest.java
@@ -54,6 +54,7 @@ class TransferStopArrivalTest {
       TRANSIT_TO_STOP,
       TRANSIT_ALIGHT_TIME,
       ACCESS_ARRIVAL.c1() + TRANSIT_C1,
+      0,
       TRANSIT_TRIP
     );
 

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2Test.java
@@ -25,24 +25,29 @@ class TransitStopArrivalC2Test {
   private static final int ACCESS_C1 = ACCESS_WALK.c1();
   private static final AccessStopArrivalC2<RaptorTripSchedule> ACCESS_ARRIVAL =
     new AccessStopArrivalC2<>(ACCESS_DEPARTURE_TIME, ACCESS_WALK);
+  private static final int TRANSIT_BOARD_STOP_POSITION = 0;
   private static final int TRANSIT_TO_STOP = 101;
   private static final int TRANSIT_BOARD_TIME = 9 * 60 * 60;
   private static final int TRANSIT_LEG_DURATION = 1200;
   private static final int TRANSIT_ALIGHT_TIME = TRANSIT_BOARD_TIME + TRANSIT_LEG_DURATION;
-  private static final RaptorTripSchedule TRANSIT_TRIP = TestTripSchedule.schedule(pattern("T1", 0))
-    .arrivals(TRANSIT_ALIGHT_TIME)
+  private static final RaptorTripSchedule TRANSIT_TRIP = TestTripSchedule.schedule(
+    pattern("T1", ACCESS_TO_STOP, TRANSIT_TO_STOP)
+  )
+    .times(TRANSIT_BOARD_TIME, TRANSIT_ALIGHT_TIME)
     .build();
   private static final int TRANSIT_TRAVEL_DURATION =
     ACCESS_DURATION + BOARD_SLACK + TRANSIT_LEG_DURATION;
   private static final int TRANSIT_C1 = 128000;
   private static final int TRANSIT_C2 = 8000;
   private static final int ROUND = 1;
+
   private final TransitStopArrivalC2<RaptorTripSchedule> subject = new TransitStopArrivalC2<>(
     ACCESS_ARRIVAL.timeShiftNewArrivalTime(TRANSIT_BOARD_TIME - BOARD_SLACK),
     TRANSIT_TO_STOP,
     TRANSIT_ALIGHT_TIME,
     ACCESS_ARRIVAL.c1() + TRANSIT_C1,
     TRANSIT_C2,
+    TRANSIT_BOARD_STOP_POSITION,
     TRANSIT_TRIP
   );
 
@@ -64,7 +69,7 @@ class TransitStopArrivalC2Test {
 
   @Test
   public void boardStop() {
-    assertEquals(ACCESS_TO_STOP, subject.boardStop());
+    assertEquals(ACCESS_TO_STOP, subject.boardStopIndex());
   }
 
   @Test

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalC2Test.java
@@ -68,8 +68,8 @@ class TransitStopArrivalC2Test {
   }
 
   @Test
-  public void boardStop() {
-    assertEquals(ACCESS_TO_STOP, subject.boardStopIndex());
+  public void boardStopPosition() {
+    assertEquals(0, subject.boardStopPosition());
   }
 
   @Test

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/arrivals/stop/TransitStopArrivalTest.java
@@ -42,6 +42,7 @@ class TransitStopArrivalTest {
     TRANSIT_TO_STOP,
     TRANSIT_ALIGHT_TIME,
     ACCESS_ARRIVAL.c1() + TRANSIT_C1,
+    0,
     TRANSIT_TRIP
   );
 
@@ -62,8 +63,8 @@ class TransitStopArrivalTest {
   }
 
   @Test
-  public void boardStop() {
-    assertEquals(ACCESS_TO_STOP, subject.boardStop());
+  public void boardStopPosition() {
+    assertEquals(0, subject.boardStopPosition());
   }
 
   @Test

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC1Test.java
@@ -18,15 +18,15 @@ public class PatternRideC1Test {
 
     assertTrue(
       comparator.leftDominanceExist(
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null)
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null)
       )
     );
 
     assertFalse(
       comparator.leftDominanceExist(
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
 
@@ -34,22 +34,22 @@ public class PatternRideC1Test {
     // criterion in this direction — different trips are incomparable, only lower index dominates)
     assertFalse(
       comparator.leftDominanceExist(
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null),
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null),
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
 
     assertTrue(
       comparator.leftDominanceExist(
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC1<>(null, 0, 0, 0, C1_HIGH, C1_HIGH, TRIP_SORT_INDEX_1, null)
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC1<>(null, 0, 0, C1_HIGH, C1_HIGH, TRIP_SORT_INDEX_1, null)
       )
     );
 
     assertFalse(
       comparator.leftDominanceExist(
-        new PatternRideC1<>(null, 0, 0, 0, C1_HIGH, C1_HIGH, TRIP_SORT_INDEX_1, null),
-        new PatternRideC1<>(null, 0, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC1<>(null, 0, 0, C1_HIGH, C1_HIGH, TRIP_SORT_INDEX_1, null),
+        new PatternRideC1<>(null, 0, 0, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
   }

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2Test.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/multicriteria/ride/PatternRideC2Test.java
@@ -20,14 +20,14 @@ public class PatternRideC2Test {
 
     assertTrue(
       comparator.leftDominanceExist(
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null)
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null)
       )
     );
     assertFalse(
       comparator.leftDominanceExist(
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
 
@@ -35,36 +35,36 @@ public class PatternRideC2Test {
     // criterion in this direction — different trips are incomparable, only lower index dominates)
     assertFalse(
       comparator.leftDominanceExist(
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null),
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_2, null),
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
 
     assertTrue(
       comparator.leftDominanceExist(
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC2<>(null, 0, 0, 0, C1_HIGH, C1_HIGH, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC2<>(null, 0, 0, C1_HIGH, C1_HIGH, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
 
     assertFalse(
       comparator.leftDominanceExist(
-        new PatternRideC2<>(null, 0, 0, 0, C1_HIGH, C1_HIGH, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC2<>(null, 0, 0, C1_HIGH, C1_HIGH, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
 
     assertTrue(
       comparator.leftDominanceExist(
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_HIGH, TRIP_SORT_INDEX_1, null),
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_HIGH, TRIP_SORT_INDEX_1, null),
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null)
       )
     );
 
     assertFalse(
       comparator.leftDominanceExist(
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
-        new PatternRideC2<>(null, 0, 0, 0, C1_LOW, C1_LOW, C1_HIGH, TRIP_SORT_INDEX_1, null)
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_LOW, TRIP_SORT_INDEX_1, null),
+        new PatternRideC2<>(null, 0, 0, C1_LOW, C1_LOW, C1_HIGH, TRIP_SORT_INDEX_1, null)
       )
     );
   }

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/path/DestinationArrivalTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/path/DestinationArrivalTest.java
@@ -47,7 +47,7 @@ public class DestinationArrivalTest {
 
   private static final ArrivalView<RaptorTripSchedule> TRANSIT_ARRIVAL =
     STOP_ARRIVAL_FACTORY.createTransitStopArrival(
-      new PatternRideC1<>(ACCESS_ARRIVAL, ANY, ANY, ANY, ANY, ANY, ANY, A_TRIP),
+      new PatternRideC1<>(ACCESS_ARRIVAL, ANY, ANY, ANY, ANY, ANY, A_TRIP),
       TRANSIT_STOP,
       TRANSIT_ALIGHT_TIME,
       ACCESS_ARRIVAL.c1() + TRANSIT_COST

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/path/PathMapperTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/path/PathMapperTest.java
@@ -45,8 +45,7 @@ public class PathMapperTest implements RaptorTestConstants {
       C1_CALCULATOR,
       RaptorTestConstants::stopIndexToName,
       null,
-      lifeCycle(),
-      false
+      lifeCycle()
     );
 
     //When:
@@ -64,8 +63,7 @@ public class PathMapperTest implements RaptorTestConstants {
       SLACK_PROVIDER,
       C1_CALCULATOR,
       RaptorTestConstants::stopIndexToName,
-      null,
-      false
+      null
     );
 
     //When:
@@ -138,8 +136,7 @@ public class PathMapperTest implements RaptorTestConstants {
       FLEX_COST_CALCULATOR,
       RaptorTestConstants::stopIndexToName,
       null,
-      lifeCycle(),
-      false
+      lifeCycle()
     );
     // When:
     RaptorPath<TestTripSchedule> path = mapper.mapToPath(destArrival);
@@ -156,8 +153,7 @@ public class PathMapperTest implements RaptorTestConstants {
       FLEX_SLACK_PROVIDER,
       FLEX_COST_CALCULATOR,
       RaptorTestConstants::stopIndexToName,
-      null,
-      false
+      null
     );
     // When:
     RaptorPath<TestTripSchedule> path = mapper.mapToPath(destArrival);

--- a/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/transit/TripTimesSearchTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/rangeraptor/transit/TripTimesSearchTest.java
@@ -4,12 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.access;
 import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.bus;
+import static org.opentripplanner.raptor._data.stoparrival.TestArrivals.busReverseSearch;
 import static org.opentripplanner.raptor._data.transit.TestAccessEgress.free;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor.rangeraptor.transit.TripTimesSearch.findTripForwardSearch;
-import static org.opentripplanner.raptor.rangeraptor.transit.TripTimesSearch.findTripForwardSearchApproximateTime;
 import static org.opentripplanner.raptor.rangeraptor.transit.TripTimesSearch.findTripReverseSearch;
-import static org.opentripplanner.raptor.rangeraptor.transit.TripTimesSearch.findTripReverseSearchApproximateTime;
 import static org.opentripplanner.utils.time.TimeUtils.timeToStrLong;
 
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.view.ArrivalView;
 import org.opentripplanner.raptor.spi.BoardAndAlightTime;
-import org.opentripplanner.utils.time.TimeUtils;
 
 public class TripTimesSearchTest implements RaptorTestConstants {
 
@@ -39,27 +37,12 @@ public class TripTimesSearchTest implements RaptorTestConstants {
     BoardAndAlightTime r;
 
     // Search AFTER EDT
-    r = findTripForwardSearch(busFwd(STOP_A, STOP_C, C_ALIGHT_LATE, schedule));
+    r = findTripForwardSearch(busFwd(STOP_A, STOP_C, A_BOARD_EARLY, schedule));
 
     assertTimes(r, A_BOARD_TIME, C_ALIGHT_TIME);
 
     // Search BEFORE LAT
-    r = findTripReverseSearch(busRev(STOP_C, STOP_A, A_BOARD_EARLY, schedule));
-
-    assertTimes(r, A_BOARD_TIME, C_ALIGHT_TIME);
-  }
-
-  @Test
-  public void findTripWithApproximateTimes() {
-    BoardAndAlightTime r;
-
-    // Search AFTER EDT
-    r = findTripForwardSearchApproximateTime(busFwd(STOP_A, STOP_C, C_ALIGHT_LATE, schedule));
-
-    assertTimes(r, A_BOARD_TIME, C_ALIGHT_TIME);
-
-    // Search BEFORE LAT
-    r = findTripReverseSearchApproximateTime(busRev(STOP_C, STOP_A, A_BOARD_EARLY, schedule));
+    r = findTripReverseSearch(busRev(STOP_C, STOP_A, C_ALIGHT_LATE, schedule));
 
     assertTimes(r, A_BOARD_TIME, C_ALIGHT_TIME);
   }
@@ -69,12 +52,12 @@ public class TripTimesSearchTest implements RaptorTestConstants {
     BoardAndAlightTime r;
 
     // Search AFTER EDT
-    r = findTripForwardSearch(busFwd(STOP_A, STOP_C, C_ALIGHT_TIME, schedule));
+    r = findTripForwardSearch(busFwd(STOP_A, STOP_C, A_BOARD_TIME, schedule));
 
     assertTimes(r, A_BOARD_TIME, C_ALIGHT_TIME);
 
     // Search BEFORE LAT
-    r = findTripReverseSearch(busRev(STOP_C, STOP_A, A_BOARD_TIME, schedule));
+    r = findTripReverseSearch(busRev(STOP_C, STOP_A, C_ALIGHT_TIME, schedule));
 
     assertTimes(r, A_BOARD_TIME, C_ALIGHT_TIME);
   }
@@ -95,68 +78,32 @@ public class TripTimesSearchTest implements RaptorTestConstants {
     int c2 = schedule.departure(4);
     int d = schedule.departure(5);
 
-    // With one option the approximate time does not matter, early 09:50 or late 10:30
-    assertForwardAppxTime("09:50", STOP_A, a, STOP_D, d, schedule);
-    assertForwardAppxTime("10:30", STOP_A, a, STOP_D, d, schedule);
-    assertReverseAppxTime("09:50", STOP_D, a, STOP_A, d, schedule);
-    assertReverseAppxTime("10:30", STOP_D, a, STOP_A, d, schedule);
+    // When a stop appears only once, the position is unambiguous
+    assertForwardSearch(STOP_A, a, STOP_D, d, schedule);
+    assertReverseSearch(STOP_A, a, STOP_D, d, schedule);
 
-    // Picking the closest trip from B to C, for 10:03:30 it is the first loop
-    assertForwardAppxTime("10:03:30", STOP_B, b1, STOP_C, c1, schedule);
-    assertReverseAppxTime("10:03:30", STOP_C, b1, STOP_B, c1, schedule);
-    assertForwardAppxTime("10:03:31", STOP_B, b2, STOP_C, c2, schedule);
-    assertReverseAppxTime("10:03:31", STOP_C, b2, STOP_B, c2, schedule);
+    // Boarding at the first occurrence of B, alighting at the first occurrence of C
+    assertForwardSearch(STOP_B, b1, STOP_C, c1, schedule);
+    assertReverseSearch(STOP_B, b1, STOP_C, c1, schedule);
 
-    // Avoid boarding early, riding the loop and then get off. Avoid: B~C~B~C~D, expect: B~C~D
-    assertForwardAppxTime("10:00", STOP_B, b2, STOP_D, d, schedule);
-    assertReverseAppxTime("10:00", STOP_D, b2, STOP_B, d, schedule);
+    // Boarding at the second occurrence of B, alighting at the second occurrence of C
+    assertForwardSearch(STOP_B, b2, STOP_C, c2, schedule);
+    assertReverseSearch(STOP_B, b2, STOP_C, c2, schedule);
 
-    // Avoid late alighting, ride the loop before getting off. Avoid: A~B~C~B~C, expect: A~B~C
-    assertForwardAppxTime("10:50", STOP_A, a, STOP_C, c1, schedule);
-    assertReverseAppxTime("10:50", STOP_C, a, STOP_A, c1, schedule);
-  }
+    // Boarding at the second occurrence of B, alighting at D (path: B~C~D, not B~C~B~C~D)
+    assertForwardSearch(STOP_B, b2, STOP_D, d, schedule);
+    assertReverseSearch(STOP_B, b2, STOP_D, d, schedule);
 
-  @Test
-  public void noTripFoundWhenArrivalIsToEarly() {
-    assertThrows(
-      IllegalStateException.class,
-      () -> findTripForwardSearch(busFwd(STOP_A, STOP_C, C_ALIGHT_TIME - 1, schedule)),
-      "No stops matching 'toStop'."
-    );
-  }
-
-  @Test
-  public void noTripFoundWhenReverseArrivalIsToLate() {
-    assertThrows(
-      IllegalStateException.class,
-      () -> findTripReverseSearch(busRev(STOP_C, STOP_A, A_BOARD_TIME + 1, schedule)),
-      "No stops matching 'fromStop'."
-    );
-  }
-
-  @Test
-  public void noTripFoundWhenArrivalIsWayTooEarly() {
-    assertThrows(
-      IllegalStateException.class,
-      () -> findTripForwardSearch(busFwd(STOP_A, STOP_C, 0, schedule)),
-      "No stops matching 'toStop'."
-    );
-  }
-
-  @Test
-  public void noTripFoundWhenReverseArrivalIsWayTooEarly() {
-    assertThrows(
-      IllegalStateException.class,
-      () -> findTripReverseSearch(busRev(STOP_C, STOP_A, 10_000, schedule)),
-      "No stops matching 'fromStop'."
-    );
+    // Boarding at A, alighting at the first occurrence of C (path: A~B~C, not A~B~C~B~C)
+    assertForwardSearch(STOP_A, a, STOP_C, c1, schedule);
+    assertReverseSearch(STOP_A, a, STOP_C, c1, schedule);
   }
 
   @Test
   public void noTripFoundWhenFromStopIsMissing() {
     assertThrows(
       IllegalStateException.class,
-      () -> findTripForwardSearch(busFwd(STOP_A, STOP_A, C_ALIGHT_LATE, schedule)),
+      () -> findTripForwardSearch(busFwd(STOP_A, STOP_A, A_BOARD_TIME, schedule)),
       "No stops matching 'fromStop'."
     );
   }
@@ -165,7 +112,7 @@ public class TripTimesSearchTest implements RaptorTestConstants {
   public void noTripFoundWhenToStopIsMissingInReverseSearch() {
     assertThrows(
       IllegalStateException.class,
-      () -> findTripReverseSearch(busRev(STOP_C, STOP_C, A_BOARD_EARLY, schedule)),
+      () -> findTripReverseSearch(busRev(STOP_C, STOP_C, C_ALIGHT_TIME, schedule)),
       "No stops matching 'toStop'"
     );
   }
@@ -192,17 +139,17 @@ public class TripTimesSearchTest implements RaptorTestConstants {
     // TEST FORWARD SEARCH
     {
       // Board in the 2nd loop at stop 2 and get off at stop 3
-      r = findTripForwardSearch(busFwd(122, 133, 800, schedule));
+      r = findTripForwardSearch(busFwd(122, 133, 710, schedule));
       assertEquals(710, r.boardTime());
       assertEquals(800, r.alightTime());
 
       // Board in the 1st loop at stop 4 and get off at stop 3
-      r = findTripForwardSearch(busFwd(144, 133, 800, schedule));
+      r = findTripForwardSearch(busFwd(144, 133, 410, schedule));
       assertEquals(410, r.boardTime());
       assertEquals(800, r.alightTime());
 
       // Board in the 1st stop, ride the loop twice, alight at the last stop
-      r = findTripForwardSearch(busFwd(1, 1155, 1100, schedule));
+      r = findTripForwardSearch(busFwd(1, 1155, 10, schedule));
       assertEquals(10, r.boardTime());
       assertEquals(1100, r.alightTime());
     }
@@ -210,72 +157,71 @@ public class TripTimesSearchTest implements RaptorTestConstants {
     // TEST REVERSE SEARCH
     {
       // Board in the 2nd loop at stop 2 and get off at stop 3
-      r = findTripReverseSearch(busRev(133, 122, 710, schedule));
+      r = findTripReverseSearch(busRev(133, 122, 800, schedule));
       assertEquals(710, r.boardTime());
       assertEquals(800, r.alightTime());
 
       // Board in the 1st loop at stop 4 and get off at stop 3
-      r = findTripReverseSearch(busRev(133, 144, 410, schedule));
+      r = findTripReverseSearch(busRev(133, 144, 800, schedule));
       assertEquals(410, r.boardTime());
       assertEquals(800, r.alightTime());
 
       // Board in the 1st stop, ride the loop twice, alight at the last stop
-      r = findTripReverseSearch(busRev(1155, 1, 10, schedule));
+      r = findTripReverseSearch(busRev(1155, 1, 1100, schedule));
       assertEquals(10, r.boardTime());
       assertEquals(1100, r.alightTime());
     }
   }
 
+  /**
+   * Forward search: the access arrives at the board stop at {@code boardTime}. Uses
+   * {@code findDepartureStopPosition} to identify which stop position was boarded.
+   */
   private static ArrivalView<TestTripSchedule> busFwd(
-    int accessStop,
-    int transitToStop,
-    int arrivalTime,
+    int boardStop,
+    int alightStop,
+    int boardTime,
     TestTripSchedule trip
   ) {
-    var access = access(accessStop, -9999, free(accessStop));
-    return bus(1, transitToStop, arrivalTime, -9999, -9999, trip, access);
+    var access = access(boardStop, boardTime, free(boardStop));
+    return bus(1, alightStop, -9999, -9999, -9999, trip, access);
   }
 
+  /**
+   * Reverse search: the access arrives at the alight stop at {@code alightTime}. Uses
+   * {@code findArrivalStopPosition} to identify which stop position was alighted, which correctly
+   * handles the last stop in a pattern.
+   */
   private static ArrivalView<TestTripSchedule> busRev(
-    int accessStop,
-    int transitToStop,
-    int arrivalTime,
+    int alightStop,
+    int boardStop,
+    int alightTime,
     TestTripSchedule trip
   ) {
-    var access = access(accessStop, -9999, free(accessStop));
-    return bus(1, transitToStop, arrivalTime, -9999, -9999, trip, access);
+    var access = access(alightStop, alightTime, free(alightStop));
+    return busReverseSearch(1, boardStop, -9999, -9999, -9999, trip, access);
   }
 
-  private void assertForwardAppxTime(
-    String approximateArrivalTime,
+  private void assertForwardSearch(
     int boardStop,
-    int expBoardTime,
+    int boardTime,
     int alightStop,
     int expAlightTime,
     TestTripSchedule schedule
   ) {
-    int arrivalTime = TimeUtils.time(approximateArrivalTime);
-    var bus = busFwd(boardStop, alightStop, arrivalTime, schedule);
-
-    var r = findTripForwardSearchApproximateTime(bus);
-
-    assertTimes(r, expBoardTime, expAlightTime);
+    var r = findTripForwardSearch(busFwd(boardStop, alightStop, boardTime, schedule));
+    assertTimes(r, boardTime, expAlightTime);
   }
 
-  private void assertReverseAppxTime(
-    String approximateArrivalTime,
+  private void assertReverseSearch(
     int boardStop,
     int expBoardTime,
     int alightStop,
-    int expAlightTime,
+    int alightTime,
     TestTripSchedule schedule
   ) {
-    int arrivalTime = TimeUtils.time(approximateArrivalTime);
-    var bus = busRev(boardStop, alightStop, arrivalTime, schedule);
-
-    var r = findTripReverseSearchApproximateTime(bus);
-
-    assertTimes(r, expBoardTime, expAlightTime);
+    var r = findTripReverseSearch(busRev(alightStop, boardStop, alightTime, schedule));
+    assertTimes(r, expBoardTime, alightTime);
   }
 
   private void assertTimes(BoardAndAlightTime r, int expBoardTime, int expAlightTime) {

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripPatternTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripPatternTest.java
@@ -3,9 +3,10 @@ package org.opentripplanner.raptor.spi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestTripPattern;
 
-public class RaptorTripPatternTest {
+public class RaptorTripPatternTest implements RaptorTestConstants {
 
   private final TestTripPattern subject = TestTripPattern.pattern("L12", 1, 1, 2, 3, 5, 7, 8, 1);
 

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripPatternTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripPatternTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.raptor.spi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
@@ -8,23 +9,100 @@ import org.opentripplanner.raptor._data.transit.TestTripPattern;
 
 public class RaptorTripPatternTest implements RaptorTestConstants {
 
-  private final TestTripPattern subject = TestTripPattern.pattern("L12", 1, 1, 2, 3, 5, 7, 8, 1);
+  /// Note! Even if the restrictions allow alighting at stop 0 and boarding at the last stop,
+  /// the general rule that you are not allowed to board at the last stop and alight at the first
+  /// should still be enforced.
+  private TestTripPattern subject = TestTripPattern.of("L12", 1, 1, 1, 1, 8, 1, 1, 1, 1)
+    .restrictions("* b - a * b - a *")
+    .build();
+  private int n = subject.numberOfStopsInPattern();
 
   @Test
-  public void findStopPositionAfter() {
-    assertEquals(0, subject.findStopPositionAfter(0, 1));
-    assertEquals(1, subject.findStopPositionAfter(1, 1));
-    assertEquals(7, subject.findStopPositionAfter(2, 1));
-    assertEquals(7, subject.findStopPositionAfter(7, 1));
-    assertEquals(3, subject.findStopPositionAfter(0, 3));
+  public void findBoardStopPositionAfter() {
+    int[] epected = { 0, 1, 5, 5, 5, 5, -1, -1, -1 };
+    assertNumberOfExpectedResultsMatchesPattern(epected, 0);
+
+    for (int i = 0; i < epected.length; ++i) {
+      assertEquals(epected[i], subject.findBoardStopPositionAfter(i, 1), "i=" + i);
+    }
+
+    var ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findBoardStopPositionBefore(-1, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 8]: -1", ex.getMessage());
+
+    ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findBoardStopPositionBefore(n, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 8]: 9", ex.getMessage());
   }
 
   @Test
-  public void findStopPositionBefore() {
-    assertEquals(0, subject.findStopPositionBefore(0, 1));
-    assertEquals(1, subject.findStopPositionBefore(1, 1));
-    assertEquals(1, subject.findStopPositionBefore(6, 1));
-    assertEquals(7, subject.findStopPositionBefore(7, 1));
-    assertEquals(3, subject.findStopPositionBefore(3, 3));
+  public void findBoardStopPositionBefore() {
+    int[] epected = { -1, 0, 1, 1, 1, 1, 5, 5, 5 };
+    assertNumberOfExpectedResultsMatchesPattern(epected, 0);
+
+    for (int i = 0; i < epected.length; ++i) {
+      assertEquals(epected[i], subject.findBoardStopPositionBefore(i, 1), "i=" + i);
+    }
+
+    var ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findBoardStopPositionBefore(-1, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 8]: -1", ex.getMessage());
+
+    ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findBoardStopPositionBefore(n, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 8]: 9", ex.getMessage());
+  }
+
+  @Test
+  public void findAlightStopPositionAfter() {
+    int[] epected = { 3, 3, 3, 7, 7, 7, 7, 8, -1 };
+    assertNumberOfExpectedResultsMatchesPattern(epected, 0);
+
+    for (int i = 0; i < epected.length; ++i) {
+      assertEquals(epected[i], subject.findAlightStopPositionAfter(i, 1), "i=" + i);
+    }
+
+    var ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findAlightStopPositionAfter(-1, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 8]: -1", ex.getMessage());
+
+    ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findAlightStopPositionAfter(n, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 8]: 9", ex.getMessage());
+  }
+
+  @Test
+  public void findAlightStopPositionBefore() {
+    int delta = 1;
+    int[] epected = { -1, -1, -1, -1, 3, 3, 3, 3, 7, 8 };
+    assertNumberOfExpectedResultsMatchesPattern(epected, delta);
+
+    for (int i = 0; i < epected.length; ++i) {
+      assertEquals(epected[i], subject.findAlightStopPositionBefore(i, 1), "i=" + i);
+    }
+
+    var ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findAlightStopPositionBefore(-1, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 9]: -1", ex.getMessage());
+
+    ex = assertThrows(IllegalArgumentException.class, () ->
+      subject.findAlightStopPositionBefore(n + delta, 1)
+    );
+    assertEquals("The 'startPos' is not in range[0, 9]: 10", ex.getMessage());
+  }
+
+  private void assertNumberOfExpectedResultsMatchesPattern(int[] epected, int delta) {
+    assertEquals(
+      subject.numberOfStopsInPattern() + delta,
+      epected.length,
+      "Number of of expected results matches pattern"
+    );
   }
 }

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripPatternTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripPatternTest.java
@@ -19,11 +19,11 @@ public class RaptorTripPatternTest implements RaptorTestConstants {
 
   @Test
   public void findBoardStopPositionAfter() {
-    int[] epected = { 0, 1, 5, 5, 5, 5, -1, -1, -1 };
-    assertNumberOfExpectedResultsMatchesPattern(epected, 0);
+    int[] expected = { 0, 1, 5, 5, 5, 5, -1, -1, -1 };
+    assertNumberOfExpectedResultsMatchesPattern(expected, 0);
 
-    for (int i = 0; i < epected.length; ++i) {
-      assertEquals(epected[i], subject.findBoardStopPositionAfter(i, 1), "i=" + i);
+    for (int i = 0; i < expected.length; ++i) {
+      assertEquals(expected[i], subject.findBoardStopPositionAfter(i, 1), "i=" + i);
     }
 
     var ex = assertThrows(IllegalArgumentException.class, () ->
@@ -39,11 +39,11 @@ public class RaptorTripPatternTest implements RaptorTestConstants {
 
   @Test
   public void findBoardStopPositionBefore() {
-    int[] epected = { -1, 0, 1, 1, 1, 1, 5, 5, 5 };
-    assertNumberOfExpectedResultsMatchesPattern(epected, 0);
+    int[] expected = { -1, 0, 1, 1, 1, 1, 5, 5, 5 };
+    assertNumberOfExpectedResultsMatchesPattern(expected, 0);
 
-    for (int i = 0; i < epected.length; ++i) {
-      assertEquals(epected[i], subject.findBoardStopPositionBefore(i, 1), "i=" + i);
+    for (int i = 0; i < expected.length; ++i) {
+      assertEquals(expected[i], subject.findBoardStopPositionBefore(i, 1), "i=" + i);
     }
 
     var ex = assertThrows(IllegalArgumentException.class, () ->
@@ -59,11 +59,11 @@ public class RaptorTripPatternTest implements RaptorTestConstants {
 
   @Test
   public void findAlightStopPositionAfter() {
-    int[] epected = { 3, 3, 3, 7, 7, 7, 7, 8, -1 };
-    assertNumberOfExpectedResultsMatchesPattern(epected, 0);
+    int[] expected = { 3, 3, 3, 7, 7, 7, 7, 8, -1 };
+    assertNumberOfExpectedResultsMatchesPattern(expected, 0);
 
-    for (int i = 0; i < epected.length; ++i) {
-      assertEquals(epected[i], subject.findAlightStopPositionAfter(i, 1), "i=" + i);
+    for (int i = 0; i < expected.length; ++i) {
+      assertEquals(expected[i], subject.findAlightStopPositionAfter(i, 1), "i=" + i);
     }
 
     var ex = assertThrows(IllegalArgumentException.class, () ->
@@ -80,11 +80,11 @@ public class RaptorTripPatternTest implements RaptorTestConstants {
   @Test
   public void findAlightStopPositionBefore() {
     int delta = 1;
-    int[] epected = { -1, -1, -1, -1, 3, 3, 3, 3, 7, 8 };
-    assertNumberOfExpectedResultsMatchesPattern(epected, delta);
+    int[] expected = { -1, -1, -1, -1, 3, 3, 3, 3, 7, 8 };
+    assertNumberOfExpectedResultsMatchesPattern(expected, delta);
 
-    for (int i = 0; i < epected.length; ++i) {
-      assertEquals(epected[i], subject.findAlightStopPositionBefore(i, 1), "i=" + i);
+    for (int i = 0; i < expected.length; ++i) {
+      assertEquals(expected[i], subject.findAlightStopPositionBefore(i, 1), "i=" + i);
     }
 
     var ex = assertThrows(IllegalArgumentException.class, () ->
@@ -98,10 +98,10 @@ public class RaptorTripPatternTest implements RaptorTestConstants {
     assertEquals("The 'startPos' is not in range[0, 9]: 10", ex.getMessage());
   }
 
-  private void assertNumberOfExpectedResultsMatchesPattern(int[] epected, int delta) {
+  private void assertNumberOfExpectedResultsMatchesPattern(int[] expected, int delta) {
     assertEquals(
       subject.numberOfStopsInPattern() + delta,
-      epected.length,
+      expected.length,
       "Number of of expected results matches pattern"
     );
   }

--- a/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
+++ b/raptor/src/test/java/org/opentripplanner/raptor/spi/RaptorTripScheduleTest.java
@@ -39,20 +39,6 @@ class RaptorTripScheduleTest {
   }
 
   @Test
-  void findArrivalStopPosition() {
-    assertEquals("10:00:00", timeToStrLong(subject.arrival(0, STOP_A)));
-    assertEquals("10:05:00", timeToStrLong(subject.arrival(1, STOP_A)));
-    assertEquals("10:55:00", timeToStrLong(subject.arrival(2, STOP_A)));
-  }
-
-  @Test
-  void findDepartureStopPosition() {
-    assertEquals("10:01:00", timeToStrLong(subject.departure(0, STOP_A)));
-    assertEquals("10:46:00", timeToStrLong(subject.departure(0, STOP_E)));
-    assertEquals("10:56:00", timeToStrLong(subject.departure(2, STOP_A)));
-  }
-
-  @Test
   void restrictedFindArrivalStopPosition() {
     var subject = TestTripSchedule.schedule(
       TestTripPattern.of("flex-with-repeating-stops", STOP_F, STOP_A, STOP_A, STOP_B, STOP_C)


### PR DESCRIPTION
### Summary

Replaces the **global stop index** stored in Raptor's boarding state with the **stop's position
within the trip pattern**, making the stored coordinate consistent with the pattern-relative model
used throughout the routing algorithm. Builds on #7747.


### Issue

Raptor works entirely in pattern-relative coordinates — patterns, positions, trips — but the
boarding state was storing a global `boardStopIndex`. This forced a pattern lookup every time the
position was needed, and the time-based fallback in `TripTimesSearch` (used when the position
wasn't known) could produce wrong results for constrained transfers and circular lines.


#### Performance Impact

The performance impact of this change is 1-3% for the McRaptor, none for the other routing profiles
in Raptor. The reson for this is that:
- in the standard profile, the board stop index is swapped with stop position. The hot loop does not use
  this, so swaping one `int` for another in the state has no impact. 
- in the McRaptor the board stop position is added - causing on extra integer to be saved for all transit
  arrivals. This increase the memory used and hence slow down the McRaptor by 1-3%. An alternative
  approach would be to refactor the logic for trip boarding so it can be reused in the Raptor algorithm 
  **and in the Path mapping/Optimized Transfer**. This is considered way more difficult/risky. If this is
  done later, then the boarding stop position can be removed from the McRaptor state again.
  
I have tested this on my local hardware (more samples/stable/exact results) and on the [performance CI test](https://otp-performance.leonard.io/d/9sXJ43gVk/otp-performance?orgId=1&from=now-7d&to=now&timezone=browser&var-category=top-5000&var-location=skanetrafiken&var-branch=dev-2.x).   


#### Bug Fixes

This eliminates a rare bug currently present in the _via search_ and the _direct transit search_.
The current implementation would use the wrong boarding position for looping patterns in cases
where the boarding stop is visited twice, and we want the first visit to be boarded as a result of
a guarranteed/stay-seated transfer or pass-thorough stop between the two visits. This is just a 
latent bug in the case of direct transit search, since we currently does not support constrained
transfers and via search.


#### After this PR

- **`RaptorTripPattern`** gains four new default SPI methods — `findBoardStopPositionAfter`, 
  `findBoardStopPositionBefore`, `findAlightStopPositionAfter`, `findAlightStopPositionBefore` — 
  that respect boarding/alighting restrictions when searching for a stop within a pattern. These
  methods SHOULD be used instead of other alternatives - if possible.
- **`TripTimesSearch`** is simplified from ~300 lines with time-based approximate search to a small
  utility with two static methods. The approximate-time variants are removed now that the board
  position is stored directly.
- **`ViaConnectionStopArrivalEventListener`** is fixed to use the exact `boardStopPosition` instead
  of a time-based lookup, which could fail for constrained transfers or incorrectly board from the
  first stop on circular lines.
- Deprecated stop-index-based arrival/departure methods are removed from `RaptorTripSchedule` and
  `TripStopTime`.


### Unit tests

✅ Existing tests updated to the position-based model. `TripTimesSearchTest` is significantly
simplified. `RaptorTripPatternTest` covers the new board/alight-aware position lookups. No behavior
change in routing — no new test scenarios needed beyond what the base branch already covers.

### Documentation

🟥 No user-facing behavior or configuration changed.

### Changelog

✅ This PR includes a very small bugfix, but it is noteworthy. It is very hard to analyze if it
occours.

### Bumping the serialization version id

🟥 No serialized graph fields changed.
