### PR TITLE
Apply the repository naming convention to the timetable domain

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
@@ -28,7 +28,7 @@ import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.organization.ContactInfo;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
@@ -92,7 +92,7 @@ class CarpoolItineraryMapperTest {
   private static final String UNNAMED_INTERSECTION = "unnamed";
 
   private final CarpoolItineraryMapper mapper = new CarpoolItineraryMapper();
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   @Test
   void nullContact_returnsNull() {

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolAccessEgressTest.java
@@ -21,7 +21,7 @@ import org.opentripplanner.raptor.spi.RaptorCostConverter;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class CarpoolAccessEgressTest {
 
@@ -148,7 +148,7 @@ class CarpoolAccessEgressTest {
   void getFinalStateForAccessReturnsStateAtTransitStopChainEnd() {
     var walkToPickup = createGraphPath(Duration.ofSeconds(80));
     var walkFromDropoff = createGraphPath(Duration.ofSeconds(40));
-    var stop = TimetableRepositoryForTest.of().stop("Central Station", 59.91, 10.74).build();
+    var stop = TransitRepositoryForTest.of().stop("Central Station", 59.91, 10.74).build();
 
     var access = newAccessEgress(
       1_000,
@@ -171,7 +171,7 @@ class CarpoolAccessEgressTest {
   void getFinalStateForEgressReturnsStateAtTransitStopChainStart() {
     var walkToPickup = createGraphPath(Duration.ofSeconds(80));
     var walkFromDropoff = createGraphPath(Duration.ofSeconds(40));
-    var stop = TimetableRepositoryForTest.of().stop("Central Station", 59.91, 10.74).build();
+    var stop = TransitRepositoryForTest.of().stop("Central Station", 59.91, 10.74).build();
 
     var egress = newAccessEgress(
       1_000,
@@ -199,7 +199,7 @@ class CarpoolAccessEgressTest {
       null,
       1.0,
       EndpointLabel.EMPTY,
-      EndpointLabel.forStop(TimetableRepositoryForTest.of().stop("Stop", 59.91, 10.74).build())
+      EndpointLabel.forStop(TransitRepositoryForTest.of().stop("Stop", 59.91, 10.74).build())
     );
 
     assertEquals(access.sharedSegments().getLast().states.getLast(), access.getFinalState());

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/CarpoolingServiceTestContext.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/CarpoolingServiceTestContext.java
@@ -50,7 +50,7 @@ record CarpoolingServiceTestContext(
     var vertexCreationService = new VertexCreationService(
       VertexLinkerTestFactory.of(model.graph())
     );
-    TransitService transitService = new DefaultTransitService(model.timetableRepository());
+    TransitService transitService = new DefaultTransitService(model.transitRepository());
     var repository = new DefaultCarpoolingRepository();
     var carReachableVertexSnapper = CarReachableVertexSnapper.createDefault();
     var resolver = new CarpoolTripVertexResolver(vertexCreationService, carReachableVertexSnapper);

--- a/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/EmissionDataReaderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/EmissionDataReaderTest.java
@@ -12,12 +12,12 @@ import org.opentripplanner.ext.emission.internal.DefaultEmissionRepository;
 import org.opentripplanner.ext.emission.internal.csvdata.trip.TripHopMapper;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 class EmissionDataReaderTest implements EmissionTestData {
 
-  private TimetableRepositoryForTest data = TimetableRepositoryForTest.of();
+  private TransitRepositoryForTest data = TransitRepositoryForTest.of();
   private final EmissionRepository repository = new DefaultEmissionRepository();
   private DataImportIssueStore issueStore = new DefaultDataImportIssueStore();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/trip/EmissionAggregatorTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/trip/EmissionAggregatorTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.model.Gram;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 class EmissionAggregatorTest {
@@ -24,7 +24,7 @@ class EmissionAggregatorTest {
   private static final String STOP_C_ID;
 
   static {
-    var builder = TimetableRepositoryForTest.of();
+    var builder = TransitRepositoryForTest.of();
     STOP_A = builder.stop("A").build();
     STOP_B = builder.stop("B").build();
     STOP_C = builder.stop("C").build();

--- a/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/csvdata/trip/TripHopMapperTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.model.Gram;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 class TripHopMapperTest {
@@ -36,7 +36,7 @@ class TripHopMapperTest {
   private static final Gram CO2_ANY = Gram.of(10.0);
 
   static {
-    var builder = TimetableRepositoryForTest.of();
+    var builder = TransitRepositoryForTest.of();
     STOP_A = builder.stop(STOP_ID_A).build();
     STOP_B = builder.stop(STOP_ID_B).build();
     STOP_C = builder.stop(STOP_ID_C).build();

--- a/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/graphbuilder/EmissionGraphBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/emission/internal/graphbuilder/EmissionGraphBuilderTest.java
@@ -16,7 +16,7 @@ import org.opentripplanner.graph_builder.model.ConfiguredDataSource;
 import org.opentripplanner.gtfs.config.GtfsDefaultParameters;
 import org.opentripplanner.gtfs.config.GtfsFeedParameters;
 import org.opentripplanner.model.plan.Emission;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class EmissionGraphBuilderTest implements EmissionTestData {
 
@@ -34,7 +34,7 @@ public class EmissionGraphBuilderTest implements EmissionTestData {
       feedDataSources,
       EmissionParameters.DEFAULT,
       emissionRepository,
-      new TimetableRepository(),
+      new TransitRepository(),
       DataImportIssueStore.NOOP
     );
     subject.buildGraph();

--- a/application/src/ext-test/java/org/opentripplanner/ext/empiricaldelay/internal/graphbuilder/EmpiricalDelayGraphBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/empiricaldelay/internal/graphbuilder/EmpiricalDelayGraphBuilderTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -13,7 +13,7 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class EmpiricalDelayGraphBuilderTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final RegularStop STOP_A = TEST_MODEL.stop("STOP-A", 1, 1).build();
   private static final RegularStop STOP_B = TEST_MODEL.stop("STOP-B", 2, 1).build();
@@ -23,7 +23,7 @@ class EmpiricalDelayGraphBuilderTest {
 
   @Test
   void createStopIdsByTripIdMap() {
-    var trip = TimetableRepositoryForTest.trip("Trip-A").build();
+    var trip = TransitRepositoryForTest.trip("Trip-A").build();
 
     var stopTimes = List.of(
       TEST_MODEL.stopTime(trip, 0, STOP_A),

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/DefaultFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/DefaultFareServiceTest.java
@@ -25,7 +25,7 @@ import org.opentripplanner.model.fare.ItineraryFare;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.core.FareType;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Money;
 
 class DefaultFareServiceTest implements PlanTestConstants {
@@ -108,7 +108,7 @@ class DefaultFareServiceTest implements PlanTestConstants {
     var itin = newItinerary(Place.forStop(AIRPORT_STOP), T11_00)
       .bus(1, T11_05, T11_12, Place.forStop(CITY_CENTER_A_STOP))
       .staySeatedBus(
-        TimetableRepositoryForTest.route("123").build(),
+        TransitRepositoryForTest.route("123").build(),
         2,
         T11_12,
         T11_16,

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HSLFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HSLFareServiceTest.java
@@ -3,7 +3,7 @@ package org.opentripplanner.ext.fares.service.gtfs.v1.custom;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.FEED_ID;
 import static org.opentripplanner.transit.model.basic.Money.euros;
 
 import java.util.LinkedList;
@@ -21,7 +21,7 @@ import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.fares.FareService;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
@@ -73,7 +73,7 @@ public class HSLFareServiceTest implements PlanTestConstants {
     FareZone C = FareZone.of(new FeedScopedId(FEED_ID, "C")).build();
     FareZone D = FareZone.of(new FeedScopedId(FEED_ID, "D")).build();
 
-    var testModel = TimetableRepositoryForTest.of();
+    var testModel = TransitRepositoryForTest.of();
     Place A1 = testModel.place("A1", sb -> sb.withCoordinate(10.0, 12.0).addFareZone(A));
     Place A2 = testModel.place("A2", sb -> sb.withCoordinate(10.0, 12.0).addFareZone(A));
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.FEED_ID;
 
 import java.time.Duration;
 import java.util.LinkedList;

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/AreasTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/AreasTest.java
@@ -15,12 +15,12 @@ import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Money;
 
 class AreasTest implements PlanTestConstants {
 
-  private static final TimetableRepositoryForTest MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest MODEL = TransitRepositoryForTest.of();
 
   private static final FeedScopedId LEG_GROUP1 = id("leg-group1");
   private static final int ID = 100;

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CombinedInterlinedLegsFareServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CombinedInterlinedLegsFareServiceTest.java
@@ -23,13 +23,13 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.core.FareType;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.network.Route;
 
 class CombinedInterlinedLegsFareServiceTest implements PlanTestConstants {
 
-  static final Route ROUTE = TimetableRepositoryForTest.route("route-1").build();
+  static final Route ROUTE = TransitRepositoryForTest.route("route-1").build();
   static final Itinerary INTERLINED_WITH_DIFFERENT_ROUTE = newItinerary(
     Place.forStop(AIRPORT_STOP),
     T11_00

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferAcrossNetworksTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferAcrossNetworksTest.java
@@ -12,15 +12,15 @@ import org.opentripplanner.ext.fares.model.FareTestConstants;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 
 class CostedTransferAcrossNetworksTest implements PlanTestConstants, FareTestConstants {
 
-  private static final Route ROUTE_A = TimetableRepositoryForTest.route("A")
+  private static final Route ROUTE_A = TransitRepositoryForTest.route("A")
     .withGroupOfRoutes(List.of(NETWORK_A))
     .build();
-  private static final Route ROUTE_B = TimetableRepositoryForTest.route("B")
+  private static final Route ROUTE_B = TransitRepositoryForTest.route("B")
     .withGroupOfRoutes(List.of(NETWORK_B))
     .build();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferInNetworkTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/CostedTransferInNetworkTest.java
@@ -14,7 +14,7 @@ import org.opentripplanner.ext.fares.model.FareTestConstants;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 
 class CostedTransferInNetworkTest implements PlanTestConstants, FareTestConstants {
@@ -22,7 +22,7 @@ class CostedTransferInNetworkTest implements PlanTestConstants, FareTestConstant
   private static final Route ROUTE_1 = routeInNetwork("r1");
   private static final Route ROUTE_2 = routeInNetwork("r2");
   private static final Route ROUTE_3 = routeInNetwork("r3");
-  private static final Route ROUTE_4 = TimetableRepositoryForTest.route("r4").build();
+  private static final Route ROUTE_4 = TransitRepositoryForTest.route("r4").build();
   private static final FeedScopedId LEG_GROUP = id("leg-group-a");
 
   private static final GtfsFaresV2Service SERVICE = GtfsFaresV2Service.of()
@@ -128,6 +128,6 @@ class CostedTransferInNetworkTest implements PlanTestConstants, FareTestConstant
   }
 
   private static Route routeInNetwork(String id) {
-    return TimetableRepositoryForTest.route(id).withGroupOfRoutes(List.of(NETWORK_A)).build();
+    return TransitRepositoryForTest.route(id).withGroupOfRoutes(List.of(NETWORK_A)).build();
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferAcrossNetworksTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferAcrossNetworksTest.java
@@ -11,15 +11,15 @@ import org.opentripplanner.ext.fares.model.FareTestConstants;
 import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 
 class FreeTransferAcrossNetworksTest implements PlanTestConstants, FareTestConstants {
 
-  private static final Route ROUTE_A = TimetableRepositoryForTest.route("A")
+  private static final Route ROUTE_A = TransitRepositoryForTest.route("A")
     .withGroupOfRoutes(List.of(NETWORK_A))
     .build();
-  private static final Route ROUTE_B = TimetableRepositoryForTest.route("B")
+  private static final Route ROUTE_B = TransitRepositoryForTest.route("B")
     .withGroupOfRoutes(List.of(NETWORK_B))
     .build();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferInNetworkTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferInNetworkTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.groupOfRoutes;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.groupOfRoutes;
 
 import java.util.List;
 import java.util.Set;
@@ -15,7 +15,7 @@ import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.fare.FareProduct;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
 import org.opentripplanner.transit.model.network.Route;
@@ -23,7 +23,7 @@ import org.opentripplanner.transit.model.network.Route;
 class FreeTransferInNetworkTest implements PlanTestConstants {
 
   private static final GroupOfRoutes NETWORK = groupOfRoutes("n1").build();
-  private static final Route ROUTE = TimetableRepositoryForTest.route("r1")
+  private static final Route ROUTE = TransitRepositoryForTest.route("r1")
     .withGroupOfRoutes(List.of(NETWORK))
     .build();
   private static final FeedScopedId LEG_GROUP = id("leg-group1");

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferTimeLimitTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/FreeTransferTimeLimitTest.java
@@ -15,13 +15,13 @@ import org.opentripplanner.ext.fares.model.FareTransferRule;
 import org.opentripplanner.ext.fares.model.TimeLimitType;
 import org.opentripplanner.model.fare.FareOffer;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 
 class FreeTransferTimeLimitTest implements PlanTestConstants, FareTestConstants {
 
   private static final FeedScopedId LEG_GROUP = id("leg-group-a");
-  private static final Route R1 = TimetableRepositoryForTest.route("r1")
+  private static final Route R1 = TransitRepositoryForTest.route("r1")
     .withGroupOfRoutes(List.of(NETWORK_A))
     .build();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2ServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/GtfsFaresV2ServiceTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.FEED_ID;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;

--- a/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/SameGroupIdPriorityTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/fares/service/gtfs/v2/SameGroupIdPriorityTest.java
@@ -19,13 +19,13 @@ import org.opentripplanner.ext.fares.model.FareLegRuleBuilder;
 import org.opentripplanner.ext.fares.model.FareTestConstants;
 import org.opentripplanner.model.plan.TestTransitLeg;
 import org.opentripplanner.model.plan.TransitLeg;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 
 class SameGroupIdPriorityTest implements FareTestConstants {
 
   private static final FeedScopedId A_1 = id("a1");
-  private static final Route ROUTE = TimetableRepositoryForTest.route("route1")
+  private static final Route ROUTE = TransitRepositoryForTest.route("route1")
     .withGroupOfRoutes(List.of(NETWORK_A))
     .build();
   private static final ImmutableMultimap<FeedScopedId, FeedScopedId> EMPTY_STOP_AREAS =

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/AreaStopsToVerticesMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/AreaStopsToVerticesMapperTest.java
@@ -20,14 +20,14 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetModelForTest;
 import org.opentripplanner.street.model.StreetTraversalPermission;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class AreaStopsToVerticesMapperTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final AreaStop BERLIN_AREA_STOP = TEST_MODEL.areaStop("berlin")
     .withGeometry(Polygons.BERLIN)
@@ -36,7 +36,7 @@ class AreaStopsToVerticesMapperTest {
     .withAreaStop(AreaStopsToVerticesMapperTest.BERLIN_AREA_STOP)
     .build();
 
-  public static final TimetableRepository TRANSIT_MODEL = new TimetableRepository(SITE_REPOSITORY);
+  public static final TransitRepository TRANSIT_MODEL = new TransitRepository(SITE_REPOSITORY);
 
   static List<TestCase> testCases() {
     return List.of(

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIndexTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIndexTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.model.FlexStopTimesFactory.area;
 import static org.opentripplanner.model.FlexStopTimesFactory.groupStop;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.trip;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.trip;
 
 import java.time.LocalDate;
 import java.util.Collection;
@@ -15,19 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
 import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.timetable.Trip;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class FlexIndexTest {
 
-  public static final Route ROUTE_2 = TimetableRepositoryForTest.route("r2").build();
+  public static final Route ROUTE_2 = TransitRepositoryForTest.route("r2").build();
 
   @Test
   void testFlexTripSpanningMidnight() {
-    TimetableRepository repo = new TimetableRepository();
+    TransitRepository repo = new TransitRepository();
 
     FeedScopedId serviceId = id("S1");
     Trip trip = trip("T1").withServiceId(serviceId).build();
@@ -70,7 +70,7 @@ class FlexIndexTest {
 
   @Test
   void testFlexTripStartingAfterMidnight() {
-    TimetableRepository repo = new TimetableRepository();
+    TransitRepository repo = new TransitRepository();
     FeedScopedId serviceId = id("S2");
     Trip trip = trip("T2").withServiceId(serviceId).build();
 
@@ -100,7 +100,7 @@ class FlexIndexTest {
 
   @Test
   void routesAtArea() {
-    var repo = new TimetableRepository();
+    var repo = new TransitRepository();
 
     var st1 = area("10:00", "12:00");
     var st2 = area("14:00", "16:00");
@@ -120,7 +120,7 @@ class FlexIndexTest {
 
   @Test
   void routesAtGroup() {
-    var repo = new TimetableRepository();
+    var repo = new TransitRepository();
 
     var st1 = groupStop("10:00", "12:00");
     var st2 = groupStop("14:00", "16:00");

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -36,7 +36,7 @@ import org.opentripplanner.standalone.api.TestServerContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This test checks the combination of transit and flex works.
@@ -59,7 +59,7 @@ public class FlexIntegrationTest {
 
   static Graph graph;
 
-  static TimetableRepository timetableRepository;
+  static TransitRepository transitRepository;
 
   static TransferRepository transferRepository;
 
@@ -70,11 +70,11 @@ public class FlexIntegrationTest {
     OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
     TestOtpModel model = FlexIntegrationTestData.cobbOsm();
     graph = model.graph();
-    timetableRepository = model.timetableRepository();
+    transitRepository = model.transitRepository();
     transferRepository = model.transferRepository();
     addGtfsToGraph(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       List.of(
         FlexIntegrationTestData.COBB_BUS_30_GTFS,
@@ -84,7 +84,7 @@ public class FlexIntegrationTest {
     );
     service = TestServerContext.createServerContext(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       model.fareServiceFactory().makeFareService(),
       null,
@@ -94,7 +94,7 @@ public class FlexIntegrationTest {
 
   @Test
   void addFlexTripsAndPatternsToGraph() {
-    assertFalse(timetableRepository.getAllTripPatterns().isEmpty());
+    assertFalse(transitRepository.getAllTripPatterns().isEmpty());
   }
 
   @Test
@@ -199,7 +199,7 @@ public class FlexIntegrationTest {
 
   private static void addGtfsToGraph(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     List<File> gtfsFiles
   ) {
@@ -207,17 +207,17 @@ public class FlexIntegrationTest {
     var gtfsBundles = gtfsFiles.stream().map(GtfsBundleTestFactory::forTest).toList();
     GtfsModule gtfsModule = GtfsModuleTestFactory.forTest(
       gtfsBundles,
-      timetableRepository,
+      transitRepository,
       graph,
       LocalDateRange.ofUnbounded()
     );
     gtfsModule.buildGraph();
 
     // link stations to streets
-    TestStreetLinkerModule.link(graph, timetableRepository);
+    TestStreetLinkerModule.link(graph, transitRepository);
 
     // link flex locations to streets
-    new AreaStopsToVerticesMapper(graph, timetableRepository).buildGraph();
+    new AreaStopsToVerticesMapper(graph, transitRepository).buildGraph();
 
     // generate direct transfers
     var req = RouteRequest.defaultValue();
@@ -225,14 +225,14 @@ public class FlexIntegrationTest {
     // we don't have a complete coverage of the entire area so use straight lines for transfers
     new DirectTransferGenerator(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       DataImportIssueStore.NOOP,
       Duration.ofMinutes(10),
       List.of(req)
     ).buildGraph();
 
-    timetableRepository.index();
+    transitRepository.index();
     graph.index();
     transferRepository.index();
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTestData.java
@@ -18,7 +18,7 @@ import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public final class FlexIntegrationTestData {
 
@@ -44,20 +44,20 @@ public final class FlexIntegrationTestData {
 
   private static TestOtpModel buildFlexGraph(File file) {
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(new SiteRepository());
+    var transitRepository = new TransitRepository(new SiteRepository());
     GtfsBundle gtfsBundle = GtfsBundleTestFactory.forTest(file);
     GtfsModule module = GtfsModuleTestFactory.forTest(
       List.of(gtfsBundle),
-      timetableRepository,
+      transitRepository,
       graph,
       LocalDateRange.ofInclusiveEnd(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
     );
     OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
     module.buildGraph();
-    timetableRepository.index();
+    transitRepository.index();
     graph.index();
     OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
-    assertTrue(timetableRepository.hasFlexTrips());
-    return new TestOtpModel(graph, timetableRepository, TransferServiceTestFactory.withFlex());
+    assertTrue(transitRepository.hasFlexTrips());
+    return new TestOtpModel(graph, transitRepository, TransferServiceTestFactory.withFlex());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/GtfsFlexTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/GtfsFlexTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This test makes sure that one of the example feeds in the GTFS-Flex repo works. It's the City of
@@ -23,17 +23,17 @@ import org.opentripplanner.transit.service.TimetableRepository;
  */
 class GtfsFlexTest {
 
-  private static TimetableRepository timetableRepository;
+  private static TransitRepository transitRepository;
 
   @BeforeAll
   static void setup() {
     TestOtpModel model = FlexIntegrationTestData.aspenGtfs();
-    timetableRepository = model.timetableRepository();
+    transitRepository = model.transitRepository();
   }
 
   @Test
   void parseAspenTaxiAsUnscheduledTrip() {
-    var flexTrips = timetableRepository.getAllFlexTrips();
+    var flexTrips = transitRepository.getAllFlexTrips();
     assertFalse(flexTrips.isEmpty());
     assertEquals(
       Set.of("t_1289262_b_29084_tn_0", "t_1289257_b_28352_tn_0"),
@@ -48,6 +48,6 @@ class GtfsFlexTest {
 
   @Test
   void shouldGeneratePatternForFlexTripWithSingleStop() {
-    assertFalse(timetableRepository.getAllTripPatterns().isEmpty());
+    assertFalse(transitRepository.getAllTripPatterns().isEmpty());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/template/ClosestTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/template/ClosestTripTest.java
@@ -20,7 +20,7 @@ import org.opentripplanner.place.api.NearbyStop;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.transfer.regular.model.PathTransfer;
 import org.opentripplanner.transit.api.request.TripRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
 import org.opentripplanner.transit.model.filter.transit.TripMatcherFactory;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -31,7 +31,7 @@ class ClosestTripTest {
 
   private static final UnscheduledTrip FLEX_TRIP = UnscheduledTrip.of(id("123"))
     .withStopTimes(List.of(area("10:00", "11:00"), area("10:00", "11:00")))
-    .withTrip(TimetableRepositoryForTest.trip("123").build())
+    .withTrip(TransitRepositoryForTest.trip("123").build())
     .build();
 
   private static final LocalDate DATE = LocalDate.of(2025, 2, 28);

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/template/FlexTemplateFactoryTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/template/FlexTemplateFactoryTest.java
@@ -32,14 +32,14 @@ import org.opentripplanner.place.api.NearbyStop;
 import org.opentripplanner.street.model.vertex.StreetLocation;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.state.State;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 class FlexTemplateFactoryTest {
 
-  private static final TimetableRepositoryForTest MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest MODEL = TransitRepositoryForTest.of();
 
   /**
    * Any calculator will do. The only thing we will test here is that a new scheduled calculator
@@ -75,7 +75,7 @@ class FlexTemplateFactoryTest {
   private static final StopLocation GROUP_STOP_12 = MODEL.groupStop("G", STOP_G1, STOP_G2);
   private static final StopLocation GROUP_STOP_34 = MODEL.groupStop("G", STOP_G3, STOP_G4);
 
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("Trip").build();
+  private static final Trip TRIP = TransitRepositoryForTest.trip("Trip").build();
   private static final int T_10_00 = time("10:00");
   private static final int T_10_10 = time("10:10");
   private static final int T_10_20 = time("10:20");

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
@@ -36,7 +36,7 @@ import org.opentripplanner.street.linking.TemporaryVerticesContainer;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
 import org.opentripplanner.transit.model.network.grouppriority.TransitGroupPriorityService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
 /**
@@ -50,14 +50,14 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
 class ScheduledDeviatedTripIntegrationTest {
 
   static Graph graph;
-  static TimetableRepository timetableRepository;
+  static TransitRepository transitRepository;
   static TransferRepository transferRepository;
 
   float delta = 0.01f;
 
   @Test
   void parseCobbCountyAsScheduledDeviatedTrip() {
-    var flexTrips = timetableRepository.getAllFlexTrips();
+    var flexTrips = transitRepository.getAllFlexTrips();
     assertFalse(flexTrips.isEmpty());
     assertEquals(72, flexTrips.size());
 
@@ -94,11 +94,11 @@ class ScheduledDeviatedTripIntegrationTest {
    */
   @Test
   void flexTripInTransitMode() {
-    var feedId = timetableRepository.getFeedIds().iterator().next();
+    var feedId = transitRepository.getFeedIds().iterator().next();
 
     var serverContext = TestServerContext.createServerContext(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       new DefaultFareService()
     );
@@ -143,11 +143,11 @@ class ScheduledDeviatedTripIntegrationTest {
    */
   @Test
   void intermediateEstimatedCallsSkipFlexWindowStops() {
-    var feedId = timetableRepository.getFeedIds().iterator().next();
+    var feedId = transitRepository.getFeedIds().iterator().next();
 
     var serverContext = TestServerContext.createServerContext(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       new DefaultFareService()
     );
@@ -190,8 +190,8 @@ class ScheduledDeviatedTripIntegrationTest {
    */
   @Test
   void shouldNotInterpolateFlexTimes() {
-    var feedId = timetableRepository.getFeedIds().iterator().next();
-    var pattern = timetableRepository.getTripPatternForId(new FeedScopedId(feedId, "090z:0:01"));
+    var feedId = transitRepository.getFeedIds().iterator().next();
+    var pattern = transitRepository.getTripPatternForId(new FeedScopedId(feedId, "090z:0:01"));
 
     assertEquals(4, pattern.numberOfStops());
 
@@ -205,7 +205,7 @@ class ScheduledDeviatedTripIntegrationTest {
   static void setup() {
     TestOtpModel model = FlexIntegrationTestData.cobbFlexGtfs();
     graph = model.graph();
-    timetableRepository = model.timetableRepository();
+    transitRepository = model.transitRepository();
     transferRepository = TransferServiceTestFactory.defaultTransferRepository();
   }
 
@@ -247,8 +247,8 @@ class ScheduledDeviatedTripIntegrationTest {
   }
 
   private static FlexTrip<?, ?> getFlexTrip() {
-    var feedId = timetableRepository.getFeedIds().iterator().next();
+    var feedId = transitRepository.getFeedIds().iterator().next();
     var tripId = new FeedScopedId(feedId, "a326c618-d42c-4bd1-9624-c314fbf8ecd8");
-    return timetableRepository.getFlexTrip(tripId);
+    return transitRepository.getFlexTrip(tripId);
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/UnscheduledTripTest.java
@@ -24,7 +24,7 @@ import org.opentripplanner.model.FlexStopTimesFactory;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.routing.api.request.framework.TimePenalty;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.utils.time.DurationUtils;
@@ -41,7 +41,7 @@ class UnscheduledTripTest {
   private static final int T14_00 = TimeUtils.hm2time(14, 0);
   private static final int T15_00 = TimeUtils.hm2time(15, 0);
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final RegularStop REGULAR_STOP = TEST_MODEL.stop("stop").build();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -23,7 +23,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationRepository;
 import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationService;
 import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -32,11 +32,11 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class LuceneIndexTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final Agency BVG = Agency.of(id("bvg"))
     .withName("BVG")
@@ -122,9 +122,9 @@ class LuceneIndexTest {
     List.of(ALEXANDERPLATZ_STATION, BERLIN_HAUPTBAHNHOF_STATION, FIVE_POINTS_STATION).forEach(
       siteRepository::withStation
     );
-    var timetableRepository = new TimetableRepository(siteRepository.build());
-    timetableRepository.index();
-    var transitService = new DefaultTransitService(timetableRepository) {
+    var transitRepository = new TransitRepository(siteRepository.build());
+    transitRepository.index();
+    var transitService = new DefaultTransitService(transitRepository) {
       private final Multimap<StopLocation, TransitMode> modes = ImmutableMultimap.<
           StopLocation,
           TransitMode
@@ -151,7 +151,7 @@ class LuceneIndexTest {
 
       @Override
       public Set<Route> findRoutes(StopLocation stop) {
-        return Set.of(TimetableRepositoryForTest.route("route1").withAgency(BVG).build());
+        return Set.of(TransitRepositoryForTest.route("route1").withAgency(BVG).build());
       }
 
       @Override
@@ -169,7 +169,7 @@ class LuceneIndexTest {
     };
     var stopConsolidationService = new DefaultStopConsolidationService(
       new DefaultStopConsolidationRepository(),
-      timetableRepository
+      transitRepository
     );
     index = new LuceneIndex(transitService, stopConsolidationService);
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/geocoder/StopClusterMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/geocoder/StopClusterMapperTest.java
@@ -11,16 +11,16 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationRepository;
 import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationService;
 import org.opentripplanner.ext.stopconsolidation.model.ConsolidatedStopGroup;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class StopClusterMapperTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final RegularStop STOP_A = TEST_MODEL.stop("A").build();
   private static final RegularStop STOP_B = TEST_MODEL.stop("B").build();
   private static final RegularStop STOP_C = TEST_MODEL.stop("C").build();
@@ -28,7 +28,7 @@ class StopClusterMapperTest {
   private static final SiteRepository SITE_REPOSITORY = TEST_MODEL.siteRepositoryBuilder()
     .withRegularStops(STOPS)
     .build();
-  private static final TimetableRepository TIMETABLE_REPOSITORY = new TimetableRepository(
+  private static final TransitRepository TIMETABLE_REPOSITORY = new TransitRepository(
     SITE_REPOSITORY
   );
   private static final List<StopLocation> LOCATIONS = STOPS.stream()

--- a/application/src/ext-test/java/org/opentripplanner/ext/ojp/resource/OjpMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/ojp/resource/OjpMapperTest.java
@@ -21,7 +21,7 @@ import org.opentripplanner.api.model.transit.DefaultFeedIdMapper;
 import org.opentripplanner.ext.ojp.mapping.StopEventResponseMapper;
 import org.opentripplanner.ext.ojp.service.CallAtStop;
 import org.opentripplanner.model.TripTimeOnDate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -37,14 +37,14 @@ class OjpMapperTest {
   private static final String ROUTE_ID = "r1";
   private static final LocalDate SERVICE_DATE = LocalDate.of(2025, 2, 10);
   private static final SiteRepositoryBuilder SITE_REPOSITORY_BUILDER = SiteRepository.of();
-  private static final TimetableRepositoryForTest TEST_MODEL = new TimetableRepositoryForTest(
+  private static final TransitRepositoryForTest TEST_MODEL = new TransitRepositoryForTest(
     SITE_REPOSITORY_BUILDER
   );
   private static final RegularStop STOP_1 = TEST_MODEL.stop("s1").build();
   private static final RegularStop STOP_2 = TEST_MODEL.stop("s2").build();
-  private static final Route ROUTE = TimetableRepositoryForTest.route(id(ROUTE_ID)).build();
+  private static final Route ROUTE = TransitRepositoryForTest.route(id(ROUTE_ID)).build();
   private static final String TRIP_ID = "t1";
-  private static final Trip TRIP = TimetableRepositoryForTest.trip(TRIP_ID).build();
+  private static final Trip TRIP = TransitRepositoryForTest.trip(TRIP_ID).build();
 
   private static final String START_TIME = "07:30:00";
   private static final TripTimes TRIP_TIMES = TripTimesFactory.tripTimes(
@@ -52,11 +52,8 @@ class OjpMapperTest {
     TEST_MODEL.stopTimesEvery5Minutes(5, TRIP, START_TIME),
     new Deduplicator()
   );
-  private static final TripPattern TRIP_PATTERN = TimetableRepositoryForTest.tripPattern(
-    "tp1",
-    ROUTE
-  )
-    .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_1, STOP_2))
+  private static final TripPattern TRIP_PATTERN = TransitRepositoryForTest.tripPattern("tp1", ROUTE)
+    .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_1, STOP_2))
     .withScheduledTimeTableBuilder(builder -> builder.addTripTimes(TRIP_TIMES))
     .build();
   private static final TripTimeOnDate TRIP_TIMES_ON_DATE = new TripTimeOnDate(

--- a/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/realtimeresolver/RealtimeResolverTest.java
@@ -22,22 +22,22 @@ import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 
 class RealtimeResolverTest {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
-  private final Route route1 = TimetableRepositoryForTest.route("route1").build();
-  private final Route route2 = TimetableRepositoryForTest.route("route2").build();
+  private final Route route1 = TransitRepositoryForTest.route("route1").build();
+  private final Route route2 = TransitRepositoryForTest.route("route2").build();
 
   private final RegularStop stop1 = testModel.stop("stop1", 1, 1).build();
   private final RegularStop stop2 = testModel.stop("stop2", 2, 1).build();
@@ -93,7 +93,7 @@ class RealtimeResolverTest {
       .bus(route1, 1, time("11:20"), time("11:40"), Place.forStop(stop3))
       .build();
 
-    var model = new TimetableRepository();
+    var model = new TransitRepository();
     model.index();
     var transitService = new DefaultTransitService(model);
 
@@ -164,23 +164,23 @@ class RealtimeResolverTest {
     List<TripPattern> patterns,
     LocalDate serviceDate
   ) {
-    var timetableRepository = new TimetableRepository();
+    var transitRepository = new TransitRepository();
     CalendarServiceData calendarServiceData = new CalendarServiceData();
 
     patterns.forEach(pattern -> {
-      timetableRepository.addTripPattern(pattern.getId(), pattern);
+      transitRepository.addTripPattern(pattern.getId(), pattern);
 
       var serviceCode = pattern.getScheduledTimetable().getTripTimes().getFirst().getServiceCode();
-      timetableRepository.getServiceCodes().put(pattern.getId(), serviceCode);
+      transitRepository.getServiceCodes().put(pattern.getId(), serviceCode);
 
       calendarServiceData.putServiceDatesForServiceId(pattern.getId(), List.of(serviceDate));
     });
 
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
-    timetableRepository.index();
+    transitRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.index();
 
-    return new DefaultTransitService(timetableRepository) {
-      final TransitAlertService alertService = new TransitAlertServiceImpl(timetableRepository);
+    return new DefaultTransitService(transitRepository) {
+      final TransitAlertService alertService = new TransitAlertServiceImpl(transitRepository);
 
       @Override
       public TransitAlertService getTransitAlertService() {

--- a/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/DecorateConsolidatedStopNamesTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/DecorateConsolidatedStopNamesTest.java
@@ -91,12 +91,12 @@ class DecorateConsolidatedStopNamesTest {
   }
 
   private static DecorateConsolidatedStopNames defaultFilter() {
-    var timetableRepository = TestStopConsolidationModel.buildTimetableRepository();
+    var transitRepository = TestStopConsolidationModel.buildTransitRepository();
 
     var repo = new DefaultStopConsolidationRepository();
     repo.addGroups(GROUPS);
 
-    var service = new DefaultStopConsolidationService(repo, timetableRepository);
+    var service = new DefaultStopConsolidationService(repo, transitRepository);
     return new DecorateConsolidatedStopNames(service);
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModuleTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModuleTest.java
@@ -20,13 +20,13 @@ class StopConsolidationModuleTest {
   void replacePatterns() {
     var groups = List.of(new ConsolidatedStopGroup(STOP_D.getId(), List.of(STOP_B.getId())));
 
-    var timetableRepository = TestStopConsolidationModel.buildTimetableRepository();
-    timetableRepository.addTripPattern(PATTERN.getId(), PATTERN);
+    var transitRepository = TestStopConsolidationModel.buildTransitRepository();
+    transitRepository.addTripPattern(PATTERN.getId(), PATTERN);
     var repo = new DefaultStopConsolidationRepository();
-    var module = new StopConsolidationModule(timetableRepository, repo, groups);
+    var module = new StopConsolidationModule(transitRepository, repo, groups);
     module.buildGraph();
 
-    var modifiedPattern = timetableRepository.getTripPatternForId(PATTERN.getId());
+    var modifiedPattern = transitRepository.getTripPatternForId(PATTERN.getId());
     assertFalse(modifiedPattern.getRoutingTripPattern().getPattern().sameAs(PATTERN));
     assertFalse(modifiedPattern.sameAs(PATTERN));
 
@@ -37,7 +37,7 @@ class StopConsolidationModuleTest {
       .getStop(1);
     assertEquals(modifiedStop, STOP_D);
 
-    var patterns = List.copyOf(timetableRepository.getAllTripPatterns());
+    var patterns = List.copyOf(transitRepository.getAllTripPatterns());
 
     var stops = patterns.stream().map(TripPattern::getStops).toList();
     assertEquals(List.of(List.of(STOP_A, STOP_D, STOP_C)), stops);

--- a/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/TestStopConsolidationModel.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/TestStopConsolidationModel.java
@@ -2,31 +2,31 @@ package org.opentripplanner.ext.stopconsolidation;
 
 import java.util.List;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.RegularStop;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class TestStopConsolidationModel {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   public static final RegularStop STOP_A = TEST_MODEL.stop("A").withCoordinate(1, 1).build();
   public static final RegularStop STOP_B = TEST_MODEL.stop("B").withCoordinate(1.1, 1.1).build();
   public static final RegularStop STOP_C = TEST_MODEL.stop("C").withCoordinate(1.2, 1.2).build();
-  public static final StopPattern STOP_PATTERN = TimetableRepositoryForTest.stopPattern(
+  public static final StopPattern STOP_PATTERN = TransitRepositoryForTest.stopPattern(
     STOP_A,
     STOP_B,
     STOP_C
   );
   static final String SECONDARY_FEED_ID = "secondary";
-  static final Agency AGENCY = TimetableRepositoryForTest.agency("agency")
+  static final Agency AGENCY = TransitRepositoryForTest.agency("agency")
     .copy()
     .withId(new FeedScopedId(SECONDARY_FEED_ID, "agency"))
     .build();
-  static final Route ROUTE = TimetableRepositoryForTest.route(
+  static final Route ROUTE = TransitRepositoryForTest.route(
     new FeedScopedId(SECONDARY_FEED_ID, "route-33")
   )
     .withAgency(AGENCY)
@@ -40,9 +40,9 @@ class TestStopConsolidationModel {
     .withStopPattern(STOP_PATTERN)
     .build();
 
-  static TimetableRepository buildTimetableRepository() {
+  static TransitRepository buildTransitRepository() {
     var siteRepositoryBuilder = TEST_MODEL.siteRepositoryBuilder();
     List.of(STOP_A, STOP_B, STOP_C, STOP_D).forEach(siteRepositoryBuilder::withRegularStop);
-    return new TimetableRepository(siteRepositoryBuilder.build());
+    return new TransitRepository(siteRepositoryBuilder.build());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/internal/DefaultStopConsolidationServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/stopconsolidation/internal/DefaultStopConsolidationServiceTest.java
@@ -3,7 +3,7 @@ package org.opentripplanner.ext.stopconsolidation.internal;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class DefaultStopConsolidationServiceTest {
 
@@ -11,7 +11,7 @@ class DefaultStopConsolidationServiceTest {
   void isActive() {
     var service = new DefaultStopConsolidationService(
       new DefaultStopConsolidationRepository(),
-      new TimetableRepository()
+      new TransitRepository()
     );
     assertFalse(service.isActive());
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
@@ -10,7 +10,7 @@ import org.opentripplanner.standalone.api.TestServerContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.test.support.HttpForTest;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class VectorTilesResourceTest {
 
@@ -21,7 +21,7 @@ class VectorTilesResourceTest {
     var resource = new VectorTilesResource(
       TestServerContext.createServerContext(
         new Graph(),
-        new TimetableRepository(),
+        new TransitRepository(),
         TransferServiceTestFactory.defaultTransferRepository(),
         new DefaultFareService()
       ),

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/LayerFiltersTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/LayerFiltersTest.java
@@ -7,13 +7,13 @@ import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.PatternTestModel;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 class LayerFiltersTest {
 
-  private static final RegularStop STOP = TimetableRepositoryForTest.of().stop("1").build();
+  private static final RegularStop STOP = TransitRepositoryForTest.of().stop("1").build();
   private static final LocalDate DATE = LocalDate.of(2024, 9, 5);
   private static final TripPattern PATTERN = PatternTestModel.pattern();
 

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/TestTransitService.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/TestTransitService.java
@@ -1,23 +1,23 @@
 package org.opentripplanner.ext.vectortiles.layers;
 
 import java.util.Set;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class TestTransitService extends DefaultTransitService {
 
-  public TestTransitService(TimetableRepository timetableRepository) {
-    super(timetableRepository);
+  public TestTransitService(TransitRepository transitRepository) {
+    super(transitRepository);
   }
 
   @Override
   public Set<Route> findRoutes(StopLocation stop) {
     return Set.of(
-      TimetableRepositoryForTest.route("1").withMode(TransitMode.RAIL).withGtfsType(100).build()
+      TransitRepositoryForTest.route("1").withMode(TransitMode.RAIL).withGtfsType(100).build()
     );
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/areastops/AreaStopPropertyMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/areastops/AreaStopPropertyMapperTest.java
@@ -6,21 +6,21 @@ import static org.opentripplanner.inspector.vector.KeyValue.kv;
 import java.util.List;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.service.SiteRepository;
 
 class AreaStopPropertyMapperTest {
 
-  private static final TimetableRepositoryForTest MODEL = new TimetableRepositoryForTest(
+  private static final TransitRepositoryForTest MODEL = new TransitRepositoryForTest(
     SiteRepository.of()
   );
   private static final AreaStop STOP = MODEL.areaStop("123").build();
-  private static final Route ROUTE_WITH_COLOR = TimetableRepositoryForTest.route("123")
+  private static final Route ROUTE_WITH_COLOR = TransitRepositoryForTest.route("123")
     .withColor("ffffff")
     .build();
-  private static final Route ROUTE_WITHOUT_COLOR = TimetableRepositoryForTest.route("456").build();
+  private static final Route ROUTE_WITHOUT_COLOR = TransitRepositoryForTest.route("456").build();
 
   @Test
   void map() {

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/areastops/AreaStopsLayerBuilderTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/areastops/AreaStopsLayerBuilderTest.java
@@ -16,7 +16,7 @@ import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
 import org.opentripplanner.transit.service.SiteRepositoryBuilder;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class AreaStopsLayerBuilderTest {
 
@@ -52,16 +52,16 @@ class AreaStopsLayerBuilderTest {
     .withGeometry(Polygons.BERLIN)
     .build();
 
-  private final TimetableRepository timetableRepository = new TimetableRepository(
+  private final TransitRepository transitRepository = new TransitRepository(
     siteRepositoryBuilder.withAreaStop(AREA_STOP).build()
   );
 
   @Test
   void getAreaStops() {
-    timetableRepository.index();
+    transitRepository.index();
 
     var subject = new AreaStopsLayerBuilder(
-      new DefaultTransitService(timetableRepository),
+      new DefaultTransitService(transitRepository),
       LAYER_CONFIG,
       Locale.ENGLISH
     );

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapperTest.java
@@ -9,10 +9,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.ext.vectortiles.layers.TestTransitService;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class DigitransitStationPropertyMapperTest {
 
@@ -20,9 +20,9 @@ public class DigitransitStationPropertyMapperTest {
 
   @Test
   void map() {
-    var timetableRepository = new TimetableRepository(new SiteRepository());
-    timetableRepository.index();
-    var transitService = new TestTransitService(timetableRepository);
+    var transitRepository = new TransitRepository(new SiteRepository());
+    transitRepository.index();
+    var transitService = new TestTransitService(transitRepository);
 
     var mapper = DigitransitStationPropertyMapper.create(transitService, Locale.US);
 
@@ -32,7 +32,7 @@ public class DigitransitStationPropertyMapperTest {
       .withName(I18NString.of("A station"))
       .build();
 
-    TimetableRepositoryForTest.of().stop("stop-1").withParentStation(station).build();
+    TransitRepositoryForTest.of().stop("stop-1").withParentStation(station).build();
 
     Map<String, Object> map = new HashMap<>();
     mapper.map(station).forEach(o -> map.put(o.key(), o.value()));

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/RealtimeStopsLayerTest.java
@@ -22,12 +22,12 @@ import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class RealtimeStopsLayerTest {
 
@@ -56,11 +56,11 @@ public class RealtimeStopsLayerTest {
 
   @Test
   void realtimeStopLayer() {
-    var timetableRepository = new TimetableRepository(new SiteRepository());
-    timetableRepository.initTimeZone(ZoneIds.HELSINKI);
-    timetableRepository.index();
-    var transitService = new DefaultTransitService(timetableRepository) {
-      final TransitAlertService alertService = new TransitAlertServiceImpl(timetableRepository);
+    var transitRepository = new TransitRepository(new SiteRepository());
+    transitRepository.initTimeZone(ZoneIds.HELSINKI);
+    transitRepository.index();
+    var transitService = new DefaultTransitService(transitRepository) {
+      final TransitAlertService alertService = new TransitAlertServiceImpl(transitRepository);
 
       @Override
       public TransitAlertService getTransitAlertService() {
@@ -68,7 +68,7 @@ public class RealtimeStopsLayerTest {
       }
     };
 
-    Route route = TimetableRepositoryForTest.route("route").build();
+    Route route = TransitRepositoryForTest.route("route").build();
     var itinerary = newItinerary(Place.forStop(stop), time("11:00"))
       .bus(route, 1, time("11:05"), time("11:20"), Place.forStop(stop2))
       .build();

--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerTest.java
@@ -16,7 +16,7 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class StopsLayerTest {
 
@@ -53,9 +53,9 @@ public class StopsLayerTest {
 
   @Test
   public void digitransitStopPropertyMapperTest() {
-    var timetableRepository = new TimetableRepository(new SiteRepository());
-    timetableRepository.index();
-    var transitService = new TestTransitService(timetableRepository);
+    var transitRepository = new TransitRepository(new SiteRepository());
+    transitRepository.index();
+    var transitService = new TestTransitService(transitRepository);
 
     DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(
       transitService,
@@ -74,9 +74,9 @@ public class StopsLayerTest {
 
   @Test
   public void digitransitStopPropertyMapperTranslationTest() {
-    var timetableRepository = new TimetableRepository(new SiteRepository());
-    timetableRepository.index();
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitRepository = new TransitRepository(new SiteRepository());
+    transitRepository.index();
+    var transitService = new DefaultTransitService(transitRepository);
 
     DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(
       transitService,

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/CarpoolingRepository.java
@@ -65,7 +65,7 @@ public interface CarpoolingRepository {
    * {@code now.minus(expiry)}. Removing such trips bounds the memory use of instances that run for a
    * long time without restarting, since the SIRI source is not guaranteed to send an explicit
    * cancellation for a journey once it has completed. This mirrors how real-time timetable data is
-   * purged once its service date has passed (see {@code TimetableSnapshot#purgeExpiredData}), with
+   * purged once its service date has passed (see {@code TimetableRepository#purgeExpiredData}), with
    * the difference that carpool trips carry a concrete instant rather than a service date.
    * <p>
    * The scan is throttled so that it runs at most once per sweep interval no matter how often it is

--- a/application/src/ext/java/org/opentripplanner/ext/emission/configure/EmissionGraphBuilderModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/configure/EmissionGraphBuilderModule.java
@@ -9,7 +9,7 @@ import org.opentripplanner.ext.emission.internal.graphbuilder.EmissionGraphBuild
 import org.opentripplanner.graph_builder.GraphBuilderDataSources;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.standalone.config.BuildConfig;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 @Module
 public class EmissionGraphBuilderModule {
@@ -21,7 +21,7 @@ public class EmissionGraphBuilderModule {
     GraphBuilderDataSources dataSources,
     BuildConfig config,
     @Nullable EmissionRepository emissionRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore
   ) {
     if (emissionRepository == null) {
@@ -33,7 +33,7 @@ public class EmissionGraphBuilderModule {
       dataSources.getEmissionConfiguredDataSource(),
       config.emission,
       emissionRepository,
-      timetableRepository,
+      transitRepository,
       issueStore
     );
   }

--- a/application/src/ext/java/org/opentripplanner/ext/emission/internal/graphbuilder/EmissionGraphBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/emission/internal/graphbuilder/EmissionGraphBuilder.java
@@ -17,7 +17,7 @@ import org.opentripplanner.gtfs.config.GtfsFeedParameters;
 import org.opentripplanner.gtfs.graphbuilder.GtfsBundle;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +32,7 @@ public class EmissionGraphBuilder implements GraphBuilderModule {
   private final EmissionRepository emissionRepository;
   private final Iterable<ConfiguredCompositeDataSource<GtfsFeedParameters>> gtfsDataSources;
   private final Iterable<ConfiguredDataSource<EmissionFeedParameters>> emissionDataSources;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   private final DataImportIssueStore issueStore;
 
@@ -41,14 +41,14 @@ public class EmissionGraphBuilder implements GraphBuilderModule {
     Iterable<ConfiguredDataSource<EmissionFeedParameters>> emissionDataSources,
     EmissionParameters parameters,
     EmissionRepository emissionRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore
   ) {
     this.gtfsDataSources = gtfsDataSources;
     this.emissionDataSources = emissionDataSources;
     this.parameters = parameters;
     this.emissionRepository = emissionRepository;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.issueStore = issueStore;
   }
 
@@ -78,7 +78,7 @@ public class EmissionGraphBuilder implements GraphBuilderModule {
 
   private Map<FeedScopedId, List<StopLocation>> createStopsByTripIdMap() {
     var map = new HashMap<FeedScopedId, List<StopLocation>>();
-    for (TripPattern pattern : timetableRepository.getAllTripPatterns()) {
+    for (TripPattern pattern : transitRepository.getAllTripPatterns()) {
       pattern.scheduledTripsAsStream().forEach(it -> map.put(it.getId(), pattern.getStops()));
     }
     return map;

--- a/application/src/ext/java/org/opentripplanner/ext/empiricaldelay/configure/EmpiricalDelayGraphBuilderModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/empiricaldelay/configure/EmpiricalDelayGraphBuilderModule.java
@@ -11,7 +11,7 @@ import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.GraphBuilderDataSources;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.standalone.config.BuildConfig;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 @Module
 public class EmpiricalDelayGraphBuilderModule {
@@ -23,7 +23,7 @@ public class EmpiricalDelayGraphBuilderModule {
     GraphBuilderDataSources dataSources,
     BuildConfig config,
     @Nullable EmpiricalDelayRepository empiricalDelayRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore,
     DeduplicatorService deduplicator
   ) {
@@ -37,7 +37,7 @@ public class EmpiricalDelayGraphBuilderModule {
       issueStore,
       config.empiricalDelay,
       empiricalDelayRepository,
-      timetableRepository
+      transitRepository
     );
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/empiricaldelay/internal/graphbuilder/EmpiricalDelayGraphBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/empiricaldelay/internal/graphbuilder/EmpiricalDelayGraphBuilder.java
@@ -17,7 +17,7 @@ import org.opentripplanner.graph_builder.model.ConfiguredCompositeDataSource;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +33,7 @@ public class EmpiricalDelayGraphBuilder implements GraphBuilderModule {
   private final DataImportIssueStore issueStore;
   private final EmpiricalDelayParameters parameters;
   private final EmpiricalDelayRepository repository;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   public EmpiricalDelayGraphBuilder(
     Iterable<ConfiguredCompositeDataSource<EmpiricalDelayFeedParameters>> dataSources,
@@ -41,14 +41,14 @@ public class EmpiricalDelayGraphBuilder implements GraphBuilderModule {
     DataImportIssueStore issueStore,
     EmpiricalDelayParameters parameters,
     EmpiricalDelayRepository repository,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     this.dataSources = Objects.requireNonNull(dataSources);
     this.deduplicator = Objects.requireNonNull(deduplicator);
     this.issueStore = Objects.requireNonNull(issueStore);
     this.parameters = Objects.requireNonNull(parameters);
     this.repository = Objects.requireNonNull(repository);
-    this.timetableRepository = Objects.requireNonNull(timetableRepository);
+    this.transitRepository = Objects.requireNonNull(transitRepository);
   }
 
   public void buildGraph() {
@@ -58,7 +58,7 @@ public class EmpiricalDelayGraphBuilder implements GraphBuilderModule {
       return;
     }
     var mapper = new TripDelaysMapper(
-      createStopIdsByTripIdMap(timetableRepository.getAllTripPatterns()),
+      createStopIdsByTripIdMap(transitRepository.getAllTripPatterns()),
       issueStore,
       deduplicator
     );

--- a/application/src/ext/java/org/opentripplanner/ext/flex/AreaStopsToVerticesMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/AreaStopsToVerticesMapper.java
@@ -12,7 +12,7 @@ import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,29 +26,29 @@ public class AreaStopsToVerticesMapper implements GraphBuilderModule {
   private static final Logger LOG = LoggerFactory.getLogger(AreaStopsToVerticesMapper.class);
 
   private final Graph graph;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   @Inject
-  public AreaStopsToVerticesMapper(Graph graph, TimetableRepository timetableRepository) {
+  public AreaStopsToVerticesMapper(Graph graph, TransitRepository transitRepository) {
     this.graph = graph;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
   }
 
   @Override
   @SuppressWarnings("Convert2MethodRef")
   public void buildGraph() {
-    if (!timetableRepository.getSiteRepository().hasAreaStops()) {
+    if (!transitRepository.getSiteRepository().hasAreaStops()) {
       return;
     }
 
     ProgressTracker progress = ProgressTracker.track(
       "Add flex locations to street vertices",
       1,
-      timetableRepository.getSiteRepository().listAreaStops().size()
+      transitRepository.getSiteRepository().listAreaStops().size()
     );
 
     LOG.info(progress.startMessage());
-    var results = timetableRepository
+    var results = transitRepository
       .getSiteRepository()
       .listAreaStops()
       .parallelStream()

--- a/application/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
@@ -14,7 +14,7 @@ import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class FlexIndex {
 
@@ -28,10 +28,10 @@ public class FlexIndex {
 
   private final Multimap<StopLocation, Route> routeByStop;
 
-  public FlexIndex(TimetableRepository timetableRepository) {
+  public FlexIndex(TransitRepository transitRepository) {
     var routeByStopBuilder = ImmutableSetMultimap.<StopLocation, Route>builder();
 
-    for (FlexTrip<?, ?> flexTrip : timetableRepository.getAllFlexTrips()) {
+    for (FlexTrip<?, ?> flexTrip : transitRepository.getAllFlexTrips()) {
       var route = flexTrip.getTrip().getRoute();
       routeById.put(route.getId(), route);
       tripById.put(flexTrip.getTrip().getId(), flexTrip);
@@ -47,7 +47,7 @@ public class FlexIndex {
         }
       }
 
-      timetableRepository
+      transitRepository
         .getTripCalendar()
         .listServiceDates(flexTrip.getTrip().getServiceId())
         .forEach(serviceDate -> {

--- a/application/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/application/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -50,7 +50,7 @@ import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.transit.model.site.StopType;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 
 public class LuceneIndex implements Serializable {
@@ -78,10 +78,10 @@ public class LuceneIndex implements Serializable {
    * constructor.
    */
   public LuceneIndex(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     StopConsolidationService stopConsolidationService
   ) {
-    this(new DefaultTransitService(timetableRepository), stopConsolidationService);
+    this(new DefaultTransitService(transitRepository), stopConsolidationService);
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/geocoder/configure/GeocoderModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/geocoder/configure/GeocoderModule.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.framework.application.OTPFeature;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This module builds the Lucene geocoder based on whether the feature flag is on or off.
@@ -19,11 +19,11 @@ public class GeocoderModule {
   @Singleton
   @Nullable
   LuceneIndex luceneIndex(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable StopConsolidationService stopConsolidationService
   ) {
     if (OTPFeature.SandboxAPIGeocoder.isOn()) {
-      return new LuceneIndex(timetableRepository, stopConsolidationService);
+      return new LuceneIndex(transitRepository, stopConsolidationService);
     } else {
       return null;
     }

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -55,7 +55,7 @@ public class SiriAzureETUpdater implements SiriAzureMessageHandler {
   private Future<?> processMessage(List<EstimatedTimetableDeliveryStructure> updates) {
     return writeToGraphCallback.execute(context -> {
       var result = adapter
-        .forUpdate(context.mutableSnapshot())
+        .forUpdate(context.timetableRepository())
         .applyEstimatedTimetable(
           context.entityResolver(feedId),
           feedId,

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.siri.SiriAlertsUpdateHandler;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.opentripplanner.updater.trip.siri.SiriFuzzyTripMatcherCache;
@@ -23,10 +23,10 @@ public class SiriAzureSXUpdater implements SiriAzureMessageHandler {
 
   public SiriAzureSXUpdater(
     SiriAzureSXUpdaterParameters config,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache
   ) {
-    this.transitAlertService = new TransitAlertServiceImpl(timetableRepository);
+    this.transitAlertService = new TransitAlertServiceImpl(transitRepository);
     this.updateHandler = new SiriAlertsUpdateHandler(
       config.feedId(),
       transitAlertService,

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
@@ -34,7 +34,7 @@ import org.opentripplanner.framework.retry.OtpRetry;
 import org.opentripplanner.framework.retry.OtpRetryBuilder;
 import org.opentripplanner.framework.retry.OtpRetryException;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.spi.GraphUpdater;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -134,12 +134,12 @@ public class SiriAzureUpdater implements GraphUpdater {
 
   public static SiriAzureUpdater createSXUpdater(
     SiriAzureSXUpdaterParameters config,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache
   ) {
     var messageHandler = new SiriAzureSXUpdater(
       config,
-      timetableRepository,
+      transitRepository,
       siriFuzzyTripMatcherCache
     );
     return new SxWrapper(config, messageHandler);

--- a/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/StopConsolidationModule.java
@@ -10,7 +10,7 @@ import org.opentripplanner.ext.stopconsolidation.model.ConsolidatedStopGroup;
 import org.opentripplanner.ext.stopconsolidation.model.StopReplacement;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,15 +28,15 @@ public class StopConsolidationModule implements GraphBuilderModule {
   private static final Logger LOG = LoggerFactory.getLogger(StopConsolidationModule.class);
 
   private final StopConsolidationRepository repository;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final Collection<ConsolidatedStopGroup> groups;
 
   public StopConsolidationModule(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     StopConsolidationRepository repository,
     Collection<ConsolidatedStopGroup> groups
   ) {
-    this.timetableRepository = Objects.requireNonNull(timetableRepository);
+    this.transitRepository = Objects.requireNonNull(transitRepository);
     this.repository = Objects.requireNonNull(repository);
     this.groups = Objects.requireNonNull(groups);
   }
@@ -45,19 +45,19 @@ public class StopConsolidationModule implements GraphBuilderModule {
   public void buildGraph() {
     repository.addGroups(groups);
 
-    var service = new DefaultStopConsolidationService(repository, timetableRepository);
+    var service = new DefaultStopConsolidationService(repository, transitRepository);
 
     var stopsToReplace = service.secondaryStops();
     var replacements = service.replacements();
 
-    timetableRepository
+    transitRepository
       .getAllTripPatterns()
       .stream()
       .filter(pattern -> pattern.containsAnyStopId(stopsToReplace))
       .forEach(pattern -> {
         LOG.info("Replacing stop(s) in pattern {}", pattern);
         var modifiedPattern = modifyStopsInPattern(pattern, replacements);
-        timetableRepository.addTripPattern(modifiedPattern.getId(), modifiedPattern);
+        transitRepository.addTripPattern(modifiedPattern.getId(), modifiedPattern);
       });
   }
 
@@ -71,14 +71,14 @@ public class StopConsolidationModule implements GraphBuilderModule {
   }
 
   public static StopConsolidationModule of(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     StopConsolidationRepository repo,
     DataSource ds
   ) {
     LOG.info("Reading stop consolidation information from '{}'", ds);
     try (var inputStream = ds.asInputStream()) {
       var groups = StopConsolidationParser.parseGroups(inputStream);
-      return new StopConsolidationModule(timetableRepository, repo, groups);
+      return new StopConsolidationModule(transitRepository, repo, groups);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/configure/StopConsolidationServiceModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/configure/StopConsolidationServiceModule.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationRepository;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
 import org.opentripplanner.ext.stopconsolidation.internal.DefaultStopConsolidationService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 @Module
 public class StopConsolidationServiceModule {
@@ -17,7 +17,7 @@ public class StopConsolidationServiceModule {
   @Nullable
   StopConsolidationService service(
     @Nullable StopConsolidationRepository repo,
-    TimetableRepository tm
+    TransitRepository tm
   ) {
     if (repo == null) {
       return null;

--- a/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/internal/DefaultStopConsolidationService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/stopconsolidation/internal/DefaultStopConsolidationService.java
@@ -12,7 +12,7 @@ import org.opentripplanner.ext.stopconsolidation.model.ConsolidatedStopGroup;
 import org.opentripplanner.ext.stopconsolidation.model.StopReplacement;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,14 +21,14 @@ public class DefaultStopConsolidationService implements StopConsolidationService
   private static final Logger LOG = LoggerFactory.getLogger(DefaultStopConsolidationService.class);
 
   private final StopConsolidationRepository repo;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   public DefaultStopConsolidationService(
     StopConsolidationRepository repo,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     this.repo = Objects.requireNonNull(repo);
-    this.timetableRepository = Objects.requireNonNull(timetableRepository);
+    this.transitRepository = Objects.requireNonNull(transitRepository);
   }
 
   @Override
@@ -37,7 +37,7 @@ public class DefaultStopConsolidationService implements StopConsolidationService
       .groups()
       .stream()
       .flatMap(group -> {
-        var primaryStop = timetableRepository.getSiteRepository().getRegularStop(group.primary());
+        var primaryStop = transitRepository.getSiteRepository().getRegularStop(group.primary());
         if (primaryStop == null) {
           LOG.error(
             "Could not find primary stop with id {}. Ignoring stop group {}.",
@@ -107,7 +107,7 @@ public class DefaultStopConsolidationService implements StopConsolidationService
       .flatMap(g -> g.secondaries().stream())
       .filter(secondary -> secondary.getFeedId().equals(agency.getId().getFeedId()))
       .findAny()
-      .map(id -> timetableRepository.getSiteRepository().getRegularStop(id));
+      .map(id -> transitRepository.getSiteRepository().getRegularStop(id));
   }
 
   @Override
@@ -119,6 +119,6 @@ public class DefaultStopConsolidationService implements StopConsolidationService
       .map(ConsolidatedStopGroup::primary)
       .findAny()
       .orElse(id);
-    return Optional.ofNullable(timetableRepository.getSiteRepository().getRegularStop(primaryId));
+    return Optional.ofNullable(transitRepository.getSiteRepository().getRegularStop(primaryId));
   }
 }

--- a/application/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
+++ b/application/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
@@ -23,7 +23,7 @@ import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.transit.model.site.RegularStop;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,20 +47,20 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
 
   private final Graph graph;
   private final VertexLinker linker;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final DataImportIssueStore issueStore;
   private final double radiusMeters;
 
   public DirectTransferAnalyzer(
     Graph graph,
     VertexLinker linker,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore,
     double radiusMeters
   ) {
     this.graph = graph;
     this.linker = linker;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.issueStore = issueStore;
     this.radiusMeters = radiusMeters;
   }
@@ -68,7 +68,7 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
   @Override
   public void buildGraph() {
     /* Initialize transit index which is needed by the nearby stop finder. */
-    timetableRepository.index();
+    transitRepository.index();
 
     LOG.info("Analyzing transfers (this can be time consuming)...");
 
@@ -76,7 +76,7 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
     List<TransferInfo> directTransfersNotFound = new ArrayList<>();
 
     var straightLineNearbyStopFinder = new StraightLineNearbyStopFinder(
-      timetableRepository.getSiteRepository()::findRegularStops
+      transitRepository.getSiteRepository()::findRegularStops
     );
     var linkingContextFactory = new LinkingContextFactory(graph, new VertexCreationService(linker));
     var streetNearbyStopFinder = StreetNearbyStopFinder.of(linkingContextFactory).build();
@@ -109,7 +109,7 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
       } catch (Exception ignored) {}
 
       RegularStop originStop = Objects.requireNonNull(
-        timetableRepository.getSiteRepository().getRegularStop(originStopVertex.getId())
+        transitRepository.getSiteRepository().getRegularStop(originStopVertex.getId())
       );
 
       /* Get stops found by both street and euclidean search */
@@ -194,7 +194,7 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
   }
 
   private RegularStop getRegularStop(FeedScopedId id) {
-    return timetableRepository.getSiteRepository().getRegularStop(id);
+    return transitRepository.getSiteRepository().getRegularStop(id);
   }
 
   private static class TransferInfo {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
@@ -13,7 +13,7 @@ import org.opentripplanner.apis.transmodel.mapping.FixedFeedIdGenerator;
 import org.opentripplanner.framework.time.ZoneIdFallback;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.config.RouterConfig;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 @Module
 public class TransmodelSchemaModule {
@@ -24,12 +24,12 @@ public class TransmodelSchemaModule {
   @TransmodelSchema
   public GraphQLSchema provideTransmodelSchema(
     RouteRequest defaultRouteRequest,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     RouterConfig routerConfig
   ) {
     FeedScopedIdMapper feedIdMapper;
     if (routerConfig.transmodelApi().hideFeedId()) {
-      String fixedFeedId = FixedFeedIdGenerator.generate(timetableRepository.getAgencies());
+      String fixedFeedId = FixedFeedIdGenerator.generate(transitRepository.getAgencies());
       feedIdMapper = new HideFeedIdMapper(fixedFeedId);
     } else {
       feedIdMapper = new DefaultFeedIdMapper();
@@ -37,7 +37,7 @@ public class TransmodelSchemaModule {
 
     TransmodelGraphQLSchemaFactory factory = new TransmodelGraphQLSchemaFactory(
       defaultRouteRequest,
-      ZoneIdFallback.zoneId(timetableRepository.getTimeZone()),
+      ZoneIdFallback.zoneId(transitRepository.getTimeZone()),
       routerConfig.transitTuningConfig(),
       feedIdMapper,
       routerConfig.server().apiDocumentationProfile()

--- a/application/src/main/java/org/opentripplanner/framework/event/EventHandler.java
+++ b/application/src/main/java/org/opentripplanner/framework/event/EventHandler.java
@@ -3,15 +3,15 @@ package org.opentripplanner.framework.event;
 import org.opentripplanner.framework.transaction.api.WriteContext;
 
 /**
- * A write-side event handler that receives a mutable repository snapshot at dispatch time.
+ * A write-side event handler that receives a mutable repository at dispatch time.
  *
  * <p>A {@code RepositoryEventHandler} is invoked inside an active {@link WriteContext}. The
- * context injects the mutable snapshot for the handler's repository as the second argument to
+ * context injects the mutable repository for the handler as the second argument to
  * {@link #handle(DomainEvent, Object)}, so the handler never holds a stored reference to anything
  * mutable.
  *
  * @param <E> the domain event type this handler responds to
- * @param <M> the mutable snapshot type this handler writes to
+ * @param <M> the mutable repository type this handler writes to
  */
 public interface EventHandler<E extends DomainEvent, M> {
   /**
@@ -20,11 +20,11 @@ public interface EventHandler<E extends DomainEvent, M> {
   Class<E> eventType();
 
   /**
-   * Handle the event, writing to the provided mutable snapshot.
+   * Handle the event, writing to the provided mutable repository.
    *
-   * @param event           the domain event
-   * @param mutableSnapshot the mutable snapshot for this handler's repository, injected by the
-   *                        {@link WriteContext}
+   * @param event      the domain event
+   * @param repository the mutable repository for this handler, injected by the
+   *                   {@link WriteContext}
    */
-  void handle(E event, M mutableSnapshot);
+  void handle(E event, M repository);
 }

--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -32,7 +32,7 @@ import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.street.StreetRepository;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.lang.OtpNumberFormat;
 import org.opentripplanner.utils.time.DurationUtils;
 import org.slf4j.Logger;
@@ -48,7 +48,7 @@ public class GraphBuilder implements Runnable {
 
   private final Queue<GraphBuilderModule> graphBuilderModules = new LinkedList<>();
   private final Graph graph;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final DataImportIssueStore issueStore;
   private final Closeable closeDataSourcesHandle;
   private final DeduplicatorService deduplicator;
@@ -59,14 +59,14 @@ public class GraphBuilder implements Runnable {
   public GraphBuilder(
     Graph baseGraph,
     DeduplicatorService deduplicator,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore,
     Closeable closeDataSourcesHandle,
     GraphBuildCacheManager cacheManager
   ) {
     this.graph = baseGraph;
     this.deduplicator = deduplicator;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.issueStore = issueStore;
     this.closeDataSourcesHandle = closeDataSourcesHandle;
     this.cacheManager = cacheManager;
@@ -84,7 +84,7 @@ public class GraphBuilder implements Runnable {
     StreetDetailsRepository streetDetailsRepository,
     FareServiceFactory fareServiceFactory,
     StreetRepository streetRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     WorldEnvelopeRepository worldEnvelopeRepository,
     VehicleParkingRepository vehicleParkingService,
@@ -99,7 +99,7 @@ public class GraphBuilder implements Runnable {
     boolean hasNetex = dataSources.has(NETEX);
     boolean hasTransitData = hasGtfs || hasNetex;
 
-    timetableRepository.initTimeZone(config.transitModelTimeZone);
+    transitRepository.initTimeZone(config.transitModelTimeZone);
 
     GraphBuilderFactory.Builder builder = DaggerGraphBuilderFactory.builder();
     builder
@@ -108,7 +108,7 @@ public class GraphBuilder implements Runnable {
       .osmInfoGraphBuildRepository(osmInfoGraphBuildRepository)
       .streetDetailsRepository(streetDetailsRepository)
       .streetRepository(streetRepository)
-      .timetableRepository(timetableRepository)
+      .transitRepository(transitRepository)
       .transferRepository(transferRepository)
       .worldEnvelopeRepository(worldEnvelopeRepository)
       .vehicleParkingRepository(vehicleParkingService)
@@ -117,7 +117,7 @@ public class GraphBuilder implements Runnable {
       .empiricalDelayRepository(empiricalDelayRepository)
       .fareServiceFactory(fareServiceFactory)
       .dataSources(dataSources)
-      .timeZoneId(timetableRepository.getTimeZone());
+      .timeZoneId(transitRepository.getTimeZone());
 
     var factory = builder.build();
 
@@ -143,7 +143,7 @@ public class GraphBuilder implements Runnable {
       graphBuilder.addModule(factory.tripPatternNamer());
       graphBuilder.addModuleOptional(
         factory.timeZoneAdjusterModule(),
-        timetableRepository.getAgencyTimeZones().size() > 1
+        transitRepository.getAgencyTimeZones().size() > 1
       );
 
       if (hasOsm || graphBuilder.graph.hasStreets) {
@@ -229,7 +229,7 @@ public class GraphBuilder implements Runnable {
       new DataImportIssueSummary(issueStore.listIssues()).logSummary();
 
       // Log before we validate, this way we have more information if the validation fails
-      logGraphBuilderCompleteStatus(startTime, graph, timetableRepository, deduplicator);
+      logGraphBuilderCompleteStatus(startTime, graph, transitRepository, deduplicator);
 
       validate();
     } finally {
@@ -275,7 +275,7 @@ public class GraphBuilder implements Runnable {
    * configuration, for example, then this function will throw a {@link OtpAppException}.
    */
   private void validate() {
-    if (hasTransitData() && !timetableRepository.hasTransit()) {
+    if (hasTransitData() && !transitRepository.hasTransit()) {
       throw new OtpAppException(
         "The provided transit data have no trips within the configured transit service period. " +
           "There is something wrong with your data - see the log above. Another possibility is that the " +
@@ -295,16 +295,16 @@ public class GraphBuilder implements Runnable {
   private static void logGraphBuilderCompleteStatus(
     long startTime,
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DeduplicatorService deduplicator
   ) {
     long endTime = System.currentTimeMillis();
     String time = DurationUtils.durationToStr(Duration.ofMillis(endTime - startTime));
     var f = new OtpNumberFormat();
-    var nStops = f.formatNumber(timetableRepository.getSiteRepository().stopIndexSize());
-    var nPatterns = f.formatNumber(timetableRepository.getAllTripPatterns().size());
+    var nStops = f.formatNumber(transitRepository.getSiteRepository().stopIndexSize());
+    var nPatterns = f.formatNumber(transitRepository.getAllTripPatterns().size());
     var nTransfers = f.formatNumber(
-      timetableRepository.getConstrainedTransferService().listAll().size()
+      transitRepository.getConstrainedTransferService().listAll().size()
     );
     var nVertices = f.formatNumber(graph.countVertices());
     var nEdges = f.formatNumber(graph.countEdges());

--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
@@ -27,7 +27,7 @@ import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +60,7 @@ public class GraphStats {
 
   private Graph graph;
 
-  private TimetableRepository timetableRepository;
+  private TransitRepository transitRepository;
 
   private CsvWriter writer;
 
@@ -97,7 +97,7 @@ public class GraphStats {
     File graphFile = new File(graphPath);
     SerializedGraphObject serializedGraphObject = SerializedGraphObject.load(graphFile);
     graph = serializedGraphObject.graph;
-    timetableRepository = serializedGraphObject.timetableRepository;
+    transitRepository = serializedGraphObject.transitRepository;
 
     /* open output stream (same for all commands) */
     if (outPath != null) {
@@ -226,7 +226,7 @@ public class GraphStats {
             "empiricalDistTrips",
           }
         );
-        Collection<TripPattern> patterns = timetableRepository.getAllTripPatterns();
+        Collection<TripPattern> patterns = transitRepository.getAllTripPatterns();
         Multiset<Integer> counts = TreeMultiset.create();
         int nPatterns = patterns.size();
         LOG.info("total number of patterns is: {}", nPatterns);

--- a/application/src/main/java/org/opentripplanner/graph_builder/configure/GraphBuilderModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/configure/GraphBuilderModule.java
@@ -9,7 +9,7 @@ import org.opentripplanner.graph_builder.GraphBuilderDataSources;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.cache.GraphBuildCacheManager;
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 @Module
 public class GraphBuilderModule {
@@ -19,7 +19,7 @@ public class GraphBuilderModule {
   static GraphBuilder provideGraphBuilder(
     Graph baseGraph,
     DeduplicatorService deduplicator,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore,
     GraphBuilderDataSources closeDataSourcesHandle,
     GraphBuildCacheManager cacheManager
@@ -27,7 +27,7 @@ public class GraphBuilderModule {
     return new GraphBuilder(
       baseGraph,
       deduplicator,
-      timetableRepository,
+      transitRepository,
       issueStore,
       closeDataSourcesHandle,
       cacheManager

--- a/application/src/main/java/org/opentripplanner/graph_builder/model/GraphBuilderModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/model/GraphBuilderModule.java
@@ -4,7 +4,7 @@ package org.opentripplanner.graph_builder.model;
 public interface GraphBuilderModule {
   /**
    * Process whatever inputs were supplied to this module and update the model objects(graph,
-   * timetableRepository and issueStore).
+   * transitRepository and issueStore).
    */
   void buildGraph();
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/AddTransitEntitiesToTimetable.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/AddTransitEntitiesToTimetable.java
@@ -8,7 +8,7 @@ import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.TransitDataImport;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class AddTransitEntitiesToTimetable {
 
@@ -20,76 +20,76 @@ public class AddTransitEntitiesToTimetable {
 
   public static void addToTimetable(
     TransitDataImport dataImport,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
-    new AddTransitEntitiesToTimetable(dataImport).applyToTimetableRepository(timetableRepository);
+    new AddTransitEntitiesToTimetable(dataImport).applyToTransitRepository(transitRepository);
   }
 
-  private void applyToTimetableRepository(TimetableRepository timetableRepository) {
-    timetableRepository.mergeSiteRepositories(dataImport.siteRepository());
+  private void applyToTransitRepository(TransitRepository transitRepository) {
+    transitRepository.mergeSiteRepositories(dataImport.siteRepository());
 
     // Netex specific entities
     for (var tripOnServiceDate : dataImport.getTripOnServiceDates()) {
-      timetableRepository.addTripOnServiceDate(tripOnServiceDate);
+      transitRepository.addTripOnServiceDate(tripOnServiceDate);
     }
-    timetableRepository.addOperators(dataImport.getAllOperators());
-    timetableRepository.addNoticeAssignments(dataImport.getNoticeAssignments());
-    timetableRepository.addScheduledStopPointMapping(dataImport.stopsByScheduledStopPoint());
+    transitRepository.addOperators(dataImport.getAllOperators());
+    transitRepository.addNoticeAssignments(dataImport.getNoticeAssignments());
+    transitRepository.addScheduledStopPointMapping(dataImport.stopsByScheduledStopPoint());
 
-    addFeedInfo(timetableRepository);
-    addAgencies(timetableRepository);
-    addServices(timetableRepository);
-    addTripPatterns(timetableRepository);
+    addFeedInfo(transitRepository);
+    addAgencies(transitRepository);
+    addServices(transitRepository);
+    addTripPatterns(transitRepository);
 
     /* Interpret the transfers explicitly defined in transfers.txt. */
-    addTransfers(timetableRepository);
+    addTransfers(transitRepository);
 
     if (OTPFeature.FlexRouting.isOn()) {
-      addFlexTrips(timetableRepository);
+      addFlexTrips(transitRepository);
     }
   }
 
-  private void addFeedInfo(TimetableRepository timetableRepository) {
+  private void addFeedInfo(TransitRepository transitRepository) {
     for (FeedInfo info : dataImport.getAllFeedInfos()) {
-      timetableRepository.addFeedInfo(info);
+      transitRepository.addFeedInfo(info);
     }
   }
 
-  private void addAgencies(TimetableRepository timetableRepository) {
+  private void addAgencies(TransitRepository transitRepository) {
     for (Agency agency : dataImport.getAllAgencies()) {
-      timetableRepository.addAgency(agency);
+      transitRepository.addAgency(agency);
     }
   }
 
-  private void addTransfers(TimetableRepository timetableRepository) {
-    timetableRepository.getConstrainedTransferService().addAll(dataImport.getAllTransfers());
+  private void addTransfers(TransitRepository transitRepository) {
+    transitRepository.getConstrainedTransferService().addAll(dataImport.getAllTransfers());
   }
 
-  private void addServices(TimetableRepository timetableRepository) {
+  private void addServices(TransitRepository transitRepository) {
     /* Assign 0-based numeric codes to all GTFS service IDs. */
     for (FeedScopedId serviceId : dataImport.getAllServiceIds()) {
-      timetableRepository
+      transitRepository
         .getServiceCodes()
-        .put(serviceId, timetableRepository.getServiceCodes().size());
+        .put(serviceId, transitRepository.getServiceCodes().size());
     }
   }
 
-  private void addTripPatterns(TimetableRepository timetableRepository) {
+  private void addTripPatterns(TransitRepository transitRepository) {
     Collection<TripPattern> tripPatterns = dataImport.getTripPatterns();
 
     /* Loop over all new TripPatterns setting the service codes. */
     for (TripPattern tripPattern : tripPatterns) {
       // TODO this could be more elegant
-      tripPattern.getScheduledTimetable().setServiceCodes(timetableRepository.getServiceCodes());
+      tripPattern.getScheduledTimetable().setServiceCodes(transitRepository.getServiceCodes());
 
       // Store the tripPattern in the timetable repository so it will be serialized and usable in routing.
-      timetableRepository.addTripPattern(tripPattern.getId(), tripPattern);
+      transitRepository.addTripPattern(tripPattern.getId(), tripPattern);
     }
   }
 
-  private void addFlexTrips(TimetableRepository timetableRepository) {
+  private void addFlexTrips(TransitRepository transitRepository) {
     for (FlexTrip<?, ?> flexTrip : dataImport.getAllFlexTrips()) {
-      timetableRepository.addFlexTrip(flexTrip.getId(), flexTrip);
+      transitRepository.addFlexTrip(flexTrip.getId(), flexTrip);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -40,7 +40,7 @@ import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.transit.StopResolver;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StationElement;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,19 +76,19 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
   private final Map<Platform, OsmBoardingLocationVertex> existingBoardingLocationsAtAreas;
 
   /**
-   * @param timetableRepository This module requires the timetable repository because at the time
+   * @param transitRepository This module requires the timetable repository because at the time
    *                            of the instantiation the site repository is empty.
    */
   @Inject
   public OsmBoardingLocationsModule(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     VertexLinker linker,
     OsmInfoGraphBuildService osmInfoGraphBuildService
   ) {
     this.graph = graph;
     this.stopResolver = id ->
-      Objects.requireNonNull(timetableRepository.getSiteRepository().getRegularStop(id));
+      Objects.requireNonNull(transitRepository.getSiteRepository().getRegularStop(id));
     this.osmInfoGraphBuildService = osmInfoGraphBuildService;
     this.vertexFactory = new VertexFactory(graph);
     this.linker = linker;

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/RouteToCentroidStationIdsValidator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/RouteToCentroidStationIdsValidator.java
@@ -6,26 +6,26 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class RouteToCentroidStationIdsValidator implements GraphBuilderModule {
 
   private final DataImportIssueStore issueStore;
   private final Collection<FeedScopedId> transitRouteToStationCentroid;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   public RouteToCentroidStationIdsValidator(
     DataImportIssueStore issueStore,
     Collection<FeedScopedId> transitRouteToStationCentroid,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     this.issueStore = issueStore;
     this.transitRouteToStationCentroid = transitRouteToStationCentroid;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
   }
 
   private void validate() {
-    var stationIds = timetableRepository
+    var stationIds = transitRepository
       .getSiteRepository()
       .listStations()
       .stream()

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -33,7 +33,7 @@ import org.opentripplanner.street.search.TraverseModeSet;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,7 @@ public class StreetLinkerModule implements GraphBuilderModule {
   private static final TraverseModeSet WALK_ONLY = new TraverseModeSet(TraverseMode.WALK);
   private final Graph graph;
   private final VehicleParkingRepository parkingRepository;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final DataImportIssueStore issueStore;
   private final VertexLinker vertexLinker;
 
@@ -60,23 +60,23 @@ public class StreetLinkerModule implements GraphBuilderModule {
     Graph graph,
     VertexLinker linker,
     VehicleParkingRepository parkingRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore
   ) {
     this.graph = graph;
     this.parkingRepository = parkingRepository;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.issueStore = issueStore;
     this.vertexLinker = linker;
   }
 
   @Override
   public void buildGraph() {
-    timetableRepository.index();
+    transitRepository.index();
     graph.requestIndex();
 
     if (graph.hasStreets) {
-      linkTransitStops(graph, timetableRepository);
+      linkTransitStops(graph, transitRepository);
       linkTransitEntrances(graph);
       linkStationCentroids(graph);
       linkVehicleParks(graph, issueStore);
@@ -86,22 +86,22 @@ public class StreetLinkerModule implements GraphBuilderModule {
     graph.calculateConvexHull();
   }
 
-  public void linkTransitStops(Graph graph, TimetableRepository timetableRepository) {
+  public void linkTransitStops(Graph graph, TransitRepository transitRepository) {
     List<TransitStopVertex> vertices = graph.getVerticesOfType(TransitStopVertex.class);
     var progress = ProgressTracker.track("Linking transit stops to graph", 5000, vertices.size());
     LOG.info(progress.startMessage());
 
     Set<StopLocation> stopLocationsUsedForFlexTrips = Set.of();
     if (OTPFeature.FlexRouting.isOn()) {
-      stopLocationsUsedForFlexTrips = getStopLocationsUsedForFlexTrips(timetableRepository);
+      stopLocationsUsedForFlexTrips = getStopLocationsUsedForFlexTrips(transitRepository);
     }
 
     Set<StopLocation> stopLocationsUsedForCarsAllowedTrips =
-      timetableRepository.getStopLocationsUsedForCarsAllowedTrips();
+      transitRepository.getStopLocationsUsedForCarsAllowedTrips();
 
     for (TransitStopVertex stopVertex : vertices) {
       var stop = Objects.requireNonNull(
-        timetableRepository.getSiteRepository().getRegularStop(stopVertex.getId())
+        transitRepository.getSiteRepository().getRegularStop(stopVertex.getId())
       );
       // Stops with pathways do not need to be connected to the street network, since there are explicit entrances defined for that
       if (stopVertex.hasPathways()) {
@@ -368,10 +368,8 @@ public class StreetLinkerModule implements GraphBuilderModule {
     }
   }
 
-  private Set<StopLocation> getStopLocationsUsedForFlexTrips(
-    TimetableRepository timetableRepository
-  ) {
-    Set<StopLocation> stopLocations = timetableRepository
+  private Set<StopLocation> getStopLocationsUsedForFlexTrips(TransitRepository transitRepository) {
+    Set<StopLocation> stopLocations = transitRepository
       .getAllFlexTrips()
       .stream()
       .flatMap(t -> t.getStops().stream())

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/TimeZoneAdjusterModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/TimeZoneAdjusterModule.java
@@ -8,32 +8,32 @@ import java.util.HashMap;
 import java.util.Map;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * Adjust all scheduled times to match the transit model timezone.
  */
 public class TimeZoneAdjusterModule implements GraphBuilderModule {
 
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   @Inject
-  public TimeZoneAdjusterModule(TimetableRepository timetableRepository) {
-    this.timetableRepository = timetableRepository;
+  public TimeZoneAdjusterModule(TransitRepository transitRepository) {
+    this.transitRepository = transitRepository;
   }
 
   @Override
   public void buildGraph() {
     // TODO: We assume that all time zones follow the same DST rules. In reality we need to split up
     //  the services for each DST transition
-    final Instant serviceStart = timetableRepository.getTransitServiceStarts();
+    final Instant serviceStart = transitRepository.getTransitServiceStarts();
     var graphOffset = Duration.ofSeconds(
-      timetableRepository.getTimeZone().getRules().getOffset(serviceStart).getTotalSeconds()
+      transitRepository.getTimeZone().getRules().getOffset(serviceStart).getTotalSeconds()
     );
 
     Map<ZoneId, Duration> agencyShift = new HashMap<>();
 
-    timetableRepository
+    transitRepository
       .getAllTripPatterns()
       .forEach(pattern -> {
         var timeShift = agencyShift.computeIfAbsent(
@@ -51,8 +51,8 @@ public class TimeZoneAdjusterModule implements GraphBuilderModule {
           .withScheduledTimeTableBuilder(builder -> builder.withAdjustedTimes(timeShift))
           .build();
         // replace the original pattern with the updated pattern in the transit model
-        timetableRepository.addTripPattern(updatedPattern.getId(), updatedPattern);
+        transitRepository.addTripPattern(updatedPattern.getId(), updatedPattern);
       });
-    timetableRepository.index();
+    transitRepository.index();
   }
 }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/TripPatternNamer.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/TripPatternNamer.java
@@ -12,24 +12,24 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.TripTimes;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TripPatternNamer implements GraphBuilderModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(TripPatternNamer.class);
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   @Inject
-  public TripPatternNamer(TimetableRepository timetableRepository) {
-    this.timetableRepository = timetableRepository;
+  public TripPatternNamer(TransitRepository transitRepository) {
+    this.transitRepository = transitRepository;
   }
 
   @Override
   public void buildGraph() {
     /* Generate unique human-readable names for all the TableTripPatterns. */
-    generateUniqueNames(timetableRepository.getAllTripPatterns());
+    generateUniqueNames(transitRepository.getAllTripPatterns());
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderFactory.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderFactory.java
@@ -50,7 +50,7 @@ import org.opentripplanner.street.StreetRepository;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 @Singleton
 @Component(
@@ -114,7 +114,7 @@ public interface GraphBuilderFactory {
     Builder graph(Graph graph);
 
     @BindsInstance
-    Builder timetableRepository(TimetableRepository timetableRepository);
+    Builder transitRepository(TransitRepository transitRepository);
 
     @BindsInstance
     Builder transferRepository(TransferRepository transferRepository);

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -55,7 +55,7 @@ import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * Configure all modules that are not simple enough to be injected.
@@ -129,7 +129,7 @@ public class GraphBuilderModules {
     BuildConfig config,
     Graph graph,
     DeduplicatorService deduplicator,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     StreetDetailsRepository streetDetailsRepository,
     DataImportIssueStore issueStore,
     FareServiceFactory fareServiceFactory
@@ -140,7 +140,7 @@ public class GraphBuilderModules {
     }
     return new GtfsModule(
       gtfsBundles,
-      timetableRepository,
+      transitRepository,
       streetDetailsRepository,
       graph,
       deduplicator,
@@ -159,14 +159,14 @@ public class GraphBuilderModules {
     BuildConfig config,
     Graph graph,
     DeduplicatorService deduplicator,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     StreetDetailsRepository streetDetailsRepository,
     VehicleParkingRepository parkingRepository,
     DataImportIssueStore issueStore
   ) {
     return new NetexConfigure(config).createNetexModule(
       dataSources.getNetexConfiguredDataSource(),
-      timetableRepository,
+      transitRepository,
       parkingRepository,
       streetDetailsRepository,
       graph,
@@ -180,17 +180,11 @@ public class GraphBuilderModules {
   static StreetLinkerModule provideStreetLinkerModule(
     Graph graph,
     VehicleParkingRepository parkingRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore,
     VertexLinker linker
   ) {
-    return new StreetLinkerModule(
-      graph,
-      linker,
-      parkingRepository,
-      timetableRepository,
-      issueStore
-    );
+    return new StreetLinkerModule(graph, linker, parkingRepository, transitRepository, issueStore);
   }
 
   @Provides
@@ -208,15 +202,15 @@ public class GraphBuilderModules {
     BuildConfig config,
     Graph graph,
     VehicleParkingRepository parkingRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore,
     VertexLinker linker
   ) {
     PruneIslands pruneIslands = new PruneIslands(
       graph,
-      timetableRepository,
+      transitRepository,
       issueStore,
-      new StreetLinkerModule(graph, linker, parkingRepository, timetableRepository, issueStore)
+      new StreetLinkerModule(graph, linker, parkingRepository, transitRepository, issueStore)
     );
     pruneIslands.setPruningThresholdIslandWithoutStops(
       config.islandPruning.pruningThresholdIslandWithoutStops
@@ -264,13 +258,13 @@ public class GraphBuilderModules {
   static DirectTransferGenerator provideDirectTransferGenerator(
     BuildConfig config,
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     DataImportIssueStore issueStore
   ) {
     return new DirectTransferGenerator(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       issueStore,
       config.regularTransferParameters()
@@ -283,13 +277,13 @@ public class GraphBuilderModules {
     BuildConfig config,
     Graph graph,
     VertexLinker linker,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore
   ) {
     return new DirectTransferAnalyzer(
       graph,
       linker,
-      timetableRepository,
+      transitRepository,
       issueStore,
       config.regularTransferParameters().maxDuration().toSeconds() * WalkPreferences.DEFAULT.speed()
     );
@@ -341,13 +335,13 @@ public class GraphBuilderModules {
   @Singleton
   @Nullable
   static StopConsolidationModule providesStopConsolidationModule(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable StopConsolidationRepository repo,
     GraphBuilderDataSources dataSources
   ) {
     return dataSources
       .stopConsolidation()
-      .map(ds -> StopConsolidationModule.of(timetableRepository, repo, ds))
+      .map(ds -> StopConsolidationModule.of(transitRepository, repo, ds))
       .orElse(null);
   }
 
@@ -357,12 +351,12 @@ public class GraphBuilderModules {
   static RouteToCentroidStationIdsValidator routeToCentroidStationIdValidator(
     DataImportIssueStore issueStore,
     BuildConfig config,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     var ids = config.transitRouteToStationCentroid();
     return ids.isEmpty()
       ? null
-      : new RouteToCentroidStationIdsValidator(issueStore, ids, timetableRepository);
+      : new RouteToCentroidStationIdsValidator(issueStore, ids, transitRepository);
   }
 
   @Provides

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModule.java
@@ -8,7 +8,7 @@ import org.opentripplanner.service.worldenvelope.model.WorldEnvelope;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,24 +28,24 @@ public class CalculateWorldEnvelopeModule implements GraphBuilderModule {
   private static final int LOG_EVERY_N_COORDINATE = 1_000_000;
 
   private final Graph graph;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final WorldEnvelopeRepository worldEnvelopeRepository;
 
   @Inject
   public CalculateWorldEnvelopeModule(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     WorldEnvelopeRepository worldEnvelopeRepository
   ) {
     this.graph = graph;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.worldEnvelopeRepository = worldEnvelopeRepository;
   }
 
   @Override
   public void buildGraph() {
     var vertices = graph.getVertices();
-    var stops = timetableRepository.getSiteRepository().listStopLocations();
+    var stops = transitRepository.getSiteRepository().listStopLocations();
     WorldEnvelope envelope = build(vertices, stops);
     worldEnvelopeRepository.saveEnvelope(envelope);
   }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
@@ -29,7 +29,7 @@ import org.opentripplanner.street.model.vertex.VertexLabel;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
 import org.opentripplanner.street.search.state.State;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +45,7 @@ public class PruneIslands implements GraphBuilderModule {
   private static final Logger LOG = LoggerFactory.getLogger(PruneIslands.class);
 
   private final Graph graph;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final DataImportIssueStore issueStore;
   private final StreetLinkerModule streetLinkerModule;
   private int pruningThresholdWithoutStops;
@@ -55,12 +55,12 @@ public class PruneIslands implements GraphBuilderModule {
 
   public PruneIslands(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DataImportIssueStore issueStore,
     StreetLinkerModule streetLinkerModule
   ) {
     this.graph = graph;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.issueStore = issueStore;
     this.streetLinkerModule = streetLinkerModule;
   }
@@ -83,7 +83,7 @@ public class PruneIslands implements GraphBuilderModule {
     // reconnect stops that got disconnected
     if (streetLinkerModule != null) {
       LOG.info("Reconnecting stops");
-      streetLinkerModule.linkTransitStops(graph, timetableRepository);
+      streetLinkerModule.linkTransitStops(graph, transitRepository);
     }
 
     // clean up pruned street vertices

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
@@ -32,7 +32,7 @@ import org.opentripplanner.transfer.regular.model.PathTransfer;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +54,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   private final List<RouteRequest> transferRequests;
   private final Map<StreetMode, TransferParametersForMode> transferParametersForMode;
   private final Graph graph;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final TransferRepository transferRepository;
   private final DataImportIssueStore issueStore;
 
@@ -63,14 +63,14 @@ public class DirectTransferGenerator implements GraphBuilderModule {
    */
   public DirectTransferGenerator(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     DataImportIssueStore issueStore,
     Duration defaultMaxTransferDuration,
     List<RouteRequest> transferRequests
   ) {
     this.graph = graph;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.issueStore = issueStore;
     this.defaultMaxTransferDuration = defaultMaxTransferDuration;
     this.transferRequests = transferRequests;
@@ -80,13 +80,13 @@ public class DirectTransferGenerator implements GraphBuilderModule {
 
   public DirectTransferGenerator(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     DataImportIssueStore issueStore,
     RegularTransferParameters parameters
   ) {
     this.graph = graph;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.issueStore = issueStore;
     this.defaultMaxTransferDuration = parameters.maxDuration();
     this.transferRequests = parameters.requests();
@@ -97,16 +97,16 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   @Override
   public void buildGraph() {
     // Initialize transit model index which is needed by the nearby stop finder.
-    timetableRepository.index();
+    transitRepository.index();
 
     // The linker will use streets if they are available, or straight-line distance otherwise.
     NearbyStopFinder nearbyStopFinder = createNearbyStopFinder(defaultMaxTransferDuration);
 
     List<TransitStopVertex> stops = graph.getVerticesOfType(TransitStopVertex.class);
     Set<StopLocation> carsAllowedStops =
-      timetableRepository.getStopLocationsUsedForCarsAllowedTrips();
+      transitRepository.getStopLocationsUsedForCarsAllowedTrips();
     Set<StopLocation> bikesAllowedStops =
-      timetableRepository.getStopLocationsUsedForBikesAllowedTrips();
+      transitRepository.getStopLocationsUsedForBikesAllowedTrips();
 
     LOG.info("Creating transfers based on requests:");
     transferRequests.forEach(transferProfile -> LOG.info(transferProfile.toString()));
@@ -136,8 +136,8 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     // Parse the transfer configuration from the parameters given in the build config.
     TransferConfiguration transferConfiguration = parseTransferParameters(nearbyStopFinder);
 
-    var transitService = new DefaultTransitService(timetableRepository);
-    var emptyStops = timetableRepository
+    var transitService = new DefaultTransitService(transitRepository);
+    var emptyStops = transitRepository
       .getSiteRepository()
       .listStopLocations()
       .stream()
@@ -161,7 +161,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
          * Use map based on the list of edges, so that only distinct transfers are stored. */
         Map<TransferKey, PathTransfer> distinctTransfers = new HashMap<>();
         RegularStop stop = Objects.requireNonNull(
-          timetableRepository.getSiteRepository().getRegularStop(ts0.getId())
+          transitRepository.getSiteRepository().getRegularStop(ts0.getId())
         );
 
         if (stop.transfersNotAllowed()) {
@@ -234,7 +234,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
    * enabled.
    */
   private NearbyStopFinder createNearbyStopFinder(Duration radiusAsDuration) {
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitService = new DefaultTransitService(transitRepository);
     NearbyStopFinder finder;
     if (!graph.hasStreets) {
       LOG.info(
@@ -388,7 +388,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         .defaultNearbyStopFinderForMode()
         .get(mode)
         .findNearbyStops(ts0, transferProfile, transferProfile.journey().transfer().mode(), false);
-      var repository = timetableRepository.getSiteRepository();
+      var repository = transitRepository.getSiteRepository();
       for (NearbyStop sd : nearbyStops) {
         // Skip the origin stop, loop transfers are not needed.
         var nearbyStop = repository.getStopLocation(sd.stopId);
@@ -418,7 +418,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         .findNearbyStops(ts0, transferProfile, transferProfile.journey().transfer().mode(), true);
       // This code is for finding transfers from AreaStops to Stops, transfers
       // from Stops to AreaStops and between Stops are already covered above.
-      var repository = timetableRepository.getSiteRepository();
+      var repository = transitRepository.getSiteRepository();
       for (NearbyStop sd : nearbyStops) {
         // Skip the origin stop, loop transfers are not needed.
         var nearbyStop = repository.getStopLocation(sd.stopId);
@@ -494,7 +494,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     var nearbyStops = nearbyStopFinder
       .get(mode)
       .findNearbyStops(ts0, transferProfile, transferProfile.journey().transfer().mode(), false);
-    var repository = timetableRepository.getSiteRepository();
+    var repository = transitRepository.getSiteRepository();
     for (NearbyStop sd : nearbyStops) {
       var nearbyStop = repository.getStopLocation(sd.stopId);
       // Skip the origin stop, loop transfers are not needed.

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -42,7 +42,7 @@ import org.opentripplanner.service.streetdetails.internal.DefaultStreetDetailsRe
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +68,7 @@ public class GtfsModule implements GraphBuilderModule {
   private final List<GtfsBundle> gtfsBundles;
   private final FareServiceFactory fareServiceFactory;
 
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final StreetDetailsRepository streetDetailsRepository;
   private final Graph graph;
   private final DataImportIssueStore issueStore;
@@ -79,7 +79,7 @@ public class GtfsModule implements GraphBuilderModule {
 
   public GtfsModule(
     List<GtfsBundle> bundles,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     StreetDetailsRepository streetDetailsRepository,
     Graph graph,
     DeduplicatorService deduplicator,
@@ -90,7 +90,7 @@ public class GtfsModule implements GraphBuilderModule {
     int subwayAccessTime_s
   ) {
     this.gtfsBundles = bundles;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.streetDetailsRepository = streetDetailsRepository;
     this.graph = graph;
     this.deduplicator = deduplicator;
@@ -106,13 +106,13 @@ public class GtfsModule implements GraphBuilderModule {
    */
   public static GtfsModule forTest(
     List<GtfsBundle> bundles,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     Graph graph,
     LocalDateRange transitPeriodLimit
   ) {
     return new GtfsModule(
       bundles,
-      timetableRepository,
+      transitRepository,
       new DefaultStreetDetailsRepository(),
       graph,
       new Deduplicator(),
@@ -140,7 +140,7 @@ public class GtfsModule implements GraphBuilderModule {
         feedIdsEncountered.put(feedId, gtfsBundle);
 
         GTFSToTransitDataImportMapper mapper = new GTFSToTransitDataImportMapper(
-          new TransitDataImportBuilder(timetableRepository.getSiteRepository(), issueStore),
+          new TransitDataImportBuilder(transitRepository.getSiteRepository(), issueStore),
           feedId,
           issueStore,
           gtfsBundle.parameters().discardMinTransferTimes(),
@@ -179,7 +179,7 @@ public class GtfsModule implements GraphBuilderModule {
         // NB! The calls below have side effects - the builder state is updated!
         createTripPatterns(
           deduplicator,
-          timetableRepository,
+          transitRepository,
           builder,
           calendarServiceData.getServiceIds(),
           geometryProcessor,
@@ -188,16 +188,11 @@ public class GtfsModule implements GraphBuilderModule {
 
         TransitDataImport dataImport = builder.build();
 
-        addTimetableRepositoryToGraph(
-          graph,
-          timetableRepository,
-          streetDetailsRepository,
-          dataImport
-        );
+        addTransitRepositoryToGraph(graph, transitRepository, streetDetailsRepository, dataImport);
 
         if (gtfsBundle.parameters().blockBasedInterlining()) {
           new InterlineProcessor(
-            timetableRepository.getConstrainedTransferService(),
+            transitRepository.getConstrainedTransferService(),
             builder.getStaySeatedNotAllowed(),
             gtfsBundle.parameters().maxInterlineDistance(),
             issueStore,
@@ -211,11 +206,11 @@ public class GtfsModule implements GraphBuilderModule {
       throw new RuntimeException(e);
     }
 
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.updateCalendarServiceData(calendarServiceData);
     TransitWithFutureDateValidator.validate(
       calendarServiceData,
       issueStore,
-      timetableRepository.getTimeZone()
+      transitRepository.getTimeZone()
     );
   }
 
@@ -269,7 +264,7 @@ public class GtfsModule implements GraphBuilderModule {
    */
   private void createTripPatterns(
     DeduplicatorService deduplicator,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransitDataImportBuilder builder,
     Set<FeedScopedId> calServiceIds,
     GeometryProcessor geometryProcessor,
@@ -283,21 +278,21 @@ public class GtfsModule implements GraphBuilderModule {
       geometryProcessor
     );
     buildTPOp.run();
-    timetableRepository.setHasFrequencyService(
-      timetableRepository.hasFrequencyService() || buildTPOp.hasFrequencyBasedTrips()
+    transitRepository.setHasFrequencyService(
+      transitRepository.hasFrequencyService() || buildTPOp.hasFrequencyBasedTrips()
     );
-    timetableRepository.setHasScheduledService(
-      timetableRepository.hasScheduledService() || buildTPOp.hasScheduledTrips()
+    transitRepository.setHasScheduledService(
+      transitRepository.hasScheduledService() || buildTPOp.hasScheduledTrips()
     );
   }
 
-  private void addTimetableRepositoryToGraph(
+  private void addTransitRepositoryToGraph(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     StreetDetailsRepository streetDetailsRepository,
     TransitDataImport dataImport
   ) {
-    AddTransitEntitiesToTimetable.addToTimetable(dataImport, timetableRepository);
+    AddTransitEntitiesToTimetable.addToTimetable(dataImport, transitRepository);
     AddTransitEntitiesToGraph.addToGraph(
       dataImport,
       subwayAccessTime_s,

--- a/application/src/main/java/org/opentripplanner/model/TransitDataImport.java
+++ b/application/src/main/java/org/opentripplanner/model/TransitDataImport.java
@@ -72,7 +72,7 @@ public interface TransitDataImport {
   boolean hasActiveTransit();
 
   /**
-   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   * @see org.opentripplanner.transit.service.TransitRepository#findStopByScheduledStopPoint(FeedScopedId)
    */
   Map<FeedScopedId, RegularStop> stopsByScheduledStopPoint();
 }

--- a/application/src/main/java/org/opentripplanner/model/impl/DefaultTransitDataImport.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/DefaultTransitDataImport.java
@@ -169,7 +169,7 @@ class DefaultTransitDataImport implements TransitDataImport {
   }
 
   /**
-   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   * @see org.opentripplanner.transit.service.TransitRepository#findStopByScheduledStopPoint(FeedScopedId)
    */
   @Override
   public Map<FeedScopedId, RegularStop> stopsByScheduledStopPoint() {

--- a/application/src/main/java/org/opentripplanner/model/impl/TransitDataImportBuilder.java
+++ b/application/src/main/java/org/opentripplanner/model/impl/TransitDataImportBuilder.java
@@ -266,7 +266,7 @@ public class TransitDataImportBuilder {
   }
 
   /**
-   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   * @see org.opentripplanner.transit.service.TransitRepository#findStopByScheduledStopPoint(FeedScopedId)
    */
   public Map<FeedScopedId, RegularStop> stopsByScheduledStopPoints() {
     return stopsByScheduledStopPoints;

--- a/application/src/main/java/org/opentripplanner/netex/NetexBundle.java
+++ b/application/src/main/java/org/opentripplanner/netex/NetexBundle.java
@@ -124,19 +124,19 @@ public class NetexBundle implements Closeable {
   /** Load all files entries in the bundle */
   private void loadFileEntries() {
     // Load global shared files
-    loadFilesThenMapToTimetableRepository("shared file", hierarchy.sharedEntries());
+    loadFilesThenMapToTransitRepository("shared file", hierarchy.sharedEntries());
 
     for (GroupEntries group : hierarchy.groups()) {
       LOG.info("reading group {}", group.name());
 
       scopeInputData(() -> {
         // Load shared group files
-        loadFilesThenMapToTimetableRepository("shared group file", group.sharedEntries());
+        loadFilesThenMapToTransitRepository("shared group file", group.sharedEntries());
 
         for (DataSource entry : group.independentEntries()) {
           scopeInputData(() -> {
             // Load each independent file in group
-            loadFilesThenMapToTimetableRepository("group file", List.of(entry));
+            loadFilesThenMapToTransitRepository("group file", List.of(entry));
           });
         }
       });
@@ -163,7 +163,7 @@ public class NetexBundle implements Closeable {
    * when read, would lead to missing references, since the order entries are read is not enforced
    * in any way.
    */
-  private void loadFilesThenMapToTimetableRepository(
+  private void loadFilesThenMapToTransitRepository(
     String fileDescription,
     Iterable<DataSource> entries
   ) {

--- a/application/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/application/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -22,7 +22,7 @@ import org.opentripplanner.service.vehicleparking.VehicleParkingRepository;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VehicleParkingHelper;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This module is used for importing the NeTEx CEN Technical Standard for exchanging Public
@@ -36,7 +36,7 @@ public class NetexModule implements GraphBuilderModule {
 
   private final Graph graph;
   private final DeduplicatorService deduplicator;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final VehicleParkingRepository parkingRepository;
   private final StreetDetailsRepository streetDetailsRepository;
   private final DataImportIssueStore issueStore;
@@ -56,7 +56,7 @@ public class NetexModule implements GraphBuilderModule {
   public NetexModule(
     Graph graph,
     DeduplicatorService deduplicator,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     VehicleParkingRepository parkingRepository,
     StreetDetailsRepository streetDetailsRepository,
     DataImportIssueStore issueStore,
@@ -66,7 +66,7 @@ public class NetexModule implements GraphBuilderModule {
   ) {
     this.graph = graph;
     this.deduplicator = deduplicator;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.parkingRepository = parkingRepository;
     this.streetDetailsRepository = streetDetailsRepository;
     this.issueStore = issueStore;
@@ -99,7 +99,7 @@ public class NetexModule implements GraphBuilderModule {
 
         TransitDataImport otpService = transitBuilder.build();
 
-        AddTransitEntitiesToTimetable.addToTimetable(otpService, timetableRepository);
+        AddTransitEntitiesToTimetable.addToTimetable(otpService, transitRepository);
         AddTransitEntitiesToGraph.addToGraph(
           otpService,
           subwayAccessTime,
@@ -113,12 +113,12 @@ public class NetexModule implements GraphBuilderModule {
         lots.forEach(linker::linkVehicleParkingToGraph);
       }
 
-      timetableRepository.updateCalendarServiceData(calendarServiceData);
+      transitRepository.updateCalendarServiceData(calendarServiceData);
 
       TransitWithFutureDateValidator.validate(
         calendarServiceData,
         issueStore,
-        timetableRepository.getTimeZone()
+        transitRepository.getTimeZone()
       );
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/application/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
+++ b/application/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
@@ -15,7 +15,7 @@ import org.opentripplanner.service.streetdetails.StreetDetailsRepository;
 import org.opentripplanner.service.vehicleparking.VehicleParkingRepository;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * Responsible for dependency injection and creating main NeTEx module objects. This decouple the
@@ -38,7 +38,7 @@ public class NetexConfigure {
 
   public NetexModule createNetexModule(
     Iterable<ConfiguredCompositeDataSource<NetexFeedParameters>> netexSources,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     VehicleParkingRepository parkingRepository,
     StreetDetailsRepository streetDetailsRepository,
     Graph graph,
@@ -49,7 +49,7 @@ public class NetexConfigure {
 
     for (ConfiguredCompositeDataSource<NetexFeedParameters> it : netexSources) {
       var transitServiceBuilder = new TransitDataImportBuilder(
-        timetableRepository.getSiteRepository(),
+        transitRepository.getSiteRepository(),
         issueStore
       );
       netexBundles.add(netexBundle(transitServiceBuilder, it));
@@ -58,7 +58,7 @@ public class NetexConfigure {
     return new NetexModule(
       graph,
       deduplicator,
-      timetableRepository,
+      transitRepository,
       parkingRepository,
       streetDetailsRepository,
       issueStore,

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -140,7 +140,7 @@ class TripMapper {
     );
 
     // TODO RTM - Instead of getting the first headsign from the StopTime this could be the
-    //          - default behaviour of the TimetableRepository - So, in the NeTEx mapper we would just
+    //          - default behaviour of the TransitRepository - So, in the NeTEx mapper we would just
     //          - ignore setting the headsign on the Trip.
     builder.withHeadsign(new NonLocalizedString(headsign.get()));
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitData.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitData.java
@@ -19,7 +19,7 @@ import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.SiteRepository;
 
 /**
- * This is a replica of public transportation data already present in TimetableRepository, but rearranged
+ * This is a replica of public transportation data already present in TransitRepository, but rearranged
  * and indexed differently for efficient use by the Raptor router. Patterns and trips are split out
  * by days, retaining only the services actually running on any particular day.
  *

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorTransitDataMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorTransitDataMapper.java
@@ -26,13 +26,13 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopTransferPriority;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Maps the RaptorTransitData object from the TimetableRepository object. The ServiceDay hierarchy is reversed,
+ * Maps the RaptorTransitData object from the TransitRepository object. The ServiceDay hierarchy is reversed,
  * with service days at the top level, which contains TripPatternForDate objects that contain only
  * TripSchedules running on that particular date. This makes it faster to filter out TripSchedules
  * when doing Range Raptor searches.
@@ -51,22 +51,20 @@ public class RaptorTransitDataMapper {
   private final TransferRepository transferRepository;
 
   private RaptorTransitDataMapper(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository
   ) {
-    this.transitService = new DefaultTransitService(timetableRepository);
-    this.siteRepository = timetableRepository.getSiteRepository();
+    this.transitService = new DefaultTransitService(transitRepository);
+    this.siteRepository = transitRepository.getSiteRepository();
     this.transferRepository = transferRepository;
   }
 
   public static RaptorTransitData map(
     TransitTuningParameters tuningParameters,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository
   ) {
-    return new RaptorTransitDataMapper(timetableRepository, transferRepository).map(
-      tuningParameters
-    );
+    return new RaptorTransitDataMapper(transitRepository, transferRepository).map(tuningParameters);
   }
 
   private RaptorTransitData map(TransitTuningParameters tuningParameters) {
@@ -74,7 +72,7 @@ public class RaptorTransitDataMapper {
     List<List<PathTransfer>> transfersByStopIndex;
     ConstrainedTransfersForPatterns constrainedTransfers = null;
 
-    LOG.info("Mapping raptorTransitData from TimetableRepository...");
+    LOG.info("Mapping raptorTransitData from TransitRepository...");
 
     Collection<TripPattern> allTripPatterns = transitService.listTripPatterns();
 

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TimetableUpdateMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TimetableUpdateMapper.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p><b>Future improvement:</b> The per-date caches maintained here duplicate information that
  * would ideally come from a single authoritative datasource. However,
- * {@link org.opentripplanner.transit.model.timetable.TimetableSnapshot} only stores real-time
+ * {@link org.opentripplanner.transit.repository.TimetableRepository} only stores real-time
  * timetables, while these caches also cover scheduled trip patterns sourced from
  * {@link RaptorTransitData}. Once scheduled and real-time data live in the same structure, the
  * state tracked here could be derived directly from that structure on each call, making this

--- a/application/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -40,7 +40,7 @@ import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.lang.OtpNumberFormat;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
@@ -67,7 +67,7 @@ public class SerializedGraphObject implements Serializable {
   public final OsmInfoGraphBuildRepository osmInfoGraphBuildRepository;
 
   public final StreetDetailsRepository streetDetailsRepository;
-  public final TimetableRepository timetableRepository;
+  public final TransitRepository transitRepository;
   public final TransferRepository transferRepository;
   public final WorldEnvelopeRepository worldEnvelopeRepository;
   private final Collection<Edge> edges;
@@ -101,7 +101,7 @@ public class SerializedGraphObject implements Serializable {
     @Nullable OsmInfoGraphBuildRepository osmInfoGraphBuildRepository,
     StreetDetailsRepository streetDetailsRepository,
     StreetRepository streetRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     WorldEnvelopeRepository worldEnvelopeRepository,
     VehicleParkingRepository parkingRepository,
@@ -118,7 +118,7 @@ public class SerializedGraphObject implements Serializable {
     this.osmInfoGraphBuildRepository = osmInfoGraphBuildRepository;
     this.streetDetailsRepository = streetDetailsRepository;
     this.streetRepository = streetRepository;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.transferRepository = transferRepository;
     this.worldEnvelopeRepository = worldEnvelopeRepository;
     this.parkingRepository = parkingRepository;
@@ -212,9 +212,9 @@ public class SerializedGraphObject implements Serializable {
       );
       LOG.debug("Graph read.");
       serObj.reconstructEdgeLists();
-      serObj.timetableRepository.getSiteRepository().reindexAfterDeserialization();
-      serObj.timetableRepository.index();
-      logSerializationCompleteStatus(serObj.graph, serObj.timetableRepository);
+      serObj.transitRepository.getSiteRepository().reindexAfterDeserialization();
+      serObj.transitRepository.index();
+      logSerializationCompleteStatus(serObj.graph, serObj.transitRepository);
       return serObj;
     } catch (IOException e) {
       LOG.error("IO exception while loading graph: {}", e.getLocalizedMessage(), e);
@@ -287,14 +287,14 @@ public class SerializedGraphObject implements Serializable {
 
   private static void logSerializationCompleteStatus(
     Graph graph,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     var f = new OtpNumberFormat();
-    var nStops = f.formatNumber(timetableRepository.getSiteRepository().stopIndexSize());
+    var nStops = f.formatNumber(transitRepository.getSiteRepository().stopIndexSize());
     var nTransfers = f.formatNumber(
-      timetableRepository.getConstrainedTransferService().listAll().size()
+      transitRepository.getConstrainedTransferService().listAll().size()
     );
-    var nPatterns = f.formatNumber(timetableRepository.getAllTripPatterns().size());
+    var nPatterns = f.formatNumber(transitRepository.getAllTripPatterns().size());
     var nVertices = f.formatNumber(graph.countVertices());
     var nEdges = f.formatNumber(graph.countEdges());
 

--- a/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -30,7 +30,7 @@ public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
   private final ArrayList<TransitAlertService> transitAlertServices = new ArrayList<>();
 
   /**
-   * Constructor which scans over all existing GraphUpdaters associated with a TimetableRepository
+   * Constructor which scans over all existing GraphUpdaters associated with a TransitRepository
    * instance and retains references to all their TransitAlertService instances.
    * This implies that these instances are expected to remain in use indefinitely (not be replaced
    * with new instances or taken out of service over time).

--- a/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -14,7 +14,7 @@ import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.timetable.Direction;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This is the primary implementation of TransitAlertService, which actually retains its own set
@@ -33,12 +33,12 @@ import org.opentripplanner.transit.service.TimetableRepository;
  */
 public class TransitAlertServiceImpl implements TransitAlertService {
 
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   private Multimap<EntityKey, TransitAlert> alerts = HashMultimap.create();
 
-  public TransitAlertServiceImpl(TimetableRepository timetableRepository) {
-    this.timetableRepository = timetableRepository;
+  public TransitAlertServiceImpl(TransitRepository transitRepository) {
+    this.transitRepository = transitRepository;
   }
 
   @Override
@@ -79,7 +79,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
   ) {
     EntitySelector.Stop entitySelector = new EntitySelector.Stop(stopId, stopConditions);
     var result = findMatchingAlerts(entitySelector);
-    var stop = timetableRepository.getSiteRepository().getStopLocation(stopId);
+    var stop = transitRepository.getSiteRepository().getStopLocation(stopId);
 
     if (stop != null && stop.isPartOfStation()) {
       // Add alerts for parent-station

--- a/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/application/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -20,7 +20,7 @@ import org.opentripplanner.standalone.config.ConfigModel;
 import org.opentripplanner.standalone.configure.ConstructApplication;
 import org.opentripplanner.standalone.configure.LoadApplication;
 import org.opentripplanner.standalone.server.GrizzlyServer;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.configure.UpdaterConfigurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,7 +154,7 @@ public class OTPMain {
         app.osmInfoGraphBuildRepository(),
         app.streetDetailsRepository(),
         app.streetRepository(),
-        app.timetableRepository(),
+        app.transitRepository(),
         app.transferRepository(),
         app.worldEnvelopeRepository(),
         app.vehicleParkingRepository(),
@@ -191,7 +191,7 @@ public class OTPMain {
 
   private static void startOtpWebServer(CommandLineParameters params, ConstructApplication app) {
     // Index graph for travel search
-    app.timetableRepository().freeze();
+    app.transitRepository().freeze();
     app.transferRepository().index();
     app.graph().index();
 
@@ -205,7 +205,7 @@ public class OTPMain {
     if (params.doServe()) {
       GrizzlyServer grizzlyServer = app.createGrizzlyServer();
 
-      registerShutdownHookToGracefullyShutDownServer(app.timetableRepository(), app.raptorConfig());
+      registerShutdownHookToGracefullyShutDownServer(app.transitRepository(), app.raptorConfig());
 
       // Loop to restart server on uncaught fatal exceptions.
       while (true) {
@@ -232,12 +232,12 @@ public class OTPMain {
    * </ol>
    */
   private static void registerShutdownHookToGracefullyShutDownServer(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     RaptorConfig<?> raptorConfig
   ) {
     ApplicationShutdownSupport.addShutdownHook("server-shutdown", () -> {
       LOG.info("OTP shutdown started...");
-      UpdaterConfigurator.shutdownGraph(timetableRepository);
+      UpdaterConfigurator.shutdownGraph(transitRepository);
       raptorConfig.shutdown();
       WeakCollectionCleaner.DEFAULT.exit();
       DeferredAuthorityFactory.exit();

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -40,7 +40,7 @@ import org.opentripplanner.street.StreetRepository;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.configure.UpdaterConfigurator;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
@@ -83,7 +83,7 @@ public class ConstructApplication {
     Graph graph,
     OsmInfoGraphBuildRepository osmInfoGraphBuildRepository,
     StreetDetailsRepository streetDetailsRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     WorldEnvelopeRepository worldEnvelopeRepository,
     ConfigModel config,
@@ -104,26 +104,26 @@ public class ConstructApplication {
     // This is intentionally done here rather than in a Dagger provider because the mapping
     // is heavy and should not run inside the DI container's initialization.
     var tuningParameters = config.routerConfig().transitTuningConfig();
-    if (!timetableRepository.hasTransit() || !timetableRepository.isIndexed()) {
+    if (!transitRepository.hasTransit() || !transitRepository.isIndexed()) {
       LOG.warn(
         "Cannot create Raptor data, that requires the graph to have transit data and be indexed."
       );
     }
     LOG.info("Creating transit layer for Raptor routing.");
-    timetableRepository.initRaptorTransitData(
-      RaptorTransitDataMapper.map(tuningParameters, timetableRepository, transferRepository)
+    transitRepository.initRaptorTransitData(
+      RaptorTransitDataMapper.map(tuningParameters, transitRepository, transferRepository)
     );
     var scheduledRaptorTransitData = new RaptorTransitData(
-      timetableRepository.getRaptorTransitData()
+      transitRepository.getRaptorTransitData()
     );
-    var scheduledTripCalendars = timetableRepository.copyTripCalendarForRealTimeUpdates();
+    var scheduledTripCalendars = transitRepository.copyTripCalendarForRealTimeUpdates();
 
     ConstructApplicationFactory.Builder builder = DaggerConstructApplicationFactory.builder();
     this.factory = builder
       .configModel(config)
       .graph(graph)
       .streetDetailsRepository(streetDetailsRepository)
-      .timetableRepository(timetableRepository)
+      .transitRepository(transitRepository)
       .transferRepository(transferRepository)
       .worldEnvelopeRepository(worldEnvelopeRepository)
       .vehicleParkingRepository(vehicleParkingRepository)
@@ -168,7 +168,7 @@ public class ConstructApplication {
       factory.streetDetailsRepository(),
       fareServiceFactory(),
       factory.streetRepository(),
-      factory.timetableRepository(),
+      factory.transitRepository(),
       factory.transferRepository(),
       factory.worldEnvelopeRepository(),
       factory.vehicleParkingRepository(),
@@ -213,7 +213,7 @@ public class ConstructApplication {
       realtimeVehicleRepository(),
       vehicleRentalRepository(),
       vehicleParkingRepository(),
-      timetableRepository(),
+      transitRepository(),
       carpoolingRepository(),
       carpoolTripVertexResolver(),
       factory.updateManager(),
@@ -226,7 +226,7 @@ public class ConstructApplication {
 
     initEllipsoidToGeoidDifference();
 
-    initializeTransferCache(routerConfig().transitTuningConfig(), timetableRepository());
+    initializeTransferCache(routerConfig().transitTuningConfig(), transitRepository());
 
     if (OTPFeature.SandboxAPIGeocoder.isOn()) {
       LOG.info("Initializing geocoder");
@@ -247,7 +247,7 @@ public class ConstructApplication {
 
   public static void initializeTransferCache(
     TransitTuningParameters transitTuningConfig,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     var transferCacheRequests = transitTuningConfig.transferCacheRequests();
     if (!transferCacheRequests.isEmpty()) {
@@ -260,7 +260,7 @@ public class ConstructApplication {
       LOG.info(progress.startMessage());
 
       transferCacheRequests.forEach(request -> {
-        timetableRepository.getRaptorTransitData().initTransferCacheForRequest(request);
+        transitRepository.getRaptorTransitData().initTransferCacheForRequest(request);
 
         //noinspection Convert2MethodRef
         progress.step(s -> LOG.info(s));
@@ -270,8 +270,8 @@ public class ConstructApplication {
     }
   }
 
-  public TimetableRepository timetableRepository() {
-    return factory.timetableRepository();
+  public TransitRepository transitRepository() {
+    return factory.transitRepository();
   }
 
   public TransferRepository transferRepository() {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
@@ -67,8 +67,8 @@ import org.opentripplanner.transfer.regular.configure.TransferServiceModule;
 import org.opentripplanner.transit.configure.StaticTransitService;
 import org.opentripplanner.transit.configure.TransitModule;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.warmup.WarmupLauncher;
@@ -126,7 +126,7 @@ public interface ConstructApplicationFactory {
   VehicleParkingRepository vehicleParkingRepository();
   VehicleParkingService vehicleParkingService();
   UpdateManager updateManager();
-  RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableRepositoryHandle();
+  RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableRepositoryHandle();
   DataImportIssueSummary dataImportIssueSummary();
 
   @Nullable

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
@@ -69,7 +69,7 @@ import org.opentripplanner.transit.configure.TransitModule;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.warmup.WarmupLauncher;
 import org.opentripplanner.warmup.configure.WarmupModule;
@@ -116,7 +116,7 @@ public interface ConstructApplicationFactory {
   Graph graph();
   LinkingContextFactory linkingContextFactory();
   VertexLinker vertexLinker();
-  TimetableRepository timetableRepository();
+  TransitRepository transitRepository();
   TransferRepository transferRepository();
   WorldEnvelopeRepository worldEnvelopeRepository();
   WorldEnvelopeService worldEnvelopeService();
@@ -189,7 +189,7 @@ public interface ConstructApplicationFactory {
     Builder graph(Graph graph);
 
     @BindsInstance
-    Builder timetableRepository(TimetableRepository timetableRepository);
+    Builder transitRepository(TransitRepository transitRepository);
 
     @BindsInstance
     Builder transferRepository(TransferRepository transferRepository);

--- a/application/src/main/java/org/opentripplanner/standalone/configure/LoadApplication.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/LoadApplication.java
@@ -18,7 +18,7 @@ import org.opentripplanner.standalone.config.ConfigModel;
 import org.opentripplanner.street.StreetRepository;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This class is responsible for loading configuration and setting up the OTP data store.
@@ -64,7 +64,7 @@ public class LoadApplication {
       obj.graph,
       obj.osmInfoGraphBuildRepository,
       obj.streetDetailsRepository,
-      obj.timetableRepository,
+      obj.transitRepository,
       obj.transferRepository,
       obj.worldEnvelopeRepository,
       obj.parkingRepository,
@@ -83,7 +83,7 @@ public class LoadApplication {
       factory.emptyGraph(),
       factory.emptyOsmInfoGraphBuildRepository(),
       factory.emptyStreetDetailsRepository(),
-      factory.emptyTimetableRepository(),
+      factory.emptyTransitRepository(),
       factory.emptyTransferRepository(),
       factory.emptyWorldEnvelopeRepository(),
       factory.emptyVehicleParkingRepository(),
@@ -111,7 +111,7 @@ public class LoadApplication {
     Graph graph,
     OsmInfoGraphBuildRepository osmInfoGraphBuildRepository,
     StreetDetailsRepository streetDetailsRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     WorldEnvelopeRepository worldEnvelopeRepository,
     VehicleParkingRepository parkingRepository,
@@ -127,7 +127,7 @@ public class LoadApplication {
       graph,
       osmInfoGraphBuildRepository,
       streetDetailsRepository,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       worldEnvelopeRepository,
       config(),

--- a/application/src/main/java/org/opentripplanner/standalone/configure/LoadApplicationFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/LoadApplicationFactory.java
@@ -33,7 +33,7 @@ import org.opentripplanner.street.configure.StreetRepositoryModule;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transfer.regular.configure.TransferRepositoryModule;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * Dagger dependency injection Factory to create components for the OTP load application phase.
@@ -73,7 +73,7 @@ public interface LoadApplicationFactory {
   StreetDetailsRepository emptyStreetDetailsRepository();
 
   @Singleton
-  TimetableRepository emptyTimetableRepository();
+  TransitRepository emptyTransitRepository();
 
   @Singleton
   TransferRepository emptyTransferRepository();

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -40,8 +40,8 @@ import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.service.StreetLimitationParametersService;
 import org.opentripplanner.transfer.regular.RegularTransferService;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
@@ -64,7 +64,7 @@ public class RequestScopedModule {
   @HttpRequestScoped
   static TransitService transitService(
     TransitRepository transitRepository,
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableRepositoryHandle,
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableRepositoryHandle,
     TransactionScope transactionScope
   ) {
     var timetableSnapshot = timetableRepositoryHandle.repositorySnapshot(transactionScope);

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -43,7 +43,7 @@ import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -63,12 +63,12 @@ public class RequestScopedModule {
   @Provides
   @HttpRequestScoped
   static TransitService transitService(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableRepositoryHandle,
     TransactionScope transactionScope
   ) {
     var timetableSnapshot = timetableRepositoryHandle.repositorySnapshot(transactionScope);
-    return new DefaultTransitService(timetableRepository, timetableSnapshot);
+    return new DefaultTransitService(transitRepository, timetableSnapshot);
   }
 
   @Provides

--- a/application/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
@@ -23,7 +23,7 @@ import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueSummary;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * This class is responsible for wiring up various metrics to micrometer, which we use for
@@ -33,7 +33,7 @@ public class MetricsLogging {
 
   @Inject
   public MetricsLogging(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     RaptorConfig<TripSchedule> raptorConfig,
     DataImportIssueSummary issueSummary
   ) {
@@ -49,12 +49,12 @@ public class MetricsLogging {
     new ProcessorMetrics().bindTo(Metrics.globalRegistry);
     new UptimeMetrics().bindTo(Metrics.globalRegistry);
     if (OTPFeature.AlertMetrics.isOn()) {
-      new AlertMetrics(timetableRepository::getTransitAlertService).bindTo(Metrics.globalRegistry);
+      new AlertMetrics(transitRepository::getTransitAlertService).bindTo(Metrics.globalRegistry);
     }
 
-    if (timetableRepository.getRaptorTransitData() != null) {
+    if (transitRepository.getRaptorTransitData() != null) {
       new GuavaCacheMetrics(
-        timetableRepository.getRaptorTransitData().getTransferCache().getTransferCache(),
+        transitRepository.getRaptorTransitData().getTransferCache().getTransferCache(),
         "raptorTransfersCache",
         List.of(Tag.of("cache", "raptorTransfers"))
       ).bindTo(Metrics.globalRegistry);
@@ -65,15 +65,15 @@ public class MetricsLogging {
       List.of(Tag.of("pool", "commonPool"))
     ).bindTo(Metrics.globalRegistry);
 
-    if (timetableRepository.getUpdaterManager() != null) {
+    if (transitRepository.getUpdaterManager() != null) {
       new ExecutorServiceMetrics(
-        timetableRepository.getUpdaterManager().getPollingUpdaterPool(),
+        transitRepository.getUpdaterManager().getPollingUpdaterPool(),
         "pollingGraphUpdaters",
         List.of(Tag.of("pool", "pollingGraphUpdaters"))
       ).bindTo(Metrics.globalRegistry);
 
       new ExecutorServiceMetrics(
-        timetableRepository.getUpdaterManager().getNonPollingUpdaterPool(),
+        transitRepository.getUpdaterManager().getNonPollingUpdaterPool(),
         "nonPollingGraphUpdaters",
         List.of(Tag.of("pool", "nonPollingGraphUpdaters"))
       ).bindTo(Metrics.globalRegistry);

--- a/application/src/main/java/org/opentripplanner/transfer/constrained/raptoradaptor/TransferIndexGenerator.java
+++ b/application/src/main/java/org/opentripplanner/transfer/constrained/raptoradaptor/TransferIndexGenerator.java
@@ -111,7 +111,7 @@ public class TransferIndexGenerator {
 
   /**
    * The cache is valid if it is not null, not dirty and no other component created new patterns.
-   * In theory all real-time pattern creations should be done through the TimetableSnapshot and would
+   * In theory all real-time pattern creations should be done through the TimetableRepository and would
    * be detected by the dirty flag.
    * But since the TripPattern builder is publicly accessible, there is no strong guarantee about this.
    * The risk is IndexOutOfBoundsException: The cached ConstrainedTransfersForPatterns wraps arrays

--- a/application/src/main/java/org/opentripplanner/transit/configure/TransitModule.java
+++ b/application/src/main/java/org/opentripplanner/transit/configure/TransitModule.java
@@ -12,10 +12,10 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransit
 import org.opentripplanner.standalone.config.ConfigModel;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositoryLifecycle;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
@@ -42,8 +42,8 @@ public abstract class TransitModule {
   @Provides
   @Singleton
   public static RepositoryHandle<
-    ReadOnlyTimetableSnapshot,
-    MutableTimetableSnapshot
+    TimetableRepositorySnapshot,
+    TimetableRepository
   > timetableRepositoryHandle(
     TimetableSnapshotParameters parameters,
     TransitRepository transitRepository,
@@ -51,12 +51,10 @@ public abstract class TransitModule {
     RaptorTransitData scheduledRaptorTransitData,
     DefaultTripCalendars tripCalendars
   ) {
-    var mutableBuffer = new TimetableSnapshot(scheduledRaptorTransitData, tripCalendars);
-    var timetableSnapshotLifecycle = new TimetableSnapshotLifecycle(
-      mutableBuffer,
-      parameters.purgeExpiredData(),
-      () -> LocalDate.now(transitRepository.getTimeZone())
+    var buffer = new DefaultTimetableRepository(scheduledRaptorTransitData, tripCalendars);
+    var lifecycle = new TimetableRepositoryLifecycle(buffer, parameters.purgeExpiredData(), () ->
+      LocalDate.now(transitRepository.getTimeZone())
     );
-    return repositoryRegistry.registerRepository(mutableBuffer, timetableSnapshotLifecycle);
+    return repositoryRegistry.registerRepository(buffer, lifecycle);
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/configure/TransitModule.java
+++ b/application/src/main/java/org/opentripplanner/transit/configure/TransitModule.java
@@ -17,7 +17,7 @@ import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
 import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 
 @Module
@@ -46,7 +46,7 @@ public abstract class TransitModule {
     MutableTimetableSnapshot
   > timetableRepositoryHandle(
     TimetableSnapshotParameters parameters,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     RepositoryRegistry repositoryRegistry,
     RaptorTransitData scheduledRaptorTransitData,
     DefaultTripCalendars tripCalendars
@@ -55,7 +55,7 @@ public abstract class TransitModule {
     var timetableSnapshotLifecycle = new TimetableSnapshotLifecycle(
       mutableBuffer,
       parameters.purgeExpiredData(),
-      () -> LocalDate.now(timetableRepository.getTimeZone())
+      () -> LocalDate.now(transitRepository.getTimeZone())
     );
     return repositoryRegistry.registerRepository(mutableBuffer, timetableSnapshotLifecycle);
   }

--- a/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -75,8 +75,8 @@ public final class TripPattern
    * TripPatterns hold a reference to a Timetable (i.e. TripTimes for all Trips in the pattern) for
    * only scheduled trips from the GTFS or NeTEx data. If any trips were later updated in real time,
    * there will be another Timetable holding those updates and reading through to the scheduled one.
-   * That other realtime Timetable is retrieved from a TimetableSnapshot (see end of Javadoc on
-   * TimetableSnapshot for more details).
+   * That other realtime Timetable is retrieved from a TimetableRepositorySnapshot (see end of Javadoc on
+   * DefaultTimetableRepository for more details).
    * TODO RT_AB: The above system should be changed to integrate realtime and scheduled data more
    *   closely. The Timetable may become obsolete or change significantly when they are integrated.
    */

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableSnapshot.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TimetableSnapshot.java
@@ -138,7 +138,7 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
   /**
    * The realTimeAdded* maps are indexes on the trips created at runtime (extra-journey), and the
    * Route, TripPattern, TripOnServiceDate they refer to.
-   * They are meant to override the corresponding indexes in TimetableRepositoryIndex.
+   * They are meant to override the corresponding indexes in TransitRepositoryIndex.
    */
   private final Map<FeedScopedId, Route> realtimeAddedRoutes;
   private final Map<FeedScopedId, Trip> realTimeAddedTrips;

--- a/application/src/main/java/org/opentripplanner/transit/repository/DefaultTimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/repository/DefaultTimetableRepository.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.model.timetable;
+package org.opentripplanner.transit.repository;
 
 import static org.opentripplanner.utils.collection.CollectionUtils.getByNullableKey;
 
@@ -35,32 +35,40 @@ import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
+import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
+import org.opentripplanner.transit.model.timetable.Timetable;
+import org.opentripplanner.transit.model.timetable.TimetableBuilder;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A TimetableSnapshot holds a set of realtime-updated Timetables frozen at a moment in time. It
+ * The default implementation of both {@link TimetableRepository} and
+ * {@link TimetableRepositorySnapshot}: a mutable instance serves as the repository (write
+ * buffer), and committing it produces a read-only instance of the same class which serves as the
+ * published snapshot. It holds a set of realtime-updated Timetables frozen at a moment in time. It
  * can return a Timetable for any TripPattern in the public transit network considering all
  * accumulated realtime updates, falling back on the scheduled Timetable if no updates have been
  * applied for a given TripPattern.
  * <p>
  * This is a central part of managing concurrency when many routing searches may be happening, but
  * realtime updates are also streaming in which change the vehicle arrival and departure times.
- * Any given request will only see one unchanging TimetableSnapshot over the course of its search.
+ * Any given request will only see one unchanging snapshot over the course of its search.
  * <p>
- * An instance of TimetableSnapshot first serves as a buffer to accumulate a batch of incoming
- * updates on top of any already known updates to the base schedules. From time to time such a batch
- * of updates is committed (like a database transaction). At this point the TimetableSnapshot is
- * treated as immutable and becomes available for use by new incoming routing requests.
+ * A mutable instance first serves as a buffer to accumulate a batch of incoming updates on top of
+ * any already known updates to the base schedules. From time to time such a batch of updates is
+ * committed (like a database transaction). At this point an immutable copy is created and becomes
+ * available for use by new incoming routing requests.
  * <p>
  * All updates to a snapshot must be completed before it is handed off to any searches. A single
  * snapshot should be used for an entire search, and should remain unchanged for that duration to
  * provide a consistent view not only of trips that have been boarded, but of relative arrival and
  * departure times of other trips that have not necessarily been boarded.
  * <p>
- * A TimetableSnapshot instance may only be modified by a single thread. This makes it easier to
+ * An instance may only be modified by a single thread. This makes it easier to
  * reason about how the snapshot is built up and used. Write operations are applied one by one, in
  * order, with no concurrent access. Read operations are then allowed concurrently by many threads
  * after writing is forbidden.
@@ -81,18 +89,18 @@ import org.slf4j.LoggerFactory;
  * guarantee of safe-publication without synchronization.
  * (see <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.5">final Field Semantics</a>)
  */
-public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTimetableSnapshot {
+public class DefaultTimetableRepository implements TimetableRepository {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TimetableSnapshot.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultTimetableRepository.class);
 
   /**
-   * During the construction phase of the TimetableSnapshot, before it is considered immutable and
+   * During the construction phase of an instance, before it is considered immutable and
    * used in routing, this Map holds all timetables that have been modified and are waiting to be
    * indexed.
    * A real-time timetable overrides the scheduled timetable of a TripPattern for only a single
    * service date. There can be only one overriding timetable per TripPattern and per service date.
    * This is enforced by indexing the map with a pair (TripPattern, service date).
-   * This map is cleared when the TimetableSnapshot becomes read-only.
+   * This map is cleared when the instance becomes read-only.
    */
   private final Map<TripPatternAndServiceDate, Timetable> dirtyTimetables = new HashMap<>();
 
@@ -106,7 +114,7 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
    * The members of the SortedSet (the Timetable for a particular day) are treated as copy-on-write
    * when we're updating them. If an update will modify the timetable for a particular day, that
    * timetable is replicated before any modifications are applied to avoid affecting any previous
-   * TimetableSnapshots still in circulation which reference that same Timetable instance. <p>
+   * snapshots still in circulation which reference that same Timetable instance. <p>
    * Alternative implementations: A. This could be an array indexed using the integer pattern
    * indexes. B. It could be made into a flat hashtable with compound keys (TripPattern, LocalDate).
    * The compound key approach better reflects the fact that there should be only one Timetable per
@@ -174,7 +182,7 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
    */
   private boolean dirty = false;
 
-  public TimetableSnapshot(
+  public DefaultTimetableRepository(
     RaptorTransitData raptorTransitData,
     DefaultTripCalendars tripCalendars
   ) {
@@ -196,7 +204,7 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
     );
   }
 
-  TimetableSnapshot(
+  DefaultTimetableRepository(
     Map<FeedScopedId, SortedSet<Timetable>> timetables,
     Map<TripIdAndServiceDate, TripPattern> realTimeNewTripPatternsForModifiedTrips,
     Map<FeedScopedId, Route> realtimeAddedRoutes,
@@ -406,23 +414,23 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
    * Updating the raptor data is now also part of the commit. Previously this was done after the
    * commit. The amount of work triggered by each commit stayed the same.
    *
-   * @return an immutable copy of this TimetableSnapshot with all updates applied
+   * @return an immutable copy of this repository with all updates applied
    */
-  public TimetableSnapshot commit() {
+  public DefaultTimetableRepository commit() {
     return commit(false);
   }
 
-  public TimetableSnapshot commit(boolean force) {
+  public DefaultTimetableRepository commit(boolean force) {
     validateNotReadOnly();
 
     if (!force && !this.isDirty()) {
       return null;
     }
 
-    return createReadOnlySnapshot();
+    return createSnapshot();
   }
 
-  public @NonNull TimetableSnapshot createReadOnlySnapshot() {
+  public @NonNull DefaultTimetableRepository createSnapshot() {
     RaptorTransitData updatedRaptorData = timetableUpdateMapper.map(
       realtimeRaptorTransitData,
       dirtyTimetables.values(),
@@ -430,7 +438,7 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
       new TripPatternForDateMapper(tripCalendars.getServiceCodesRunningForDate())
     );
 
-    var timetableSnapshot = new TimetableSnapshot(
+    var snapshot = new DefaultTimetableRepository(
       Map.copyOf(timetables),
       Map.copyOf(realTimeNewTripPatternsForModifiedTrips),
       Map.copyOf(realtimeAddedRoutes),
@@ -452,7 +460,7 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
     dirtyTimetables.clear();
     dirty = false;
 
-    return timetableSnapshot;
+    return snapshot;
   }
 
   /**
@@ -756,7 +764,7 @@ public class TimetableSnapshot implements ReadOnlyTimetableSnapshot, MutableTime
 
   private void validateNotReadOnly() {
     if (readOnly) {
-      throw new ConcurrentModificationException("This TimetableSnapshot is read-only.");
+      throw new ConcurrentModificationException("This DefaultTimetableRepository is read-only.");
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepository.java
@@ -4,10 +4,10 @@ import java.time.LocalDate;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 
-public interface MutableTimetableSnapshot extends ReadOnlyTimetableSnapshot {
+public interface TimetableRepository extends TimetableRepositorySnapshot {
   void update(RealTimeTripUpdate realTimeTripUpdate);
 
-  ReadOnlyTimetableSnapshot createReadOnlySnapshot();
+  TimetableRepositorySnapshot createSnapshot();
 
   void clear(String feedId);
 

--- a/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepository.java
@@ -4,14 +4,50 @@ import java.time.LocalDate;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 
+/**
+ * The mutable repository for the realtime-updated timetables. It is managed by the transaction
+ * framework: trip updaters obtain it through a
+ * {@link org.opentripplanner.framework.transaction.api.WriteContext} on the single writer thread,
+ * and {@link #createSnapshot()} is called at commit time to publish a new immutable
+ * {@link TimetableRepositorySnapshot} for the request threads.
+ */
 public interface TimetableRepository extends TimetableRepositorySnapshot {
+  /**
+   * Update the TripTimes of one Trip in a Timetable of a TripPattern. If the Trip of the TripTimes
+   * does not exist yet in the Timetable, add it. If the update assigns the trip to a new pattern
+   * (the stop pattern was modified in real time), the trip is associated with that pattern for the
+   * service date of the update.
+   */
   void update(RealTimeTripUpdate realTimeTripUpdate);
 
+  /**
+   * Produce an immutable snapshot of the current state of this repository.
+   */
   TimetableRepositorySnapshot createSnapshot();
 
+  /**
+   * Clear all realtime data for the provided feed id, reverting every trip of that feed to its
+   * scheduled timetable and pattern.
+   */
   void clear(String feedId);
 
+  /**
+   * If a previous realtime update has changed which trip pattern is associated with the given trip
+   * on the given service date, dissociate the trip from that pattern and remove the trip's
+   * timetables from that pattern on that particular service date.
+   *
+   * <p>For this service date, the trip will revert to its original trip pattern from the scheduled
+   * data, remaining on that pattern unless it's changed again by a future realtime update.
+   *
+   * @return true if the trip was found to be shifted to a different trip pattern by a realtime
+   * message and an attempt was made to re-associate it with its originally scheduled trip pattern.
+   */
   boolean revertTripToScheduledTripPattern(FeedScopedId tripId, LocalDate serviceDate);
 
+  /**
+   * Remove all realtime data which is valid for a service date on-or-before the one supplied.
+   *
+   * @return true if any data has been modified and false if no purging has happened.
+   */
   boolean purgeExpiredData(LocalDate serviceDate);
 }

--- a/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositoryLifecycle.java
+++ b/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositoryLifecycle.java
@@ -4,6 +4,12 @@ import java.time.LocalDate;
 import java.util.function.Supplier;
 import org.opentripplanner.framework.transaction.api.RepositoryLifecycle;
 
+/**
+ * Copy-on-write / freeze lifecycle for the realtime-timetable repository. The repository is a
+ * single long-lived buffer shared by all transactions: {@link #copyOnWrite} hands out the same
+ * buffer instance, and {@link #freeze} publishes an immutable snapshot of it (after optionally
+ * purging expired data).
+ */
 public class TimetableRepositoryLifecycle
   implements RepositoryLifecycle<TimetableRepositorySnapshot, TimetableRepository> {
 

--- a/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositoryLifecycle.java
+++ b/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositoryLifecycle.java
@@ -4,16 +4,16 @@ import java.time.LocalDate;
 import java.util.function.Supplier;
 import org.opentripplanner.framework.transaction.api.RepositoryLifecycle;
 
-public class TimetableSnapshotLifecycle
-  implements RepositoryLifecycle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> {
+public class TimetableRepositoryLifecycle
+  implements RepositoryLifecycle<TimetableRepositorySnapshot, TimetableRepository> {
 
-  private final MutableTimetableSnapshot buffer;
+  private final TimetableRepository buffer;
   private final boolean purgeExpiredData;
   private final Supplier<LocalDate> localDateNow;
   private LocalDate lastPurgeDate = null;
 
-  public TimetableSnapshotLifecycle(
-    MutableTimetableSnapshot buffer,
+  public TimetableRepositoryLifecycle(
+    TimetableRepository buffer,
     boolean purgeExpiredData,
     Supplier<LocalDate> localDateNow
   ) {
@@ -23,12 +23,12 @@ public class TimetableSnapshotLifecycle
   }
 
   @Override
-  public MutableTimetableSnapshot copyOnWrite(ReadOnlyTimetableSnapshot readOnlySnapshot) {
+  public TimetableRepository copyOnWrite(TimetableRepositorySnapshot snapshot) {
     return buffer;
   }
 
   @Override
-  public ReadOnlyTimetableSnapshot freeze(MutableTimetableSnapshot mutableSnapshot) {
+  public TimetableRepositorySnapshot freeze(TimetableRepository repository) {
     if (purgeExpiredData) {
       final LocalDate today = localDateNow.get();
       // Keep data for today and the previous day; purge anything older
@@ -38,6 +38,6 @@ public class TimetableSnapshotLifecycle
         buffer.purgeExpiredData(previously);
       }
     }
-    return buffer.createReadOnlySnapshot();
+    return buffer.createSnapshot();
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositorySnapshot.java
+++ b/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositorySnapshot.java
@@ -14,45 +14,112 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 
+/**
+ * An immutable, read-only snapshot of the realtime-updated timetables. A new snapshot is published
+ * each time a transaction that touched the {@link TimetableRepository} commits. Request
+ * threads read a snapshot resolved at the start of the request, through the request-scoped
+ * {@link org.opentripplanner.transit.service.TransitService}.
+ */
 public interface TimetableRepositorySnapshot {
+  /**
+   * Return the updated timetable for the specified pattern if one is available in this snapshot,
+   * or the originally scheduled timetable if there are no updates in this snapshot.
+   */
   Timetable resolve(TripPattern pattern, @Nullable LocalDate serviceDate);
 
+  /**
+   * Return the current trip pattern given a trip id and a service date, if it has been changed
+   * from the scheduled pattern by an update with a different stop pattern.
+   *
+   * @return trip pattern created by the updater; null if the trip is on its original trip pattern
+   */
   @Nullable
   TripPattern getNewTripPatternForModifiedTrip(FeedScopedId tripId, LocalDate serviceDate);
 
+  /**
+   * List trips which have been canceled by realtime updates.
+   */
   List<TripOnServiceDate> listCanceledTrips();
 
+  /**
+   * Return true if any trip has been assigned to a new trip pattern by a realtime update.
+   */
   boolean hasNewTripPatternsForModifiedTrips();
 
+  /**
+   * Return the route created by a realtime update for the given id, or null if no route was added
+   * with this id.
+   */
   @Nullable
   Route getRealtimeAddedRoute(FeedScopedId id);
 
+  /**
+   * List all routes created by realtime updates, that is routes which are not present in the
+   * scheduled data.
+   */
   Collection<Route> listRealTimeAddedRoutes();
 
+  /**
+   * Return the trip created by a realtime update for the given id, or null if no trip was added
+   * with this id.
+   */
   @Nullable
   Trip getRealTimeAddedTrip(FeedScopedId id);
 
+  /**
+   * List all trips created by realtime updates, that is trips which are not present in the
+   * scheduled data.
+   */
   Collection<Trip> listRealTimeAddedTrips();
 
+  /**
+   * Return the pattern created by a realtime update for the given realtime-added trip, or null if
+   * the trip is not realtime-added.
+   */
   @Nullable
   TripPattern getRealTimeAddedPatternForTrip(Trip trip);
 
+  /**
+   * Return the patterns created by realtime updates for the given route.
+   */
   Collection<TripPattern> getRealTimeAddedPatternForRoute(Route route);
 
+  /**
+   * Return the trip-on-service-date created by a realtime update for the given id, or null if no
+   * trip-on-service-date was added with this id.
+   */
   @Nullable
   TripOnServiceDate getRealTimeAddedTripOnServiceDateById(FeedScopedId id);
 
+  /**
+   * Return the trip-on-service-date created by a realtime update for the given trip and service
+   * date, or null if the trip is not realtime-added on that date.
+   */
   @Nullable
   TripOnServiceDate getRealTimeAddedTripOnServiceDateForTripAndDay(
     TripIdAndServiceDate tripIdAndServiceDate
   );
 
+  /**
+   * List all trips-on-service-date created by realtime updates.
+   */
   Collection<? extends TripOnServiceDate> listRealTimeAddedTripOnServiceDate();
 
+  /**
+   * Return the trips-on-service-date that replace the given trip-on-service-date according to
+   * realtime updates.
+   */
   Collection<TripOnServiceDate> getRealTimeReplacedByTripOnServiceDate(FeedScopedId id);
 
+  /**
+   * Return the patterns created by realtime updates which visit the given stop.
+   */
   Collection<TripPattern> getPatternsForStop(StopLocation stop);
 
+  /**
+   * Return the raptor transit data that includes the realtime updates of this snapshot. This is
+   * the transit data used for routing with this snapshot.
+   */
   RaptorTransitData getRealtimeRaptorTransitData();
 
   /**

--- a/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositorySnapshot.java
+++ b/application/src/main/java/org/opentripplanner/transit/repository/TimetableRepositorySnapshot.java
@@ -14,7 +14,7 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 
-public interface ReadOnlyTimetableSnapshot {
+public interface TimetableRepositorySnapshot {
   Timetable resolve(TripPattern pattern, @Nullable LocalDate serviceDate);
 
   @Nullable

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -65,7 +65,7 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.updater.GraphUpdaterStatus;
 import org.opentripplanner.utils.collection.CollectionsView;
 import org.opentripplanner.utils.collection.SetUtils;
@@ -74,7 +74,7 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
 /**
  * Default implementation of the Transit Service and Transit Editor Service.
  * A new instance of this class should be created for each request.
- * This ensures that the same TimetableSnapshot is used for the
+ * This ensures that the same TimetableRepositorySnapshot is used for the
  * duration of the request (which may involve several method calls).
  */
 public class DefaultTransitService implements TransitEditorService {
@@ -92,7 +92,7 @@ public class DefaultTransitService implements TransitEditorService {
    * instance does not contain any real-time information.
    */
   @Nullable
-  private final ReadOnlyTimetableSnapshot timetableSnapshot;
+  private final TimetableRepositorySnapshot timetableSnapshot;
 
   /**
    * Helper for fetching stop times for APIs.
@@ -113,7 +113,7 @@ public class DefaultTransitService implements TransitEditorService {
 
   public DefaultTransitService(
     TransitRepository transitRepository,
-    @Nullable ReadOnlyTimetableSnapshot timetableSnapshot
+    @Nullable TimetableRepositorySnapshot timetableSnapshot
   ) {
     this.transitRepository = transitRepository;
     this.transitRepositoryIndex = transitRepository.getTransitRepositoryIndex();
@@ -499,7 +499,7 @@ public class DefaultTransitService implements TransitEditorService {
    * Returns all the patterns for a specific stop. If includeRealtimeUpdates is set, new patterns
    * added by realtime updates are added to the collection.
    * A set is used here because trip patterns
-   * that were updated by realtime data is both part of the TransitRepositoryIndex and the TimetableSnapshot
+   * that were updated by realtime data is both part of the TransitRepositoryIndex and the TimetableRepositorySnapshot
    */
   @Override
   public Collection<TripPattern> findPatterns(StopLocation stop, boolean includeRealtimeUpdates) {

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -83,9 +83,9 @@ public class DefaultTransitService implements TransitEditorService {
     new TIntHashSet()
   );
 
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
-  private final TimetableRepositoryIndex timetableRepositoryIndex;
+  private final TransitRepositoryIndex transitRepositoryIndex;
 
   /**
    * A nullable timetable snapshot containing real-time updates. If {@code null} then this
@@ -107,19 +107,19 @@ public class DefaultTransitService implements TransitEditorService {
    * {@link org.opentripplanner.standalone.api.OtpServerRequestContext} if real-time data is needed.
    */
   @Inject
-  public DefaultTransitService(TimetableRepository timetableRepository) {
-    this(timetableRepository, null);
+  public DefaultTransitService(TransitRepository transitRepository) {
+    this(transitRepository, null);
   }
 
   public DefaultTransitService(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable ReadOnlyTimetableSnapshot timetableSnapshot
   ) {
-    this.timetableRepository = timetableRepository;
-    this.timetableRepositoryIndex = timetableRepository.getTimetableRepositoryIndex();
+    this.transitRepository = transitRepository;
+    this.transitRepositoryIndex = transitRepository.getTransitRepositoryIndex();
     this.timetableSnapshot = timetableSnapshot;
     this.stopTimesHelper = new StopTimesHelper(this);
-    this.replacementHelper = new ReplacementHelper(this, timetableRepository, timetableSnapshot);
+    this.replacementHelper = new ReplacementHelper(this, transitRepository, timetableSnapshot);
   }
 
   @Override
@@ -154,82 +154,82 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public Collection<String> listFeedIds() {
-    return this.timetableRepository.getFeedIds();
+    return this.transitRepository.getFeedIds();
   }
 
   @Override
   public Collection<Agency> listAgencies() {
     OTPRequestTimeoutException.checkForTimeout();
-    return this.timetableRepository.getAgencies();
+    return this.transitRepository.getAgencies();
   }
 
   @Override
   public Optional<Agency> findAgency(FeedScopedId id) {
-    return this.timetableRepository.findAgencyById(id);
+    return this.transitRepository.findAgencyById(id);
   }
 
   @Override
   public FeedInfo getFeedInfo(String feedId) {
-    return this.timetableRepository.getFeedInfo(feedId);
+    return this.transitRepository.getFeedInfo(feedId);
   }
 
   @Override
   public Collection<Notice> findNotices(AbstractTransitEntity<?, ?> entity) {
-    return this.timetableRepository.getNoticesByElement().get(entity);
+    return this.transitRepository.getNoticesByElement().get(entity);
   }
 
   @Override
   public TripPattern getTripPattern(FeedScopedId id) {
-    return this.timetableRepository.getTripPatternForId(id);
+    return this.transitRepository.getTripPatternForId(id);
   }
 
   @Override
   public Collection<TripPattern> listTripPatterns() {
     OTPRequestTimeoutException.checkForTimeout();
-    return this.timetableRepository.getAllTripPatterns();
+    return this.transitRepository.getAllTripPatterns();
   }
 
   @Override
   public Station getStation(FeedScopedId id) {
-    return this.timetableRepository.getSiteRepository().getStationById(id);
+    return this.transitRepository.getSiteRepository().getStationById(id);
   }
 
   @Override
   public MultiModalStation getMultiModalStation(FeedScopedId id) {
-    return this.timetableRepository.getSiteRepository().getMultiModalStation(id);
+    return this.transitRepository.getSiteRepository().getMultiModalStation(id);
   }
 
   @Override
   public Collection<Station> listStations() {
     OTPRequestTimeoutException.checkForTimeout();
-    return this.timetableRepository.getSiteRepository().listStations();
+    return this.transitRepository.getSiteRepository().listStations();
   }
 
   @Override
   public TIntSet getServiceCodesRunningForDate(LocalDate serviceDate) {
-    return timetableRepository
+    return transitRepository
       .getServiceCodesRunningForDate()
       .getOrDefault(serviceDate, EMPTY_SERVICE_CODES);
   }
 
   @Override
   public Agency getAgency(FeedScopedId id) {
-    return this.timetableRepositoryIndex.getAgencyForId(id);
+    return this.transitRepositoryIndex.getAgencyForId(id);
   }
 
   @Override
   public RegularStop getRegularStop(FeedScopedId id) {
-    return this.timetableRepository.getSiteRepository().getRegularStop(id);
+    return this.transitRepository.getSiteRepository().getRegularStop(id);
   }
 
   @Override
   public Entrance getEntrance(FeedScopedId id) {
-    return this.timetableRepository.getSiteRepository().getEntrance(id);
+    return this.transitRepository.getSiteRepository().getEntrance(id);
   }
 
   @Override
   public AreaStop getAreaStop(FeedScopedId id) {
-    return Objects.requireNonNull(this.timetableRepository.getSiteRepository().getAreaStop(id));
+    return Objects.requireNonNull(this.transitRepository.getSiteRepository().getAreaStop(id));
   }
 
   @Override
@@ -240,7 +240,7 @@ public class DefaultTransitService implements TransitEditorService {
         return realtimeAddedRoute;
       }
     }
-    return timetableRepositoryIndex.getRouteForId(id);
+    return transitRepositoryIndex.getRouteForId(id);
   }
 
   @Override
@@ -258,11 +258,11 @@ public class DefaultTransitService implements TransitEditorService {
   public Set<Route> findRoutes(StopLocation stop) {
     OTPRequestTimeoutException.checkForTimeout();
     Collection<Route> flexRoutes = List.of();
-    var flexIndex = timetableRepositoryIndex.getFlexIndex();
+    var flexIndex = transitRepositoryIndex.getFlexIndex();
     if (flexIndex != null) {
       flexRoutes = flexIndex.findRoutes(stop);
     }
-    var fixedRoutes = timetableRepositoryIndex.getRoutesForStop(stop);
+    var fixedRoutes = transitRepositoryIndex.getRoutesForStop(stop);
 
     return SetUtils.combine(flexRoutes, fixedRoutes);
   }
@@ -270,35 +270,35 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public Collection<TripPattern> findPatterns(StopLocation stop) {
     OTPRequestTimeoutException.checkForTimeout();
-    return this.timetableRepositoryIndex.getPatternsForStop(stop);
+    return this.transitRepositoryIndex.getPatternsForStop(stop);
   }
 
   @Override
   public Collection<Operator> listOperators() {
     OTPRequestTimeoutException.checkForTimeout();
-    return this.timetableRepository.getOperators();
+    return this.transitRepository.getOperators();
   }
 
   @Override
   public Operator getOperator(FeedScopedId id) {
-    return this.timetableRepositoryIndex.getOperatorForId(id);
+    return this.transitRepositoryIndex.getOperatorForId(id);
   }
 
   @Override
   public Collection<StopLocation> listStopLocations() {
     OTPRequestTimeoutException.checkForTimeout();
-    return timetableRepository.getSiteRepository().listStopLocations();
+    return transitRepository.getSiteRepository().listStopLocations();
   }
 
   @Override
   public Collection<GroupStop> listGroupStops() {
     OTPRequestTimeoutException.checkForTimeout();
-    return timetableRepository.getSiteRepository().listGroupStops();
+    return transitRepository.getSiteRepository().listGroupStops();
   }
 
   @Override
   public StopLocation getStopLocation(FeedScopedId id) {
-    return timetableRepository.getSiteRepository().getStopLocation(id);
+    return transitRepository.getSiteRepository().getStopLocation(id);
   }
 
   @Override
@@ -309,18 +309,18 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public Collection<StopLocation> findStopOrChildStops(FeedScopedId id) {
-    return timetableRepository.getSiteRepository().findStopOrChildStops(id);
+    return transitRepository.getSiteRepository().findStopOrChildStops(id);
   }
 
   @Override
   public Collection<StopLocationsGroup> listStopLocationGroups() {
     OTPRequestTimeoutException.checkForTimeout();
-    return timetableRepository.getSiteRepository().listStopLocationGroups();
+    return transitRepository.getSiteRepository().listStopLocationGroups();
   }
 
   @Override
   public StopLocationsGroup getStopLocationsGroup(FeedScopedId id) {
-    return timetableRepository.getSiteRepository().getStopLocationsGroup(id);
+    return transitRepository.getSiteRepository().getStopLocationsGroup(id);
   }
 
   @Override
@@ -337,7 +337,7 @@ public class DefaultTransitService implements TransitEditorService {
   @Nullable
   @Override
   public Trip getScheduledTrip(FeedScopedId id) {
-    return this.timetableRepositoryIndex.getTripForId(id);
+    return this.transitRepositoryIndex.getTripForId(id);
   }
 
   /**
@@ -371,11 +371,11 @@ public class DefaultTransitService implements TransitEditorService {
     OTPRequestTimeoutException.checkForTimeout();
     if (timetableSnapshot != null) {
       return new CollectionsView<>(
-        timetableRepositoryIndex.getAllTrips(),
+        transitRepositoryIndex.getAllTrips(),
         timetableSnapshot.listRealTimeAddedTrips()
       );
     }
-    return Collections.unmodifiableCollection(timetableRepositoryIndex.getAllTrips());
+    return Collections.unmodifiableCollection(transitRepositoryIndex.getAllTrips());
   }
 
   @Override
@@ -383,11 +383,11 @@ public class DefaultTransitService implements TransitEditorService {
     OTPRequestTimeoutException.checkForTimeout();
     if (timetableSnapshot != null) {
       return new CollectionsView<>(
-        timetableRepositoryIndex.getAllRoutes(),
+        transitRepositoryIndex.getAllRoutes(),
         timetableSnapshot.listRealTimeAddedRoutes()
       );
     }
-    return timetableRepositoryIndex.getAllRoutes();
+    return transitRepositoryIndex.getAllRoutes();
   }
 
   @Override
@@ -398,7 +398,7 @@ public class DefaultTransitService implements TransitEditorService {
         return realtimeAddedTripPattern;
       }
     }
-    return this.timetableRepositoryIndex.getPatternForTrip(trip);
+    return this.transitRepositoryIndex.getPatternForTrip(trip);
   }
 
   @Override
@@ -414,7 +414,7 @@ public class DefaultTransitService implements TransitEditorService {
   public Collection<TripPattern> findPatterns(Route route) {
     OTPRequestTimeoutException.checkForTimeout();
     Collection<TripPattern> tripPatterns = new HashSet<>(
-      timetableRepositoryIndex.getPatternsForRoute(route)
+      transitRepositoryIndex.getPatternsForRoute(route)
     );
     if (timetableSnapshot != null) {
       Collection<TripPattern> realTimeAddedPatternForRoute =
@@ -426,7 +426,7 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public MultiModalStation findMultiModalStation(Station station) {
-    return this.timetableRepository.getSiteRepository().getMultiModalStationForStation(station);
+    return this.transitRepository.getSiteRepository().getMultiModalStationForStation(station);
   }
 
   @Override
@@ -499,7 +499,7 @@ public class DefaultTransitService implements TransitEditorService {
    * Returns all the patterns for a specific stop. If includeRealtimeUpdates is set, new patterns
    * added by realtime updates are added to the collection.
    * A set is used here because trip patterns
-   * that were updated by realtime data is both part of the TimetableRepositoryIndex and the TimetableSnapshot
+   * that were updated by realtime data is both part of the TransitRepositoryIndex and the TimetableSnapshot
    */
   @Override
   public Collection<TripPattern> findPatterns(StopLocation stop, boolean includeRealtimeUpdates) {
@@ -516,18 +516,18 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public Collection<GroupOfRoutes> listGroupsOfRoutes() {
     OTPRequestTimeoutException.checkForTimeout();
-    return timetableRepositoryIndex.getAllGroupOfRoutes();
+    return transitRepositoryIndex.getAllGroupOfRoutes();
   }
 
   @Override
   public Collection<Route> findRoutes(GroupOfRoutes groupOfRoutes) {
     OTPRequestTimeoutException.checkForTimeout();
-    return timetableRepositoryIndex.getRoutesForGroupOfRoutes(groupOfRoutes);
+    return transitRepositoryIndex.getRoutesForGroupOfRoutes(groupOfRoutes);
   }
 
   @Override
   public GroupOfRoutes getGroupOfRoutes(FeedScopedId id) {
-    return timetableRepositoryIndex.getGroupOfRoutesForId(id);
+    return transitRepositoryIndex.getGroupOfRoutesForId(id);
   }
 
   /**
@@ -569,18 +569,18 @@ public class DefaultTransitService implements TransitEditorService {
         return tripOnServiceDate;
       }
     }
-    return timetableRepository.getTripOnServiceDateById(id);
+    return transitRepository.getTripOnServiceDateById(id);
   }
 
   @Override
   public Collection<TripOnServiceDate> listTripsOnServiceDate() {
     if (timetableSnapshot != null) {
       return new CollectionsView<>(
-        timetableRepository.getAllTripsOnServiceDates(),
+        transitRepository.getAllTripsOnServiceDates(),
         timetableSnapshot.listRealTimeAddedTripOnServiceDate()
       );
     }
-    return timetableRepository.getAllTripsOnServiceDates();
+    return transitRepository.getAllTripsOnServiceDates();
   }
 
   @Override
@@ -592,7 +592,7 @@ public class DefaultTransitService implements TransitEditorService {
         return tripOnServiceDate;
       }
     }
-    return timetableRepositoryIndex.getTripOnServiceDateForTripAndDay(tripIdAndServiceDate);
+    return transitRepositoryIndex.getTripOnServiceDateForTripAndDay(tripIdAndServiceDate);
   }
 
   /**
@@ -618,12 +618,12 @@ public class DefaultTransitService implements TransitEditorService {
         return true;
       }
     }
-    return this.timetableRepositoryIndex.containsTrip(id);
+    return this.transitRepositoryIndex.containsTrip(id);
   }
 
   @Override
   public Optional<RegularStop> findStopByScheduledStopPoint(FeedScopedId scheduledStopPoint) {
-    return timetableRepository.findStopByScheduledStopPoint(scheduledStopPoint);
+    return transitRepository.findStopByScheduledStopPoint(scheduledStopPoint);
   }
 
   /**
@@ -648,13 +648,13 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   @Nullable
   public FeedScopedId getOrCreateServiceIdForDate(LocalDate serviceDate) {
-    return timetableRepository.getOrCreateServiceIdForDate(serviceDate);
+    return transitRepository.getOrCreateServiceIdForDate(serviceDate);
   }
 
   @Override
   public RaptorTransitData getRaptorTransitData() {
     OTPRequestTimeoutException.checkForTimeout();
-    return this.timetableRepository.getRaptorTransitData();
+    return this.transitRepository.getRaptorTransitData();
   }
 
   @Override
@@ -665,38 +665,38 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public TripCalendars getTripCalendars() {
-    return this.timetableRepository.getTripCalendar();
+    return this.transitRepository.getTripCalendar();
   }
 
   @Override
   public ZoneId getTimeZone() {
-    return this.timetableRepository.getTimeZone();
+    return this.transitRepository.getTimeZone();
   }
 
   @Override
   public TransitAlertService getTransitAlertService() {
-    return this.timetableRepository.getTransitAlertService();
+    return this.transitRepository.getTransitAlertService();
   }
 
   @Override
   public FlexIndex getFlexIndex() {
-    return this.timetableRepositoryIndex.getFlexIndex();
+    return this.transitRepositoryIndex.getFlexIndex();
   }
 
   @Override
   public Instant getTransitServiceEnds() {
-    return timetableRepository.getTransitServiceEnds();
+    return transitRepository.getTransitServiceEnds();
   }
 
   @Override
   public Instant getTransitServiceStarts() {
-    return timetableRepository.getTransitServiceStarts();
+    return transitRepository.getTransitServiceStarts();
   }
 
   @Override
   public Collection<RegularStop> findRegularStopsByBoundingBox(Envelope envelope) {
     OTPRequestTimeoutException.checkForTimeout();
-    return timetableRepository.getSiteRepository().findRegularStops(envelope);
+    return transitRepository.getSiteRepository().findRegularStops(envelope);
   }
 
   @Override
@@ -704,7 +704,7 @@ public class DefaultTransitService implements TransitEditorService {
     FindRegularStopsByBoundingBoxRequest request
   ) {
     OTPRequestTimeoutException.checkForTimeout();
-    Collection<RegularStop> stops = timetableRepository
+    Collection<RegularStop> stops = transitRepository
       .getSiteRepository()
       .findRegularStops(request.envelope());
 
@@ -717,12 +717,12 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public Collection<AreaStop> findAreaStops(Envelope envelope) {
     OTPRequestTimeoutException.checkForTimeout();
-    return timetableRepository.getSiteRepository().findAreaStops(envelope);
+    return transitRepository.getSiteRepository().findAreaStops(envelope);
   }
 
   @Override
   public GraphUpdaterStatus getUpdaterStatus() {
-    return timetableRepository.getUpdaterManager();
+    return transitRepository.getUpdaterManager();
   }
 
   @Override
@@ -739,29 +739,27 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public Set<LocalDate> listServiceDates() {
-    return Collections.unmodifiableSet(
-      timetableRepository.getServiceCodesRunningForDate().keySet()
-    );
+    return Collections.unmodifiableSet(transitRepository.getServiceCodesRunningForDate().keySet());
   }
 
   @Override
   public Map<LocalDate, TIntSet> getServiceCodesRunningForDate() {
-    return Collections.unmodifiableMap(timetableRepository.getServiceCodesRunningForDate());
+    return Collections.unmodifiableMap(transitRepository.getServiceCodesRunningForDate());
   }
 
   @Override
   public ConstrainedTransferService getConstrainedTransferService() {
-    return timetableRepository.getConstrainedTransferService();
+    return transitRepository.getConstrainedTransferService();
   }
 
   @Override
   public boolean transitFeedCovers(Instant dateTime) {
-    return timetableRepository.transitFeedCovers(dateTime);
+    return transitRepository.transitFeedCovers(dateTime);
   }
 
   @Override
   public boolean hasScheduledServicesAfter(LocalDate date, StopLocation stop) {
-    return timetableRepositoryIndex.hasScheduledServicesAfter(date, stop);
+    return transitRepositoryIndex.hasScheduledServicesAfter(date, stop);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/service/ReplacementHelper.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/ReplacementHelper.java
@@ -10,7 +10,7 @@ import org.opentripplanner.transit.model.network.ReplacementForRelation;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 
 /**
  * <p>Encapsulates the part of Transit Service which deals with Route/Trip/TripOnServiceDate
@@ -35,12 +35,12 @@ public class ReplacementHelper {
   private final TransitRepository transitRepository;
 
   @Nullable
-  private final ReadOnlyTimetableSnapshot timetableSnapshot;
+  private final TimetableRepositorySnapshot timetableSnapshot;
 
   public ReplacementHelper(
     TransitService transitService,
     TransitRepository transitRepository,
-    @Nullable ReadOnlyTimetableSnapshot timetableSnapshot
+    @Nullable TimetableRepositorySnapshot timetableSnapshot
   ) {
     this.transitService = transitService;
     this.transitRepository = transitRepository;

--- a/application/src/main/java/org/opentripplanner/transit/service/ReplacementHelper.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/ReplacementHelper.java
@@ -32,24 +32,24 @@ public class ReplacementHelper {
   );
 
   private final TransitService transitService;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   @Nullable
   private final ReadOnlyTimetableSnapshot timetableSnapshot;
 
   public ReplacementHelper(
     TransitService transitService,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable ReadOnlyTimetableSnapshot timetableSnapshot
   ) {
     this.transitService = transitService;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.timetableSnapshot = timetableSnapshot;
   }
 
   public Collection<ReplacedByRelation> getReplacedBy(TripOnServiceDate tripOnServiceDate) {
     var id = tripOnServiceDate.getId();
-    var replacedBy = timetableRepository.getReplacedByTripOnServiceDate(id);
+    var replacedBy = transitRepository.getReplacedByTripOnServiceDate(id);
     Stream<TripOnServiceDate> tripsOnServiceDate;
     if (timetableSnapshot != null) {
       tripsOnServiceDate = Stream.concat(
@@ -96,7 +96,7 @@ public class ReplacementHelper {
   private boolean hasReplacedByTripOnServiceDates(TripOnServiceDate tripOnServiceDate) {
     var id = tripOnServiceDate.getId();
     return (
-      !timetableRepository.getReplacedByTripOnServiceDate(id).isEmpty() ||
+      !transitRepository.getReplacedByTripOnServiceDate(id).isEmpty() ||
       (timetableSnapshot != null &&
         timetableSnapshot.getRealTimeReplacedByTripOnServiceDate(id).isEmpty())
     );

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitRepository.java
@@ -58,28 +58,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The TimetableRepository groups together all instances making up OTP's primary internal representation
+ * The TransitRepository groups together all instances making up OTP's primary internal representation
  * of the public transportation network. Although the names of many entities are derived from
  * GTFS concepts, these are actually independent of the data source from which they are loaded.
  * Both GTFS and NeTEx entities are mapped to these same internal OTP entities. If a concept exists
  * in both GTFS and NeTEx, the GTFS name is used in the internal model. For concepts that exist
  * only in NeTEx, the NeTEx name is used in the internal model.
  * <p>
- * A TimetableRepository instance also includes references to some transient indexes of its contents, to
+ * A TransitRepository instance also includes references to some transient indexes of its contents, to
  * the RaptorTransitData derived from it, and to some other services and utilities that operate upon
  * its contents.
  * <p>
- * The TimetableRepository stands in opposition to two other aggregates: the Graph (representing the
- * street network) and the RaptorTransitData (representing many of the same things in the TimetableRepository
+ * The TransitRepository stands in opposition to two other aggregates: the Graph (representing the
+ * street network) and the RaptorTransitData (representing many of the same things in the TransitRepository
  * but rearranged to be more efficient for Raptor routing).
  * <p>
- * At this point the TimetableRepository is not often read directly. Many requests will look at the
- * RaptorTransitData rather than the TimetableRepository it's derived from. Both are often accessed via the
- * TransitService rather than directly reading the fields of TimetableRepository or RaptorTransitData.
+ * At this point the TransitRepository is not often read directly. Many requests will look at the
+ * RaptorTransitData rather than the TransitRepository it's derived from. Both are often accessed via the
+ * TransitService rather than directly reading the fields of TransitRepository or RaptorTransitData.
  */
-public class TimetableRepository implements Serializable {
+public class TransitRepository implements Serializable {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TimetableRepository.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TransitRepository.class);
   private static final PowerOfTwoThrottle FREEZE_LOG_THROTTLE = new PowerOfTwoThrottle();
 
   private final Collection<Agency> agencies = new ArrayList<>();
@@ -94,14 +94,14 @@ public class TimetableRepository implements Serializable {
   private SiteRepository siteRepository;
 
   /**
-   * The RaptorTransitData representation (optimized and rearranged for Raptor) of this TimetableRepository's
+   * The RaptorTransitData representation (optimized and rearranged for Raptor) of this TransitRepository's
    * scheduled (non-realtime) contents.
    */
   private transient RaptorTransitData raptorTransitData;
 
   private final DefaultTripCalendars tripCalendar = new DefaultTripCalendars();
 
-  private transient TimetableRepositoryIndex index;
+  private transient TransitRepositoryIndex index;
   private ZoneId timeZone = null;
   private boolean timeZoneExplicitlySet = false;
 
@@ -127,12 +127,12 @@ public class TimetableRepository implements Serializable {
   private boolean frozen = false;
 
   @Inject
-  public TimetableRepository(SiteRepository siteRepository) {
+  public TransitRepository(SiteRepository siteRepository) {
     this.siteRepository = Objects.requireNonNull(siteRepository);
   }
 
   /** No-argument constructor, required for deserialization. */
-  public TimetableRepository() {
+  public TransitRepository() {
     this(new SiteRepository());
   }
 
@@ -146,7 +146,7 @@ public class TimetableRepository implements Serializable {
     if (index == null) {
       LOG.info("Index timetable repository...");
       this.tripCalendar.initializeServiceCodes();
-      this.index = new TimetableRepositoryIndex(this);
+      this.index = new TransitRepositoryIndex(this);
       LOG.info("Index timetable repository complete.");
     }
   }
@@ -358,7 +358,7 @@ public class TimetableRepository implements Serializable {
 
   /**
    * Returns the alert service. If no updaters are configured an empty instance is returned.
-   * See  {@link TimetableRepository#initUpdaterManager(GraphUpdaterManager)}.
+   * See  {@link TransitRepository#initUpdaterManager(GraphUpdaterManager)}.
    */
   public TransitAlertService getTransitAlertService() {
     if (transitAlertService == null) {
@@ -535,7 +535,7 @@ public class TimetableRepository implements Serializable {
    * possibility that the index is not initialized (during graph build).
    */
   @Nullable
-  TimetableRepositoryIndex getTimetableRepositoryIndex() {
+  TransitRepositoryIndex getTransitRepositoryIndex() {
     return index;
   }
 
@@ -610,7 +610,7 @@ public class TimetableRepository implements Serializable {
         LOG.warn(
           """
           THIS SHOULD NOT HAPPEN
-          Attempting to modify TimetableRepository after it has been frozen.
+          Attempting to modify TransitRepository after it has been frozen.
           Count: {}
           """,
           n,

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitRepository.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitRepository.java
@@ -122,7 +122,7 @@ public class TransitRepository implements Serializable {
   private final Map<FeedScopedId, RegularStop> stopsByScheduledStopPointRefs = new HashMap<>();
 
   /// Updates are not allowed after the repository is frozen. All realtime updates should be
-  /// applied to the TimetableSnapshot. The repository is modifiable during graph build then
+  /// applied to the TimetableRepository. The repository is modifiable during graph build then
   /// frozen when the server is started.
   private boolean frozen = false;
 
@@ -153,7 +153,7 @@ public class TransitRepository implements Serializable {
 
   /**
    * Make the Timetable repository immutable when the otp server is started. After this point,
-   * all modifications should be done to the TimetableSnapshot.
+   * all modifications should be done to the TimetableRepository.
    */
   public void freeze() {
     index();

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitRepositoryIndex.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitRepositoryIndex.java
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
  * For performance reasons these indexes are not part of the serialized state of the graph.
  * They are rebuilt at runtime after graph deserialization.
  */
-class TimetableRepositoryIndex {
+class TransitRepositoryIndex {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TimetableRepositoryIndex.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TransitRepositoryIndex.class);
 
   // TODO: consistently key on model object or id string
   private final Map<FeedScopedId, Agency> agencyForId = new HashMap<>();
@@ -55,18 +55,18 @@ class TimetableRepositoryIndex {
   private final Map<FeedScopedId, GroupOfRoutes> groupOfRoutesForId = new HashMap<>();
   private FlexIndex flexIndex = null;
 
-  TimetableRepositoryIndex(TimetableRepository timetableRepository) {
+  TransitRepositoryIndex(TransitRepository transitRepository) {
     LOG.info("Timetable repository index init...");
 
-    for (Agency agency : timetableRepository.getAgencies()) {
+    for (Agency agency : transitRepository.getAgencies()) {
       this.agencyForId.put(agency.getId(), agency);
     }
 
-    for (Operator operator : timetableRepository.getOperators()) {
+    for (Operator operator : transitRepository.getOperators()) {
       this.operatorForId.put(operator.getId(), operator);
     }
 
-    for (TripPattern pattern : timetableRepository.getAllTripPatterns()) {
+    for (TripPattern pattern : transitRepository.getAllTripPatterns()) {
       patternsForRoute.put(pattern.getRoute(), pattern);
       pattern
         .scheduledTripsAsStream()
@@ -88,7 +88,7 @@ class TimetableRepositoryIndex {
       groupOfRoutesForId.put(groupOfRoutes.getId(), groupOfRoutes);
     }
 
-    for (TripOnServiceDate tripOnServiceDate : timetableRepository.getAllTripsOnServiceDates()) {
+    for (TripOnServiceDate tripOnServiceDate : transitRepository.getAllTripsOnServiceDates()) {
       tripOnServiceDateForTripAndDay.put(
         new TripIdAndServiceDate(
           tripOnServiceDate.getTrip().getId(),
@@ -98,10 +98,10 @@ class TimetableRepositoryIndex {
       );
     }
 
-    initializeServiceData(timetableRepository.getTripCalendar());
+    initializeServiceData(transitRepository.getTripCalendar());
 
     if (OTPFeature.FlexRouting.isOn()) {
-      flexIndex = new FlexIndex(timetableRepository);
+      flexIndex = new FlexIndex(transitRepository);
       for (Route route : flexIndex.getAllFlexRoutes()) {
         routeForId.put(route.getId(), route);
       }

--- a/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -56,12 +56,12 @@ import org.opentripplanner.updater.GraphUpdaterStatus;
  * fetching tables of specific information like the routes passing through a particular stop, or for
  * gaining access to the entirety of the data to perform routing.
  * <p>
- * TODO RT_AB: this interface seems to provide direct access to RaptorTransitData but not TimetableRepository.
- *   Is this intentional, because RaptorTransitData is meant to be read-only and TimetableRepository is not?
+ * TODO RT_AB: this interface seems to provide direct access to RaptorTransitData but not TransitRepository.
+ *   Is this intentional, because RaptorTransitData is meant to be read-only and TransitRepository is not?
  *   Should this be renamed TransitDataService since it seems to provide access to the data but
  *   not to transit routing functionality (which is provided by the RoutingService)?
- *   The DefaultTransitService implementation has a TimetableRepository instance and many of its methods
- *   read through to that TimetableRepository instance. But that field itself is not exposed, while the
+ *   The DefaultTransitService implementation has a TransitRepository instance and many of its methods
+ *   read through to that TransitRepository instance. But that field itself is not exposed, while the
  *   RaptorTransitData is here. It seems like exposing the raw RaptorTransitData is still a risk since it's
  *   copy-on-write and shares a lot of objects with any other RaptorTransitData instances.
  */
@@ -417,7 +417,7 @@ public interface TransitService {
   boolean containsTrip(FeedScopedId id);
 
   /**
-   * @see TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   * @see TransitRepository#findStopByScheduledStopPoint(FeedScopedId)
    */
   Optional<RegularStop> findStopByScheduledStopPoint(FeedScopedId scheduledStopPoint);
 

--- a/application/src/main/java/org/opentripplanner/updater/DefaultRealTimeUpdateContext.java
+++ b/application/src/main/java/org/opentripplanner/updater/DefaultRealTimeUpdateContext.java
@@ -3,7 +3,7 @@ package org.opentripplanner.updater;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.trip.gtfs.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.trip.siri.EntityResolver;
@@ -19,7 +19,7 @@ public class DefaultRealTimeUpdateContext implements RealTimeUpdateContext {
    * all in-progress real-time additions that have not yet been committed to a published snapshot.
    * <p>
    * A {@link MutableTimetableSnapshot} cannot be used directly for these lookups, because every
-   * lookup must also fall back to scheduled data in the {@link TimetableRepository} when an entity
+   * lookup must also fall back to scheduled data in the {@link TransitRepository} when an entity
    * is not found in the real-time snapshot. The {@link DefaultTransitService} combines both: it
    * checks the snapshot first, then falls back to the static index.
    * <p>
@@ -32,19 +32,19 @@ public class DefaultRealTimeUpdateContext implements RealTimeUpdateContext {
    */
   public DefaultRealTimeUpdateContext(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     MutableTimetableSnapshot timetableSnapshotBuffer
   ) {
     this.graph = graph;
     this.timetableSnapshotBuffer = timetableSnapshotBuffer;
-    this.transitService = new DefaultTransitService(timetableRepository, timetableSnapshotBuffer);
+    this.transitService = new DefaultTransitService(transitRepository, timetableSnapshotBuffer);
   }
 
   /**
    * Constructor for unit tests only.
    */
-  public DefaultRealTimeUpdateContext(Graph graph, TimetableRepository timetableRepository) {
-    this(graph, timetableRepository, null);
+  public DefaultRealTimeUpdateContext(Graph graph, TransitRepository transitRepository) {
+    this(graph, transitRepository, null);
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/updater/DefaultRealTimeUpdateContext.java
+++ b/application/src/main/java/org/opentripplanner/updater/DefaultRealTimeUpdateContext.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.updater;
 
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
@@ -11,33 +11,32 @@ import org.opentripplanner.updater.trip.siri.EntityResolver;
 public class DefaultRealTimeUpdateContext implements RealTimeUpdateContext {
 
   private final Graph graph;
-  private final MutableTimetableSnapshot timetableSnapshotBuffer;
+  private final TimetableRepository timetableRepository;
   private final TransitService transitService;
 
   /**
-   * The context needs the mutable snapshot so that entity lookups (trips, routes, patterns) see
+   * The context needs the mutable repository so that entity lookups (trips, routes, patterns) see
    * all in-progress real-time additions that have not yet been committed to a published snapshot.
    * <p>
-   * A {@link MutableTimetableSnapshot} cannot be used directly for these lookups, because every
+   * A {@link TimetableRepository} cannot be used directly for these lookups, because every
    * lookup must also fall back to scheduled data in the {@link TransitRepository} when an entity
-   * is not found in the real-time snapshot. The {@link DefaultTransitService} combines both: it
-   * checks the snapshot first, then falls back to the static index.
+   * is not found in the real-time repository. The {@link DefaultTransitService} combines both: it
+   * checks the repository first, then falls back to the static index.
    * <p>
-   * {@link DefaultTransitService} accepts a {@link org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot},
-   * because in request scope it must never receive a mutable snapshot. The cast here is safe as
-   * long as {@link MutableTimetableSnapshot} and {@link org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot}
-   * share a single implementation — which is enforced by {@link MutableTimetableSnapshot} extending
-   * {@link org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot}. A cleaner separation
+   * {@link DefaultTransitService} accepts a {@link org.opentripplanner.transit.repository.TimetableRepositorySnapshot},
+   * because in request scope it must never receive the mutable repository. Passing the repository
+   * here is safe because {@link TimetableRepository} extends
+   * {@link org.opentripplanner.transit.repository.TimetableRepositorySnapshot}. A cleaner separation
    * would require merging scheduled and real-time data into a single unified store - this is the end goal!
    */
   public DefaultRealTimeUpdateContext(
     Graph graph,
     TransitRepository transitRepository,
-    MutableTimetableSnapshot timetableSnapshotBuffer
+    TimetableRepository timetableRepository
   ) {
     this.graph = graph;
-    this.timetableSnapshotBuffer = timetableSnapshotBuffer;
-    this.transitService = new DefaultTransitService(transitRepository, timetableSnapshotBuffer);
+    this.timetableRepository = timetableRepository;
+    this.transitService = new DefaultTransitService(transitRepository, timetableRepository);
   }
 
   /**
@@ -48,8 +47,8 @@ public class DefaultRealTimeUpdateContext implements RealTimeUpdateContext {
   }
 
   @Override
-  public MutableTimetableSnapshot mutableSnapshot() {
-    return timetableSnapshotBuffer;
+  public TimetableRepository timetableRepository() {
+    return timetableRepository;
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/updater/GraphWriterService.java
+++ b/application/src/main/java/org/opentripplanner/updater/GraphWriterService.java
@@ -6,7 +6,7 @@ import org.opentripplanner.framework.transaction.api.RepositoryHandle;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,25 +28,25 @@ public class GraphWriterService implements WriteToGraphCallback {
     MutableTimetableSnapshot
   > timetableHandle;
   private final Graph graph;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   public GraphWriterService(
     UpdateManager updateManager,
     RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle,
     Graph graph,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     this.updateManager = updateManager;
     this.timetableHandle = timetableHandle;
     this.graph = graph;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
   }
 
   @Override
   public Future<Void> execute(GraphWriterRunnable runnable) {
     return updateManager.submit(ctx -> {
       var mutableSnapshot = ctx.repository(timetableHandle);
-      var context = new DefaultRealTimeUpdateContext(graph, timetableRepository, mutableSnapshot);
+      var context = new DefaultRealTimeUpdateContext(graph, transitRepository, mutableSnapshot);
       try {
         runnable.run(context);
       } catch (Exception e) {

--- a/application/src/main/java/org/opentripplanner/updater/GraphWriterService.java
+++ b/application/src/main/java/org/opentripplanner/updater/GraphWriterService.java
@@ -4,8 +4,8 @@ import java.util.concurrent.Future;
 import org.opentripplanner.framework.transaction.UpdateManager;
 import org.opentripplanner.framework.transaction.api.RepositoryHandle;
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.slf4j.Logger;
@@ -14,7 +14,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Serialises all graph write operations by delegating to {@link UpdateManager}, which owns the
  * single-threaded executor. Each write task receives a freshly-constructed
- * {@link DefaultRealTimeUpdateContext} backed by the mutable timetable snapshot for that task.
+ * {@link DefaultRealTimeUpdateContext} backed by the mutable realtime-timetable repository for
+ * that task.
  * <p>
  * This class will eventually be removed once all updaters submit directly to {@link UpdateManager}.
  */
@@ -23,16 +24,13 @@ public class GraphWriterService implements WriteToGraphCallback {
   private static final Logger LOG = LoggerFactory.getLogger(GraphWriterService.class);
 
   private final UpdateManager updateManager;
-  private final RepositoryHandle<
-    ReadOnlyTimetableSnapshot,
-    MutableTimetableSnapshot
-  > timetableHandle;
+  private final RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle;
   private final Graph graph;
   private final TransitRepository transitRepository;
 
   public GraphWriterService(
     UpdateManager updateManager,
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle,
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle,
     Graph graph,
     TransitRepository transitRepository
   ) {
@@ -45,8 +43,8 @@ public class GraphWriterService implements WriteToGraphCallback {
   @Override
   public Future<Void> execute(GraphWriterRunnable runnable) {
     return updateManager.submit(ctx -> {
-      var mutableSnapshot = ctx.repository(timetableHandle);
-      var context = new DefaultRealTimeUpdateContext(graph, transitRepository, mutableSnapshot);
+      var repository = ctx.repository(timetableHandle);
+      var context = new DefaultRealTimeUpdateContext(graph, transitRepository, repository);
       try {
         runnable.run(context);
       } catch (Exception e) {

--- a/application/src/main/java/org/opentripplanner/updater/RealTimeUpdateContext.java
+++ b/application/src/main/java/org/opentripplanner/updater/RealTimeUpdateContext.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.updater;
 
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.trip.gtfs.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.trip.siri.EntityResolver;
@@ -12,10 +12,10 @@ import org.opentripplanner.updater.trip.siri.EntityResolver;
  */
 public interface RealTimeUpdateContext {
   /**
-   * Return the mutable timetable snapshot (write buffer) for this update task. Callers must only
-   * use this from the single writer thread.
+   * Return the mutable realtime-timetable repository (write buffer) for this update task. Callers
+   * must only use this from the single writer thread.
    */
-  MutableTimetableSnapshot mutableSnapshot();
+  TimetableRepository timetableRepository();
 
   /**
    * Return the street model (graph).

--- a/application/src/main/java/org/opentripplanner/updater/alert/gtfs/GtfsRealtimeAlertsUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/gtfs/GtfsRealtimeAlertsUpdater.java
@@ -8,7 +8,7 @@ import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -31,12 +31,12 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
 
   public GtfsRealtimeAlertsUpdater(
     GtfsRealtimeAlertsUpdaterParameters config,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     super(config);
     this.url = config.url();
     this.headers = HttpHeaders.of().acceptProtobuf().add(config.headers()).build();
-    TransitAlertService transitAlertService = new TransitAlertServiceImpl(timetableRepository);
+    TransitAlertService transitAlertService = new TransitAlertServiceImpl(transitRepository);
 
     this.transitAlertService = transitAlertService;
 

--- a/application/src/main/java/org/opentripplanner/updater/alert/siri/SiriSXUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/siri/SiriSXUpdater.java
@@ -10,7 +10,7 @@ import org.opentripplanner.framework.retry.OtpRetry;
 import org.opentripplanner.framework.retry.OtpRetryBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.TransitAlertProvider;
 import org.opentripplanner.updater.spi.PollingGraphUpdater;
 import org.opentripplanner.updater.spi.PollingGraphUpdaterParameters;
@@ -48,7 +48,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
 
   public SiriSXUpdater(
     Parameters config,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache,
     SiriLoader siriLoader
   ) {
@@ -63,7 +63,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
     //Keeping original requestorRef use as base for updated requestorRef to be used in retries
     this.originalRequestorRef = requestorRef;
     this.blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
-    this.transitAlertService = new TransitAlertServiceImpl(timetableRepository);
+    this.transitAlertService = new TransitAlertServiceImpl(transitRepository);
     this.updateHandler = new SiriAlertsUpdateHandler(
       config.feedId(),
       transitAlertService,
@@ -125,11 +125,11 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
           //   Such runnables should be illustrated in documentation as e.g. a little box labeled
           //   "change trip ABC123 by making stop 53 late by 2 minutes."
           //   Also clarify how this runnable works without even using the supplied
-          //   (graph, timetableRepository) parameters. There are multiple TransitAlertServices and they
+          //   (graph, transitRepository) parameters. There are multiple TransitAlertServices and they
           //   are not versioned along with the Graph, they are attached to updaters.
           //
           // This is submitting a runnable to an executor, but that runnable only writes back to
-          // objects referenced by updateHandler itself, rather than the graph or timetableRepository
+          // objects referenced by updateHandler itself, rather than the graph or transitRepository
           // supplied for writing, and apparently with no versioning. This seems like a
           // misinterpretation of the realtime design.
           // If this is an intentional choice to live-patch a single server-wide instance of an

--- a/application/src/main/java/org/opentripplanner/updater/configure/SiriUpdaterModule.java
+++ b/application/src/main/java/org/opentripplanner/updater/configure/SiriUpdaterModule.java
@@ -2,7 +2,7 @@ package org.opentripplanner.updater.configure;
 
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.siri.SiriSXUpdater;
 import org.opentripplanner.updater.alert.siri.SiriSXUpdaterParameters;
 import org.opentripplanner.updater.alert.siri.lite.SiriLiteHttpLoader;
@@ -36,12 +36,12 @@ public class SiriUpdaterModule {
 
   public static SiriSXUpdater createSiriSXUpdater(
     SiriSXUpdater.Parameters params,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache
   ) {
     return new SiriSXUpdater(
       params,
-      timetableRepository,
+      transitRepository,
       siriFuzzyTripMatcherCache,
       createLoader(params)
     );

--- a/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -24,7 +24,7 @@ import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.openinghours.OpeningHoursCalendarService;
 import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterService;
 import org.opentripplanner.updater.UpdatersParameters;
@@ -56,7 +56,7 @@ public class UpdaterConfigurator {
   private final Graph graph;
   private final DeduplicatorService deduplicator;
   private final VertexLinker linker;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final UpdatersParameters updatersParameters;
   private final RealtimeVehicleRepository realtimeVehicleRepository;
   private final VehicleRentalRepository vehicleRentalRepository;
@@ -86,7 +86,7 @@ public class UpdaterConfigurator {
     RealtimeVehicleRepository realtimeVehicleRepository,
     VehicleRentalRepository vehicleRentalRepository,
     VehicleParkingRepository parkingRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable CarpoolingRepository carpoolingRepository,
     @Nullable CarpoolTripVertexResolver carpoolTripVertexResolver,
     UpdateManager updateManager,
@@ -98,7 +98,7 @@ public class UpdaterConfigurator {
     this.linker = linker;
     this.realtimeVehicleRepository = realtimeVehicleRepository;
     this.vehicleRentalRepository = vehicleRentalRepository;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.updatersParameters = updatersParameters;
     this.parkingRepository = parkingRepository;
     this.updateManager = updateManager;
@@ -114,7 +114,7 @@ public class UpdaterConfigurator {
     RealtimeVehicleRepository realtimeVehicleRepository,
     VehicleRentalRepository vehicleRentalRepository,
     VehicleParkingRepository parkingRepository,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     @Nullable CarpoolingRepository carpoolingRepository,
     @Nullable CarpoolTripVertexResolver carpoolTripVertexResolver,
     UpdateManager updateManager,
@@ -128,7 +128,7 @@ public class UpdaterConfigurator {
       realtimeVehicleRepository,
       vehicleRentalRepository,
       parkingRepository,
-      timetableRepository,
+      transitRepository,
       carpoolingRepository,
       carpoolTripVertexResolver,
       updateManager,
@@ -153,7 +153,7 @@ public class UpdaterConfigurator {
       updateManager,
       timetableRepositoryHandle,
       graph,
-      timetableRepository
+      transitRepository
     );
     var updaterManager = new GraphUpdaterManager(
       graphWriterService,
@@ -169,12 +169,12 @@ public class UpdaterConfigurator {
     }
     // Otherwise add it to the graph
     else {
-      timetableRepository.initUpdaterManager(updaterManager);
+      transitRepository.initUpdaterManager(updaterManager);
     }
   }
 
-  public static void shutdownGraph(TimetableRepository timetableRepository) {
-    GraphUpdaterManager updaterManager = timetableRepository.getUpdaterManager();
+  public static void shutdownGraph(TransitRepository transitRepository) {
+    GraphUpdaterManager updaterManager = transitRepository.getUpdaterManager();
     if (updaterManager != null) {
       updaterManager.stop();
     }
@@ -219,7 +219,7 @@ public class UpdaterConfigurator {
       }
     }
     for (var configItem : updatersParameters.getGtfsRealtimeAlertsUpdaterParameters()) {
-      updaters.add(new GtfsRealtimeAlertsUpdater(configItem, timetableRepository));
+      updaters.add(new GtfsRealtimeAlertsUpdater(configItem, transitRepository));
     }
     for (var configItem : updatersParameters.getPollingStoptimeUpdaterParameters()) {
       updaters.add(new PollingTripUpdater(configItem, provideGtfsAdapter()));
@@ -262,7 +262,7 @@ public class UpdaterConfigurator {
       updaters.add(
         SiriUpdaterModule.createSiriSXUpdater(
           configItem,
-          timetableRepository,
+          transitRepository,
           siriFuzzyTripMatcherCache()
         )
       );
@@ -271,7 +271,7 @@ public class UpdaterConfigurator {
       updaters.add(
         SiriUpdaterModule.createSiriSXUpdater(
           configItem,
-          timetableRepository,
+          transitRepository,
           siriFuzzyTripMatcherCache()
         )
       );
@@ -306,11 +306,7 @@ public class UpdaterConfigurator {
     }
     for (var configItem : updatersParameters.getSiriAzureSXUpdaterParameters()) {
       updaters.add(
-        SiriAzureUpdater.createSXUpdater(
-          configItem,
-          timetableRepository,
-          siriFuzzyTripMatcherCache()
-        )
+        SiriAzureUpdater.createSXUpdater(configItem, transitRepository, siriFuzzyTripMatcherCache())
       );
     }
     for (var configItem : updatersParameters.getMqttSiriETUpdaterParameters()) {
@@ -324,19 +320,19 @@ public class UpdaterConfigurator {
 
   private SiriRealTimeTripUpdateAdapter provideSiriAdapter(boolean fuzzyTripMatching) {
     var cache = fuzzyTripMatching ? siriFuzzyTripMatcherCache() : null;
-    return new SiriRealTimeTripUpdateAdapter(timetableRepository, deduplicator, cache);
+    return new SiriRealTimeTripUpdateAdapter(transitRepository, deduplicator, cache);
   }
 
   private SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache() {
     if (siriFuzzyTripMatcherCache == null) {
-      siriFuzzyTripMatcherCache = new SiriFuzzyTripMatcherCache(timetableRepository);
+      siriFuzzyTripMatcherCache = new SiriFuzzyTripMatcherCache(transitRepository);
     }
     return siriFuzzyTripMatcherCache;
   }
 
   private GtfsRealTimeTripUpdateAdapter provideGtfsAdapter() {
-    return new GtfsRealTimeTripUpdateAdapter(timetableRepository, deduplicator, () ->
-      LocalDate.now(timetableRepository.getTimeZone())
+    return new GtfsRealTimeTripUpdateAdapter(transitRepository, deduplicator, () ->
+      LocalDate.now(transitRepository.getTimeZone())
     );
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -22,8 +22,8 @@ import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.street.model.openinghours.OpeningHoursCalendarService;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterService;
@@ -72,8 +72,8 @@ public class UpdaterConfigurator {
   private final VehicleParkingRepository parkingRepository;
   private final UpdateManager updateManager;
   private final RepositoryHandle<
-    ReadOnlyTimetableSnapshot,
-    MutableTimetableSnapshot
+    TimetableRepositorySnapshot,
+    TimetableRepository
   > timetableRepositoryHandle;
 
   @Nullable
@@ -90,7 +90,7 @@ public class UpdaterConfigurator {
     @Nullable CarpoolingRepository carpoolingRepository,
     @Nullable CarpoolTripVertexResolver carpoolTripVertexResolver,
     UpdateManager updateManager,
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableRepositoryHandle,
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableRepositoryHandle,
     UpdatersParameters updatersParameters
   ) {
     this.graph = graph;
@@ -118,7 +118,7 @@ public class UpdaterConfigurator {
     @Nullable CarpoolingRepository carpoolingRepository,
     @Nullable CarpoolTripVertexResolver carpoolTripVertexResolver,
     UpdateManager updateManager,
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableRepositoryHandle,
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableRepositoryHandle,
     UpdatersParameters updatersParameters
   ) {
     new UpdaterConfigurator(

--- a/application/src/main/java/org/opentripplanner/updater/package.md
+++ b/application/src/main/java/org/opentripplanner/updater/package.md
@@ -156,8 +156,8 @@ modifications until the new buffer is in place, without introducing any further 
 
 Below is a high-level diagram of how the timetable snapshots are used to look up arrival and
 departure times for a particular TripPattern. Each Route is associated with N different TripPatterns
-(essentially, N different unique sequences of stops). The TimetableSnapshot is used to look up a
-Timetable for a given TripPattern. That Timetable provides an unchanging view of both
+(essentially, N different unique sequences of stops). The TimetableRepositorySnapshot is used to
+look up a Timetable for a given TripPattern. That Timetable provides an unchanging view of both
 realtime-updated and original scheduled arrival/departure times for all trips that match the given
 TripPattern. The arrays of arrival and departure times for all these trips are parallel to the array
 of stops for the TripPattern used to look them up. They have the same length, and a given index

--- a/application/src/main/java/org/opentripplanner/updater/trip/TripUpdateApplier.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/TripUpdateApplier.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.updater.trip;
 
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.updater.spi.UpdateSuccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +21,7 @@ public class TripUpdateApplier {
 
   private TripUpdateApplier() {}
 
-  public static UpdateSuccess apply(MutableTimetableSnapshot buffer, RealTimeTripUpdate update) {
+  public static UpdateSuccess apply(TimetableRepository buffer, RealTimeTripUpdate update) {
     var trip = update.updatedTripTimes().getTrip();
     var serviceDate = update.serviceDate();
 

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/CanceledTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/CanceledTripHandler.java
@@ -7,7 +7,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.Trip;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.updater.spi.UpdateSuccess;
@@ -23,9 +23,9 @@ import org.opentripplanner.updater.trip.gtfs.model.TripUpdate;
 class CanceledTripHandler {
 
   private final TransitEditorService transitEditorService;
-  private final MutableTimetableSnapshot buffer;
+  private final TimetableRepository buffer;
 
-  CanceledTripHandler(TransitEditorService transitEditorService, MutableTimetableSnapshot buffer) {
+  CanceledTripHandler(TransitEditorService transitEditorService, TimetableRepository buffer) {
     this.transitEditorService = transitEditorService;
     this.buffer = buffer;
   }

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/DuplicatedTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/DuplicatedTripHandler.java
@@ -10,7 +10,7 @@ import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.updater.spi.UpdateSuccess;
@@ -23,12 +23,12 @@ import org.opentripplanner.updater.trip.gtfs.model.TripUpdate;
 class DuplicatedTripHandler {
 
   private final TransitEditorService transitEditorService;
-  private final MutableTimetableSnapshot buffer;
+  private final TimetableRepository buffer;
   private final DeduplicatorService deduplicator;
 
   DuplicatedTripHandler(
     TransitEditorService transitEditorService,
-    MutableTimetableSnapshot buffer,
+    TimetableRepository buffer,
     DeduplicatorService deduplicator
   ) {
     this.transitEditorService = transitEditorService;

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
@@ -5,8 +5,8 @@ import java.util.function.Supplier;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
 import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.trip.patterncache.TripPatternCache;
 import org.opentripplanner.updater.trip.patterncache.TripPatternIdGenerator;
 
@@ -16,7 +16,7 @@ import org.opentripplanner.updater.trip.patterncache.TripPatternIdGenerator;
  */
 public class GtfsRealTimeTripUpdateAdapter {
 
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final Supplier<LocalDate> localDateNow;
   private final TripPatternCache tripPatternCache;
   private final TripTimesUpdater tripTimesUpdater;
@@ -26,14 +26,14 @@ public class GtfsRealTimeTripUpdateAdapter {
    * Constructor to allow tests to provide their own clock, not using system time.
    */
   public GtfsRealTimeTripUpdateAdapter(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DeduplicatorService deduplicator,
     Supplier<LocalDate> localDateNow
   ) {
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.localDateNow = localDateNow;
     this.tripPatternCache = new TripPatternCache(new TripPatternIdGenerator());
-    this.tripTimesUpdater = new TripTimesUpdater(timetableRepository.getTimeZone(), deduplicator);
+    this.tripTimesUpdater = new TripTimesUpdater(transitRepository.getTimeZone(), deduplicator);
     this.deduplicator = deduplicator;
   }
 
@@ -44,7 +44,7 @@ public class GtfsRealTimeTripUpdateAdapter {
    * additions.
    */
   public GtfsRealTimeUpdateHandler forUpdate(MutableTimetableSnapshot buffer) {
-    var editorService = new DefaultTransitService(timetableRepository, buffer);
+    var editorService = new DefaultTransitService(transitRepository, buffer);
     return new GtfsRealTimeUpdateHandler(
       buffer,
       localDateNow,

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
@@ -3,7 +3,7 @@ package org.opentripplanner.updater.trip.gtfs;
 import java.time.LocalDate;
 import java.util.function.Supplier;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.transit.service.TransitRepository;
@@ -12,7 +12,7 @@ import org.opentripplanner.updater.trip.patterncache.TripPatternIdGenerator;
 
 /**
  * Application-scoped factory for GTFS-RT trip update processing. Holds stable, application-lifetime
- * state and produces a per-task {@link GtfsRealTimeUpdateHandler} via {@link #forUpdate(MutableTimetableSnapshot)}.
+ * state and produces a per-task {@link GtfsRealTimeUpdateHandler} via {@link #forUpdate(TimetableRepository)}.
  */
 public class GtfsRealTimeTripUpdateAdapter {
 
@@ -43,7 +43,7 @@ public class GtfsRealTimeTripUpdateAdapter {
    * the given buffer, so all pattern and trip lookups within the task see in-progress real-time
    * additions.
    */
-  public GtfsRealTimeUpdateHandler forUpdate(MutableTimetableSnapshot buffer) {
+  public GtfsRealTimeUpdateHandler forUpdate(TimetableRepository buffer) {
     var editorService = new DefaultTransitService(transitRepository, buffer);
     return new GtfsRealTimeUpdateHandler(
       buffer,

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeUpdateHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeUpdateHandler.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.framework.DataValidationException;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.ResultLogger;
 import org.opentripplanner.updater.spi.UpdateError;
@@ -29,7 +29,7 @@ import org.opentripplanner.updater.trip.gtfs.model.TripUpdate;
  */
 public class GtfsRealTimeUpdateHandler {
 
-  private final MutableTimetableSnapshot buffer;
+  private final TimetableRepository buffer;
   private final Supplier<LocalDate> localDateNow;
   private final ScheduledTripHandler scheduledTripHandler;
   private final NewTripHandler addedTripHandler;
@@ -37,7 +37,7 @@ public class GtfsRealTimeUpdateHandler {
   private final DuplicatedTripHandler duplicatedTripHandler;
 
   GtfsRealTimeUpdateHandler(
-    MutableTimetableSnapshot buffer,
+    TimetableRepository buffer,
     Supplier<LocalDate> localDateNow,
     ScheduledTripHandler scheduledTripHandler,
     NewTripHandler addedTripHandler,

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/NewTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/NewTripHandler.java
@@ -18,7 +18,7 @@ import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.updater.spi.UpdateSuccess;
@@ -34,13 +34,13 @@ import org.opentripplanner.updater.trip.patterncache.TripPatternCache;
 class NewTripHandler {
 
   private final TransitEditorService transitEditorService;
-  private final MutableTimetableSnapshot buffer;
+  private final TimetableRepository buffer;
   private final TripTimesUpdater tripTimesUpdater;
   private final TripPatternCache tripPatternCache;
 
   NewTripHandler(
     TransitEditorService transitEditorService,
-    MutableTimetableSnapshot buffer,
+    TimetableRepository buffer,
     TripTimesUpdater tripTimesUpdater,
     TripPatternCache tripPatternCache
   ) {

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
@@ -12,7 +12,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.Trip;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.updater.spi.UpdateSuccess;
@@ -30,13 +30,13 @@ import org.opentripplanner.updater.trip.patterncache.TripPatternCache;
 class ScheduledTripHandler {
 
   private final TransitEditorService transitEditorService;
-  private final MutableTimetableSnapshot buffer;
+  private final TimetableRepository buffer;
   private final TripTimesUpdater tripTimesUpdater;
   private final TripPatternCache tripPatternCache;
 
   ScheduledTripHandler(
     TransitEditorService transitEditorService,
-    MutableTimetableSnapshot buffer,
+    TimetableRepository buffer,
     TripTimesUpdater tripTimesUpdater,
     TripPatternCache tripPatternCache
   ) {

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdater.java
@@ -19,9 +19,9 @@ import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimesBuilder;
 import org.opentripplanner.transit.model.timetable.Timetable;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.updater.trip.gtfs.interpolation.BackwardsDelayInterpolator;
@@ -51,7 +51,7 @@ class TripTimesUpdater {
   /**
    * Apply the TripUpdate to the appropriate TripTimes from a Timetable. The existing TripTimes must
    * not be modified directly because they may be shared with the underlying scheduledTimetable, or
-   * other updated Timetables. The {@link TimetableSnapshot} performs the protective copying of this
+   * other updated Timetables. The {@link TimetableRepository} performs the protective copying of this
    * Timetable. It is not done in this update method to avoid repeatedly cloning the same Timetable
    * when several updates are applied to it at once. We assume here that all trips in a timetable
    * are from the same feed, which should always be the case.

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/updater/TripUpdateGraphWriterRunnable.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/updater/TripUpdateGraphWriterRunnable.java
@@ -53,7 +53,7 @@ public class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
   @Override
   public void run(RealTimeUpdateContext context) {
     var result = adapter
-      .forUpdate(context.mutableSnapshot())
+      .forUpdate(context.timetableRepository())
       .applyTripUpdates(
         fuzzyTripMatching ? context.gtfsRealtimeFuzzyTripMatcher() : null,
         forwardsDelayPropagationType,

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
@@ -192,7 +192,7 @@ class AddedTripBuilder {
       }
       route = createRoute(agency);
       isAddedRoute = true;
-      LOG.info("Adding route {} to timetableRepository.", route);
+      LOG.info("Adding route {} to transitRepository.", route);
     }
 
     Trip trip = createTrip(route, calServiceId);

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/EntityResolver.java
@@ -112,7 +112,7 @@ public class EntityResolver {
   /**
    * Resolve a {@link RegularStop} from a scheduled stop point or quay id.
    *
-   * @see org.opentripplanner.transit.service.TimetableRepository#findStopByScheduledStopPoint(FeedScopedId)
+   * @see org.opentripplanner.transit.service.TransitRepository#findStopByScheduledStopPoint(FeedScopedId)
    */
   RegularStop resolveQuay(String stopPointRef) {
     var id = resolveId(stopPointRef);

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCache.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCache.java
@@ -9,7 +9,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +25,8 @@ public class SiriFuzzyTripMatcherCache {
   final Map<String, Set<Trip>> internalPlanningCodeCache = new HashMap<>();
   final Map<String, Set<Trip>> startStopTripCache = new HashMap<>();
 
-  public SiriFuzzyTripMatcherCache(TimetableRepository timetableRepository) {
-    initCache(new DefaultTransitService(timetableRepository, null));
+  public SiriFuzzyTripMatcherCache(TransitRepository transitRepository) {
+    initCache(new DefaultTransitService(transitRepository, null));
   }
 
   private void initCache(TransitService index) {

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -4,7 +4,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
 import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.trip.patterncache.TripPatternCache;
 import org.opentripplanner.updater.trip.patterncache.TripPatternIdGenerator;
 
@@ -27,18 +27,18 @@ public class SiriRealTimeTripUpdateAdapter {
   private final TripPatternCache tripPatternCache;
 
   private final DeduplicatorService deduplicator;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   @Nullable
   private final SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache;
 
   public SiriRealTimeTripUpdateAdapter(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     DeduplicatorService deduplicator,
     @Nullable SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache
   ) {
     this.deduplicator = deduplicator;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.siriFuzzyTripMatcherCache = siriFuzzyTripMatcherCache;
     this.tripPatternCache = new TripPatternCache(tripPatternIdGenerator);
   }
@@ -49,7 +49,7 @@ public class SiriRealTimeTripUpdateAdapter {
    * buffer, so all pattern and trip lookups within the task see in-progress real-time additions.
    */
   public SiriRealTimeUpdateHandler forUpdate(MutableTimetableSnapshot buffer) {
-    var transitService = new DefaultTransitService(timetableRepository, buffer);
+    var transitService = new DefaultTransitService(transitRepository, buffer);
     var fuzzyTripMatcher = siriFuzzyTripMatcherCache != null
       ? new SiriFuzzyTripMatcher(siriFuzzyTripMatcherCache, transitService)
       : null;

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeTripUpdateAdapter.java
@@ -2,7 +2,7 @@ package org.opentripplanner.updater.trip.siri;
 
 import javax.annotation.Nullable;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.trip.patterncache.TripPatternCache;
@@ -11,7 +11,7 @@ import org.opentripplanner.updater.trip.patterncache.TripPatternIdGenerator;
 /**
  * Application-scoped factory for SIRI-ET estimated timetable processing. Holds stable,
  * application-lifetime state and produces a per-task {@link SiriRealTimeUpdateHandler} via
- * {@link #forUpdate(MutableTimetableSnapshot)}.
+ * {@link #forUpdate(TimetableRepository)}.
  */
 public class SiriRealTimeTripUpdateAdapter {
 
@@ -48,7 +48,7 @@ public class SiriRealTimeTripUpdateAdapter {
    * {@link org.opentripplanner.transit.service.TransitEditorService} constructed from the given
    * buffer, so all pattern and trip lookups within the task see in-progress real-time additions.
    */
-  public SiriRealTimeUpdateHandler forUpdate(MutableTimetableSnapshot buffer) {
+  public SiriRealTimeUpdateHandler forUpdate(TimetableRepository buffer) {
     var transitService = new DefaultTransitService(transitRepository, buffer);
     var fuzzyTripMatcher = siriFuzzyTripMatcherCache != null
       ? new SiriFuzzyTripMatcher(siriFuzzyTripMatcherCache, transitService)

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeUpdateHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeUpdateHandler.java
@@ -18,7 +18,7 @@ import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
+import org.opentripplanner.transit.repository.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.UpdateError;
@@ -45,7 +45,7 @@ public class SiriRealTimeUpdateHandler {
   private static final Logger LOG = LoggerFactory.getLogger(SiriRealTimeUpdateHandler.class);
 
   private final TransitEditorService transitEditorService;
-  private final MutableTimetableSnapshot buffer;
+  private final TimetableRepository buffer;
 
   @Nullable
   private final SiriFuzzyTripMatcher fuzzyTripMatcher;
@@ -56,7 +56,7 @@ public class SiriRealTimeUpdateHandler {
 
   SiriRealTimeUpdateHandler(
     TransitEditorService transitEditorService,
-    MutableTimetableSnapshot buffer,
+    TimetableRepository buffer,
     @Nullable SiriFuzzyTripMatcher fuzzyTripMatcher,
     TripPatternCache tripPatternCache,
     DeduplicatorService deduplicator,

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeUpdateHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeUpdateHandler.java
@@ -316,7 +316,7 @@ public class SiriRealTimeUpdateHandler {
   }
 
   /**
-   * Add a (new) trip to the timetableRepository and the buffer
+   * Add a (new) trip to the transitRepository and the buffer
    */
   private UpdateSuccess addTripToGraphAndBuffer(TripUpdate tripUpdate) {
     Trip trip = tripUpdate.tripTimes().getTrip();

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/updater/EstimatedTimetableHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/updater/EstimatedTimetableHandler.java
@@ -32,7 +32,7 @@ public class EstimatedTimetableHandler {
     RealTimeUpdateContext context
   ) {
     return adapter
-      .forUpdate(context.mutableSnapshot())
+      .forUpdate(context.timetableRepository())
       .applyEstimatedTimetable(
         context.entityResolver(feedId),
         feedId,

--- a/application/src/main/java/org/opentripplanner/warmup/WarmupLauncher.java
+++ b/application/src/main/java/org/opentripplanner/warmup/WarmupLauncher.java
@@ -3,7 +3,7 @@ package org.opentripplanner.warmup;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.warmup.api.WarmupParameters;
 import org.slf4j.Logger;
@@ -25,16 +25,16 @@ public class WarmupLauncher {
   private final WarmupParameters parameters;
 
   private final Supplier<OtpServerRequestContext> serverContextSupplier;
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   public WarmupLauncher(
     @Nullable WarmupParameters parameters,
     Supplier<OtpServerRequestContext> serverContextSupplier,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     this.parameters = parameters;
     this.serverContextSupplier = serverContextSupplier;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
   }
 
   /**
@@ -48,7 +48,7 @@ public class WarmupLauncher {
     if (parameters == null) {
       return;
     }
-    GraphUpdaterManager updaterManager = timetableRepository.getUpdaterManager();
+    GraphUpdaterManager updaterManager = transitRepository.getUpdaterManager();
     if (updaterManager == null) {
       LOG.info("Application warmup configured but no updaters found. Skipping warmup.");
       return;

--- a/application/src/main/java/org/opentripplanner/warmup/configure/WarmupModule.java
+++ b/application/src/main/java/org/opentripplanner/warmup/configure/WarmupModule.java
@@ -6,7 +6,7 @@ import jakarta.inject.Singleton;
 import javax.annotation.Nullable;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.warmup.WarmupLauncher;
 import org.opentripplanner.warmup.api.WarmupParameters;
 
@@ -32,12 +32,12 @@ public class WarmupModule {
   static WarmupLauncher provideWarmupLauncher(
     @Nullable WarmupParameters parameters,
     RequestScopedFactory.Builder requestScopedComponentBuilder,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     return new WarmupLauncher(
       parameters,
       () -> requestScopedComponentBuilder.build().createServerContext(),
-      timetableRepository
+      transitRepository
     );
   }
 }

--- a/application/src/test-fixtures/java/org/opentripplanner/apis/support/graphql/DataFetchingSupport.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/apis/support/graphql/DataFetchingSupport.java
@@ -12,7 +12,7 @@ import graphql.schema.DataFetchingEnvironmentImpl;
 import java.util.Map;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -31,7 +31,7 @@ public class DataFetchingSupport {
     return dataFetchingEnvironment(
       source,
       arguments,
-      new DefaultTransitService(new TimetableRepository())
+      new DefaultTransitService(new TransitRepository())
     );
   }
 

--- a/application/src/test-fixtures/java/org/opentripplanner/ext/fares/model/FareModelForTest.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/ext/fares/model/FareModelForTest.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.ext.fares.model;
 
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.OTHER_FEED_AGENCY;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.OTHER_FEED_AGENCY;
 
 import java.time.ZonedDateTime;
 import org.opentripplanner.core.model.i18n.I18NString;

--- a/application/src/test-fixtures/java/org/opentripplanner/ext/fares/model/FareTestConstants.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/ext/fares/model/FareTestConstants.java
@@ -2,7 +2,7 @@ package org.opentripplanner.ext.fares.model;
 
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.ext.fares.model.FareModelForTest.fareProduct;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.groupOfRoutes;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.groupOfRoutes;
 
 import java.time.LocalTime;
 import org.opentripplanner.core.model.id.FeedScopedId;

--- a/application/src/test-fixtures/java/org/opentripplanner/graph_builder/module/TestStreetLinkerModule.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/graph_builder/module/TestStreetLinkerModule.java
@@ -5,25 +5,25 @@ import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.service.vehicleparking.VehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class TestStreetLinkerModule {
 
   /** For test only */
-  public static void link(Graph graph, TimetableRepository timetableRepository) {
-    link(graph, new DefaultVehicleParkingRepository(), timetableRepository);
+  public static void link(Graph graph, TransitRepository transitRepository) {
+    link(graph, new DefaultVehicleParkingRepository(), transitRepository);
   }
 
   public static void link(
     Graph graph,
     VehicleParkingRepository parkingRepository,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     new StreetLinkerModule(
       graph,
       VertexLinkerTestFactory.of(graph),
       parkingRepository,
-      timetableRepository,
+      transitRepository,
       DataImportIssueStore.NOOP
     ).buildGraph();
   }

--- a/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
@@ -7,19 +7,19 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.service.streetdetails.internal.DefaultStreetDetailsRepository;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class GtfsModuleTestFactory {
 
   public static GtfsModule forTest(
     List<GtfsBundle> bundles,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     Graph graph,
     LocalDateRange transitPeriodLimit
   ) {
     return new GtfsModule(
       bundles,
-      timetableRepository,
+      transitRepository,
       new DefaultStreetDetailsRepository(),
       graph,
       new Deduplicator(),

--- a/application/src/test-fixtures/java/org/opentripplanner/model/FlexStopTimesFactory.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/model/FlexStopTimesFactory.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.model;
 
 import org.opentripplanner._support.geometry.Polygons;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -10,7 +10,7 @@ import org.opentripplanner.utils.time.TimeUtils;
 
 public class FlexStopTimesFactory {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final StopLocation AREA_STOP = TEST_MODEL.areaStop("area")
     .withGeometry(Polygons.BERLIN)
     .build();
@@ -23,7 +23,7 @@ public class FlexStopTimesFactory {
     REGULAR_STOP_3
   );
 
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("flex").build();
+  private static final Trip TRIP = TransitRepositoryForTest.trip("flex").build();
 
   public static StopTime area(String startTime, String endTime) {
     return area(AREA_STOP, endTime, startTime);

--- a/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLegBuilder.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/model/plan/TestTransitLegBuilder.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
 import org.opentripplanner.transit.model.network.Route;
@@ -74,7 +74,7 @@ public class TestTransitLegBuilder {
   }
 
   public TestTransitLegBuilder withNetwork(FeedScopedId id) {
-    var route = TimetableRepositoryForTest.route(id)
+    var route = TransitRepositoryForTest.route(id)
       .withGroupOfRoutes(List.of(GroupOfRoutes.of(id).build()))
       .build();
     return withRoute(route);

--- a/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
@@ -57,7 +57,7 @@ import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
 import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 
 public class TestServerContext {
@@ -67,13 +67,13 @@ public class TestServerContext {
   /** Create a context for unit testing using default RoutingRequest. */
   public static OtpServerRequestContext createServerContext(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     FareService fareService
   ) {
     return createServerContext(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       fareService,
       null,
@@ -84,7 +84,7 @@ public class TestServerContext {
   /** Create a context for unit testing */
   public static OtpServerRequestContext createServerContext(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     FareService fareService,
     @Nullable RouteRequest request,
@@ -98,20 +98,20 @@ public class TestServerContext {
     if (flexParameters == null) {
       flexParameters = routerConfig.flexParameters();
     }
-    timetableRepository.index();
+    transitRepository.index();
 
     TransitTuningParameters tuningParameters = routerConfig.transitTuningConfig();
     var scheduledRaptorData = RaptorTransitDataMapper.map(
       tuningParameters,
-      timetableRepository,
+      transitRepository,
       transferRepository
     );
-    timetableRepository.initRaptorTransitData(scheduledRaptorData);
+    transitRepository.initRaptorTransitData(scheduledRaptorData);
 
     var registry = TransactionFactory.createRepositoryRegistry();
     var timetableSnapshot = new TimetableSnapshot(
-      new RaptorTransitData(timetableRepository.getRaptorTransitData()),
-      timetableRepository.copyTripCalendarForRealTimeUpdates()
+      new RaptorTransitData(transitRepository.getRaptorTransitData()),
+      transitRepository.copyTripCalendarForRealTimeUpdates()
     );
     RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle =
       registry.registerRepositorySnapshot(
@@ -121,7 +121,7 @@ public class TestServerContext {
 
     return buildContext(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       fareService,
       request,
@@ -138,7 +138,7 @@ public class TestServerContext {
    */
   public static OtpServerRequestContext createServerContext(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     FareService fareService,
     RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle,
@@ -155,7 +155,7 @@ public class TestServerContext {
     }
     return buildContext(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       fareService,
       request,
@@ -168,7 +168,7 @@ public class TestServerContext {
 
   private static OtpServerRequestContext buildContext(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     FareService fareService,
     RouteRequest request,
@@ -179,7 +179,7 @@ public class TestServerContext {
   ) {
     var transactionScope = registry.scope();
     var transitService = new DefaultTransitService(
-      timetableRepository,
+      transitRepository,
       timetableHandle.repositorySnapshot(transactionScope)
     );
 
@@ -292,7 +292,7 @@ public class TestServerContext {
   public static OtpServerRequestContext ofGraph(Graph graph) {
     return createServerContext(
       graph,
-      new TimetableRepository(),
+      new TransitRepository(),
       new DefaultTransferRepository(new TransferIndex()),
       new DefaultFareService()
     );

--- a/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
@@ -52,10 +52,10 @@ import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
 import org.opentripplanner.transfer.regular.internal.DefaultTransferRepository;
 import org.opentripplanner.transfer.regular.internal.TransferIndex;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositoryLifecycle;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
@@ -109,14 +109,14 @@ public class TestServerContext {
     transitRepository.initRaptorTransitData(scheduledRaptorData);
 
     var registry = TransactionFactory.createRepositoryRegistry();
-    var timetableSnapshot = new TimetableSnapshot(
+    var timetableSnapshot = new DefaultTimetableRepository(
       new RaptorTransitData(transitRepository.getRaptorTransitData()),
       transitRepository.copyTripCalendarForRealTimeUpdates()
     );
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle =
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle =
       registry.registerRepositorySnapshot(
         timetableSnapshot,
-        new TimetableSnapshotLifecycle(timetableSnapshot, false, LocalDate::now)
+        new TimetableRepositoryLifecycle(timetableSnapshot, false, LocalDate::now)
       );
 
     return buildContext(
@@ -141,7 +141,7 @@ public class TestServerContext {
     TransitRepository transitRepository,
     TransferRepository transferRepository,
     FareService fareService,
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle,
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle,
     org.opentripplanner.framework.transaction.RepositoryRegistry registry,
     @Nullable RouteRequest request,
     @Nullable FlexParameters flexParameters
@@ -175,7 +175,7 @@ public class TestServerContext {
     FlexParameters flexParameters,
     RouterConfig routerConfig,
     org.opentripplanner.framework.transaction.RepositoryRegistry registry,
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle
   ) {
     var transactionScope = registry.scope();
     var transitService = new DefaultTransitService(

--- a/application/src/test-fixtures/java/org/opentripplanner/street/search/state/TestStateBuilder.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/street/search/state/TestStateBuilder.java
@@ -33,7 +33,7 @@ import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.request.StreetSearchRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 /**
@@ -41,7 +41,7 @@ import org.opentripplanner.transit.model.site.RegularStop;
  */
 public class TestStateBuilder {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   private static final Instant DEFAULT_START_TIME = OffsetDateTime.parse(
     "2023-04-18T12:00:00+02:00"

--- a/application/src/test-fixtures/java/org/opentripplanner/transfer/constrained/TransferTestData.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/transfer/constrained/TransferTestData.java
@@ -6,7 +6,7 @@ import org.opentripplanner.transfer.constrained.model.StationTransferPoint;
 import org.opentripplanner.transfer.constrained.model.StopTransferPoint;
 import org.opentripplanner.transfer.constrained.model.TransferPoint;
 import org.opentripplanner.transfer.constrained.model.TripTransferPoint;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -14,7 +14,7 @@ import org.opentripplanner.transit.model.timetable.Trip;
 
 public class TransferTestData {
 
-  private static TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   public static final Station STATION = TEST_MODEL.station("Central Station").build();
 
@@ -36,20 +36,14 @@ public class TransferTestData {
     .build();
   public static final RegularStop ANY_STOP = TEST_MODEL.stop("any", 60.0, 11.0).build();
 
-  public static final Route ROUTE_1 = TimetableRepositoryForTest.route("1").build();
-  public static final Route ROUTE_2 = TimetableRepositoryForTest.route("2").build();
-  public static final Route ANY_ROUTE = TimetableRepositoryForTest.route("ANY").build();
+  public static final Route ROUTE_1 = TransitRepositoryForTest.route("1").build();
+  public static final Route ROUTE_2 = TransitRepositoryForTest.route("2").build();
+  public static final Route ANY_ROUTE = TransitRepositoryForTest.route("ANY").build();
 
-  public static final Trip TRIP_11 = TimetableRepositoryForTest.trip("11")
-    .withRoute(ROUTE_1)
-    .build();
-  public static final Trip TRIP_12 = TimetableRepositoryForTest.trip("12")
-    .withRoute(ROUTE_1)
-    .build();
-  public static final Trip TRIP_21 = TimetableRepositoryForTest.trip("21")
-    .withRoute(ROUTE_2)
-    .build();
-  public static final Trip ANY_TRIP = TimetableRepositoryForTest.trip("999")
+  public static final Trip TRIP_11 = TransitRepositoryForTest.trip("11").withRoute(ROUTE_1).build();
+  public static final Trip TRIP_12 = TransitRepositoryForTest.trip("12").withRoute(ROUTE_1).build();
+  public static final Trip TRIP_21 = TransitRepositoryForTest.trip("21").withRoute(ROUTE_2).build();
+  public static final Trip ANY_TRIP = TransitRepositoryForTest.trip("999")
     .withRoute(ANY_ROUTE)
     .build();
 

--- a/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitRepositoryTestBuilder.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitRepositoryTestBuilder.java
@@ -31,12 +31,12 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * A builder for timetable repository to simplify setting up timetable entities for tests
  */
-public class TimetableRepositoryTestBuilder {
+public class TransitRepositoryTestBuilder {
 
   private final List<Agency> agencies = new ArrayList<>();
   private final List<Operator> operators = new ArrayList<>();
@@ -55,7 +55,7 @@ public class TimetableRepositoryTestBuilder {
   private final Agency defaultAgency;
   private final Route defaultRoute;
 
-  TimetableRepositoryTestBuilder(ZoneId timeZone, LocalDate defaultServiceDate) {
+  TransitRepositoryTestBuilder(ZoneId timeZone, LocalDate defaultServiceDate) {
     this.timeZone = timeZone;
     this.defaultServiceDate = defaultServiceDate;
 
@@ -63,53 +63,53 @@ public class TimetableRepositoryTestBuilder {
     defaultRoute = route("Route1");
   }
 
-  public TimetableRepository build(SiteRepository siteRepository) {
-    var timetableRepository = new TimetableRepository(siteRepository);
-    timetableRepository.initTimeZone(timeZone);
+  public TransitRepository build(SiteRepository siteRepository) {
+    var transitRepository = new TransitRepository(siteRepository);
+    transitRepository.initTimeZone(timeZone);
 
     for (var agency : agencies) {
-      timetableRepository.addAgency(agency);
+      transitRepository.addAgency(agency);
     }
 
-    timetableRepository.addOperators(operators);
+    transitRepository.addOperators(operators);
 
     for (TripPattern tripPattern : tripPatterns.values()) {
-      timetableRepository.addTripPattern(tripPattern.getId(), tripPattern);
+      transitRepository.addTripPattern(tripPattern.getId(), tripPattern);
     }
 
     for (var flexTrip : flexTrips) {
-      timetableRepository.addFlexTrip(flexTrip.getId(), flexTrip);
+      transitRepository.addFlexTrip(flexTrip.getId(), flexTrip);
     }
 
     for (TripOnServiceDate tripOnServiceDate : tripOnServiceDates) {
-      timetableRepository.addTripOnServiceDate(tripOnServiceDate);
+      transitRepository.addTripOnServiceDate(tripOnServiceDate);
     }
 
     var calendarServiceData = new CalendarServiceData();
     int serviceCodeCounter = 0;
     for (var serviceCode : serviceCodes.values()) {
       calendarServiceData.putServiceDatesForServiceId(serviceCode.id(), serviceCode.serviceDates());
-      timetableRepository.getServiceCodes().put(serviceCode.id(), serviceCodeCounter);
+      transitRepository.getServiceCodes().put(serviceCode.id(), serviceCodeCounter);
       serviceCodeCounter += 1;
     }
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.updateCalendarServiceData(calendarServiceData);
 
-    timetableRepository
+    transitRepository
       .getAllTripPatterns()
       .forEach(pattern -> {
-        pattern.getScheduledTimetable().setServiceCodes(timetableRepository.getServiceCodes());
+        pattern.getScheduledTimetable().setServiceCodes(transitRepository.getServiceCodes());
       });
 
-    timetableRepository
+    transitRepository
       .getAllTripPatterns()
       .forEach(pattern -> {
-        pattern.getScheduledTimetable().setServiceCodes(timetableRepository.getServiceCodes());
+        pattern.getScheduledTimetable().setServiceCodes(transitRepository.getServiceCodes());
       });
 
-    timetableRepository.addScheduledStopPointMapping(scheduledStopPointMapping);
+    transitRepository.addScheduledStopPointMapping(scheduledStopPointMapping);
 
-    timetableRepository.index();
-    return timetableRepository;
+    transitRepository.index();
+    return transitRepository;
   }
 
   public Agency agency(String id) {
@@ -219,7 +219,7 @@ public class TimetableRepositoryTestBuilder {
     return trip;
   }
 
-  public TimetableRepositoryTestBuilder addScheduledStopPointMapping(
+  public TransitRepositoryTestBuilder addScheduledStopPointMapping(
     FeedScopedId scheduledStopPointId,
     RegularStop stop
   ) {

--- a/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironment.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironment.java
@@ -18,10 +18,10 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.Rapto
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transit.model.network.grouppriority.TransitGroupPriorityService;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositoryLifecycle;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
@@ -37,10 +37,7 @@ public final class TransitTestEnvironment {
 
   private final TransitRepository transitRepository;
   private final RepositoryRegistry repositoryRegistry;
-  private final RepositoryHandle<
-    ReadOnlyTimetableSnapshot,
-    MutableTimetableSnapshot
-  > timetableHandle;
+  private final RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle;
   private final UpdateManager updateManager;
   private final LocalDate defaultServiceDate;
 
@@ -73,13 +70,13 @@ public final class TransitTestEnvironment {
     this.transitRepository.initRaptorTransitData(scheduledRaptorData);
 
     this.repositoryRegistry = TransactionFactory.createRepositoryRegistry();
-    var timetableSnapshot = new TimetableSnapshot(
+    var timetableSnapshot = new DefaultTimetableRepository(
       new RaptorTransitData(transitRepository.getRaptorTransitData()),
       transitRepository.copyTripCalendarForRealTimeUpdates()
     );
     this.timetableHandle = repositoryRegistry.registerRepositorySnapshot(
       timetableSnapshot,
-      new TimetableSnapshotLifecycle(timetableSnapshot, false, () -> defaultServiceDate)
+      new TimetableRepositoryLifecycle(timetableSnapshot, false, () -> defaultServiceDate)
     );
     var threadFactory = new ThreadFactoryBuilder().setNameFormat("test-commit").build();
     // Use atomic commits (commit immediately after each task) so test assertions see results right away
@@ -120,7 +117,7 @@ public final class TransitTestEnvironment {
     return transitRepository;
   }
 
-  public RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle() {
+  public RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle() {
     return timetableHandle;
   }
 
@@ -128,7 +125,7 @@ public final class TransitTestEnvironment {
     return updateManager;
   }
 
-  public ReadOnlyTimetableSnapshot timetableSnapshot() {
+  public TimetableRepositorySnapshot timetableSnapshot() {
     return timetableHandle.repositorySnapshot(repositoryRegistry.scope());
   }
 

--- a/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironment.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironment.java
@@ -23,19 +23,19 @@ import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
 import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
 /**
  * A helper class for setting up and interacting with transit data for tests.
  * <p>
- * The builder is used to create a SiteRepository and a TimetableRepository that can then be queried
+ * The builder is used to create a SiteRepository and a TransitRepository that can then be queried
  * by a TransitService.
  */
 public final class TransitTestEnvironment {
 
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
   private final RepositoryRegistry repositoryRegistry;
   private final RepositoryHandle<
     ReadOnlyTimetableSnapshot,
@@ -57,25 +57,25 @@ public final class TransitTestEnvironment {
   }
 
   TransitTestEnvironment(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository,
     LocalDate defaultServiceDate
   ) {
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
     this.defaultServiceDate = defaultServiceDate;
 
-    this.timetableRepository.index();
+    this.transitRepository.index();
     var scheduledRaptorData = RaptorTransitDataMapper.map(
       new TestTransitTuningParameters(),
-      timetableRepository,
+      transitRepository,
       transferRepository
     );
-    this.timetableRepository.initRaptorTransitData(scheduledRaptorData);
+    this.transitRepository.initRaptorTransitData(scheduledRaptorData);
 
     this.repositoryRegistry = TransactionFactory.createRepositoryRegistry();
     var timetableSnapshot = new TimetableSnapshot(
-      new RaptorTransitData(timetableRepository.getRaptorTransitData()),
-      timetableRepository.copyTripCalendarForRealTimeUpdates()
+      new RaptorTransitData(transitRepository.getRaptorTransitData()),
+      transitRepository.copyTripCalendarForRealTimeUpdates()
     );
     this.timetableHandle = repositoryRegistry.registerRepositorySnapshot(
       timetableSnapshot,
@@ -102,22 +102,22 @@ public final class TransitTestEnvironment {
    * Get the timezone of the timetable repository
    */
   public ZoneId timeZone() {
-    return timetableRepository.getTimeZone();
+    return transitRepository.getTimeZone();
   }
 
   /**
    * Returns a new fresh TransitService backed by the current snapshot.
    */
   public TransitService transitService() {
-    return new DefaultTransitService(timetableRepository, timetableSnapshot());
+    return new DefaultTransitService(transitRepository, timetableSnapshot());
   }
 
   public String feedId() {
     return FeedScopedIdForTestFactory.FEED_ID;
   }
 
-  public TimetableRepository timetableRepository() {
-    return timetableRepository;
+  public TransitRepository transitRepository() {
+    return transitRepository;
   }
 
   public RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle() {
@@ -137,7 +137,7 @@ public final class TransitTestEnvironment {
    * TransitService timezone.
    */
   public LocalTimeParser localTimeParser() {
-    return new LocalTimeParser(timetableRepository.getTimeZone(), defaultServiceDate);
+    return new LocalTimeParser(transitRepository.getTimeZone(), defaultServiceDate);
   }
 
   /**
@@ -174,10 +174,10 @@ public final class TransitTestEnvironment {
   public RaptorRoutingRequestTransitData raptorRoutingRequestTransitData(LocalDate serviceDate) {
     var transitSearchTimeZero = ServiceDateUtils.asStartOfService(
       serviceDate,
-      timetableRepository.getTimeZone()
+      transitRepository.getTimeZone()
     );
     return new RaptorRoutingRequestTransitData(
-      timetableRepository.getRaptorTransitData(),
+      transitRepository.getRaptorTransitData(),
       TransitGroupPriorityService.empty(),
       transitSearchTimeZero,
       0,

--- a/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironmentBuilder.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironmentBuilder.java
@@ -21,7 +21,7 @@ import org.opentripplanner.transit.service.SiteRepository;
 public class TransitTestEnvironmentBuilder {
 
   private final SiteRepositoryTestBuilder site;
-  private final TimetableRepositoryTestBuilder timetable;
+  private final TransitRepositoryTestBuilder timetable;
 
   private final LocalDate defaultServiceDate;
 
@@ -29,14 +29,14 @@ public class TransitTestEnvironmentBuilder {
     this.defaultServiceDate = defaultServiceDate;
 
     site = new SiteRepositoryTestBuilder(SiteRepository.of());
-    timetable = new TimetableRepositoryTestBuilder(timeZone, defaultServiceDate);
+    timetable = new TransitRepositoryTestBuilder(timeZone, defaultServiceDate);
   }
 
   public TransitTestEnvironment build() {
     var siteRepository = site.build();
-    var timetableRepository = timetable.build(siteRepository);
+    var transitRepository = timetable.build(siteRepository);
     return new TransitTestEnvironment(
-      timetableRepository,
+      transitRepository,
       TransferServiceTestFactory.defaultTransferRepository(),
       defaultServiceDate
     );
@@ -85,7 +85,7 @@ public class TransitTestEnvironmentBuilder {
 
   /* TIMETABLE ENTITIES */
 
-  public TimetableRepositoryTestBuilder timetable() {
+  public TransitRepositoryTestBuilder timetable() {
     return timetable;
   }
 

--- a/application/src/test-fixtures/java/org/opentripplanner/updater/trip/gtfs/GtfsRtTestHelper.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/updater/trip/gtfs/GtfsRtTestHelper.java
@@ -21,7 +21,7 @@ public class GtfsRtTestHelper {
   GtfsRtTestHelper(TransitTestEnvironment transitTestEnvironment) {
     this.transitTestEnvironment = transitTestEnvironment;
     this.gtfsAdapter = new GtfsRealTimeTripUpdateAdapter(
-      transitTestEnvironment.timetableRepository(),
+      transitTestEnvironment.transitRepository(),
       DeduplicatorService.NOOP,
       transitTestEnvironment::defaultServiceDate
     );

--- a/application/src/test-fixtures/java/org/opentripplanner/updater/trip/siri/SiriTestHelper.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/updater/trip/siri/SiriTestHelper.java
@@ -18,7 +18,7 @@ public class SiriTestHelper {
 
   SiriTestHelper(TransitTestEnvironment transitTestEnvironment) {
     this.transitTestEnvironment = transitTestEnvironment;
-    var repo = transitTestEnvironment.timetableRepository();
+    var repo = transitTestEnvironment.transitRepository();
     this.siriAdapter = new SiriRealTimeTripUpdateAdapter(repo, DeduplicatorService.NOOP, null);
     var cache = new SiriFuzzyTripMatcherCache(repo);
     this.siriAdapterWithFuzzyMatching = new SiriRealTimeTripUpdateAdapter(
@@ -63,7 +63,7 @@ public class SiriTestHelper {
           var buffer = ctx.repository(transitTestEnvironment.timetableHandle());
           var feedId = transitTestEnvironment.feedId();
           var transitService = new DefaultTransitService(
-            transitTestEnvironment.timetableRepository(),
+            transitTestEnvironment.transitRepository(),
             buffer
           );
           resultRef.set(

--- a/application/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/application/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -54,7 +54,7 @@ import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.time.DurationUtils;
 
 public class ConstantsForTests {
@@ -146,7 +146,7 @@ public class ConstantsForTests {
   public static TestOtpModel buildNewPortlandGraph(boolean withElevation) {
     try {
       var graph = new Graph();
-      var timetableRepository = new TimetableRepository(new SiteRepository());
+      var transitRepository = new TransitRepository(new SiteRepository());
       var fareFactory = new GtfsFareServiceFactory();
       // Add street data from OSM
       {
@@ -160,10 +160,10 @@ public class ConstantsForTests {
       }
       // Add transit data from GTFS
       {
-        addGtfsToGraph(graph, timetableRepository, PORTLAND_GTFS, fareFactory, "prt");
+        addGtfsToGraph(graph, transitRepository, PORTLAND_GTFS, fareFactory, "prt");
       }
       // Link transit stops to streets
-      TestStreetLinkerModule.link(graph, timetableRepository);
+      TestStreetLinkerModule.link(graph, transitRepository);
 
       // Add elevation data
       if (withElevation) {
@@ -181,7 +181,7 @@ public class ConstantsForTests {
       var transferRepository = TransferServiceTestFactory.defaultTransferRepository();
       new DirectTransferGenerator(
         graph,
-        timetableRepository,
+        transitRepository,
         transferRepository,
         DataImportIssueStore.NOOP,
         Duration.ofMinutes(30),
@@ -190,7 +190,7 @@ public class ConstantsForTests {
 
       graph.index();
 
-      return new TestOtpModel(graph, timetableRepository, transferRepository, fareFactory);
+      return new TestOtpModel(graph, transitRepository, transferRepository, fareFactory);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -200,7 +200,7 @@ public class ConstantsForTests {
     try {
       var siteRepository = new SiteRepository();
       var graph = new Graph();
-      var timetableRepository = new TimetableRepository(siteRepository);
+      var transitRepository = new TransitRepository(siteRepository);
       // Add street data from OSM
       var osmProvider = new DefaultOsmProvider(osmFile, true);
       var osmInfoRepository = new DefaultOsmInfoGraphBuildRepository();
@@ -226,7 +226,7 @@ public class ConstantsForTests {
       } else {
         transferRepository = TransferServiceTestFactory.defaultTransferRepository();
       }
-      return new TestOtpModel(graph, timetableRepository, transferRepository);
+      return new TestOtpModel(graph, transitRepository, transferRepository);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -237,14 +237,14 @@ public class ConstantsForTests {
 
     addGtfsToGraph(
       otpModel.graph(),
-      otpModel.timetableRepository(),
+      otpModel.transitRepository(),
       gtfsPath,
       new GtfsFareServiceFactory(),
       null
     );
 
     // Link transit stops to streets
-    TestStreetLinkerModule.link(otpModel.graph(), otpModel.timetableRepository());
+    TestStreetLinkerModule.link(otpModel.graph(), otpModel.transitRepository());
 
     return otpModel;
   }
@@ -256,10 +256,10 @@ public class ConstantsForTests {
   public static TestOtpModel buildGtfsGraph(File gtfsFile, FareServiceFactory fareServiceFactory) {
     var siteRepository = new SiteRepository();
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(siteRepository);
+    var transitRepository = new TransitRepository(siteRepository);
     var transferRepository = TransferServiceTestFactory.defaultTransferRepository();
-    addGtfsToGraph(graph, timetableRepository, gtfsFile, fareServiceFactory, null);
-    return new TestOtpModel(graph, timetableRepository, transferRepository, fareServiceFactory);
+    addGtfsToGraph(graph, transitRepository, gtfsFile, fareServiceFactory, null);
+    return new TestOtpModel(graph, transitRepository, transferRepository, fareServiceFactory);
   }
 
   public static TestOtpModel buildNewMinimalNetexGraph() {
@@ -268,7 +268,7 @@ public class ConstantsForTests {
       var siteRepository = new SiteRepository();
       var parkingRepository = new DefaultVehicleParkingRepository();
       var graph = new Graph();
-      var timetableRepository = new TimetableRepository(siteRepository);
+      var transitRepository = new TransitRepository(siteRepository);
       var streetDetailsRepository = new DefaultStreetDetailsRepository();
       // Add street data from OSM
       {
@@ -294,7 +294,7 @@ public class ConstantsForTests {
         new NetexConfigure(buildConfig)
           .createNetexModule(
             sources,
-            timetableRepository,
+            transitRepository,
             parkingRepository,
             streetDetailsRepository,
             graph,
@@ -304,11 +304,11 @@ public class ConstantsForTests {
           .buildGraph();
       }
       // Link transit stops to streets
-      TestStreetLinkerModule.link(graph, timetableRepository);
+      TestStreetLinkerModule.link(graph, transitRepository);
 
       return new TestOtpModel(
         graph,
-        timetableRepository,
+        transitRepository,
         TransferServiceTestFactory.defaultTransferRepository()
       );
     } catch (Exception e) {
@@ -318,7 +318,7 @@ public class ConstantsForTests {
 
   public static void addGtfsToGraph(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     File file,
     FareServiceFactory fareServiceFactory,
     @Nullable String feedId
@@ -327,7 +327,7 @@ public class ConstantsForTests {
 
     var module = new GtfsModule(
       List.of(bundle),
-      timetableRepository,
+      transitRepository,
       new DefaultStreetDetailsRepository(),
       graph,
       new Deduplicator(),
@@ -340,7 +340,7 @@ public class ConstantsForTests {
 
     module.buildGraph();
 
-    timetableRepository.index();
+    transitRepository.index();
     graph.index();
   }
 

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -223,13 +223,13 @@ public abstract class GtfsTest {
     transitRepository.initRaptorTransitData(scheduledRaptorData);
     var registry =
       org.opentripplanner.framework.transaction.internal.TransactionFactory.createRepositoryRegistry();
-    var timetableSnapshot = new org.opentripplanner.transit.model.timetable.TimetableSnapshot(
+    var timetableSnapshot = new org.opentripplanner.transit.repository.DefaultTimetableRepository(
       new RaptorTransitData(scheduledRaptorData),
       transitRepository.copyTripCalendarForRealTimeUpdates()
     );
     var timetableHandle = registry.registerRepositorySnapshot(
       timetableSnapshot,
-      new org.opentripplanner.transit.repository.TimetableSnapshotLifecycle(
+      new org.opentripplanner.transit.repository.TimetableRepositoryLifecycle(
         timetableSnapshot,
         false,
         LocalDate::now

--- a/application/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/application/src/test/java/org/opentripplanner/GtfsTest.java
@@ -48,7 +48,7 @@ import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterService;
 import org.opentripplanner.updater.alert.gtfs.AlertsUpdateHandler;
@@ -64,7 +64,7 @@ public abstract class GtfsTest {
   protected static final String FEED_ID = "FEED";
 
   public Graph graph;
-  public TimetableRepository timetableRepository;
+  public TransitRepository transitRepository;
 
   AlertsUpdateHandler alertsUpdateHandler;
   GtfsRealTimeTripUpdateAdapter tripUpdateAdapter;
@@ -197,35 +197,35 @@ public abstract class GtfsTest {
 
     alertsUpdateHandler = new AlertsUpdateHandler(false);
     graph = new Graph();
-    timetableRepository = new TimetableRepository(new SiteRepository());
-    timetableRepository.initUpdaterManager(
+    transitRepository = new TransitRepository(new SiteRepository());
+    transitRepository.initUpdaterManager(
       new GraphUpdaterManager(GraphWriterService.NOOP, RunnableUtils.NOOP, List.of())
     );
     TransferRepository transferRepository = TransferServiceTestFactory.defaultTransferRepository();
 
     GtfsModule gtfsGraphBuilderImpl = GtfsModule.forTest(
       gtfsBundleList,
-      timetableRepository,
+      transitRepository,
       graph,
       LocalDateRange.ofUnbounded()
     );
 
     gtfsGraphBuilderImpl.buildGraph();
-    timetableRepository.index();
+    transitRepository.index();
     graph.index();
 
     TransitTuningParameters tuningParameters = RouterConfig.DEFAULT.transitTuningConfig();
     var scheduledRaptorData = RaptorTransitDataMapper.map(
       tuningParameters,
-      timetableRepository,
+      transitRepository,
       transferRepository
     );
-    timetableRepository.initRaptorTransitData(scheduledRaptorData);
+    transitRepository.initRaptorTransitData(scheduledRaptorData);
     var registry =
       org.opentripplanner.framework.transaction.internal.TransactionFactory.createRepositoryRegistry();
     var timetableSnapshot = new org.opentripplanner.transit.model.timetable.TimetableSnapshot(
       new RaptorTransitData(scheduledRaptorData),
-      timetableRepository.copyTripCalendarForRealTimeUpdates()
+      transitRepository.copyTripCalendarForRealTimeUpdates()
     );
     var timetableHandle = registry.registerRepositorySnapshot(
       timetableSnapshot,
@@ -243,11 +243,11 @@ public abstract class GtfsTest {
       );
 
     tripUpdateAdapter = new GtfsRealTimeTripUpdateAdapter(
-      timetableRepository,
+      transitRepository,
       new Deduplicator(),
       LocalDate::now
     );
-    alertPatchServiceImpl = new TransitAlertServiceImpl(timetableRepository);
+    alertPatchServiceImpl = new TransitAlertServiceImpl(transitRepository);
     alertsUpdateHandler.setTransitAlertService(alertPatchServiceImpl);
     alertsUpdateHandler.setFeedId(FEED_ID);
 
@@ -280,7 +280,7 @@ public abstract class GtfsTest {
     }
     serverContext = TestServerContext.createServerContext(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       new DefaultFareService(),
       timetableHandle,

--- a/application/src/test/java/org/opentripplanner/TestOtpModel.java
+++ b/application/src/test/java/org/opentripplanner/TestOtpModel.java
@@ -4,24 +4,24 @@ import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public record TestOtpModel(
   Graph graph,
-  TimetableRepository timetableRepository,
+  TransitRepository transitRepository,
   TransferRepository transferRepository,
   FareServiceFactory fareServiceFactory
 ) {
   public TestOtpModel(
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository
   ) {
-    this(graph, timetableRepository, transferRepository, new GtfsFareServiceFactory());
+    this(graph, transitRepository, transferRepository, new GtfsFareServiceFactory());
   }
 
   public TestOtpModel index() {
-    timetableRepository.index();
+    transitRepository.index();
     transferRepository.index();
     graph.index();
     return this;

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -118,10 +118,10 @@ import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.transit.service.TransitRepository;
@@ -303,7 +303,7 @@ class GraphQLIntegrationTest {
     transitRepository.updateCalendarServiceData(calendarServiceData);
     transitRepository.index();
 
-    TimetableSnapshot timetableSnapshot = new TimetableSnapshot(
+    DefaultTimetableRepository timetableSnapshot = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -103,7 +103,7 @@ import org.opentripplanner.street.model.edge.ElevatorBoardEdge;
 import org.opentripplanner.street.search.state.TestStateBuilder;
 import org.opentripplanner.test.support.FilePatternSource;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
@@ -123,13 +123,13 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.collection.ListUtils;
 
 class GraphQLIntegrationTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final Station OMEGA = TEST_MODEL.station("Omega").build();
   private static final Place A = TEST_MODEL.place("A", 5.0, 8.0);
@@ -148,10 +148,10 @@ class GraphQLIntegrationTest {
   private static final List<RegularStop> STOP_LOCATIONS = Stream.of(A, B, C, D, E, F, G, H)
     .map(p -> (RegularStop) p.stop)
     .toList();
-  private static final Route ROUTE = TimetableRepositoryForTest.route("a-route").build();
+  private static final Route ROUTE = TransitRepositoryForTest.route("a-route").build();
   private static final String ADDED_TRIP_ID = "ADDED_TRIP";
   private static final String REPLACEMENT_TRIP_ID = "REPLACEMENT_TRIP";
-  public static final String FEED_ID = TimetableRepositoryForTest.FEED_ID;
+  public static final String FEED_ID = TransitRepositoryForTest.FEED_ID;
 
   private static final VehicleRentalStation VEHICLE_RENTAL_STATION =
     new TestVehicleRentalStationBuilder()
@@ -189,7 +189,7 @@ class GraphQLIntegrationTest {
   private static final VehicleParkingRepository PARKING_REPOSITORY =
     new DefaultVehicleParkingRepository();
   private static final NearbyPlaceFinder PLACE_FINDER = (_, _, _, _, _, _, _, _, _, _, _, _) -> {
-    var stop = TimetableRepositoryForTest.of().stop("A").build();
+    var stop = TransitRepositoryForTest.of().stop("A").build();
     return List.of(
       new PlaceAtDistance(stop, 0),
       new PlaceAtDistance(VEHICLE_RENTAL_STATION, 30),
@@ -214,16 +214,16 @@ class GraphQLIntegrationTest {
     STOP_LOCATIONS.forEach(siteRepositoryBuilder::withRegularStop);
     siteRepositoryBuilder.withStation(OMEGA);
     var siteRepository = siteRepositoryBuilder.build();
-    var timetableRepository = new TimetableRepository(siteRepository);
+    var transitRepository = new TransitRepository(siteRepository);
 
     var cal_id = FeedScopedIdForTestFactory.id("CAL_1");
-    var trip = TimetableRepositoryForTest.trip("123")
+    var trip = TransitRepositoryForTest.trip("123")
       .withHeadsign(I18NString.of("Trip Headsign"))
       .withServiceId(cal_id)
       .build();
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, "11:00");
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, DEDUPLICATOR);
-    var trip2 = TimetableRepositoryForTest.trip("321Canceled")
+    var trip2 = TransitRepositoryForTest.trip("321Canceled")
       .withHeadsign(I18NString.of("Trip Headsign"))
       .withServiceId(cal_id)
       .build();
@@ -234,7 +234,7 @@ class GraphQLIntegrationTest {
     // wrong, because currently there is no way to represent a BUS replacing a BUS in GTFS
     // data so that the replacement link exists, or is even implied by some attribute. We
     // still include the test in the hope that one day it becomes possible.
-    var tripToBeReplaced = TimetableRepositoryForTest.trip(REPLACEMENT_TRIP_ID)
+    var tripToBeReplaced = TransitRepositoryForTest.trip(REPLACEMENT_TRIP_ID)
       .withServiceId(cal_id)
       .build();
     final TripPattern pattern = TEST_MODEL.pattern(BUS)
@@ -252,11 +252,11 @@ class GraphQLIntegrationTest {
       )
       .build();
 
-    timetableRepository.addTripPattern(id("pattern-1"), pattern);
+    transitRepository.addTripPattern(id("pattern-1"), pattern);
 
     // A trip whose visit at stop B is canceled (skipped), while it still calls at stops A and D.
     // Stop B is part of the stops query, so its canceledCalls field returns this skipped call.
-    var canceledTrip = TimetableRepositoryForTest.trip("CanceledTrip")
+    var canceledTrip = TransitRepositoryForTest.trip("CanceledTrip")
       .withHeadsign(I18NString.of("Trip Headsign"))
       .withServiceId(cal_id)
       .build();
@@ -270,26 +270,26 @@ class GraphQLIntegrationTest {
       canceledStopTimes,
       DEDUPLICATOR
     ).withServiceCode(SERVICE_CODE);
-    final TripPattern canceledPattern = TimetableRepositoryForTest.tripPattern(
+    final TripPattern canceledPattern = TransitRepositoryForTest.tripPattern(
       "canceled-pattern",
-      TimetableRepositoryForTest.route("canceled-route").withMode(BUS).build()
+      TransitRepositoryForTest.route("canceled-route").withMode(BUS).build()
     )
-      .withStopPattern(TimetableRepositoryForTest.stopPattern(A.stop, B.stop, D.stop))
+      .withStopPattern(TransitRepositoryForTest.stopPattern(A.stop, B.stop, D.stop))
       .withScheduledTimeTableBuilder(builder -> builder.addTripTimes(canceledTripTimes))
       .build();
-    timetableRepository.addTripPattern(id("canceled-pattern"), canceledPattern);
+    transitRepository.addTripPattern(id("canceled-pattern"), canceledPattern);
 
     var feedInfo = FeedInfoTestFactory.dummyForTest(FEED_ID);
-    timetableRepository.addFeedInfo(feedInfo);
+    transitRepository.addFeedInfo(feedInfo);
 
     var agency = Agency.of(new FeedScopedId(FEED_ID, "agency-xx"))
       .withName("speedtransit")
       .withUrl("www.otp-foo.bar")
       .withTimezone("Europe/Berlin")
       .build();
-    timetableRepository.addAgency(agency);
+    transitRepository.addAgency(agency);
 
-    timetableRepository.initTimeZone(BERLIN);
+    transitRepository.initTimeZone(BERLIN);
 
     // Crate a calendar (needed for testing cancelled trips)
     CalendarServiceData calendarServiceData = new CalendarServiceData();
@@ -299,9 +299,9 @@ class GraphQLIntegrationTest {
       cal_id,
       List.of(firstDate, secondDate, SERVICE_DATE)
     );
-    timetableRepository.getServiceCodes().put(cal_id, SERVICE_CODE);
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
-    timetableRepository.index();
+    transitRepository.getServiceCodes().put(cal_id, SERVICE_CODE);
+    transitRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.index();
 
     TimetableSnapshot timetableSnapshot = new TimetableSnapshot(
       RaptorTransitDataTestFactory.empty(),
@@ -326,7 +326,7 @@ class GraphQLIntegrationTest {
       Arrays.stream(TransitMode.values())
         .sorted(Comparator.comparing(Enum::name))
         .map(m ->
-          TimetableRepositoryForTest.route(m.name())
+          TransitRepositoryForTest.route(m.name())
             .withMode(m)
             .withLongName(I18NString.of("Long name for %s".formatted(m)))
             .withGtfsSortOrder(sortOrder(m))
@@ -334,7 +334,7 @@ class GraphQLIntegrationTest {
             .build()
         ),
       Stream.of(
-        TimetableRepositoryForTest.route("replacement")
+        TransitRepositoryForTest.route("replacement")
           .withMode(BUS)
           .withLongName(I18NString.of("Long name for replacement bus"))
           .withGtfsType(714)
@@ -362,7 +362,7 @@ class GraphQLIntegrationTest {
         RealTimeTripUpdate.of(
           TripPattern.of(new FeedScopedId(FEED_ID, "ADDED_TRIP_PATTERN"))
             .withRoute(t.getRoute())
-            .withStopPattern(TimetableRepositoryForTest.stopPattern(A.stop, B.stop, C.stop, D.stop))
+            .withStopPattern(TransitRepositoryForTest.stopPattern(A.stop, B.stop, C.stop, D.stop))
             .withRealTimeStopPatternModified()
             .build(),
           realTimeTripTimes,
@@ -375,9 +375,9 @@ class GraphQLIntegrationTest {
 
     var snapshot = timetableSnapshot.commit();
 
-    TransitEditorService transitService = new DefaultTransitService(timetableRepository, snapshot) {
+    TransitEditorService transitService = new DefaultTransitService(transitRepository, snapshot) {
       private final TransitAlertService alertService = new TransitAlertServiceImpl(
-        timetableRepository
+        transitRepository
       );
 
       @Override

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/LegImplTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
 import org.opentripplanner.model.plan.leg.StopArrival;
 import org.opentripplanner.model.plan.leg.StreetLeg;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.AreaStop;
@@ -30,19 +30,19 @@ import org.opentripplanner.transit.model.timetable.Trip;
 
 class LegImplTest implements PlanTestConstants {
 
-  private static final TimetableRepositoryForTest MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest MODEL = TransitRepositoryForTest.of();
   private static final AreaStop AREA_STOP = MODEL.areaStop("a1").build();
   private static final RegularStop REGULAR_STOP = MODEL.stop("r1", 60.0, 10.0).build();
   private static final GroupStop GROUP_STOP = MODEL.groupStop("g1", REGULAR_STOP);
-  private static final StopPattern STOP_PATTERN = TimetableRepositoryForTest.stopPattern(
+  private static final StopPattern STOP_PATTERN = TransitRepositoryForTest.stopPattern(
     REGULAR_STOP,
     REGULAR_STOP,
     AREA_STOP,
     GROUP_STOP,
     REGULAR_STOP
   );
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("trip1").build();
-  private static final TripPattern PATTERN = TimetableRepositoryForTest.tripPattern(
+  private static final Trip TRIP = TransitRepositoryForTest.trip("trip1").build();
+  private static final TripPattern PATTERN = TransitRepositoryForTest.tripPattern(
     "p",
     TRIP.getRoute()
   )

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
@@ -50,9 +50,9 @@ import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalSe
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class LegacyRouteRequestMapperTest implements PlanTestConstants {
 
@@ -62,13 +62,13 @@ class LegacyRouteRequestMapperTest implements PlanTestConstants {
 
   static {
     Graph graph = new Graph();
-    var testModel = TimetableRepositoryForTest.of();
+    var testModel = TransitRepositoryForTest.of();
     var stopModelBuilder = testModel
       .siteRepositoryBuilder()
       .withRegularStop(testModel.stop("stop1").build());
-    var timetableRepository = new TimetableRepository(stopModelBuilder.build());
-    timetableRepository.initTimeZone(ZoneIds.BERLIN);
-    final DefaultTransitService transitService = new DefaultTransitService(timetableRepository);
+    var transitRepository = new TransitRepository(stopModelBuilder.build());
+    transitRepository.initTimeZone(ZoneIds.BERLIN);
+    final DefaultTransitService transitService = new DefaultTransitService(transitRepository);
     var transferService = TransferServiceTestFactory.defaultTransferService();
     var routeRequest = RouteRequest.defaultValue();
     var vertexLinker = VertexLinkerTestFactory.of(graph);

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
@@ -31,7 +31,7 @@ import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalSe
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class _RouteRequestTestContext {
 
@@ -58,9 +58,9 @@ class _RouteRequestTestContext {
     this.locale = locale;
 
     Graph graph = new Graph();
-    var timetableRepository = new TimetableRepository();
-    timetableRepository.initTimeZone(ZoneIds.BERLIN);
-    final DefaultTransitService transitService = new DefaultTransitService(timetableRepository);
+    var transitRepository = new TransitRepository();
+    transitRepository.initTimeZone(ZoneIds.BERLIN);
+    final DefaultTransitService transitService = new DefaultTransitService(transitRepository);
     var transferService = TransferServiceTestFactory.defaultTransferService();
     var routeRequest = RouteRequest.defaultValue();
     var vertexLinker = VertexLinkerTestFactory.of(graph);

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/support/filter/StopArrivalByTypeFilterTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLStopType;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.leg.StopArrival;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -25,7 +25,7 @@ import org.opentripplanner.transit.model.site.StopLocation;
 
 class StopArrivalByTypeFilterTest {
 
-  public static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  public static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   public static final RegularStop REGULAR = TEST_MODEL.stop("r").build();
   public static final AreaStop AREA = TEST_MODEL.areaStop("a").build();
   public static final GroupStop GROUP = TEST_MODEL.groupStop("g", REGULAR, REGULAR);

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/FixedFeedIdGeneratorTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/FixedFeedIdGeneratorTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.organization.Agency;
 
 class FixedFeedIdGeneratorTest {
@@ -32,7 +32,7 @@ class FixedFeedIdGeneratorTest {
 
   Agency agency(String feedScope, int id) {
     // We use the test builder to make sure we get back an agency with all required fields
-    return TimetableRepositoryForTest.agency("Agency " + id)
+    return TransitRepositoryForTest.agency("Agency " + id)
       .copy()
       .withId(new FeedScopedId(feedScope, Integer.toString(id)))
       .build();

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/TripRequestMapperTest.java
@@ -45,28 +45,28 @@ import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.VehicleRoutingOptimizeType;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class TripRequestMapperTest implements PlanTestConstants {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Duration MAX_FLEXIBLE = Duration.ofMinutes(20);
   private static final Function<StopLocation, String> STOP_TO_ID = s -> s.getId().toString();
 
-  private static final Route ROUTE1 = TimetableRepositoryForTest.route("route1").build();
-  private static final Route ROUTE2 = TimetableRepositoryForTest.route("route2").build();
+  private static final Route ROUTE1 = TransitRepositoryForTest.route("route1").build();
+  private static final Route ROUTE2 = TransitRepositoryForTest.route("route2").build();
 
   private static final RegularStop STOP1 = TEST_MODEL.stop("ST:stop1", 1, 1).build();
   private static final RegularStop STOP2 = TEST_MODEL.stop("ST:stop2", 2, 1).build();
   private static final RegularStop STOP3 = TEST_MODEL.stop("ST:stop3", 3, 1).build();
 
   private static final Graph GRAPH = new Graph();
-  private static final TimetableRepository TIMETABLE_REPOSITORY;
+  private static final TransitRepository TIMETABLE_REPOSITORY;
   private static final TransferRepository TRANSFER_REPOSITORY;
   private static final Map.Entry<String, Object> ARGUMENT_FROM = entry(
     "from",
@@ -93,7 +93,7 @@ public class TripRequestMapperTest implements PlanTestConstants {
       .build();
 
     TRANSFER_REPOSITORY = TransferServiceTestFactory.defaultTransferRepository();
-    TIMETABLE_REPOSITORY = new TimetableRepository(siteRepository);
+    TIMETABLE_REPOSITORY = new TransitRepository(siteRepository);
     TIMETABLE_REPOSITORY.initTimeZone(ZoneIds.STOCKHOLM);
     var calendarServiceData = new CalendarServiceData();
     LocalDate serviceDate = itinerary.startTime().toLocalDate();

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/model/plan/TripPlanTimePenaltyDtoTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/model/plan/TripPlanTimePenaltyDtoTest.java
@@ -10,7 +10,7 @@ import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.model.plan.ItineraryBuilder;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.TestItineraryBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.utils.time.DurationUtils;
 
 class TripPlanTimePenaltyDtoTest {
@@ -20,7 +20,7 @@ class TripPlanTimePenaltyDtoTest {
     Cost.costOfSeconds(21)
   );
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
   private final Place placeA = Place.forStop(testModel.stop("A").build());
   private final Place placeB = Place.forStop(testModel.stop("B").build());
 

--- a/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResourceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResourceTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.standalone.api.TestServerContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.test.support.HttpForTest;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class DebugVectorTilesResourceTest {
 
@@ -32,7 +32,7 @@ class DebugVectorTilesResourceTest {
     var resource = new DebugVectorTilesResource(
       TestServerContext.createServerContext(
         new Graph(),
-        new TimetableRepository(),
+        new TransitRepository(),
         TransferServiceTestFactory.defaultTransferRepository(),
         new NoopFareServiceFactory().makeFareService()
       )

--- a/application/src/test/java/org/opentripplanner/ext/flex/FlexAccessEgressBookingTest.java
+++ b/application/src/test/java/org/opentripplanner/ext/flex/FlexAccessEgressBookingTest.java
@@ -12,13 +12,13 @@ import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.TestStateBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 
 class FlexAccessEgressBookingTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static StopTime stopWithWindowAndPickupBooking(int start, int end, BookingInfo booking) {
     var st = new StopTime();
@@ -44,7 +44,7 @@ class FlexAccessEgressBookingTest {
     int requestedBookingTime
   ) {
     var trip = UnscheduledTrip.of(FeedScopedIdForTestFactory.id("flex"))
-      .withTrip(TimetableRepositoryForTest.trip("t1").build())
+      .withTrip(TransitRepositoryForTest.trip("t1").build())
       .withStopTimes(stopTimes)
       .build();
 

--- a/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/TransactionFrameworkTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/TransactionFrameworkTest.java
@@ -25,13 +25,13 @@ import org.opentripplanner.framework.transaction.moduletest.candyshop.base.Entit
 import org.opentripplanner.framework.transaction.moduletest.candyshop.customer.Customer;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.customer.CustomerRepository;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.customer.CustomerRepositoryLifecycle;
-import org.opentripplanner.framework.transaction.moduletest.candyshop.customer.CustomerSnapshot;
+import org.opentripplanner.framework.transaction.moduletest.candyshop.customer.CustomerRepositorySnapshot;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.event.CustomerEventHandler;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.event.CustomerOrderDomainEvent;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.event.OrderEventHandler;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.order.Order;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.order.OrderRepository;
-import org.opentripplanner.framework.transaction.moduletest.candyshop.order.OrderSnapshot;
+import org.opentripplanner.framework.transaction.moduletest.candyshop.order.OrderRepositorySnapshot;
 
 /**
  * This test demonstrates how the snapshot framework can be used with two repositories. The example
@@ -67,8 +67,8 @@ public class TransactionFrameworkTest {
 
   private RepositoryRegistry registry;
   private UpdateManager updateManager;
-  private RepositoryHandle<CustomerSnapshot, CustomerRepository> customerRepoHandler;
-  private RepositoryHandle<OrderSnapshot, OrderRepository> orderRepoHandler;
+  private RepositoryHandle<CustomerRepositorySnapshot, CustomerRepository> customerRepoHandler;
+  private RepositoryHandle<OrderRepositorySnapshot, OrderRepository> orderRepoHandler;
   private final List<TestEvent> eventLog = new ArrayList<>();
 
   @BeforeEach

--- a/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/customer/CustomerRepository.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/customer/CustomerRepository.java
@@ -14,7 +14,7 @@ public class CustomerRepository extends AbstractRepository<Customer> {
     this(new HashMap<>());
   }
 
-  CustomerSnapshot freeze() {
-    return new CustomerSnapshot(copyOfEntitiesById());
+  CustomerRepositorySnapshot freeze() {
+    return new CustomerRepositorySnapshot(copyOfEntitiesById());
   }
 }

--- a/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/customer/CustomerRepositoryLifecycle.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/customer/CustomerRepositoryLifecycle.java
@@ -9,15 +9,15 @@ import org.opentripplanner.framework.transaction.api.RepositoryLifecycle;
  * follow every task.
  */
 public class CustomerRepositoryLifecycle
-  implements RepositoryLifecycle<CustomerSnapshot, CustomerRepository> {
+  implements RepositoryLifecycle<CustomerRepositorySnapshot, CustomerRepository> {
 
   @Override
-  public CustomerRepository copyOnWrite(CustomerSnapshot snapshot) {
+  public CustomerRepository copyOnWrite(CustomerRepositorySnapshot snapshot) {
     return snapshot.copyOnWrite();
   }
 
   @Override
-  public CustomerSnapshot freeze(CustomerRepository repository) {
+  public CustomerRepositorySnapshot freeze(CustomerRepository repository) {
     return repository.freeze();
   }
 }

--- a/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/customer/CustomerRepositorySnapshot.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/customer/CustomerRepositorySnapshot.java
@@ -4,9 +4,9 @@ import java.util.HashMap;
 import java.util.Map;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.base.AbstractRepository;
 
-public class CustomerSnapshot extends AbstractRepository<Customer> {
+public class CustomerRepositorySnapshot extends AbstractRepository<Customer> {
 
-  CustomerSnapshot(Map<Integer, Customer> aById) {
+  CustomerRepositorySnapshot(Map<Integer, Customer> aById) {
     super(aById);
   }
 

--- a/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/order/OrderRepository.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/order/OrderRepository.java
@@ -13,19 +13,19 @@ import org.opentripplanner.framework.transaction.moduletest.candyshop.base.Abstr
  */
 public class OrderRepository
   extends AbstractRepository<Order>
-  implements RepositoryLifecycle<OrderSnapshot, OrderRepository> {
+  implements RepositoryLifecycle<OrderRepositorySnapshot, OrderRepository> {
 
   public OrderRepository() {
     super(new HashMap<>());
   }
 
   @Override
-  public OrderRepository copyOnWrite(OrderSnapshot readOnlySnapshot) {
+  public OrderRepository copyOnWrite(OrderRepositorySnapshot readOnlySnapshot) {
     return this;
   }
 
   @Override
-  public OrderSnapshot freeze(OrderRepository mutableSnapshot) {
-    return new OrderSnapshot(copyOfEntitiesById());
+  public OrderRepositorySnapshot freeze(OrderRepository repository) {
+    return new OrderRepositorySnapshot(copyOfEntitiesById());
   }
 }

--- a/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/order/OrderRepositorySnapshot.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/candyshop/order/OrderRepositorySnapshot.java
@@ -3,9 +3,9 @@ package org.opentripplanner.framework.transaction.moduletest.candyshop.order;
 import java.util.Map;
 import org.opentripplanner.framework.transaction.moduletest.candyshop.base.AbstractRepository;
 
-public class OrderSnapshot extends AbstractRepository<Order> {
+public class OrderRepositorySnapshot extends AbstractRepository<Order> {
 
-  public OrderSnapshot(Map<Integer, Order> aById) {
+  public OrderRepositorySnapshot(Map<Integer, Order> aById) {
     super(aById);
   }
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
@@ -35,13 +35,13 @@ import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
 import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.test.support.ResourceLoader;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class OsmBoardingLocationsModuleTest {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   static Stream<Arguments> herrenbergTestCases() {
     return Stream.of(
@@ -89,7 +89,7 @@ class OsmBoardingLocationsModuleTest {
       .build();
 
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(siteRepo);
+    var transitRepository = new TransitRepository(siteRepo);
     var factory = new VertexFactory(graph);
 
     var provider = new DefaultOsmProvider(file, false);
@@ -114,7 +114,7 @@ class OsmBoardingLocationsModuleTest {
     var platformVertex = factory.transitStop(ofStop(platform));
     var busVertex = factory.transitStop(ofStop(busStop));
 
-    timetableRepository.index();
+    transitRepository.index();
     graph.index();
 
     assertEquals(0, busVertex.getIncoming().size());
@@ -126,7 +126,7 @@ class OsmBoardingLocationsModuleTest {
     var osmService = new DefaultOsmInfoGraphBuildService(osmInfoRepository);
     new OsmBoardingLocationsModule(
       graph,
-      timetableRepository,
+      transitRepository,
       VertexLinkerTestFactory.of(graph),
       osmService
     ).buildGraph();
@@ -305,7 +305,7 @@ class OsmBoardingLocationsModuleTest {
       .build();
     new OsmBoardingLocationsModule(
       graph,
-      new TimetableRepository(siteRepo),
+      new TransitRepository(siteRepo),
       VertexLinkerTestFactory.of(graph),
       new DefaultOsmInfoGraphBuildService(osmInfoRepository)
     ).buildGraph();
@@ -371,7 +371,7 @@ class OsmBoardingLocationsModuleTest {
       .build();
 
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(siteRepo);
+    var transitRepository = new TransitRepository(siteRepo);
     var factory = new VertexFactory(graph);
 
     var osmInfoRepository = new DefaultOsmInfoGraphBuildRepository();
@@ -388,7 +388,7 @@ class OsmBoardingLocationsModuleTest {
     var platformVertex1 = factory.transitStop(ofStop(platform1));
     var platformVertex2 = factory.transitStop(ofStop(platform2));
 
-    timetableRepository.index();
+    transitRepository.index();
     graph.index();
 
     // Both vertices should start unlinked
@@ -400,7 +400,7 @@ class OsmBoardingLocationsModuleTest {
     var osmService = new DefaultOsmInfoGraphBuildService(osmInfoRepository);
     new OsmBoardingLocationsModule(
       graph,
-      timetableRepository,
+      transitRepository,
       VertexLinkerTestFactory.of(graph),
       osmService
     ).buildGraph();

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/StreetLinkerModuleTest.java
@@ -31,7 +31,7 @@ import org.opentripplanner.street.model.edge.StreetTransitStopLink;
 import org.opentripplanner.street.model.vertex.OsmBoardingLocationVertex;
 import org.opentripplanner.street.model.vertex.SplitterVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.CarAccess;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -41,7 +41,7 @@ import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class StreetLinkerModuleTest {
 
@@ -83,7 +83,7 @@ class StreetLinkerModuleTest {
   void linkFlexStop() {
     OTPFeature.FlexRouting.testOn(() -> {
       var model = new TestModel();
-      var flexTrip = TimetableRepositoryForTest.of().unscheduledTrip(
+      var flexTrip = TransitRepositoryForTest.of().unscheduledTrip(
         "flex",
         model.stop(),
         model.stop()
@@ -116,7 +116,7 @@ class StreetLinkerModuleTest {
   void linkFlexStopWithBoardingLocation() {
     OTPFeature.FlexRouting.testOn(() -> {
       var model = new TestModel().withStopLinkedToBoardingLocation();
-      var flexTrip = TimetableRepositoryForTest.of().unscheduledTrip(
+      var flexTrip = TransitRepositoryForTest.of().unscheduledTrip(
         "flex",
         model.stop(),
         model.stop()
@@ -160,7 +160,7 @@ class StreetLinkerModuleTest {
   @Test
   void linkCarsAllowedStop() {
     var model = new TestModel();
-    var carsAllowedTrip = TimetableRepositoryForTest.of()
+    var carsAllowedTrip = TransitRepositoryForTest.of()
       .trip("carsAllowedTrip")
       .withCarsAllowed(CarAccess.ALLOWED)
       .build();
@@ -192,7 +192,7 @@ class StreetLinkerModuleTest {
     private final TransitStopVertex stopVertex;
     private final StreetLinkerModule module;
     private final RegularStop stop;
-    private final TimetableRepository timetableRepository;
+    private final TransitRepository transitRepository;
     private final Graph graph;
 
     public TestModel() {
@@ -218,7 +218,7 @@ class StreetLinkerModuleTest {
         .build();
       builder.withRegularStop(stop);
 
-      timetableRepository = new TimetableRepository(builder.build());
+      transitRepository = new TransitRepository(builder.build());
 
       stopVertex = TransitStopVertex.of()
         .withId(stop.getId())
@@ -232,7 +232,7 @@ class StreetLinkerModuleTest {
         graph,
         new VertexLinker(graph, GeofencingZoneService.EMPTY, TRAVERSE_AREA_EDGES, 0, false),
         new DefaultVehicleParkingRepository(),
-        timetableRepository,
+        transitRepository,
         DataImportIssueStore.NOOP
       );
 
@@ -258,11 +258,11 @@ class StreetLinkerModuleTest {
     }
 
     public void withFlexTrip(UnscheduledTrip flexTrip) {
-      timetableRepository.addFlexTrip(flexTrip.getId(), flexTrip);
+      transitRepository.addFlexTrip(flexTrip.getId(), flexTrip);
     }
 
     public void withCarsAllowedTrip(Trip trip, StopLocation... stops) {
-      Route route = TimetableRepositoryForTest.route("carsAllowedRoute").build();
+      Route route = TransitRepositoryForTest.route("carsAllowedRoute").build();
       var stopTimes = Arrays.stream(stops)
         .map(s -> {
           var stopTime = new StopTime();
@@ -275,7 +275,7 @@ class StreetLinkerModuleTest {
         .toList();
       StopPattern stopPattern = new StopPattern(stopTimes);
       var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, DeduplicatorService.NOOP);
-      TripPattern tripPattern = TimetableRepositoryForTest.tripPattern(
+      TripPattern tripPattern = TransitRepositoryForTest.tripPattern(
         "carsAllowedTripPattern",
         route
       )
@@ -283,7 +283,7 @@ class StreetLinkerModuleTest {
         .withScheduledTimeTableBuilder(builder -> builder.addTripTimes(tripTimes))
         .build();
 
-      timetableRepository.addTripPattern(tripPattern.getId(), tripPattern);
+      transitRepository.addTripPattern(tripPattern.getId(), tripPattern);
     }
 
     /**

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
@@ -19,12 +19,12 @@ import org.opentripplanner.street.model.edge.VehicleParkingEdge;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
 import org.opentripplanner.streetadapter.VertexFactory;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class VehicleParkingLinkingTest {
 
   private Graph graph;
-  private TimetableRepository timetableRepository;
+  private TransitRepository transitRepository;
   private IntersectionVertex A;
   private IntersectionVertex B;
 
@@ -37,7 +37,7 @@ public class VehicleParkingLinkingTest {
     VehicleParkingTestGraphData graphData = new VehicleParkingTestGraphData();
     graphData.initGraph();
     graph = graphData.getGraph();
-    timetableRepository = graphData.getTimetableRepository();
+    transitRepository = graphData.getTransitRepository();
     A = graphData.getAVertex();
     B = graphData.getBVertex();
     vertexFactory = new VertexFactory(graph);
@@ -53,7 +53,7 @@ public class VehicleParkingLinkingTest {
       .build();
     var parkingVertex = vertexFactory.vehicleParkingEntrance(parking);
 
-    TestStreetLinkerModule.link(graph, timetableRepository);
+    TestStreetLinkerModule.link(graph, transitRepository);
 
     assertEquals(1, parkingVertex.getOutgoing().size());
     parkingVertex.getOutgoing().forEach(e -> assertEquals(e.getToVertex(), A));
@@ -75,7 +75,7 @@ public class VehicleParkingLinkingTest {
       .build();
     var parkingVertex = vertexFactory.vehicleParkingEntrance(parking.getEntrances().get(0));
 
-    TestStreetLinkerModule.link(graph, timetableRepository);
+    TestStreetLinkerModule.link(graph, transitRepository);
 
     var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
     assertEquals(2, streetLinks.size());
@@ -108,7 +108,7 @@ public class VehicleParkingLinkingTest {
       .build();
     var parkingVertex = vertexFactory.vehicleParkingEntrance(parking.getEntrances().get(0));
 
-    TestStreetLinkerModule.link(graph, timetableRepository);
+    TestStreetLinkerModule.link(graph, transitRepository);
 
     var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
     assertEquals(4, streetLinks.size());
@@ -142,7 +142,7 @@ public class VehicleParkingLinkingTest {
 
     graph.remove(A);
 
-    TestStreetLinkerModule.link(graph, timetableRepository);
+    TestStreetLinkerModule.link(graph, transitRepository);
 
     assertEquals(1, vehicleParking.getEntrances().size());
 
@@ -171,7 +171,7 @@ public class VehicleParkingLinkingTest {
 
     graph.remove(A);
 
-    TestStreetLinkerModule.link(graph, vehicleParkingService, timetableRepository);
+    TestStreetLinkerModule.link(graph, vehicleParkingService, transitRepository);
 
     assertEquals(0, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/CalculateWorldEnvelopeModuleTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 class CalculateWorldEnvelopeModuleTest {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   private final List<V> vertexes = List.of(new V(10d, 12d), new V(11d, 13d), new V(14d, 15d));
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessorTest.java
@@ -22,7 +22,7 @@ import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueSto
 import org.opentripplanner.model.ShapePoint;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.SiteRepository;
 
@@ -30,7 +30,7 @@ class GeometryProcessorTest {
 
   public static final FeedScopedId SHAPE_ID = id("s1");
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final RegularStop STOP_A = TEST_MODEL.stop("A").withCoordinate(0, 0).build();
   private static final RegularStop STOP_B = TEST_MODEL.stop("B").withCoordinate(0.1, 0).build();
   private static final RegularStop STOP_C = TEST_MODEL.stop("C").withCoordinate(0.2, 0).build();
@@ -271,7 +271,7 @@ class GeometryProcessorTest {
   void test(List<RegularStop> stops, List<ShapePoint> shapePoints, List<LineString> expected) {
     var builder = new TransitDataImportBuilder(REPO, NOOP);
 
-    var trip = TimetableRepositoryForTest.trip("t").withShapeId(SHAPE_ID).build();
+    var trip = TransitRepositoryForTest.trip("t").withShapeId(SHAPE_ID).build();
 
     var stopTimes = IntStream.range(0, stops.size())
       .mapToObj(index -> TEST_MODEL.stopTime(trip, index, stops.get(index)))
@@ -290,7 +290,7 @@ class GeometryProcessorTest {
   void testShapeDistance() {
     var builder = new TransitDataImportBuilder(REPO, NOOP);
 
-    var trip = TimetableRepositoryForTest.trip("t").withShapeId(SHAPE_ID).build();
+    var trip = TransitRepositoryForTest.trip("t").withShapeId(SHAPE_ID).build();
 
     var stopTimes = List.of(
       TEST_MODEL.stopTime(trip, 0, STOP_A),
@@ -329,7 +329,7 @@ class GeometryProcessorTest {
     var builder = new TransitDataImportBuilder(REPO, NOOP);
 
     // Trip with no shape_id at all
-    var trip = TimetableRepositoryForTest.trip("t").build();
+    var trip = TransitRepositoryForTest.trip("t").build();
     var stops = List.of(STOP_A, STOP_B, STOP_C);
     var stopTimes = IntStream.range(0, stops.size())
       .mapToObj(index -> TEST_MODEL.stopTime(trip, index, stops.get(index)))
@@ -354,7 +354,7 @@ class GeometryProcessorTest {
       .put(SHAPE_ID, List.of(new ShapePoint(0, 0, 0, 0.0), new ShapePoint(1, 1, 1, 1.0)));
 
     var invalidRef = id("unknown");
-    var trip = TimetableRepositoryForTest.trip("t").withShapeId(invalidRef).build();
+    var trip = TransitRepositoryForTest.trip("t").withShapeId(invalidRef).build();
 
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, "8:00");
     builder.getStopTimesSortedByTrip().put(trip, stopTimes);

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningUtils.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningUtils.java
@@ -6,7 +6,7 @@ import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.osm.DefaultOsmProvider;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class IslandPruningUtils {
 
@@ -19,7 +19,7 @@ class IslandPruningUtils {
   ) {
     try {
       var graph = new Graph();
-      var timetableRepository = new TimetableRepository(new SiteRepository());
+      var transitRepository = new TransitRepository(new SiteRepository());
       // Add street data from OSM
       var osmProvider = new DefaultOsmProvider(osmFile, true);
 
@@ -31,13 +31,13 @@ class IslandPruningUtils {
 
       osmModule.buildGraph();
 
-      timetableRepository.index();
+      transitRepository.index();
       graph.index();
 
       // Prune floating islands and set noThru where necessary
       PruneIslands pruneIslands = new PruneIslands(
         graph,
-        timetableRepository,
+        transitRepository,
         DataImportIssueStore.NOOP,
         null
       );

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/SubgraphOnlyFerryTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/SubgraphOnlyFerryTest.java
@@ -6,12 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertexBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 class SubgraphOnlyFerryTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final RegularStop REGULAR_STOP1 = TEST_MODEL.stop("TEST-1").build();
   private static final RegularStop REGULAR_STOP2 = TEST_MODEL.stop("TEST-2").build();
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.test.support.ResourceLoader;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class LinkingTest {
 
@@ -33,16 +33,16 @@ public class LinkingTest {
     // build the graph without the added stops
     TestOtpModel model = buildGraphNoTransit();
     Graph g1 = model.graph();
-    TimetableRepository timetableRepository1 = model.timetableRepository();
+    TransitRepository transitRepository1 = model.transitRepository();
     addRegularStopGrid(g1);
-    link(g1, timetableRepository1);
+    link(g1, transitRepository1);
 
     TestOtpModel model2 = buildGraphNoTransit();
     Graph g2 = model2.graph();
-    TimetableRepository timetableRepository2 = model2.timetableRepository();
+    TransitRepository transitRepository2 = model2.transitRepository();
     addExtraStops(g2);
     addRegularStopGrid(g2);
-    link(g2, timetableRepository2);
+    link(g2, transitRepository2);
 
     var transitStopVertices = g1.getVerticesOfType(TransitStopVertex.class);
     assertEquals(966, transitStopVertices.size());
@@ -75,7 +75,7 @@ public class LinkingTest {
   public static TestOtpModel buildGraphNoTransit() {
     var siteRepository = new SiteRepository();
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(siteRepository);
+    var transitRepository = new TransitRepository(siteRepository);
     var file = ResourceLoader.of(LinkingTest.class).file("columbus.osm.pbf");
     var provider = new DefaultOsmProvider(file, false);
 
@@ -83,7 +83,7 @@ public class LinkingTest {
 
     return new TestOtpModel(
       graph,
-      timetableRepository,
+      transitRepository,
       TransferServiceTestFactory.defaultTransferRepository()
     );
   }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/linking/TestGraph.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/linking/TestGraph.java
@@ -10,9 +10,9 @@ import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.street.search.TraverseModeSet;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * Get graphs of Columbus Ohio with real OSM streets and a synthetic transit system for use in
@@ -20,7 +20,7 @@ import org.opentripplanner.transit.service.TimetableRepository;
  */
 class TestGraph {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   /**
    * Add a regular grid of stops to the graph. Note! Not all of these stops
@@ -65,8 +65,8 @@ class TestGraph {
   }
 
   /** link the stops in the graph */
-  public static void link(Graph graph, TimetableRepository timetableRepository) {
-    timetableRepository.index();
+  public static void link(Graph graph, TransitRepository transitRepository) {
+    transitRepository.index();
     graph.index();
 
     VertexLinker linker = VertexLinkerTestFactory.of(graph);

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGeneratorTestData.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGeneratorTestData.java
@@ -13,7 +13,7 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.BikeAccess;
 import org.opentripplanner.transit.model.network.CarAccess;
@@ -86,7 +86,7 @@ class DirectTransferGeneratorTestData extends GraphRoutingTest {
 
     new DirectTransferGenerator(
       model.graph(),
-      model.timetableRepository(),
+      model.transitRepository(),
       model.transferRepository(),
       DataImportIssueStore.NOOP,
       regularTransferParameters.build()
@@ -151,7 +151,7 @@ class DirectTransferGeneratorTestData extends GraphRoutingTest {
       street(V22, V23, 100, StreetTraversalPermission.ALL);
 
       if (addPatterns) {
-        var agency = TimetableRepositoryForTest.agency("Agency");
+        var agency = TransitRepositoryForTest.agency("Agency");
 
         tripPattern(
           TripPattern.of(FeedScopedIdForTestFactory.id("TP0"))
@@ -175,7 +175,7 @@ class DirectTransferGeneratorTestData extends GraphRoutingTest {
               builder.addTripTimes(
                 ScheduledTripTimes.of()
                   .withTrip(
-                    TimetableRepositoryForTest.trip("bikesAllowedTrip")
+                    TransitRepositoryForTest.trip("bikesAllowedTrip")
                       .withBikesAllowed(BikeAccess.ALLOWED)
                       .build()
                   )
@@ -212,7 +212,7 @@ class DirectTransferGeneratorTestData extends GraphRoutingTest {
     private static ScheduledTripTimes createCarsAllowedTripTimesWithTwoStops() {
       return ScheduledTripTimes.of()
         .withTrip(
-          TimetableRepositoryForTest.trip("carsAllowed").withCarsAllowed(CarAccess.ALLOWED).build()
+          TransitRepositoryForTest.trip("carsAllowed").withCarsAllowed(CarAccess.ALLOWED).build()
         )
         .withDepartureTimes("00:00 01:00")
         .build();

--- a/application/src/test/java/org/opentripplanner/gtfs/GenerateTripPatternsOperationTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/GenerateTripPatternsOperationTest.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.gtfs;
 
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.trip;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.trip;
 
 import java.util.Collection;
 import java.util.List;
@@ -21,7 +21,7 @@ import org.opentripplanner.graph_builder.issues.TripUndefinedService;
 import org.opentripplanner.graph_builder.module.geometry.GeometryProcessor;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -51,11 +51,11 @@ class GenerateTripPatternsOperationTest {
 
   @BeforeAll
   static void setupClass() {
-    TimetableRepositoryForTest timetableRepositoryForTest = TimetableRepositoryForTest.of();
-    stopA = timetableRepositoryForTest.stop("stopA").build();
-    stopB = timetableRepositoryForTest.stop("stopB").build();
-    stopC = timetableRepositoryForTest.stop("stopC").build();
-    siteRepository = timetableRepositoryForTest
+    TransitRepositoryForTest transitRepositoryForTest = TransitRepositoryForTest.of();
+    stopA = transitRepositoryForTest.stop("stopA").build();
+    stopB = transitRepositoryForTest.stop("stopB").build();
+    stopC = transitRepositoryForTest.stop("stopC").build();
+    siteRepository = transitRepositoryForTest
       .siteRepositoryBuilder()
       .withRegularStop(stopA)
       .withRegularStop(stopB)

--- a/application/src/test/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTest.java
@@ -16,7 +16,7 @@ import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class GtfsModuleTest {
 
@@ -27,14 +27,14 @@ class GtfsModuleTest {
     var bundle = GtfsBundleTestFactory.forTest(ConstantsForTests.SIMPLE_GTFS);
     var module = GtfsModuleTestFactory.forTest(
       List.of(bundle),
-      model.timetableRepository,
+      model.transitRepository,
       model.graph,
       LocalDateRange.ofUnbounded()
     );
 
     module.buildGraph();
 
-    var frequencyTripPattern = model.timetableRepository
+    var frequencyTripPattern = model.transitRepository
       .getAllTripPatterns()
       .stream()
       .filter(p -> !p.getScheduledTimetable().getFrequencyEntries().isEmpty())
@@ -46,7 +46,7 @@ class GtfsModuleTest {
     assertNotNull(tripPattern.getGeometry());
     assertNotNull(tripPattern.getHopGeometry(0));
 
-    var pattern = model.timetableRepository.getTripPatternForId(tripPattern.getId());
+    var pattern = model.transitRepository.getTripPatternForId(tripPattern.getId());
     assertNotNull(pattern.getGeometry());
     assertNotNull(pattern.getHopGeometry(0));
   }
@@ -58,7 +58,7 @@ class GtfsModuleTest {
 
     var module = GtfsModuleTestFactory.forTest(
       bundles,
-      model.timetableRepository,
+      model.transitRepository,
       model.graph,
       LocalDateRange.ofUnbounded()
     );
@@ -68,11 +68,11 @@ class GtfsModuleTest {
   private static TestModels buildTestModel() {
     var siteRepository = new SiteRepository();
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(siteRepository);
-    return new TestModels(graph, timetableRepository);
+    var transitRepository = new TransitRepository(siteRepository);
+    return new TestModels(graph, transitRepository);
   }
 
-  record TestModels(Graph graph, TimetableRepository timetableRepository) {}
+  record TestModels(Graph graph, TransitRepository transitRepository) {}
 
   static GtfsBundle bundle(String feedId) {
     return GtfsBundleTestFactory.forTest(
@@ -106,7 +106,7 @@ class GtfsModuleTest {
 
       var module = GtfsModuleTestFactory.forTest(
         bundles,
-        model.timetableRepository,
+        model.transitRepository,
         model.graph,
         LocalDateRange.ofUnbounded()
       );
@@ -115,7 +115,7 @@ class GtfsModuleTest {
 
       assertEquals(
         expectedTransfers,
-        model.timetableRepository.getConstrainedTransferService().listAll().size()
+        model.transitRepository.getConstrainedTransferService().listAll().size()
       );
     }
   }

--- a/application/src/test/java/org/opentripplanner/gtfs/interlining/InterlineProcessorTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/interlining/InterlineProcessorTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.gtfs.mapping.StaySeatedNotAllowed;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.transfer.constrained.internal.DefaultConstrainedTransferService;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -26,7 +26,7 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class InterlineProcessorTest implements PlanTestConstants {
 
-  private static TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   List<TripPattern> patterns = List.of(
     tripPattern("trip-1", "block-1", "service-1"),
@@ -151,7 +151,7 @@ class InterlineProcessorTest implements PlanTestConstants {
   }
 
   private static TripPattern tripPattern(String tripId, String blockId, String serviceId) {
-    var trip = TimetableRepositoryForTest.trip(tripId)
+    var trip = TransitRepositoryForTest.trip(tripId)
       .withGtfsBlockId(blockId)
       .withServiceId(new FeedScopedId("1", serviceId))
       .build();

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/AgencyMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/AgencyMapperTest.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.model.Agency;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 public class AgencyMapperTest {
 
@@ -32,7 +32,7 @@ public class AgencyMapperTest {
   private static final String FARE_URL = "www.url.com/fare";
 
   private final AgencyMapper subject = new AgencyMapper(
-    new IdFactory(TimetableRepositoryForTest.FEED_ID)
+    new IdFactory(TransitRepositoryForTest.FEED_ID)
   );
 
   static {
@@ -58,7 +58,7 @@ public class AgencyMapperTest {
 
     result = subject.map(AGENCY);
 
-    assertEquals(TimetableRepositoryForTest.FEED_ID, result.getId().getFeedId());
+    assertEquals(TransitRepositoryForTest.FEED_ID, result.getId().getFeedId());
     assertEquals(ID, result.getId().getId());
     assertEquals(NAME, result.getName());
     assertEquals(LANG, result.getLang());

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
 import org.opentripplanner.core.model.accessibility.Accessibility;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.BoardingArea;
 import org.opentripplanner.transit.model.site.RegularStop;
 
@@ -40,7 +40,7 @@ public class BoardingAreaMapperTest {
   private static final int VEHICLE_TYPE = 5;
 
   private static final int WHEELCHAIR_BOARDING = 1;
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final RegularStop PARENT_STOP = TEST_MODEL.stop(PARENT).build();
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationGroupMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/LocationGroupMapperTest.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.gtfs.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.FEED_ID;
 
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeAssignmentMapperTest.java
@@ -15,13 +15,13 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripStopTimes;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 
 class NoticeAssignmentMapperTest {
 
-  private static final String FEED_ID = TimetableRepositoryForTest.FEED_ID;
+  private static final String FEED_ID = TransitRepositoryForTest.FEED_ID;
   private static final IdFactory ID_FACTORY = new IdFactory(FEED_ID);
 
   private static final String NOTICE_ID = "N1";

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/NoticeMapperTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.onebusaway.gtfs.model.AgencyAndIdFactory.obaId;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.FEED_ID;
 
 import org.junit.jupiter.api.Test;
 

--- a/application/src/test/java/org/opentripplanner/gtfs/mapping/StopMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/mapping/StopMapperTest.java
@@ -16,7 +16,7 @@ import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.framework.application.OTPFeature;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -145,7 +145,7 @@ public class StopMapperTest {
 
   @Test
   void testMapWithParentStation() {
-    TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+    TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
     Station parentStation = testModel.station("Parent").build();
 
     StopMapper mapperWithStation = new StopMapper(

--- a/application/src/test/java/org/opentripplanner/inspector/vector/VectorTileResponseFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/inspector/vector/VectorTileResponseFactoryTest.java
@@ -13,14 +13,14 @@ import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.api.TestServerContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class VectorTileResponseFactoryTest {
 
   public static final OtpServerRequestContext SERVER_CONTEXT =
     TestServerContext.createServerContext(
       new Graph(),
-      new TimetableRepository(),
+      new TransitRepository(),
       TransferServiceTestFactory.defaultTransferRepository(),
       new DefaultFareService()
     );

--- a/application/src/test/java/org/opentripplanner/model/ShapeGeometryTest.java
+++ b/application/src/test/java/org/opentripplanner/model/ShapeGeometryTest.java
@@ -6,17 +6,17 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class ShapeGeometryTest {
 
   @Test
   public void useShapeGeometries() {
     TestOtpModel model = ConstantsForTests.buildGtfsGraph(ConstantsForTests.SHAPE_DIST_GTFS);
-    TimetableRepository timetableRepository = model.timetableRepository();
+    TransitRepository transitRepository = model.transitRepository();
 
     // data includes 2 trips, of which one has incorrect shape_dist_traveled parametrization in stop_times
-    for (TripPattern pattern : timetableRepository.getAllTripPatterns()) {
+    for (TripPattern pattern : transitRepository.getAllTripPatterns()) {
       // examine if shape extraction worked at first stop intervals, where dist parameter is wrong
       assertTrue(pattern.getHopGeometry(0).getCoordinates().length > 2);
       assertTrue(pattern.getHopGeometry(1).getCoordinates().length > 2);

--- a/application/src/test/java/org/opentripplanner/model/TripPatternTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TripPatternTest.java
@@ -9,7 +9,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.street.geometry.GeometryUtils;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -28,7 +28,7 @@ public class TripPatternTest {
    */
   @Test
   public void testSetHopGeometriesFromPattern() {
-    var testModel = TimetableRepositoryForTest.of();
+    var testModel = TransitRepositoryForTest.of();
     var stationOrigin = testModel.station("S1").withCoordinate(0.0, 0.0).build();
     var stationDestination = testModel.station("S2").withCoordinate(1.0, 1.0).build();
     var stopOrigin = testModel
@@ -103,7 +103,7 @@ public class TripPatternTest {
     }
 
     var stopPattern = builder.build();
-    var route = TimetableRepositoryForTest.route("R1").build();
+    var route = TransitRepositoryForTest.route("R1").build();
 
     return TripPattern.of(new FeedScopedId(route.getId().getFeedId(), "T1"))
       .withRoute(route)

--- a/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitDataTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -21,12 +21,12 @@ import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
 class TripTimeOnDateTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final LocalDate DATE = LocalDate.of(2025, 3, 18);
   private static final Instant MIDNIGHT = ServiceDateUtils.asStartOfService(
@@ -37,7 +37,7 @@ class TripTimeOnDateTest {
   @Test
   void gtfsSequence() {
     var pattern = TEST_MODEL.pattern(TransitMode.BUS).build();
-    var trip = TimetableRepositoryForTest.trip("123").build();
+    var trip = TransitRepositoryForTest.trip("123").build();
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, "11:00");
 
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
@@ -54,7 +54,7 @@ class TripTimeOnDateTest {
   @Test
   void hasArrivedStop() {
     var pattern = TEST_MODEL.pattern(TransitMode.BUS).build();
-    var trip = TimetableRepositoryForTest.trip("123").build();
+    var trip = TransitRepositoryForTest.trip("123").build();
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, "11:00");
 
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator())
@@ -72,7 +72,7 @@ class TripTimeOnDateTest {
   @Test
   void hasDepartedStop() {
     var pattern = TEST_MODEL.pattern(TransitMode.BUS).build();
-    var trip = TimetableRepositoryForTest.trip("123").build();
+    var trip = TransitRepositoryForTest.trip("123").build();
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, "11:00");
 
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator())
@@ -160,11 +160,11 @@ class TripTimeOnDateTest {
   }
 
   private static TripTimeOnDate tripTimeOnDate() {
-    var trip = TimetableRepositoryForTest.trip("123").build();
+    var trip = TransitRepositoryForTest.trip("123").build();
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(5, trip, "11:00");
     var stops = stopTimes.stream().map(StopTime::getStop).toList();
     var pattern = TEST_MODEL.pattern(TransitMode.BUS)
-      .withStopPattern(TimetableRepositoryForTest.stopPattern(stops))
+      .withStopPattern(TransitRepositoryForTest.stopPattern(stops))
       .build();
     var tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
     return new TripTimeOnDate(tripTimes, 2, pattern, DATE, MIDNIGHT);
@@ -172,10 +172,10 @@ class TripTimeOnDateTest {
 
   @Test
   void testFromTripTimesWithScheduleFallback() {
-    var testModel = TimetableRepositoryForTest.of();
-    var trip = TimetableRepositoryForTest.trip("123").build();
+    var testModel = TransitRepositoryForTest.of();
+    var trip = TransitRepositoryForTest.trip("123").build();
     var siteRepository = testModel.siteRepositoryBuilder().build();
-    var timetableRepository = new TimetableRepository(siteRepository);
+    var transitRepository = new TransitRepository(siteRepository);
     var tripTimes = ScheduledTripTimes.of()
       .withTrip(trip)
       .withDepartureTimes(new int[] { 0, 1 })
@@ -184,8 +184,8 @@ class TripTimeOnDateTest {
       .pattern(TransitMode.BUS)
       .withScheduledTimeTableBuilder(builder -> builder.addTripTimes(tripTimes))
       .build();
-    timetableRepository.addTripPattern(tripPattern.getId(), tripPattern);
-    timetableRepository.index();
+    transitRepository.addTripPattern(tripPattern.getId(), tripPattern);
+    transitRepository.index();
     var timetableSnapshot = new TimetableSnapshot(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()

--- a/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
+++ b/application/src/test/java/org/opentripplanner/model/TripTimeOnDateTest.java
@@ -19,8 +19,8 @@ import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Timetable;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
@@ -186,7 +186,7 @@ class TripTimeOnDateTest {
       .build();
     transitRepository.addTripPattern(tripPattern.getId(), tripPattern);
     transitRepository.index();
-    var timetableSnapshot = new TimetableSnapshot(
+    var timetableSnapshot = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );

--- a/application/src/test/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImplTest.java
+++ b/application/src/test/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImplTest.java
@@ -28,7 +28,7 @@ import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceCalendarDate;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
 public class CalendarServiceDataFactoryImplTest {
@@ -120,7 +120,7 @@ public class CalendarServiceDataFactoryImplTest {
 
   private static GtfsContext createCtxBuilder() throws IOException {
     GtfsContextBuilder ctxBuilder = contextBuilder(
-      TimetableRepositoryForTest.FEED_ID,
+      TransitRepositoryForTest.FEED_ID,
       ConstantsForTests.SIMPLE_GTFS
     );
     TransitDataImportBuilder builder = ctxBuilder
@@ -129,9 +129,7 @@ public class CalendarServiceDataFactoryImplTest {
 
     // Supplement test data with at least one entity in all collections
     builder.getCalendarDates().add(removeMondayFromAlldays());
-    builder
-      .getFeedInfos()
-      .add(FeedInfoTestFactory.dummyForTest(TimetableRepositoryForTest.FEED_ID));
+    builder.getFeedInfos().add(FeedInfoTestFactory.dummyForTest(TransitRepositoryForTest.FEED_ID));
 
     return ctxBuilder.build();
   }

--- a/application/src/test/java/org/opentripplanner/model/impl/DefaultTransitDataImportTest.java
+++ b/application/src/test/java/org/opentripplanner/model/impl/DefaultTransitDataImportTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.gtfs.GtfsContextBuilder.contextBuilder;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.FEED_ID;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/application/src/test/java/org/opentripplanner/model/impl/TransitDataImportBuilderLimitPeriodTest.java
+++ b/application/src/test/java/org/opentripplanner/model/impl/TransitDataImportBuilderLimitPeriodTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.calendar.ServiceCalendar;
 import org.opentripplanner.model.calendar.ServiceCalendarDate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.network.Route;
@@ -49,7 +49,7 @@ public class TransitDataImportBuilderLimitPeriodTest {
   private static final FeedScopedId SERVICE_C_OUT = FeedScopedIdForTestFactory.id("CalSrvOut");
   private static final FeedScopedId SERVICE_D_OUT = FeedScopedIdForTestFactory.id("CalSrvDOut");
   private static final Deduplicator DEDUPLICATOR = new Deduplicator();
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final RegularStop STOP_1 = TEST_MODEL.stop("Stop-1").build();
   private static final RegularStop STOP_2 = TEST_MODEL.stop("Stop-2").build();
   private static final List<StopTime> STOP_TIMES = List.of(
@@ -58,7 +58,7 @@ public class TransitDataImportBuilderLimitPeriodTest {
   );
   private static final StopPattern STOP_PATTERN = new StopPattern(STOP_TIMES);
   private static int SEQ_NR = 0;
-  private final Route route = TimetableRepositoryForTest.route(newId().getId()).build();
+  private final Route route = TransitRepositoryForTest.route(newId().getId()).build();
   private final Trip tripCSIn = createTrip("TCalIn", SERVICE_C_IN);
   private final Trip tripCSOut = createTrip("TCalOut", SERVICE_C_OUT);
   private final Trip tripCSDIn = createTrip("TDateIn", SERVICE_D_IN);
@@ -214,7 +214,7 @@ public class TransitDataImportBuilderLimitPeriodTest {
   }
 
   private Trip createTrip(String id, FeedScopedId serviceId) {
-    return TimetableRepositoryForTest.trip(id)
+    return TransitRepositoryForTest.trip(id)
       .withServiceId(serviceId)
       .withDirection(Direction.INBOUND)
       .withRoute(route)

--- a/application/src/test/java/org/opentripplanner/model/impl/TransitDataImportBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/model/impl/TransitDataImportBuilderTest.java
@@ -19,12 +19,12 @@ import org.opentripplanner.model.FeedInfoTestFactory;
 import org.opentripplanner.model.Frequency;
 import org.opentripplanner.model.calendar.ServiceCalendar;
 import org.opentripplanner.model.calendar.ServiceCalendarDate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 
 public class TransitDataImportBuilderTest {
 
-  private static final String FEED_ID = TimetableRepositoryForTest.FEED_ID;
+  private static final String FEED_ID = TransitRepositoryForTest.FEED_ID;
   private static final FeedScopedId SERVICE_WEEKDAYS_ID = FeedScopedIdForTestFactory.id("weekdays");
 
   private static TransitDataImportBuilder subject;

--- a/application/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
@@ -20,7 +20,7 @@ import org.opentripplanner.framework.model.TimeAndCost;
 import org.opentripplanner.model.SystemNotice;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 
@@ -210,12 +210,12 @@ public class ItineraryTest implements PlanTestConstants {
   @Test
   void normalization() {
     var zoneId = ZoneId.of("Europe/Oslo");
-    var model = TimetableRepositoryForTest.of();
+    var model = TransitRepositoryForTest.of();
     var stopA = model.stop("A", 60.0, 10.0).build();
     var stopB = model.stop("B", 60.0, 10.01).build();
-    var stopPattern = TimetableRepositoryForTest.stopPattern(stopA, stopB);
-    var trip = TimetableRepositoryForTest.trip("trip1").build();
-    var tripPattern = TimetableRepositoryForTest.tripPattern("p", trip.getRoute())
+    var stopPattern = TransitRepositoryForTest.stopPattern(stopA, stopB);
+    var trip = TransitRepositoryForTest.trip("trip1").build();
+    var tripPattern = TransitRepositoryForTest.tripPattern("p", trip.getRoute())
       .withStopPattern(stopPattern)
       .build();
 

--- a/application/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -21,7 +21,7 @@ import org.opentripplanner.model.plan.leg.ViaLocationType;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.model.vertex.SimpleVertex;
 import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.SiteRepository;
 
@@ -59,7 +59,7 @@ public class PlaceTest {
 
   @Test
   public void sameLocationBasedOnStopId() {
-    var testModel = TimetableRepositoryForTest.of();
+    var testModel = TransitRepositoryForTest.of();
     var s1 = testModel.stop("1").withCoordinate(1.0, 1.0).build();
     var s2 = testModel.stop("2").withCoordinate(1.0, 2.0).build();
 
@@ -142,7 +142,7 @@ public class PlaceTest {
 
   @Test
   public void forStop() {
-    var testModel = TimetableRepositoryForTest.of();
+    var testModel = TransitRepositoryForTest.of();
     var stop = testModel.stop("1").withCoordinate(1.0, 1.0).build();
 
     Place place = Place.forStop(stop);
@@ -157,7 +157,7 @@ public class PlaceTest {
 
   @Test
   public void forStopWithViaLocationType() {
-    var testModel = TimetableRepositoryForTest.of();
+    var testModel = TransitRepositoryForTest.of();
     var stop = testModel.stop("1").withCoordinate(1.0, 1.0).build();
     var type = ViaLocationType.PASS_THROUGH;
 

--- a/application/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
@@ -2,7 +2,7 @@ package org.opentripplanner.model.plan;
 
 import static org.opentripplanner.utils.time.TimeUtils.time;
 
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.utils.time.DurationUtils;
 
 public interface PlanTestConstants {
@@ -63,55 +63,55 @@ public interface PlanTestConstants {
   int T11_55 = time("11:55");
 
   /**
-   * @deprecated Create the TimetableRepositoryForTest per test, do not share between tests - it has state
+   * @deprecated Create the TransitRepositoryForTest per test, do not share between tests - it has state
    */
   @Deprecated
-  TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place A = Place.forStop(TEST_MODEL.stop("A").withCoordinate(5.0, 8.0).build());
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place B = Place.forStop(TEST_MODEL.stop("B").withCoordinate(6.0, 8.5).build());
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place C = Place.forStop(TEST_MODEL.stop("C").withCoordinate(7.0, 9.0).build());
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place D = Place.forStop(TEST_MODEL.stop("D").withCoordinate(8.0, 9.5).build());
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place E = Place.forStop(TEST_MODEL.stop("E").withCoordinate(9.0, 10.0).build());
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place F = Place.forStop(TEST_MODEL.stop("F").withCoordinate(9.0, 10.5).build());
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place G = Place.forStop(TEST_MODEL.stop("G").withCoordinate(9.5, 11.0).build());
 
   /**
-   * @deprecated Depend on TimetableRepositoryForTest. Create per test, do not share between tests - it has state
+   * @deprecated Depend on TransitRepositoryForTest. Create per test, do not share between tests - it has state
    */
   @Deprecated
   Place H = Place.forStop(TEST_MODEL.stop("H").withCoordinate(10.0, 11.5).build());

--- a/application/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -5,7 +5,7 @@ import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.street.search.TraverseMode.BICYCLE;
 import static org.opentripplanner.street.search.TraverseMode.CAR;
 import static org.opentripplanner.street.search.TraverseMode.WALK;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.route;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -35,7 +35,7 @@ import org.opentripplanner.street.model.StreetModelForTest;
 import org.opentripplanner.street.search.TraverseMode;
 import org.opentripplanner.transfer.constrained.model.ConstrainedTransfer;
 import org.opentripplanner.transfer.constrained.model.TransferConstraint;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
@@ -462,7 +462,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
 
   /** Create a dummy trip */
   private static Trip trip(String id, Route route) {
-    return TimetableRepositoryForTest.trip(id)
+    return TransitRepositoryForTest.trip(id)
       .withRoute(route)
       .withHeadsign(I18NString.of("Trip headsign %s".formatted(id)))
       .build();

--- a/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReferenceTest.java
@@ -15,7 +15,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLeg;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -25,7 +25,7 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
@@ -33,7 +33,7 @@ import org.opentripplanner.utils.lang.RunnableUtils;
 
 class ScheduledTransitLegReferenceTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final int SERVICE_CODE = 555;
   private static final LocalDate SERVICE_DATE = LocalDate.of(2023, 1, 1);
   private static final int NUMBER_OF_STOPS = 3;
@@ -68,38 +68,38 @@ class ScheduledTransitLegReferenceTest {
       .withRegularStop(stop3a)
       .withRegularStop(stop3b)
       .build();
-    TimetableRepository timetableRepository = new TimetableRepository(siteRepository);
-    timetableRepository.initUpdaterManager(
+    TransitRepository transitRepository = new TransitRepository(siteRepository);
+    transitRepository.initUpdaterManager(
       new GraphUpdaterManager(WriteToGraphCallback.NOOP, RunnableUtils.NOOP, List.of())
     );
     // build transit data
     CalendarServiceData calendarServiceData = new CalendarServiceData();
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.updateCalendarServiceData(calendarServiceData);
     for (var item : Map.of(
       SIMPLE_TRIP_ID,
-      TimetableRepositoryForTest.stopPattern(stop1, stop2, stop3a),
+      TransitRepositoryForTest.stopPattern(stop1, stop2, stop3a),
       TRIP_ID_WITH_MULTIPLE_CALLS,
-      TimetableRepositoryForTest.stopPattern(stop1, stop2, stop3a, stop3b),
+      TransitRepositoryForTest.stopPattern(stop1, stop2, stop3a, stop3b),
       LOOP_TRIP_ID,
-      TimetableRepositoryForTest.stopPattern(stop1, stop2, stop3a, stop1, stop2, stop3b)
+      TransitRepositoryForTest.stopPattern(stop1, stop2, stop3a, stop1, stop2, stop3b)
     ).entrySet()) {
-      Trip trip = TimetableRepositoryForTest.trip(item.getKey().getId()).build();
+      Trip trip = TransitRepositoryForTest.trip(item.getKey().getId()).build();
       var tripTimes = TripTimesFactory.tripTimes(
         trip,
         TEST_MODEL.stopTimesEvery5Minutes(item.getValue().getSize(), trip, "11:00"),
         new Deduplicator()
       ).withServiceCode(SERVICE_CODE);
-      TripPattern tripPattern = TimetableRepositoryForTest.tripPattern(
+      TripPattern tripPattern = TransitRepositoryForTest.tripPattern(
         "TRIP_PATTERN_" + item.getKey().getId(),
-        TimetableRepositoryForTest.route(id("1")).build()
+        TransitRepositoryForTest.route(id("1")).build()
       )
         .withStopPattern(item.getValue())
         .withScheduledTimeTableBuilder(builder -> builder.addTripTimes(tripTimes))
         .build();
-      timetableRepository.addTripPattern(tripPattern.getId(), tripPattern);
-      timetableRepository.getServiceCodes().put(tripPattern.getId(), SERVICE_CODE);
+      transitRepository.addTripPattern(tripPattern.getId(), tripPattern);
+      transitRepository.getServiceCodes().put(tripPattern.getId(), SERVICE_CODE);
       FeedScopedId tripOnServiceDateId = id("TRIP_ON_SERVICE_DATE" + item.getKey().getId());
-      timetableRepository.addTripOnServiceDate(
+      transitRepository.addTripOnServiceDate(
         TripOnServiceDate.of(tripOnServiceDateId)
           .withTrip(trip)
           .withServiceDate(SERVICE_DATE)
@@ -111,12 +111,12 @@ class ScheduledTransitLegReferenceTest {
       calendarServiceData.putServiceDatesForServiceId(tripPattern.getId(), List.of(SERVICE_DATE));
     }
 
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.updateCalendarServiceData(calendarServiceData);
 
-    timetableRepository.index();
+    transitRepository.index();
 
     // build transit service
-    transitService = new DefaultTransitService(timetableRepository);
+    transitService = new DefaultTransitService(transitRepository);
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/model/plan/paging/cursor/PageCursorTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/paging/cursor/PageCursorTest.java
@@ -30,12 +30,12 @@ import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.SortOrder;
 import org.opentripplanner.model.plan.TestItineraryBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.utils.collection.ListSection;
 
 class PageCursorTest implements PlanTestConstants {
 
-  public static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  public static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   public static final Place A = Place.forStop(
     TEST_MODEL.stop("A").withCoordinate(5.0, 8.0).build()
   );

--- a/application/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.street.geometry.GeometryUtils;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -125,7 +125,7 @@ class FlexStopsMapperTest {
         .withValue("UnrestrictedPublicTransportAreas")
     );
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
   private final SiteRepositoryBuilder siteRepositoryBuilder = testModel.siteRepositoryBuilder();
 
   @Test

--- a/application/src/test/java/org/opentripplanner/netex/mapping/MultiModalStationMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/MultiModalStationMapperTest.java
@@ -9,7 +9,7 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.netex.NetexTestDataSupport;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.rutebanken.netex.model.StopPlace;
 
 class MultiModalStationMapperTest {
@@ -18,7 +18,7 @@ class MultiModalStationMapperTest {
   void testMissingCoordinates() {
     DataImportIssueStore dataIssueStore = new DefaultDataImportIssueStore();
     FeedScopedIdFactory feedScopeIdFactory = new FeedScopedIdFactory(
-      TimetableRepositoryForTest.FEED_ID
+      TransitRepositoryForTest.FEED_ID
     );
     MultiModalStationMapper multiModalStationMapper = new MultiModalStationMapper(
       dataIssueStore,

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -63,7 +63,7 @@ public class NetexTestDataSample {
     .withName(new MultilingualString().withValue("everyday"));
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   private final JourneyPattern journeyPattern;
   private final HierarchicalMapById<JourneyPattern_VersionStructure> journeyPatternById =
@@ -94,7 +94,7 @@ public class NetexTestDataSample {
     JAXBElement<LineRefStructure> lineRef = createWrappedRef(line.getId(), LineRefStructure.class);
 
     // Add OTP Route (correspond to Netex Line)
-    otpRouteByid.add(TimetableRepositoryForTest.route(line.getId()).build());
+    otpRouteByid.add(TransitRepositoryForTest.route(line.getId()).build());
 
     // Add Netex Route (not the same as an OTP Route)
     String routeId = "RUT:Route:1";

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.framework.EntityById;
@@ -47,7 +47,7 @@ public class NoticeAssignmentMapperTest {
     noticeAssignment.setNoticedObjectRef(new VersionOfObjectRefStructure().withRef(ROUTE_ID));
     noticeAssignment.setNotice(NOTICE);
 
-    Route route = TimetableRepositoryForTest.route(ROUTE_ID).build();
+    Route route = TransitRepositoryForTest.route(ROUTE_ID).build();
 
     EntityById<Route> routesById = new DefaultEntityById<>();
     routesById.add(route);
@@ -88,7 +88,7 @@ public class NoticeAssignmentMapperTest {
       )
     );
 
-    var trip = TimetableRepositoryForTest.trip("1").build();
+    var trip = TransitRepositoryForTest.trip("1").build();
     StopTime stopTime1 = createStopTime(1, trip);
     StopTime stopTime2 = createStopTime(2, trip);
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/RouteMapperTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.netex.index.NetexEntityIndex;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.network.BikeAccess;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
@@ -102,7 +102,7 @@ class RouteMapperTest {
       transitBuilder.getGroupsOfRoutesByRouteId(),
       transitBuilder.getGroupOfRouteById(),
       netexIndex.readOnlyView(),
-      TimetableRepositoryForTest.TIME_ZONE_ID,
+      TransitRepositoryForTest.TIME_ZONE_ID,
       EMPTY_FERRY_WITHOUT_BICYCLE_IDS
     );
 
@@ -210,7 +210,7 @@ class RouteMapperTest {
       ArrayListMultimap.create(),
       new DefaultEntityById<>(),
       netexIndex.readOnlyView(),
-      TimetableRepositoryForTest.TIME_ZONE_ID,
+      TransitRepositoryForTest.TIME_ZONE_ID,
       EMPTY_FERRY_WITHOUT_BICYCLE_IDS
     );
 
@@ -246,7 +246,7 @@ class RouteMapperTest {
       transitBuilder.getGroupsOfRoutesByRouteId(),
       transitBuilder.getGroupOfRouteById(),
       netexIndex.readOnlyView(),
-      TimetableRepositoryForTest.TIME_ZONE_ID,
+      TransitRepositoryForTest.TIME_ZONE_ID,
       EMPTY_FERRY_WITHOUT_BICYCLE_IDS
     );
 
@@ -278,7 +278,7 @@ class RouteMapperTest {
   }
 
   private Agency createAgency() {
-    return TimetableRepositoryForTest.agency("Ruter AS")
+    return TransitRepositoryForTest.agency("Ruter AS")
       .copy()
       .withId(MappingSupport.ID_FACTORY.createId(AUTHORITY_ID))
       .build();

--- a/application/src/test/java/org/opentripplanner/netex/mapping/StopTimesMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/StopTimesMapperTest.java
@@ -17,7 +17,7 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.rutebanken.netex.model.StopPointInJourneyPattern;
@@ -30,7 +30,7 @@ public class StopTimesMapperTest {
   private static final BigInteger TWO = BigInteger.valueOf(2);
 
   private static final LocalTime QUARTER_PAST_FIVE = LocalTime.of(5, 15);
-  public static final Trip TRIP = TimetableRepositoryForTest.trip("T1").build();
+  public static final Trip TRIP = TransitRepositoryForTest.trip("T1").build();
 
   @Test
   public void testCalculateOtpTime() {

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TransferMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TransferMapperTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.transfer.constrained.model.TripTransferPoint;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DefaultEntityById;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
@@ -375,8 +375,8 @@ class TransferMapperTest {
 
   private DefaultEntityById<Trip> createTripsIndex() {
     var trips = new DefaultEntityById<Trip>();
-    trips.add(TimetableRepositoryForTest.trip(FROM_JOURNEY_ID).build());
-    trips.add(TimetableRepositoryForTest.trip(TO_JOURNEY_ID).build());
+    trips.add(TransitRepositoryForTest.trip(FROM_JOURNEY_ID).build());
+    trips.add(TransitRepositoryForTest.trip(TO_JOURNEY_ID).build());
     return trips;
   }
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
@@ -19,7 +19,7 @@ import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueSto
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.SiteRepository;
 import org.rutebanken.netex.model.AccessibilityAssessment;
@@ -55,7 +55,7 @@ class TripMapperTest {
     var access = new AccessibilityAssessment();
 
     var transitBuilder = new TransitDataImportBuilder(new SiteRepository(), ISSUE_STORE);
-    transitBuilder.getRoutes().add(TimetableRepositoryForTest.route(ROUTE_ID).build());
+    transitBuilder.getRoutes().add(TransitRepositoryForTest.route(ROUTE_ID).build());
 
     TripMapper tripMapper = new TripMapper(
       ID_FACTORY,
@@ -87,7 +87,7 @@ class TripMapperTest {
       new SiteRepository(),
       ISSUE_STORE
     );
-    transitBuilder.getRoutes().add(TimetableRepositoryForTest.route(ROUTE_ID).build());
+    transitBuilder.getRoutes().add(TransitRepositoryForTest.route(ROUTE_ID).build());
 
     TripMapper tripMapper = new TripMapper(
       ID_FACTORY,
@@ -114,7 +114,7 @@ class TripMapperTest {
       new SiteRepository(),
       ISSUE_STORE
     );
-    transitBuilder.getRoutes().add(TimetableRepositoryForTest.route(ROUTE_ID).build());
+    transitBuilder.getRoutes().add(TransitRepositoryForTest.route(ROUTE_ID).build());
 
     JourneyPattern journeyPattern = new JourneyPattern().withId(JOURNEY_PATTERN_ID);
     journeyPattern.setRouteRef(new RouteRefStructure().withRef(ROUTE_ID));

--- a/application/src/test/java/org/opentripplanner/netex/mapping/calendar/CalendarServiceBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/calendar/CalendarServiceBuilderTest.java
@@ -2,7 +2,7 @@ package org.opentripplanner.netex.mapping.calendar;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.FEED_ID;
 
 import java.time.LocalDate;
 import java.util.Collection;

--- a/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StopFinderTraverseVisitorTest.java
+++ b/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StopFinderTraverseVisitorTest.java
@@ -6,12 +6,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.place.api.NearbyStop;
 import org.opentripplanner.street.search.state.TestStateBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 class StopFinderTraverseVisitorTest {
 
-  static final RegularStop STOP = TimetableRepositoryForTest.of().stop("a-stop", 1, 1).build();
+  static final RegularStop STOP = TransitRepositoryForTest.of().stop("a-stop", 1, 1).build();
 
   @Test
   void deduplicateStops() {

--- a/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinderTest.java
+++ b/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinderTest.java
@@ -32,7 +32,7 @@ class StraightLineNearbyStopFinderTest extends GraphRoutingTest {
         }
       }
     );
-    siteRepository = model.timetableRepository().getSiteRepository();
+    siteRepository = model.transitRepository().getSiteRepository();
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/place/placefinder/PlaceFinderTraverseVisitorTest.java
+++ b/application/src/test/java/org/opentripplanner/place/placefinder/PlaceFinderTraverseVisitorTest.java
@@ -5,8 +5,8 @@ import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.model.plan.PlanTestConstants.T11_00;
 import static org.opentripplanner.model.plan.PlanTestConstants.T11_05;
 import static org.opentripplanner.model.plan.PlanTestConstants.T11_10;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.tripPattern;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.route;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.tripPattern;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -17,7 +17,7 @@ import org.opentripplanner.place.api.PlaceType;
 import org.opentripplanner.service.vehiclerental.model.TestVehicleRentalStationBuilder;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.search.state.TestStateBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -25,11 +25,11 @@ import org.opentripplanner.transit.model.network.TripPatternBuilder;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class PlaceFinderTraverseVisitorTest {
 
-  static TimetableRepositoryForTest model = TimetableRepositoryForTest.of();
+  static TransitRepositoryForTest model = TransitRepositoryForTest.of();
   static final Station STATION1 = Station.of(id("S1"))
     .withName(new NonLocalizedString("Station 1"))
     .withCoordinate(1.1, 1.1)
@@ -55,7 +55,7 @@ public class PlaceFinderTraverseVisitorTest {
 
   static final Route R = route("r").build();
 
-  static final TimetableRepository TIMETABLE_REPO = new TimetableRepository(
+  static final TransitRepository TIMETABLE_REPO = new TransitRepository(
     model.siteRepositoryBuilder().withRegularStops(List.of(STOP1, STOP2, STOP3, STOP4)).build()
   );
 

--- a/application/src/test/java/org/opentripplanner/place/placefinder/StreetNearbyPlaceFinderTest.java
+++ b/application/src/test/java/org/opentripplanner/place/placefinder/StreetNearbyPlaceFinderTest.java
@@ -19,7 +19,7 @@ import org.opentripplanner.service.vehiclerental.street.VehicleRentalPlaceVertex
 import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -56,7 +56,7 @@ class StreetNearbyPlaceFinderTest extends GraphRoutingTest {
       new Builder() {
         @Override
         public void build() {
-          var a = TimetableRepositoryForTest.agency("Agency");
+          var a = TransitRepositoryForTest.agency("Agency");
 
           R1 = route("R1", TransitMode.BUS, a);
           R2 = route("R2", TransitMode.TRAM, a);
@@ -126,7 +126,7 @@ class StreetNearbyPlaceFinderTest extends GraphRoutingTest {
       }
     );
 
-    transitService = new DefaultTransitService(otpModel.timetableRepository());
+    transitService = new DefaultTransitService(otpModel.transitRepository());
     var vertexLinker = VertexLinkerTestFactory.of(otpModel.graph());
     var linkingContextFactory = new LinkingContextFactory(
       otpModel.graph(),

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/FilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/FilterTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -27,15 +27,15 @@ public class FilterTest {
   static final String AGENCY_ID_2 = "RUT:Agency:2";
   static final String AGENCY_ID_3 = "RUT:Agency:3";
 
-  static final Agency AGENCY_1 = TimetableRepositoryForTest.agency("A")
+  static final Agency AGENCY_1 = TransitRepositoryForTest.agency("A")
     .copy()
     .withId(id(AGENCY_ID_1))
     .build();
-  static final Agency AGENCY_2 = TimetableRepositoryForTest.agency("B")
+  static final Agency AGENCY_2 = TransitRepositoryForTest.agency("B")
     .copy()
     .withId(id(AGENCY_ID_2))
     .build();
-  static final Agency AGENCY_3 = TimetableRepositoryForTest.agency("C")
+  static final Agency AGENCY_3 = TransitRepositoryForTest.agency("C")
     .copy()
     .withId(id(AGENCY_ID_3))
     .build();
@@ -50,7 +50,7 @@ public class FilterTest {
   static final String JOURNEY_PATTERN_ID_3 = "RUT:JourneyPattern:3";
   static final String JOURNEY_PATTERN_ID_4 = "RUT:JourneyPattern:4";
 
-  static final StopPattern STOP_PATTERN = TimetableRepositoryForTest.of().stopPattern(2);
+  static final StopPattern STOP_PATTERN = TransitRepositoryForTest.of().stopPattern(2);
 
   private static final SubMode LOCAL_BUS = SubMode.getOrBuildAndCacheForever("localBus");
   private static final SubMode NIGHT_BUS = SubMode.getOrBuildAndCacheForever("nightBus");
@@ -58,10 +58,10 @@ public class FilterTest {
   final String GROUP_OF_Routes_ID_1 = "RUT:GroupOfLines:1";
   final String GROUP_OF_Routes_ID_2 = "RUT:GroupOfLines:2";
 
-  final GroupOfRoutes GROUP_OF_ROUTES_1 = TimetableRepositoryForTest.groupOfRoutes(
+  final GroupOfRoutes GROUP_OF_ROUTES_1 = TransitRepositoryForTest.groupOfRoutes(
     GROUP_OF_Routes_ID_1
   ).build();
-  final GroupOfRoutes GROUP_OF_ROUTES_2 = TimetableRepositoryForTest.groupOfRoutes(
+  final GroupOfRoutes GROUP_OF_ROUTES_2 = TransitRepositoryForTest.groupOfRoutes(
     GROUP_OF_Routes_ID_2
   ).build();
 
@@ -80,18 +80,18 @@ public class FilterTest {
     """
   )
   public void testOne() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_2).build();
-    Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_3).build();
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_2).build();
+    Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_3).build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -122,18 +122,18 @@ public class FilterTest {
     """
   )
   public void testTwo() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_2).build();
-    Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_3).build();
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_2).build();
+    Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_3).build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -163,29 +163,29 @@ public class FilterTest {
     """
   )
   public void testThree() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1)
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1)
       .withAgency(AGENCY_1)
       .withMode(TransitMode.BUS)
       .withNetexSubmode("schoolBus")
       .build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2)
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2)
       .withAgency(AGENCY_2)
       .withMode(TransitMode.RAIL)
       .withNetexSubmode("railShuttle")
       .build();
-    Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3)
+    Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3)
       .withAgency(AGENCY_3)
       .withMode(TransitMode.TRAM)
       .build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -229,18 +229,18 @@ public class FilterTest {
     """
   )
   public void testFour() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1).build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2).build();
-    Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3).build();
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1).build();
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2).build();
+    Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3).build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -277,14 +277,14 @@ public class FilterTest {
     """
   )
   public void testFive() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1).build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2).build();
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1).build();
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2).build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -318,18 +318,18 @@ public class FilterTest {
     """
   )
   public void testSix() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_1).build();
-    Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_1).build();
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_1).build();
+    Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_1).build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -364,18 +364,18 @@ public class FilterTest {
     """
   )
   public void testSeven() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_2).build();
-    Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_2).build();
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1).withAgency(AGENCY_1).build();
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2).withAgency(AGENCY_2).build();
+    Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3).withAgency(AGENCY_2).build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -410,27 +410,27 @@ public class FilterTest {
     """
   )
   public void testEight() {
-    final Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1)
+    final Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1)
       .withMode(TransitMode.BUS)
       .withAgency(AGENCY_1)
       .build();
-    final Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2)
+    final Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2)
       .withMode(TransitMode.RAIL)
       .withAgency(AGENCY_1)
       .build();
-    final Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3)
+    final Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3)
       .withMode(TransitMode.BUS)
       .withAgency(AGENCY_2)
       .build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -467,34 +467,34 @@ public class FilterTest {
     """
   )
   public void testNine() {
-    Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1)
+    Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1)
       .withAgency(AGENCY_1)
       .withMode(TransitMode.BUS)
       .build();
-    Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2)
+    Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2)
       .withAgency(AGENCY_1)
       .withMode(TransitMode.RAIL)
       .build();
-    Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3)
+    Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3)
       .withAgency(AGENCY_1)
       .withMode(TransitMode.BUS)
       .build();
-    Route route4 = TimetableRepositoryForTest.route(ROUTE_ID_4)
+    Route route4 = TransitRepositoryForTest.route(ROUTE_ID_4)
       .withAgency(AGENCY_2)
       .withMode(TransitMode.BUS)
       .build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_4, route4)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_4, route4)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -533,31 +533,31 @@ public class FilterTest {
     """
   )
   public void testTen() {
-    final Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1)
+    final Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1)
       .withMode(TransitMode.BUS)
       .withAgency(AGENCY_1)
       .build();
-    final Route route2 = TimetableRepositoryForTest.route(ROUTE_ID_2)
+    final Route route2 = TransitRepositoryForTest.route(ROUTE_ID_2)
       .withMode(TransitMode.RAIL)
       .withAgency(AGENCY_1)
       .build();
-    final Route route3 = TimetableRepositoryForTest.route(ROUTE_ID_3)
+    final Route route3 = TransitRepositoryForTest.route(ROUTE_ID_3)
       .withMode(TransitMode.BUS)
       .withAgency(AGENCY_1)
       .build();
-    final Route route4 = TimetableRepositoryForTest.route(ROUTE_ID_4).withAgency(AGENCY_2).build();
+    final Route route4 = TransitRepositoryForTest.route(ROUTE_ID_4).withAgency(AGENCY_2).build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_3, route3)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_4, route4)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_4, route4)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -581,17 +581,17 @@ public class FilterTest {
 
   @Test
   void testDifferentSubModesInRoute() {
-    final Route route1 = TimetableRepositoryForTest.route(ROUTE_ID_1)
+    final Route route1 = TransitRepositoryForTest.route(ROUTE_ID_1)
       .withMode(TransitMode.BUS)
       .withAgency(AGENCY_1)
       .build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .withNetexSubmode(LOCAL_BUS)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route1)
         .withStopPattern(STOP_PATTERN)
         .withNetexSubmode(NIGHT_BUS)
         .build()
@@ -626,18 +626,18 @@ public class FilterTest {
 
   @Test
   public void testGroupOfLinesSelectFunctionality() {
-    var route1 = TimetableRepositoryForTest.route(ROUTE_ID_1)
+    var route1 = TransitRepositoryForTest.route(ROUTE_ID_1)
       .withGroupOfRoutes(List.of(GROUP_OF_ROUTES_1))
       .build();
-    var route2 = TimetableRepositoryForTest.route(ROUTE_ID_2)
+    var route2 = TransitRepositoryForTest.route(ROUTE_ID_2)
       .withGroupOfRoutes(List.of(GROUP_OF_ROUTES_2))
       .build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build()
     );
@@ -658,18 +658,18 @@ public class FilterTest {
 
   @Test
   public void testGroupOfLinesExcludeFunctionality() {
-    var route1 = TimetableRepositoryForTest.route(ROUTE_ID_1)
+    var route1 = TransitRepositoryForTest.route(ROUTE_ID_1)
       .withGroupOfRoutes(List.of(GROUP_OF_ROUTES_1))
       .build();
-    var route2 = TimetableRepositoryForTest.route(ROUTE_ID_2)
+    var route2 = TransitRepositoryForTest.route(ROUTE_ID_2)
       .withGroupOfRoutes(List.of(GROUP_OF_ROUTES_2))
       .build();
 
     var patterns = List.of(
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_1, route1)
         .withStopPattern(STOP_PATTERN)
         .build(),
-      TimetableRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
+      TransitRepositoryForTest.tripPattern(JOURNEY_PATTERN_ID_2, route2)
         .withStopPattern(STOP_PATTERN)
         .build()
     );

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -54,7 +54,7 @@ import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -64,7 +64,7 @@ import org.opentripplanner.transit.model.site.RegularStopBuilder;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StationBuilder;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public abstract class GraphRoutingTest {
 
@@ -73,10 +73,10 @@ public abstract class GraphRoutingTest {
   protected TestOtpModel modelOf(Builder builder) {
     builder.build();
     Graph graph = builder.graph();
-    TimetableRepository timetableRepository = builder.timetableRepository();
+    TransitRepository transitRepository = builder.transitRepository();
     return new TestOtpModel(
       graph,
-      timetableRepository,
+      transitRepository,
       TransferServiceTestFactory.defaultTransferRepository()
     ).index();
   }
@@ -84,13 +84,13 @@ public abstract class GraphRoutingTest {
   public abstract static class Builder {
 
     private final Graph graph;
-    private final TimetableRepository timetableRepository;
+    private final TransitRepository transitRepository;
     private final VertexFactory vertexFactory;
     private final VehicleParkingHelper vehicleParkingHelper;
 
     protected Builder() {
       graph = new Graph();
-      timetableRepository = new TimetableRepository(new SiteRepository());
+      transitRepository = new TransitRepository(new SiteRepository());
       vertexFactory = new VertexFactory(graph);
       vehicleParkingHelper = new VehicleParkingHelper(graph);
     }
@@ -101,8 +101,8 @@ public abstract class GraphRoutingTest {
       return graph;
     }
 
-    public TimetableRepository timetableRepository() {
-      return timetableRepository;
+    public TransitRepository transitRepository() {
+      return transitRepository;
     }
 
     // -- Street network
@@ -242,28 +242,26 @@ public abstract class GraphRoutingTest {
     }
 
     RegularStop stopEntity(String id, Consumer<RegularStopBuilder> body) {
-      var siteRepositoryBuilder = timetableRepository.getSiteRepository().withContext();
-      var testModel = new TimetableRepositoryForTest(siteRepositoryBuilder);
+      var siteRepositoryBuilder = transitRepository.getSiteRepository().withContext();
+      var testModel = new TransitRepositoryForTest(siteRepositoryBuilder);
 
       var stopBuilder = testModel.stop(id);
       body.accept(stopBuilder);
 
       var stop = stopBuilder.build();
-      timetableRepository.mergeSiteRepositories(
-        siteRepositoryBuilder.withRegularStop(stop).build()
-      );
+      transitRepository.mergeSiteRepositories(siteRepositoryBuilder.withRegularStop(stop).build());
       return stop;
     }
 
     public Station stationEntity(String id, Consumer<StationBuilder> stationBuilder) {
-      var siteRepositoryBuilder = timetableRepository.getSiteRepository().withContext();
-      var testModel = new TimetableRepositoryForTest(siteRepositoryBuilder);
+      var siteRepositoryBuilder = transitRepository.getSiteRepository().withContext();
+      var testModel = new TransitRepositoryForTest(siteRepositoryBuilder);
 
       var builder = testModel.station(id);
       stationBuilder.accept(builder);
       var station = builder.build();
 
-      timetableRepository.mergeSiteRepositories(siteRepositoryBuilder.withStation(station).build());
+      transitRepository.mergeSiteRepositories(siteRepositoryBuilder.withStation(station).build());
       return station;
     }
 
@@ -486,24 +484,24 @@ public abstract class GraphRoutingTest {
     }
 
     public Route route(String id, TransitMode mode, Agency agency) {
-      return TimetableRepositoryForTest.route(id).withAgency(agency).withMode(mode).build();
+      return TransitRepositoryForTest.route(id).withAgency(agency).withMode(mode).build();
     }
 
     // Transit
     public void tripPattern(TripPattern tripPattern) {
-      timetableRepository.addTripPattern(tripPattern.getId(), tripPattern);
+      transitRepository.addTripPattern(tripPattern.getId(), tripPattern);
     }
 
     public StopTime st(TransitStopVertex s1) {
       var st = new StopTime();
-      var stop = timetableRepository.getSiteRepository().getRegularStop(s1.getId());
+      var stop = transitRepository.getSiteRepository().getRegularStop(s1.getId());
       st.setStop(stop);
       return st;
     }
 
     public StopTime st(TransitStopVertex s1, boolean board, boolean alight) {
       var st = new StopTime();
-      var stop = timetableRepository.getSiteRepository().getRegularStop(s1.getId());
+      var stop = transitRepository.getSiteRepository().getRegularStop(s1.getId());
       st.setStop(stop);
       st.setPickupType(board ? PickDrop.SCHEDULED : PickDrop.NONE);
       st.setDropOffType(alight ? PickDrop.SCHEDULED : PickDrop.NONE);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -136,7 +136,7 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
     graph = otpModel.graph();
 
     graph.hasStreets = true;
-    TestStreetLinkerModule.link(graph, otpModel.timetableRepository());
+    TestStreetLinkerModule.link(graph, otpModel.transitRepository());
     String label = stop.getLabelString();
     this.stopLocation = GenericLocation.fromStopId(stop.getId(), label);
   }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -54,28 +54,22 @@ public class TestBanning {
   }
 
   private List<TripPattern> getTestPatterns() {
-    Agency agency1 = TimetableRepositoryForTest.agency("A")
-      .copy()
-      .withId(id("RUT:Agency:1"))
-      .build();
-    Agency agency2 = TimetableRepositoryForTest.agency("B")
-      .copy()
-      .withId(id("RUT:Agency:2"))
-      .build();
+    Agency agency1 = TransitRepositoryForTest.agency("A").copy().withId(id("RUT:Agency:1")).build();
+    Agency agency2 = TransitRepositoryForTest.agency("B").copy().withId(id("RUT:Agency:2")).build();
 
-    Route route1 = TimetableRepositoryForTest.route("RUT:Route:1").withAgency(agency1).build();
-    Route route2 = TimetableRepositoryForTest.route("RUT:Route:2").withAgency(agency1).build();
-    Route route3 = TimetableRepositoryForTest.route("RUT:Route:3").withAgency(agency2).build();
+    Route route1 = TransitRepositoryForTest.route("RUT:Route:1").withAgency(agency1).build();
+    Route route2 = TransitRepositoryForTest.route("RUT:Route:2").withAgency(agency1).build();
+    Route route3 = TransitRepositoryForTest.route("RUT:Route:3").withAgency(agency2).build();
 
-    final StopPattern stopPattern = TimetableRepositoryForTest.of().stopPattern(2);
+    final StopPattern stopPattern = TransitRepositoryForTest.of().stopPattern(2);
     return List.of(
-      TimetableRepositoryForTest.tripPattern("RUT:JourneyPattern:1", route1)
+      TransitRepositoryForTest.tripPattern("RUT:JourneyPattern:1", route1)
         .withStopPattern(stopPattern)
         .build(),
-      TimetableRepositoryForTest.tripPattern("RUT:JourneyPattern:2", route2)
+      TransitRepositoryForTest.tripPattern("RUT:JourneyPattern:2", route2)
         .withStopPattern(stopPattern)
         .build(),
-      TimetableRepositoryForTest.tripPattern("RUT:JourneyPattern:3", route3)
+      TransitRepositoryForTest.tripPattern("RUT:JourneyPattern:3", route3)
         .withStopPattern(stopPattern)
         .build()
     );

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/PagingFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/PagingFilterTest.java
@@ -19,13 +19,13 @@ import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.SortOrder;
 import org.opentripplanner.model.plan.TestItineraryBuilder;
 import org.opentripplanner.routing.algorithm.filterchain.framework.sort.SortOrderComparator;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.utils.collection.ListSection;
 import org.opentripplanner.utils.time.TimeUtils;
 
 public class PagingFilterTest implements PlanTestConstants {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final Place A = TEST_MODEL.place("A", 10, 11);
   private static final Place B = TEST_MODEL.place("B", 10, 13);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/SingleCriteriaComparatorTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/SingleCriteriaComparatorTest.java
@@ -9,12 +9,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.grouppriority.DefaultTransitGroupPriorityCalculator;
 
 class SingleCriteriaComparatorTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final DefaultTransitGroupPriorityCalculator GROUP_PRIORITY_CALCULATOR =
     new DefaultTransitGroupPriorityCalculator();
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/mcmax/ItemTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/mcmax/ItemTest.java
@@ -9,11 +9,11 @@ import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class ItemTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Place A = TEST_MODEL.place("A", 10, 11);
   private static final Place B = TEST_MODEL.place("B", 10, 11);
   private static final Itinerary ITINERARY = newItinerary(A).bus(1, 1, 2, B).build();

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/mcmax/McMaxLimitFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/system/mcmax/McMaxLimitFilterTest.java
@@ -12,12 +12,12 @@ import org.opentripplanner.core.model.basic.Cost;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.routing.algorithm.filterchain.filters.system.SingleCriteriaComparator;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.grouppriority.DefaultTransitGroupPriorityCalculator;
 
 class McMaxLimitFilterTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final DefaultTransitGroupPriorityCalculator GROUP_PRIORITY_CALCULATOR =
     new DefaultTransitGroupPriorityCalculator();
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/DecorateTransitAlertTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/DecorateTransitAlertTest.java
@@ -14,7 +14,7 @@ import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.alertpatch.TransitAlertBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class DecorateTransitAlertTest implements PlanTestConstants {
 
@@ -62,7 +62,7 @@ class DecorateTransitAlertTest implements PlanTestConstants {
   @Test
   void testSkipsLegRebuildWhenNoAlertsMatch() {
     // Alert service with no alerts at all — nothing can match.
-    var transitAlertService = new TransitAlertServiceImpl(new TimetableRepository());
+    var transitAlertService = new TransitAlertServiceImpl(new TransitRepository());
     var decorator = new DecorateTransitAlert(transitAlertService, ignore -> null);
 
     var i1 = newItinerary(A).bus(31, 0, 30, E).build();
@@ -81,7 +81,7 @@ class DecorateTransitAlertTest implements PlanTestConstants {
   }
 
   private static TransitAlertServiceImpl buildService(TransitAlertBuilder builder) {
-    var transitAlertService = new TransitAlertServiceImpl(new TimetableRepository());
+    var transitAlertService = new TransitAlertServiceImpl(new TransitRepository());
     transitAlertService.setAlerts(
       List.of(builder.addTimePeriod(new TimePeriod(0, TimePeriod.OPEN_ENDED)).build())
     );

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/framework/groupids/GroupByAllSameStationsTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/framework/groupids/GroupByAllSameStationsTest.java
@@ -7,13 +7,13 @@ import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStopBuilder;
 import org.opentripplanner.transit.model.site.Station;
 
 class GroupByAllSameStationsTest implements PlanTestConstants {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   Station STATION_1 = testModel.station("1").build();
   Station STATION_2 = testModel.station("2").build();

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/framework/groupids/GroupBySameRoutesAndStopsTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/filterchain/framework/groupids/GroupBySameRoutesAndStopsTest.java
@@ -8,13 +8,13 @@ import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.Route;
 
 class GroupBySameRoutesAndStopsTest implements PlanTestConstants {
 
-  Route routeA = TimetableRepositoryForTest.route("A").build();
-  Route routeB = TimetableRepositoryForTest.route("B").build();
+  Route routeA = TransitRepositoryForTest.route("A").build();
+  Route routeB = TransitRepositoryForTest.route("B").build();
 
   Itinerary i1 = newItinerary(A)
     .bus(routeA, 21, T11_06, T11_28, E)

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
@@ -58,7 +58,7 @@ import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.street.search.state.TestStateBuilder;
 import org.opentripplanner.transfer.regular.model.DefaultRaptorTransfer;
 import org.opentripplanner.transfer.regular.model.PathTransfer;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -68,12 +68,12 @@ import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.model.timetable.booking.RoutingBookingInfo;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.utils.time.TimeUtils;
 
 public class RaptorPathToItineraryMapperTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final int BOARD_COST_SEC = 60;
   private static final int TRANSFER_COST_SEC = 120;
   private static final double[] TRANSIT_RELUCTANCE = new double[] { 1.0 };
@@ -267,7 +267,7 @@ public class RaptorPathToItineraryMapperTest {
   }
 
   private TripTimes buildTripTimes(TripPattern originalPattern) {
-    var trip = TimetableRepositoryForTest.trip("test").build();
+    var trip = TransitRepositoryForTest.trip("test").build();
     var stopTimes = new ArrayList<StopTime>();
     for (int i = 0; i < originalPattern.numberOfStops(); i++) {
       var st = new StopTime();
@@ -312,12 +312,12 @@ public class RaptorPathToItineraryMapperTest {
     Instant dateTime = LocalDateTime.of(2022, Month.OCTOBER, 10, 12, 0, 0)
       .atZone(ZoneIds.STOCKHOLM)
       .toInstant();
-    TimetableRepository timetableRepository = new TimetableRepository();
-    timetableRepository.initTimeZone(ZoneIds.CET);
-    timetableRepository.index();
+    TransitRepository transitRepository = new TransitRepository();
+    transitRepository.initTimeZone(ZoneIds.CET);
+    transitRepository.index();
     return new RaptorPathToItineraryMapper<>(
       new Graph(),
-      new DefaultTransitService(timetableRepository),
+      new DefaultTransitService(transitRepository),
       new DefaultStreetDetailsService(new DefaultStreetDetailsRepository()),
       getRaptorTransitData(),
       dateTime.atZone(ZoneIds.CET),

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -89,7 +89,7 @@ public abstract class SnapshotTestBase {
       TestOtpModel model = getGraph();
       serverContext = TestServerContext.createServerContext(
         model.graph(),
-        model.timetableRepository(),
+        model.transitRepository(),
         model.transferRepository(),
         model.fareServiceFactory().makeFareService(),
         null,

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/startonboardaccess/TripAndServiceDateResolverTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/startonboardaccess/TripAndServiceDateResolverTest.java
@@ -53,8 +53,8 @@ class TripAndServiceDateResolverTest {
       .withServiceDate(SERVICE_DATE)
       .withTripAlteration(TripAlteration.PLANNED)
       .build();
-    env.timetableRepository().addTripOnServiceDate(tripOnServiceDate);
-    env.timetableRepository().index();
+    env.transitRepository().addTripOnServiceDate(tripOnServiceDate);
+    env.transitRepository().index();
 
     var reference = TripOnDateReference.ofTripOnServiceDateId(id("TOSD-1"));
     var result = new TripAndServiceDateResolver(env.transitService()).resolve(reference);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouterTest.java
@@ -25,12 +25,12 @@ import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.search.state.State;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class AccessEgressRouterTest extends GraphRoutingTest {
 
   private Graph graph;
-  private TimetableRepository timetableRepository;
+  private TransitRepository transitRepository;
 
   private TransitStopVertex stopForCentroidRoutingStation;
   private TransitStopVertex stopForNoCentroidRoutingStation;
@@ -81,7 +81,7 @@ class AccessEgressRouterTest extends GraphRoutingTest {
       }
     );
     graph = otpModel.graph();
-    timetableRepository = otpModel.timetableRepository();
+    transitRepository = otpModel.transitRepository();
   }
 
   @Test
@@ -228,7 +228,7 @@ class AccessEgressRouterTest extends GraphRoutingTest {
     if (nearbyStop.edges.isEmpty()) {
       return (
         "direct[" +
-        timetableRepository.getSiteRepository().getStopLocation(nearbyStop.stopId).getName() +
+        transitRepository.getSiteRepository().getStopLocation(nearbyStop.stopId).getName() +
         "]"
       );
     } else {
@@ -262,7 +262,7 @@ class AccessEgressRouterTest extends GraphRoutingTest {
     try (var verticesContainer = new TemporaryVerticesContainer()) {
       var vertexLinker = VertexLinkerTestFactory.of(graph);
       var vertexCreationService = new VertexCreationService(vertexLinker);
-      var transitService = new DefaultTransitService(timetableRepository);
+      var transitService = new DefaultTransitService(transitRepository);
       var linkingContextFactory = new LinkingContextFactory(
         graph,
         vertexCreationService,

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitDataTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransitDataTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.StopTime;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -21,7 +21,7 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class RaptorTransitDataTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final TripTimes TRIP_TIMES;
 
   private static final RoutingTripPattern TRIP_PATTERN;
@@ -31,14 +31,14 @@ class RaptorTransitDataTest {
     var stopTime = new StopTime();
     stopTime.setStop(stop);
     var stopPattern = new StopPattern(List.of(stopTime));
-    var route = TimetableRepositoryForTest.route("1").build();
+    var route = TransitRepositoryForTest.route("1").build();
     TRIP_PATTERN = TripPattern.of(FeedScopedIdForTestFactory.id("P1"))
       .withRoute(route)
       .withStopPattern(stopPattern)
       .build()
       .getRoutingTripPattern();
     TRIP_TIMES = TripTimesFactory.tripTimes(
-      TimetableRepositoryForTest.trip("1").withRoute(route).build(),
+      TransitRepositoryForTest.trip("1").withRoute(route).build(),
       List.of(new StopTime()),
       new Deduplicator()
     );

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.Frequency;
 import org.opentripplanner.model.StopTime;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
@@ -25,11 +25,11 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class TripPatternForDateTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final RegularStop STOP = TEST_MODEL.stop("TEST:STOP", 0, 0).build();
-  private static final Route ROUTE = TimetableRepositoryForTest.route("1").build();
+  private static final Route ROUTE = TransitRepositoryForTest.route("1").build();
   private static final ScheduledTripTimes TRIP_TIMES = TripTimesFactory.tripTimes(
-    TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build(),
+    TransitRepositoryForTest.trip("1").withRoute(ROUTE).build(),
     List.of(new StopTime()),
     new Deduplicator()
   );

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/PatternCostCalculatorTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/PatternCostCalculatorTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.raptorlegacy._data.transit.TestRoute.route;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.agency;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.agency;
 
 import java.time.Duration;
 import java.util.List;
@@ -26,7 +26,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.Gener
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.framework.CostLinearFunction;
 import org.opentripplanner.test.support.TestTableParser;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.network.RouteBuilder;
 import org.opentripplanner.transit.model.organization.Agency;
 
@@ -218,7 +218,7 @@ public class PatternCostCalculatorTest {
   }
 
   private static TestTripPattern pattern(boolean unpreferredRoute, boolean unpreferredAgency) {
-    RouteBuilder builder = TimetableRepositoryForTest.route(
+    RouteBuilder builder = TransitRepositoryForTest.route(
       unpreferredRoute ? UNPREFERRED_ROUTE_ID : DEFAULT_ROUTE_ID
     );
 

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/GeneralizedCostParametersMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/GeneralizedCostParametersMapperTest.java
@@ -2,8 +2,8 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.agency;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.agency;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.route;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapperTest.java
@@ -31,14 +31,14 @@ import org.opentripplanner.routing.via.model.ViaCoordinateTransfer;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.vertex.LabelledIntersectionVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 class RaptorRequestMapperTest {
 
   private static final GenericLocation TO = GenericLocation.fromCoordinate(60.0, 10.0);
   private static final GenericLocation FROM = GenericLocation.fromCoordinate(62.0, 12.0);
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final StopLocation STOP_A = TEST_MODEL.stop("Stop:A").build();
   private static final PassThroughViaLocation PASS_THROUGH_VIA_LOCATION =
     new PassThroughViaLocation("Via A", List.of(STOP_A.getId()));

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorTransitDataMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorTransitDataMapperTest.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitTuningParametersTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -15,7 +15,7 @@ import org.opentripplanner.transit.service.SiteRepositoryMock;
 
 class RaptorTransitDataMapperTest {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   private final Station STATION_A = testModel
     .station("A")

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapperTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -21,7 +21,7 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 public class TripPatternForDateMapperTest {
 
-  private static TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final LocalDate SERVICE_DATE = LocalDate.of(2009, 8, 7);
   private static final int SERVICE_CODE = 555;
@@ -34,7 +34,7 @@ public class TripPatternForDateMapperTest {
   @BeforeAll
   public static void setUp() throws Exception {
     var pattern = TEST_MODEL.pattern(BUS).build();
-    var trip = TimetableRepositoryForTest.trip("1").build();
+    var trip = TransitRepositoryForTest.trip("1").build();
     var tripTimes = TripTimesFactory.tripTimes(
       trip,
       TEST_MODEL.stopTimesEvery5Minutes(5, trip, "11:00"),

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/DefaultTransitDataProviderFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/DefaultTransitDataProviderFilterTest.java
@@ -32,7 +32,7 @@ import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -53,9 +53,9 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class DefaultTransitDataProviderFilterTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
-  private static final Route ROUTE = TimetableRepositoryForTest.route("1").build();
+  private static final Route ROUTE = TransitRepositoryForTest.route("1").build();
 
   private static final FeedScopedId TRIP_ID = FeedScopedIdForTestFactory.id("T1");
 
@@ -101,7 +101,7 @@ class DefaultTransitDataProviderFilterTest {
 
     var stopPattern = new StopPattern(List.of(stopTimeStart, stopTimeEnd));
     var tripPattern = TripPattern.of(FeedScopedIdForTestFactory.id("P1"))
-      .withRoute(TimetableRepositoryForTest.route("1").build())
+      .withRoute(TransitRepositoryForTest.route("1").build())
       .withStopPattern(stopPattern)
       .build()
       .getRoutingTripPattern();
@@ -150,7 +150,7 @@ class DefaultTransitDataProviderFilterTest {
     var stopTime4 = getStopTime("TEST:4", PickDrop.SCHEDULED);
     var stopPattern = new StopPattern(List.of(stopTime1, stopTime2, stopTime3, stopTime4));
     var tripPattern = TripPattern.of(FeedScopedIdForTestFactory.id("P1"))
-      .withRoute(TimetableRepositoryForTest.route("1").build())
+      .withRoute(TransitRepositoryForTest.route("1").build())
       .withStopPattern(stopPattern)
       .build()
       .getRoutingTripPattern();
@@ -277,7 +277,7 @@ class DefaultTransitDataProviderFilterTest {
               SubMode.of(TransmodelTransportSubmode.UNKNOWN.getValue())
             )
           ),
-          List.of(TimetableRepositoryForTest.OTHER_AGENCY.getId())
+          List.of(TransitRepositoryForTest.OTHER_AGENCY.getId())
         )
       )
       .build();
@@ -308,7 +308,7 @@ class DefaultTransitDataProviderFilterTest {
               SubMode.of(TransmodelTransportSubmode.UNKNOWN.getValue())
             )
           ),
-          List.of(TimetableRepositoryForTest.OTHER_AGENCY.getId())
+          List.of(TransitRepositoryForTest.OTHER_AGENCY.getId())
         )
       )
       .build();
@@ -332,7 +332,7 @@ class DefaultTransitDataProviderFilterTest {
           TransitFilterRequest.of()
             .addSelect(
               SelectRequest.of()
-                .withAgencies(List.of(TimetableRepositoryForTest.AGENCY.getId()))
+                .withAgencies(List.of(TransitRepositoryForTest.AGENCY.getId()))
                 .build()
             )
             .addNot(
@@ -452,13 +452,13 @@ class DefaultTransitDataProviderFilterTest {
     var transitFilter = TransitFilterRequest.of()
       .addSelect(
         SelectRequest.of()
-          .withAgencies(List.of(TimetableRepositoryForTest.OTHER_AGENCY.getId()))
+          .withAgencies(List.of(TransitRepositoryForTest.OTHER_AGENCY.getId()))
           .withTransportModes(List.of(new MainAndSubMode(TransitMode.BUS)))
           .build()
       )
       .addSelect(
         SelectRequest.of()
-          .withAgencies(List.of(TimetableRepositoryForTest.AGENCY.getId()))
+          .withAgencies(List.of(TransitRepositoryForTest.AGENCY.getId()))
           .withTransportModes(List.of(new MainAndSubMode(TransitMode.RAIL)))
           .build()
       )
@@ -720,7 +720,7 @@ class DefaultTransitDataProviderFilterTest {
 
   @Test
   void testBikesAllowed() {
-    RouteBuilder routeBuilder = TimetableRepositoryForTest.route("1");
+    RouteBuilder routeBuilder = TransitRepositoryForTest.route("1");
     TripBuilder trip = Trip.of(FeedScopedIdForTestFactory.id("T1")).withRoute(routeBuilder.build());
 
     assertEquals(
@@ -892,7 +892,7 @@ class DefaultTransitDataProviderFilterTest {
   }
 
   private TripPatternForDate createTestTripPatternForDate() {
-    Route route = TimetableRepositoryForTest.route("1").build();
+    Route route = TransitRepositoryForTest.route("1").build();
 
     var stopTime = new StopTime();
     stopTime.setStop(STOP_FOR_TEST);
@@ -904,7 +904,7 @@ class DefaultTransitDataProviderFilterTest {
       .getRoutingTripPattern();
 
     TripTimes tripTimes = TripTimesFactory.tripTimes(
-      TimetableRepositoryForTest.trip("1").withRoute(route).build(),
+      TransitRepositoryForTest.trip("1").withRoute(route).build(),
       List.of(new StopTime()),
       new Deduplicator()
     );

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
@@ -19,7 +19,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitData;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -31,7 +31,7 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
 
 public class RaptorRoutingRequestTransitDataCreatorTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   public static final FeedScopedId TP_ID_1 = id("1");
   public static final FeedScopedId TP_ID_2 = id("2");
@@ -100,23 +100,23 @@ public class RaptorRoutingRequestTransitDataCreatorTest {
     var date = LocalDate.of(2025, 10, 10);
     List<TripTimes> tripTimes = List.of(
       ScheduledTripTimes.of()
-        .withTrip(TimetableRepositoryForTest.trip("Test").build())
+        .withTrip(TransitRepositoryForTest.trip("Test").build())
         .withDepartureTimes("23:45 23:55")
         .build(),
       ScheduledTripTimes.of()
-        .withTrip(TimetableRepositoryForTest.trip("Test").build())
+        .withTrip(TransitRepositoryForTest.trip("Test").build())
         .withDepartureTimes("23:47 23:57")
         .build(),
       ScheduledTripTimes.of()
-        .withTrip(TimetableRepositoryForTest.trip("Test").build())
+        .withTrip(TransitRepositoryForTest.trip("Test").build())
         .withDepartureTimes("23:49 23:59")
         .build(),
       ScheduledTripTimes.of()
-        .withTrip(TimetableRepositoryForTest.trip("Test").build())
+        .withTrip(TransitRepositoryForTest.trip("Test").build())
         .withDepartureTimes("23:51 24:01")
         .build(),
       ScheduledTripTimes.of()
-        .withTrip(TimetableRepositoryForTest.trip("Test").build())
+        .withTrip(TransitRepositoryForTest.trip("Test").build())
         .withDepartureTimes("23:53 24:03")
         .build()
     );
@@ -182,7 +182,7 @@ public class RaptorRoutingRequestTransitDataCreatorTest {
 
   private TripTimes createTripTimesForTest() {
     return ScheduledTripTimes.of()
-      .withTrip(TimetableRepositoryForTest.trip("Test").build())
+      .withTrip(TransitRepositoryForTest.trip("Test").build())
       .withDepartureTimes("00:00 02:00")
       .build();
   }
@@ -200,7 +200,7 @@ public class RaptorRoutingRequestTransitDataCreatorTest {
 
   private static RoutingTripPattern createTripPattern(FeedScopedId id) {
     return TripPattern.of(id)
-      .withRoute(TimetableRepositoryForTest.route("1").withMode(TransitMode.BUS).build())
+      .withRoute(TransitRepositoryForTest.route("1").withMode(TransitMode.BUS).build())
       .withStopPattern(new StopPattern(List.of(createStopTime(), createStopTime())))
       .build()
       .getRoutingTripPattern();

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
@@ -17,7 +17,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.raptor.spi.RaptorTimeTable;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
@@ -256,11 +256,9 @@ public class TestRouteData {
     }
 
     public TestRouteData build() {
-      var routeBuilder = TimetableRepositoryForTest.route(route)
-        .withMode(mode)
-        .withShortName(route);
+      var routeBuilder = TransitRepositoryForTest.route(route).withMode(mode).withShortName(route);
       if (agency != null) {
-        routeBuilder.withAgency(TimetableRepositoryForTest.agency(agency));
+        routeBuilder.withAgency(TransitRepositoryForTest.agency(agency));
       }
       if (submode != null) {
         routeBuilder.withNetexSubmode(submode);

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestTransitCaseData.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestTransitCaseData.java
@@ -1,13 +1,13 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import java.time.LocalDate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 
 public final class TestTransitCaseData {
 
-  private static TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   public static final Station STATION_A = TEST_MODEL.station("A")
     .withCoordinate(60.0, 11.1)

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDatesTest.java
@@ -12,7 +12,7 @@ import org.opentripplanner.model.Frequency;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.raptor.spi.SearchDirection;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
@@ -28,7 +28,7 @@ class TripPatternForDatesTest {
   private static final int FREQUENCY_START = 7 * 60 * 60;
   private static final int FREQUENCY_END = 23 * 60 * 60;
   private static final int HEADWAY = 300;
-  private static final Route ROUTE = TimetableRepositoryForTest.route("1").build();
+  private static final Route ROUTE = TransitRepositoryForTest.route("1").build();
   private static final LocalDate SERVICE_DATE = LocalDate.of(2024, 11, 1);
 
   @Test
@@ -65,7 +65,7 @@ class TripPatternForDatesTest {
   }
 
   private static TripPatternForDates getTestSubjectWithExactFrequency() {
-    var testModel = TimetableRepositoryForTest.of();
+    var testModel = TransitRepositoryForTest.of();
     var stop1 = testModel.stop("FEED:STOP1", 0, 0).build();
     var stop2 = testModel.stop("FEED:STOP2", 0, 0).build();
 
@@ -86,7 +86,7 @@ class TripPatternForDatesTest {
       .build()
       .getRoutingTripPattern();
 
-    Trip trip = TimetableRepositoryForTest.trip("1").withRoute(ROUTE).build();
+    Trip trip = TransitRepositoryForTest.trip("1").withRoute(ROUTE).build();
     final ScheduledTripTimes tripTimes = TripTimesFactory.tripTimes(
       trip,
       List.of(stopTime1, stopTime2),

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
@@ -10,7 +10,7 @@ import org.opentripplanner.transfer.constrained.model.ConstrainedTransfer;
 import org.opentripplanner.transfer.constrained.model.TransferConstraint;
 import org.opentripplanner.transfer.constrained.model.TransferPriority;
 import org.opentripplanner.transfer.constrained.model.TripTransferPoint;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.utils.time.TimeUtils;
 
@@ -154,7 +154,7 @@ public class TestTransferBuilder<T extends RaptorTripSchedule> {
 
   private static <T extends RaptorTripSchedule> Trip createDummyTrip(T trip) {
     // Set an uniq id: pattern + the first stop departure time
-    return TimetableRepositoryForTest.trip(
+    return TransitRepositoryForTest.trip(
       trip.pattern().debugInfo() + ":" + TimeUtils.timeToStrCompact(trip.departure(0))
     ).build();
   }

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/via/ViaRoutingWorkerTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/via/ViaRoutingWorkerTest.java
@@ -20,7 +20,7 @@ import org.opentripplanner.routing.api.request.ViaLocationDeprecated;
 import org.opentripplanner.routing.api.request.request.JourneyRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.api.response.ViaRoutingResponseConnection;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.utils.time.TimeUtils;
 
 /**
@@ -50,7 +50,7 @@ public class ViaRoutingWorkerTest {
   private static List<Itinerary> firstSearch;
   private static List<Itinerary> secondSearch;
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   private final Place fromA = testModel.place("A", 5.0, 8.0);
   private final Place viaC = testModel.place("C", 7.0, 9.0);

--- a/application/src/test/java/org/opentripplanner/routing/api/DefaultRoutingServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/api/DefaultRoutingServiceTest.java
@@ -34,7 +34,7 @@ public class DefaultRoutingServiceTest extends GtfsTest {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    transitService = new DefaultTransitService(timetableRepository);
+    transitService = new DefaultTransitService(transitRepository);
   }
 
   @Override
@@ -47,7 +47,7 @@ public class DefaultRoutingServiceTest extends GtfsTest {
     /* Graph vertices */
     for (Vertex vertex : graph.getVertices()) {
       if (vertex instanceof TransitStopVertex tsv) {
-        RegularStop stop = timetableRepository.getSiteRepository().getRegularStop(tsv.getId());
+        RegularStop stop = transitRepository.getSiteRepository().getRegularStop(tsv.getId());
         Vertex index_vertex = graph.getStopVertex(stop.getId());
         assertEquals(index_vertex, vertex);
       }

--- a/application/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -54,7 +54,7 @@ import org.opentripplanner.street.internal.DefaultStreetRepository;
 import org.opentripplanner.street.model.StreetModelDetails;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * Tests that saving a graph and reloading it (round trip through serialization and deserialization)
@@ -106,7 +106,7 @@ public class GraphSerializationTest {
       osmGraphBuildRepository,
       streetDetailsRepository,
       streetRepository,
-      model.timetableRepository(),
+      model.transitRepository(),
       model.transferRepository(),
       weRepo,
       parkingRepository,
@@ -139,7 +139,7 @@ public class GraphSerializationTest {
       osmGraphBuildRepository,
       streetDetailsRepository,
       streetRepository,
-      model.timetableRepository(),
+      model.transitRepository(),
       model.transferRepository(),
       worldEnvelopeRepository,
       parkingRepository,
@@ -247,7 +247,7 @@ public class GraphSerializationTest {
     OsmInfoGraphBuildRepository osmInfoGraphBuildRepository,
     StreetDetailsRepository streetDetailsRepository,
     StreetRepository streetRepository,
-    TimetableRepository originalTimetableRepository,
+    TransitRepository originalTransitRepository,
     TransferRepository originalTransferRepository,
     WorldEnvelopeRepository worldEnvelopeRepository,
     VehicleParkingRepository vehicleParkingRepository,
@@ -262,7 +262,7 @@ public class GraphSerializationTest {
       osmInfoGraphBuildRepository,
       streetDetailsRepository,
       streetRepository,
-      originalTimetableRepository,
+      originalTransitRepository,
       originalTransferRepository,
       worldEnvelopeRepository,
       vehicleParkingRepository,
@@ -277,22 +277,22 @@ public class GraphSerializationTest {
     serializedObj.save(new FileDataSource(tempFile, FileType.GRAPH));
     SerializedGraphObject deserializedGraph = SerializedGraphObject.load(tempFile);
     Graph copiedGraph1 = deserializedGraph.graph;
-    TimetableRepository copiedTimetableRepository1 = deserializedGraph.timetableRepository;
+    TransitRepository copiedTransitRepository1 = deserializedGraph.transitRepository;
     // Index both graph - we do no know if the original is indexed, because it is cached and
     // might be indexed by other tests.
 
-    originalTimetableRepository.index();
+    originalTransitRepository.index();
     originalGraph.index();
 
-    copiedTimetableRepository1.index();
+    copiedTransitRepository1.index();
     copiedGraph1.index();
 
     assertNoDifferences(originalGraph, copiedGraph1);
 
     SerializedGraphObject deserializedGraph2 = SerializedGraphObject.load(tempFile);
     Graph copiedGraph2 = deserializedGraph2.graph;
-    TimetableRepository copiedTimetableRepository2 = deserializedGraph2.timetableRepository;
-    copiedTimetableRepository2.index();
+    TransitRepository copiedTransitRepository2 = deserializedGraph2.transitRepository;
+    copiedTransitRepository2.index();
     copiedGraph2.index();
     assertNoDifferences(copiedGraph1, copiedGraph2);
   }

--- a/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/impl/TransitAlertServiceImplTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class TransitAlertServiceImplTest {
 
@@ -34,7 +34,7 @@ class TransitAlertServiceImplTest {
     .withCoordinate(51.5306090, -0.1239491)
     .build();
 
-  private static final TimetableRepository TIMETABLE_REPOSITORY = new TimetableRepository(
+  private static final TransitRepository TIMETABLE_REPOSITORY = new TransitRepository(
     getSiteRepository()
   );
 

--- a/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/linking/LinkingContextFactoryTest.java
@@ -36,7 +36,7 @@ import org.opentripplanner.street.model.vertex.TemporaryStreetLocation;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.TraverseMode;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.service.SiteRepository;
@@ -52,7 +52,7 @@ class LinkingContextFactoryTest {
   private static final FeedScopedId ALPHA_ID = id("alpha");
   private static final FeedScopedId OMEGA_ID = id("omega");
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   private final Station stationAlpha = testModel
     .station("alpha")

--- a/application/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
@@ -35,7 +35,7 @@ class AlternativeLegsTest extends GtfsTest {
 
   @Test
   void testPreviousLegs() {
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitService = new DefaultTransitService(transitRepository);
 
     var originalLeg = new ScheduledTransitLegReference(
       new FeedScopedId(FEED_ID, "1.2"),
@@ -68,7 +68,7 @@ class AlternativeLegsTest extends GtfsTest {
 
   @Test
   void testNextLegs() {
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitService = new DefaultTransitService(transitRepository);
 
     var originalLeg = new ScheduledTransitLegReference(
       new FeedScopedId(FEED_ID, "2.2"),
@@ -101,7 +101,7 @@ class AlternativeLegsTest extends GtfsTest {
 
   @Test
   void testCircularRoutes() {
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitService = new DefaultTransitService(transitRepository);
 
     var originalLeg = new ScheduledTransitLegReference(
       new FeedScopedId(FEED_ID, "19.1"),
@@ -128,7 +128,7 @@ class AlternativeLegsTest extends GtfsTest {
 
   @Test
   void testComplexCircularRoutes() {
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitService = new DefaultTransitService(transitRepository);
 
     var originalLeg = new ScheduledTransitLegReference(
       new FeedScopedId(FEED_ID, "19.1"),

--- a/application/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
@@ -9,7 +9,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.Frequency;
 import org.opentripplanner.model.StopTime;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
@@ -23,7 +23,7 @@ public class FrequencyEntryTest {
   private static final ScheduledTripTimes TRIP_TIMES;
 
   static {
-    Trip trip = TimetableRepositoryForTest.trip("testtrip").build();
+    Trip trip = TransitRepositoryForTest.trip("testtrip").build();
 
     List<StopTime> stopTimes = new ArrayList<>();
 
@@ -31,7 +31,7 @@ public class FrequencyEntryTest {
     for (int i = 0; i < STOP_NUM; ++i) {
       FeedScopedId id = FeedScopedIdForTestFactory.id(i + "");
 
-      RegularStop stop = TimetableRepositoryForTest.of().stop(id.getId(), 0.0, 0.0).build();
+      RegularStop stop = TransitRepositoryForTest.of().stop(id.getId(), 0.0, 0.0).build();
 
       StopTime stopTime = new StopTime();
       stopTime.setStop(stop);

--- a/application/src/test/java/org/opentripplanner/service/paging/TestPagingModel.java
+++ b/application/src/test/java/org/opentripplanner/service/paging/TestPagingModel.java
@@ -13,7 +13,7 @@ import org.opentripplanner.model.plan.SortOrder;
 import org.opentripplanner.model.plan.TestItineraryBuilder;
 import org.opentripplanner.model.plan.paging.cursor.PageCursor;
 import org.opentripplanner.routing.algorithm.filterchain.framework.sort.SortOrderComparator;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.utils.time.TimeUtils;
 
 class TestPagingModel {
@@ -61,7 +61,7 @@ class TestPagingModel {
 
   private static final Instant TRANSIT_START_TIME = TestItineraryBuilder.newTime(0).toInstant();
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Place A = Place.forStop(TEST_MODEL.stop("A").build());
   private static final Place B = Place.forStop(TEST_MODEL.stop("B").build());
 

--- a/application/src/test/java/org/opentripplanner/service/vehicleparking/VehicleParkingTestGraphData.java
+++ b/application/src/test/java/org/opentripplanner/service/vehicleparking/VehicleParkingTestGraphData.java
@@ -6,7 +6,7 @@ import org.opentripplanner.street.model.StreetTraversalPermission;
 import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class VehicleParkingTestGraphData {
 
@@ -15,12 +15,12 @@ public class VehicleParkingTestGraphData {
 
   protected Graph graph;
 
-  protected TimetableRepository timetableRepository;
+  protected TransitRepository transitRepository;
 
   public void initGraph() {
     var siteRepository = new SiteRepository();
     graph = new Graph();
-    timetableRepository = new TimetableRepository(siteRepository);
+    transitRepository = new TransitRepository(siteRepository);
     graph.hasStreets = true;
 
     var factory = new VertexFactory(graph);
@@ -35,8 +35,8 @@ public class VehicleParkingTestGraphData {
     return graph;
   }
 
-  public TimetableRepository getTimetableRepository() {
-    return timetableRepository;
+  public TransitRepository getTransitRepository() {
+    return transitRepository;
   }
 
   public IntersectionVertex getAVertex() {

--- a/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
@@ -60,7 +60,7 @@ import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
 import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 /**
  * Verifies the real Dagger scoping added for issue #7441: bindings inside one {@link
@@ -75,7 +75,7 @@ class RequestScopedFactoryTest {
 
   @Test
   void requestScopedBindingsAreCachedWithinOneRequestButNotAcrossRequests() {
-    var timetableRepository = new TimetableRepository();
+    var transitRepository = new TransitRepository();
     var repositoryRegistry = TransactionFactory.createRepositoryRegistry();
     var timetableSnapshot = new TimetableSnapshot(
       RaptorTransitDataTestFactory.empty(),
@@ -91,10 +91,10 @@ class RequestScopedFactoryTest {
     var vertexLinker = VertexLinkerTestFactory.of(graph);
     var transferRepository = new DefaultTransferRepository(new TransferIndex());
     // Only used to wire up the throwaway helper services below; not part of what's under test.
-    var placeholderTransitService = new DefaultTransitService(timetableRepository);
+    var placeholderTransitService = new DefaultTransitService(transitRepository);
 
     var factory = DaggerRequestScopedFactoryTest_TestFactory.builder()
-      .timetableRepository(timetableRepository)
+      .transitRepository(transitRepository)
       .repositoryRegistry(repositoryRegistry)
       .timetableRepositoryHandle(timetableRepositoryHandle)
       .routerConfig(routerConfig)
@@ -176,7 +176,7 @@ class RequestScopedFactoryTest {
     @Component.Builder
     interface Builder {
       @BindsInstance
-      Builder timetableRepository(TimetableRepository timetableRepository);
+      Builder transitRepository(TransitRepository transitRepository);
 
       @BindsInstance
       Builder repositoryRegistry(RepositoryRegistry repositoryRegistry);

--- a/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
@@ -55,10 +55,10 @@ import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
 import org.opentripplanner.transfer.regular.internal.DefaultTransferRepository;
 import org.opentripplanner.transfer.regular.internal.TransferIndex;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositoryLifecycle;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 
@@ -77,13 +77,13 @@ class RequestScopedFactoryTest {
   void requestScopedBindingsAreCachedWithinOneRequestButNotAcrossRequests() {
     var transitRepository = new TransitRepository();
     var repositoryRegistry = TransactionFactory.createRepositoryRegistry();
-    var timetableSnapshot = new TimetableSnapshot(
+    var timetableSnapshot = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
     var timetableRepositoryHandle = repositoryRegistry.registerRepositorySnapshot(
       timetableSnapshot,
-      new TimetableSnapshotLifecycle(timetableSnapshot, false, () -> LocalDate.of(2026, 1, 1))
+      new TimetableRepositoryLifecycle(timetableSnapshot, false, () -> LocalDate.of(2026, 1, 1))
     );
 
     var routerConfig = RouterConfig.DEFAULT;
@@ -183,10 +183,7 @@ class RequestScopedFactoryTest {
 
       @BindsInstance
       Builder timetableRepositoryHandle(
-        RepositoryHandle<
-          ReadOnlyTimetableSnapshot,
-          MutableTimetableSnapshot
-        > timetableRepositoryHandle
+        RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableRepositoryHandle
       );
 
       @BindsInstance

--- a/application/src/test/java/org/opentripplanner/standalone/server/AlertMetricsTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/server/AlertMetricsTest.java
@@ -13,7 +13,7 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.alertpatch.TransitAlertBuilder;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class AlertMetricsTest {
 
@@ -32,7 +32,7 @@ class AlertMetricsTest {
   void registerMultiGauge() {
     var alert1 = alertBuilder("1").withSeverity(INFO).build();
     var alert2 = alertBuilder("2").withEffect(DETOUR).build();
-    var service = new TransitAlertServiceImpl(new TimetableRepository());
+    var service = new TransitAlertServiceImpl(new TransitRepository());
     service.setAlerts(List.of(alert1, alert2));
 
     var binder = new AlertMetrics(() -> service);

--- a/application/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/BicycleRoutingTest.java
@@ -38,7 +38,7 @@ public class BicycleRoutingTest {
     );
     herrenbergGraph = model.graph();
 
-    model.timetableRepository().index();
+    model.transitRepository().index();
     herrenbergGraph.index();
   }
 

--- a/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
+++ b/application/src/test/java/org/opentripplanner/street/integration/WalkRoutingTest.java
@@ -31,7 +31,7 @@ class WalkRoutingTest {
     );
     roundabout = model.graph();
 
-    model.timetableRepository().index();
+    model.transitRepository().index();
     roundabout.index();
   }
 

--- a/application/src/test/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequestBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequestBuilderTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.filter.selector.FilterRequest;
 import org.opentripplanner.transit.model.filter.transit.TripTimeOnDateSelectRequest;
@@ -23,7 +23,7 @@ import org.opentripplanner.transit.service.ArrivalDeparture;
 
 class TripTimeOnDateRequestBuilderTest {
 
-  private static final RegularStop STOP = TimetableRepositoryForTest.of().stop("1").build();
+  private static final RegularStop STOP = TransitRepositoryForTest.of().stop("1").build();
   private static final Instant TIME = Instant.parse("2025-03-02T10:00:00Z");
 
   @Test

--- a/application/src/test/java/org/opentripplanner/transit/model/TransitRepositoryArchitectureTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/TransitRepositoryArchitectureTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner._support.arch.ArchComponent;
 import org.opentripplanner._support.arch.Package;
 
-public class TimetableRepositoryArchitectureTest {
+public class TransitRepositoryArchitectureTest {
 
   private static final Package TRANSIT_FRAMEWORK = TRANSIT_MODEL.subPackage("framework");
   private static final Package BASIC = TRANSIT_MODEL.subPackage("basic");

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/PatternTestModel.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/PatternTestModel.java
@@ -13,18 +13,18 @@ import org.opentripplanner.transit.service.SiteRepository;
 
 public class PatternTestModel {
 
-  public static final Route ROUTE_1 = TimetableRepositoryForTest.route("1").build();
+  public static final Route ROUTE_1 = TransitRepositoryForTest.route("1").build();
 
   private static final FeedScopedId SERVICE_ID = id("service");
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("t1")
+  private static final Trip TRIP = TransitRepositoryForTest.trip("t1")
     .withRoute(ROUTE_1)
     .withServiceId(SERVICE_ID)
     .build();
-  private static final TimetableRepositoryForTest MODEL = new TimetableRepositoryForTest(
+  private static final TransitRepositoryForTest MODEL = new TransitRepositoryForTest(
     SiteRepository.of()
   );
   private static final RegularStop STOP_1 = MODEL.stop("1").build();
-  private static final StopPattern STOP_PATTERN = TimetableRepositoryForTest.stopPattern(
+  private static final StopPattern STOP_PATTERN = TransitRepositoryForTest.stopPattern(
     STOP_1,
     STOP_1
   );
@@ -39,7 +39,7 @@ public class PatternTestModel {
       .withDepartureTimes("10:00 10:05")
       .build();
 
-    return TimetableRepositoryForTest.tripPattern("1", ROUTE_1)
+    return TransitRepositoryForTest.tripPattern("1", ROUTE_1)
       .withStopPattern(STOP_PATTERN)
       .withScheduledTimeTableBuilder(builder -> builder.addTripTimes(tt))
       .build();

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TransitRepositoryForTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TransitRepositoryForTest.java
@@ -61,7 +61,7 @@ import org.opentripplanner.utils.time.TimeUtils;
  * @deprecated This has been deprecated in favour of {@link TransitTestEnvironment}
  */
 @Deprecated
-public class TimetableRepositoryForTest {
+public class TransitRepositoryForTest {
 
   public static final String FEED_ID = "F";
   public static final String TIME_ZONE_ID = "Europe/Paris";
@@ -99,12 +99,12 @@ public class TimetableRepositoryForTest {
 
   private final SiteRepositoryBuilder siteRepositoryBuilder;
 
-  public TimetableRepositoryForTest(SiteRepositoryBuilder siteRepositoryBuilder) {
+  public TransitRepositoryForTest(SiteRepositoryBuilder siteRepositoryBuilder) {
     this.siteRepositoryBuilder = siteRepositoryBuilder;
   }
 
-  public static TimetableRepositoryForTest of() {
-    return new TimetableRepositoryForTest(SiteRepository.of());
+  public static TransitRepositoryForTest of() {
+    return new TransitRepositoryForTest(SiteRepository.of());
   }
 
   public static Agency agency(String name) {

--- a/application/src/test/java/org/opentripplanner/transit/model/_data/TripTimesForTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/_data/TripTimesForTest.java
@@ -15,13 +15,13 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
  */
 public class TripTimesForTest {
 
-  private static final TimetableRepositoryForTest REPO = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest REPO = TransitRepositoryForTest.of();
 
   /**
    * A minimal {@link ScheduledTripTimes} with two stops and no real-time updates.
    */
   public static TripTimes scheduled() {
-    Trip trip = TimetableRepositoryForTest.trip("test-trip").build();
+    Trip trip = TransitRepositoryForTest.trip("test-trip").build();
     var stop1 = REPO.stop("A", 0.0, 0.0).build();
     var stop2 = REPO.stop("B", 0.0, 0.0).build();
 

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/RouteMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/RouteMatcherFactoryTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.api.request.FindRoutesRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
 import org.opentripplanner.transit.model.network.Route;
@@ -24,13 +24,13 @@ class RouteMatcherFactoryTest {
   @BeforeEach
   void setup() {
     route1 = Route.of(new FeedScopedId("feedId", "routeId"))
-      .withAgency(TimetableRepositoryForTest.agency("AGENCY"))
+      .withAgency(TransitRepositoryForTest.agency("AGENCY"))
       .withMode(TransitMode.BUS)
       .withShortName("ROUTE1")
       .withLongName(I18NString.of("ROUTE1LONG"))
       .build();
     route2 = Route.of(new FeedScopedId("otherFeedId", "otherRouteId"))
-      .withAgency(TimetableRepositoryForTest.agency("OTHER_AGENCY"))
+      .withAgency(TransitRepositoryForTest.agency("OTHER_AGENCY"))
       .withMode(TransitMode.RAIL)
       .withShortName("ROUTE2")
       .withLongName(I18NString.of("ROUTE2LONG"))

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.filter.expr.Matcher;
@@ -25,7 +25,7 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 
 class TripOnServiceDateMatcherFactoryTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private TripOnServiceDate tripOnServiceDateRut;
   private TripOnServiceDate tripOnServiceDateRut2;
@@ -87,13 +87,13 @@ class TripOnServiceDateMatcherFactoryTest {
       .withServiceDate(LocalDate.of(2024, 2, 24))
       .build();
 
-    patternRut = TimetableRepositoryForTest.tripPattern(
+    patternRut = TransitRepositoryForTest.tripPattern(
       "pattern:rut",
       tripOnServiceDateRut.getTrip().getRoute()
     )
       .withStopPattern(TEST_MODEL.stopPattern(2))
       .build();
-    patternAkt = TimetableRepositoryForTest.tripPattern(
+    patternAkt = TransitRepositoryForTest.tripPattern(
       "pattern:akt",
       tripOnServiceDateAkt.getTrip().getRoute()
     )

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactoryTest.java
@@ -2,8 +2,8 @@ package org.opentripplanner.transit.model.filter.transit;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.agency;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.agency;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.route;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -14,7 +14,7 @@ import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.transit.api.request.CancellationPolicy;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequestBuilder;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.filter.selector.FilterRequest;
@@ -25,7 +25,7 @@ import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 
 class TripTimeOnDateMatcherFactoryTest {
 
-  private static final RegularStop STOP = TimetableRepositoryForTest.of().stop("1").build();
+  private static final RegularStop STOP = TransitRepositoryForTest.of().stop("1").build();
   private static final LocalDate DATE = LocalDate.of(2025, 3, 2);
 
   private static final Route ROUTE_1 = route("r1")
@@ -653,15 +653,15 @@ class TripTimeOnDateMatcherFactoryTest {
   }
 
   private static TripPattern pattern(Route route) {
-    return TimetableRepositoryForTest.tripPattern("p1", route)
-      .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP, STOP))
+    return TransitRepositoryForTest.tripPattern("p1", route)
+      .withStopPattern(TransitRepositoryForTest.stopPattern(STOP, STOP))
       .build();
   }
 
   private static TripTimeOnDate tripTimeOnDate(Route route1) {
     final TripPattern pattern = pattern(route1);
     var tripTimes = ScheduledTripTimes.of()
-      .withTrip(TimetableRepositoryForTest.trip("t1").withRoute(route1).build())
+      .withTrip(TransitRepositoryForTest.trip("t1").withRoute(route1).build())
       .withArrivalTimes("10:00 10:05")
       .withDepartureTimes("10:00 10:05")
       .build();

--- a/application/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/RouteTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -39,7 +39,7 @@ class RouteTest {
   private static final String FLEXIBLE_LINE_TYPE = "flexible line type";
   private static final Integer GTFS_SORT_ORDER = 0;
   private static final String URL = "url";
-  public static final Agency AGENCY = TimetableRepositoryForTest.AGENCY;
+  public static final Agency AGENCY = TransitRepositoryForTest.AGENCY;
   private static final Route SUBJECT = Route.of(FeedScopedIdForTestFactory.id(ID))
     .withShortName(SHORT_NAME)
     .withLongName(LONG_NAME)
@@ -114,7 +114,7 @@ class RouteTest {
       )
     );
     assertFalse(
-      SUBJECT.sameAs(SUBJECT.copy().withAgency(TimetableRepositoryForTest.agency("X")).build())
+      SUBJECT.sameAs(SUBJECT.copy().withAgency(TransitRepositoryForTest.agency("X")).build())
     );
     assertFalse(
       SUBJECT.sameAs(

--- a/application/src/test/java/org/opentripplanner/transit/model/network/StopPatternTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/StopPatternTest.java
@@ -8,12 +8,12 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.PickDrop;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 class StopPatternTest {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
   @Test
   void boardingAlightingConditions() {
@@ -27,7 +27,7 @@ class StopPatternTest {
 
     var areaStop = testModel.areaStop("area").build();
 
-    Trip t = TimetableRepositoryForTest.trip("trip").build();
+    Trip t = TransitRepositoryForTest.trip("trip").build();
 
     StopPattern stopPattern = new StopPattern(
       List.of(
@@ -56,7 +56,7 @@ class StopPatternTest {
     var s2 = testModel.stop("2", 61.0, 11.0).build();
     var s3 = testModel.stop("3", 62.0, 11.0).build();
 
-    Trip t = TimetableRepositoryForTest.trip("trip").build();
+    Trip t = TransitRepositoryForTest.trip("trip").build();
 
     StopPattern stopPattern = new StopPattern(
       List.of(
@@ -82,7 +82,7 @@ class StopPatternTest {
     var s3 = testModel.stop("3").build();
     var s4 = testModel.stop("4").build();
 
-    var pattern = TimetableRepositoryForTest.stopPattern(s1, s2, s3);
+    var pattern = TransitRepositoryForTest.stopPattern(s1, s2, s3);
 
     assertEquals(List.of(s1, s2, s3), pattern.getStops());
 
@@ -97,7 +97,7 @@ class StopPatternTest {
     var s3 = testModel.stop("3").build();
     var s4 = testModel.stop("4").build();
 
-    var pattern = TimetableRepositoryForTest.stopPattern(s1, s2, s3);
+    var pattern = TransitRepositoryForTest.stopPattern(s1, s2, s3);
 
     assertEquals(List.of(s1, s2, s3), pattern.getStops());
 
@@ -111,7 +111,7 @@ class StopPatternTest {
     var s2 = testModel.stop("2").build();
     var s3 = testModel.stop("3").build();
 
-    var pattern = TimetableRepositoryForTest.stopPattern(s1, s2, s3);
+    var pattern = TransitRepositoryForTest.stopPattern(s1, s2, s3);
 
     assertEquals(PickDrop.SCHEDULED, pattern.getPickup(0));
     assertEquals(PickDrop.SCHEDULED, pattern.getPickup(1));

--- a/application/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.site.RegularStop;
 
@@ -20,15 +20,15 @@ class TripPatternTest {
 
   private static final String ID = "1";
   private static final String NAME = "short name";
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
-  private static final Route ROUTE = TimetableRepositoryForTest.route("routeId").build();
+  private static final Route ROUTE = TransitRepositoryForTest.route("routeId").build();
   public static final RegularStop STOP_A = TEST_MODEL.stop("A").build();
   public static final RegularStop STOP_X = TEST_MODEL.stop("X").build();
   public static final RegularStop STOP_B = TEST_MODEL.stop("B").build();
   public static final RegularStop STOP_Y = TEST_MODEL.stop("Y").build();
   public static final RegularStop STOP_C = TEST_MODEL.stop("C").build();
-  private static final StopPattern STOP_PATTERN = TimetableRepositoryForTest.stopPattern(
+  private static final StopPattern STOP_PATTERN = TransitRepositoryForTest.stopPattern(
     STOP_A,
     STOP_B,
     STOP_C
@@ -76,7 +76,7 @@ class TripPatternTest {
     var pattern = TripPattern.of(id("replacement"))
       .withName("replacement")
       .withRoute(ROUTE)
-      .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A, STOP_B, STOP_X, STOP_Y))
+      .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_A, STOP_B, STOP_X, STOP_Y))
       .withOriginalTripPattern(SUBJECT)
       .build();
 
@@ -98,7 +98,7 @@ class TripPatternTest {
     assertFalse(SUBJECT.sameAs(SUBJECT.copy().withName("X").build()));
     assertFalse(
       SUBJECT.sameAs(
-        SUBJECT.copy().withRoute(TimetableRepositoryForTest.route("anotherId").build()).build()
+        SUBJECT.copy().withRoute(TransitRepositoryForTest.route("anotherId").build()).build()
       )
     );
     assertFalse(SUBJECT.sameAs(SUBJECT.copy().withMode(TransitMode.RAIL).build()));

--- a/application/src/test/java/org/opentripplanner/transit/model/network/grouppriority/TripAdapterTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/network/grouppriority/TripAdapterTest.java
@@ -3,12 +3,12 @@ package org.opentripplanner.transit.model.network.grouppriority;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 class TripAdapterTest {
 
-  private final Trip trip = TimetableRepositoryForTest.trip("Trip").build();
+  private final Trip trip = TransitRepositoryForTest.trip("Trip").build();
 
   private final TripAdapter subject = new TripAdapter(trip);
 

--- a/application/src/test/java/org/opentripplanner/transit/model/site/AreaStopTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/AreaStopTest.java
@@ -14,7 +14,7 @@ import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.service.SiteRepository;
 
 class AreaStopTest {
@@ -25,7 +25,7 @@ class AreaStopTest {
 
   private static final I18NString URL = new NonLocalizedString("url");
 
-  private static final String ZONE_ID = TimetableRepositoryForTest.TIME_ZONE_ID;
+  private static final String ZONE_ID = TransitRepositoryForTest.TIME_ZONE_ID;
 
   private static final Geometry GEOMETRY = Polygons.OSLO;
 

--- a/application/src/test/java/org/opentripplanner/transit/model/site/BoardingAreaTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/BoardingAreaTest.java
@@ -11,14 +11,14 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class BoardingAreaTest {
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
   private static final I18NString DESCRIPTION = new NonLocalizedString("description");
-  private static final RegularStop PARENT_STOP = TimetableRepositoryForTest.of()
+  private static final RegularStop PARENT_STOP = TransitRepositoryForTest.of()
     .stop("stopId")
     .build();
 

--- a/application/src/test/java/org/opentripplanner/transit/model/site/EntranceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/EntranceTest.java
@@ -12,7 +12,7 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class EntranceTest {
 
@@ -24,7 +24,7 @@ class EntranceTest {
   public static final WgsCoordinate COORDINATE = new WgsCoordinate(0, 0);
   private static final StopLevel LEVEL = new StopLevel("level", 0);
   private static final Accessibility WHEELCHAIR_ACCESSIBILITY = Accessibility.POSSIBLE;
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Station PARENT_STATION = TEST_MODEL.station("stationId").build();
 
   private static final Entrance SUBJECT = Entrance.of(FeedScopedIdForTestFactory.id(ID))

--- a/application/src/test/java/org/opentripplanner/transit/model/site/GroupOfStationsTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/GroupOfStationsTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class GroupOfStationsTest {
 
-  private static TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");

--- a/application/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
@@ -15,12 +15,12 @@ import org.opentripplanner._support.geometry.Polygons;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.service.SiteRepository;
 
 class GroupStopTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
@@ -116,7 +116,7 @@ class GroupStopTest {
     assertFalse(
       SUBJECT.sameAs(
         SUBJECT.copy()
-          .addLocation(TimetableRepositoryForTest.of().stop("2:stop", 1d, 2d).build())
+          .addLocation(TransitRepositoryForTest.of().stop("2:stop", 1d, 2d).build())
           .build()
       )
     );

--- a/application/src/test/java/org/opentripplanner/transit/model/site/MultiModalStationTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/MultiModalStationTest.java
@@ -12,14 +12,14 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class MultiModalStationTest {
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
 
-  private static TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Station STATION_1 = TEST_MODEL.station("1:1").build();
   private static final Station STATION_2 = TEST_MODEL.station("1:2").build();
 

--- a/application/src/test/java/org/opentripplanner/transit/model/site/PathwayNodeTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/PathwayNodeTest.java
@@ -12,14 +12,14 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class PathwayNodeTest {
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
   private static final I18NString DESCRIPTION = new NonLocalizedString("description");
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Station PARENT_STATION = TEST_MODEL.station("stationId").build();
   private static final String CODE = "code";
 

--- a/application/src/test/java/org/opentripplanner/transit/model/site/PathwayTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/PathwayTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class PathwayTest {
 
@@ -20,7 +20,7 @@ class PathwayTest {
   private static final PathwayNode FROM = PathwayNode.of(FeedScopedIdForTestFactory.id("1:node"))
     .withCoordinate(new WgsCoordinate(20, 30))
     .build();
-  private static final RegularStop TO = TimetableRepositoryForTest.of().stop("1:stop").build();
+  private static final RegularStop TO = TransitRepositoryForTest.of().stop("1:stop").build();
   public static final int TRAVERSAL_TIME = 120;
 
   private final Pathway subject = Pathway.of(FeedScopedIdForTestFactory.id(ID))

--- a/application/src/test/java/org/opentripplanner/transit/model/site/RegularStopTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/RegularStopTest.java
@@ -15,7 +15,7 @@ import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.service.SiteRepository;
@@ -25,7 +25,7 @@ class RegularStopTest {
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
   private static final I18NString DESCRIPTION = new NonLocalizedString("description");
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Station PARENT_STATION = TEST_MODEL.station("stationId").build();
   private static final String CODE = "code";
 
@@ -35,7 +35,7 @@ class RegularStopTest {
   private static final String NETEX_SUBMODE_NAME = "submode";
   private static final SubMode NETEX_SUBMODE = SubMode.of(NETEX_SUBMODE_NAME);
   private static final TransitMode VEHICLE_TYPE = TransitMode.BUS;
-  public static final ZoneId TIME_ZONE = ZoneId.of(TimetableRepositoryForTest.TIME_ZONE_ID);
+  public static final ZoneId TIME_ZONE = ZoneId.of(TransitRepositoryForTest.TIME_ZONE_ID);
   private static final String PLATFORM_CODE = "platformCode";
 
   private static final RegularStop SUBJECT = SiteRepository.of()
@@ -99,9 +99,7 @@ class RegularStopTest {
     assertFalse(SUBJECT.sameAs(SUBJECT.copy().withVehicleType(TransitMode.TRAM).build()));
     assertFalse(
       SUBJECT.sameAs(
-        SUBJECT.copy()
-          .withTimeZone(ZoneId.of(TimetableRepositoryForTest.OTHER_TIME_ZONE_ID))
-          .build()
+        SUBJECT.copy().withTimeZone(ZoneId.of(TransitRepositoryForTest.OTHER_TIME_ZONE_ID)).build()
       )
     );
     assertFalse(SUBJECT.sameAs(SUBJECT.copy().withPlatformCode("X").build()));

--- a/application/src/test/java/org/opentripplanner/transit/model/site/StationTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/site/StationTest.java
@@ -12,7 +12,7 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class StationTest {
 
@@ -23,9 +23,9 @@ class StationTest {
 
   public static final WgsCoordinate COORDINATE = new WgsCoordinate(0, 0);
   private static final StopTransferPriority PRIORITY = StopTransferPriority.ALLOWED;
-  private static final ZoneId TIMEZONE = ZoneId.of(TimetableRepositoryForTest.TIME_ZONE_ID);
+  private static final ZoneId TIMEZONE = ZoneId.of(TransitRepositoryForTest.TIME_ZONE_ID);
   private static final I18NString URL = new NonLocalizedString("url");
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Station PARENT_STATION = TEST_MODEL.station("stationId").build();
 
   private static final Station SUBJECT = Station.of(FeedScopedIdForTestFactory.id(ID))
@@ -80,9 +80,7 @@ class StationTest {
     assertFalse(SUBJECT.sameAs(SUBJECT.copy().withUrl(new NonLocalizedString("X")).build()));
     assertFalse(
       SUBJECT.sameAs(
-        SUBJECT.copy()
-          .withTimezone(ZoneId.of(TimetableRepositoryForTest.OTHER_TIME_ZONE_ID))
-          .build()
+        SUBJECT.copy().withTimezone(ZoneId.of(TransitRepositoryForTest.OTHER_TIME_ZONE_ID)).build()
       )
     );
   }

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesTest.java
@@ -17,14 +17,14 @@ import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.StopTime;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 class RealTimeTripTimesTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static final String TRIP_ID = "testTripId";
 
@@ -40,7 +40,7 @@ class RealTimeTripTimesTest {
   );
 
   static TripTimes createInitialTripTimes() {
-    Trip trip = TimetableRepositoryForTest.trip(TRIP_ID).build();
+    Trip trip = TransitRepositoryForTest.trip(TRIP_ID).build();
 
     List<StopTime> stopTimes = new LinkedList<>();
 
@@ -69,7 +69,7 @@ class RealTimeTripTimesTest {
 
     @Test
     void shouldHandleBothNullScenario() {
-      Trip trip = TimetableRepositoryForTest.trip("TRIP").build();
+      Trip trip = TransitRepositoryForTest.trip("TRIP").build();
       List<StopTime> stopTimes = List.of(EMPTY_STOPPOINT, EMPTY_STOPPOINT, EMPTY_STOPPOINT);
 
       TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
@@ -80,7 +80,7 @@ class RealTimeTripTimesTest {
 
     @Test
     void shouldHandleTripOnlyHeadSignScenario() {
-      Trip trip = TimetableRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
+      Trip trip = TransitRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
       List<StopTime> stopTimes = List.of(EMPTY_STOPPOINT, EMPTY_STOPPOINT, EMPTY_STOPPOINT);
 
       TripTimes tripTimes = TripTimesFactory.tripTimes(trip, stopTimes, new Deduplicator());
@@ -91,7 +91,7 @@ class RealTimeTripTimesTest {
 
     @Test
     void shouldHandleStopsOnlyHeadSignScenario() {
-      Trip trip = TimetableRepositoryForTest.trip("TRIP").build();
+      Trip trip = TransitRepositoryForTest.trip("TRIP").build();
       StopTime stopWithHeadsign = new StopTime();
       stopWithHeadsign.setStopHeadsign(STOP_TEST_DIRECTION);
       List<StopTime> stopTimes = List.of(stopWithHeadsign, stopWithHeadsign, stopWithHeadsign);
@@ -104,7 +104,7 @@ class RealTimeTripTimesTest {
 
     @Test
     void shouldHandleStopsEqualToTripHeadSignScenario() {
-      Trip trip = TimetableRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
+      Trip trip = TransitRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
       StopTime stopWithHeadsign = new StopTime();
       stopWithHeadsign.setStopHeadsign(DIRECTION);
       List<StopTime> stopTimes = List.of(stopWithHeadsign, stopWithHeadsign, stopWithHeadsign);
@@ -117,7 +117,7 @@ class RealTimeTripTimesTest {
 
     @Test
     void shouldHandleDifferingTripAndStopHeadSignScenario() {
-      Trip trip = TimetableRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
+      Trip trip = TransitRepositoryForTest.trip("TRIP").withHeadsign(DIRECTION).build();
       StopTime stopWithHeadsign = new StopTime();
       stopWithHeadsign.setStopHeadsign(STOP_TEST_DIRECTION);
       List<StopTime> stopTimes = List.of(stopWithHeadsign, EMPTY_STOPPOINT, EMPTY_STOPPOINT);

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimesTest.java
@@ -12,13 +12,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.utils.time.TimeUtils;
 
 class ScheduledTripTimesTest {
 
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("Trip-1").build();
+  private static final Trip TRIP = TransitRepositoryForTest.trip("Trip-1").build();
 
   private static final List<FeedScopedId> STOP_IDS = List.of(id("A"), id("B"), id("C"));
   private static final int SERVICE_CODE = 5;

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableSnapshotTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableSnapshotTest.java
@@ -27,7 +27,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitDataTestFactory;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TimetableUpdateMapper;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
@@ -35,7 +35,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.TestStopLocation;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class TimetableSnapshotTest {
 
@@ -47,12 +47,12 @@ public class TimetableSnapshotTest {
   @BeforeAll
   public static void setUp() throws Exception {
     TestOtpModel model = ConstantsForTests.buildGtfsGraph(ConstantsForTests.SIMPLE_GTFS);
-    TimetableRepository timetableRepository = model.timetableRepository();
+    TransitRepository transitRepository = model.transitRepository();
 
-    feedId = timetableRepository.getFeedIds().iterator().next();
+    feedId = transitRepository.getFeedIds().iterator().next();
 
     patternIndex = new HashMap<>();
-    for (TripPattern tripPattern : timetableRepository.getAllTripPatterns()) {
+    for (TripPattern tripPattern : transitRepository.getAllTripPatterns()) {
       tripPattern
         .scheduledTripsAsStream()
         .forEach(trip -> patternIndex.put(trip.getId(), tripPattern));
@@ -173,7 +173,7 @@ public class TimetableSnapshotTest {
 
   @Test
   void testClearWithAllCollections() {
-    TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+    TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
     RegularStop STOP_A = TEST_MODEL.stop("A").build();
     RegularStop STOP_B = TEST_MODEL.stop("B").build();
 
@@ -185,11 +185,11 @@ public class TimetableSnapshotTest {
     TestStopLocation testStopLocation = new TestStopLocation(
       new FeedScopedId(feedId, "stoplocationid")
     );
-    Route route = TimetableRepositoryForTest.route(new FeedScopedId(feedId, "routeId")).build();
-    Trip trip = TimetableRepositoryForTest.trip(feedId, "tripId").build();
+    Route route = TransitRepositoryForTest.route(new FeedScopedId(feedId, "routeId")).build();
+    Trip trip = TransitRepositoryForTest.trip(feedId, "tripId").build();
     TripPattern tripPattern = TripPattern.of(new FeedScopedId(feedId, "tripPatternId"))
       .withRoute(route)
-      .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A, STOP_B))
+      .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_A, STOP_B))
       .withScheduledTimeTableBuilder(builder ->
         builder.addTripTimes(
           ScheduledTripTimes.of().withTrip(trip).withDepartureTimes(new int[] { 0, 1 }).build()

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableValidationErrorTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TimetableValidationErrorTest.java
@@ -3,7 +3,7 @@ package org.opentripplanner.transit.model.timetable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 
 class TimetableValidationErrorTest {
@@ -11,7 +11,7 @@ class TimetableValidationErrorTest {
   private TimetableValidationError subject = new TimetableValidationError(
     TimetableValidationError.ErrorCode.NEGATIVE_HOP_TIME,
     3,
-    TimetableRepositoryForTest.trip("A").withMode(TransitMode.BUS).withShortName("Line A").build()
+    TransitRepositoryForTest.trip("A").withMode(TransitMode.BUS).withShortName("Line A").build()
   );
 
   @Test

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TripOnServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TripOnServiceDateTest.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 
 class TripOnServiceDateTest {
 
@@ -22,7 +22,7 @@ class TripOnServiceDateTest {
   private static final TripOnServiceDate SUBJECT = TripOnServiceDate.of(
     FeedScopedIdForTestFactory.id(ID)
   )
-    .withTrip(TimetableRepositoryForTest.trip(TRIP_ID).build())
+    .withTrip(TransitRepositoryForTest.trip(TRIP_ID).build())
     .withServiceDate(SERVICE_DATE)
     .withTripAlteration(TRIP_ALTERATION)
     .withReplacementFor(REPLACEMENT_FOR)

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
@@ -9,7 +9,7 @@ import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.BikeAccess;
@@ -22,7 +22,7 @@ class TripTest {
   private static final String ID = "1";
   private static final String SHORT_NAME = "name";
   private static final Accessibility WHEELCHAIR_ACCESSIBILITY = Accessibility.POSSIBLE;
-  public static final Route ROUTE = TimetableRepositoryForTest.route("routeId").build();
+  public static final Route ROUTE = TransitRepositoryForTest.route("routeId").build();
   private static final Direction DIRECTION = Direction.INBOUND;
   public static final NonLocalizedString HEAD_SIGN = new NonLocalizedString("head sign");
   private static final BikeAccess BIKE_ACCESS = BikeAccess.ALLOWED;
@@ -106,7 +106,7 @@ class TripTest {
     );
     assertFalse(
       SUBJECT.sameAs(
-        SUBJECT.copy().withRoute(TimetableRepositoryForTest.route("otherRouteId").build()).build()
+        SUBJECT.copy().withRoute(TransitRepositoryForTest.route("otherRouteId").build()).build()
       )
     );
     assertFalse(SUBJECT.sameAs(SUBJECT.copy().withDirection(Direction.OUTBOUND).build()));

--- a/application/src/test/java/org/opentripplanner/transit/repository/DefaultTimetableRepositoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/repository/DefaultTimetableRepositoryTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.model.timetable;
+package org.opentripplanner.transit.repository;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -35,9 +35,17 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.TestStopLocation;
+import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
+import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
+import org.opentripplanner.transit.model.timetable.Timetable;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.TransitRepository;
 
-public class TimetableSnapshotTest {
+public class DefaultTimetableRepositoryTest {
 
   private static final ZoneId TIME_ZONE = ZoneIds.GMT;
   public static final LocalDate SERVICE_DATE = LocalDate.of(2024, 1, 1);
@@ -64,12 +72,12 @@ public class TimetableSnapshotTest {
     Timetable orig = Timetable.of().build();
     Timetable a = orig.copyOf().withServiceDate(LocalDate.now(TIME_ZONE).minusDays(1)).build();
     Timetable b = orig.copyOf().withServiceDate(LocalDate.now(TIME_ZONE)).build();
-    assertTrue(new TimetableSnapshot.SortedTimetableComparator().compare(a, b) < 0);
+    assertTrue(new DefaultTimetableRepository.SortedTimetableComparator().compare(a, b) < 0);
   }
 
   @Test
   void testUniqueDirtyTimetablesAfterMultipleUpdates() {
-    TimetableSnapshot snapshot = new TimetableSnapshot(
+    DefaultTimetableRepository snapshot = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
@@ -84,8 +92,8 @@ public class TimetableSnapshotTest {
   }
 
   @Test
-  void testCannotUpdateReadOnlyTimetableSnapshot() {
-    TimetableSnapshot committedSnapshot = createCommittedSnapshot();
+  void testCannotUpdateTimetableRepositorySnapshot() {
+    DefaultTimetableRepository committedSnapshot = createCommittedSnapshot();
     LocalDate today = LocalDate.now(TIME_ZONE);
     TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
     TripTimes tripTimes = pattern.getScheduledTimetable().getTripTimes().getFirst();
@@ -100,28 +108,28 @@ public class TimetableSnapshotTest {
   }
 
   @Test
-  void testCannotCommitReadOnlyTimetableSnapshot() {
-    TimetableSnapshot committedSnapshot = createCommittedSnapshot();
+  void testCannotCommitTimetableRepositorySnapshot() {
+    DefaultTimetableRepository committedSnapshot = createCommittedSnapshot();
     assertThrows(ConcurrentModificationException.class, () -> committedSnapshot.commit(true));
   }
 
   @Test
-  void testCannotClearReadOnlyTimetableSnapshot() {
-    TimetableSnapshot committedSnapshot = createCommittedSnapshot();
+  void testCannotClearTimetableRepositorySnapshot() {
+    DefaultTimetableRepository committedSnapshot = createCommittedSnapshot();
     assertThrows(ConcurrentModificationException.class, () -> committedSnapshot.clear(null));
   }
 
   @Test
-  void testCannotPurgeReadOnlyTimetableSnapshot() {
-    TimetableSnapshot committedSnapshot = createCommittedSnapshot();
+  void testCannotPurgeTimetableRepositorySnapshot() {
+    DefaultTimetableRepository committedSnapshot = createCommittedSnapshot();
     assertThrows(ConcurrentModificationException.class, () ->
       committedSnapshot.purgeExpiredData(null)
     );
   }
 
   @Test
-  void testCannotRevertReadOnlyTimetableSnapshot() {
-    TimetableSnapshot committedSnapshot = createCommittedSnapshot();
+  void testCannotRevertTimetableRepositorySnapshot() {
+    DefaultTimetableRepository committedSnapshot = createCommittedSnapshot();
     assertThrows(ConcurrentModificationException.class, () ->
       committedSnapshot.revertTripToScheduledTripPattern(null, null)
     );
@@ -129,7 +137,7 @@ public class TimetableSnapshotTest {
 
   @Test
   void testClear() {
-    TimetableSnapshot snapshot = new TimetableSnapshot(
+    DefaultTimetableRepository snapshot = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
@@ -206,7 +214,7 @@ public class TimetableSnapshotTest {
     patternsForStop.put(testStopLocation, tripPattern);
 
     // The entries do not necessarily make sense, they are only for testing the clear method.
-    TimetableSnapshot snapshot = new TimetableSnapshot(
+    DefaultTimetableRepository snapshot = new DefaultTimetableRepository(
       new HashMap<>(Map.of(id, ImmutableSortedSet.of())),
       new HashMap<>(Map.of(tripIdAndServiceDate, tripPattern)),
       new HashMap<>(Map.of(id, route)),
@@ -242,8 +250,8 @@ public class TimetableSnapshotTest {
       .build();
   }
 
-  private static TimetableSnapshot createCommittedSnapshot() {
-    TimetableSnapshot timetableSnapshot = new TimetableSnapshot(
+  private static DefaultTimetableRepository createCommittedSnapshot() {
+    DefaultTimetableRepository timetableSnapshot = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );

--- a/application/src/test/java/org/opentripplanner/transit/repository/TimetableRepositoryLifecycleTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/repository/TimetableRepositoryLifecycleTest.java
@@ -2,8 +2,8 @@ package org.opentripplanner.transit.repository;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.opentripplanner.transit.repository.TimetableSnapshotLifecycleTest.SameAssert.NotSame;
-import static org.opentripplanner.transit.repository.TimetableSnapshotLifecycleTest.SameAssert.Same;
+import static org.opentripplanner.transit.repository.TimetableRepositoryLifecycleTest.SameAssert.NotSame;
+import static org.opentripplanner.transit.repository.TimetableRepositoryLifecycleTest.SameAssert.Same;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -18,14 +18,13 @@ import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 
 /**
- * Tests for {@link TimetableSnapshotLifecycle}, specifically the purge-expired-data behavior
- * triggered during {@link TimetableSnapshotLifecycle#freeze(MutableTimetableSnapshot)}.
+ * Tests for {@link TimetableRepositoryLifecycle}, specifically the purge-expired-data behavior
+ * triggered during {@link TimetableRepositoryLifecycle#freeze(TimetableRepository)}.
  */
-class TimetableSnapshotLifecycleTest {
+class TimetableRepositoryLifecycleTest {
 
   private static final LocalDate TODAY = LocalDate.of(2024, Month.MAY, 30);
   private static final LocalDate TOMORROW = TODAY.plusDays(1);
@@ -85,11 +84,11 @@ class TimetableSnapshotLifecycleTest {
   ) {
     final AtomicReference<LocalDate> clock = new AtomicReference<>(YESTERDAY);
 
-    var buffer = new TimetableSnapshot(
+    var buffer = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
-    var lifecycle = new TimetableSnapshotLifecycle(buffer, purgeExpiredData, clock::get);
+    var lifecycle = new TimetableRepositoryLifecycle(buffer, purgeExpiredData, clock::get);
 
     // Add data for YESTERDAY, freeze to produce snapshot A
     buffer.update(RealTimeTripUpdate.of(PATTERN, TRIP_TIMES, YESTERDAY).build());

--- a/application/src/test/java/org/opentripplanner/transit/repository/TimetableSnapshotLifecycleTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/repository/TimetableSnapshotLifecycleTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitDataTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
@@ -31,14 +31,14 @@ class TimetableSnapshotLifecycleTest {
   private static final LocalDate TOMORROW = TODAY.plusDays(1);
   private static final LocalDate YESTERDAY = TODAY.minusDays(1);
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
-  private static final TripPattern PATTERN = TimetableRepositoryForTest.tripPattern(
+  private static final TripPattern PATTERN = TransitRepositoryForTest.tripPattern(
     "pattern",
-    TimetableRepositoryForTest.route("r1").build()
+    TransitRepositoryForTest.route("r1").build()
   )
     .withStopPattern(
-      TimetableRepositoryForTest.stopPattern(
+      TransitRepositoryForTest.stopPattern(
         TEST_MODEL.stop("1").build(),
         TEST_MODEL.stop("2").build()
       )
@@ -46,7 +46,7 @@ class TimetableSnapshotLifecycleTest {
     .build();
   private static final TripTimes TRIP_TIMES = ScheduledTripTimes.of()
     .withArrivalTimes("00:00 00:01")
-    .withTrip(TimetableRepositoryForTest.trip("trip").build())
+    .withTrip(TransitRepositoryForTest.trip("trip").build())
     .build();
 
   enum SameAssert {

--- a/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.AGENCY;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.AGENCY;
 import static org.opentripplanner.transit.model.basic.TransitMode.BUS;
 import static org.opentripplanner.transit.model.basic.TransitMode.FERRY;
 import static org.opentripplanner.transit.model.basic.TransitMode.RAIL;
@@ -29,7 +29,7 @@ import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitDataTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
@@ -54,7 +54,7 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
 
 class DefaultTransitServiceTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
   private static TransitService service;
   private static final Station STATION = TEST_MODEL.station("C").build();
@@ -84,7 +84,7 @@ class DefaultTransitServiceTest {
   private static final TripPattern FERRY_PATTERN = TEST_MODEL.pattern(FERRY).build();
   private static final TripPattern BUS_PATTERN = TEST_MODEL.pattern(BUS).build();
 
-  private static final StopPattern REAL_TIME_STOP_PATTERN = TimetableRepositoryForTest.stopPattern(
+  private static final StopPattern REAL_TIME_STOP_PATTERN = TransitRepositoryForTest.stopPattern(
     STOP_A,
     STOP_B
   );
@@ -94,11 +94,11 @@ class DefaultTransitServiceTest {
     .build();
 
   static FeedScopedId CALENDAR_ID = id("CAL_1");
-  static Trip TRIP = TimetableRepositoryForTest.trip("123")
+  static Trip TRIP = TransitRepositoryForTest.trip("123")
     .withHeadsign(I18NString.of("Trip Headsign"))
     .withServiceId(CALENDAR_ID)
     .build();
-  private static final Trip ADDED_TRIP = TimetableRepositoryForTest.trip("REAL_TIME_ADDED_TRIP")
+  private static final Trip ADDED_TRIP = TransitRepositoryForTest.trip("REAL_TIME_ADDED_TRIP")
     .withServiceId(CALENDAR_ID)
     .build();
   private static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = ScheduledTripTimes.of()
@@ -122,7 +122,7 @@ class DefaultTransitServiceTest {
     .build();
 
   static FeedScopedId CALENDAR_ID_TWO = id("CAL_2");
-  static Trip TRIP_TODAY = TimetableRepositoryForTest.trip("12345")
+  static Trip TRIP_TODAY = TransitRepositoryForTest.trip("12345")
     .withHeadsign(I18NString.of("Trip Headsign"))
     .withServiceId(CALENDAR_ID_TWO)
     .build();
@@ -162,13 +162,13 @@ class DefaultTransitServiceTest {
       .build();
 
     var deduplicator = new Deduplicator();
-    var timetableRepository = new TimetableRepository(siteRepository);
+    var transitRepository = new TransitRepository(siteRepository);
     var canceledStopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, TRIP, "11:30");
     var canceledTripTimes = TripTimesFactory.tripTimes(TRIP, canceledStopTimes, deduplicator)
       .createRealTimeFromScheduledTimes()
       .withCanceled()
       .build();
-    timetableRepository.addTripPattern(RAIL_PATTERN.getId(), RAIL_PATTERN);
+    transitRepository.addTripPattern(RAIL_PATTERN.getId(), RAIL_PATTERN);
 
     // Crate a calendar (needed for testing cancelled trips)
     CalendarServiceData calendarServiceData = new CalendarServiceData();
@@ -185,25 +185,25 @@ class DefaultTransitServiceTest {
       List.of(firstDate, secondDate)
     );
 
-    var serviceCodes = timetableRepository.getServiceCodes();
+    var serviceCodes = transitRepository.getServiceCodes();
     serviceCodes.put(SERVICE_ID, SERVICE_CODE);
     serviceCodes.put(CALENDAR_ID, SERVICE_CODE);
     serviceCodes.put(CALENDAR_ID_TWO, 1);
 
-    timetableRepository.addTripPattern(RAIL_PATTERN.getId(), RAIL_PATTERN);
-    timetableRepository.addTripPattern(BUS_PATTERN.getId(), BUS_PATTERN);
-    timetableRepository.addTripPattern(BUS_PATTERN_TODAY.getId(), BUS_PATTERN_TODAY);
+    transitRepository.addTripPattern(RAIL_PATTERN.getId(), RAIL_PATTERN);
+    transitRepository.addTripPattern(BUS_PATTERN.getId(), BUS_PATTERN);
+    transitRepository.addTripPattern(BUS_PATTERN_TODAY.getId(), BUS_PATTERN_TODAY);
 
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.updateCalendarServiceData(calendarServiceData);
 
-    timetableRepository.index();
+    transitRepository.index();
 
     TimetableSnapshot timetableSnapshot = new TimetableSnapshot(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
     TripTimes tripTimes = ScheduledTripTimes.of()
-      .withTrip(TimetableRepositoryForTest.trip("123").build())
+      .withTrip(TransitRepositoryForTest.trip("123").build())
       .withDepartureTimes(new int[] { 0, 1 })
       .withServiceCode(SERVICE_CODE)
       .build();
@@ -227,7 +227,7 @@ class DefaultTransitServiceTest {
 
     var snapshot = timetableSnapshot.commit();
 
-    service = new DefaultTransitService(timetableRepository, snapshot) {
+    service = new DefaultTransitService(transitRepository, snapshot) {
       @Override
       public Collection<TripPattern> findPatterns(StopLocation stop) {
         if (stop.equals(STOP_B)) {

--- a/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
@@ -46,10 +46,10 @@ import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 
 class DefaultTransitServiceTest {
@@ -198,7 +198,7 @@ class DefaultTransitServiceTest {
 
     transitRepository.index();
 
-    TimetableSnapshot timetableSnapshot = new TimetableSnapshot(
+    DefaultTimetableRepository timetableSnapshot = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );

--- a/application/src/test/java/org/opentripplanner/transit/service/StopTimesHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/StopTimesHelperTest.java
@@ -33,9 +33,9 @@ class StopTimesHelperTest {
   @BeforeAll
   public static void setUp() throws Exception {
     TestOtpModel model = ConstantsForTests.buildGtfsGraph(ConstantsForTests.SIMPLE_GTFS);
-    TimetableRepository timetableRepository = model.timetableRepository();
-    transitService = new DefaultTransitService(timetableRepository);
-    feedId = timetableRepository.getFeedIds().iterator().next();
+    TransitRepository transitRepository = model.transitRepository();
+    transitService = new DefaultTransitService(transitRepository);
+    feedId = transitRepository.getFeedIds().iterator().next();
     stopId = new FeedScopedId(feedId, "J");
     var originalPattern = transitService.findPattern(
       transitService.getTrip(new FeedScopedId(feedId, "5.1"))
@@ -48,9 +48,9 @@ class StopTimesHelperTest {
       .withScheduledTimeTableBuilder(builder -> builder.addOrUpdateTripTimes(newTripTimes.build()))
       .build();
     // replace the original pattern by the updated pattern in the transit model
-    timetableRepository.addTripPattern(pattern.getId(), pattern);
-    timetableRepository.index();
-    transitService = new DefaultTransitService(timetableRepository);
+    transitRepository.addTripPattern(pattern.getId(), pattern);
+    transitRepository.index();
+    transitService = new DefaultTransitService(transitRepository);
     stopTimesHelper = new StopTimesHelper(transitService);
   }
 

--- a/application/src/test/java/org/opentripplanner/transit/service/TransitRepositoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/TransitRepositoryTest.java
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.framework.application.OtpFileNames.BUILD_CONFIG_FILENAME;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.route;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.stopPattern;
-import static org.opentripplanner.transit.model._data.TimetableRepositoryForTest.tripPattern;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.route;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.stopPattern;
+import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.tripPattern;
 
 import java.util.Map;
 import java.util.Set;
@@ -18,7 +18,7 @@ import org.opentripplanner.ext.fares.service.gtfs.v1.GtfsFareServiceFactory;
 import org.opentripplanner.graph_builder.module.TimeZoneAdjusterModule;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.test.support.ResourceLoader;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.BikeAccess;
 import org.opentripplanner.transit.model.network.CarAccess;
@@ -26,12 +26,12 @@ import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.Trip;
 
-class TimetableRepositoryTest {
+class TransitRepositoryTest {
 
   public static final String FAKE_FEED_ID = "FAKE";
   public static final FeedScopedId SAMPLE_TRIP_ID = new FeedScopedId(FAKE_FEED_ID, "1.2");
   private static final ResourceLoader RESOURCE_LOADER = ResourceLoader.of(
-    TimetableRepositoryTest.class
+    TransitRepositoryTest.class
   );
 
   @Test
@@ -39,23 +39,22 @@ class TimetableRepositoryTest {
     // First GTFS bundle should be added successfully
     var siteRepository = new SiteRepository();
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(siteRepository);
+    var transitRepository = new TransitRepository(siteRepository);
     ConstantsForTests.addGtfsToGraph(
       graph,
-      timetableRepository,
+      transitRepository,
       ConstantsForTests.SIMPLE_GTFS,
       new GtfsFareServiceFactory(),
       FAKE_FEED_ID
     );
 
     // Then time zone should match the one provided in the feed
-    assertEquals("America/New_York", timetableRepository.getTimeZone().getId());
+    assertEquals("America/New_York", transitRepository.getTimeZone().getId());
 
     // Then trip times should be same as in input data
-    TimetableRepositoryIndex timetableRepositoryIndex =
-      timetableRepository.getTimetableRepositoryIndex();
-    Trip trip = timetableRepositoryIndex.getTripForId(SAMPLE_TRIP_ID);
-    Timetable timetable = timetableRepositoryIndex.getPatternForTrip(trip).getScheduledTimetable();
+    TransitRepositoryIndex transitRepositoryIndex = transitRepository.getTransitRepositoryIndex();
+    Trip trip = transitRepositoryIndex.getTripForId(SAMPLE_TRIP_ID);
+    Timetable timetable = transitRepositoryIndex.getPatternForTrip(trip).getScheduledTimetable();
     assertEquals(20 * 60, timetable.getTripTimes(trip).getDepartureTime(0));
 
     // Should throw on second bundle, with different agency time zone
@@ -64,7 +63,7 @@ class TimetableRepositoryTest {
       () ->
         ConstantsForTests.addGtfsToGraph(
           graph,
-          timetableRepository,
+          transitRepository,
           RESOURCE_LOADER.file("kcm_gtfs.zip"),
           new GtfsFareServiceFactory(),
           null
@@ -79,15 +78,15 @@ class TimetableRepositoryTest {
   void validateTimeZonesWithExplicitTimeZone() {
     var siteRepository = new SiteRepository();
     var graph = new Graph();
-    var timetableRepository = new TimetableRepository(siteRepository);
+    var transitRepository = new TransitRepository(siteRepository);
 
     // Whit explicit time zone
-    timetableRepository.initTimeZone(ZoneIds.CHICAGO);
+    transitRepository.initTimeZone(ZoneIds.CHICAGO);
 
     // First GTFS bundle should be added successfully
     ConstantsForTests.addGtfsToGraph(
       graph,
-      timetableRepository,
+      transitRepository,
       ConstantsForTests.SIMPLE_GTFS,
       new GtfsFareServiceFactory(),
       FAKE_FEED_ID
@@ -96,44 +95,43 @@ class TimetableRepositoryTest {
     // Should load second bundle, with different agency time zone
     ConstantsForTests.addGtfsToGraph(
       graph,
-      timetableRepository,
+      transitRepository,
       RESOURCE_LOADER.file("kcm_gtfs.zip"),
       new GtfsFareServiceFactory(),
       null
     );
 
-    new TimeZoneAdjusterModule(timetableRepository).buildGraph();
+    new TimeZoneAdjusterModule(transitRepository).buildGraph();
 
-    TimetableRepositoryIndex timetableRepositoryIndex =
-      timetableRepository.getTimetableRepositoryIndex();
+    TransitRepositoryIndex transitRepositoryIndex = transitRepository.getTransitRepositoryIndex();
 
     // Then time zone should match the one provided in the feed
-    assertEquals("America/Chicago", timetableRepository.getTimeZone().getId());
+    assertEquals("America/Chicago", transitRepository.getTimeZone().getId());
 
     // Then trip times should be on hour less than in input data
-    Trip trip = timetableRepositoryIndex.getTripForId(SAMPLE_TRIP_ID);
-    Timetable timetable = timetableRepositoryIndex.getPatternForTrip(trip).getScheduledTimetable();
+    Trip trip = transitRepositoryIndex.getTripForId(SAMPLE_TRIP_ID);
+    Timetable timetable = transitRepositoryIndex.getPatternForTrip(trip).getScheduledTimetable();
     assertEquals(20 * 60 - 60 * 60, timetable.getTripTimes(trip).getDepartureTime(0));
   }
 
   @Test
   void scheduledStopPoints() {
-    var repo = new TimetableRepository();
+    var repo = new TransitRepository();
     var sspId = id("ssp-1");
-    var stop = TimetableRepositoryForTest.of().stop("stop-1").build();
+    var stop = TransitRepositoryForTest.of().stop("stop-1").build();
     repo.addScheduledStopPointMapping(Map.of(sspId, stop));
     assertEquals(stop, repo.findStopByScheduledStopPoint(sspId).get());
   }
 
   @Test
   void testGetStopLocationsUsedForBikesAllowedTrips() {
-    var repo = new TimetableRepository();
-    var S11 = TimetableRepositoryForTest.of().stop("S11").build();
-    var S12 = TimetableRepositoryForTest.of().stop("S12").build();
-    var S13 = TimetableRepositoryForTest.of().stop("S13").build();
-    var S21 = TimetableRepositoryForTest.of().stop("S21").build();
-    var S22 = TimetableRepositoryForTest.of().stop("S22").build();
-    var S23 = TimetableRepositoryForTest.of().stop("S23").build();
+    var repo = new TransitRepository();
+    var S11 = TransitRepositoryForTest.of().stop("S11").build();
+    var S12 = TransitRepositoryForTest.of().stop("S12").build();
+    var S13 = TransitRepositoryForTest.of().stop("S13").build();
+    var S21 = TransitRepositoryForTest.of().stop("S21").build();
+    var S22 = TransitRepositoryForTest.of().stop("S22").build();
+    var S23 = TransitRepositoryForTest.of().stop("S23").build();
     var R1 = route("R1").withMode(TransitMode.BUS).build();
     var R2 = route("R2").withMode(TransitMode.BUS).build();
     var TP1 = tripPattern("TP1", R1)
@@ -141,7 +139,7 @@ class TimetableRepositoryTest {
       .withScheduledTimeTableBuilder(builder ->
         builder.addTripTimes(
           ScheduledTripTimes.of()
-            .withTrip(TimetableRepositoryForTest.trip("T1").build())
+            .withTrip(TransitRepositoryForTest.trip("T1").build())
             .withDepartureTimes("00:00 01:00 02:00")
             .build()
         )
@@ -153,7 +151,7 @@ class TimetableRepositoryTest {
         builder.addTripTimes(
           ScheduledTripTimes.of()
             .withTrip(
-              TimetableRepositoryForTest.trip("T2").withBikesAllowed(BikeAccess.ALLOWED).build()
+              TransitRepositoryForTest.trip("T2").withBikesAllowed(BikeAccess.ALLOWED).build()
             )
             .withDepartureTimes("00:00 01:00 02:00")
             .build()
@@ -167,13 +165,13 @@ class TimetableRepositoryTest {
 
   @Test
   void testGetStopLocationsUsedForCarsAllowedTrips() {
-    var repo = new TimetableRepository();
-    var S11 = TimetableRepositoryForTest.of().stop("S11").build();
-    var S12 = TimetableRepositoryForTest.of().stop("S12").build();
-    var S13 = TimetableRepositoryForTest.of().stop("S13").build();
-    var S21 = TimetableRepositoryForTest.of().stop("S21").build();
-    var S22 = TimetableRepositoryForTest.of().stop("S22").build();
-    var S23 = TimetableRepositoryForTest.of().stop("S23").build();
+    var repo = new TransitRepository();
+    var S11 = TransitRepositoryForTest.of().stop("S11").build();
+    var S12 = TransitRepositoryForTest.of().stop("S12").build();
+    var S13 = TransitRepositoryForTest.of().stop("S13").build();
+    var S21 = TransitRepositoryForTest.of().stop("S21").build();
+    var S22 = TransitRepositoryForTest.of().stop("S22").build();
+    var S23 = TransitRepositoryForTest.of().stop("S23").build();
     var R1 = route("R1").withMode(TransitMode.RAIL).build();
     var R2 = route("R2").withMode(TransitMode.RAIL).build();
     var TP1 = tripPattern("TP1", R1)
@@ -181,7 +179,7 @@ class TimetableRepositoryTest {
       .withScheduledTimeTableBuilder(builder ->
         builder.addTripTimes(
           ScheduledTripTimes.of()
-            .withTrip(TimetableRepositoryForTest.trip("T1").build())
+            .withTrip(TransitRepositoryForTest.trip("T1").build())
             .withDepartureTimes("00:00 01:00 02:00")
             .build()
         )
@@ -193,7 +191,7 @@ class TimetableRepositoryTest {
         builder.addTripTimes(
           ScheduledTripTimes.of()
             .withTrip(
-              TimetableRepositoryForTest.trip("T2").withCarsAllowed(CarAccess.ALLOWED).build()
+              TransitRepositoryForTest.trip("T2").withCarsAllowed(CarAccess.ALLOWED).build()
             )
             .withDepartureTimes("00:00 01:00 02:00")
             .build()

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/LoadModel.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/LoadModel.java
@@ -3,11 +3,11 @@ package org.opentripplanner.transit.speed_test;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 record LoadModel(
   Graph graph,
-  TimetableRepository timetableRepository,
+  TransitRepository transitRepository,
   TransferRepository transferRepository,
   BuildConfig buildConfig
 ) {}

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SetupHelper.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SetupHelper.java
@@ -9,7 +9,7 @@ import org.opentripplanner.standalone.config.ConfigModel;
 import org.opentripplanner.standalone.config.OtpConfigLoader;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.speed_test.options.SpeedTestCmdLineOpts;
 
 /**
@@ -32,14 +32,14 @@ class SetupHelper {
       );
     }
 
-    TimetableRepository timetableRepository = serializedGraphObject.timetableRepository;
+    TransitRepository transitRepository = serializedGraphObject.transitRepository;
     TransferRepository transferRepository = serializedGraphObject.transferRepository;
-    timetableRepository.index();
+    transitRepository.index();
     transferRepository.index();
     graph.index();
     return new LoadModel(
       graph,
-      timetableRepository,
+      transitRepository,
       transferRepository,
       serializedGraphObject.buildConfig
     );

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedIntegrationTest.java
@@ -97,7 +97,7 @@ public class SpeedIntegrationTest {
       config,
       routerConfig,
       model.graph(),
-      model.timetableRepository(),
+      model.transitRepository(),
       model.transferRepository()
     );
 

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -42,10 +42,10 @@ import org.opentripplanner.standalone.server.DefaultServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
-import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
-import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
-import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepository;
+import org.opentripplanner.transit.repository.TimetableRepositoryLifecycle;
+import org.opentripplanner.transit.repository.TimetableRepositorySnapshot;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.speed_test.model.SpeedTestProfile;
@@ -123,14 +123,14 @@ public class SpeedTest {
 
     var parameters = TimetableSnapshotParameters.DEFAULT;
     var registry = TransactionFactory.createRepositoryRegistry();
-    var timetableSnapshot = new TimetableSnapshot(
+    var timetableSnapshot = new DefaultTimetableRepository(
       new RaptorTransitData(transitRepository.getRaptorTransitData()),
       transitRepository.copyTripCalendarForRealTimeUpdates()
     );
-    RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle =
+    RepositoryHandle<TimetableRepositorySnapshot, TimetableRepository> timetableHandle =
       registry.registerRepositorySnapshot(
         timetableSnapshot,
-        new TimetableSnapshotLifecycle(
+        new TimetableRepositoryLifecycle(
           timetableSnapshot,
           parameters.purgeExpiredData(),
           LocalDate::now

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -47,7 +47,7 @@ import org.opentripplanner.transit.repository.MutableTimetableSnapshot;
 import org.opentripplanner.transit.repository.ReadOnlyTimetableSnapshot;
 import org.opentripplanner.transit.repository.TimetableSnapshotLifecycle;
 import org.opentripplanner.transit.service.DefaultTransitService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.speed_test.model.SpeedTestProfile;
 import org.opentripplanner.transit.speed_test.model.testcase.CsvFileSupport;
 import org.opentripplanner.transit.speed_test.model.testcase.ExpectedResults;
@@ -68,7 +68,7 @@ public class SpeedTest {
 
   private static final String TRAVEL_SEARCH_FILENAME = "travelSearch";
 
-  private final TimetableRepository timetableRepository;
+  private final TransitRepository transitRepository;
 
   private final SpeedTestTimer timer = new SpeedTestTimer();
 
@@ -90,13 +90,13 @@ public class SpeedTest {
     SpeedTestConfig config,
     RouterConfig routerConfig,
     Graph graph,
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     TransferRepository transferRepository
   ) {
     this.opts = opts;
     this.config = config;
     this.routerConfig = routerConfig;
-    this.timetableRepository = timetableRepository;
+    this.transitRepository = transitRepository;
 
     this.tcIO = new CsvFileSupport(
       opts.rootDir(),
@@ -109,23 +109,23 @@ public class SpeedTest {
     this.testCaseDefinitions = tcIO.readTestCaseDefinitions();
     this.expectedResultsByTcId = tcIO.readExpectedResults();
 
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitService = new DefaultTransitService(transitRepository);
     var realtimeVehicleRepository = new DefaultRealtimeVehicleRepository();
 
     TransitTuningParameters tuningParameters = routerConfig.transitTuningConfig();
     var scheduledRaptorData = RaptorTransitDataMapper.map(
       tuningParameters,
-      timetableRepository,
+      transitRepository,
       transferRepository
     );
 
-    timetableRepository.initRaptorTransitData(scheduledRaptorData);
+    transitRepository.initRaptorTransitData(scheduledRaptorData);
 
     var parameters = TimetableSnapshotParameters.DEFAULT;
     var registry = TransactionFactory.createRepositoryRegistry();
     var timetableSnapshot = new TimetableSnapshot(
-      new RaptorTransitData(timetableRepository.getRaptorTransitData()),
-      timetableRepository.copyTripCalendarForRealTimeUpdates()
+      new RaptorTransitData(transitRepository.getRaptorTransitData()),
+      transitRepository.copyTripCalendarForRealTimeUpdates()
     );
     RepositoryHandle<ReadOnlyTimetableSnapshot, MutableTimetableSnapshot> timetableHandle =
       registry.registerRepositorySnapshot(
@@ -151,7 +151,7 @@ public class SpeedTest {
       realtimeVehicleRepository,
       new DefaultVehicleRentalService(),
       new DefaultVehicleParkingRepository(),
-      timetableRepository,
+      transitRepository,
       // The speed test does not enable the CarPooling feature, so it supplies neither a carpooling
       // repository nor a resolver.
       null,
@@ -160,8 +160,8 @@ public class SpeedTest {
       timetableHandle,
       routerConfig.updaterConfig()
     );
-    if (timetableRepository.getUpdaterManager() != null) {
-      timetableRepository.getUpdaterManager().startUpdaters();
+    if (transitRepository.getUpdaterManager() != null) {
+      transitRepository.getUpdaterManager().startUpdaters();
     }
 
     var raptorConfig = new RaptorConfig<TripSchedule>(
@@ -171,7 +171,7 @@ public class SpeedTest {
 
     var vertexLinker = VertexLinkerTestFactory.of(graph);
 
-    // Creating raptor transit data should be integrated into the TimetableRepository, but for now
+    // Creating raptor transit data should be integrated into the TransitRepository, but for now
     // we do it manually here
 
     this.serverContext = new DefaultServerRequestContext(
@@ -191,7 +191,7 @@ public class SpeedTest {
       new TransactionScope() {},
       routerConfig.transitTuningConfig(),
       new DefaultTransitService(
-        timetableRepository,
+        transitRepository,
         timetableHandle.repositorySnapshot(registry.scope())
       ),
       null,
@@ -215,7 +215,7 @@ public class SpeedTest {
       null
     );
 
-    initializeTransferCache(routerConfig.transitTuningConfig(), timetableRepository);
+    initializeTransferCache(routerConfig.transitTuningConfig(), transitRepository);
 
     timer.setUp(opts.groupResultsByCategory());
   }
@@ -233,7 +233,7 @@ public class SpeedTest {
       var routerConfig = new OtpConfigLoader(opts.rootDir()).loadRouterConfig();
       OtpStartupInfo.logInfo("Run Speed Test");
       var model = SetupHelper.loadGraph(opts.rootDir(), config.graph());
-      var timetableRepository = model.timetableRepository();
+      var transitRepository = model.transitRepository();
       var transferRepository = model.transferRepository();
       var buildConfig = model.buildConfig();
       var graph = model.graph();
@@ -244,17 +244,17 @@ public class SpeedTest {
         config,
         routerConfig,
         graph,
-        timetableRepository,
+        transitRepository,
         transferRepository
       );
 
-      assertTestDateHasData(timetableRepository, config, buildConfig);
+      assertTestDateHasData(transitRepository, config, buildConfig);
 
       // and run it
       speedTest.runTest();
 
-      if (speedTest.timetableRepository.getUpdaterManager() != null) {
-        speedTest.timetableRepository.getUpdaterManager().stop();
+      if (speedTest.transitRepository.getUpdaterManager() != null) {
+        speedTest.transitRepository.getUpdaterManager().stop();
       }
     } catch (OtpAppException ae) {
       System.err.println(ae.getMessage());
@@ -351,7 +351,7 @@ public class SpeedTest {
       config,
       profile,
       routerConfig.routingRequestDefaults(),
-      timetableRepository.getTimeZone()
+      transitRepository.getTimeZone()
     );
     var routingRequest = speedTestRequest.toRouteRequest();
     return serverContext.routingService().route(routingRequest);

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/TransferCacheTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/TransferCacheTest.java
@@ -8,7 +8,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.Rapto
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.OtpStartupInfo;
 import org.opentripplanner.standalone.config.OtpConfigLoader;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.speed_test.model.timer.SpeedTestTimer;
 import org.opentripplanner.transit.speed_test.options.SpeedTestCmdLineOpts;
 import org.opentripplanner.transit.speed_test.options.SpeedTestConfig;
@@ -27,23 +27,23 @@ public class TransferCacheTest {
       var routerConfig = new OtpConfigLoader(opts.rootDir()).loadRouterConfig();
       SetupHelper.loadOtpFeatures(opts);
       var model = SetupHelper.loadGraph(opts.rootDir(), config.graph());
-      var timetableRepository = model.timetableRepository();
+      var transitRepository = model.transitRepository();
       var transferRepository = model.transferRepository();
       var buildConfig = model.buildConfig();
 
       var timer = new SpeedTestTimer();
       timer.setUp(false);
 
-      // Creating transitLayerForRaptor should be integrated into the TimetableRepository, but for now
+      // Creating transitLayerForRaptor should be integrated into the TransitRepository, but for now
       // we do it manually here
       TransitTuningParameters tuningParameters = routerConfig.transitTuningConfig();
-      timetableRepository.initRaptorTransitData(
-        RaptorTransitDataMapper.map(tuningParameters, timetableRepository, transferRepository)
+      transitRepository.initRaptorTransitData(
+        RaptorTransitDataMapper.map(tuningParameters, transitRepository, transferRepository)
       );
 
-      assertTestDateHasData(timetableRepository, config, buildConfig);
+      assertTestDateHasData(transitRepository, config, buildConfig);
 
-      measureTransferCacheComputation(timer, timetableRepository);
+      measureTransferCacheComputation(timer, transitRepository);
 
       timer.finishUp();
     } catch (Exception e) {
@@ -58,14 +58,14 @@ public class TransferCacheTest {
    */
   private static void measureTransferCacheComputation(
     SpeedTestTimer timer,
-    TimetableRepository timetableRepository
+    TransitRepository transitRepository
   ) {
     IntStream.range(1, 7).forEach(reluctance -> {
       var routeRequest = RouteRequest.of()
         .withPreferences(b -> b.withWalk(c -> c.withReluctance(reluctance)))
         .buildDefault();
       timer.recordTimer("transfer_cache_computation", () ->
-        timetableRepository.getRaptorTransitData().initTransferCacheForRequest(routeRequest)
+        transitRepository.getRaptorTransitData().initTransferCacheForRequest(routeRequest)
       );
     });
   }

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/support/AssertSpeedTestSetup.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/support/AssertSpeedTestSetup.java
@@ -3,17 +3,17 @@ package org.opentripplanner.transit.speed_test.support;
 import org.opentripplanner.framework.application.OtpAppException;
 import org.opentripplanner.framework.application.OtpFileNames;
 import org.opentripplanner.standalone.config.BuildConfig;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.transit.speed_test.options.SpeedTestConfig;
 
 public class AssertSpeedTestSetup {
 
   public static void assertTestDateHasData(
-    TimetableRepository timetableRepository,
+    TransitRepository transitRepository,
     SpeedTestConfig config,
     BuildConfig buildConfig
   ) {
-    int numberOfPatternForTestDate = timetableRepository
+    int numberOfPatternForTestDate = transitRepository
       .getRaptorTransitData()
       .getTripPatternsForRunningDate(config.testDate())
       .size();

--- a/application/src/test/java/org/opentripplanner/updater/alert/gtfs/AlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/gtfs/AlertsUpdateHandlerTest.java
@@ -25,15 +25,13 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 public class AlertsUpdateHandlerTest {
 
   private AlertsUpdateHandler handler;
 
-  private final TransitAlertService service = new TransitAlertServiceImpl(
-    new TimetableRepository()
-  );
+  private final TransitAlertService service = new TransitAlertServiceImpl(new TransitRepository());
 
   @BeforeEach
   public void setUp() {

--- a/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
@@ -81,14 +81,14 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
   public void setUp() throws Exception {
     super.setUp();
 
-    realTimeUpdateContext = new DefaultRealTimeUpdateContext(graph, timetableRepository);
+    realTimeUpdateContext = new DefaultRealTimeUpdateContext(graph, transitRepository);
     if (transitService == null) {
-      transitService = new DefaultTransitService(timetableRepository);
+      transitService = new DefaultTransitService(transitRepository);
     } else {
       transitAlertService.getAllAlerts().clear();
     }
     if (alertsUpdateHandler == null) {
-      transitAlertService = new TransitAlertServiceImpl(timetableRepository);
+      transitAlertService = new TransitAlertServiceImpl(transitRepository);
       alertsUpdateHandler = new SiriAlertsUpdateHandler(
         FEED_ID,
         transitAlertService,
@@ -461,7 +461,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     assertTrue(transitAlertService.getAllAlerts().isEmpty());
 
-    var modelZoneId = timetableRepository.getTimeZone();
+    var modelZoneId = transitRepository.getTimeZone();
     var situationNumber = "TST:SituationNumber:1234";
     var startTime = LocalDateTime.parse("2014-01-01T00:00:00").atZone(modelZoneId);
     var endTime = LocalDateTime.parse("2014-01-01T23:59:59").atZone(modelZoneId);
@@ -500,7 +500,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     assertTrue(transitAlertService.getAllAlerts().isEmpty());
 
-    ZoneId zoneId = timetableRepository.getTimeZone();
+    ZoneId zoneId = transitRepository.getTimeZone();
     final String situationNumber = "TST:SituationNumber:1234";
     final ZonedDateTime startTime = LocalDateTime.parse("2014-01-01T00:00:00").atZone(zoneId);
     final ZonedDateTime endTime = LocalDateTime.parse("2014-01-01T23:59:59").atZone(zoneId);

--- a/application/src/test/java/org/opentripplanner/updater/trip/TripUpdateApplierTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TripUpdateApplierTest.java
@@ -16,8 +16,8 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
 
 /**
  * Tests for {@link TripUpdateApplier}, covering the three-phase update logic that was
@@ -72,8 +72,11 @@ class TripUpdateApplierTest {
     .withRealTimeStopPatternModified()
     .build();
 
-  private static TimetableSnapshot createBuffer() {
-    return new TimetableSnapshot(RaptorTransitDataTestFactory.empty(), new DefaultTripCalendars());
+  private static DefaultTimetableRepository createBuffer() {
+    return new DefaultTimetableRepository(
+      RaptorTransitDataTestFactory.empty(),
+      new DefaultTripCalendars()
+    );
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/updater/trip/TripUpdateApplierTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TripUpdateApplierTest.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 import java.time.Month;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitDataTestFactory;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.calendar.DefaultTripCalendars;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -27,10 +27,10 @@ class TripUpdateApplierTest {
 
   private static final LocalDate TODAY = LocalDate.of(2024, Month.MAY, 30);
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
 
-  private static final Route ROUTE = TimetableRepositoryForTest.route("route1").build();
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("trip1").build();
+  private static final Route ROUTE = TransitRepositoryForTest.route("route1").build();
+  private static final Trip TRIP = TransitRepositoryForTest.trip("trip1").build();
   private static final RegularStop STOP_1 = TEST_MODEL.stop("S1").build();
   private static final RegularStop STOP_2 = TEST_MODEL.stop("S2").build();
   private static final RegularStop STOP_3 = TEST_MODEL.stop("S3").build();
@@ -44,31 +44,31 @@ class TripUpdateApplierTest {
    * Scheduled pattern (stops S1, S2) with the trip in its scheduled timetable. Phase 2 of
    * apply() reads from the scheduled timetable to create a DELETED entry.
    */
-  private static final TripPattern SCHEDULED_PATTERN = TimetableRepositoryForTest.tripPattern(
+  private static final TripPattern SCHEDULED_PATTERN = TransitRepositoryForTest.tripPattern(
     "sched",
     ROUTE
   )
-    .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_1, STOP_2))
+    .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_1, STOP_2))
     .withScheduledTimeTableBuilder(ttb -> ttb.addTripTimes(SCHEDULED_TRIP_TIMES))
     .build();
 
   /**
    * Modified pattern (stops S1, S3) flagged as real-time stop-pattern-modified.
    */
-  private static final TripPattern MODIFIED_PATTERN = TimetableRepositoryForTest.tripPattern(
+  private static final TripPattern MODIFIED_PATTERN = TransitRepositoryForTest.tripPattern(
     "modified",
     ROUTE
   )
-    .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_1, STOP_3))
+    .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_1, STOP_3))
     .withRealTimeStopPatternModified()
     .build();
 
   /** A second modified pattern (stops S2, S3) for the all-three-phases test. */
-  private static final TripPattern SECOND_MODIFIED_PATTERN = TimetableRepositoryForTest.tripPattern(
+  private static final TripPattern SECOND_MODIFIED_PATTERN = TransitRepositoryForTest.tripPattern(
     "modified2",
     ROUTE
   )
-    .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_2, STOP_3))
+    .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_2, STOP_3))
     .withRealTimeStopPatternModified()
     .build();
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/LegacyTimetableRepositoryIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/LegacyTimetableRepositoryIntegrationTest.java
@@ -29,7 +29,7 @@ import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.Timetable;
-import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
+import org.opentripplanner.transit.repository.DefaultTimetableRepository;
 import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.spi.UpdateSuccess;
 import org.opentripplanner.updater.trip.gtfs.interpolation.BackwardsDelayPropagationType;
@@ -42,7 +42,7 @@ import org.opentripplanner.updater.trip.gtfs.model.TripUpdate;
  * feed from disk. It's also very hard to follow. All in all, I would say its usefulness is
  * questionable.
  */
-public class LegacyTimetableSnapshotIntegrationTest {
+public class LegacyTimetableRepositoryIntegrationTest {
 
   private static final ZoneId TIME_ZONE = ZoneIds.GMT;
   public static final LocalDate SERVICE_DATE = LocalDate.of(2024, 1, 1);
@@ -70,7 +70,7 @@ public class LegacyTimetableSnapshotIntegrationTest {
     LocalDate yesterday = today.minusDays(1);
     LocalDate tomorrow = today.plusDays(1);
     TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
-    TimetableSnapshot resolver = new TimetableSnapshot(
+    DefaultTimetableRepository resolver = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
@@ -121,7 +121,7 @@ public class LegacyTimetableSnapshotIntegrationTest {
     LocalDate yesterday = today.minusDays(1);
     TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
 
-    TimetableSnapshot resolver = new TimetableSnapshot(
+    DefaultTimetableRepository resolver = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
@@ -162,7 +162,7 @@ public class LegacyTimetableSnapshotIntegrationTest {
     assertNotSame(updatedNow, resolver.resolve(pattern, yesterday));
 
     // exception if we try to modify a snapshot
-    TimetableSnapshot snapshot = resolver.commit();
+    DefaultTimetableRepository snapshot = resolver.commit();
     assertThrows(ConcurrentModificationException.class, () -> {
       updateSnapshot(snapshot, pattern, tripUpdate, yesterday);
     });
@@ -175,13 +175,13 @@ public class LegacyTimetableSnapshotIntegrationTest {
       LocalDate yesterday = today.minusDays(1);
       TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
 
-      TimetableSnapshot resolver = new TimetableSnapshot(
+      DefaultTimetableRepository resolver = new DefaultTimetableRepository(
         RaptorTransitDataTestFactory.empty(),
         new DefaultTripCalendars()
       );
 
       // only return a new snapshot if there are changes
-      TimetableSnapshot snapshot = resolver.commit();
+      DefaultTimetableRepository snapshot = resolver.commit();
       assertNull(snapshot);
 
       TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -255,7 +255,7 @@ public class LegacyTimetableSnapshotIntegrationTest {
 
     GtfsRealtime.TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    TimetableSnapshot resolver = new TimetableSnapshot(
+    DefaultTimetableRepository resolver = new DefaultTimetableRepository(
       RaptorTransitDataTestFactory.empty(),
       new DefaultTripCalendars()
     );
@@ -279,7 +279,7 @@ public class LegacyTimetableSnapshotIntegrationTest {
   }
 
   private UpdateSuccess updateSnapshot(
-    TimetableSnapshot resolver,
+    DefaultTimetableRepository resolver,
     TripPattern pattern,
     GtfsRealtime.TripUpdate tripUpdate,
     LocalDate serviceDate

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/LegacyTimetableSnapshotIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/LegacyTimetableSnapshotIntegrationTest.java
@@ -30,7 +30,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.spi.UpdateSuccess;
 import org.opentripplanner.updater.trip.gtfs.interpolation.BackwardsDelayPropagationType;
 import org.opentripplanner.updater.trip.gtfs.interpolation.ForwardsDelayPropagationType;
@@ -52,12 +52,12 @@ public class LegacyTimetableSnapshotIntegrationTest {
   @BeforeAll
   public static void setUp() throws Exception {
     TestOtpModel model = ConstantsForTests.buildGtfsGraph(ConstantsForTests.SIMPLE_GTFS);
-    TimetableRepository timetableRepository = model.timetableRepository();
+    TransitRepository transitRepository = model.transitRepository();
 
-    feedId = timetableRepository.getFeedIds().iterator().next();
+    feedId = transitRepository.getFeedIds().iterator().next();
 
     patternIndex = new HashMap<>();
-    for (TripPattern tripPattern : timetableRepository.getAllTripPatterns()) {
+    for (TripPattern tripPattern : transitRepository.getAllTripPatterns()) {
       tripPattern
         .scheduledTripsAsStream()
         .forEach(trip -> patternIndex.put(trip.getId(), tripPattern));

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdaterTest.java
@@ -39,7 +39,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.TripTimes;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.spi.UpdateErrorType;
 import org.opentripplanner.updater.trip.gtfs.interpolation.BackwardsDelayPropagationType;
 import org.opentripplanner.updater.trip.gtfs.interpolation.ForwardsDelayPropagationType;
@@ -66,12 +66,12 @@ public class TripTimesUpdaterTest {
   @BeforeAll
   public static void setUp() throws Exception {
     TestOtpModel model = ConstantsForTests.buildGtfsGraph(ConstantsForTests.SIMPLE_GTFS);
-    TimetableRepository timetableRepository = model.timetableRepository();
+    TransitRepository transitRepository = model.transitRepository();
 
-    feedId = timetableRepository.getFeedIds().stream().findFirst().get();
+    feedId = transitRepository.getFeedIds().stream().findFirst().get();
     patternIndex = new HashMap<>();
 
-    for (TripPattern pattern : timetableRepository.getAllTripPatterns()) {
+    for (TripPattern pattern : transitRepository.getAllTripPatterns()) {
       pattern.scheduledTripsAsStream().forEach(trip -> patternIndex.put(trip.getId(), pattern));
     }
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/BackwardsDelayAlwaysInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/BackwardsDelayAlwaysInterpolatorTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.StopRealTimeState;
@@ -16,11 +16,11 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class BackwardsDelayAlwaysInterpolatorTest {
 
-  static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP_ID").build();
+  static final Trip TRIP = TransitRepositoryForTest.trip("TRIP_ID").build();
   static final int STOP_COUNT = 5;
   static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
     TRIP,
-    TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
+    TransitRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
     new Deduplicator()
   );
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/BackwardsDelayRequiredInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/BackwardsDelayRequiredInterpolatorTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.StopRealTimeState;
@@ -16,11 +16,11 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class BackwardsDelayRequiredInterpolatorTest {
 
-  static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP_ID").build();
+  static final Trip TRIP = TransitRepositoryForTest.trip("TRIP_ID").build();
   public static final int STOP_COUNT = 5;
   static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
     TRIP,
-    TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
+    TransitRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
     new Deduplicator()
   );
 
@@ -199,7 +199,7 @@ class BackwardsDelayRequiredInterpolatorTest {
   void useDepartureTimeForMissingArrivalTime() {
     var tripTimes = TripTimesFactory.tripTimes(
       TRIP,
-      TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:10"),
+      TransitRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:10"),
       new Deduplicator()
     );
     var realTimeTime = 5;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/DefaultForwardsDelayInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/DefaultForwardsDelayInterpolatorTest.java
@@ -12,7 +12,7 @@ import static org.opentripplanner.transit.model.timetable.StopRealTimeState.NO_D
 import java.util.List;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.StopRealTimeState;
@@ -21,11 +21,11 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 class DefaultForwardsDelayInterpolatorTest {
 
-  static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP_ID").build();
+  static final Trip TRIP = TransitRepositoryForTest.trip("TRIP_ID").build();
   static final int STOP_COUNT = 20;
   static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
     TRIP,
-    TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
+    TransitRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
     new Deduplicator()
   );
 
@@ -141,8 +141,8 @@ class DefaultForwardsDelayInterpolatorTest {
     var builder = TripTimesFactory.tripTimes(
       TRIP,
       List.of(
-        TimetableRepositoryForTest.of().stopTime(TRIP, 0, 0),
-        TimetableRepositoryForTest.of().stopTime(TRIP, 1, 300, 600)
+        TransitRepositoryForTest.of().stopTime(TRIP, 0, 0),
+        TransitRepositoryForTest.of().stopTime(TRIP, 1, 300, 600)
       ),
       new Deduplicator()
     ).createRealTimeWithoutScheduledTimes();

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/NoDataBackwardsEarlinessInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/interpolation/NoDataBackwardsEarlinessInterpolatorTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
@@ -19,11 +19,11 @@ import org.opentripplanner.utils.collection.ListUtils;
 
 class NoDataBackwardsEarlinessInterpolatorTest {
 
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP_ID").build();
+  private static final Trip TRIP = TransitRepositoryForTest.trip("TRIP_ID").build();
   private static final int STOP_COUNT = 5;
   private static final ScheduledTripTimes SCHEDULED_TRIP_TIMES = TripTimesFactory.tripTimes(
     TRIP,
-    TimetableRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
+    TransitRepositoryForTest.of().stopTimesEvery5Minutes(STOP_COUNT, TRIP, "00:00"),
     DeduplicatorService.NOOP
   );
   private static final int SIX_MINUTES_EARLY = -6 * 60;

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/addition/AddedTest.java
@@ -89,8 +89,8 @@ class AddedTest implements RealtimeTestConstants {
     assertEquals(TransitMode.RAIL, route.getMode());
 
     TransitService transitService = env.transitService();
-    var fromTimetableRepository = transitService.getRoute(route.getId());
-    assertEquals(fromTimetableRepository, route);
+    var fromTransitRepository = transitService.getRoute(route.getId());
+    assertEquals(fromTransitRepository, route);
     var patternsForRoute = transitService.findPatterns(route);
     assertEquals(1, patternsForRoute.size());
     assertEquals(pattern, patternsForRoute.stream().findFirst().orElseThrow());

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/AddedTripBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/AddedTripBuilderTest.java
@@ -22,7 +22,7 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
@@ -37,20 +37,20 @@ import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
 import org.opentripplanner.transit.service.TransitEditorService;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.alert.siri.mapping.SiriTransportModeMapper;
 import org.opentripplanner.updater.spi.UpdateErrorType;
 import uk.org.siri.siri21.VehicleModesEnumeration;
 
 class AddedTripBuilderTest {
 
-  private static final Agency AGENCY = TimetableRepositoryForTest.AGENCY;
+  private static final Agency AGENCY = TransitRepositoryForTest.AGENCY;
   private static final ZoneId TIME_ZONE = AGENCY.getTimezone();
   private static final Operator OPERATOR = Operator.of(FeedScopedIdForTestFactory.id("OPERATOR_ID"))
     .withName("OPERATOR_NAME")
     .build();
-  private static final Route REPLACED_ROUTE = TimetableRepositoryForTest.route("REPLACED_ROUTE")
+  private static final Route REPLACED_ROUTE = TransitRepositoryForTest.route("REPLACED_ROUTE")
     .withAgency(AGENCY)
     .withOperator(OPERATOR)
     .build();
@@ -66,7 +66,7 @@ class AddedTripBuilderTest {
   private static final String HEADSIGN = "TEST TRIP TOWARDS TEST ISLAND";
 
   /* Transit model */
-  private static final TimetableRepositoryForTest MODEL_TEST = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest MODEL_TEST = TransitRepositoryForTest.of();
 
   private static final RegularStop STOP_A = MODEL_TEST.stop("A").build();
   private static final RegularStop STOP_B = MODEL_TEST.stop("B").build();
@@ -80,7 +80,7 @@ class AddedTripBuilderTest {
     .build();
 
   private final Deduplicator DEDUPLICATOR = new Deduplicator();
-  private final TimetableRepository TRANSIT_MODEL = new TimetableRepository(SITE_REPOSITORY);
+  private final TransitRepository TRANSIT_MODEL = new TransitRepository(SITE_REPOSITORY);
   private TransitEditorService transitService;
   private EntityResolver ENTITY_RESOLVER;
 
@@ -88,11 +88,11 @@ class AddedTripBuilderTest {
   void setUp() {
     // Add entities to transit model for the entity resolver
     TRANSIT_MODEL.addAgency(AGENCY);
-    final TripPattern pattern = TimetableRepositoryForTest.tripPattern(
+    final TripPattern pattern = TransitRepositoryForTest.tripPattern(
       "REPLACED_ROUTE_PATTERN_ID",
       REPLACED_ROUTE
     )
-      .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A, STOP_B))
+      .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_A, STOP_B))
       .build();
     TRANSIT_MODEL.addTripPattern(pattern.getId(), pattern);
 
@@ -113,7 +113,7 @@ class AddedTripBuilderTest {
     // Create the entity resolver only after the model has been indexed
     ENTITY_RESOLVER = new EntityResolver(
       new DefaultTransitService(TRANSIT_MODEL),
-      TimetableRepositoryForTest.FEED_ID
+      TransitRepositoryForTest.FEED_ID
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/EntityResolverTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/EntityResolverTest.java
@@ -10,15 +10,15 @@ import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.LocalTimeParser;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 
 class EntityResolverTest {
 
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final RegularStop STOP_1 = TEST_MODEL.stop("stop-1").build();
   private static final RegularStop STOP_2 = TEST_MODEL.stop("stop-2").build();
   private static final SiteRepository SITE_REPOSITORY = TEST_MODEL.siteRepositoryBuilder()
@@ -29,9 +29,9 @@ class EntityResolverTest {
 
   @Test
   void resolveScheduledStopPointId() {
-    var timetableRepository = new TimetableRepository();
-    timetableRepository.addScheduledStopPointMapping(Map.of(SSP_ID, STOP_1));
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitRepository = new TransitRepository();
+    transitRepository.addScheduledStopPointMapping(Map.of(SSP_ID, STOP_1));
+    var transitService = new DefaultTransitService(transitRepository);
     var resolver = new EntityResolver(transitService, FEED_ID);
     var stop = resolver.resolveQuay(SSP_ID.getId());
     assertEquals(STOP_1, stop);
@@ -39,8 +39,8 @@ class EntityResolverTest {
 
   @Test
   void resolveQuayId() {
-    var timetableRepository = new TimetableRepository(SITE_REPOSITORY);
-    var transitService = new DefaultTransitService(timetableRepository);
+    var transitRepository = new TransitRepository(SITE_REPOSITORY);
+    var transitService = new DefaultTransitService(transitRepository);
     var resolver = new EntityResolver(transitService, FEED_ID);
     var stop = resolver.resolveQuay(STOP_1.getId().getId());
     assertEquals(STOP_1, stop);
@@ -48,9 +48,9 @@ class EntityResolverTest {
 
   @Test
   void scheduledStopPointTakesPrecedence() {
-    var timetableRepository = new TimetableRepository(SITE_REPOSITORY);
-    var transitService = new DefaultTransitService(timetableRepository);
-    timetableRepository.addScheduledStopPointMapping(Map.of(SSP_ID, STOP_2));
+    var transitRepository = new TransitRepository(SITE_REPOSITORY);
+    var transitService = new DefaultTransitService(transitRepository);
+    transitRepository.addScheduledStopPointMapping(Map.of(SSP_ID, STOP_2));
     var resolver = new EntityResolver(transitService, FEED_ID);
     assertEquals(STOP_2, resolver.resolveQuay(SSP_ID.getId()));
     assertEquals(STOP_1, resolver.resolveQuay(STOP_1.getId().getId()));
@@ -104,7 +104,7 @@ class EntityResolverTest {
   }
 
   private static EntityResolver newResolver() {
-    var transitService = new DefaultTransitService(new TimetableRepository());
+    var transitService = new DefaultTransitService(new TransitRepository());
     return new EntityResolver(transitService, FEED_ID);
   }
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilderTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.core.model.id.FeedScopedIdForTestFactory;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -32,7 +32,7 @@ import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.SiteRepository;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.spi.UpdateErrorType;
 import uk.org.siri.siri21.DepartureBoardingActivityEnumeration;
 
@@ -40,9 +40,9 @@ class ModifiedTripBuilderTest {
 
   /* Transit model */
 
-  private static final Agency AGENCY = TimetableRepositoryForTest.AGENCY;
+  private static final Agency AGENCY = TransitRepositoryForTest.AGENCY;
   private static final ZoneId TIME_ZONE = AGENCY.getTimezone();
-  private static final TimetableRepositoryForTest TEST_MODEL = TimetableRepositoryForTest.of();
+  private static final TransitRepositoryForTest TEST_MODEL = TransitRepositoryForTest.of();
   private static final Station STATION_A = TEST_MODEL.station("A").build();
   private static final Station STATION_B = TEST_MODEL.station("B").build();
   private static final Station STATION_C = TEST_MODEL.station("C").build();
@@ -61,20 +61,20 @@ class ModifiedTripBuilderTest {
     .build();
   private static final RegularStop STOP_D = TEST_MODEL.stop("D").build();
 
-  private static final Route ROUTE = TimetableRepositoryForTest.route("ROUTE_ID")
+  private static final Route ROUTE = TransitRepositoryForTest.route("ROUTE_ID")
     .withAgency(AGENCY)
     .build();
 
-  private static final TripPattern PATTERN = TimetableRepositoryForTest.tripPattern(
+  private static final TripPattern PATTERN = TransitRepositoryForTest.tripPattern(
     "PATTERN_ID",
     ROUTE
   )
-    .withStopPattern(TimetableRepositoryForTest.stopPattern(STOP_A_1, STOP_B_1, STOP_C_1))
+    .withStopPattern(TransitRepositoryForTest.stopPattern(STOP_A_1, STOP_B_1, STOP_C_1))
     .build();
 
   private static final FeedScopedId SERVICE_ID = FeedScopedIdForTestFactory.id("CAL_1");
 
-  private static final Trip TRIP = TimetableRepositoryForTest.trip("TRIP")
+  private static final Trip TRIP = TransitRepositoryForTest.trip("TRIP")
     .withRoute(ROUTE)
     .withServiceId(SERVICE_ID)
     .build();
@@ -122,14 +122,14 @@ class ModifiedTripBuilderTest {
     .withRegularStop(STOP_C_1)
     .withRegularStop(STOP_D)
     .build();
-  private final TimetableRepository timetableRepository = new TimetableRepository(siteRepository);
+  private final TransitRepository transitRepository = new TransitRepository(siteRepository);
   private EntityResolver entityResolver;
 
   @BeforeEach
   void setUp() {
     // Add entities to transit model for the entity resolver
-    timetableRepository.addAgency(AGENCY);
-    timetableRepository.addTripPattern(PATTERN.getId(), PATTERN);
+    transitRepository.addAgency(AGENCY);
+    transitRepository.addTripPattern(PATTERN.getId(), PATTERN);
 
     // Crate a scheduled calendar, to have the SERVICE_DATE be within the transit feed coverage
     CalendarServiceData calendarServiceData = new CalendarServiceData();
@@ -137,16 +137,16 @@ class ModifiedTripBuilderTest {
       SERVICE_ID,
       List.of(SERVICE_DATE.minusDays(1), SERVICE_DATE, SERVICE_DATE.plusDays(1))
     );
-    timetableRepository.getServiceCodes().put(SERVICE_ID, 0);
-    timetableRepository.updateCalendarServiceData(calendarServiceData);
+    transitRepository.getServiceCodes().put(SERVICE_ID, 0);
+    transitRepository.updateCalendarServiceData(calendarServiceData);
 
     // Create transit model index
-    timetableRepository.index();
+    transitRepository.index();
 
     // Create the entity resolver only after the model has been indexed
     entityResolver = new EntityResolver(
-      new DefaultTransitService(timetableRepository),
-      TimetableRepositoryForTest.FEED_ID
+      new DefaultTransitService(transitRepository),
+      TransitRepositoryForTest.FEED_ID
     );
   }
 
@@ -156,7 +156,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(),
       false,
@@ -176,7 +176,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(
         TestCall.of()
@@ -216,7 +216,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(
         TestCall.of()
@@ -262,7 +262,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(
         TestCall.of()
@@ -305,7 +305,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(
         TestCall.of()
@@ -351,7 +351,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(
         TestCall.of()
@@ -527,7 +527,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(
         TestCall.of()
@@ -567,7 +567,7 @@ class ModifiedTripBuilderTest {
       TRIP_TIMES,
       PATTERN,
       SERVICE_DATE,
-      timetableRepository.getTimeZone(),
+      transitRepository.getTimeZone(),
       entityResolver,
       List.of(
         TestCall.of()

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
@@ -109,7 +109,7 @@ class SiriFuzzyTripMatcherTest implements RealtimeTestConstants {
   private static TripAndPattern match(EstimatedVehicleJourney evj, TransitTestEnvironment env)
     throws UpdateException {
     var transitService = env.transitService();
-    var cache = new SiriFuzzyTripMatcherCache(env.timetableRepository());
+    var cache = new SiriFuzzyTripMatcherCache(env.transitRepository());
     var fuzzyMatcher = new SiriFuzzyTripMatcher(cache, transitService);
     return fuzzyMatcher.match(
       EstimatedVehicleJourneyWrapper.of(evj),

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingAvailabilityUpdaterTest.java
@@ -17,7 +17,7 @@ import org.opentripplanner.service.vehicleparking.model.VehicleParkingSpaces;
 import org.opentripplanner.standalone.config.routerconfig.updaters.VehicleParkingUpdaterConfig;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.DefaultRealTimeUpdateContext;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.spi.DataSource;
@@ -115,7 +115,7 @@ class VehicleParkingAvailabilityUpdaterTest {
   }
 
   private void runUpdaterOnce(VehicleParkingAvailabilityUpdater updater) {
-    var context = new DefaultRealTimeUpdateContext(new Graph(), new TimetableRepository());
+    var context = new DefaultRealTimeUpdateContext(new Graph(), new TransitRepository());
     WriteToGraphCallback callback = runnable -> {
       runnable.run(context);
       return CompletableFuture.completedFuture(null);

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -22,7 +22,7 @@ import org.opentripplanner.street.model.StreetModelForTest;
 import org.opentripplanner.street.model.edge.StreetVehicleParkingLink;
 import org.opentripplanner.street.model.edge.VehicleParkingEdge;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
-import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.transit.service.TransitRepository;
 import org.opentripplanner.updater.DefaultRealTimeUpdateContext;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.spi.DataSource;
@@ -44,14 +44,14 @@ class VehicleParkingUpdaterTest {
     VehicleParkingTestGraphData graphData = new VehicleParkingTestGraphData();
     graphData.initGraph();
     graph = graphData.getGraph();
-    TimetableRepository timetableRepository = graphData.getTimetableRepository();
+    TransitRepository transitRepository = graphData.getTransitRepository();
     parkingRepository = new DefaultVehicleParkingRepository();
-    realTimeUpdateContext = new DefaultRealTimeUpdateContext(graph, timetableRepository);
+    realTimeUpdateContext = new DefaultRealTimeUpdateContext(graph, transitRepository);
 
     dataSource = (DataSource<VehicleParking>) Mockito.mock(DataSource.class);
     when(dataSource.update()).thenReturn(true);
 
-    timetableRepository.index();
+    transitRepository.index();
     graph.index();
 
     var parameters = new VehicleParkingUpdaterParameters() {

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_position/RealtimeVehicleMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_position/RealtimeVehicleMatcherTest.java
@@ -32,7 +32,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleRepository;
 import org.opentripplanner.standalone.config.routerconfig.updaters.VehiclePositionsUpdaterConfig;
 import org.opentripplanner.street.geometry.WgsCoordinate;
-import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
@@ -44,9 +44,9 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 
 public class RealtimeVehicleMatcherTest {
 
-  private final TimetableRepositoryForTest testModel = TimetableRepositoryForTest.of();
+  private final TransitRepositoryForTest testModel = TransitRepositoryForTest.of();
 
-  private static final Route ROUTE = TimetableRepositoryForTest.route("1").build();
+  private static final Route ROUTE = TransitRepositoryForTest.route("1").build();
   private static final Set<VehiclePositionsUpdaterConfig.VehiclePositionFeature> FEATURES = Set.of(
     POSITION,
     STOP_POSITION,
@@ -92,8 +92,8 @@ public class RealtimeVehicleMatcherTest {
 
     final String secondTripId = "trip2";
 
-    var trip1 = TimetableRepositoryForTest.trip(tripId).build();
-    var trip2 = TimetableRepositoryForTest.trip(secondTripId).build();
+    var trip1 = TransitRepositoryForTest.trip(tripId).build();
+    var trip2 = TransitRepositoryForTest.trip(secondTripId).build();
 
     List<StopTime> stopTimes = hasStopTimes
       ? testModel.stopTimesEvery5Minutes(3, trip1, "11:00")
@@ -102,7 +102,7 @@ public class RealtimeVehicleMatcherTest {
 
     // Map positions to trips in feed
     RealtimeVehiclePatternMatcher matcher = new RealtimeVehiclePatternMatcher(
-      TimetableRepositoryForTest.FEED_ID,
+      TransitRepositoryForTest.FEED_ID,
       ignored -> trip2,
       ignored -> pattern,
       (id, time) -> pattern,
@@ -128,7 +128,7 @@ public class RealtimeVehicleMatcherTest {
 
     var tripId = "trip1";
     var scopedTripId = FeedScopedIdForTestFactory.id(tripId);
-    var trip1 = TimetableRepositoryForTest.trip(tripId).build();
+    var trip1 = TransitRepositoryForTest.trip(tripId).build();
 
     var stopTimes = List.of(
       testModel.stopTime(trip1, 10),
@@ -142,7 +142,7 @@ public class RealtimeVehicleMatcherTest {
 
     // Map positions to trips in feed
     RealtimeVehiclePatternMatcher matcher = new RealtimeVehiclePatternMatcher(
-      TimetableRepositoryForTest.FEED_ID,
+      TransitRepositoryForTest.FEED_ID,
       tripForId::get,
       patternForTrip::get,
       (id, time) -> patternForTrip.get(id),
@@ -183,7 +183,7 @@ public class RealtimeVehicleMatcherTest {
 
   private void testVehiclePositions(VehiclePosition pos) {
     var repository = new DefaultRealtimeVehicleRepository();
-    var trip = TimetableRepositoryForTest.trip(tripId).build();
+    var trip = TransitRepositoryForTest.trip(tripId).build();
     var stopTimes = List.of(
       testModel.stopTime(trip, 0),
       testModel.stopTime(trip, 1),
@@ -200,7 +200,7 @@ public class RealtimeVehicleMatcherTest {
 
     // Map positions to trips in feed
     var matcher = new RealtimeVehiclePatternMatcher(
-      TimetableRepositoryForTest.FEED_ID,
+      TransitRepositoryForTest.FEED_ID,
       tripForId::get,
       patternForTrip::get,
       (id, time) -> patternForTrip.get(id),
@@ -232,7 +232,7 @@ public class RealtimeVehicleMatcherTest {
 
   private void testVehiclePositionOccupancy(VehiclePosition pos) {
     var repository = new DefaultRealtimeVehicleRepository();
-    var trip = TimetableRepositoryForTest.trip(tripId).build();
+    var trip = TransitRepositoryForTest.trip(tripId).build();
     var stopTimes = List.of(
       testModel.stopTime(trip, 0),
       testModel.stopTime(trip, 1),
@@ -249,7 +249,7 @@ public class RealtimeVehicleMatcherTest {
 
     // Map positions to trips in feed
     RealtimeVehiclePatternMatcher matcher = new RealtimeVehiclePatternMatcher(
-      TimetableRepositoryForTest.FEED_ID,
+      TransitRepositoryForTest.FEED_ID,
       tripForId::get,
       patternForTrip::get,
       (id, time) -> patternForTrip.get(id),
@@ -283,8 +283,8 @@ public class RealtimeVehicleMatcherTest {
     var scopedTripId1 = FeedScopedIdForTestFactory.id(tripId1);
     var scopedTripId2 = FeedScopedIdForTestFactory.id(tripId2);
 
-    var trip1 = TimetableRepositoryForTest.trip(tripId1).build();
-    var trip2 = TimetableRepositoryForTest.trip(tripId2).build();
+    var trip1 = TransitRepositoryForTest.trip(tripId1).build();
+    var trip2 = TransitRepositoryForTest.trip(tripId2).build();
 
     var stopTimes1 = List.of(
       testModel.stopTime(trip1, 0),
@@ -310,7 +310,7 @@ public class RealtimeVehicleMatcherTest {
 
     // Map positions to trips in feed
     RealtimeVehiclePatternMatcher matcher = new RealtimeVehiclePatternMatcher(
-      TimetableRepositoryForTest.FEED_ID,
+      TransitRepositoryForTest.FEED_ID,
       tripForId::get,
       patternForTrip::get,
       (id, time) -> patternForTrip.get(id),
@@ -356,7 +356,7 @@ public class RealtimeVehicleMatcherTest {
   @ParameterizedTest(name = "{0} + serviceDates={1} should resolve to {2}")
   @MethodSource("inferenceTestCases")
   void inferServiceDayOfTripAt6(String time, Set<String> serviceDateStrings, String expectedDate) {
-    var trip = TimetableRepositoryForTest.trip(tripId).build();
+    var trip = TransitRepositoryForTest.trip(tripId).build();
     var hasTripTimes = serviceDateStrings == null;
 
     ScheduledTripTimes tripTimes = null;
@@ -386,7 +386,7 @@ public class RealtimeVehicleMatcherTest {
 
   @Test
   void inferServiceDateCloseToMidnight() {
-    var trip = TimetableRepositoryForTest.trip(tripId).build();
+    var trip = TransitRepositoryForTest.trip(tripId).build();
 
     var fiveToMidnight = LocalTime.parse("23:55").toSecondOfDay();
     var fivePastMidnight = fiveToMidnight + (10 * 60);

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
 
     <properties>
-        <otp.serialization.version.id>267</otp.serialization.version.id>
+        <otp.serialization.version.id>268</otp.serialization.version.id>
 
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>34.4</geotools.version>

--- a/street/src/main/java/org/opentripplanner/street/graph/Graph.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/Graph.java
@@ -39,10 +39,10 @@ import org.slf4j.LoggerFactory;
  * In OTP1, the Graph contained vertices and edges representing the entire transportation network,
  * including edges representing both street segments and public transit lines connecting stops. In
  * OTP2, the Graph edges now represent only the street network. Transit routing is performed on
- * other data structures suited to the Raptor algorithm (the TimetableRepository). Some transit-related
+ * other data structures suited to the Raptor algorithm (the TransitRepository). Some transit-related
  * vertices are still present in the Graph, specifically those representing transit stops,
  * entrances, and elevators. Their presence in the street graph creates a connection between the two
- * routable data structures (identifying where stops in the TimetableRepository are located relative to
+ * routable data structures (identifying where stops in the TransitRepository are located relative to
  * roads).
  * <p>
  * Other data structures related to street routing, such as elevation data and vehicle parking


### PR DESCRIPTION
## Summary

Apply the repository naming convention from the Snapshot Framework TODO list (related to #7826) to the timetable domain, in two commits.

**Commit 1 — `TimetableRepository` → `TransitRepository`** (a task of its own on the #7826 list). This frees the `TimetableRepository` name for the realtime timetable repository. Classes and identifiers named after it follow:

| Old name | New name |
|---|---|
| `TimetableRepository` | `TransitRepository` |
| `TimetableRepositoryIndex` | `TransitRepositoryIndex` |
| `TimetableRepositoryForTest` | `TransitRepositoryForTest` |
| `TimetableRepositoryTestBuilder` | `TransitRepositoryTestBuilder` |
| identifiers `timetableRepository` | `transitRepository` |

⚠️ `TransitRepository` is part of the serialized graph, so the **serialization version id is bumped** (267 → 268).

**Commit 2 — the realtime timetable snapshot types**, following `interface XRepository`, `interface XRepositorySnapshot`, `class DefaultXRepository` (see [this comment](https://github.com/opentripplanner/OpenTripPlanner/pull/7834#issuecomment-5003880004)):

| Old name | New name |
|---|---|
| `ReadOnlyTimetableSnapshot` | `TimetableRepositorySnapshot` |
| `MutableTimetableSnapshot` | `TimetableRepository` |
| `TimetableSnapshot` (in `transit.model.timetable`) | `DefaultTimetableRepository` (moved to `transit.repository`) |
| `TimetableSnapshotLifecycle` | `TimetableRepositoryLifecycle` |
| `MutableTimetableSnapshot.createReadOnlySnapshot()` | `TimetableRepository.createSnapshot()` |
| `RealTimeUpdateContext.mutableSnapshot()` | `RealTimeUpdateContext.timetableRepository()` |

The candyshop test exemplar is renamed the same way (`OrderSnapshot` → `OrderRepositorySnapshot`, `CustomerSnapshot` → `CustomerRepositorySnapshot`), and per the JavaDoc task on the #7826 list, all methods of the renamed public interfaces now have JavaDoc.

Notes:

- `TimetableSnapshotParameters` (build/router config type) is deliberately **not** renamed, to keep the config surface unchanged.
- The other half of the TODO item — all read access goes through the domain service — already holds: request threads read through `DefaultTransitService`, and only the request-scoped DI wiring resolves a snapshot per request.
- The recommendation that the mutable repository and the immutable snapshot should be **separate classes** (with `copyOnWrite` producing a fresh mutable repository from the frozen snapshot) is out of scope here; `DefaultTimetableRepository` still implements both interfaces the way `TimetableSnapshot` did.
- Apart from the serialization version id, this is a pure rename/move with no behavior changes.

## Issue

Related to #7826 (checklist items on the live TODO list; the issue stays open).

## Unit tests

Existing tests renamed along with the types (`DefaultTimetableRepositoryTest`, `TimetableRepositoryLifecycleTest`, `LegacyTimetableRepositoryIntegrationTest`, `TransitRepositoryTest`, `TransitRepositoryArchitectureTest`). Full suite green.

## Documentation

Updated `updater/package.md` and JavaDoc on the renamed interfaces and referencing classes.
