### PR TITLE
fix(transmodel): skip flex-window stops in intermediate estimated calls

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTripIntegrationTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.flex.trip;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.test.support.PolylineAssert.assertThatPolylinesAreEqual;
 
 import java.time.LocalDateTime;
@@ -14,12 +15,14 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner._support.time.ZoneIds;
 import org.opentripplanner.api.model.geometry.EncodedPolyline;
+import org.opentripplanner.apis.transmodel.model.TripTimeOnDateHelper;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.service.gtfs.v1.DefaultFareService;
 import org.opentripplanner.ext.flex.FlexIntegrationTestData;
 import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter;
@@ -128,6 +131,52 @@ class ScheduledDeviatedTripIntegrationTest {
     assertThatPolylinesAreEqual(
       legGeometry.points(),
       "kfsmEjojcOa@eBRKfBfHR|ALjBBhVArMG|OCrEGx@OhAKj@a@tAe@hA]l@MPgAnAgw@nr@cDxCm@t@c@t@c@x@_@~@]pAyAdIoAhG}@lE{AzHWhAtt@t~Aj@tAb@~AXdBHn@FlBC`CKnA_@nC{CjOa@dCOlAEz@E|BRtUCbCQ~CWjD??qBvXBl@kBvWOzAc@dDOx@sHv]aIG?q@@c@ZaB\\mA"
+    );
+  }
+
+  /**
+   * A flex service journey with fixed endpoints is routed as a regular scheduled leg, and its
+   * flexible-area stop shows up as an intermediate stop. That stop has no scheduled
+   * arrival/departure time (only a time window), so it must be excluded from the Transmodel
+   * {@code intermediateEstimatedCalls}. Otherwise the {@link StopTime#MISSING_VALUE} placeholder
+   * would be rendered as a bogus time (the day before the trip). See issue #7034.
+   */
+  @Test
+  void intermediateEstimatedCallsSkipFlexWindowStops() {
+    var feedId = timetableRepository.getFeedIds().iterator().next();
+
+    var serverContext = TestServerContext.createServerContext(
+      graph,
+      timetableRepository,
+      transferRepository,
+      new DefaultFareService()
+    );
+
+    var from = GenericLocation.fromStopId(
+      new FeedScopedId(feedId, "cujv"),
+      "Transfer Point for Route 30"
+    );
+    var to = GenericLocation.fromStopId(
+      new FeedScopedId(feedId, "yz85"),
+      "Zone 1 - PUBLIX Super Market,Zone 1 Collection Point"
+    );
+
+    var leg = getItineraries(from, to, serverContext).get(0).legs().get(0);
+
+    // The flexible-area stop is exposed as an intermediate stop on the leg ...
+    var intermediateStopIds = leg
+      .listIntermediateStops()
+      .stream()
+      .map(s -> s.place.stop.getId().getId())
+      .collect(Collectors.toList());
+    assertTrue(intermediateStopIds.contains("zone_1"));
+
+    // ... but it must not appear among the intermediate estimated calls, and every returned call
+    // must carry a real scheduled time.
+    var intermediateCalls = TripTimeOnDateHelper.getIntermediateTripTimeOnDatesForLeg(leg);
+    assertTrue(intermediateCalls.stream().allMatch(TripTimeOnDate::hasScheduledTimes));
+    assertFalse(
+      intermediateCalls.stream().anyMatch(c -> c.getStop().getId().getId().equals("zone_1"))
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/TripTimeOnDateHelper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/TripTimeOnDateHelper.java
@@ -94,6 +94,12 @@ public class TripTimeOnDateHelper {
 
   /**
    * Find trip time shorts for all intermediate stops for a leg.
+   * <p>
+   * Intermediate stops without scheduled times are skipped. This is the case for the flexible
+   * area stops of a flex service journey with fixed endpoints: the trip is routed as a regular
+   * scheduled leg, but the flexible-area stop in between carries no scheduled arrival/departure
+   * time (only a time window), so it cannot be rendered as an {@code EstimatedCall} and is not a
+   * boardable stop. See issue #7034.
    */
   public static List<TripTimeOnDate> getIntermediateTripTimeOnDatesForLeg(Leg leg) {
     if (!leg.isScheduledTransitLeg()) {
@@ -108,6 +114,7 @@ public class TripTimeOnDateHelper {
       .mapToObj(i ->
         new TripTimeOnDate(tripTimes, i, tripPattern, serviceDate, serviceDateMidnight)
       )
+      .filter(TripTimeOnDate::hasScheduledTimes)
       .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
## Summary

Fixes the inconsistent `aimedDepartureTime` reported for the intermediate call of a flex trip in issue #7034, where the intermediate estimated call returned a timestamp on the day _before_ the trip (e.g. `2025-10-22T23:43:21+02:00` for a trip departing `2025-10-23T09:00`).

## Root cause

A flex service journey with fixed endpoints (a `ScheduledDeviatedTrip`: fixed stop → flexible area → fixed stop) is **also** added to the regular scheduled timetable as an ordinary `TripPattern`. Regular Raptor routes it as a `ScheduledTransitLeg`, and the flexible-area stop in between becomes a non-boardable intermediate stop (`PickDrop.NONE`) whose scheduled arrival/departure are `StopTime.MISSING_VALUE (-999)` — flex-window stops are intentionally not interpolated during graph build.

The Transmodel `EstimatedCall` time fields are non-null and convert `-999` seconds relative to service-day midnight into a wall-clock instant (`midnight − 999s = 23:43:21` the previous day), so `intermediateEstimatedCalls` emitted a bogus timestamp for that stop.

## Change

`TripTimeOnDateHelper.getIntermediateTripTimeOnDatesForLeg` now filters out intermediate stops without scheduled times (`TripTimeOnDate::hasScheduledTimes`). The flexible-area stop is non-boardable and has no point-in-time, so it is no longer emitted as an `EstimatedCall`. This matches the reasoning in the issue thread ("should there even be an intermediate stop here?").

## Scope / limitation

This targets the trip-planner `intermediateEstimatedCalls` path from the issue. `serviceJourneyEstimatedCalls` / `StopPlace.estimatedCalls` / `DatedServiceJourney.estimatedCalls` iterate _all_ stops and are intentionally left unchanged here to preserve their "all calls" semantics. The GTFS GraphQL API already models flex-window stops correctly as a time window (`StopCall.schedule`).
A complete fix would require a breaking change in the Transmodel API.

## Testing

- New regression test `ScheduledDeviatedTripIntegrationTest#intermediateEstimatedCallsSkipFlexWindowStops` routes the real fixed→fixed flex scenario and asserts the flexible-area stop (`zone_1`) is excluded from the intermediate estimated calls and that every returned call has scheduled times. Verified it fails without the fix.
- No GraphQL schema change (verified via `TransmodelGraphQLSchemaTest`).

closes #7034
