### PR TITLE
Expose service date as LocalDate in VehicleJourneyIdAndServiceDate

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
@@ -2,7 +2,6 @@ package org.opentripplanner.updater.trip.siri;
 
 import java.time.Duration;
 import java.time.LocalDate;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -12,7 +11,6 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.service.TransitService;
-import org.opentripplanner.utils.time.ServiceDateUtils;
 
 /**
  * This class is responsible for resolving references to various entities in the transit model for
@@ -75,14 +73,12 @@ public class EntityResolver {
   }
 
   @Nullable
-  public TripOnServiceDate resolveTripOnServiceDate(
+  TripOnServiceDate resolveTripOnServiceDate(
     VehicleJourneyIdAndServiceDate vehicleJourneyIdAndServiceDate
   ) {
     return resolveTripOnServiceDate(
       vehicleJourneyIdAndServiceDate.vehicleJourneyId(),
-      Optional.ofNullable(vehicleJourneyIdAndServiceDate.serviceDate())
-        .flatMap(ServiceDateUtils::parseStringToOptional)
-        .orElse(null)
+      vehicleJourneyIdAndServiceDate.serviceDate()
     );
   }
 
@@ -146,16 +142,25 @@ public class EntityResolver {
     return transitService.getOperator(resolveId(operatorRef));
   }
 
+  /**
+   * Resolve the service date of a vehicle journey, trying in order:
+   * <ol>
+   *   <li>the service date given by the journey's FramedVehicleJourneyRef -> DataFrameRef,</li>
+   *   <li>the service date of the DatedServiceJourney referenced by the journey's
+   *       DatedVehicleJourneyRef or EstimatedVehicleJourneyCode,</li>
+   *   <li>the date of the aimed departure time at the first call, shifted back by the number of
+   *       days the scheduled trip's first departure lies after midnight (for trips running past
+   *       midnight).</li>
+   * </ol>
+   * Return {@code null} if none of these strategies succeed.
+   */
   @Nullable
   public LocalDate resolveServiceDate(EstimatedVehicleJourneyWrapper journey) {
     var vehicleJourneyIdAndServiceDate = journey.vehicleJourneyIdAndServiceDate();
-    if (vehicleJourneyIdAndServiceDate != null) {
-      var serviceDate = Optional.ofNullable(vehicleJourneyIdAndServiceDate.serviceDate())
-        .flatMap(ServiceDateUtils::parseStringToOptional)
-        .orElse(null);
-      if (serviceDate != null) {
-        return serviceDate;
-      }
+    if (
+      vehicleJourneyIdAndServiceDate != null && vehicleJourneyIdAndServiceDate.serviceDate() != null
+    ) {
+      return vehicleJourneyIdAndServiceDate.serviceDate();
     }
 
     FeedScopedId datedServiceJourneyId = resolveDatedServiceJourneyId(journey);

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
@@ -37,7 +37,7 @@ public class EntityResolver {
    * EstimatedVehicleJourneyCode (for a trip that was previously added by a real-time message).
    */
   @Nullable
-  public Trip resolveTrip(EstimatedVehicleJourneyWrapper journey) {
+  Trip resolveTrip(EstimatedVehicleJourneyWrapper journey) {
     var vehicleJourneyIdAndServiceDate = journey.vehicleJourneyIdAndServiceDate();
     if (vehicleJourneyIdAndServiceDate != null) {
       Trip trip = resolveTrip(vehicleJourneyIdAndServiceDate.vehicleJourneyId());
@@ -124,7 +124,7 @@ public class EntityResolver {
    *
    * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
    */
-  public RegularStop resolveQuay(String stopPointRef) {
+  RegularStop resolveQuay(String stopPointRef) {
     var id = resolveId(stopPointRef);
     return transitService
       .findStopByScheduledStopPoint(id)
@@ -134,11 +134,11 @@ public class EntityResolver {
   /**
    * Resolve a {@link Route} from a line id.
    */
-  public Route resolveRoute(String lineRef) {
+  Route resolveRoute(String lineRef) {
     return transitService.getRoute(resolveId(lineRef));
   }
 
-  public Operator resolveOperator(String operatorRef) {
+  Operator resolveOperator(String operatorRef) {
     return transitService.getOperator(resolveId(operatorRef));
   }
 
@@ -155,7 +155,7 @@ public class EntityResolver {
    * Return {@code null} if none of these strategies succeed.
    */
   @Nullable
-  public LocalDate resolveServiceDate(EstimatedVehicleJourneyWrapper journey) {
+  LocalDate resolveServiceDate(EstimatedVehicleJourneyWrapper journey) {
     var vehicleJourneyIdAndServiceDate = journey.vehicleJourneyIdAndServiceDate();
     if (
       vehicleJourneyIdAndServiceDate != null && vehicleJourneyIdAndServiceDate.serviceDate() != null

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/VehicleJourneyIdAndServiceDate.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/VehicleJourneyIdAndServiceDate.java
@@ -1,6 +1,9 @@
 package org.opentripplanner.updater.trip.siri;
 
+import java.time.LocalDate;
 import javax.annotation.Nullable;
+import org.opentripplanner.utils.time.ServiceDateUtils;
+import uk.org.siri.siri21.DataFrameRefStructure;
 import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
 
 /**
@@ -8,17 +11,28 @@ import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
  */
 record VehicleJourneyIdAndServiceDate(
   @Nullable String vehicleJourneyId,
-  @Nullable String serviceDate
+  @Nullable LocalDate serviceDate
 ) {
   @Nullable
   static VehicleJourneyIdAndServiceDate of(@Nullable FramedVehicleJourneyRefStructure ref) {
     if (ref == null) {
       return null;
     }
-    var dataFrameRef = ref.getDataFrameRef();
     return new VehicleJourneyIdAndServiceDate(
       ref.getDatedVehicleJourneyRef(),
-      dataFrameRef != null ? dataFrameRef.getValue() : null
+      parseServiceDate(ref.getDataFrameRef())
     );
+  }
+
+  /**
+   * The Nordic SIRI profile requires the DataFrameRef to contain the service date. A value that is
+   * not a valid date is treated as a missing service date.
+   */
+  @Nullable
+  private static LocalDate parseServiceDate(@Nullable DataFrameRefStructure dataFrameRef) {
+    if (dataFrameRef == null || dataFrameRef.getValue() == null) {
+      return null;
+    }
+    return ServiceDateUtils.parseStringToOptional(dataFrameRef.getValue()).orElse(null);
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/EstimatedVehicleJourneyWrapperTest.java
@@ -146,7 +146,7 @@ class EstimatedVehicleJourneyWrapperTest {
     var result = EstimatedVehicleJourneyWrapper.of(journey).vehicleJourneyIdAndServiceDate();
 
     assertEquals("SJ:1", result.vehicleJourneyId());
-    assertEquals("2024-05-07", result.serviceDate());
+    assertEquals(LocalDate.of(2024, 5, 7), result.serviceDate());
   }
 
   @Test
@@ -186,7 +186,7 @@ class EstimatedVehicleJourneyWrapperTest {
 
     assertEquals(1, result.size());
     assertEquals("REPLACED:2", result.getFirst().vehicleJourneyId());
-    assertEquals("2024-05-07", result.getFirst().serviceDate());
+    assertEquals(LocalDate.of(2024, 5, 7), result.getFirst().serviceDate());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Change `VehicleJourneyIdAndServiceDate.serviceDate` from `String` to `LocalDate`, parsing the `DataFrameRef` value once at construction instead of in every consumer. The Nordic SIRI profile requires the `DataFrameRef` to contain the service date; a value that is not a valid date is treated as a missing service date (same behavior as before, where unparseable values were silently dropped by each consumer).
- Simplify the two `EntityResolver` call sites that previously parsed the string themselves.
- Add javadoc on `EntityResolver.resolveServiceDate` describing the fallback resolution strategy.
- Reduce visibility of `EntityResolver` methods that are only used within the `updater.trip.siri` package.

## Issue

None

## Unit tests

Updated `EstimatedVehicleJourneyWrapperTest` to assert on `LocalDate` values.
