### PR TITLE
Only compute OSM edge name fallback when required

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/BarrierEdgeBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/BarrierEdgeBuilder.java
@@ -42,7 +42,9 @@ public class BarrierEdgeBuilder {
         );
         wheelchairAccessible = wheelchairAccessible && barrier.isWheelchairAccessible();
         if (!barrier.hasNoName()) {
-          name = edgeNamer.getName(barrier, ("barrier " + barrier.getId()).intern());
+          name = edgeNamer
+            .getName(barrier)
+            .orElseGet(() -> I18NString.of(("barrier " + barrier.getId()).intern()));
         }
       }
     }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -594,7 +594,14 @@ public class OsmModule implements GraphBuilderModule {
     var geometry = geometryFactory.createLineString(nodes);
 
     return Optional.of(
-      new Platform(params.edgeNamer().getName(way, "platform " + way.getId()), geometry, references)
+      new Platform(
+        params
+          .edgeNamer()
+          .getName(way)
+          .orElseGet(() -> I18NString.of("platform " + way.getId())),
+        geometry,
+        references
+      )
     );
   }
 
@@ -706,9 +713,15 @@ public class OsmModule implements GraphBuilderModule {
       );
     }
 
-    String label = "way " + way.getId() + " from " + index;
-    label = label.intern();
-    I18NString name = params.edgeNamer().getName(way, label);
+    I18NString name = params
+      .edgeNamer()
+      .getName(way)
+      .orElseGet(() -> {
+        String label = "way " + way.getId() + " from " + index;
+        label = label.intern();
+        return I18NString.of(label);
+      });
+
     float carSpeed = way
       .getOsmProvider()
       .getOsmTagMapper()

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -651,24 +651,21 @@ class WalkableAreaBuilder {
       // No intersections - not really possible
       return Set.of();
     }
-    final String forwardLabel = String.format(
-      LABEL_TEMPLATE,
-      parent.getId(),
-      vertex1.getLabel(),
-      vertex2.getLabel()
-    );
+    final long parentId = parent.getId();
 
     float carSpeed = parent
       .getOsmProvider()
       .getOsmTagMapper()
       .getCarSpeedForWay(parent, TraverseDirection.DIRECTIONLESS, issueStore);
 
-    I18NString name = namer.getName(parent).orElseGet(() -> I18NString.of(forwardLabel));
+    var forwardName = namer
+      .getName(parent)
+      .orElseGet(() -> fallbackName(vertex2, vertex1, parentId));
     AreaEdgeBuilder streetEdgeBuilder = new AreaEdgeBuilder()
       .withFromVertex(vertex1)
       .withToVertex(vertex2)
       .withGeometry(line)
-      .withName(name)
+      .withName(forwardName)
       .withMeterLength(length)
       .withPermission(areaPermissions)
       .withBack(false)
@@ -678,18 +675,14 @@ class WalkableAreaBuilder {
       .withWheelchairAccessible(wheelchairAccessible)
       .withLink(parent.isLink());
 
-    final String backwardLabel = String.format(
-      LABEL_TEMPLATE,
-      parent.getId(),
-      vertex2.getLabel(),
-      vertex1.getLabel()
-    );
-    name = namer.getName(parent).orElseGet(() -> I18NString.of(backwardLabel));
+    var backwardName = namer
+      .getName(parent)
+      .orElseGet(() -> fallbackName(vertex1, vertex2, parentId));
     AreaEdgeBuilder backStreetEdgeBuilder = new AreaEdgeBuilder()
       .withFromVertex(vertex2)
       .withToVertex(vertex1)
       .withGeometry(line.reverse())
-      .withName(name)
+      .withName(backwardName)
       .withMeterLength(length)
       .withPermission(areaPermissions)
       .withBack(true)
@@ -782,6 +775,16 @@ class WalkableAreaBuilder {
     }
     alreadyAddedEdges.add(edge);
     return false;
+  }
+
+  private static I18NString fallbackName(
+    IntersectionVertex vertex1,
+    IntersectionVertex vertex2,
+    long parentId
+  ) {
+    return I18NString.of(
+      String.format(LABEL_TEMPLATE, parentId, vertex2.getLabel(), vertex1.getLabel())
+    );
   }
 
   // ---- Inner types -------------------------------------------------------------------

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -651,7 +651,7 @@ class WalkableAreaBuilder {
       // No intersections - not really possible
       return Set.of();
     }
-    String label = String.format(
+    final String forwardLabel = String.format(
       LABEL_TEMPLATE,
       parent.getId(),
       vertex1.getLabel(),
@@ -663,7 +663,7 @@ class WalkableAreaBuilder {
       .getOsmTagMapper()
       .getCarSpeedForWay(parent, TraverseDirection.DIRECTIONLESS, issueStore);
 
-    I18NString name = namer.getName(parent, label);
+    I18NString name = namer.getName(parent).orElseGet(() -> I18NString.of(forwardLabel));
     AreaEdgeBuilder streetEdgeBuilder = new AreaEdgeBuilder()
       .withFromVertex(vertex1)
       .withToVertex(vertex2)
@@ -678,8 +678,13 @@ class WalkableAreaBuilder {
       .withWheelchairAccessible(wheelchairAccessible)
       .withLink(parent.isLink());
 
-    label = String.format(LABEL_TEMPLATE, parent.getId(), vertex2.getLabel(), vertex1.getLabel());
-    name = namer.getName(parent, label);
+    final String backwardLabel = String.format(
+      LABEL_TEMPLATE,
+      parent.getId(),
+      vertex2.getLabel(),
+      vertex1.getLabel()
+    );
+    name = namer.getName(parent).orElseGet(() -> I18NString.of(backwardLabel));
     AreaEdgeBuilder backStreetEdgeBuilder = new AreaEdgeBuilder()
       .withFromVertex(vertex2)
       .withToVertex(vertex1)
@@ -712,8 +717,9 @@ class WalkableAreaBuilder {
       Area namedArea = new Area();
       OsmEntity areaEntity = area.parent;
 
-      String id = "way (area) " + areaEntity.getId();
-      I18NString name = namer.getName(areaEntity, id);
+      I18NString name = namer
+        .getName(areaEntity)
+        .orElseGet(() -> I18NString.of("way (area) " + areaEntity.getId()));
       namedArea.setName(name);
 
       WayProperties wayData = findAreaProperties(areaEntity);

--- a/application/src/main/java/org/opentripplanner/graph_builder/services/osm/EdgeNamer.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/services/osm/EdgeNamer.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.graph_builder.services.osm;
 
+import java.util.Optional;
 import org.opentripplanner.core.model.i18n.I18NString;
-import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.graph_builder.module.osm.OsmDatabase;
 import org.opentripplanner.graph_builder.module.osm.StreetEdgePair;
 import org.opentripplanner.osm.model.OsmEntity;
@@ -33,15 +33,9 @@ public interface EdgeNamer {
    * Get the edge name.
    *
    * @param entity relation or way from which to get the name
-   * @param id when a name can not be created from an OSM entity, this is used
    */
-  default I18NString getName(OsmEntity entity, String id) {
-    var name = name(entity);
-
-    if (name == null) {
-      name = new NonLocalizedString(id);
-    }
-    return name;
+  default Optional<I18NString> getName(OsmEntity entity) {
+    return Optional.ofNullable(name(entity));
   }
 
   enum EdgeNamerType {


### PR DESCRIPTION
## Summary

The fallback name computation (e.g. `way 12345 from 3`, `barrier 12345`, `platform 12345`) for OSM edges was previously computed eagerly for every edge, even though it is only used for the small number of edges that don't already have a name from the OSM data. Building these fallback strings (`String.format`/concatenation plus `intern()`) accounted for roughly 5-8% of total edge building wall-clock time.

This PR changes `EdgeNamer#getName` to return `Optional<I18NString>` instead of taking a fallback id/label and eagerly constructing a `NonLocalizedString`. Callers now use `.orElseGet(...)` so the fallback string is only built lazily when no name could be derived from the OSM entity itself.

- `EdgeNamer.getName(OsmEntity, String)` → `EdgeNamer.getName(OsmEntity)` returning `Optional<I18NString>`
- Updated call sites in `OsmModule`, `BarrierEdgeBuilder`, and `WalkableAreaBuilder` to lazily compute their fallback label only in `orElseGet`
- `WalkableAreaBuilder` also unifies the forward/backward fallback name computation into a single `fallbackName` helper

## Test plan
- [x] `mvn test` for the affected modules