### PR TITLE
Rename stopIndex to stopPosition in UpdateError and UpdateException

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/spi/UpdateError.java
+++ b/application/src/main/java/org/opentripplanner/updater/spi/UpdateError.java
@@ -10,7 +10,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 public record UpdateError(
   @Nullable FeedScopedId tripId,
   UpdateErrorType errorType,
-  @Nullable Integer stopIndex,
+  @Nullable Integer stopPosition,
   @Nullable String producer,
   /**
    * A best-effort, human-readable trip identifier used for logging when the trip could not be
@@ -24,10 +24,10 @@ public record UpdateError(
     var id = tripId != null ? tripId.toString() : tripReference;
     if (id == null) {
       return "no trip id";
-    } else if (stopIndex == null) {
+    } else if (stopPosition == null) {
       return id;
     } else {
-      return "%s{stopIndex=%s}".formatted(id, stopIndex);
+      return "%s{stopPosition=%s}".formatted(id, stopPosition);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/spi/UpdateException.java
+++ b/application/src/main/java/org/opentripplanner/updater/spi/UpdateException.java
@@ -13,7 +13,7 @@ public class UpdateException extends RuntimeException {
   private final FeedScopedId tripId;
 
   @Nullable
-  private final Integer stopIndex;
+  private final Integer stopPosition;
 
   /// A best-effort trip identifier used for logging when no resolved [FeedScopedId] is available.
   @Nullable
@@ -22,12 +22,12 @@ public class UpdateException extends RuntimeException {
   private UpdateException(
     @Nullable FeedScopedId tripId,
     UpdateErrorType errorType,
-    @Nullable Integer stopIndex,
+    @Nullable Integer stopPosition,
     @Nullable String tripReference
   ) {
     this.tripId = tripId;
     this.errorType = errorType;
-    this.stopIndex = stopIndex;
+    this.stopPosition = stopPosition;
     this.tripReference = tripReference;
   }
 
@@ -35,8 +35,8 @@ public class UpdateException extends RuntimeException {
     return new UpdateException(tripId, errorType, null, null);
   }
 
-  public static UpdateException ofStopIndex(UpdateErrorType updateErrorType, int stopIndex) {
-    return new UpdateException(null, updateErrorType, stopIndex, null);
+  public static UpdateException ofStopPosition(UpdateErrorType updateErrorType, int stopPosition) {
+    return new UpdateException(null, updateErrorType, stopPosition, null);
   }
 
   public static UpdateException noTripId(UpdateErrorType errorType) {
@@ -50,27 +50,27 @@ public class UpdateException extends RuntimeException {
   public static UpdateException of(
     FeedScopedId tripId,
     UpdateErrorType updateErrorType,
-    int stopIndex
+    int stopPosition
   ) {
-    return new UpdateException(tripId, updateErrorType, stopIndex, null);
+    return new UpdateException(tripId, updateErrorType, stopPosition, null);
   }
 
   /// Gives an updated exception with the specified tripId
   public UpdateException withTripId(FeedScopedId tripId) {
-    return new UpdateException(tripId, this.errorType, this.stopIndex, this.tripReference);
+    return new UpdateException(tripId, this.errorType, this.stopPosition, this.tripReference);
   }
 
   /// Gives an updated exception with a best-effort trip identifier for logging, used when the trip
   /// could not be resolved to a [FeedScopedId].
   public UpdateException withTripReference(@Nullable String tripReference) {
-    return new UpdateException(this.tripId, this.errorType, this.stopIndex, tripReference);
+    return new UpdateException(this.tripId, this.errorType, this.stopPosition, tripReference);
   }
 
-  /// The index of the GTFS-RT stop time update or SIRI call in the list of updates, which
+  /// The position of the GTFS-RT stop time update or SIRI call in the list of updates, which
   /// does not necessarily correspond to the stop position in pattern.
   @Nullable
-  public Integer stopIndex() {
-    return stopIndex;
+  public Integer stopPosition() {
+    return stopPosition;
   }
 
   public UpdateErrorType errorType() {
@@ -78,10 +78,10 @@ public class UpdateException extends RuntimeException {
   }
 
   public UpdateError toError() {
-    return new UpdateError(tripId, errorType, stopIndex, null, tripReference);
+    return new UpdateError(tripId, errorType, stopPosition, null, tripReference);
   }
 
   public UpdateError toError(String producer) {
-    return new UpdateError(tripId, errorType, stopIndex, producer, tripReference);
+    return new UpdateError(tripId, errorType, stopPosition, producer, tripReference);
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
@@ -233,7 +233,7 @@ class ModifiedTripBuilder {
         //Current stop is being updated
         var callStop = entityResolver.resolveQuay(call.getStopPointRef());
         if (callStop == null) {
-          throw UpdateException.ofStopIndex(UNKNOWN_STOP, i);
+          throw UpdateException.ofStopPosition(UNKNOWN_STOP, i);
         }
 
         if (!stop.equals(callStop) && !stop.isPartOfSameStationAs(callStop)) {
@@ -259,7 +259,7 @@ class ModifiedTripBuilder {
         break;
       }
       if (!matchFound) {
-        throw UpdateException.ofStopIndex(STOP_MISMATCH, i);
+        throw UpdateException.ofStopPosition(STOP_MISMATCH, i);
       }
     }
     var newStopPattern = builder.build();

--- a/application/src/test/java/org/opentripplanner/updater/spi/UpdateErrorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/spi/UpdateErrorTest.java
@@ -34,14 +34,14 @@ class UpdateErrorTest {
   }
 
   @Test
-  void stopIndexIsAppendedToResolvedTripId() {
+  void stopPositionIsAppendedToResolvedTripId() {
     var error = new UpdateError(TRIP_ID, UpdateErrorType.INVALID_ARRIVAL_TIME, 3, null, null);
-    assertEquals("F:Trip1{stopIndex=3}", error.debugId());
+    assertEquals("F:Trip1{stopPosition=3}", error.debugId());
   }
 
   @Test
-  void stopIndexIsAppendedToTripReference() {
+  void stopPositionIsAppendedToTripReference() {
     var error = new UpdateError(null, UpdateErrorType.INVALID_ARRIVAL_TIME, 3, null, "SJ:1");
-    assertEquals("SJ:1{stopIndex=3}", error.debugId());
+    assertEquals("SJ:1{stopPosition=3}", error.debugId());
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilderTest.java
@@ -286,7 +286,7 @@ class ModifiedTripBuilderTest {
     );
 
     var updateError = assertFailure(UpdateErrorType.NEGATIVE_DWELL_TIME, tripUpdate::build);
-    assertEquals(1, updateError.stopIndex());
+    assertEquals(1, updateError.stopPosition());
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up from the SIRI-ET refactoring review (deferred in #7773). Renames `stopIndex` → `stopPosition` in `UpdateError` and `UpdateException` (and their call sites).

The value these types carry is the **0-based ordinal of a call/stop along a trip** — "which stop failed" — populated from `ModifiedTripBuilder`'s `for (int i = 0; i < numberOfStops; i++)` loop (and, via `DataValidationExceptionMapper`, from the equivalent per-stop position in `TimetableValidationError`).

In OTP, `stopIndex` already has a distinct, entrenched meaning: the **global index of a stop in the system-wide stop array**, used for O(1) Raptor lookups — e.g. `RaptorTripPattern.stopIndex(int stopPositionInPattern)`, `getStopByIndex(...)`, `transfersByStopIndex`. Calling a *position along a trip* `stopIndex` collides with that concept. `stopPosition` is the term OTP uses for the ordinal-along-a-pattern concept (cf. the ~140 `stopPositionInPattern` usages).

> Reviewer (leonardehrenfried, #7773): "Nowadays we call this the stop position."

## Changes

- `UpdateError` — record component `stopPosition`; debug log now emits `{stopPosition=%s}`.
- `UpdateException` — field, accessor `stopPosition()`, factory `ofStopPosition(...)`, the `of(tripId, type, int stopPosition)` parameter, and both `toError(...)` methods; Javadoc reworded.
- `ModifiedTripBuilder` — two `ofStopPosition(...)` call sites.
- Tests updated (`UpdateErrorTest`, `ModifiedTripBuilderTest`).

Pure rename — no behavior change.

### Out of scope

- `TimetableValidationError.stopIndex()` — arguably the same misnomer, but it lives in the transit model rather than the updater SPI; left for a possible later follow-up.
- The `RaptorTripPattern`/`RoutingTripPattern` `stopIndex(int)` accessors — these correctly denote the global stop index.
