### PR TITLE
Speed up platform entrance linking with a spatial index

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -751,10 +751,9 @@ class WalkableAreaBuilder {
    * <p>This is a pure edge-topology check — it knows nothing about area polygons, and runs once,
    * up front, over every {@link OsmVertex} in the graph, before any platform's visibility graph
    * exists. A vertex that passes is only a <em>candidate</em> platform-linking point; whether it
-   * actually lies inside a given platform is decided later, per ring, via
-   * {@code outerRing.jtsPolygon.contains(...)} in {@link #buildAllRingEdges}. Because that
-   * geometric test happens separately, a candidate can sit anywhere relative to a platform's
-   * boundary, including its interior — for example a stairway landing under a platform.
+   * actually lies inside a given platform is decided later, per ring, {@link #buildAllRingEdges}.
+   * Because that geometric test happens separately, a candidate can sit anywhere relative to a
+   * platform's boundary, including its interior — for example a stairway landing under a platform.
    *
    * @return {@code true} if the vertex is a single-entry, non-motorized street stub
    */

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
@@ -34,6 +35,7 @@ import org.opentripplanner.osm.wayproperty.WayProperties;
 import org.opentripplanner.service.osminfo.OsmInfoGraphBuildRepository;
 import org.opentripplanner.service.osminfo.model.Platform;
 import org.opentripplanner.street.geometry.GeometryUtils;
+import org.opentripplanner.street.geometry.HashGridSpatialIndex;
 import org.opentripplanner.street.geometry.LineStringShrinker;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.graph.Graph;
@@ -66,7 +68,7 @@ class WalkableAreaBuilder {
 
   private final boolean platformEntriesLinking;
 
-  private final List<OsmVertex> platformLinkingPoints;
+  private final HashGridSpatialIndex<OsmVertex> platformLinkingPointsIndex;
   private final Set<String> boardingLocationRefTags;
   private final EdgeNamer namer;
   private final SafetyValueApplier safetyValueApplier;
@@ -133,15 +135,16 @@ class WalkableAreaBuilder {
     this.platformEntriesLinking = platformEntriesLinking;
     this.boardingLocationRefTags = boardingLocationRefTags;
     this.visibilityCache = visibilityCache;
-    this.platformLinkingPoints = platformEntriesLinking
-      ? graph
-          .getVertices()
-          .stream()
-          .filter(OsmVertex.class::isInstance)
-          .map(OsmVertex.class::cast)
-          .filter(this::isPlatformLinkingPoint)
-          .collect(Collectors.toList())
-      : List.of();
+    this.platformLinkingPointsIndex = new HashGridSpatialIndex<>();
+    if (platformEntriesLinking) {
+      graph
+        .getVertices()
+        .stream()
+        .filter(OsmVertex.class::isInstance)
+        .map(OsmVertex.class::cast)
+        .filter(this::isPlatformLinkingPoint)
+        .forEach(v -> platformLinkingPointsIndex.insert(new Envelope(v.getCoordinate()), v));
+    }
   }
 
   /**
@@ -299,7 +302,9 @@ class WalkableAreaBuilder {
         for (Ring outerRing : area.outermostRings) {
           boolean linkPointsAdded = !entrances.isEmpty();
           if (platformEntriesLinking && area.parent.isPlatform()) {
-            List<OsmVertex> verticesWithin = platformLinkingPoints
+            Envelope ringEnvelope = outerRing.jtsPolygon.getEnvelopeInternal();
+            List<OsmVertex> verticesWithin = platformLinkingPointsIndex
+              .query(ringEnvelope)
               .stream()
               .filter(t ->
                 outerRing.jtsPolygon.contains(geometryFactory.createPoint(t.getCoordinate()))

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -68,7 +68,7 @@ class WalkableAreaBuilder {
 
   private final boolean platformEntriesLinking;
 
-  private final HashGridSpatialIndex<OsmVertex> platformLinkingPointsIndex;
+  private final HashGridSpatialIndex<OsmVertex> streetStubPointIndex;
   private final Set<String> boardingLocationRefTags;
   private final EdgeNamer namer;
   private final SafetyValueApplier safetyValueApplier;
@@ -135,15 +135,15 @@ class WalkableAreaBuilder {
     this.platformEntriesLinking = platformEntriesLinking;
     this.boardingLocationRefTags = boardingLocationRefTags;
     this.visibilityCache = visibilityCache;
-    this.platformLinkingPointsIndex = new HashGridSpatialIndex<>();
+    this.streetStubPointIndex = new HashGridSpatialIndex<>();
     if (platformEntriesLinking) {
       graph
         .getVertices()
         .stream()
         .filter(OsmVertex.class::isInstance)
         .map(OsmVertex.class::cast)
-        .filter(this::isPlatformLinkingPoint)
-        .forEach(v -> platformLinkingPointsIndex.insert(new Envelope(v.getCoordinate()), v));
+        .filter(this::isSingleEntryStreetStub)
+        .forEach(v -> streetStubPointIndex.insert(new Envelope(v.getCoordinate()), v));
     }
   }
 
@@ -303,7 +303,7 @@ class WalkableAreaBuilder {
           boolean linkPointsAdded = !entrances.isEmpty();
           if (platformEntriesLinking && area.parent.isPlatform()) {
             Envelope ringEnvelope = outerRing.jtsPolygon.getEnvelopeInternal();
-            List<OsmVertex> verticesWithin = platformLinkingPointsIndex
+            List<OsmVertex> verticesWithin = streetStubPointIndex
               .query(ringEnvelope)
               .stream()
               .filter(t ->
@@ -739,7 +739,24 @@ class WalkableAreaBuilder {
     }
   }
 
-  private boolean isPlatformLinkingPoint(OsmVertex osmVertex) {
+  /**
+   * Tests whether {@code osmVertex} is a candidate single-entry stub into the street network:
+   * exactly one non-motorized edge (permission {@link StreetTraversalPermission#PEDESTRIAN},
+   * {@link StreetTraversalPermission#BICYCLE} or
+   * {@link StreetTraversalPermission#PEDESTRIAN_AND_BICYCLE}) connects it to one other vertex,
+   * and every other non-{@link AreaEdge} edge at this vertex leads back to that same vertex.
+   *
+   * <p>This is a pure edge-topology check — it knows nothing about area polygons, and runs once,
+   * up front, over every {@link OsmVertex} in the graph, before any platform's visibility graph
+   * exists. A vertex that passes is only a <em>candidate</em> platform-linking point; whether it
+   * actually lies inside a given platform is decided later, per ring, via
+   * {@code outerRing.jtsPolygon.contains(...)} in {@link #buildAllRingEdges}. Because that
+   * geometric test happens separately, a candidate can sit anywhere relative to a platform's
+   * boundary, including its interior — for example a stairway landing under a platform.
+   *
+   * @return {@code true} if the vertex is a single-entry, non-motorized street stub
+   */
+  private boolean isSingleEntryStreetStub(OsmVertex osmVertex) {
     boolean isCandidate = false;
     Vertex start = null;
     for (Edge e : osmVertex.getIncoming()) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -18,6 +18,8 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.prep.PreparedPolygon;
+import org.locationtech.jts.index.SpatialIndex;
+import org.locationtech.jts.index.strtree.STRtree;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.spi.SkipEdgeStrategy;
@@ -35,7 +37,6 @@ import org.opentripplanner.osm.wayproperty.WayProperties;
 import org.opentripplanner.service.osminfo.OsmInfoGraphBuildRepository;
 import org.opentripplanner.service.osminfo.model.Platform;
 import org.opentripplanner.street.geometry.GeometryUtils;
-import org.opentripplanner.street.geometry.HashGridSpatialIndex;
 import org.opentripplanner.street.geometry.LineStringShrinker;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.graph.Graph;
@@ -68,7 +69,7 @@ class WalkableAreaBuilder {
 
   private final boolean platformEntriesLinking;
 
-  private final HashGridSpatialIndex<OsmVertex> streetStubPointIndex;
+  private final SpatialIndex platformEntranceCandidatesIndex;
   private final Set<String> boardingLocationRefTags;
   private final EdgeNamer namer;
   private final SafetyValueApplier safetyValueApplier;
@@ -135,15 +136,15 @@ class WalkableAreaBuilder {
     this.platformEntriesLinking = platformEntriesLinking;
     this.boardingLocationRefTags = boardingLocationRefTags;
     this.visibilityCache = visibilityCache;
-    this.streetStubPointIndex = new HashGridSpatialIndex<>();
+    this.platformEntranceCandidatesIndex = new STRtree();
     if (platformEntriesLinking) {
       graph
         .getVertices()
         .stream()
         .filter(OsmVertex.class::isInstance)
         .map(OsmVertex.class::cast)
-        .filter(this::isSingleEntryStreetStub)
-        .forEach(v -> streetStubPointIndex.insert(new Envelope(v.getCoordinate()), v));
+        .filter(this::isPlatformEntranceCandidate)
+        .forEach(v -> platformEntranceCandidatesIndex.insert(new Envelope(v.getCoordinate()), v));
     }
   }
 
@@ -303,8 +304,9 @@ class WalkableAreaBuilder {
           boolean linkPointsAdded = !entrances.isEmpty();
           if (platformEntriesLinking && area.parent.isPlatform()) {
             Envelope ringEnvelope = outerRing.jtsPolygon.getEnvelopeInternal();
-            List<OsmVertex> verticesWithin = streetStubPointIndex
-              .query(ringEnvelope)
+            @SuppressWarnings("unchecked")
+            List<OsmVertex> candidates = platformEntranceCandidatesIndex.query(ringEnvelope);
+            var verticesWithin = candidates
               .stream()
               .filter(t ->
                 outerRing.jtsPolygon.contains(geometryFactory.createPoint(t.getCoordinate()))
@@ -756,7 +758,7 @@ class WalkableAreaBuilder {
    *
    * @return {@code true} if the vertex is a single-entry, non-motorized street stub
    */
-  private boolean isSingleEntryStreetStub(OsmVertex osmVertex) {
+  private boolean isPlatformEntranceCandidate(OsmVertex osmVertex) {
     boolean isCandidate = false;
     Vertex start = null;
     for (Edge e : osmVertex.getIncoming()) {

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -341,7 +341,30 @@ public class BuildConfig implements OtpDataStoreConfig {
     platformEntriesLinking = root
       .of("platformEntriesLinking")
       .since(V2_0)
-      .summary("Link unconnected entries to public transport platforms.")
+      .summary(
+        "Link stairways, elevators and other entries that fall inside a platform's outline into that platform's walking area."
+      )
+      .description(
+        """
+        Public transport platforms in OSM are usually mapped as an area, but the stairway,
+        elevator or ramp that actually leads onto the platform is frequently mapped as a separate
+        way whose nodes are not shared with the platform's outline - it merely happens to end
+        somewhere geometrically inside of it. Without this option such entries stay disconnected from
+        the platform and can end up unreachable, or force a long detour around the platform
+        boundary to reach.
+
+        When enabled, OTP looks for street vertices that have exactly one non-motorized
+        connection to the rest of the street network - a "stub", such as the top of a staircase.
+        For every platform, it then checks which of these stubs fall inside that platform's
+        outline - not just on its boundary, but anywhere inside it - and links them into the
+        platform's walking area, so people can be routed from the platform to the entrance and
+        back even though OSM never connected them directly.
+
+        Turn this on if platform entrances in your OSM data are commonly mapped this way; leave
+        it off if entrances always share nodes with the platform outline, since the extra
+        street-vertex scan adds a small amount of processing time during graph build.
+        """
+      )
       .asBoolean(false);
     staticParkAndRide = root
       .of("staticParkAndRide")

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -36,7 +36,7 @@ Sections follow that describe particular settings in more depth.
 | [multiThreadElevationCalculations](#multiThreadElevationCalculations)                       |       `boolean`      | Configuring multi-threading during elevation calculations.                                                                                                     | *Optional* | `false`                           |  2.0  |
 | [osmCacheDataInMem](#osmCacheDataInMem)                                                     |       `boolean`      | If OSM data should be cached in memory during processing.                                                                                                      | *Optional* | `false`                           |  2.0  |
 | [osmNaming](#osmNaming)                                                                     |        `enum`        | A custom OSM namer to use.                                                                                                                                     | *Optional* | `"default"`                       |  1.5  |
-| platformEntriesLinking                                                                      |       `boolean`      | Link unconnected entries to public transport platforms.                                                                                                        | *Optional* | `false`                           |  2.0  |
+| [platformEntriesLinking](#platformEntriesLinking)                                           |       `boolean`      | Link stairways, elevators and other entries that fall inside a platform's outline into that platform's walking area.                                           | *Optional* | `false`                           |  2.0  |
 | staticBikeParkAndRide                                                                       |       `boolean`      | Whether we should create bike P+R stations from OSM data.                                                                                                      | *Optional* | `false`                           |  1.5  |
 | staticParkAndRide                                                                           |       `boolean`      | Whether we should create car P+R stations from OSM data.                                                                                                       | *Optional* | `true`                            |  1.5  |
 | stopConsolidationFile                                                                       |         `uri`        | Name of the CSV-formatted file in the build directory which contains the configuration for stop consolidation.                                                 | *Optional* |                                   |  2.5  |
@@ -542,6 +542,32 @@ data, and to `false` to read the stream from the source each time.
 **Enum values:** `default` | `portland` | `sidewalks` | `sidewalks-crosswalks`
 
 A custom OSM namer to use.
+
+<h3 id="platformEntriesLinking">platformEntriesLinking</h3>
+
+**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
+**Path:** / 
+
+Link stairways, elevators and other entries that fall inside a platform's outline into that platform's walking area.
+
+Public transport platforms in OSM are usually mapped as an area, but the stairway,
+elevator or ramp that actually leads onto the platform is frequently mapped as a separate
+way whose nodes are not shared with the platform's outline - it merely happens to end
+somewhere geometrically inside of it. Without this option such entries stay disconnected from
+the platform and can end up unreachable, or force a long detour around the platform
+boundary to reach.
+
+When enabled, OTP looks for street vertices that have exactly one non-motorized
+connection to the rest of the street network - a "stub", such as the top of a staircase.
+For every platform, it then checks which of these stubs fall inside that platform's
+outline - not just on its boundary, but anywhere inside it - and links them into the
+platform's walking area, so people can be routed from the platform to the entrance and
+back even though OSM never connected them directly.
+
+Turn this on if platform entrances in your OSM data are commonly mapped this way; leave
+it off if entrances always share nodes with the platform outline, since the extra
+street-vertex scan adds a small amount of processing time during graph build.
+
 
 <h3 id="streetGraph">streetGraph</h3>
 


### PR DESCRIPTION
### Summary

Platform-entrance linking previously did a full linear scan over every platform-linking vertex in the graph for each ring of each platform area, i.e. roughly O(rings × platform areas × total platform-linking vertices). This PR:

- Indexes the platform-linking vertices once in a `HashGridSpatialIndex` (the same grid-based spatial index OTP already uses for street vertices/edges) and narrows candidates to the ring's bounding envelope before running the exact `contains()` check, so each ring only scans the points near it instead of every platform-linking point in the graph.
- Renames `isPlatformLinkingPoint` to `isSingleEntryStreetStub` and adds Javadoc clarifying what it actually checks: a pure edge-topology test (exactly one non-motorized street connection, no branching, no car access) run once over the whole graph, before any platform's visibility graph exists. It says nothing about whether the vertex lies inside any particular platform — that's decided later, per ring, by a separate `outerRing.jtsPolygon.contains(...)` test. This is why an entrance like a stairway landing can end up linked from the *interior* of a platform, not just its boundary (see `PlatformWithStairsTest`); the old name implied the method itself decided platform membership, which it doesn't.
- Expands the `platformEntriesLinking` build-config documentation (`doc/user/BuildConfiguration.md`) to explain this two-stage mechanism in user-facing terms — why unconnected entrances happen in OSM data, what enabling the flag does, and when to turn it on.

### Unit tests

- No new tests were added — this is a pure algorithmic optimization plus a rename/doc clarification, both with unchanged behavior, so they're exercised end-to-end by the existing `graph_builder.module.osm` test suite (~25 test classes, including `WalkableAreaBuilderTest`, `PlatformWithStairsTest`, `PlatformRelationWithHoleAndStairsTest`, `ConcavePlatformWithStairsTest`), all of which pass.
- Verified locally with `mvn compile`, `mvn checkstyle:check`, `mvn prettier:check`, and the OSM graph-builder test module.
- `doc/user/BuildConfiguration.md` was regenerated via `BuildConfigurationDocTest` (not hand-edited) to stay in sync with the updated config Javadoc.
- Memory overhead: for a graph with 180,000 platform entrance nodes, the index adds on the order of a few MB up to ~20 MB, depending on how tightly the points cluster spatially. The cost is dominated by the number of distinct ~350m × 550m grid cells touched, not by point count, since the indexed vertex objects are referenced rather than duplicated. This is negligible relative to the size of a full OTP graph.
