### PR TITLE
Restore the graphUpdateScheduler metric lost in the transaction framework merge

### DIFF
--- a/application/src/main/java/org/opentripplanner/framework/transaction/UpdateManager.java
+++ b/application/src/main/java/org/opentripplanner/framework/transaction/UpdateManager.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.framework.transaction;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import org.opentripplanner.framework.event.DomainEvent;
@@ -60,6 +61,13 @@ public interface UpdateManager {
    * @return a {@link Future} that completes after the task (and commit, in atomic mode) has run
    */
   Future<Void> submit(Consumer<WriteContext> task);
+
+  /**
+   * The single-threaded executor running all submitted write tasks. Exposed for monitoring
+   * purposes only, e.g. to observe the length of the task queue on the writer thread. Never
+   * submit tasks directly to the executor — use {@link #submit(Consumer)}.
+   */
+  ExecutorService writerThreadExecutor();
 
   /**
    * Shut down the writer thread and (if configured) the periodic commit scheduler.

--- a/application/src/main/java/org/opentripplanner/framework/transaction/internal/DefaultUpdateManager.java
+++ b/application/src/main/java/org/opentripplanner/framework/transaction/internal/DefaultUpdateManager.java
@@ -6,9 +6,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.event.DomainEvent;
@@ -39,7 +41,17 @@ class DefaultUpdateManager implements UpdateManager {
     @Nullable Duration commitInterval
   ) {
     this.transactionManager = transactionManager;
-    this.executor = Executors.newSingleThreadExecutor(threadFactory);
+    // Equivalent to Executors.newSingleThreadExecutor(threadFactory), except the executor is not
+    // hidden behind a delegating wrapper — micrometer needs the ThreadPoolExecutor itself to read
+    // queue and pool-size gauges without reflective access to JDK internals.
+    this.executor = new ThreadPoolExecutor(
+      1,
+      1,
+      0L,
+      TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue<>(),
+      threadFactory
+    );
     this.periodicCommitScheduler = commitInterval != null && !commitInterval.isZero()
       ? new PeriodicCommitScheduler(name, commitInterval, threadFactory, this::submitCommit)
       : null;
@@ -58,6 +70,11 @@ class DefaultUpdateManager implements UpdateManager {
   @Override
   public Future<Void> submit(Consumer<WriteContext> task) {
     return useAtomicCommit() ? submitAndAutoCommit(task) : submitAndReturn(task);
+  }
+
+  @Override
+  public ExecutorService writerThreadExecutor() {
+    return executor;
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import org.opentripplanner.framework.application.OTPFeature;
+import org.opentripplanner.framework.transaction.UpdateManager;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueSummary;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
@@ -35,7 +36,8 @@ public class MetricsLogging {
   public MetricsLogging(
     TimetableRepository timetableRepository,
     RaptorConfig<TripSchedule> raptorConfig,
-    DataImportIssueSummary issueSummary
+    DataImportIssueSummary issueSummary,
+    UpdateManager updateManager
   ) {
     new ClassLoaderMetrics().bindTo(Metrics.globalRegistry);
     new FileDescriptorMetrics().bindTo(Metrics.globalRegistry);
@@ -78,6 +80,12 @@ public class MetricsLogging {
         List.of(Tag.of("pool", "nonPollingGraphUpdaters"))
       ).bindTo(Metrics.globalRegistry);
     }
+
+    new ExecutorServiceMetrics(
+      updateManager.writerThreadExecutor(),
+      "graphUpdateScheduler",
+      List.of(Tag.of("pool", "graphUpdateScheduler"))
+    ).bindTo(Metrics.globalRegistry);
 
     if (raptorConfig.isMultiThreaded()) {
       new ExecutorServiceMetrics(

--- a/application/src/test/java/org/opentripplanner/framework/transaction/internal/UpdateManagerMetricsTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/internal/UpdateManagerMetricsTest.java
@@ -1,0 +1,44 @@
+package org.opentripplanner.framework.transaction.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the "graphUpdateScheduler" metric wired up in
+ * {@link org.opentripplanner.standalone.server.MetricsLogging}: micrometer can only read queue and
+ * pool-size gauges from an unwrapped {@link java.util.concurrent.ThreadPoolExecutor}. If the writer
+ * executor is created through {@code Executors.newSingleThreadExecutor(..)}, micrometer needs
+ * reflective access to JDK internals to unwrap it, which fails silently at runtime and drops the
+ * queue gauges.
+ */
+class UpdateManagerMetricsTest {
+
+  @Test
+  void writerThreadExecutorExposesQueueMetrics() {
+    var threadFactory = new ThreadFactoryBuilder().setNameFormat("metrics-test").build();
+    var updateManager = TransactionFactory.createUpdateManagerWithAtomicCommits(
+      "metrics-test",
+      TransactionFactory.createRepositoryRegistry(),
+      threadFactory
+    );
+    try {
+      var registry = new SimpleMeterRegistry();
+      new ExecutorServiceMetrics(
+        updateManager.writerThreadExecutor(),
+        "graphUpdateScheduler",
+        List.of(Tag.of("pool", "graphUpdateScheduler"))
+      ).bindTo(registry);
+
+      var queuedTasks = registry.find("executor.queued").tag("name", "graphUpdateScheduler");
+      assertThat(queuedTasks.gauge()).isNotNull();
+    } finally {
+      updateManager.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Restores the `graphUpdateScheduler` metric that was lost when the transaction framework was merged in #7689 — the `ExecutorServiceMetrics` binding for the single graph-writer thread was removed when the writer executor moved into `UpdateManager`. This addresses the *Add back "graphUpdateScheduler" metric* item in #7826 (see also the original [review comment](https://github.com/opentripplanner/OpenTripPlanner/pull/7689#discussion_r3594515384)).

Related to #7826.

## Changes

- `UpdateManager` exposes `writerThreadExecutor()`, documented as monitoring-only. This follows the existing precedent of `GraphUpdaterManager` exposing its pools solely for `MetricsLogging`.
- `MetricsLogging` injects `UpdateManager` and re-binds the metric under its original name `graphUpdateScheduler`, so existing dashboards keep working.
- `DefaultUpdateManager` creates the writer executor as a plain single-thread `ThreadPoolExecutor` instead of `Executors.newSingleThreadExecutor()`. Micrometer can only read the queue/pool gauges from an unwrapped `ThreadPoolExecutor`: unwrapping the JDK's delegating wrapper requires reflective access to `java.util.concurrent`, which is not opened at runtime, so the metric would silently fail to register (verified below). The executor configuration is otherwise identical.
- New `UpdateManagerMetricsTest` asserts the `executor.queued` gauge actually binds, guarding against that silent regression.

## Verification

Verified on a locally running instance (Norway graph, one polling updater): all executor meters are served on `/otp/actuators/prometheus`, and `executor_completed_tasks_total` advances as tasks flow through the writer thread:

```
executor_active_threads{name="graphUpdateScheduler",pool="graphUpdateScheduler"} 0.0
executor_completed_tasks_total{name="graphUpdateScheduler",pool="graphUpdateScheduler"} 21.0
executor_pool_core_threads{name="graphUpdateScheduler",pool="graphUpdateScheduler"} 1.0
executor_pool_max_threads{name="graphUpdateScheduler",pool="graphUpdateScheduler"} 1.0
executor_pool_size_threads{name="graphUpdateScheduler",pool="graphUpdateScheduler"} 1.0
executor_queue_remaining_tasks{name="graphUpdateScheduler",pool="graphUpdateScheduler"} 2.147483647E9
executor_queued_tasks{name="graphUpdateScheduler",pool="graphUpdateScheduler"} 0.0
```

The unwrapped-`ThreadPoolExecutor` change is load-bearing, not defensive. An A/B check binding `ExecutorServiceMetrics` to both executor variants, run with the same JVM flags as a production launch (no `--add-opens java.base/java.util.concurrent`), shows the wrapped executor registers **no meters at all** — the only trace is one INFO log line at startup:

```
INFO ExecutorServiceMetrics: Cannot unwrap ThreadPoolExecutor for monitoring from
java.util.concurrent.Executors$DelegatedExecutorService due to
java.lang.reflect.InaccessibleObjectException: Unable to make field private final
java.util.concurrent.ExecutorService Executors$DelegatedExecutorService.e accessible:
module java.base does not "opens java.util.concurrent" to unnamed module
```

The plain `ThreadPoolExecutor` registers all 7 meters. Since the original pre-#7689 binding used `Executors.newSingleThreadScheduledExecutor()` — the same wrapper mechanism — the metric most likely never registered on modern JDKs, so this PR does not just restore it but makes it work.

## Notes

The restored binding is also more reliable than the original for a second reason: the old binding sat inside the `if (timetableRepository.getUpdaterManager() != null)` block, but `MetricsLogging` is constructed *before* `UpdaterConfigurator.configure()` sets the updater manager, so that guard is false at bind time. Injecting the `UpdateManager` singleton directly sidesteps the ordering issue.

By the same argument, the pre-existing `pollingGraphUpdaters` / `nonPollingGraphUpdaters` bindings appear to never fire; that is left untouched here as a separate issue.
