### PR TITLE
Explicitly check out base branch in post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # explicitly check out the base branch: this workflow must never run fork PR code
+          ref: ${{ github.event.pull_request.base.ref }}
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
       - name: Configure git user
@@ -65,6 +67,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # explicitly check out the base branch: this workflow must never run fork PR code
+          ref: ${{ github.event.pull_request.base.ref }}
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
       - name: Bump serialization version


### PR DESCRIPTION
## PR Instructions

Since upgrading to actions/checkout@v7 the changelog and serialization version bump steps didn't work anymore: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/29234128905

It appears that this code is necessary to make them work again.