### PR TITLE
Report pattern-changing GTFS-RT trip updates as MODIFIED

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/ScheduledTripHandler.java
@@ -4,10 +4,7 @@ import static org.opentripplanner.updater.spi.UpdateErrorType.NO_SERVICE_ON_DATE
 import static org.opentripplanner.updater.spi.UpdateErrorType.NO_UPDATES;
 import static org.opentripplanner.updater.spi.UpdateErrorType.TRIP_NOT_FOUND;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.opentripplanner.core.model.id.FeedScopedId;
-import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
@@ -74,33 +71,25 @@ class ScheduledTripHandler {
       backwardsDelayPropagationType
     );
 
-    var updatedPickup = tripTimesPatch.updatedPickup();
-    var updatedDropoff = tripTimesPatch.updatedDropoff();
-    var replacedStopIndices = tripTimesPatch.replacedStopIndices();
-    var updatedTripTimes = tripTimesPatch.tripTimes();
-
-    Map<Integer, StopLocation> newStops = new HashMap<>();
-    for (var entry : replacedStopIndices.entrySet()) {
-      var stop = transitEditorService.getRegularStop(
-        new FeedScopedId(tripUpdate.tripId().getFeedId(), entry.getValue())
-      );
-      if (stop != null) {
-        newStops.put(entry.getKey(), stop);
-      }
+    // A pickup / drop-off override or a resolvable stop replacement moves the trip onto a pattern
+    // differing from the scheduled one. The trip is then reported as MODIFIED.
+    var feedId = tripUpdate.tripId().getFeedId();
+    var modifiedStopPattern = tripTimesPatch
+      .stopPatternChanges()
+      .deriveStopPattern(pattern, stopId -> resolveStop(feedId, stopId));
+    var patternModified = modifiedStopPattern.isPresent();
+    if (patternModified) {
+      tripTimesPatch.withModifiedTripPattern();
     }
 
-    // If there are stops with different pickup / drop off, or replaced stops, we need to change the pattern from the scheduled one
-    if (!updatedPickup.isEmpty() || !updatedDropoff.isEmpty() || !newStops.isEmpty()) {
-      StopPattern newStopPattern = pattern
-        .copyPlannedStopPattern()
-        .updatePickups(updatedPickup)
-        .updateDropoffs(updatedDropoff)
-        .replaceStops(newStops)
-        .build();
+    // Materialize and validate the trip times before touching the pattern cache, so that an
+    // invalid update does not leave an orphan real-time pattern behind.
+    var updatedTripTimes = tripTimesPatch.tripTimes();
 
+    if (patternModified) {
       final Trip trip = transitEditorService.getTrip(tripUpdate.tripId());
       final TripPattern newPattern = tripPatternCache.getOrCreateTripPattern(
-        newStopPattern,
+        modifiedStopPattern.get(),
         trip,
         pattern
       );
@@ -120,6 +109,10 @@ class ScheduledTripHandler {
           .build()
       );
     }
+  }
+
+  private StopLocation resolveStop(String feedId, String stopId) {
+    return transitEditorService.getRegularStop(new FeedScopedId(feedId, stopId));
   }
 
   private TripPattern getPatternForTripId(FeedScopedId tripId) {

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdater.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
-import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimesBuilder;
@@ -22,12 +21,12 @@ import org.opentripplanner.transit.model.timetable.Timetable;
 import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
-import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.UpdateException;
 import org.opentripplanner.updater.trip.gtfs.interpolation.BackwardsDelayInterpolator;
 import org.opentripplanner.updater.trip.gtfs.interpolation.BackwardsDelayPropagationType;
 import org.opentripplanner.updater.trip.gtfs.interpolation.ForwardsDelayInterpolator;
 import org.opentripplanner.updater.trip.gtfs.interpolation.ForwardsDelayPropagationType;
+import org.opentripplanner.updater.trip.gtfs.model.StopPatternChanges;
 import org.opentripplanner.updater.trip.gtfs.model.StopTimeUpdate;
 import org.opentripplanner.updater.trip.gtfs.model.TripTimesPatch;
 import org.opentripplanner.updater.trip.gtfs.model.TripUpdate;
@@ -59,9 +58,9 @@ class TripTimesUpdater {
    * @param tripUpdate     GTFS-RT trip update
    * @param backwardsDelay Defines when delays are propagated to previous stops and if these stops
    *                       are given the NO_DATA flag
-   * @return {@link TripTimesPatch} contains a new copy of updated TripTimes after TripUpdate has
-   * been applied on TripTimes of trip with the id specified in the trip descriptor of the
-   * TripUpdate and a list of stop indices that have been skipped with the realtime update.
+   * @return {@link TripTimesPatch} holding the not-yet-materialized updated TripTimes for the trip
+   * with the id specified in the trip descriptor of the TripUpdate, together with the pickup/drop-off
+   * changes and stop replacements that determine whether the trip moves onto a modified pattern.
    * @throws UpdateException if there are any problems with the data
    */
   public TripTimesPatch createUpdatedTripTimesFromGtfsRt(
@@ -150,13 +149,11 @@ class TripTimesUpdater {
     tripUpdate.vehicleId().ifPresent(builder::withVehicleId);
 
     builder.withRealTimeUpdated();
-    // Validate for non-increasing times. Log error if present.
-    try {
-      var result = builder.build();
-      return new TripTimesPatch(result, updatedPickups, updatedDropoffs, replacedStopIndices);
-    } catch (DataValidationException e) {
-      throw DataValidationExceptionMapper.map(e);
-    }
+
+    return new TripTimesPatch(
+      builder,
+      new StopPatternChanges(updatedPickups, updatedDropoffs, replacedStopIndices)
+    );
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/model/StopPatternChanges.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/model/StopPatternChanges.java
@@ -1,0 +1,70 @@
+package org.opentripplanner.updater.trip.gtfs.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.opentripplanner.model.PickDrop;
+import org.opentripplanner.transit.model.network.StopPattern;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.StopLocation;
+
+/**
+ * The stop-level changes a GTFS-RT trip update makes relative to a trip's planned stop pattern:
+ * pickup and drop-off overrides plus stop replacements (a skipped stop is modelled as a
+ * {@code CANCELLED} pickup and drop-off). When the update touches any of these, the trip moves onto
+ * a real-time stop pattern that differs from the planned one and is reported as {@code MODIFIED}.
+ */
+public record StopPatternChanges(
+  Map<Integer, PickDrop> updatedPickups,
+  Map<Integer, PickDrop> updatedDropoffs,
+  Map<Integer, String> replacedStopIds
+) {
+  public StopPatternChanges {
+    updatedPickups = Map.copyOf(updatedPickups);
+    updatedDropoffs = Map.copyOf(updatedDropoffs);
+    replacedStopIds = Map.copyOf(replacedStopIds);
+  }
+
+  /**
+   * The real-time stop pattern these changes produce on top of {@code plannedPattern}, or empty
+   * when they leave the planned pattern unchanged. A stop replacement whose id cannot be resolved
+   * by {@code stopResolver} is dropped, so an update that only replaces unknown stops is not a
+   * pattern change. The presence of a result is therefore the single source of truth for whether
+   * the trip runs on a modified pattern.
+   */
+  public Optional<StopPattern> deriveStopPattern(
+    TripPattern plannedPattern,
+    Function<String, StopLocation> stopResolver
+  ) {
+    var newStops = resolveReplacedStops(stopResolver);
+    if (updatedPickups.isEmpty() && updatedDropoffs.isEmpty() && newStops.isEmpty()) {
+      return Optional.empty();
+    }
+    var candidate = plannedPattern
+      .copyPlannedStopPattern()
+      .updatePickups(updatedPickups)
+      .updateDropoffs(updatedDropoffs)
+      .replaceStops(newStops)
+      .build();
+    // A non-empty set of overrides can still reproduce the planned stops (e.g. an override that
+    // repeats the scheduled pickup/drop-off). Only a candidate that actually differs is a pattern
+    // modification.
+    return candidate.equals(plannedPattern.getStopPattern())
+      ? Optional.empty()
+      : Optional.of(candidate);
+  }
+
+  private Map<Integer, StopLocation> resolveReplacedStops(
+    Function<String, StopLocation> stopResolver
+  ) {
+    Map<Integer, StopLocation> newStops = new HashMap<>();
+    replacedStopIds.forEach((stopPosition, stopId) -> {
+      var stop = stopResolver.apply(stopId);
+      if (stop != null) {
+        newStops.put(stopPosition, stop);
+      }
+    });
+    return newStops;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/model/TripTimesPatch.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/model/TripTimesPatch.java
@@ -1,46 +1,50 @@
 package org.opentripplanner.updater.trip.gtfs.model;
 
-import java.util.Map;
-import org.opentripplanner.model.PickDrop;
+import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
-import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.opentripplanner.transit.model.timetable.RealTimeTripTimesBuilder;
+import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
+import org.opentripplanner.updater.spi.UpdateException;
 
 /**
- * Contains a {@link TripTimes} and array of stop indices of a stop pattern that are skipped with a
- * realtime update.
+ * The real-time changes computed from a GTFS-RT trip update, ready to be materialized into
+ * {@link RealTimeTripTimes}. Besides the not-yet-built trip times it carries the
+ * {@link StopPatternChanges}, which the caller uses to decide whether the trip must be moved onto a
+ * modified trip pattern.
  */
 public final class TripTimesPatch {
 
-  private final RealTimeTripTimes tripTimes;
-  private final Map<Integer, PickDrop> updatedPickup;
-  private final Map<Integer, PickDrop> updatedDropoff;
-  private final Map<Integer, String> replacedStopIndices;
+  private final RealTimeTripTimesBuilder builder;
+  private final StopPatternChanges stopPatternChanges;
 
-  public TripTimesPatch(
-    RealTimeTripTimes tripTimes,
-    Map<Integer, PickDrop> updatedPickup,
-    Map<Integer, PickDrop> updatedDropoff,
-    Map<Integer, String> replacedStopIndices
-  ) {
-    this.tripTimes = tripTimes;
-    this.updatedPickup = updatedPickup;
-    this.updatedDropoff = updatedDropoff;
-    this.replacedStopIndices = replacedStopIndices;
+  public TripTimesPatch(RealTimeTripTimesBuilder builder, StopPatternChanges stopPatternChanges) {
+    this.builder = builder;
+    this.stopPatternChanges = stopPatternChanges;
   }
 
-  public RealTimeTripTimes tripTimes() {
-    return tripTimes;
+  public StopPatternChanges stopPatternChanges() {
+    return stopPatternChanges;
   }
 
-  public Map<Integer, PickDrop> updatedPickup() {
-    return updatedPickup;
+  /**
+   * Flag the resulting trip times as running on a modified trip pattern, so the API reports the
+   * trip as {@code MODIFIED}. The caller marks the patch once it has determined, from
+   * {@link #stopPatternChanges()}, that the update moves the trip onto a real-time pattern that
+   * differs from the planned one.
+   */
+  public TripTimesPatch withModifiedTripPattern() {
+    builder.withModifiedTripPattern();
+    return this;
   }
 
-  public Map<Integer, PickDrop> updatedDropoff() {
-    return updatedDropoff;
-  }
-
-  public Map<Integer, String> replacedStopIndices() {
-    return replacedStopIndices;
+  /**
+   * Materialize the updated trip times.
+   */
+  public RealTimeTripTimes tripTimes() throws UpdateException {
+    try {
+      return builder.build();
+    } catch (DataValidationException e) {
+      throw DataValidationExceptionMapper.map(e);
+    }
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdaterTest.java
@@ -129,7 +129,7 @@ public class TripTimesUpdaterTest {
         new TripUpdate(feedId, tripUpdate, NOW),
         ForwardsDelayPropagationType.DEFAULT,
         BackwardsDelayPropagationType.REQUIRED_NO_DATA
-      )
+      ).tripTimes()
     );
   }
 
@@ -316,7 +316,7 @@ public class TripTimesUpdaterTest {
         new TripUpdate(feedId, tripUpdate, NOW),
         ForwardsDelayPropagationType.DEFAULT,
         BackwardsDelayPropagationType.REQUIRED_NO_DATA
-      )
+      ).tripTimes()
     );
   }
 
@@ -338,7 +338,7 @@ public class TripTimesUpdaterTest {
         new TripUpdate(feedId, tripUpdate, NOW),
         ForwardsDelayPropagationType.NONE,
         BackwardsDelayPropagationType.REQUIRED_NO_DATA
-      )
+      ).tripTimes()
     );
   }
 
@@ -389,10 +389,15 @@ public class TripTimesUpdaterTest {
     assertTrue(updatedTripTimes.isCanceledStop(1));
     assertFalse(updatedTripTimes.isCanceledStop(2));
     assertTrue(updatedTripTimes.isNoDataStop(2));
-    var updatedPickup = p.updatedPickup();
-    var updatedDropoff = p.updatedDropoff();
-    assertIterableEquals(Map.of(1, PickDrop.CANCELLED).entrySet(), updatedPickup.entrySet());
-    assertIterableEquals(Map.of(1, PickDrop.CANCELLED).entrySet(), updatedDropoff.entrySet());
+    var changes = p.stopPatternChanges();
+    assertIterableEquals(
+      Map.of(1, PickDrop.CANCELLED).entrySet(),
+      changes.updatedPickups().entrySet()
+    );
+    assertIterableEquals(
+      Map.of(1, PickDrop.CANCELLED).entrySet(),
+      changes.updatedDropoffs().entrySet()
+    );
   }
 
   @Test
@@ -432,9 +437,10 @@ public class TripTimesUpdaterTest {
       BackwardsDelayPropagationType.REQUIRED_NO_DATA
     );
 
-    assertTrue(p.updatedDropoff().isEmpty(), "dropoffs are not modified");
-    assertTrue(p.updatedPickup().isEmpty(), "pickups are not modified");
-    assertTrue(p.replacedStopIndices().isEmpty(), "stop indices are not modified");
+    var changes = p.stopPatternChanges();
+    assertTrue(changes.updatedDropoffs().isEmpty(), "dropoffs are not modified");
+    assertTrue(changes.updatedPickups().isEmpty(), "pickups are not modified");
+    assertTrue(changes.replacedStopIds().isEmpty(), "stop indices are not modified");
     assertEquals("foo", p.tripTimes().getHeadsign(0).toString(), "headsigns [1] are not modified");
     assertEquals("foo", p.tripTimes().getHeadsign(1).toString(), "headsigns [2] are not modified");
     assertEquals("foo", p.tripTimes().getHeadsign(2).toString(), "headsigns [3] are not modified");
@@ -485,10 +491,12 @@ public class TripTimesUpdaterTest {
     assertEquals(I18NString.of("new stop headsign"), updatedTripTimes.getHeadsign(0));
     assertEquals(I18NString.of("new trip headsign"), updatedTripTimes.getHeadsign(1));
     assertEquals(I18NString.of("new trip headsign"), updatedTripTimes.getHeadsign(2));
-    var updatedPickup = p.updatedPickup();
-    var updatedDropoff = p.updatedDropoff();
-    assertEquals(Map.of(1, PickDrop.CANCELLED, 2, PickDrop.NONE), updatedPickup);
-    assertEquals(Map.of(1, PickDrop.CANCELLED, 2, PickDrop.COORDINATE_WITH_DRIVER), updatedDropoff);
+    var changes = p.stopPatternChanges();
+    assertEquals(Map.of(1, PickDrop.CANCELLED, 2, PickDrop.NONE), changes.updatedPickups());
+    assertEquals(
+      Map.of(1, PickDrop.CANCELLED, 2, PickDrop.COORDINATE_WITH_DRIVER),
+      changes.updatedDropoffs()
+    );
   }
 
   @Test
@@ -594,7 +602,7 @@ public class TripTimesUpdaterTest {
         new TripUpdate(feedId, tripUpdate, NOW),
         ForwardsDelayPropagationType.DEFAULT,
         BackwardsDelayPropagationType.NONE
-      )
+      ).tripTimes()
     );
   }
 
@@ -845,7 +853,7 @@ public class TripTimesUpdaterTest {
         new TripUpdate(feedId, tripUpdate, NOW),
         ForwardsDelayPropagationType.DEFAULT,
         BackwardsDelayPropagationType.REQUIRED_NO_DATA
-      )
+      ).tripTimes()
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/model/StopPatternChangesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/model/StopPatternChangesTest.java
@@ -1,0 +1,57 @@
+package org.opentripplanner.updater.trip.gtfs.model;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.PickDrop;
+import org.opentripplanner.transit.model._data.PatternTestModel;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.StopLocation;
+
+class StopPatternChangesTest {
+
+  /**
+   * A two-stop pattern whose stops all have {@code SCHEDULED} pickup and drop-off.
+   */
+  private final TripPattern plannedPattern = PatternTestModel.pattern();
+
+  /**
+   * A resolver that resolves no stop id, used when the update carries no resolvable stop
+   * replacement.
+   */
+  private static final Function<String, StopLocation> RESOLVES_NOTHING = id -> null;
+
+  @Test
+  void noOverridesLeavePlannedPatternUnchanged() {
+    var changes = new StopPatternChanges(Map.of(), Map.of(), Map.of());
+
+    assertThat(changes.deriveStopPattern(plannedPattern, RESOLVES_NOTHING)).isEmpty();
+  }
+
+  @Test
+  void overrideThatReproducesThePlannedPatternIsNotAModification() {
+    // A pickup override that repeats the scheduled value builds a stop pattern identical to the
+    // planned one, so the trip must not be reported as running on a modified pattern.
+    var changes = new StopPatternChanges(Map.of(0, PickDrop.SCHEDULED), Map.of(), Map.of());
+
+    assertThat(changes.deriveStopPattern(plannedPattern, RESOLVES_NOTHING)).isEmpty();
+  }
+
+  @Test
+  void overrideThatChangesAPickupIsAModification() {
+    var changes = new StopPatternChanges(Map.of(0, PickDrop.NONE), Map.of(), Map.of());
+
+    assertThat(changes.deriveStopPattern(plannedPattern, RESOLVES_NOTHING)).isPresent();
+  }
+
+  @Test
+  void unresolvableStopReplacementAloneIsNotAModification() {
+    // An assigned_stop_id that cannot be resolved is dropped, so an update carrying only such a
+    // replacement leaves the trip on its planned pattern.
+    var changes = new StopPatternChanges(Map.of(), Map.of(), Map.of(0, "unknown-stop"));
+
+    assertThat(changes.deriveStopPattern(plannedPattern, RESOLVES_NOTHING)).isEmpty();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancelAfterPatternChangeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancelAfterPatternChangeTest.java
@@ -61,7 +61,7 @@ class CancelAfterPatternChangeTest implements RealtimeTestConstants {
     );
 
     assertEquals(
-      "U | A 0:01 0:01:01 | B [C] 0:01:52 0:01:58 | C 0:02:50 0:02:51",
+      "P U | A 0:01 0:01:01 | B [C] 0:01:52 0:01:58 | C 0:02:50 0:02:51",
       env.tripData(TRIP_1_ID).showTimetable()
     );
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/AssignedStopIdsTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/AssignedStopIdsTest.java
@@ -67,11 +67,11 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
 
     assertSuccess(rt.applyTripUpdate(tripUpdate1));
     assertEquals(
-      "U | D 9:50 9:50 | B 10:01 10:01 | C 10:02 10:02",
+      "P U | D 9:50 9:50 | B 10:01 10:01 | C 10:02 10:02",
       env.tripData(TRIP_1_ID).showTimetable()
     );
     assertTrue(env.tripData(TRIP_1_ID).tripPattern().isStopPatternModifiedInRealTime());
-    assertEquals(List.of("F:Route1::001:RT[U]"), env.raptorData().summarizePatterns());
+    assertEquals(List.of("F:Route1::001:RT[P U]"), env.raptorData().summarizePatterns());
 
     var tripUpdate2 = rt
       .tripUpdateScheduled(TRIP_1_ID)
@@ -82,11 +82,11 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
 
     assertSuccess(rt.applyTripUpdate(tripUpdate2));
     assertEquals(
-      "U | E 9:55 9:55 | B 10:01 10:01 | C 10:02 10:02",
+      "P U | E 9:55 9:55 | B 10:01 10:01 | C 10:02 10:02",
       env.tripData(TRIP_1_ID).showTimetable()
     );
     assertTrue(env.tripData(TRIP_1_ID).tripPattern().isStopPatternModifiedInRealTime());
-    assertEquals(List.of("F:Route1::002:RT[U]"), env.raptorData().summarizePatterns());
+    assertEquals(List.of("F:Route1::002:RT[P U]"), env.raptorData().summarizePatterns());
 
     var tripUpdate3 = rt
       .tripUpdateScheduled(TRIP_1_ID)
@@ -126,7 +126,7 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
 
     assertSuccess(rt.applyTripUpdate(tripUpdate1));
     assertEquals(
-      "U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
+      "P U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
       env.tripData(TRIP_1_ID).showTimetable()
     );
     assertEquals(
@@ -136,22 +136,22 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
     assertTrue(env.tripData(TRIP_1_ID).tripPattern().isStopPatternModifiedInRealTime());
     assertFalse(env.tripData(TRIP_2_ID).tripPattern().isStopPatternModifiedInRealTime());
     assertEquals(
-      List.of("F:Pattern1[S]", "F:Route1::001:RT[U]"),
+      List.of("F:Pattern1[S]", "F:Route1::001:RT[P U]"),
       env.raptorData().summarizePatterns()
     );
 
     assertSuccess(rt.applyTripUpdates(List.of(tripUpdate1, tripUpdate2)));
     assertEquals(
-      "U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
+      "P U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
       env.tripData(TRIP_1_ID).showTimetable()
     );
     assertEquals(
-      "U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
+      "P U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
       env.tripData(TRIP_2_ID).showTimetable()
     );
     assertTrue(env.tripData(TRIP_1_ID).tripPattern().isStopPatternModifiedInRealTime());
     assertTrue(env.tripData(TRIP_2_ID).tripPattern().isStopPatternModifiedInRealTime());
-    assertEquals(List.of("F:Route1::001:RT[U,U]"), env.raptorData().summarizePatterns());
+    assertEquals(List.of("F:Route1::001:RT[P U,P U]"), env.raptorData().summarizePatterns());
 
     assertSuccess(rt.applyTripUpdate(tripUpdate2));
     assertEquals(
@@ -159,13 +159,13 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
       env.tripData(TRIP_1_ID).showTimetable()
     );
     assertEquals(
-      "U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
+      "P U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
       env.tripData(TRIP_2_ID).showTimetable()
     );
     assertFalse(env.tripData(TRIP_1_ID).tripPattern().isStopPatternModifiedInRealTime());
     assertTrue(env.tripData(TRIP_2_ID).tripPattern().isStopPatternModifiedInRealTime());
     assertEquals(
-      List.of("F:Pattern1[S]", "F:Route1::001:RT[U]"),
+      List.of("F:Pattern1[S]", "F:Route1::001:RT[P U]"),
       env.raptorData().summarizePatterns()
     );
 
@@ -222,11 +222,11 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
 
     assertSuccess(rt.applyTripUpdates(List.of(tripUpdate11, tripUpdate12)));
     assertEquals(
-      "U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
+      "P U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
       env.tripData(TRIP_1_ID, SERVICE_DATE).showTimetable()
     );
     assertEquals(
-      "U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
+      "P U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
       env.tripData(TRIP_2_ID, SERVICE_DATE).showTimetable()
     );
     assertEquals(
@@ -250,7 +250,7 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
       env.tripData(TRIP_2_ID, SERVICE_DATE_PLUS).tripPattern().isStopPatternModifiedInRealTime()
     );
     assertEquals(
-      List.of("F:Route1::001:RT[U,U]"),
+      List.of("F:Route1::001:RT[P U,P U]"),
       env.raptorData(SERVICE_DATE).summarizePatterns()
     );
     assertEquals(List.of("F:Pattern1[S,S]"), env.raptorData(SERVICE_DATE_PLUS).summarizePatterns());
@@ -259,19 +259,19 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
       rt.applyTripUpdates(List.of(tripUpdate11, tripUpdate12, tripUpdate21, tripUpdate22))
     );
     assertEquals(
-      "U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
+      "P U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
       env.tripData(TRIP_1_ID, SERVICE_DATE).showTimetable()
     );
     assertEquals(
-      "U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
+      "P U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
       env.tripData(TRIP_2_ID, SERVICE_DATE).showTimetable()
     );
     assertEquals(
-      "U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
+      "P U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
       env.tripData(TRIP_1_ID, SERVICE_DATE_PLUS).showTimetable()
     );
     assertEquals(
-      "U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
+      "P U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
       env.tripData(TRIP_2_ID, SERVICE_DATE_PLUS).showTimetable()
     );
     assertTrue(
@@ -287,11 +287,11 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
       env.tripData(TRIP_2_ID, SERVICE_DATE_PLUS).tripPattern().isStopPatternModifiedInRealTime()
     );
     assertEquals(
-      List.of("F:Route1::001:RT[U,U]"),
+      List.of("F:Route1::001:RT[P U,P U]"),
       env.raptorData(SERVICE_DATE).summarizePatterns()
     );
     assertEquals(
-      List.of("F:Route1::001:RT[U,U]"),
+      List.of("F:Route1::001:RT[P U,P U]"),
       env.raptorData(SERVICE_DATE_PLUS).summarizePatterns()
     );
 
@@ -305,11 +305,11 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
       env.tripData(TRIP_2_ID, SERVICE_DATE).showTimetable()
     );
     assertEquals(
-      "U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
+      "P U | E 10:01 10:01 | B 10:02 10:02 | C 10:03 10:03",
       env.tripData(TRIP_1_ID, SERVICE_DATE_PLUS).showTimetable()
     );
     assertEquals(
-      "U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
+      "P U | E 11:01 11:01 | B 11:02 11:02 | C 11:03 11:03",
       env.tripData(TRIP_2_ID, SERVICE_DATE_PLUS).showTimetable()
     );
     assertFalse(
@@ -326,7 +326,7 @@ class AssignedStopIdsTest implements RealtimeTestConstants {
     );
     assertEquals(List.of("F:Pattern1[S,S]"), env.raptorData(SERVICE_DATE).summarizePatterns());
     assertEquals(
-      List.of("F:Route1::001:RT[U,U]"),
+      List.of("F:Route1::001:RT[P U,P U]"),
       env.raptorData(SERVICE_DATE_PLUS).summarizePatterns()
     );
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedTest.java
@@ -54,7 +54,7 @@ class SkippedTest implements RealtimeTestConstants {
     assertNewTripTimesIsUpdated(env, TRIP_2_ID);
 
     assertEquals(
-      "U | A 0:01 0:01:01 | B [C] 0:01:52 0:01:58 | C 0:02:50 0:02:51",
+      "P U | A 0:01 0:01:01 | B [C] 0:01:52 0:01:58 | C 0:02:50 0:02:51",
       env.tripData(TRIP_2_ID).showTimetable()
     );
   }
@@ -83,7 +83,7 @@ class SkippedTest implements RealtimeTestConstants {
 
     assertSuccess(rt.applyTripUpdate(tripUpdate, DIFFERENTIAL));
 
-    assertThat(env.raptorData().summarizePatterns()).containsExactly("F:Route1::001:RT[U]");
+    assertThat(env.raptorData().summarizePatterns()).containsExactly("F:Route1::001:RT[P U]");
 
     // Create update to the same trip but now the skipped stop is no longer skipped
     var scheduledBuilder = rt
@@ -141,7 +141,7 @@ class SkippedTest implements RealtimeTestConstants {
     assertNewTripTimesIsUpdated(env, tripId);
 
     assertEquals(
-      "U | A [ND] 0:01 0:01:01 | B [C] 0:01:10 0:01:11 | C [ND] 0:01:20 0:01:21",
+      "P U | A [ND] 0:01 0:01:01 | B [C] 0:01:10 0:01:11 | C [ND] 0:01:20 0:01:21",
       env.tripData(tripId).showTimetable()
     );
   }

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/SkippedWithRepeatedTimesTest.java
@@ -43,7 +43,7 @@ class SkippedWithRepeatedTimesTest implements RealtimeTestConstants {
     assertSuccess(rt.applyTripUpdate(tripUpdate));
 
     assertEquals(
-      "U | A 10:00 10:00 | B [C] 10:00 10:00 | C 10:01 10:01",
+      "P U | A 10:00 10:00 | B [C] 10:00 10:00 | C 10:01 10:01",
       env.tripData(TRIP_1_ID).showTimetable()
     );
   }

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/propagation/BackwardsEarlinessPropagationCancellationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/propagation/BackwardsEarlinessPropagationCancellationTest.java
@@ -42,7 +42,7 @@ class BackwardsEarlinessPropagationCancellationTest implements RealtimeTestConst
 
     assertSuccess(rt.applyTripUpdate(tripUpdate));
     assertEquals(
-      "U | A [ND] 10:00 10:00 | B [ND] 10:10 10:10 | C [C] 10:19 10:19 | D 10:19 10:19",
+      "P U | A [ND] 10:00 10:00 | B [ND] 10:10 10:10 | C [C] 10:19 10:19 | D 10:19 10:19",
       env.tripData(TRIP_1_ID).showTimetable()
     );
   }


### PR DESCRIPTION
## Summary

Closes #7777

When a real-time update changes a trip's stop pattern (a skipped stop, a stop/quay replacement, or a pickup/drop-off change), the `RealTimeState` exposed in the APIs depended on which feed format delivered the update: SIRI-ET reported `MODIFIED` while GTFS-RT reported `UPDATED` for the same real-world event.

This PR aligns the GTFS-RT path with the SIRI behavior: the trip-pattern-modified flag is now set whenever the update produces a stop pattern that differs from the planned one (a pickup/drop-off change, a skipped stop recorded as cancelled pick/drop, or a resolvable stop replacement). This is exactly the condition under which `ScheduledTripHandler` moves the trip onto a new real-time pattern, so a trip is reported as `MODIFIED` precisely when it runs on a pattern that differs from the planned one.

Delay-only updates and updates that revert a trip back onto its planned pattern still report `UPDATED`.

## Behavior change

| Update over GTFS-RT | Before | After |
|---|---|---|
| Skipped stop | `UPDATED` | `MODIFIED` |
| Stop replacement (`assigned_stop_id`) | `UPDATED` | `MODIFIED` |
| Pickup/drop-off change | `UPDATED` | `MODIFIED` |
| Delay/times-only update | `UPDATED` | `UPDATED` (unchanged) |

SIRI-ET behavior is unchanged.

## Implementation

The pickup, drop-off and stop-replacement changes a GTFS-RT update produces are bundled into a `StopPatternChanges` value object. Its `deriveStopPattern` owns the single decision of whether the update moves the trip onto a stop pattern that differs from the planned one, returning the modified pattern or empty — it compares the rebuilt pattern for equality, so a non-empty set of overrides that reproduces the planned stops is not treated as a change (mirroring the SIRI updater).

`ScheduledTripHandler` drives both the pattern rebuild and the `MODIFIED` flag off that single decision, so the reported state can no longer diverge from the pattern the trip actually runs on. `TripTimesPatch` exposes one materialization method; the handler marks the patch modified when needed and builds the trip times once, before the real-time pattern cache is touched, so an update that fails time validation leaves no orphan pattern behind.

## Tests

- Updated the expectations in the existing GTFS module tests that exercise pattern-changing updates (`SkippedTest`, `SkippedWithRepeatedTimesTest`, `AssignedStopIdsTest`, `CancelAfterPatternChangeTest`, `BackwardsEarlinessPropagationCancellationTest`): the affected trips/patterns now carry the `P` (pattern modified) state flag. Assertions covering trips reverted to their planned pattern, delay-only updates, and post-cancellation state are unchanged, as are all SIRI tests.
- Added `StopPatternChangesTest` covering `deriveStopPattern`: no overrides, an override that reproduces the planned pattern, an override that genuinely changes it, and an unresolvable stop replacement.

## Changelog
No behavior change in the routing engine but visible change in the API --> do not skip changelog.


## Note

Pre-existing behavior, unchanged by this PR: an `assigned_stop_id` that cannot be resolved to a known stop is silently dropped. Stop resolution runs in `StopPatternChanges.deriveStopPattern` *before* the `MODIFIED`/`UPDATED` decision is made, so the two stay consistent:

- an update whose only effect is an unresolvable stop replacement produces no pattern change and is reported as `UPDATED`, with the trip staying on its planned pattern;
- when an unresolvable replacement accompanies other genuine pattern changes, those changes still yield a modified pattern (and `MODIFIED` state) — only the unknown stop replacement is dropped.
