### PR TITLE
fix: allow optional legGroupId in FareLegRule

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/model/FareLegRule.java
@@ -50,7 +50,7 @@ public final class FareLegRule implements Serializable {
       throw new IllegalArgumentException("fareProducts must contain at least one value");
     }
     builder.fareProducts.forEach(Objects::requireNonNull);
-    this.legGroupId = Objects.requireNonNull(builder.legGroupId);
+    this.legGroupId = builder.legGroupId;
     this.id = Objects.requireNonNull(builder.id);
     this.fareProducts = builder.fareProducts;
     this.networkId = builder.networkId;


### PR DESCRIPTION
### Summary
`leg_group_id` is optional in `fare_leg_rules.txt`: https://gtfs.org/documentation/schedule/reference/#fare_leg_rulestxt

The current implementation incorrectly requires it to be non-null. This change allows `leg_group_id` to be omitted.