### PR TITLE
Do not use empty string as headsign sentinel in StopTimesMapper

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
@@ -82,9 +82,6 @@ class StopTimesMapper {
       stopTime.setStopHeadsign(new NonLocalizedString(destinationDisplay));
     } else if (trip.getHeadsign() != null) {
       stopTime.setStopHeadsign(trip.getHeadsign());
-    } else {
-      // Fallback to empty string
-      stopTime.setStopHeadsign(new NonLocalizedString(""));
     }
 
     // Update pickup / dropoff


### PR DESCRIPTION
## Summary

Follow-up from the review of #7783.

In `StopTimesMapper.createAimedStopTime`, when a SIRI-ET call has no destination display and the trip has no headsign, the code stored an empty `NonLocalizedString("")` as the stop headsign. This uses the empty string as a "no data" sentinel and allocates a throwaway object on every such call.

This PR simply leaves the stop headsign unset in that case:

- removes the empty-string sentinel — absence is represented by not storing a per-stop headsign;
- removes the per-call `new NonLocalizedString("")` allocation;
- makes the SIRI added/extra-call trip path behave like every other trip, which already leaves the per-stop headsign unset when the source provides none (NeTEx: no `DestinationDisplayRef`; GTFS: no `stop_headsign`).

## Why this is safe

A missing per-stop headsign is never shown directly — it always runs through the reader fallback in `ScheduledTripTimes.getHeadsign(stopPos)`, which returns the trip headsign when no per-stop headsign is stored. `StopTime.stopHeadsign` is nullable and `StopTimeToScheduledTripTimesMapper` already handles null per-stop headsigns, so there is no NPE risk. This PR does not introduce a new headsign state: it removes a synthetic `""` placeholder that was pre-empting the fallback that all other trips already use.

## Observable effect

For the narrow case of a SIRI added/extra-call trip stop whose call has an empty destination display, the resolved headsign changes from `""` to the reader fallback:

- if the trip also has no headsign → `""` → `null` (matching a headsign-less regular scheduled trip; e.g. GraphQL `Stoptime.headsign` and Transmodel `DestinationDisplay.frontText`);
- if the trip has a headsign (added trip with a `destinationName`) → `""` → the trip's destination name, instead of an empty string.

Both APIs (GTFS and Transmodel) resolve this field through the same `TripTimeOnDate.getHeadsign()` path, and both can already return `null` today for regular trips without a headsign, so no new nullability is introduced.

addresses review comment from #7783
