### PR TITLE
Request scoped dependenct injection - 2nd step of 2

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
@@ -233,7 +233,17 @@ class ScheduledDeviatedTripIntegrationTest {
         .create(temporaryVerticesContainer, linkingRequest);
       var result = TransitRouter.route(
         request,
-        serverContext,
+        serverContext.transitService(),
+        serverContext.graph(),
+        serverContext.raptorConfig(),
+        serverContext.meterRegistry(),
+        serverContext.streetDetailsService(),
+        serverContext.transferService(),
+        serverContext.flexParameters(),
+        serverContext.rideHailingServices(),
+        serverContext.dataOverlayParameterBindings(),
+        serverContext.sorlandsbanenService(),
+        serverContext.viaTransferResolver(),
         TransitGroupPriorityService.empty(),
         transitStartOfTime,
         additionalSearchDays,

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
@@ -18,13 +18,18 @@ class VectorTilesResourceTest {
   void tileJson() {
     // the Grizzly request is awful to instantiate, using Mockito
     var grizzlyRequest = Mockito.mock(Request.class);
+    var serverContext = TestServerContext.createServerContext(
+      new Graph(),
+      new TimetableRepository(),
+      TransferServiceTestFactory.defaultTransferRepository(),
+      new DefaultFareService()
+    );
     var resource = new VectorTilesResource(
-      TestServerContext.createServerContext(
-        new Graph(),
-        new TimetableRepository(),
-        TransferServiceTestFactory.defaultTransferRepository(),
-        new DefaultFareService()
-      ),
+      serverContext.transitService(),
+      serverContext.vectorTileConfig(),
+      serverContext.worldEnvelopeService(),
+      serverContext.vehicleRentalService(),
+      serverContext.vehicleParkingService(),
       grizzlyRequest,
       "default"
     );

--- a/application/src/ext/java/org/opentripplanner/ext/dataoverlay/routing/DataOverlayContext.java
+++ b/application/src/ext/java/org/opentripplanner/ext/dataoverlay/routing/DataOverlayContext.java
@@ -6,10 +6,13 @@ import static org.opentripplanner.ext.dataoverlay.api.ParameterType.THRESHOLD;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.dataoverlay.api.DataOverlayParameters;
 import org.opentripplanner.ext.dataoverlay.api.ParameterName;
 import org.opentripplanner.ext.dataoverlay.api.ParameterType;
 import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
+import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.street.model.edge.ExtensionRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +30,27 @@ public class DataOverlayContext implements ExtensionRequestContext {
     for (ParameterName paramName : requestParameters.listParameterNames()) {
       addParameter(paramName, parameterBindings, requestParameters);
     }
+  }
+
+  /**
+   * Builds the {@link ExtensionRequestContext} list for a request, given the app-singleton
+   * {@link DataOverlayParameterBindings} (independently bindable, unlike the whole
+   * {@code OtpServerRequestContext} this replaces the need for at several router call sites).
+   */
+  public static List<ExtensionRequestContext> listExtensionRequestContexts(
+    RouteRequest request,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings
+  ) {
+    var list = new ArrayList<ExtensionRequestContext>();
+    if (OTPFeature.DataOverlay.isOn()) {
+      list.add(
+        new DataOverlayContext(
+          dataOverlayParameterBindings,
+          request.preferences().system().dataOverlay()
+        )
+      );
+    }
+    return list;
   }
 
   public Iterable<? extends Parameter> getParameters() {

--- a/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/api/resource/DebugRasterTileResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/api/resource/DebugRasterTileResource.java
@@ -15,7 +15,8 @@ import org.opentripplanner.api.resource.WebMercatorTile;
 import org.opentripplanner.ext.debugrastertiles.MapTile;
 import org.opentripplanner.ext.debugrastertiles.TileRenderer;
 import org.opentripplanner.ext.debugrastertiles.TileRendererManager;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.street.graph.Graph;
 
 /**
  * Slippy raster map tile API for rendering various graph information for inspection/debugging
@@ -34,10 +35,10 @@ public class DebugRasterTileResource {
 
   private final TileRendererManager tileRendererManager;
 
-  public DebugRasterTileResource(@Context OtpServerRequestContext serverContext) {
+  public DebugRasterTileResource(@Context Graph graph, @Context RouteRequest defaultRouteRequest) {
     this.tileRendererManager = new TileRendererManager(
-      serverContext.graph(),
-      serverContext.defaultRouteRequest().preferences().wheelchair()
+      graph,
+      defaultRouteRequest.preferences().wheelchair()
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
@@ -8,7 +8,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.Map;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import javax.annotation.Nullable;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 
 /**
@@ -20,8 +20,8 @@ public class GeocoderResource {
 
   private final LuceneIndex luceneIndex;
 
-  public GeocoderResource(@Context OtpServerRequestContext requestContext) {
-    luceneIndex = requestContext.lucenceIndex();
+  public GeocoderResource(@Context @Nullable LuceneIndex luceneIndex) {
+    this.luceneIndex = luceneIndex;
   }
 
   @GET

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/resource/OjpResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/resource/OjpResource.java
@@ -16,8 +16,14 @@ import org.opentripplanner.ext.ojp.RequestHandler;
 import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
 import org.opentripplanner.ext.ojp.service.CallAtStopService;
 import org.opentripplanner.ext.ojp.service.OjpService;
+import org.opentripplanner.place.NearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StreetNearbyStopFinder;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,10 +49,21 @@ public class OjpResource {
   private final RequestHandler handler;
   private final RouteRequest defaultRouteRequest;
 
-  public OjpResource(@Context OtpServerRequestContext context) {
-    var transitService = context.transitService();
-    var callAtStopService = new CallAtStopService(transitService, context.nearbyStopFinder());
-    var idMapper = idMapper(context.ojpApiParameters());
+  public OjpResource(
+    @Context TransitService transitService,
+    @Context Graph graph,
+    @Context LinkingContextFactory linkingContextFactory,
+    @Context OjpApiParameters ojpApiParameters,
+    @Context RouteRequest defaultRouteRequest,
+    // Only RoutingService still requires the whole context - it isn't independently
+    // request-scoped/bindable yet, see issue #7441.
+    @Context OtpServerRequestContext context
+  ) {
+    NearbyStopFinder nearbyStopFinder = graph.hasStreets
+      ? StreetNearbyStopFinder.of(linkingContextFactory).build()
+      : new StraightLineNearbyStopFinder(transitService::findRegularStopsByBoundingBox);
+    var callAtStopService = new CallAtStopService(transitService, nearbyStopFinder);
+    var idMapper = idMapper(ojpApiParameters);
     var ojpService = new OjpService(
       callAtStopService,
       context.routingService(),
@@ -54,7 +71,7 @@ public class OjpResource {
       transitService.getTimeZone()
     );
     this.handler = new RequestHandler(ojpService, OjpCodec::serialize, "OJP");
-    this.defaultRouteRequest = context.defaultRouteRequest();
+    this.defaultRouteRequest = defaultRouteRequest;
   }
 
   @POST

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/resource/OjpResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/resource/OjpResource.java
@@ -19,9 +19,9 @@ import org.opentripplanner.ext.ojp.service.OjpService;
 import org.opentripplanner.place.NearbyStopFinder;
 import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
 import org.opentripplanner.place.nearbystopfinder.StreetNearbyStopFinder;
+import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
@@ -55,9 +55,7 @@ public class OjpResource {
     @Context LinkingContextFactory linkingContextFactory,
     @Context OjpApiParameters ojpApiParameters,
     @Context RouteRequest defaultRouteRequest,
-    // Only RoutingService still requires the whole context - it isn't independently
-    // request-scoped/bindable yet, see issue #7441.
-    @Context OtpServerRequestContext context
+    @Context RoutingService routingService
   ) {
     NearbyStopFinder nearbyStopFinder = graph.hasStreets
       ? StreetNearbyStopFinder.of(linkingContextFactory).build()
@@ -66,7 +64,7 @@ public class OjpResource {
     var idMapper = idMapper(ojpApiParameters);
     var ojpService = new OjpService(
       callAtStopService,
-      context.routingService(),
+      routingService,
       idMapper,
       transitService.getTimeZone()
     );

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/resource/TriasResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/resource/TriasResource.java
@@ -27,9 +27,9 @@ import org.opentripplanner.ext.ojp.service.OjpService;
 import org.opentripplanner.place.NearbyStopFinder;
 import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
 import org.opentripplanner.place.nearbystopfinder.StreetNearbyStopFinder;
+import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
@@ -51,9 +51,7 @@ public class TriasResource {
     @Context Graph graph,
     @Context LinkingContextFactory linkingContextFactory,
     @Context TriasApiParameters triasApiParameters,
-    // Only RoutingService still requires the whole context - it isn't independently
-    // request-scoped/bindable yet, see issue #7441.
-    @Context OtpServerRequestContext context
+    @Context RoutingService routingService
   ) {
     var zoneId = triasApiParameters.timeZone().orElse(transitService.getTimeZone());
     NearbyStopFinder nearbyStopFinder = graph.hasStreets
@@ -61,7 +59,7 @@ public class TriasResource {
       : new StraightLineNearbyStopFinder(transitService::findRegularStopsByBoundingBox);
     var service = new CallAtStopService(transitService, nearbyStopFinder);
     var idMapper = idMapper(triasApiParameters);
-    var serviceMapper = new OjpService(service, context.routingService(), idMapper, zoneId);
+    var serviceMapper = new OjpService(service, routingService, idMapper, zoneId);
     this.handler = new RequestHandler(serviceMapper, TriasResource::ojpToTrias, "TRIAS");
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/resource/TriasResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/resource/TriasResource.java
@@ -24,8 +24,14 @@ import org.opentripplanner.ext.ojp.RequestHandler;
 import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.ext.ojp.service.CallAtStopService;
 import org.opentripplanner.ext.ojp.service.OjpService;
+import org.opentripplanner.place.NearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StreetNearbyStopFinder;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,11 +46,21 @@ public class TriasResource {
 
   private final RequestHandler handler;
 
-  public TriasResource(@Context OtpServerRequestContext context) {
-    var transitService = context.transitService();
-    var zoneId = context.triasApiParameters().timeZone().orElse(transitService.getTimeZone());
-    var service = new CallAtStopService(transitService, context.nearbyStopFinder());
-    var idMapper = idMapper(context.triasApiParameters());
+  public TriasResource(
+    @Context TransitService transitService,
+    @Context Graph graph,
+    @Context LinkingContextFactory linkingContextFactory,
+    @Context TriasApiParameters triasApiParameters,
+    // Only RoutingService still requires the whole context - it isn't independently
+    // request-scoped/bindable yet, see issue #7441.
+    @Context OtpServerRequestContext context
+  ) {
+    var zoneId = triasApiParameters.timeZone().orElse(transitService.getTimeZone());
+    NearbyStopFinder nearbyStopFinder = graph.hasStreets
+      ? StreetNearbyStopFinder.of(linkingContextFactory).build()
+      : new StraightLineNearbyStopFinder(transitService::findRegularStopsByBoundingBox);
+    var service = new CallAtStopService(transitService, nearbyStopFinder);
+    var idMapper = idMapper(triasApiParameters);
     var serviceMapper = new OjpService(service, context.routingService(), idMapper, zoneId);
     this.handler = new RequestHandler(serviceMapper, TriasResource::ojpToTrias, "TRIAS");
   }

--- a/application/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
@@ -16,7 +16,7 @@ import org.opentripplanner.place.NearbyStopFinder;
 import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehicleparking.model.VehicleParking;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Created by demory on 7/26/18.
@@ -29,20 +29,21 @@ public class ParkAndRideResource {
   private final NearbyStopFinder nearbyStopFinder;
 
   public ParkAndRideResource(
-    @Context OtpServerRequestContext serverContext,
+    @Context VehicleParkingService vehicleParkingService,
+    @Context TransitService transitService,
     /**
      * @deprecated The support for multiple routers are removed from OTP2.
      * See https://github.com/opentripplanner/OpenTripPlanner/issues/2760
      */
     @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
   ) {
-    this.vehicleParkingService = serverContext.vehicleParkingService();
+    this.vehicleParkingService = vehicleParkingService;
 
     // TODO OTP2 - Why are we using the StraightLineNearbyStopFinder here
     //           - This can be replaced with a search done with the SiteRepository
     //           - if we have a radius search there.
     this.nearbyStopFinder = new StraightLineNearbyStopFinder(
-      serverContext.transitService()::findRegularStopsByBoundingBox
+      transitService::findRegularStopsByBoundingBox
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
@@ -4,13 +4,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transit.service.TransitService;
 
 public class GraphReportBuilder {
 
-  public static GraphStats build(OtpServerRequestContext context) {
-    var transitService = context.transitService();
-    var graph = context.graph();
+  public static GraphStats build(TransitService transitService, Graph graph) {
     var constrainedTransfers = transitService.getConstrainedTransferService().listAll();
 
     var constrainedTransferCounts = countValues(constrainedTransfers, transfer -> {

--- a/application/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -13,7 +13,7 @@ import org.opentripplanner.ext.reportapi.model.GraphReportBuilder.GraphStats;
 import org.opentripplanner.ext.reportapi.model.TransfersReport;
 import org.opentripplanner.ext.reportapi.model.TransitGroupPriorityReport;
 import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.constrained.ConstrainedTransferService;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -29,12 +29,18 @@ public class ReportResource {
   private final ConstrainedTransferService transferService;
   private final TransitService transitService;
   private final RouteRequest defaultRequest;
+  private final Graph graph;
 
   @SuppressWarnings("unused")
-  public ReportResource(@Context OtpServerRequestContext requestContext) {
-    this.transferService = requestContext.transitService().getConstrainedTransferService();
-    this.transitService = requestContext.transitService();
-    this.defaultRequest = requestContext.defaultRouteRequest();
+  public ReportResource(
+    @Context TransitService transitService,
+    @Context RouteRequest defaultRequest,
+    @Context Graph graph
+  ) {
+    this.transferService = transitService.getConstrainedTransferService();
+    this.transitService = transitService;
+    this.defaultRequest = defaultRequest;
+    this.graph = graph;
   }
 
   @GET
@@ -56,9 +62,9 @@ public class ReportResource {
 
   @GET
   @Path("/graph.json")
-  public Response stats(@Context OtpServerRequestContext serverRequestContext) {
+  public Response stats() {
     return Response.status(Response.Status.OK)
-      .entity(CACHED_STATS.get(() -> GraphReportBuilder.build(serverRequestContext)))
+      .entity(CACHED_STATS.get(() -> GraphReportBuilder.build(transitService, graph)))
       .type("application/json")
       .build();
   }

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -31,17 +31,29 @@ import org.opentripplanner.inspector.vector.LayerBuilder;
 import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.inspector.vector.VectorTileResponseFactory;
 import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.vehicleparking.VehicleParkingService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
+import org.opentripplanner.transit.service.TransitService;
 
 @Path("/routers/{ignoreRouterId}/vectorTiles")
 public class VectorTilesResource {
 
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final VectorTileConfig vectorTileConfig;
+  private final WorldEnvelopeService worldEnvelopeService;
+  private final VehicleRentalService vehicleRentalService;
+  private final VehicleParkingService vehicleParkingService;
   private final String ignoreRouterId;
   private final Locale locale;
 
   public VectorTilesResource(
-    @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService,
+    @Context VectorTileConfig vectorTileConfig,
+    @Context WorldEnvelopeService worldEnvelopeService,
+    @Context VehicleRentalService vehicleRentalService,
+    @Context VehicleParkingService vehicleParkingService,
     @Context Request grizzlyRequest,
     /**
      * @deprecated The support for multiple routers are removed from OTP2.
@@ -50,7 +62,11 @@ public class VectorTilesResource {
     @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
   ) {
     this.locale = grizzlyRequest.getLocale();
-    this.serverContext = serverContext;
+    this.transitService = transitService;
+    this.vectorTileConfig = vectorTileConfig;
+    this.worldEnvelopeService = worldEnvelopeService;
+    this.vehicleRentalService = vehicleRentalService;
+    this.vehicleParkingService = vehicleParkingService;
     this.ignoreRouterId = ignoreRouterId;
   }
 
@@ -69,9 +85,9 @@ public class VectorTilesResource {
       z,
       locale,
       Arrays.asList(requestedLayers.split(",")),
-      serverContext.vectorTileConfig().layers(),
+      vectorTileConfig.layers(),
       VectorTilesResource::createLayerBuilder,
-      serverContext
+      new LayerBuilderContext(transitService, vehicleRentalService, vehicleParkingService)
     );
   }
 
@@ -83,11 +99,11 @@ public class VectorTilesResource {
     @Context HttpHeaders headers,
     @PathParam("layers") String requestedLayers
   ) {
-    var envelope = serverContext.worldEnvelopeService().envelope().orElseThrow();
+    var envelope = worldEnvelopeService.envelope().orElseThrow();
 
     List<String> rLayers = Arrays.asList(requestedLayers.split(","));
 
-    var config = serverContext.vectorTileConfig();
+    var config = vectorTileConfig;
     var url = config
       .basePath()
       .map(overrideBasePath ->
@@ -109,11 +125,10 @@ public class VectorTilesResource {
   }
 
   private List<FeedInfo> getFeedInfos() {
-    return serverContext
-      .transitService()
+    return transitService
       .listFeedIds()
       .stream()
-      .map(serverContext.transitService()::getFeedInfo)
+      .map(transitService::getFeedInfo)
       .filter(Predicate.not(Objects::isNull))
       .toList();
   }
@@ -121,7 +136,7 @@ public class VectorTilesResource {
   private static LayerBuilder<?> createLayerBuilder(
     LayerParameters<LayerType> layerParameters,
     Locale locale,
-    OtpServerRequestContext context
+    LayerBuilderContext context
   ) {
     return switch (layerParameters.type()) {
       case Stop -> new StopsLayerBuilder(context.transitService(), layerParameters, locale);
@@ -168,4 +183,12 @@ public class VectorTilesResource {
   public interface LayersParameters<T extends Enum<T>> {
     List<LayerParameters<T>> layers();
   }
+
+  /** The subset of services {@link #createLayerBuilder} needs, passed through {@link
+   * VectorTileResponseFactory#create} as its generic context parameter. */
+  private record LayerBuilderContext(
+    TransitService transitService,
+    VehicleRentalService vehicleRentalService,
+    VehicleParkingService vehicleParkingService
+  ) {}
 }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLAPI.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLAPI.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.opentripplanner.apis.support.TracingUtils;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,11 +29,16 @@ public class GtfsGraphQLAPI {
 
   private static final Logger LOG = LoggerFactory.getLogger(GtfsGraphQLAPI.class);
 
-  private final OtpServerRequestContext serverContext;
+  private final RouteRequest defaultRouteRequest;
+  private final GtfsApiParameters gtfsApiParameters;
   private final ObjectMapper deserializer = new ObjectMapper();
 
-  public GtfsGraphQLAPI(@Context OtpServerRequestContext serverContext) {
-    this.serverContext = serverContext;
+  public GtfsGraphQLAPI(
+    @Context RouteRequest defaultRouteRequest,
+    @Context GtfsApiParameters gtfsApiParameters
+  ) {
+    this.defaultRouteRequest = defaultRouteRequest;
+    this.gtfsApiParameters = gtfsApiParameters;
   }
 
   /**
@@ -42,10 +48,11 @@ public class GtfsGraphQLAPI {
   public static class GtfsGraphQLAPIOldPath extends GtfsGraphQLAPI {
 
     public GtfsGraphQLAPIOldPath(
-      @Context OtpServerRequestContext serverContext,
+      @Context RouteRequest defaultRouteRequest,
+      @Context GtfsApiParameters gtfsApiParameters,
       @PathParam("ignoreRouterId") String ignore
     ) {
-      super(serverContext);
+      super(defaultRouteRequest, gtfsApiParameters);
     }
   }
 
@@ -56,7 +63,8 @@ public class GtfsGraphQLAPI {
     @HeaderParam("OTPTimeout") @DefaultValue("30000") int timeout,
     @HeaderParam("OTPMaxResolves") @DefaultValue("1000000") int maxResolves,
     @Context HttpHeaders headers,
-    @Context UriInfo uriInfo
+    @Context UriInfo uriInfo,
+    @Context OtpServerRequestContext serverContext
   ) {
     if (jsonParameters == null || !jsonParameters.containsKey("query")) {
       LOG.debug("No query found in body");
@@ -68,7 +76,7 @@ public class GtfsGraphQLAPI {
 
     Locale locale = headers.getAcceptableLanguages().size() > 0
       ? headers.getAcceptableLanguages().get(0)
-      : serverContext.defaultRouteRequest().preferences().locale();
+      : defaultRouteRequest.preferences().locale();
 
     String query = (String) jsonParameters.get("query");
     Object queryVariables = jsonParameters.getOrDefault("variables", null);
@@ -98,7 +106,7 @@ public class GtfsGraphQLAPI {
       locale,
       GraphQLRequestContext.ofServerContext(serverContext),
       TracingUtils.findTagsInHeadersOrQueryParameters(
-        serverContext.gtfsApiParameters().tracingTags(),
+        gtfsApiParameters.tracingTags(),
         headers,
         uriInfo.getQueryParameters()
       )
@@ -112,11 +120,12 @@ public class GtfsGraphQLAPI {
     @HeaderParam("OTPTimeout") @DefaultValue("30000") int timeout,
     @HeaderParam("OTPMaxResolves") @DefaultValue("1000000") int maxResolves,
     @Context HttpHeaders headers,
-    @Context UriInfo uriInfo
+    @Context UriInfo uriInfo,
+    @Context OtpServerRequestContext serverContext
   ) {
     Locale locale = headers.getAcceptableLanguages().size() > 0
       ? headers.getAcceptableLanguages().get(0)
-      : serverContext.defaultRouteRequest().preferences().locale();
+      : defaultRouteRequest.preferences().locale();
     return GtfsGraphQLIndex.getGraphQLResponse(
       query,
       null,
@@ -126,7 +135,7 @@ public class GtfsGraphQLAPI {
       locale,
       GraphQLRequestContext.ofServerContext(serverContext),
       TracingUtils.findTagsInHeadersOrQueryParameters(
-        serverContext.gtfsApiParameters().tracingTags(),
+        gtfsApiParameters.tracingTags(),
         headers,
         uriInfo.getQueryParameters()
       )

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/configure/SchemaModule.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/configure/SchemaModule.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.SchemaFactory;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.standalone.configure.StaticRouteRequestDefaults;
 
 /**
  * The schema is used during application serve phase, not loading, and it depends on the default
@@ -22,7 +23,7 @@ public class SchemaModule {
   @Singleton
   @Nullable
   @GtfsSchema
-  public GraphQLSchema provideSchema(RouteRequest defaultRouteRequest) {
+  public GraphQLSchema provideSchema(@StaticRouteRequestDefaults RouteRequest defaultRouteRequest) {
     return OTPFeature.GtfsGraphQlApi.isOn()
       ? SchemaFactory.createSchemaWithDefaultInjection(defaultRouteRequest)
       : null;

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelAPI.java
@@ -42,17 +42,18 @@ public class TransmodelAPI {
   private final Collection<String> tracingHeaderTags;
   private final int maxNumberOfResultFields;
 
-  private final OtpServerRequestContext serverContext;
   private final TransmodelGraph index;
   private final ObjectMapper deserializer = new ObjectMapper();
 
-  public TransmodelAPI(@Context OtpServerRequestContext serverContext) {
-    this.serverContext = serverContext;
-    this.schema = serverContext.transmodelSchema();
+  public TransmodelAPI(
+    @Context TransmodelGraphQLSchema transmodelGraphQLSchema,
+    @Context TransmodelAPIParameters transmodelAPIParameters
+  ) {
+    this.schema = transmodelGraphQLSchema.schema();
     this.index = new TransmodelGraph(schema);
 
-    tracingHeaderTags = serverContext.transmodelAPIParameters().tracingHeaderTags();
-    maxNumberOfResultFields = serverContext.transmodelAPIParameters().maxNumberOfResultFields();
+    tracingHeaderTags = transmodelAPIParameters.tracingHeaderTags();
+    maxNumberOfResultFields = transmodelAPIParameters.maxNumberOfResultFields();
   }
 
   /**
@@ -62,10 +63,11 @@ public class TransmodelAPI {
   public static class TransmodelAPIOldPath extends TransmodelAPI {
 
     public TransmodelAPIOldPath(
-      @Context OtpServerRequestContext serverContext,
+      @Context TransmodelGraphQLSchema transmodelGraphQLSchema,
+      @Context TransmodelAPIParameters transmodelAPIParameters,
       @PathParam("ignoreRouterId") String ignore
     ) {
-      super(serverContext);
+      super(transmodelGraphQLSchema, transmodelAPIParameters);
     }
   }
 
@@ -73,7 +75,8 @@ public class TransmodelAPI {
   @Consumes(MediaType.APPLICATION_JSON)
   public Response getGraphQL(
     HashMap<String, Object> queryParameters,
-    @Context HttpHeaders headers
+    @Context HttpHeaders headers,
+    @Context OtpServerRequestContext serverContext
   ) {
     if (queryParameters == null || !queryParameters.containsKey("query")) {
       LOG.debug("No query found in body");
@@ -112,7 +115,11 @@ public class TransmodelAPI {
 
   @POST
   @Consumes("application/graphql")
-  public Response getGraphQL(String query, @Context HttpHeaders headers) {
+  public Response getGraphQL(
+    String query,
+    @Context HttpHeaders headers,
+    @Context OtpServerRequestContext serverContext
+  ) {
     return index.executeGraphQL(
       query,
       serverContext,

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraphQLSchema.java
@@ -1,0 +1,11 @@
+package org.opentripplanner.apis.transmodel;
+
+import graphql.schema.GraphQLSchema;
+import javax.annotation.Nullable;
+
+/**
+ * Wraps the Transmodel {@link GraphQLSchema} so it can be exposed as its own HK2 {@code @Context}-
+ * injectable binding. A bare {@code GraphQLSchema} is ambiguous for that purpose since the GTFS
+ * API binds one too, and JAX-RS {@code @Context} resolves by type only, not by Dagger qualifier.
+ */
+public record TransmodelGraphQLSchema(@Nullable GraphQLSchema schema) {}

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
@@ -13,6 +13,7 @@ import org.opentripplanner.apis.transmodel.mapping.FixedFeedIdGenerator;
 import org.opentripplanner.framework.time.ZoneIdFallback;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.config.RouterConfig;
+import org.opentripplanner.standalone.configure.StaticRouteRequestDefaults;
 import org.opentripplanner.transit.service.TimetableRepository;
 
 @Module
@@ -23,7 +24,7 @@ public class TransmodelSchemaModule {
   @Nullable
   @TransmodelSchema
   public GraphQLSchema provideTransmodelSchema(
-    RouteRequest defaultRouteRequest,
+    @StaticRouteRequestDefaults RouteRequest defaultRouteRequest,
     TimetableRepository timetableRepository,
     RouterConfig routerConfig
   ) {

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
@@ -45,7 +45,13 @@ import org.opentripplanner.inspector.vector.stop.StopLayerBuilder;
 import org.opentripplanner.inspector.vector.transfers.TransfersLayerBuilder;
 import org.opentripplanner.inspector.vector.vertex.VertexLayerBuilder;
 import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
+import org.opentripplanner.standalone.config.DebugUiConfig;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transfer.regular.RegularTransferService;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Slippy map vector tile API for rendering various graph information for inspection/debugging
@@ -77,10 +83,30 @@ public class DebugVectorTilesResource {
   );
   public static final String PATH = "/otp/debug/vectortiles/";
 
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final Graph graph;
+  private final DebugUiConfig debugUiConfig;
+  private final WorldEnvelopeService worldEnvelopeService;
+  private final VehicleRentalService vehicleRentalService;
+  private final StreetDetailsService streetDetailsService;
+  private final RegularTransferService transferService;
 
-  public DebugVectorTilesResource(@Context OtpServerRequestContext serverContext) {
-    this.serverContext = serverContext;
+  public DebugVectorTilesResource(
+    @Context TransitService transitService,
+    @Context Graph graph,
+    @Context DebugUiConfig debugUiConfig,
+    @Context WorldEnvelopeService worldEnvelopeService,
+    @Context VehicleRentalService vehicleRentalService,
+    @Context StreetDetailsService streetDetailsService,
+    @Context RegularTransferService transferService
+  ) {
+    this.transitService = transitService;
+    this.graph = graph;
+    this.debugUiConfig = debugUiConfig;
+    this.worldEnvelopeService = worldEnvelopeService;
+    this.vehicleRentalService = vehicleRentalService;
+    this.streetDetailsService = streetDetailsService;
+    this.transferService = transferService;
   }
 
   @GET
@@ -101,7 +127,13 @@ public class DebugVectorTilesResource {
       Arrays.asList(requestedLayers.split(",")),
       DEBUG_LAYERS,
       DebugVectorTilesResource::createLayerBuilder,
-      serverContext
+      new LayerBuilderContext(
+        transitService,
+        vehicleRentalService,
+        graph,
+        streetDetailsService,
+        transferService
+      )
     );
   }
 
@@ -113,7 +145,7 @@ public class DebugVectorTilesResource {
     @Context HttpHeaders headers,
     @PathParam("layers") String requestedLayers
   ) {
-    var envelope = serverContext.worldEnvelopeService().envelope().orElseThrow();
+    var envelope = worldEnvelopeService.envelope().orElseThrow();
     List<FeedInfo> feedInfos = feedInfos();
     List<String> layers = Arrays.asList(requestedLayers.split(","));
 
@@ -150,7 +182,7 @@ public class DebugVectorTilesResource {
       GEOFENCING_ZONES.toVectorSourceLayer(geofencingSource),
       RENTAL.toVectorSourceLayer(rentalSource),
       TRANSFERS.toVectorSourceLayer(transferSource),
-      serverContext.debugUiConfig().additionalBackgroundLayers()
+      debugUiConfig.additionalBackgroundLayers()
     );
   }
 
@@ -163,11 +195,10 @@ public class DebugVectorTilesResource {
   }
 
   private List<FeedInfo> feedInfos() {
-    return serverContext
-      .transitService()
+    return transitService
       .listFeedIds()
       .stream()
-      .map(serverContext.transitService()::getFeedInfo)
+      .map(transitService::getFeedInfo)
       .filter(Predicate.not(Objects::isNull))
       .toList();
   }
@@ -175,7 +206,7 @@ public class DebugVectorTilesResource {
   private static LayerBuilder<?> createLayerBuilder(
     LayerParameters<LayerType> layerParameters,
     Locale locale,
-    OtpServerRequestContext context
+    LayerBuilderContext context
   ) {
     return switch (layerParameters.type()) {
       case RegularStop -> new StopLayerBuilder<>(layerParameters, locale, e ->
@@ -208,4 +239,14 @@ public class DebugVectorTilesResource {
       );
     };
   }
+
+  /** The subset of services {@link #createLayerBuilder} needs, passed through {@link
+   * VectorTileResponseFactory#create} as its generic context parameter. */
+  private record LayerBuilderContext(
+    TransitService transitService,
+    VehicleRentalService vehicleRentalService,
+    Graph graph,
+    StreetDetailsService streetDetailsService,
+    RegularTransferService transferService
+  ) {}
 }

--- a/application/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
@@ -10,22 +10,21 @@ import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.api.resource.WebMercatorTile;
 import org.opentripplanner.framework.io.HttpUtils;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
 
 /**
  * Common functionality for creating a vector tile response.
  */
 public class VectorTileResponseFactory {
 
-  public static <LayerType extends Enum<LayerType>> Response create(
+  public static <LayerType extends Enum<LayerType>, C> Response create(
     int x,
     int y,
     int z,
     Locale locale,
     List<String> requestedLayers,
     List<LayerParameters<LayerType>> availableLayers,
-    LayerBuilderFactory<LayerType> layerBuilderFactory,
-    OtpServerRequestContext context
+    LayerBuilderFactory<LayerType, C> layerBuilderFactory,
+    C context
   ) {
     VectorTile.Tile.Builder mvtBuilder = VectorTile.Tile.newBuilder();
     Envelope envelope = WebMercatorTile.tile2Envelope(x, y, z);
@@ -73,11 +72,11 @@ public class VectorTileResponseFactory {
   }
 
   @FunctionalInterface
-  public interface LayerBuilderFactory<LayerType extends Enum<LayerType>> {
+  public interface LayerBuilderFactory<LayerType extends Enum<LayerType>, C> {
     LayerBuilder<?> createLayerBuilder(
       LayerParameters<LayerType> layerParameters,
       Locale locale,
-      OtpServerRequestContext context
+      C context
     );
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -252,7 +252,17 @@ public class RoutingWorker {
     debugTimingAggregator.startedDirectFlexRouter();
     try {
       return RoutingResult.ok(
-        DirectFlexRouter.route(serverContext, request, additionalSearchDays, linkingContext())
+        DirectFlexRouter.route(
+          serverContext.graph(),
+          serverContext.transitService(),
+          serverContext.transferService(),
+          serverContext.streetDetailsService(),
+          serverContext.flexParameters(),
+          serverContext.dataOverlayParameterBindings(),
+          request,
+          additionalSearchDays,
+          linkingContext()
+        )
       );
     } catch (RoutingValidationException e) {
       return RoutingResult.failed(e.getRoutingErrors());

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -232,7 +232,16 @@ public class RoutingWorker {
     debugTimingAggregator.startedDirectStreetRouter();
     try {
       return RoutingResult.ok(
-        DirectStreetRouter.route(serverContext, directBuilder.buildRequest(), linkingContext()),
+        DirectStreetRouter.route(
+          serverContext.graph(),
+          serverContext.transitService(),
+          serverContext.streetLimitationParametersService(),
+          serverContext.vehicleRentalService(),
+          serverContext.streetDetailsService(),
+          serverContext.dataOverlayParameterBindings(),
+          directBuilder.buildRequest(),
+          linkingContext()
+        ),
         emptyDirectModeHandler.removeWalkAllTheWayResults()
       );
     } catch (RoutingValidationException e) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -305,7 +305,17 @@ public class RoutingWorker {
     try {
       var transitResults = TransitRouter.route(
         request,
-        serverContext,
+        serverContext.transitService(),
+        serverContext.graph(),
+        serverContext.raptorConfig(),
+        serverContext.meterRegistry(),
+        serverContext.streetDetailsService(),
+        serverContext.transferService(),
+        serverContext.flexParameters(),
+        serverContext.rideHailingServices(),
+        serverContext.dataOverlayParameterBindings(),
+        serverContext.sorlandsbanenService(),
+        serverContext.viaTransferResolver(),
         transitGroupPriorityService,
         transitSearchTimeZero,
         additionalSearchDays,

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -129,7 +129,10 @@ public class RoutingWorker {
 
       ItineraryListFilterChain filterChain = RouteRequestToFilterChainMapper.createFilterChain(
         request,
-        serverContext,
+        serverContext.transitService(),
+        serverContext.rideHailingServices(),
+        serverContext.emissionItineraryDecorator(),
+        serverContext.stopConsolidationService(),
         earliestDepartureTimeUsed(),
         searchWindowUsed(),
         result.removeWalkAllTheWayResults() || removeWalkAllTheWayResultsFromDirectFlex,

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -9,13 +10,21 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import javax.annotation.Nullable;
+import org.opentripplanner.ext.carpooling.CarpoolingService;
+import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
+import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.ext.ridehailing.RideHailingService;
+import org.opentripplanner.ext.sorlandsbanen.SorlandsbanenNorwayService;
+import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.grouppriority.TransitGroupPriorityItineraryDecorator;
 import org.opentripplanner.model.plan.paging.cursor.PageCursorInput;
 import org.opentripplanner.raptor.api.request.SearchParams;
+import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChain;
+import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
 import org.opentripplanner.routing.algorithm.mapping.PagingServiceFactory;
 import org.opentripplanner.routing.algorithm.mapping.RouteRequestToFilterChainMapper;
 import org.opentripplanner.routing.algorithm.mapping.RoutingResponseMapper;
@@ -24,6 +33,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.router.FilterTransitW
 import org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.DirectFlexRouter;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.DirectStreetRouter;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.routing.api.response.InputField;
@@ -33,12 +43,20 @@ import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.error.RoutingValidationException;
 import org.opentripplanner.routing.framework.DebugTimingAggregator;
 import org.opentripplanner.routing.linking.LinkingContext;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.linking.mapping.LinkingContextRequestMapper;
+import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
 import org.opentripplanner.service.paging.PagingService;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.standalone.config.routerconfig.TransitRoutingConfig;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.TemporaryVerticesContainer;
 import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.model.network.grouppriority.TransitGroupPriorityService;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +73,35 @@ public class RoutingWorker {
   private final DebugTimingAggregator debugTimingAggregator;
 
   private final RouteRequest request;
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final Graph graph;
+  private final RaptorConfig<TripSchedule> raptorConfig;
+  private final MeterRegistry meterRegistry;
+  private final StreetLimitationParametersService streetLimitationParametersService;
+  private final VehicleRentalService vehicleRentalService;
+  private final StreetDetailsService streetDetailsService;
+  private final RegularTransferService transferService;
+  private final FlexParameters flexParameters;
+  private final List<RideHailingService> rideHailingServices;
+  private final ViaCoordinateTransferFactory viaTransferResolver;
+  private final LinkingContextFactory linkingContextFactory;
+  private final TransitRoutingConfig transitRoutingConfig;
+
+  @Nullable
+  private final DataOverlayParameterBindings dataOverlayParameterBindings;
+
+  @Nullable
+  private final SorlandsbanenNorwayService sorlandsbanenService;
+
+  @Nullable
+  private final CarpoolingService carpoolingService;
+
+  @Nullable
+  private final ItineraryDecorator emissionItineraryDecorator;
+
+  @Nullable
+  private final StopConsolidationService stopConsolidationService;
+
   private final ZonedDateTime transitSearchTimeZero;
   private final AdditionalSearchDays additionalSearchDays;
   private final TransitGroupPriorityService transitGroupPriorityService;
@@ -66,13 +112,50 @@ public class RoutingWorker {
   @Nullable
   private LinkingContext currentLinkingContext = null;
 
-  public RoutingWorker(OtpServerRequestContext serverContext, RoutingWorkerRequest workerRequest) {
+  public RoutingWorker(
+    TransitService transitService,
+    Graph graph,
+    RaptorConfig<TripSchedule> raptorConfig,
+    MeterRegistry meterRegistry,
+    StreetLimitationParametersService streetLimitationParametersService,
+    VehicleRentalService vehicleRentalService,
+    StreetDetailsService streetDetailsService,
+    RegularTransferService transferService,
+    FlexParameters flexParameters,
+    List<RideHailingService> rideHailingServices,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
+    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
+    ViaCoordinateTransferFactory viaTransferResolver,
+    @Nullable CarpoolingService carpoolingService,
+    @Nullable ItineraryDecorator emissionItineraryDecorator,
+    @Nullable StopConsolidationService stopConsolidationService,
+    LinkingContextFactory linkingContextFactory,
+    TransitRoutingConfig transitRoutingConfig,
+    RoutingWorkerRequest workerRequest
+  ) {
     this.request = workerRequest.request();
     this.transitSearchTimeZero = workerRequest.transitSearchTimeZero();
     this.additionalSearchDays = workerRequest.additionalSearchDays();
-    this.serverContext = serverContext;
+    this.transitService = transitService;
+    this.graph = graph;
+    this.raptorConfig = raptorConfig;
+    this.meterRegistry = meterRegistry;
+    this.streetLimitationParametersService = streetLimitationParametersService;
+    this.vehicleRentalService = vehicleRentalService;
+    this.streetDetailsService = streetDetailsService;
+    this.transferService = transferService;
+    this.flexParameters = flexParameters;
+    this.rideHailingServices = rideHailingServices;
+    this.dataOverlayParameterBindings = dataOverlayParameterBindings;
+    this.sorlandsbanenService = sorlandsbanenService;
+    this.viaTransferResolver = viaTransferResolver;
+    this.carpoolingService = carpoolingService;
+    this.emissionItineraryDecorator = emissionItineraryDecorator;
+    this.stopConsolidationService = stopConsolidationService;
+    this.linkingContextFactory = linkingContextFactory;
+    this.transitRoutingConfig = transitRoutingConfig;
     this.debugTimingAggregator = new DebugTimingAggregator(
-      serverContext.meterRegistry(),
+      meterRegistry,
       request.preferences().system().tags()
     );
     this.transitGroupPriorityService = TransitGroupPriorityService.of(
@@ -129,10 +212,10 @@ public class RoutingWorker {
 
       ItineraryListFilterChain filterChain = RouteRequestToFilterChainMapper.createFilterChain(
         request,
-        serverContext.transitService(),
-        serverContext.rideHailingServices(),
-        serverContext.emissionItineraryDecorator(),
-        serverContext.stopConsolidationService(),
+        transitService,
+        rideHailingServices,
+        emissionItineraryDecorator,
+        stopConsolidationService,
         earliestDepartureTimeUsed(),
         searchWindowUsed(),
         result.removeWalkAllTheWayResults() || removeWalkAllTheWayResultsFromDirectFlex,
@@ -169,7 +252,7 @@ public class RoutingWorker {
       result.itineraries(),
       result.errors(),
       debugTimingAggregator,
-      serverContext.transitService(),
+      transitService,
       pagingService
     );
   }
@@ -236,12 +319,12 @@ public class RoutingWorker {
     try {
       return RoutingResult.ok(
         DirectStreetRouter.route(
-          serverContext.graph(),
-          serverContext.transitService(),
-          serverContext.streetLimitationParametersService(),
-          serverContext.vehicleRentalService(),
-          serverContext.streetDetailsService(),
-          serverContext.dataOverlayParameterBindings(),
+          graph,
+          transitService,
+          streetLimitationParametersService,
+          vehicleRentalService,
+          streetDetailsService,
+          dataOverlayParameterBindings,
           directBuilder.buildRequest(),
           linkingContext()
         ),
@@ -265,12 +348,12 @@ public class RoutingWorker {
     try {
       return RoutingResult.ok(
         DirectFlexRouter.route(
-          serverContext.graph(),
-          serverContext.transitService(),
-          serverContext.transferService(),
-          serverContext.streetDetailsService(),
-          serverContext.flexParameters(),
-          serverContext.dataOverlayParameterBindings(),
+          graph,
+          transitService,
+          transferService,
+          streetDetailsService,
+          flexParameters,
+          dataOverlayParameterBindings,
           request,
           additionalSearchDays,
           linkingContext()
@@ -292,7 +375,7 @@ public class RoutingWorker {
     }
     debugTimingAggregator.startedDirectCarpoolRouter();
     try {
-      return RoutingResult.ok(serverContext.carpoolingService().routeDirect(request));
+      return RoutingResult.ok(carpoolingService.routeDirect(request));
     } catch (RoutingValidationException e) {
       return RoutingResult.failed(e.getRoutingErrors());
     } finally {
@@ -305,23 +388,23 @@ public class RoutingWorker {
     try {
       var transitResults = TransitRouter.route(
         request,
-        serverContext.transitService(),
-        serverContext.graph(),
-        serverContext.raptorConfig(),
-        serverContext.meterRegistry(),
-        serverContext.streetDetailsService(),
-        serverContext.transferService(),
-        serverContext.flexParameters(),
-        serverContext.rideHailingServices(),
-        serverContext.dataOverlayParameterBindings(),
-        serverContext.sorlandsbanenService(),
-        serverContext.viaTransferResolver(),
+        transitService,
+        graph,
+        raptorConfig,
+        meterRegistry,
+        streetDetailsService,
+        transferService,
+        flexParameters,
+        rideHailingServices,
+        dataOverlayParameterBindings,
+        sorlandsbanenService,
+        viaTransferResolver,
         transitGroupPriorityService,
         transitSearchTimeZero,
         additionalSearchDays,
         debugTimingAggregator,
         linkingContext(),
-        serverContext.carpoolingService()
+        carpoolingService
       );
       raptorSearchParamsUsed = transitResults.getSearchParams();
       var itineraries = transitResults.getItineraries();
@@ -341,8 +424,8 @@ public class RoutingWorker {
   private PagingService createPagingService(List<Itinerary> itineraries) {
     return PagingServiceFactory.createPagingService(
       searchStartTime(),
-      serverContext.transitTuningParameters(),
-      serverContext.raptorTuningParameters(),
+      transitRoutingConfig,
+      transitRoutingConfig,
       request,
       raptorSearchParamsUsed,
       pageCursorInput,
@@ -388,6 +471,6 @@ public class RoutingWorker {
 
   private LinkingContext createLinkingContext(TemporaryVerticesContainer container) {
     var linkingRequest = LinkingContextRequestMapper.map(request);
-    return serverContext.linkingContextFactory().create(container, linkingRequest);
+    return linkingContextFactory.create(container, linkingRequest);
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -4,17 +4,21 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.ridehailing.DecorateWithRideHailing;
+import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.stopconsolidation.DecorateConsolidatedStopNames;
+import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.model.plan.paging.cursor.PageCursorInput;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChain;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChainBuilder;
 import org.opentripplanner.routing.algorithm.filterchain.api.GroupBySimilarity;
+import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.ItineraryFilterPreferences;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.transit.service.TransitService;
 
 public class RouteRequestToFilterChainMapper {
 
@@ -26,7 +30,10 @@ public class RouteRequestToFilterChainMapper {
 
   public static ItineraryListFilterChain createFilterChain(
     RouteRequest request,
-    OtpServerRequestContext context,
+    TransitService transitService,
+    List<RideHailingService> rideHailingServices,
+    @Nullable ItineraryDecorator emissionItineraryDecorator,
+    @Nullable StopConsolidationService stopConsolidationService,
     Instant earliestDepartureTimeUsed,
     Duration searchWindowUsed,
     boolean removeWalkAllTheWayResults,
@@ -90,8 +97,8 @@ public class RouteRequestToFilterChainMapper {
         params.removeItinerariesWithSameRoutesAndStops()
       )
       .withTransitAlerts(
-        context.transitService().getTransitAlertService(),
-        context.transitService()::findMultiModalStation
+        transitService.getTransitAlertService(),
+        transitService::findMultiModalStation
       )
       .withSearchWindow(earliestDepartureTimeUsed, searchWindowUsed)
       .withPageCursorInputSubscriber(pageCursorInputSubscriber)
@@ -104,21 +111,19 @@ public class RouteRequestToFilterChainMapper {
       builder.withTransitGroupPriority();
     }
 
-    if (!context.rideHailingServices().isEmpty()) {
+    if (!rideHailingServices.isEmpty()) {
       builder.withRideHailingDecoratingFilter(
-        new DecorateWithRideHailing(context.rideHailingServices(), request.journey().wheelchair())
+        new DecorateWithRideHailing(rideHailingServices, request.journey().wheelchair())
       );
     }
 
     if (OTPFeature.Emission.isOn()) {
-      builder.withEmissions(context.emissionItineraryDecorator());
+      builder.withEmissions(emissionItineraryDecorator);
     }
 
-    if (
-      context.stopConsolidationService() != null && context.stopConsolidationService().isActive()
-    ) {
+    if (stopConsolidationService != null && stopConsolidationService.isActive()) {
       builder.withConsolidatedStopNamesDecorator(
-        new DecorateConsolidatedStopNames(context.stopConsolidationService())
+        new DecorateConsolidatedStopNames(stopConsolidationService)
       );
     }
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/AccessEgressFetcher.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/AccessEgressFetcher.java
@@ -164,7 +164,10 @@ class AccessEgressFetcher {
     if (OTPFeature.FlexRouting.isOn() && mode == StreetMode.FLEXIBLE) {
       var flexAccessList = FlexAccessEgressRouter.routeAccessEgress(
         accessRequest,
-        serverContext,
+        serverContext.transitService(),
+        serverContext.graph(),
+        serverContext.transferService(),
+        serverContext.streetDetailsService(),
         additionalSearchDays,
         serverContext.flexParameters(),
         serverContext.listExtensionRequestContexts(accessRequest),

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/AccessEgressFetcher.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/AccessEgressFetcher.java
@@ -9,8 +9,13 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
+import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
+import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.ridehailing.RideHailingAccessShifter;
+import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.startonboardaccess.RoutingStartOnBoardAccess;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.startonboardaccess.TripAndServiceDateResolver;
@@ -25,8 +30,11 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.Rapto
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.routing.linking.LinkingContext;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.transfer.regular.RegularTransferService;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.service.TransitServiceResolver;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
@@ -38,7 +46,16 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
 class AccessEgressFetcher {
 
   private final RouteRequest request;
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final Graph graph;
+  private final RegularTransferService transferService;
+  private final StreetDetailsService streetDetailsService;
+  private final FlexParameters flexParameters;
+  private final List<RideHailingService> rideHailingServices;
+
+  @Nullable
+  private final DataOverlayParameterBindings dataOverlayParameterBindings;
+
   private final ZonedDateTime transitSearchTimeZero;
   private final AdditionalSearchDays additionalSearchDays;
   private final LinkingContext linkingContext;
@@ -58,7 +75,13 @@ class AccessEgressFetcher {
    */
   public AccessEgressFetcher(
     RouteRequest request,
-    OtpServerRequestContext serverContext,
+    TransitService transitService,
+    Graph graph,
+    RegularTransferService transferService,
+    StreetDetailsService streetDetailsService,
+    FlexParameters flexParameters,
+    List<RideHailingService> rideHailingServices,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
     ZonedDateTime transitSearchTimeZero,
     AdditionalSearchDays additionalSearchDays,
     LinkingContext linkingContext,
@@ -66,15 +89,21 @@ class AccessEgressFetcher {
     RaptorRoutingRequestTransitData requestTransitDataProvider
   ) {
     this.request = request;
-    this.serverContext = serverContext;
+    this.transitService = transitService;
+    this.graph = graph;
+    this.transferService = transferService;
+    this.streetDetailsService = streetDetailsService;
+    this.flexParameters = flexParameters;
+    this.rideHailingServices = rideHailingServices;
+    this.dataOverlayParameterBindings = dataOverlayParameterBindings;
     this.transitSearchTimeZero = transitSearchTimeZero;
     this.additionalSearchDays = additionalSearchDays;
     this.linkingContext = linkingContext;
     this.carpoolingService = carpoolingService;
-    this.transitServiceResolver = new TransitServiceResolver(serverContext.transitService());
+    this.transitServiceResolver = new TransitServiceResolver(transitService);
     this.accessEgressMapper = new AccessEgressMapper(transitServiceResolver);
     this.tripScheduleIndexResolver = new TripScheduleIndexResolver(requestTransitDataProvider);
-    this.tripLocationResolver = new TripLocationResolver(serverContext.transitService());
+    this.tripLocationResolver = new TripLocationResolver(transitService);
   }
 
   Collection<? extends RoutingAccessEgress> fetchAccess() {
@@ -97,7 +126,6 @@ class AccessEgressFetcher {
       );
     }
 
-    var transitService = serverContext.transitService();
     var tripAndServiceDate = new TripAndServiceDateResolver(transitService).resolve(
       onBoardTripLocation.tripOnDateReference()
     );
@@ -149,7 +177,7 @@ class AccessEgressFetcher {
     var nearbyStops = AccessEgressRouter.findAccessEgresses(
       accessRequest,
       mode,
-      serverContext.listExtensionRequestContexts(accessRequest),
+      DataOverlayContext.listExtensionRequestContexts(accessRequest, dataOverlayParameterBindings),
       type,
       durationLimit,
       stopCountLimit,
@@ -164,13 +192,16 @@ class AccessEgressFetcher {
     if (OTPFeature.FlexRouting.isOn() && mode == StreetMode.FLEXIBLE) {
       var flexAccessList = FlexAccessEgressRouter.routeAccessEgress(
         accessRequest,
-        serverContext.transitService(),
-        serverContext.graph(),
-        serverContext.transferService(),
-        serverContext.streetDetailsService(),
+        transitService,
+        graph,
+        transferService,
+        streetDetailsService,
         additionalSearchDays,
-        serverContext.flexParameters(),
-        serverContext.listExtensionRequestContexts(accessRequest),
+        flexParameters,
+        DataOverlayContext.listExtensionRequestContexts(
+          accessRequest,
+          dataOverlayParameterBindings
+        ),
         type,
         linkingContext
       );
@@ -212,7 +243,7 @@ class AccessEgressFetcher {
     return RideHailingAccessShifter.shiftAccesses(
       type.isAccess(),
       accessEgressList,
-      serverContext.rideHailingServices(),
+      rideHailingServices,
       request,
       Instant.now()
     );

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -116,7 +116,13 @@ public class TransitRouter {
     var requestTransitDataProvider = createRequestTransitDataProvider(raptorTransitData);
     var fetchAccessEgress = new AccessEgressFetcher(
       request,
-      serverContext,
+      serverContext.transitService(),
+      serverContext.graph(),
+      serverContext.transferService(),
+      serverContext.streetDetailsService(),
+      serverContext.flexParameters(),
+      serverContext.rideHailingServices(),
+      serverContext.dataOverlayParameterBindings(),
       transitSearchTimeZero,
       additionalSearchDays,
       linkingContext,

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.router;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,11 +11,16 @@ import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
+import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
+import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.ext.ridehailing.RideHailingService;
+import org.opentripplanner.ext.sorlandsbanen.SorlandsbanenNorwayService;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor.api.path.RaptorPath;
 import org.opentripplanner.raptor.api.response.RaptorResponse;
+import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.raptor.extensions.extrasearch.ExtraMcRouterSearch;
 import org.opentripplanner.routing.algorithm.mapping.RaptorPathToItineraryMapper;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.street.AccessEgressPenaltyDecorator;
@@ -35,17 +41,34 @@ import org.opentripplanner.routing.error.RoutingValidationException;
 import org.opentripplanner.routing.framework.DebugTimingAggregator;
 import org.opentripplanner.routing.linking.LinkingContext;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.model.framework.EntityNotFoundException;
 import org.opentripplanner.transit.model.network.grouppriority.TransitGroupPriorityService;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitService;
 
 public class TransitRouter {
 
   public static final int NOT_SET = -1;
 
   private final RouteRequest request;
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final Graph graph;
+  private final RaptorConfig<TripSchedule> raptorConfig;
+  private final MeterRegistry meterRegistry;
+  private final StreetDetailsService streetDetailsService;
+  private final RegularTransferService transferService;
+  private final FlexParameters flexParameters;
+  private final List<RideHailingService> rideHailingServices;
+
+  @Nullable
+  private final DataOverlayParameterBindings dataOverlayParameterBindings;
+
+  @Nullable
+  private final SorlandsbanenNorwayService sorlandsbanenService;
+
   private final TransitGroupPriorityService transitGroupPriorityService;
   private final DebugTimingAggregator debugTimingAggregator;
   private final ZonedDateTime transitSearchTimeZero;
@@ -56,7 +79,17 @@ public class TransitRouter {
 
   private TransitRouter(
     RouteRequest request,
-    OtpServerRequestContext serverContext,
+    TransitService transitService,
+    Graph graph,
+    RaptorConfig<TripSchedule> raptorConfig,
+    MeterRegistry meterRegistry,
+    StreetDetailsService streetDetailsService,
+    RegularTransferService transferService,
+    FlexParameters flexParameters,
+    List<RideHailingService> rideHailingServices,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
+    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
+    ViaCoordinateTransferFactory viaTransferResolver,
     TransitGroupPriorityService transitGroupPriorityService,
     ZonedDateTime transitSearchTimeZero,
     AdditionalSearchDays additionalSearchDays,
@@ -65,19 +98,38 @@ public class TransitRouter {
     CarpoolingService carpoolingService
   ) {
     this.request = request;
-    this.serverContext = serverContext;
+    this.transitService = transitService;
+    this.graph = graph;
+    this.raptorConfig = raptorConfig;
+    this.meterRegistry = meterRegistry;
+    this.streetDetailsService = streetDetailsService;
+    this.transferService = transferService;
+    this.flexParameters = flexParameters;
+    this.rideHailingServices = rideHailingServices;
+    this.dataOverlayParameterBindings = dataOverlayParameterBindings;
+    this.sorlandsbanenService = sorlandsbanenService;
     this.transitGroupPriorityService = transitGroupPriorityService;
     this.transitSearchTimeZero = transitSearchTimeZero;
     this.additionalSearchDays = additionalSearchDays;
     this.debugTimingAggregator = debugTimingAggregator;
-    this.viaTransferResolver = serverContext.viaTransferResolver();
+    this.viaTransferResolver = viaTransferResolver;
     this.linkingContext = linkingContext;
     this.carpoolingService = carpoolingService;
   }
 
   public static TransitRouterResult route(
     RouteRequest request,
-    OtpServerRequestContext serverContext,
+    TransitService transitService,
+    Graph graph,
+    RaptorConfig<TripSchedule> raptorConfig,
+    MeterRegistry meterRegistry,
+    StreetDetailsService streetDetailsService,
+    RegularTransferService transferService,
+    FlexParameters flexParameters,
+    List<RideHailingService> rideHailingServices,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
+    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
+    ViaCoordinateTransferFactory viaTransferResolver,
     TransitGroupPriorityService priorityGroupConfigurator,
     ZonedDateTime transitSearchTimeZero,
     AdditionalSearchDays additionalSearchDays,
@@ -87,7 +139,17 @@ public class TransitRouter {
   ) {
     TransitRouter transitRouter = new TransitRouter(
       request,
-      serverContext,
+      transitService,
+      graph,
+      raptorConfig,
+      meterRegistry,
+      streetDetailsService,
+      transferService,
+      flexParameters,
+      rideHailingServices,
+      dataOverlayParameterBindings,
+      sorlandsbanenService,
+      viaTransferResolver,
       priorityGroupConfigurator,
       transitSearchTimeZero,
       additionalSearchDays,
@@ -104,25 +166,25 @@ public class TransitRouter {
       return new TransitRouterResult(List.of(), null);
     }
 
-    if (!serverContext.transitService().transitFeedCovers(request.dateTime())) {
+    if (!transitService.transitFeedCovers(request.dateTime())) {
       throw new RoutingValidationException(
         List.of(new RoutingError(RoutingErrorCode.OUTSIDE_SERVICE_PERIOD, InputField.DATE_TIME))
       );
     }
 
     var raptorTransitData = request.preferences().transit().ignoreRealtimeUpdates()
-      ? serverContext.transitService().getRaptorTransitData()
-      : serverContext.transitService().getRealtimeRaptorTransitData();
+      ? transitService.getRaptorTransitData()
+      : transitService.getRealtimeRaptorTransitData();
     var requestTransitDataProvider = createRequestTransitDataProvider(raptorTransitData);
     var fetchAccessEgress = new AccessEgressFetcher(
       request,
-      serverContext.transitService(),
-      serverContext.graph(),
-      serverContext.transferService(),
-      serverContext.streetDetailsService(),
-      serverContext.flexParameters(),
-      serverContext.rideHailingServices(),
-      serverContext.dataOverlayParameterBindings(),
+      transitService,
+      graph,
+      transferService,
+      streetDetailsService,
+      flexParameters,
+      rideHailingServices,
+      dataOverlayParameterBindings,
       transitSearchTimeZero,
       additionalSearchDays,
       linkingContext,
@@ -149,10 +211,10 @@ public class TransitRouter {
     var mapper = RaptorRequestMapper.<TripSchedule>of(
       request,
       transitSearchTimeZero,
-      serverContext.raptorConfig().isMultiThreaded(),
+      raptorConfig.isMultiThreaded(),
       accessEgresses.getAccesses(),
       accessEgresses.getEgresses(),
-      serverContext.meterRegistry(),
+      meterRegistry,
       viaTransferResolver,
       this::listStopIndexes,
       linkingContext
@@ -160,10 +222,7 @@ public class TransitRouter {
     var raptorRequest = mapper.mapRaptorRequest();
 
     // Transit routing using Raptor
-    var raptorService = new RaptorService<>(
-      serverContext.raptorConfig(),
-      extraSearchForSorlandsbanen
-    );
+    var raptorService = new RaptorService<>(raptorConfig, extraSearchForSorlandsbanen);
     var transitResponse = raptorService.route(raptorRequest, requestTransitDataProvider);
 
     checkIfTransitConnectionExists(transitResponse);
@@ -201,7 +260,7 @@ public class TransitRouter {
       var service = TransferOptimizationServiceConfigurator.createOptimizeTransferService(
         raptorTransitData::getStopByIndex,
         requestTransitDataProvider.stopNameResolver(),
-        serverContext.transitService().getConstrainedTransferService(),
+        transitService.getConstrainedTransferService(),
         requestTransitDataProvider,
         raptorTransitData.getStopBoardAlightTransferCosts(),
         request.preferences().transfer().optimization(),
@@ -213,9 +272,9 @@ public class TransitRouter {
     // Create itineraries
 
     RaptorPathToItineraryMapper<TripSchedule> itineraryMapper = new RaptorPathToItineraryMapper<>(
-      serverContext.graph(),
-      serverContext.transitService(),
-      serverContext.streetDetailsService(),
+      graph,
+      transitService,
+      streetDetailsService,
       raptorTransitData,
       transitSearchTimeZero,
       request
@@ -329,9 +388,7 @@ public class TransitRouter {
   }
 
   private IntStream listStopIndexes(FeedScopedId stopLocationId) {
-    Collection<StopLocation> stops = serverContext
-      .transitService()
-      .findStopOrChildStops(stopLocationId);
+    Collection<StopLocation> stops = transitService.findStopOrChildStops(stopLocationId);
 
     if (stops.isEmpty()) {
       throw new EntityNotFoundException(
@@ -354,9 +411,8 @@ public class TransitRouter {
     if (OTPFeature.Sorlandsbanen.isOff()) {
       return null;
     }
-    var service = serverContext.sorlandsbanenService();
-    return service == null
+    return sorlandsbanenService == null
       ? null
-      : service.createExtraMcRouterSearch(request, accessEgresses, raptorTransitData);
+      : sorlandsbanenService.createExtraMcRouterSearch(request, accessEgresses, raptorTransitData);
   }
 }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
@@ -4,6 +4,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
+import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
+import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexRouter;
 import org.opentripplanner.ext.flex.filter.FilterMapper;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
@@ -12,13 +16,21 @@ import org.opentripplanner.place.api.NearbyStop;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContext;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetMode;
+import org.opentripplanner.transfer.regular.RegularTransferService;
+import org.opentripplanner.transit.service.TransitService;
 
 public class DirectFlexRouter {
 
   public static List<Itinerary> route(
-    OtpServerRequestContext serverContext,
+    Graph graph,
+    TransitService transitService,
+    RegularTransferService transferService,
+    StreetDetailsService streetDetailsService,
+    FlexParameters flexParameters,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
     RouteRequest request,
     AdditionalSearchDays additionalSearchDays,
     LinkingContext linkingContext
@@ -31,28 +43,28 @@ public class DirectFlexRouter {
     Collection<NearbyStop> accessStops = AccessEgressRouter.findAccessEgresses(
       request,
       request.journey().direct().mode(),
-      serverContext.listExtensionRequestContexts(request),
+      DataOverlayContext.listExtensionRequestContexts(request, dataOverlayParameterBindings),
       AccessEgressType.ACCESS,
-      serverContext.flexParameters().maxAccessWalkDuration(),
+      flexParameters.maxAccessWalkDuration(),
       0,
       linkingContext
     );
     Collection<NearbyStop> egressStops = AccessEgressRouter.findAccessEgresses(
       request,
       request.journey().direct().mode(),
-      serverContext.listExtensionRequestContexts(request),
+      DataOverlayContext.listExtensionRequestContexts(request, dataOverlayParameterBindings),
       AccessEgressType.EGRESS,
-      serverContext.flexParameters().maxEgressWalkDuration(),
+      flexParameters.maxEgressWalkDuration(),
       0,
       linkingContext
     );
 
     var flexRouter = new FlexRouter(
-      serverContext.graph(),
-      serverContext.transitService(),
-      serverContext.transferService(),
-      serverContext.streetDetailsService(),
-      serverContext.flexParameters(),
+      graph,
+      transitService,
+      transferService,
+      streetDetailsService,
+      flexParameters,
       FilterMapper.map(request.journey().transit().filters()),
       request.dateTime(),
       request.bookingTime(),

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -3,6 +3,9 @@ package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
+import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
+import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.mapping.ItinerariesHelper;
@@ -11,10 +14,13 @@ import org.opentripplanner.routing.algorithm.mapping.StreetPathToLegsMapper;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.linking.LinkingContext;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.transit.service.TransitServiceResolver;
 
 /**
@@ -26,7 +32,12 @@ import org.opentripplanner.transit.service.TransitServiceResolver;
 public class DirectStreetRouter {
 
   public static List<Itinerary> route(
-    OtpServerRequestContext serverContext,
+    Graph graph,
+    TransitService transitService,
+    StreetLimitationParametersService streetLimitationParametersService,
+    VehicleRentalService vehicleRentalService,
+    StreetDetailsService streetDetailsService,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
     RouteRequest request,
     LinkingContext linkingContext
   ) {
@@ -35,28 +46,26 @@ public class DirectStreetRouter {
     }
     OTPRequestTimeoutException.checkForTimeout();
     try {
-      StreetLimitationParametersService streetLimitationParametersService =
-        serverContext.streetLimitationParametersService();
-      var maxCarSpeed = serverContext.streetLimitationParametersService().maxCarSpeed();
+      var maxCarSpeed = streetLimitationParametersService.maxCarSpeed();
       if (!straightLineDistanceIsWithinLimit(request, maxCarSpeed, linkingContext)) {
         return Collections.emptyList();
       }
 
       // we could also get a persistent router-scoped GraphPathFinder but there's no setup cost here
       GraphPathFinder gpFinder = new GraphPathFinder(
-        serverContext.listExtensionRequestContexts(request),
+        DataOverlayContext.listExtensionRequestContexts(request, dataOverlayParameterBindings),
         streetLimitationParametersService,
-        serverContext.vehicleRentalService()
+        vehicleRentalService
       );
       var paths = gpFinder.find(request, linkingContext);
 
       // Convert the internal GraphPaths to itineraries
       final StreetPathToLegsMapper streetPathToLegsMapper = new StreetPathToLegsMapper(
-        new TransitServiceResolver(serverContext.transitService()),
-        serverContext.transitService().getTimeZone(),
-        serverContext.graph().streetNotesService,
-        serverContext.streetDetailsService(),
-        serverContext.graph().ellipsoidToGeoidDifference
+        new TransitServiceResolver(transitService),
+        transitService.getTimeZone(),
+        graph.streetNotesService,
+        streetDetailsService,
+        graph.ellipsoidToGeoidDifference
       );
       List<Itinerary> itineraries = new ArrayList<>();
       for (var path : paths) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
@@ -11,9 +11,11 @@ import org.opentripplanner.place.api.NearbyStop;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContext;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.ExtensionRequestContext;
+import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.service.TransitService;
 
 public class FlexAccessEgressRouter {
@@ -22,7 +24,10 @@ public class FlexAccessEgressRouter {
 
   public static Collection<FlexAccessEgress> routeAccessEgress(
     RouteRequest request,
-    OtpServerRequestContext serverContext,
+    TransitService transitService,
+    Graph graph,
+    RegularTransferService transferService,
+    StreetDetailsService streetDetailsService,
     AdditionalSearchDays searchDays,
     FlexParameters config,
     Collection<ExtensionRequestContext> extensionRequestContexts,
@@ -31,15 +36,13 @@ public class FlexAccessEgressRouter {
   ) {
     OTPRequestTimeoutException.checkForTimeout();
 
-    TransitService transitService = serverContext.transitService();
-
     Collection<NearbyStop> accessStops = accessOrEgress.isAccess()
       ? AccessEgressRouter.findAccessEgresses(
           request,
           StreetMode.WALK,
           extensionRequestContexts,
           AccessEgressType.ACCESS,
-          serverContext.flexParameters().maxAccessWalkDuration(),
+          config.maxAccessWalkDuration(),
           0,
           linkingContext
         )
@@ -51,17 +54,17 @@ public class FlexAccessEgressRouter {
           StreetMode.WALK,
           extensionRequestContexts,
           AccessEgressType.EGRESS,
-          serverContext.flexParameters().maxEgressWalkDuration(),
+          config.maxEgressWalkDuration(),
           0,
           linkingContext
         )
       : List.of();
 
     FlexRouter flexRouter = new FlexRouter(
-      serverContext.graph(),
+      graph,
       transitService,
-      serverContext.transferService(),
-      serverContext.streetDetailsService(),
+      transferService,
+      streetDetailsService,
       config,
       FilterMapper.map(request.journey().transit().filters()),
       request.dateTime(),

--- a/application/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
+++ b/application/src/main/java/org/opentripplanner/routing/service/DefaultRoutingService.java
@@ -1,18 +1,38 @@
 package org.opentripplanner.routing.service;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.opentripplanner.ext.carpooling.CarpoolingService;
+import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
+import org.opentripplanner.ext.flex.FlexParameters;
+import org.opentripplanner.ext.ridehailing.RideHailingService;
+import org.opentripplanner.ext.sorlandsbanen.SorlandsbanenNorwayService;
+import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.framework.time.ZoneIdFallback;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.RequestPreProcessor;
 import org.opentripplanner.routing.algorithm.RoutingWorker;
 import org.opentripplanner.routing.algorithm.RoutingWorkerRequest;
+import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.via.ViaRoutingWorker;
 import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.RouteViaRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.api.response.ViaRoutingResponse;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
+import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.standalone.config.routerconfig.TransitRoutingConfig;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.service.StreetLimitationParametersService;
+import org.opentripplanner.transfer.regular.RegularTransferService;
+import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.utils.tostring.MultiLineToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,18 +46,81 @@ public class DefaultRoutingService implements RoutingService {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultRoutingService.class);
 
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final Graph graph;
+  private final RaptorConfig<TripSchedule> raptorConfig;
+  private final MeterRegistry meterRegistry;
+  private final StreetLimitationParametersService streetLimitationParametersService;
+  private final VehicleRentalService vehicleRentalService;
+  private final StreetDetailsService streetDetailsService;
+  private final RegularTransferService transferService;
+  private final FlexParameters flexParameters;
+  private final List<RideHailingService> rideHailingServices;
+  private final ViaCoordinateTransferFactory viaTransferResolver;
+  private final LinkingContextFactory linkingContextFactory;
+  private final TransitRoutingConfig transitRoutingConfig;
+
+  @Nullable
+  private final DataOverlayParameterBindings dataOverlayParameterBindings;
+
+  @Nullable
+  private final SorlandsbanenNorwayService sorlandsbanenService;
+
+  @Nullable
+  private final CarpoolingService carpoolingService;
+
+  @Nullable
+  private final ItineraryDecorator emissionItineraryDecorator;
+
+  @Nullable
+  private final StopConsolidationService stopConsolidationService;
 
   private final RequestPreProcessor requestPreProcessor;
 
-  public DefaultRoutingService(OtpServerRequestContext serverContext) {
-    this.serverContext = serverContext;
+  public DefaultRoutingService(
+    TransitService transitService,
+    Graph graph,
+    RaptorConfig<TripSchedule> raptorConfig,
+    MeterRegistry meterRegistry,
+    StreetLimitationParametersService streetLimitationParametersService,
+    VehicleRentalService vehicleRentalService,
+    StreetDetailsService streetDetailsService,
+    RegularTransferService transferService,
+    FlexParameters flexParameters,
+    List<RideHailingService> rideHailingServices,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
+    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
+    ViaCoordinateTransferFactory viaTransferResolver,
+    @Nullable CarpoolingService carpoolingService,
+    @Nullable ItineraryDecorator emissionItineraryDecorator,
+    @Nullable StopConsolidationService stopConsolidationService,
+    LinkingContextFactory linkingContextFactory,
+    TransitRoutingConfig transitRoutingConfig
+  ) {
+    this.transitService = transitService;
+    this.graph = graph;
+    this.raptorConfig = raptorConfig;
+    this.meterRegistry = meterRegistry;
+    this.streetLimitationParametersService = streetLimitationParametersService;
+    this.vehicleRentalService = vehicleRentalService;
+    this.streetDetailsService = streetDetailsService;
+    this.transferService = transferService;
+    this.flexParameters = flexParameters;
+    this.rideHailingServices = rideHailingServices;
+    this.dataOverlayParameterBindings = dataOverlayParameterBindings;
+    this.sorlandsbanenService = sorlandsbanenService;
+    this.viaTransferResolver = viaTransferResolver;
+    this.carpoolingService = carpoolingService;
+    this.emissionItineraryDecorator = emissionItineraryDecorator;
+    this.stopConsolidationService = stopConsolidationService;
+    this.linkingContextFactory = linkingContextFactory;
+    this.transitRoutingConfig = transitRoutingConfig;
 
-    var timeZone = ZoneIdFallback.zoneId(serverContext.transitService().getTimeZone());
+    var timeZone = ZoneIdFallback.zoneId(transitService.getTimeZone());
 
     this.requestPreProcessor = new RequestPreProcessor(
-      serverContext.transitService(),
-      serverContext.raptorTuningParameters(),
+      transitService,
+      transitRoutingConfig,
       timeZone
     );
   }
@@ -47,7 +130,7 @@ public class DefaultRoutingService implements RoutingService {
     LOG.debug("Request: {}", request);
     OTPRequestTimeoutException.checkForTimeout();
     request.validateOriginAndDestination();
-    var worker = new RoutingWorker(serverContext, mapRequest(request));
+    var worker = newRoutingWorker(mapRequest(request));
     var response = worker.route();
     logResponse(response);
     return response;
@@ -58,10 +141,34 @@ public class DefaultRoutingService implements RoutingService {
     LOG.debug("Request: {}", request);
     OTPRequestTimeoutException.checkForTimeout();
     var viaRoutingWorker = new ViaRoutingWorker(request, req ->
-      new RoutingWorker(serverContext, mapRequest(req)).route()
+      newRoutingWorker(mapRequest(req)).route()
     );
     // TODO: Add output logging here, see route(..) method
     return viaRoutingWorker.route();
+  }
+
+  private RoutingWorker newRoutingWorker(RoutingWorkerRequest workerRequest) {
+    return new RoutingWorker(
+      transitService,
+      graph,
+      raptorConfig,
+      meterRegistry,
+      streetLimitationParametersService,
+      vehicleRentalService,
+      streetDetailsService,
+      transferService,
+      flexParameters,
+      rideHailingServices,
+      dataOverlayParameterBindings,
+      sorlandsbanenService,
+      viaTransferResolver,
+      carpoolingService,
+      emissionItineraryDecorator,
+      stopConsolidationService,
+      linkingContextFactory,
+      transitRoutingConfig,
+      workerRequest
+    );
   }
 
   private RoutingWorkerRequest mapRequest(RouteRequest request) {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
@@ -218,7 +218,7 @@ public interface ConstructApplicationFactory {
     Builder empiricalDelayRepository(EmpiricalDelayRepository empiricalDelayRepository);
 
     @BindsInstance
-    Builder schema(RouteRequest defaultRouteRequest);
+    Builder schema(@StaticRouteRequestDefaults RouteRequest defaultRouteRequest);
 
     @BindsInstance
     Builder streetStreetRepository(StreetRepository streetRepository);

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -9,6 +9,7 @@ import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
 import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
+import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -73,6 +74,8 @@ public interface RequestScopedFactory {
   OjpApiParameters ojpApiParameters();
 
   TriasApiParameters triasApiParameters();
+
+  RoutingService routingService();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -2,6 +2,7 @@ package org.opentripplanner.standalone.configure;
 
 import dagger.Subcomponent;
 import javax.annotation.Nullable;
+import org.opentripplanner.apis.gtfs.GtfsApiParameters;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -55,6 +56,8 @@ public interface RequestScopedFactory {
   RegularTransferService transferService();
 
   VectorTileConfig vectorTileConfig();
+
+  GtfsApiParameters gtfsApiParameters();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -3,6 +3,8 @@ package org.opentripplanner.standalone.configure;
 import dagger.Subcomponent;
 import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.GtfsApiParameters;
+import org.opentripplanner.apis.transmodel.TransmodelAPIParameters;
+import org.opentripplanner.apis.transmodel.TransmodelGraphQLSchema;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -58,6 +60,10 @@ public interface RequestScopedFactory {
   VectorTileConfig vectorTileConfig();
 
   GtfsApiParameters gtfsApiParameters();
+
+  TransmodelAPIParameters transmodelAPIParameters();
+
+  TransmodelGraphQLSchema transmodelGraphQLSchema();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -3,6 +3,7 @@ package org.opentripplanner.standalone.configure;
 import dagger.Subcomponent;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
@@ -29,6 +30,8 @@ public interface RequestScopedFactory {
   Graph graph();
 
   RouteRequest defaultRouteRequest();
+
+  VehicleParkingService vehicleParkingService();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.standalone.configure;
 
 import dagger.Subcomponent;
+import javax.annotation.Nullable;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
@@ -32,6 +34,9 @@ public interface RequestScopedFactory {
   RouteRequest defaultRouteRequest();
 
   VehicleParkingService vehicleParkingService();
+
+  @Nullable
+  LuceneIndex luceneIndex();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -6,8 +6,11 @@ import org.opentripplanner.apis.gtfs.GtfsApiParameters;
 import org.opentripplanner.apis.transmodel.TransmodelAPIParameters;
 import org.opentripplanner.apis.transmodel.TransmodelGraphQLSchema;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
+import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
+import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -64,6 +67,12 @@ public interface RequestScopedFactory {
   TransmodelAPIParameters transmodelAPIParameters();
 
   TransmodelGraphQLSchema transmodelGraphQLSchema();
+
+  LinkingContextFactory linkingContextFactory();
+
+  OjpApiParameters ojpApiParameters();
+
+  TriasApiParameters triasApiParameters();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -2,8 +2,10 @@ package org.opentripplanner.standalone.configure;
 
 import dagger.Subcomponent;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -23,6 +25,10 @@ public interface RequestScopedFactory {
   TransitService transitService();
 
   OtpServerRequestContext createServerContext();
+
+  Graph graph();
+
+  RouteRequest defaultRouteRequest();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -5,10 +5,15 @@ import javax.annotation.Nullable;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -37,6 +42,16 @@ public interface RequestScopedFactory {
 
   @Nullable
   LuceneIndex luceneIndex();
+
+  DebugUiConfig debugUiConfig();
+
+  WorldEnvelopeService worldEnvelopeService();
+
+  VehicleRentalService vehicleRentalService();
+
+  StreetDetailsService streetDetailsService();
+
+  RegularTransferService transferService();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -12,6 +12,7 @@ import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.config.DebugUiConfig;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.service.TransitService;
@@ -52,6 +53,8 @@ public interface RequestScopedFactory {
   StreetDetailsService streetDetailsService();
 
   RegularTransferService transferService();
+
+  VectorTileConfig vectorTileConfig();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -14,6 +14,7 @@ import org.opentripplanner.apis.transmodel.configure.TransmodelSchema;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
 import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
 import org.opentripplanner.ext.empiricaldelay.EmpiricalDelayService;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.interactivelauncher.api.LauncherRequestDecorator;
 import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
@@ -28,9 +29,11 @@ import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.filterchain.ext.EmissionDecorator;
 import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
+import org.opentripplanner.routing.service.DefaultRoutingService;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -41,6 +44,7 @@ import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
+import org.opentripplanner.standalone.config.routerconfig.TransitRoutingConfig;
 import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
 import org.opentripplanner.standalone.server.DefaultServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
@@ -127,6 +131,61 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static FlexParameters flexParameters(RouterConfig routerConfig) {
+    return routerConfig.flexParameters();
+  }
+
+  @Provides
+  @HttpRequestScoped
+  static TransitRoutingConfig transitRoutingConfig(RouterConfig routerConfig) {
+    return routerConfig.transitTuningConfig();
+  }
+
+  @Provides
+  @HttpRequestScoped
+  static RoutingService routingService(
+    TransitService transitService,
+    Graph graph,
+    RaptorConfig<TripSchedule> raptorConfig,
+    StreetLimitationParametersService streetLimitationParametersService,
+    VehicleRentalService vehicleRentalService,
+    StreetDetailsService streetDetailsService,
+    RegularTransferService transferService,
+    FlexParameters flexParameters,
+    List<RideHailingService> rideHailingServices,
+    @Nullable DataOverlayParameterBindings dataOverlayParameterBindings,
+    @Nullable SorlandsbanenNorwayService sorlandsbanenService,
+    ViaCoordinateTransferFactory viaTransferResolver,
+    @Nullable CarpoolingService carpoolingService,
+    @Nullable @EmissionDecorator ItineraryDecorator emissionItineraryDecorator,
+    @Nullable StopConsolidationService stopConsolidationService,
+    LinkingContextFactory linkingContextFactory,
+    TransitRoutingConfig transitRoutingConfig
+  ) {
+    return new DefaultRoutingService(
+      transitService,
+      graph,
+      raptorConfig,
+      Metrics.globalRegistry,
+      streetLimitationParametersService,
+      vehicleRentalService,
+      streetDetailsService,
+      transferService,
+      flexParameters,
+      rideHailingServices,
+      dataOverlayParameterBindings,
+      sorlandsbanenService,
+      viaTransferResolver,
+      carpoolingService,
+      emissionItineraryDecorator,
+      stopConsolidationService,
+      linkingContextFactory,
+      transitRoutingConfig
+    );
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -142,6 +201,8 @@ public class RequestScopedModule {
     TransmodelAPIParameters transmodelAPIParameters,
     OjpApiParameters ojpApiParameters,
     TriasApiParameters triasApiParameters,
+    FlexParameters flexParameters,
+    TransitRoutingConfig transitRoutingConfig,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -163,9 +224,6 @@ public class RequestScopedModule {
     @Nullable LuceneIndex luceneIndex,
     FareService fareService
   ) {
-    var transitRoutingConfig = routerConfig.transitTuningConfig();
-    var flexParameters = routerConfig.flexParameters();
-
     return new DefaultServerRequestContext(
       debugUiConfig,
       fareService,

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -23,6 +23,7 @@ import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.filterchain.ext.EmissionDecorator;
 import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
@@ -73,6 +74,15 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static RouteRequest defaultRouteRequest(
+    RouterConfig routerConfig,
+    LauncherRequestDecorator launcherRequestDecorator
+  ) {
+    return launcherRequestDecorator.intercept(routerConfig.routingRequestDefaults());
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -82,6 +92,7 @@ public class RequestScopedModule {
     VertexLinker vertexLinker,
     TransactionScope transactionScope,
     TransitService transitService,
+    RouteRequest defaultRequest,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -103,8 +114,6 @@ public class RequestScopedModule {
     @Nullable LuceneIndex luceneIndex,
     FareService fareService
   ) {
-    var defaultRequest = launcherRequestDecorator.intercept(routerConfig.routingRequestDefaults());
-
     var transitRoutingConfig = routerConfig.transitTuningConfig();
     var triasApiParameters = routerConfig.triasApiParameters();
     var ojpApiParameters = routerConfig.ojpApiParameters();

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -8,6 +8,8 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.GtfsApiParameters;
 import org.opentripplanner.apis.gtfs.configure.GtfsSchema;
+import org.opentripplanner.apis.transmodel.TransmodelAPIParameters;
+import org.opentripplanner.apis.transmodel.TransmodelGraphQLSchema;
 import org.opentripplanner.apis.transmodel.configure.TransmodelSchema;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
 import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
@@ -97,6 +99,20 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static TransmodelAPIParameters transmodelAPIParameters(RouterConfig routerConfig) {
+    return routerConfig.transmodelApi();
+  }
+
+  @Provides
+  @HttpRequestScoped
+  static TransmodelGraphQLSchema transmodelGraphQLSchema(
+    @Nullable @TransmodelSchema GraphQLSchema transmodelSchema
+  ) {
+    return new TransmodelGraphQLSchema(transmodelSchema);
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -109,6 +125,7 @@ public class RequestScopedModule {
     RouteRequest defaultRequest,
     VectorTileConfig vectorTileConfig,
     GtfsApiParameters gtfsApiConfig,
+    TransmodelAPIParameters transmodelAPIParameters,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -134,7 +151,6 @@ public class RequestScopedModule {
     var triasApiParameters = routerConfig.triasApiParameters();
     var ojpApiParameters = routerConfig.ojpApiParameters();
     var flexParameters = routerConfig.flexParameters();
-    var transmodelAPIParameters = routerConfig.transmodelApi();
 
     return new DefaultServerRequestContext(
       debugUiConfig,

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -16,6 +16,8 @@ import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBin
 import org.opentripplanner.ext.empiricaldelay.EmpiricalDelayService;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.interactivelauncher.api.LauncherRequestDecorator;
+import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
+import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.sorlandsbanen.SorlandsbanenNorwayService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
@@ -113,6 +115,18 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static OjpApiParameters ojpApiParameters(RouterConfig routerConfig) {
+    return routerConfig.ojpApiParameters();
+  }
+
+  @Provides
+  @HttpRequestScoped
+  static TriasApiParameters triasApiParameters(RouterConfig routerConfig) {
+    return routerConfig.triasApiParameters();
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -126,6 +140,8 @@ public class RequestScopedModule {
     VectorTileConfig vectorTileConfig,
     GtfsApiParameters gtfsApiConfig,
     TransmodelAPIParameters transmodelAPIParameters,
+    OjpApiParameters ojpApiParameters,
+    TriasApiParameters triasApiParameters,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -148,8 +164,6 @@ public class RequestScopedModule {
     FareService fareService
   ) {
     var transitRoutingConfig = routerConfig.transitTuningConfig();
-    var triasApiParameters = routerConfig.triasApiParameters();
-    var ojpApiParameters = routerConfig.ojpApiParameters();
     var flexParameters = routerConfig.flexParameters();
 
     return new DefaultServerRequestContext(

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -36,6 +36,7 @@ import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
 import org.opentripplanner.standalone.server.DefaultServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
@@ -83,6 +84,12 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static VectorTileConfig vectorTileConfig(RouterConfig routerConfig) {
+    return routerConfig.vectorTileConfig();
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -93,6 +100,7 @@ public class RequestScopedModule {
     TransactionScope transactionScope,
     TransitService transitService,
     RouteRequest defaultRequest,
+    VectorTileConfig vectorTileConfig,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -118,7 +126,6 @@ public class RequestScopedModule {
     var triasApiParameters = routerConfig.triasApiParameters();
     var ojpApiParameters = routerConfig.ojpApiParameters();
     var gtfsApiConfig = routerConfig.gtfsApiParameters();
-    var vectorTileConfig = routerConfig.vectorTileConfig();
     var flexParameters = routerConfig.flexParameters();
     var transmodelAPIParameters = routerConfig.transmodelApi();
 

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -6,6 +6,7 @@ import graphql.schema.GraphQLSchema;
 import io.micrometer.core.instrument.Metrics;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.opentripplanner.apis.gtfs.GtfsApiParameters;
 import org.opentripplanner.apis.gtfs.configure.GtfsSchema;
 import org.opentripplanner.apis.transmodel.configure.TransmodelSchema;
 import org.opentripplanner.ext.carpooling.CarpoolingService;
@@ -90,6 +91,12 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static GtfsApiParameters gtfsApiParameters(RouterConfig routerConfig) {
+    return routerConfig.gtfsApiParameters();
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -101,6 +108,7 @@ public class RequestScopedModule {
     TransitService transitService,
     RouteRequest defaultRequest,
     VectorTileConfig vectorTileConfig,
+    GtfsApiParameters gtfsApiConfig,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -125,7 +133,6 @@ public class RequestScopedModule {
     var transitRoutingConfig = routerConfig.transitTuningConfig();
     var triasApiParameters = routerConfig.triasApiParameters();
     var ojpApiParameters = routerConfig.ojpApiParameters();
-    var gtfsApiConfig = routerConfig.gtfsApiParameters();
     var flexParameters = routerConfig.flexParameters();
     var transmodelAPIParameters = routerConfig.transmodelApi();
 

--- a/application/src/main/java/org/opentripplanner/standalone/configure/StaticRouteRequestDefaults.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/StaticRouteRequestDefaults.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.standalone.configure;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifies the raw, app-singleton {@link org.opentripplanner.routing.api.request.RouteRequest}
+ * bound from {@link org.opentripplanner.standalone.config.RouterConfig#routingRequestDefaults()}
+ * at startup — used only for one-off, build-time consumers (e.g. GraphQL schema generation).
+ * Distinguishes it from the unqualified, request-scoped {@code RouteRequest} inside {@link
+ * RequestScopedFactory}, which is a fresh, launcher-decorated copy per HTTP request. Same shape
+ * of problem as {@code StaticTransitService} — Dagger does not support a subcomponent overriding
+ * an ancestor's binding for the same, unqualified type.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+public @interface StaticRouteRequestDefaults {}

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -11,6 +11,7 @@ import org.opentripplanner.apis.transmodel.TransmodelGraphQLSchema;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
 import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
+import org.opentripplanner.routing.api.RoutingService;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -79,6 +80,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::linkingContextFactory, LinkingContextFactory.class);
     bridge(factory, RequestScopedFactory::ojpApiParameters, OjpApiParameters.class);
     bridge(factory, RequestScopedFactory::triasApiParameters, TriasApiParameters.class);
+    bridge(factory, RequestScopedFactory::routingService, RoutingService.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
 import org.opentripplanner.street.graph.Graph;
@@ -51,6 +52,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::createServerContext, OtpServerRequestContext.class);
     bridge(factory, RequestScopedFactory::graph, Graph.class);
     bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
+    bridge(factory, RequestScopedFactory::vehicleParkingService, VehicleParkingService.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -9,7 +9,10 @@ import org.opentripplanner.apis.gtfs.GtfsApiParameters;
 import org.opentripplanner.apis.transmodel.TransmodelAPIParameters;
 import org.opentripplanner.apis.transmodel.TransmodelGraphQLSchema;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
+import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
+import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -73,6 +76,9 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::gtfsApiParameters, GtfsApiParameters.class);
     bridge(factory, RequestScopedFactory::transmodelAPIParameters, TransmodelAPIParameters.class);
     bridge(factory, RequestScopedFactory::transmodelGraphQLSchema, TransmodelGraphQLSchema.class);
+    bridge(factory, RequestScopedFactory::linkingContextFactory, LinkingContextFactory.class);
+    bridge(factory, RequestScopedFactory::ojpApiParameters, OjpApiParameters.class);
+    bridge(factory, RequestScopedFactory::triasApiParameters, TriasApiParameters.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -5,8 +5,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -47,6 +49,8 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     // Binding for all request-scoped services used by resources
     bridge(factory, RequestScopedFactory::transitService, TransitService.class);
     bridge(factory, RequestScopedFactory::createServerContext, OtpServerRequestContext.class);
+    bridge(factory, RequestScopedFactory::graph, Graph.class);
+    bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -13,6 +13,7 @@ import org.opentripplanner.service.vehiclerental.VehicleRentalService;
 import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.config.DebugUiConfig;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.RegularTransferService;
@@ -65,6 +66,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::vehicleRentalService, VehicleRentalService.class);
     bridge(factory, RequestScopedFactory::streetDetailsService, StreetDetailsService.class);
     bridge(factory, RequestScopedFactory::transferService, RegularTransferService.class);
+    bridge(factory, RequestScopedFactory::vectorTileConfig, VectorTileConfig.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -6,6 +6,8 @@ import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.opentripplanner.apis.gtfs.GtfsApiParameters;
+import org.opentripplanner.apis.transmodel.TransmodelAPIParameters;
+import org.opentripplanner.apis.transmodel.TransmodelGraphQLSchema;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -69,6 +71,8 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::transferService, RegularTransferService.class);
     bridge(factory, RequestScopedFactory::vectorTileConfig, VectorTileConfig.class);
     bridge(factory, RequestScopedFactory::gtfsApiParameters, GtfsApiParameters.class);
+    bridge(factory, RequestScopedFactory::transmodelAPIParameters, TransmodelAPIParameters.class);
+    bridge(factory, RequestScopedFactory::transmodelGraphQLSchema, TransmodelGraphQLSchema.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.opentripplanner.apis.gtfs.GtfsApiParameters;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
@@ -67,6 +68,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::streetDetailsService, StreetDetailsService.class);
     bridge(factory, RequestScopedFactory::transferService, RegularTransferService.class);
     bridge(factory, RequestScopedFactory::vectorTileConfig, VectorTileConfig.class);
+    bridge(factory, RequestScopedFactory::gtfsApiParameters, GtfsApiParameters.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -7,10 +7,15 @@ import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -55,6 +60,11 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
     bridge(factory, RequestScopedFactory::vehicleParkingService, VehicleParkingService.class);
     bridge(factory, RequestScopedFactory::luceneIndex, LuceneIndex.class);
+    bridge(factory, RequestScopedFactory::debugUiConfig, DebugUiConfig.class);
+    bridge(factory, RequestScopedFactory::worldEnvelopeService, WorldEnvelopeService.class);
+    bridge(factory, RequestScopedFactory::vehicleRentalService, VehicleRentalService.class);
+    bridge(factory, RequestScopedFactory::streetDetailsService, StreetDetailsService.class);
+    bridge(factory, RequestScopedFactory::transferService, RegularTransferService.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
@@ -53,6 +54,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::graph, Graph.class);
     bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
     bridge(factory, RequestScopedFactory::vehicleParkingService, VehicleParkingService.class);
+    bridge(factory, RequestScopedFactory::luceneIndex, LuceneIndex.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DefaultServerRequestContext.java
@@ -233,7 +233,26 @@ public class DefaultServerRequestContext implements OtpServerRequestContext {
 
   @Override
   public RoutingService routingService() {
-    return new DefaultRoutingService(this);
+    return new DefaultRoutingService(
+      transitService,
+      graph,
+      raptorConfig,
+      meterRegistry,
+      streetLimitationParametersService,
+      vehicleRentalService,
+      streetDetailsService,
+      transferService,
+      flexParameters,
+      rideHailingServices,
+      dataOverlayParameterBindings,
+      sorlandsbanenService,
+      viaTransferResolver,
+      carpoolingService,
+      emissionItineraryDecorator,
+      stopConsolidationService,
+      linkingContextFactory,
+      transitRoutingConfig
+    );
   }
 
   @Override

--- a/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResourceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResourceTest.java
@@ -29,13 +29,20 @@ class DebugVectorTilesResourceTest {
 
   @Test
   void tileJson() {
+    var serverContext = TestServerContext.createServerContext(
+      new Graph(),
+      new TimetableRepository(),
+      TransferServiceTestFactory.defaultTransferRepository(),
+      new NoopFareServiceFactory().makeFareService()
+    );
     var resource = new DebugVectorTilesResource(
-      TestServerContext.createServerContext(
-        new Graph(),
-        new TimetableRepository(),
-        TransferServiceTestFactory.defaultTransferRepository(),
-        new NoopFareServiceFactory().makeFareService()
-      )
+      serverContext.transitService(),
+      serverContext.graph(),
+      serverContext.debugUiConfig(),
+      serverContext.worldEnvelopeService(),
+      serverContext.vehicleRentalService(),
+      serverContext.streetDetailsService(),
+      serverContext.transferService()
     );
     var req = HttpForTest.containerRequest();
     var tileJson = resource.getTileJson(req.getUriInfo(), req, "l1,l2");

--- a/application/src/test/java/org/opentripplanner/street/integration/BarrierRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BarrierRoutingTest.java
@@ -194,7 +194,16 @@ public class BarrierRoutingTest {
     var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
     var ctx = TestServerContext.ofGraph(graph);
 
-    var itineraries = DirectStreetRouter.route(ctx, request, linkingContext);
+    var itineraries = DirectStreetRouter.route(
+      ctx.graph(),
+      ctx.transitService(),
+      ctx.streetLimitationParametersService(),
+      ctx.vehicleRentalService(),
+      ctx.streetDetailsService(),
+      ctx.dataOverlayParameterBindings(),
+      request,
+      linkingContext
+    );
 
     assertAll(assertions.apply(itineraries));
 

--- a/application/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
@@ -95,7 +95,16 @@ public class BicycleRoutingTest {
     var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
     var ctx = TestServerContext.ofGraph(graph);
 
-    var itineraries = DirectStreetRouter.route(ctx, request, linkingContext);
+    var itineraries = DirectStreetRouter.route(
+      ctx.graph(),
+      ctx.transitService(),
+      ctx.streetLimitationParametersService(),
+      ctx.vehicleRentalService(),
+      ctx.streetDetailsService(),
+      ctx.dataOverlayParameterBindings(),
+      request,
+      linkingContext
+    );
 
     temporaryVerticesContainer.close();
 

--- a/application/src/test/java/org/opentripplanner/street/integration/CarRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/CarRoutingTest.java
@@ -144,7 +144,16 @@ public class CarRoutingTest {
     var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
     var ctx = TestServerContext.ofGraph(graph);
 
-    var itineraries = DirectStreetRouter.route(ctx, request, linkingContext);
+    var itineraries = DirectStreetRouter.route(
+      ctx.graph(),
+      ctx.transitService(),
+      ctx.streetLimitationParametersService(),
+      ctx.vehicleRentalService(),
+      ctx.streetDetailsService(),
+      ctx.dataOverlayParameterBindings(),
+      request,
+      linkingContext
+    );
     temporaryVerticesContainer.close();
 
     // make sure that we only get CAR legs

--- a/application/src/test/java/org/opentripplanner/street/integration/SplitEdgeTurnRestrictionsTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/SplitEdgeTurnRestrictionsTest.java
@@ -177,7 +177,16 @@ public class SplitEdgeTurnRestrictionsTest {
       var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
       var ctx = TestServerContext.ofGraph(graph);
 
-      var itineraries = DirectStreetRouter.route(ctx, request, linkingContext);
+      var itineraries = DirectStreetRouter.route(
+        ctx.graph(),
+        ctx.transitService(),
+        ctx.streetLimitationParametersService(),
+        ctx.vehicleRentalService(),
+        ctx.streetDetailsService(),
+        ctx.dataOverlayParameterBindings(),
+        request,
+        linkingContext
+      );
 
       // make sure that we only get CAR legs
       itineraries.forEach(i ->

--- a/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
@@ -70,7 +70,16 @@ class WalkRoutingTest {
       var linkingRequest = LinkingContextRequestMapper.map(request);
       var linkingContext = linkingContextFactory.create(temporaryVerticesContainer, linkingRequest);
       var ctx = TestServerContext.ofGraph(graph);
-      return DirectStreetRouter.route(ctx, request, linkingContext);
+      return DirectStreetRouter.route(
+        ctx.graph(),
+        ctx.transitService(),
+        ctx.streetLimitationParametersService(),
+        ctx.vehicleRentalService(),
+        ctx.streetDetailsService(),
+        ctx.dataOverlayParameterBindings(),
+        request,
+        linkingContext
+      );
     }
   }
 }


### PR DESCRIPTION
### Summary

Finishes wiring **`@HttpRequestScoped`** Dagger DI end-to-end: migrates the remaining JAX-RS
resources off the `OtpServerRequestContext` god-object, decouples the entire core routing pipeline
(`RoutingWorker` → `TransitRouter` → `AccessEgressFetcher`/`DirectStreetRouter`/`DirectFlexRouter` →
`FlexAccessEgressRouter`) from it, and makes `RoutingService` itself an independently
request-scoped component — the final step that fully unblocks `OjpResource` and `TriasResource`.

### Issue

Fixes #7441
Build on #7833

`OtpServerRequestContext` is a manually-maintained ~35-constructor-arg god object bundling ~40
services/config objects. Every resource and router that needed even one service had to depend on
the whole thing, which blocks splitting up `TransitService` (80 methods, ~157 call sites) and
makes each service's actual dependencies invisible.

**What this does, roughly in commit order:**

- **Bridge cleanup**: replaces the per-service `RequestScopedXxxSupplier` classes with a single
  `DaggerToJerseyBridge` that binds each service via a method-reference accessor —
  `AbstractBinder.createManagedInstanceProvider(RequestScopedFactory.class)` resolves through HK2's
  own request-scoped cache, so adding a new request-scoped service is now a one-line `bridge(...)`
  call. `DaggerToJerseyBridgeTest` asserts the scoping invariant directly against a real HK2
  `InjectionManager`.
- **Resource migrations** (steps 4-N): `DebugRasterTileResource`, `ParkAndRideResource`,
  `GeocoderResource`, `DebugVectorTilesResource`, `VectorTilesResource`, `ReportResource`,
  `GtfsGraphQLAPI`, and `TransmodelAPI` now declare only the services they actually use.
  `GtfsGraphQLAPI`/`TransmodelAPI` still take `OtpServerRequestContext` as a method-level `@Context`
  param for the one GraphQL-execution-root forwarding call — a deeper decoupling out of scope here.
- **Core routing pipeline decoupling**: `FlexAccessEgressRouter`, `DirectStreetRouter`,
  `DirectFlexRouter`, `RouteRequestToFilterChainMapper`, `AccessEgressFetcher`, and `TransitRouter`
  each now take the individual services they need instead of caching the whole context — prep work
  that `DataOverlayContext.listExtensionRequestContexts` (extracted as a static helper) also feeds
  into.
- **`RoutingService`** (final step): `RoutingWorker` and `DefaultRoutingService` no longer wrap
  `OtpServerRequestContext` — they take every service directly, mirroring exactly what
  `DefaultServerRequestContext.routingService()` already had as fields — so `RoutingService` can now
  be provided and bound the same way as every other `RequestScopedFactory` accessor. This fully
  unblocks `OjpResource` and `TriasResource`, which now inject `RoutingService` directly via
  `@Context` and no longer reference `OtpServerRequestContext` at all.

> **NOTE!** `OjpResource`/`TriasResource` and `GtfsGraphQLAPI`/`TransmodelAPI` still retain a thin
> `OtpServerRequestContext` dependency where it's the GraphQL execution root — fully removing it
> there is a deeper change and out of scope for this PR.

### Unit tests

✅  This PR changes the dependency injection. The transaction managment is now enforced in all resources. For most parts this should break hard when OTP is used - in case there is an error. We do not add tests for those parts. But, there are some integration test testing this.

### Documentation

✅ Javadoc added/updated on `RequestScopedFactory`, `DaggerToJerseyBridge`, and the migrated
resource/router constructors explaining what each newly-declared dependency is for.

### Changelog

🟥 No user-visible behaviour change — pure internal DI refactor. Suggest `+Skip Changelog`.

### Bumping the serialization version id

🟥 No serialized graph fields changed.
