### PR TITLE
Add start-on-board locations to GTFS GraphQL API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/GraphQLUtils.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/GraphQLUtils.java
@@ -42,9 +42,7 @@ public class GraphQLUtils {
       case OUTSIDE_BOUNDS -> GraphQLRoutingErrorCode.OUTSIDE_BOUNDS;
       case OUTSIDE_SERVICE_PERIOD -> GraphQLRoutingErrorCode.OUTSIDE_SERVICE_PERIOD;
       case WALKING_BETTER_THAN_TRANSIT -> GraphQLRoutingErrorCode.WALKING_BETTER_THAN_TRANSIT;
-      case TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME -> throw new UnsupportedOperationException(
-        "Start-on-board access is not supported in the GTFS GraphQL API yet."
-      );
+      case TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME -> GraphQLRoutingErrorCode.TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME;
     };
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImpl.java
@@ -38,6 +38,7 @@ import org.opentripplanner.apis.gtfs.mapping.routerequest.RouteRequestMapper;
 import org.opentripplanner.apis.gtfs.model.CanceledTripsSummary;
 import org.opentripplanner.apis.gtfs.support.filter.PatternByDateFilterUtil;
 import org.opentripplanner.apis.gtfs.support.time.LocalDateRangeUtil;
+import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.ext.fares.service.gtfs.GtfsFaresService;
@@ -58,11 +59,14 @@ import org.opentripplanner.place.api.PlaceAtDistance;
 import org.opentripplanner.place.api.PlaceType;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.algorithm.mapping.TripPlanMapper;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.core.FareType;
+import org.opentripplanner.routing.error.InvalidRoutingInputException;
 import org.opentripplanner.routing.error.RoutingValidationException;
 import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.routing.framework.DebugTimingAggregator;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehicleparking.model.VehicleParking;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -1014,12 +1018,35 @@ public class QueryTypeImpl implements GraphQLDataFetchers.GraphQLQueryType {
   }
 
   private DataFetcherResult getPlanResult(GraphQLRequestContext context, RouteRequest request) {
-    RoutingResponse res = context.routingService().route(request);
+    RoutingResponse res = getRoutingResponse(context, request);
     res.getDebugTimingAggregator().finishedRendering();
     return DataFetcherResult.<RoutingResponse>newResult()
       .data(res)
       .localContext(Map.of("locale", request.preferences().locale()))
       .build();
+  }
+
+  /**
+   * Route the request, translating routing failures the same way as the Transmodel API: invalid
+   * input detected while resolving the request — such as an on-board trip location referencing an
+   * unknown trip — is reported as a client error, and validation failures are returned as routing
+   * errors in an otherwise empty plan instead of surfacing as data fetching exceptions.
+   */
+  static RoutingResponse getRoutingResponse(GraphQLRequestContext context, RouteRequest request) {
+    try {
+      return context.routingService().route(request);
+    } catch (InvalidRoutingInputException e) {
+      throw new InvalidInputException(e.getMessage());
+    } catch (RoutingValidationException e) {
+      return new RoutingResponse(
+        TripPlanMapper.mapTripPlan(request, List.of()),
+        null,
+        null,
+        null,
+        e.getRoutingErrors(),
+        new DebugTimingAggregator()
+      );
+    }
   }
 
   protected static List<TransitAlert> filterAlerts(

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -2187,6 +2187,7 @@ public class GraphQLTypes {
 
     private GraphQLPlanCoordinateInput coordinate;
     private GraphQLPlanStopLocationInput stopLocation;
+    private GraphQLPlanTripLocationInput tripLocation;
 
     public GraphQLPlanLocationInput(Map<String, Object> args) {
       if (args != null) {
@@ -2195,6 +2196,9 @@ public class GraphQLTypes {
         );
         this.stopLocation = new GraphQLPlanStopLocationInput(
           (Map<String, Object>) args.get("stopLocation")
+        );
+        this.tripLocation = new GraphQLPlanTripLocationInput(
+          (Map<String, Object>) args.get("tripLocation")
         );
       }
     }
@@ -2207,12 +2211,20 @@ public class GraphQLTypes {
       return this.stopLocation;
     }
 
+    public GraphQLPlanTripLocationInput getGraphQLTripLocation() {
+      return this.tripLocation;
+    }
+
     public void setGraphQLCoordinate(GraphQLPlanCoordinateInput coordinate) {
       this.coordinate = coordinate;
     }
 
     public void setGraphQLStopLocation(GraphQLPlanStopLocationInput stopLocation) {
       this.stopLocation = stopLocation;
+    }
+
+    public void setGraphQLTripLocation(GraphQLPlanTripLocationInput tripLocation) {
+      this.tripLocation = tripLocation;
     }
   }
 
@@ -2550,6 +2562,55 @@ public class GraphQLTypes {
 
     public void setGraphQLTransit(List<GraphQLPlanTransitModePreferenceInput> transit) {
       this.transit = transit;
+    }
+  }
+
+  public static class GraphQLPlanTripLocationInput {
+
+    private java.time.OffsetDateTime scheduledDepartureTime;
+    private java.time.LocalDate serviceDate;
+    private String stopLocationId;
+    private String tripId;
+
+    public GraphQLPlanTripLocationInput(Map<String, Object> args) {
+      if (args != null) {
+        this.scheduledDepartureTime = (java.time.OffsetDateTime) args.get("scheduledDepartureTime");
+        this.serviceDate = (java.time.LocalDate) args.get("serviceDate");
+        this.stopLocationId = (String) args.get("stopLocationId");
+        this.tripId = (String) args.get("tripId");
+      }
+    }
+
+    public java.time.OffsetDateTime getGraphQLScheduledDepartureTime() {
+      return this.scheduledDepartureTime;
+    }
+
+    public java.time.LocalDate getGraphQLServiceDate() {
+      return this.serviceDate;
+    }
+
+    public String getGraphQLStopLocationId() {
+      return this.stopLocationId;
+    }
+
+    public String getGraphQLTripId() {
+      return this.tripId;
+    }
+
+    public void setGraphQLScheduledDepartureTime(java.time.OffsetDateTime scheduledDepartureTime) {
+      this.scheduledDepartureTime = scheduledDepartureTime;
+    }
+
+    public void setGraphQLServiceDate(java.time.LocalDate serviceDate) {
+      this.serviceDate = serviceDate;
+    }
+
+    public void setGraphQLStopLocationId(String stopLocationId) {
+      this.stopLocationId = stopLocationId;
+    }
+
+    public void setGraphQLTripId(String tripId) {
+      this.tripId = tripId;
     }
   }
 
@@ -4918,6 +4979,7 @@ public class GraphQLTypes {
     NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW,
     OUTSIDE_BOUNDS,
     OUTSIDE_SERVICE_PERIOD,
+    TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME,
     WALKING_BETTER_THAN_TRANSIT,
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -2565,19 +2565,48 @@ public class GraphQLTypes {
     }
   }
 
+  public static class GraphQLPlanTripIdOnServiceDateInput {
+
+    private java.time.LocalDate serviceDate;
+    private String tripId;
+
+    public GraphQLPlanTripIdOnServiceDateInput(Map<String, Object> args) {
+      if (args != null) {
+        this.serviceDate = (java.time.LocalDate) args.get("serviceDate");
+        this.tripId = (String) args.get("tripId");
+      }
+    }
+
+    public java.time.LocalDate getGraphQLServiceDate() {
+      return this.serviceDate;
+    }
+
+    public String getGraphQLTripId() {
+      return this.tripId;
+    }
+
+    public void setGraphQLServiceDate(java.time.LocalDate serviceDate) {
+      this.serviceDate = serviceDate;
+    }
+
+    public void setGraphQLTripId(String tripId) {
+      this.tripId = tripId;
+    }
+  }
+
   public static class GraphQLPlanTripLocationInput {
 
     private java.time.OffsetDateTime scheduledDepartureTime;
-    private java.time.LocalDate serviceDate;
     private String stopLocationId;
-    private String tripId;
+    private GraphQLPlanTripOnDateReferenceInput tripReference;
 
     public GraphQLPlanTripLocationInput(Map<String, Object> args) {
       if (args != null) {
         this.scheduledDepartureTime = (java.time.OffsetDateTime) args.get("scheduledDepartureTime");
-        this.serviceDate = (java.time.LocalDate) args.get("serviceDate");
         this.stopLocationId = (String) args.get("stopLocationId");
-        this.tripId = (String) args.get("tripId");
+        this.tripReference = new GraphQLPlanTripOnDateReferenceInput(
+          (Map<String, Object>) args.get("tripReference")
+        );
       }
     }
 
@@ -2585,32 +2614,57 @@ public class GraphQLTypes {
       return this.scheduledDepartureTime;
     }
 
-    public java.time.LocalDate getGraphQLServiceDate() {
-      return this.serviceDate;
-    }
-
     public String getGraphQLStopLocationId() {
       return this.stopLocationId;
     }
 
-    public String getGraphQLTripId() {
-      return this.tripId;
+    public GraphQLPlanTripOnDateReferenceInput getGraphQLTripReference() {
+      return this.tripReference;
     }
 
     public void setGraphQLScheduledDepartureTime(java.time.OffsetDateTime scheduledDepartureTime) {
       this.scheduledDepartureTime = scheduledDepartureTime;
     }
 
-    public void setGraphQLServiceDate(java.time.LocalDate serviceDate) {
-      this.serviceDate = serviceDate;
-    }
-
     public void setGraphQLStopLocationId(String stopLocationId) {
       this.stopLocationId = stopLocationId;
     }
 
-    public void setGraphQLTripId(String tripId) {
-      this.tripId = tripId;
+    public void setGraphQLTripReference(GraphQLPlanTripOnDateReferenceInput tripReference) {
+      this.tripReference = tripReference;
+    }
+  }
+
+  public static class GraphQLPlanTripOnDateReferenceInput {
+
+    private GraphQLPlanTripIdOnServiceDateInput tripIdOnServiceDate;
+    private String tripOnDateId;
+
+    public GraphQLPlanTripOnDateReferenceInput(Map<String, Object> args) {
+      if (args != null) {
+        this.tripIdOnServiceDate = new GraphQLPlanTripIdOnServiceDateInput(
+          (Map<String, Object>) args.get("tripIdOnServiceDate")
+        );
+        this.tripOnDateId = (String) args.get("tripOnDateId");
+      }
+    }
+
+    public GraphQLPlanTripIdOnServiceDateInput getGraphQLTripIdOnServiceDate() {
+      return this.tripIdOnServiceDate;
+    }
+
+    public String getGraphQLTripOnDateId() {
+      return this.tripOnDateId;
+    }
+
+    public void setGraphQLTripIdOnServiceDate(
+      GraphQLPlanTripIdOnServiceDateInput tripIdOnServiceDate
+    ) {
+      this.tripIdOnServiceDate = tripIdOnServiceDate;
+    }
+
+    public void setGraphQLTripOnDateId(String tripOnDateId) {
+      this.tripOnDateId = tripOnDateId;
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
@@ -59,6 +59,17 @@ public class RouteRequestMapper {
         : null
     );
 
+    // A start-on-board search is pinned to the boarding time of a single dated trip, so there are
+    // no other pages and the plan connection contains no page cursors to pass back.
+    if (
+      request.from().isOnBoard() &&
+      (args.getGraphQLBefore() != null || args.getGraphQLAfter() != null)
+    ) {
+      throw new InvalidInputException(
+        "Paging is not supported for a search starting on board a trip; omit 'before' and 'after'."
+      );
+    }
+
     if (args.getGraphQLBefore() != null) {
       request.withPageCursorFromEncoded(args.getGraphQLBefore());
       if (args.getGraphQLLast() != null) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.model.GenericLocation;
@@ -191,12 +192,8 @@ public class RouteRequestMapper {
 
     var stopLocation = location.getGraphQLStopLocation();
     if (stopLocation.getGraphQLStopLocationId() != null) {
-      var stopId = stopLocation.getGraphQLStopLocationId();
-      return FeedScopedId.parseOptional(stopId)
-        .map(feedScopedId -> GenericLocation.fromStopId(feedScopedId, label))
-        .orElseThrow(() ->
-          new IllegalArgumentException("Stop id %s is not of valid format.".formatted(stopId))
-        );
+      var stopId = parseClientId("stopLocationId", stopLocation.getGraphQLStopLocationId());
+      return GenericLocation.fromStopId(stopId, label);
     }
 
     var coordinate = location.getGraphQLCoordinate();
@@ -211,15 +208,30 @@ public class RouteRequestMapper {
     GraphQLTypes.GraphQLPlanTripLocationInput tripLocation
   ) {
     var tripOnDateReference = TripOnDateReference.ofTripIdAndServiceDate(
-      FeedScopedId.parseStrict(tripLocation.getGraphQLTripId()),
+      parseClientId("tripId", tripLocation.getGraphQLTripId()),
       tripLocation.getGraphQLServiceDate()
     );
-    var stopLocationId = FeedScopedId.parseStrict(tripLocation.getGraphQLStopLocationId());
+    var stopLocationId = parseClientId("stopLocationId", tripLocation.getGraphQLStopLocationId());
     var scheduledDepartureTime = tripLocation.getGraphQLScheduledDepartureTime();
 
     return scheduledDepartureTime == null
       ? TripLocation.of(tripOnDateReference, stopLocationId)
       : TripLocation.of(tripOnDateReference, stopLocationId, scheduledDepartureTime.toInstant());
+  }
+
+  /**
+   * Parses a feed-scoped id supplied by the client. A malformed id is a client mistake, so it is
+   * reported as a bad request naming the offending field rather than surfacing as a server error.
+   */
+  private static FeedScopedId parseClientId(String fieldName, String id) {
+    return FeedScopedId.parseOptional(id).orElseThrow(() ->
+      new InvalidInputException(
+        "'%s' is not a valid value for '%s', the expected format is '<feed id>:<entity id>'.".formatted(
+          id,
+          fieldName
+        )
+      )
+    );
   }
 
   static void mapViaPoints(RouteRequestBuilder request, List<Map<String, Object>> via) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
@@ -59,15 +59,20 @@ public class RouteRequestMapper {
         : null
     );
 
-    // A start-on-board search is pinned to the boarding time of a single dated trip, so there are
-    // no other pages and the plan connection contains no page cursors to pass back.
-    if (
-      request.from().isOnBoard() &&
-      (args.getGraphQLBefore() != null || args.getGraphQLAfter() != null)
-    ) {
-      throw new InvalidInputException(
-        "Paging is not supported for a search starting on board a trip; omit 'before' and 'after'."
-      );
+    // A start-on-board search is pinned to the boarding time of a single dated trip. Arriving by
+    // a given time is not supported, and there are no other pages to navigate to, so the plan
+    // connection contains no page cursors to pass back.
+    if (request.from().isOnBoard()) {
+      if (dateTime.getGraphQLLatestArrival() != null) {
+        throw new InvalidInputException(
+          "An arrive-by search is not supported for a search starting on board a trip; omit 'latestArrival'."
+        );
+      }
+      if (args.getGraphQLBefore() != null || args.getGraphQLAfter() != null) {
+        throw new InvalidInputException(
+          "Paging is not supported for a search starting on board a trip; omit 'before' and 'after'."
+        );
+      }
     }
 
     if (args.getGraphQLBefore() != null) {
@@ -197,7 +202,7 @@ public class RouteRequestMapper {
     var label = locationInput.getGraphQLLabel();
 
     var tripLocation = location.getGraphQLTripLocation();
-    if (tripLocation.getGraphQLTripId() != null) {
+    if (tripLocation.getGraphQLStopLocationId() != null) {
       return GenericLocation.fromTripLocation(mapTripLocation(tripLocation), label);
     }
 
@@ -218,16 +223,28 @@ public class RouteRequestMapper {
   private static TripLocation mapTripLocation(
     GraphQLTypes.GraphQLPlanTripLocationInput tripLocation
   ) {
-    var tripOnDateReference = TripOnDateReference.ofTripIdAndServiceDate(
-      parseClientId("tripId", tripLocation.getGraphQLTripId()),
-      tripLocation.getGraphQLServiceDate()
-    );
+    var tripOnDateReference = mapTripOnDateReference(tripLocation.getGraphQLTripReference());
     var stopLocationId = parseClientId("stopLocationId", tripLocation.getGraphQLStopLocationId());
     var scheduledDepartureTime = tripLocation.getGraphQLScheduledDepartureTime();
 
     return scheduledDepartureTime == null
       ? TripLocation.of(tripOnDateReference, stopLocationId)
       : TripLocation.of(tripOnDateReference, stopLocationId, scheduledDepartureTime.toInstant());
+  }
+
+  private static TripOnDateReference mapTripOnDateReference(
+    GraphQLTypes.GraphQLPlanTripOnDateReferenceInput tripReference
+  ) {
+    if (tripReference.getGraphQLTripOnDateId() != null) {
+      return TripOnDateReference.ofTripOnServiceDateId(
+        parseClientId("tripOnDateId", tripReference.getGraphQLTripOnDateId())
+      );
+    }
+    var tripIdOnServiceDate = tripReference.getGraphQLTripIdOnServiceDate();
+    return TripOnDateReference.ofTripIdAndServiceDate(
+      parseClientId("tripId", tripIdOnServiceDate.getGraphQLTripId()),
+      tripIdOnServiceDate.getGraphQLServiceDate()
+    );
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapper.java
@@ -19,6 +19,8 @@ import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.RouteRequestBuilder;
+import org.opentripplanner.routing.api.request.TripLocation;
+import org.opentripplanner.routing.api.request.TripOnDateReference;
 import org.opentripplanner.routing.api.request.preference.ItineraryFilterPreferences;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferencesBuilder;
 import org.opentripplanner.utils.time.DurationUtils;
@@ -179,24 +181,45 @@ public class RouteRequestMapper {
   private static GenericLocation parseGenericLocation(
     GraphQLTypes.GraphQLPlanLabeledLocationInput locationInput
   ) {
-    var stopLocation = locationInput.getGraphQLLocation().getGraphQLStopLocation();
+    var location = locationInput.getGraphQLLocation();
+    var label = locationInput.getGraphQLLabel();
+
+    var tripLocation = location.getGraphQLTripLocation();
+    if (tripLocation.getGraphQLTripId() != null) {
+      return GenericLocation.fromTripLocation(mapTripLocation(tripLocation), label);
+    }
+
+    var stopLocation = location.getGraphQLStopLocation();
     if (stopLocation.getGraphQLStopLocationId() != null) {
       var stopId = stopLocation.getGraphQLStopLocationId();
       return FeedScopedId.parseOptional(stopId)
-        .map(feedScopedId ->
-          GenericLocation.fromStopId(feedScopedId, locationInput.getGraphQLLabel())
-        )
+        .map(feedScopedId -> GenericLocation.fromStopId(feedScopedId, label))
         .orElseThrow(() ->
           new IllegalArgumentException("Stop id %s is not of valid format.".formatted(stopId))
         );
     }
 
-    var coordinate = locationInput.getGraphQLLocation().getGraphQLCoordinate();
+    var coordinate = location.getGraphQLCoordinate();
     return GenericLocation.fromCoordinate(
       coordinate.getGraphQLLatitude(),
       coordinate.getGraphQLLongitude(),
-      locationInput.getGraphQLLabel()
+      label
     );
+  }
+
+  private static TripLocation mapTripLocation(
+    GraphQLTypes.GraphQLPlanTripLocationInput tripLocation
+  ) {
+    var tripOnDateReference = TripOnDateReference.ofTripIdAndServiceDate(
+      FeedScopedId.parseStrict(tripLocation.getGraphQLTripId()),
+      tripLocation.getGraphQLServiceDate()
+    );
+    var stopLocationId = FeedScopedId.parseStrict(tripLocation.getGraphQLStopLocationId());
+    var scheduledDepartureTime = tripLocation.getGraphQLScheduledDepartureTime();
+
+    return scheduledDepartureTime == null
+      ? TripLocation.of(tripOnDateReference, stopLocationId)
+      : TripLocation.of(tripOnDateReference, stopLocationId, scheduledDepartureTime.toInstant());
   }
 
   static void mapViaPoints(RouteRequestBuilder request, List<Map<String, Object>> via) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
@@ -39,9 +39,14 @@ public class RoutingResponseMapper {
     // Create response
     var tripPlan = TripPlanMapper.mapTripPlan(request, itineraries);
 
-    // Paging
-    PageCursor nextPageCursor = pagingService.nextPageCursor();
-    PageCursor prevPageCursor = pagingService.previousPageCursor();
+    // Paging. A start-on-board search is pinned to the boarding time of a single dated trip, so
+    // there are no other pages to navigate to and no page cursors are returned.
+    PageCursor nextPageCursor = null;
+    PageCursor prevPageCursor = null;
+    if (!request.isStartOnBoardAccessRequest()) {
+      nextPageCursor = pagingService.nextPageCursor();
+      prevPageCursor = pagingService.previousPageCursor();
+    }
 
     if (LOG.isDebugEnabled()) {
       logPagingInformation(request.pageCursor(), prevPageCursor, nextPageCursor, routingErrors);

--- a/application/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -253,7 +253,7 @@ public class RouteRequest implements Serializable {
 
     if (to.isOnBoard()) {
       throw new InvalidRoutingInputException(
-        "'serviceJourneyLocation' is only supported for the 'from' location, not 'to'"
+        "An on-board trip location is only supported as the origin of a search, not the destination."
       );
     }
   }

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -4851,7 +4851,8 @@ input PlanLocationInput @oneOf {
   A position on board a specific dated transit trip. This is only supported for the origin of a
   search. The search starts on board the vehicle at the specified stop with no access leg or
   boarding cost. The request dateTime is ignored because the departure time is resolved from the
-  trip's timetable.
+  trip's timetable. Paging is not supported: the search is pinned to the boarding time, so the
+  plan connection contains no page cursors and the `before` and `after` arguments must be omitted.
   """
   tripLocation: PlanTripLocationInput
 }

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1947,7 +1947,10 @@ type QueryType {
     access, egress and transfers.
     """
     modes: PlanModesInput,
-    "The origin where the search starts. Usually coordinates but can also be a stop location."
+    """
+    The origin where the search starts. Usually coordinates, but can also be a stop location or a
+    position on board a specific dated transit trip.
+    """
     origin: PlanLabeledLocationInput!,
     "Preferences that affect what itineraries are returned. Preferences are split into categories."
     preferences: PlanPreferencesInput,
@@ -4052,6 +4055,11 @@ enum RoutingErrorCode {
   """
   OUTSIDE_SERVICE_PERIOD
   """
+  The on-board trip location could not be resolved because the trip visits the specified stop more
+  than once and no scheduled departure time was provided to disambiguate the visit.
+  """
+  TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME
+  """
   Transit connections were requested and found but because it is easier to just walk all the way
   to the destination they were removed.
     
@@ -4827,9 +4835,9 @@ input PlanLabeledLocationInput {
   location: PlanLocationInput!
 }
 
-"Plan location. Either a coordinate or a stop location should be defined."
+"Plan location. Exactly one location type should be defined."
 input PlanLocationInput @oneOf {
-  "Coordinate of the location. Note, either a coordinate or a stop location should be defined."
+  "Coordinate of the location."
   coordinate: PlanCoordinateInput
   """
   Stop, station, a group of stop places or multimodal stop place that should be used as
@@ -4839,6 +4847,13 @@ input PlanLocationInput @oneOf {
   sense for the journey is picked as the location within the station or group of stop places.
   """
   stopLocation: PlanStopLocationInput
+  """
+  A position on board a specific dated transit trip. This is only supported for the origin of a
+  search. The search starts on board the vehicle at the specified stop with no access leg or
+  boarding cost. The request dateTime is ignored because the departure time is resolved from the
+  trip's timetable.
+  """
+  tripLocation: PlanTripLocationInput
 }
 
 "Mode selections for the plan search."
@@ -4980,6 +4995,21 @@ input PlanTransitModesInput {
   in the field.
   """
   transit: [PlanTransitModePreferenceInput!]
+}
+
+"A position on board a specific dated GTFS trip."
+input PlanTripLocationInput {
+  """
+  Scheduled departure time at the stop. This disambiguates trips that visit the same stop more
+  than once, such as circular routes. If provided, it must match the timetable exactly.
+  """
+  scheduledDepartureTime: OffsetDateTime
+  "The GTFS service date on which the trip runs."
+  serviceDate: LocalDate!
+  "ID of the stop at which the rider is considered to be on board, including its feed scope."
+  stopLocationId: String!
+  "GTFS trip ID, including its feed scope."
+  tripId: String!
 }
 
 """

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -4850,9 +4850,10 @@ input PlanLocationInput @oneOf {
   """
   A position on board a specific dated transit trip. This is only supported for the origin of a
   search. The search starts on board the vehicle at the specified stop with no access leg or
-  boarding cost. The request dateTime is ignored because the departure time is resolved from the
-  trip's timetable. Paging is not supported: the search is pinned to the boarding time, so the
-  plan connection contains no page cursors and the `before` and `after` arguments must be omitted.
+  boarding cost. The request `dateTime` and `searchWindow` are ignored because the search is
+  pinned to the departure resolved from the trip's timetable, and an arrive-by search (a
+  `latestArrival` dateTime) is not supported. Paging is not supported either: the plan connection
+  contains no page cursors and the `before` and `after` arguments must be omitted.
   """
   tripLocation: PlanTripLocationInput
 }
@@ -4998,19 +4999,36 @@ input PlanTransitModesInput {
   transit: [PlanTransitModePreferenceInput!]
 }
 
-"A position on board a specific dated GTFS trip."
+"Identifies a trip by GTFS trip ID and the service date on which it runs."
+input PlanTripIdOnServiceDateInput {
+  "The GTFS service date on which the trip runs."
+  serviceDate: LocalDate!
+  "GTFS trip ID, including its feed scope."
+  tripId: String!
+}
+
+"A position on board a specific dated transit trip."
 input PlanTripLocationInput {
   """
   Scheduled departure time at the stop. This disambiguates trips that visit the same stop more
   than once, such as circular routes. If provided, it must match the timetable exactly.
   """
   scheduledDepartureTime: OffsetDateTime
-  "The GTFS service date on which the trip runs."
-  serviceDate: LocalDate!
   "ID of the stop at which the rider is considered to be on board, including its feed scope."
   stopLocationId: String!
-  "GTFS trip ID, including its feed scope."
-  tripId: String!
+  "Reference identifying the dated trip the rider is on board."
+  tripReference: PlanTripOnDateReferenceInput!
+}
+
+"Identifies a trip on a service date. Exactly one reference type should be defined."
+input PlanTripOnDateReferenceInput @oneOf {
+  "A GTFS trip ID combined with the service date on which the trip runs."
+  tripIdOnServiceDate: PlanTripIdOnServiceDateInput
+  """
+  The unique ID of a dated trip, including its feed scope. This can be used with data sources,
+  such as NeTEx, where a trip on a specific date is uniquely identified by its own ID.
+  """
+  tripOnDateId: String
 }
 
 """

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLUtilsTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLUtilsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.routing.api.response.RoutingErrorCode;
 
 class GraphQLUtilsTest {
 
@@ -12,5 +13,13 @@ class GraphQLUtilsTest {
   void typeName() {
     var name = GraphQLUtils.typeName(new GraphQLTypes.GraphQLTransitFilterInput(Map.of()));
     assertEquals("TransitFilterInput", name);
+  }
+
+  @Test
+  void startOnBoardError() {
+    assertEquals(
+      GraphQLTypes.GraphQLRoutingErrorCode.TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME,
+      GraphQLUtils.toGraphQL(RoutingErrorCode.TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME)
+    );
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImplTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/datafetchers/QueryTypeImplTest.java
@@ -1,19 +1,36 @@
 package org.opentripplanner.apis.gtfs.datafetchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.alertpatch.AlertCause;
 import org.opentripplanner.routing.alertpatch.AlertEffect;
 import org.opentripplanner.routing.alertpatch.AlertSeverity;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.api.RoutingService;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.RouteViaRequest;
+import org.opentripplanner.routing.api.response.InputField;
+import org.opentripplanner.routing.api.response.RoutingError;
+import org.opentripplanner.routing.api.response.RoutingErrorCode;
+import org.opentripplanner.routing.api.response.RoutingResponse;
+import org.opentripplanner.routing.api.response.ViaRoutingResponse;
+import org.opentripplanner.routing.error.InvalidRoutingInputException;
+import org.opentripplanner.routing.error.RoutingValidationException;
 
 public class QueryTypeImplTest {
 
@@ -168,5 +185,81 @@ public class QueryTypeImplTest {
     var filteredAlerts = QueryTypeImpl.filterAlerts(alerts, queryTypeAlertsArgs);
     assertEquals(1, filteredAlerts.size());
     assertEquals(STOP_ID, filteredAlerts.get(0).getId());
+  }
+
+  /**
+   * Invalid input detected while resolving the routing request, for example an on-board trip
+   * location referencing an unknown trip, is reported as a client error.
+   */
+  @Test
+  void invalidRoutingInputIsReportedAsClientError() {
+    var context = contextWithRoutingService(request -> {
+      throw new InvalidRoutingInputException("Trip not found: F:trip-1");
+    });
+
+    var exception = assertThrows(InvalidInputException.class, () ->
+      QueryTypeImpl.getRoutingResponse(context, planRequest())
+    );
+    assertEquals("Trip not found: F:trip-1", exception.getMessage());
+  }
+
+  /**
+   * A validation failure raised before the routing worker runs, for example an ambiguous on-board
+   * trip location, must end up in the routing errors of an empty plan instead of surfacing as a
+   * data fetching exception.
+   */
+  @Test
+  void routingValidationErrorsAreReturnedAsPlanErrors() {
+    var error = new RoutingError(
+      RoutingErrorCode.TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME,
+      InputField.FROM_PLACE
+    );
+    var context = contextWithRoutingService(request -> {
+      throw new RoutingValidationException(List.of(error));
+    });
+    var request = planRequest();
+
+    var response = QueryTypeImpl.getRoutingResponse(context, request);
+
+    assertEquals(List.of(error), response.getRoutingErrors());
+    assertTrue(response.getTripPlan().itineraries.isEmpty());
+    assertEquals(request.dateTime(), response.getTripPlan().date);
+  }
+
+  private static RouteRequest planRequest() {
+    return RouteRequest.of()
+      .withFrom(GenericLocation.fromCoordinate(60.0, 25.0))
+      .withTo(GenericLocation.fromCoordinate(60.1, 25.1))
+      .withDateTime(Instant.parse("2026-07-28T12:00:00Z"))
+      .buildRequest();
+  }
+
+  private static GraphQLRequestContext contextWithRoutingService(
+    Function<RouteRequest, RoutingResponse> routeHandler
+  ) {
+    var routingService = new RoutingService() {
+      @Override
+      public RoutingResponse route(RouteRequest request) {
+        return routeHandler.apply(request);
+      }
+
+      @Override
+      public ViaRoutingResponse route(RouteViaRequest request) {
+        throw new UnsupportedOperationException();
+      }
+    };
+    return new GraphQLRequestContext(
+      routingService,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    );
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.plan.paging.cursor.PageCursor;
 import org.opentripplanner.routing.api.request.RouteRequest;
@@ -209,10 +210,48 @@ class RouteRequestMapperTest {
     args.put("origin", Map.of("location", Map.of("stopLocation", Map.of("stopLocationId", "foo"))));
     var env = testCtx.executionContext(args);
 
-    var exception = assertThrows(IllegalArgumentException.class, () ->
+    var exception = assertThrows(InvalidInputException.class, () ->
       RouteRequestMapper.toRouteRequest(env, testCtx.context())
     );
-    assertEquals("Stop id foo is not of valid format.", exception.getMessage());
+    assertEquals(
+      "'foo' is not a valid value for 'stopLocationId', the expected format is '<feed id>:<entity id>'.",
+      exception.getMessage()
+    );
+  }
+
+  /**
+   * A malformed id inside a trip location names the offending field, so that a client can tell
+   * which of the two ids it got wrong.
+   */
+  @Test
+  void testInvalidTripLocationTripId() {
+    var args = testCtx.basicRequest();
+    args.put(
+      "origin",
+      Map.of(
+        "location",
+        Map.of(
+          "tripLocation",
+          Map.of(
+            "tripId",
+            "foo",
+            "serviceDate",
+            LocalDate.of(2026, 7, 28),
+            "stopLocationId",
+            ON_BOARD_STOP_ID
+          )
+        )
+      )
+    );
+    var env = testCtx.executionContext(args);
+
+    var exception = assertThrows(InvalidInputException.class, () ->
+      RouteRequestMapper.toRouteRequest(env, testCtx.context())
+    );
+    assertEquals(
+      "'foo' is not a valid value for 'tripId', the expected format is '<feed id>:<entity id>'.",
+      exception.getMessage()
+    );
   }
 
   private static Map<String, Object> onBoardOrigin(

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -4,6 +4,7 @@ import static graphql.Assert.assertTrue;
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -194,6 +195,56 @@ class RouteRequestMapperTest {
         scheduledDepartureTime.toInstant()
       ),
       location.tripLocation()
+    );
+  }
+
+  @Test
+  void testInvalidStopLocationId() {
+    Map<String, Object> args = testCtx.basicRequest();
+    args.put("origin", Map.of("location", Map.of("stopLocation", Map.of("stopLocationId", "foo"))));
+    var env = testCtx.executionContext(args);
+
+    var exception = assertThrows(IllegalArgumentException.class, () ->
+      RouteRequestMapper.toRouteRequest(env, testCtx.context())
+    );
+    assertEquals("Stop id foo is not of valid format.", exception.getMessage());
+  }
+
+  /**
+   * The scheduled departure time is optional; it is only needed to disambiguate patterns which
+   * visit the same stop more than once.
+   */
+  @Test
+  void testOnBoardTripLocationWithoutScheduledDepartureTime() {
+    var serviceDate = LocalDate.of(2026, 7, 28);
+    var args = testCtx.basicRequest();
+    args.put(
+      "origin",
+      Map.of(
+        "label",
+        "On board route 10",
+        "location",
+        Map.of(
+          "tripLocation",
+          Map.of("tripId", "F:trip-10", "serviceDate", serviceDate, "stopLocationId", "F:stop-3")
+        )
+      )
+    );
+
+    var request = RouteRequestMapper.toRouteRequest(
+      testCtx.executionContext(args),
+      testCtx.context()
+    );
+
+    assertEquals(
+      TripLocation.of(
+        TripOnDateReference.ofTripIdAndServiceDate(
+          FeedScopedId.parseStrict("F:trip-10"),
+          serviceDate
+        ),
+        FeedScopedId.parseStrict("F:stop-3")
+      ),
+      request.from().tripLocation()
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.plan.paging.cursor.PageCursor;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.TripLocation;
+import org.opentripplanner.routing.api.request.TripOnDateReference;
 import org.opentripplanner.routing.api.request.preference.ItineraryFilterDebugProfile;
 
 class RouteRequestMapperTest {
@@ -142,6 +144,57 @@ class RouteRequestMapperTest {
     assertEquals(originLabel, routeRequest.from().label());
     assertEquals(FeedScopedId.parseStrict(stopB), routeRequest.to().stopId());
     assertEquals(destinationLabel, routeRequest.to().label());
+  }
+
+  @Test
+  void testOnBoardTripLocation() {
+    var serviceDate = LocalDate.of(2026, 7, 28);
+    var scheduledDepartureTime = OffsetDateTime.of(
+      serviceDate,
+      LocalTime.of(12, 34),
+      ZoneOffset.UTC
+    );
+    var args = testCtx.basicRequest();
+    args.put(
+      "origin",
+      Map.of(
+        "label",
+        "On board route 10",
+        "location",
+        Map.of(
+          "tripLocation",
+          Map.of(
+            "tripId",
+            "F:trip-10",
+            "serviceDate",
+            serviceDate,
+            "stopLocationId",
+            "F:stop-3",
+            "scheduledDepartureTime",
+            scheduledDepartureTime
+          )
+        )
+      )
+    );
+
+    var request = RouteRequestMapper.toRouteRequest(
+      testCtx.executionContext(args),
+      testCtx.context()
+    );
+    var location = request.from();
+
+    assertEquals("On board route 10", location.label());
+    assertEquals(
+      TripLocation.of(
+        TripOnDateReference.ofTripIdAndServiceDate(
+          FeedScopedId.parseStrict("F:trip-10"),
+          serviceDate
+        ),
+        FeedScopedId.parseStrict("F:stop-3"),
+        scheduledDepartureTime.toInstant()
+      ),
+      location.tripLocation()
+    );
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -221,7 +221,7 @@ class RouteRequestMapperTest {
 
   /**
    * A malformed id inside a trip location names the offending field, so that a client can tell
-   * which of the two ids it got wrong.
+   * which of the ids it got wrong.
    */
   @Test
   void testInvalidTripLocationTripId() {
@@ -233,10 +233,11 @@ class RouteRequestMapperTest {
         Map.of(
           "tripLocation",
           Map.of(
-            "tripId",
-            "foo",
-            "serviceDate",
-            LocalDate.of(2026, 7, 28),
+            "tripReference",
+            Map.of(
+              "tripIdOnServiceDate",
+              Map.of("tripId", "foo", "serviceDate", LocalDate.of(2026, 7, 28))
+            ),
             "stopLocationId",
             ON_BOARD_STOP_ID
           )
@@ -250,6 +251,69 @@ class RouteRequestMapperTest {
     );
     assertEquals(
       "'foo' is not a valid value for 'tripId', the expected format is '<feed id>:<entity id>'.",
+      exception.getMessage()
+    );
+  }
+
+  /**
+   * A dated trip may also be referenced directly by its own unique id, used with data sources
+   * such as NeTEx where a trip on a specific date has its own identifier.
+   */
+  @Test
+  void testOnBoardTripLocationWithTripOnDateId() {
+    var args = testCtx.basicRequest();
+    args.put(
+      "origin",
+      Map.of(
+        "location",
+        Map.of(
+          "tripLocation",
+          Map.of(
+            "tripReference",
+            Map.of("tripOnDateId", "F:dated-trip-10"),
+            "stopLocationId",
+            ON_BOARD_STOP_ID
+          )
+        )
+      )
+    );
+
+    var request = RouteRequestMapper.toRouteRequest(
+      testCtx.executionContext(args),
+      testCtx.context()
+    );
+
+    assertEquals(
+      TripLocation.of(
+        TripOnDateReference.ofTripOnServiceDateId(FeedScopedId.parseStrict("F:dated-trip-10")),
+        FeedScopedId.parseStrict(ON_BOARD_STOP_ID)
+      ),
+      request.from().tripLocation()
+    );
+  }
+
+  /**
+   * Arriving on board by a given time is not supported, so an arrive-by search with an on-board
+   * origin is rejected.
+   */
+  @Test
+  void testOnBoardTripLocationRejectsArriveBy() {
+    var args = testCtx.basicRequest();
+    args.put("origin", onBoardOrigin(LocalDate.of(2026, 7, 28), null));
+    args.put(
+      "dateTime",
+      Map.of(
+        "latestArrival",
+        OffsetDateTime.of(LocalDate.of(2026, 7, 28), LocalTime.of(15, 0), ZoneOffset.UTC)
+      )
+    );
+    var env = testCtx.executionContext(args);
+
+    var exception = assertThrows(InvalidInputException.class, () ->
+      RouteRequestMapper.toRouteRequest(env, testCtx.context())
+    );
+    assertEquals(
+      "An arrive-by search is not supported for a search starting on board a trip; omit 'latestArrival'.",
       exception.getMessage()
     );
   }
@@ -281,8 +345,10 @@ class RouteRequestMapperTest {
     @Nullable OffsetDateTime scheduledDepartureTime
   ) {
     var tripLocation = new HashMap<String, Object>();
-    tripLocation.put("tripId", ON_BOARD_TRIP_ID);
-    tripLocation.put("serviceDate", serviceDate);
+    tripLocation.put(
+      "tripReference",
+      Map.of("tripIdOnServiceDate", Map.of("tripId", ON_BOARD_TRIP_ID, "serviceDate", serviceDate))
+    );
     tripLocation.put("stopLocationId", ON_BOARD_STOP_ID);
     if (scheduledDepartureTime != null) {
       tripLocation.put("scheduledDepartureTime", scheduledDepartureTime);

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.model.plan.paging.cursor.PageCursor;
@@ -27,6 +28,9 @@ import org.opentripplanner.routing.api.request.preference.ItineraryFilterDebugPr
 class RouteRequestMapperTest {
 
   private static final Locale LOCALE = Locale.GERMAN;
+  private static final String ON_BOARD_TRIP_ID = "F:trip-10";
+  private static final String ON_BOARD_STOP_ID = "F:stop-3";
+  private static final String ON_BOARD_LABEL = "On board route 10";
   private final _RouteRequestTestContext testCtx = _RouteRequestTestContext.of(LOCALE);
 
   @Test
@@ -156,27 +160,7 @@ class RouteRequestMapperTest {
       ZoneOffset.UTC
     );
     var args = testCtx.basicRequest();
-    args.put(
-      "origin",
-      Map.of(
-        "label",
-        "On board route 10",
-        "location",
-        Map.of(
-          "tripLocation",
-          Map.of(
-            "tripId",
-            "F:trip-10",
-            "serviceDate",
-            serviceDate,
-            "stopLocationId",
-            "F:stop-3",
-            "scheduledDepartureTime",
-            scheduledDepartureTime
-          )
-        )
-      )
-    );
+    args.put("origin", onBoardOrigin(serviceDate, scheduledDepartureTime));
 
     var request = RouteRequestMapper.toRouteRequest(
       testCtx.executionContext(args),
@@ -184,30 +168,15 @@ class RouteRequestMapperTest {
     );
     var location = request.from();
 
-    assertEquals("On board route 10", location.label());
+    assertEquals(ON_BOARD_LABEL, location.label());
     assertEquals(
       TripLocation.of(
-        TripOnDateReference.ofTripIdAndServiceDate(
-          FeedScopedId.parseStrict("F:trip-10"),
-          serviceDate
-        ),
-        FeedScopedId.parseStrict("F:stop-3"),
+        onBoardTripReference(serviceDate),
+        FeedScopedId.parseStrict(ON_BOARD_STOP_ID),
         scheduledDepartureTime.toInstant()
       ),
       location.tripLocation()
     );
-  }
-
-  @Test
-  void testInvalidStopLocationId() {
-    Map<String, Object> args = testCtx.basicRequest();
-    args.put("origin", Map.of("location", Map.of("stopLocation", Map.of("stopLocationId", "foo"))));
-    var env = testCtx.executionContext(args);
-
-    var exception = assertThrows(IllegalArgumentException.class, () ->
-      RouteRequestMapper.toRouteRequest(env, testCtx.context())
-    );
-    assertEquals("Stop id foo is not of valid format.", exception.getMessage());
   }
 
   /**
@@ -218,18 +187,7 @@ class RouteRequestMapperTest {
   void testOnBoardTripLocationWithoutScheduledDepartureTime() {
     var serviceDate = LocalDate.of(2026, 7, 28);
     var args = testCtx.basicRequest();
-    args.put(
-      "origin",
-      Map.of(
-        "label",
-        "On board route 10",
-        "location",
-        Map.of(
-          "tripLocation",
-          Map.of("tripId", "F:trip-10", "serviceDate", serviceDate, "stopLocationId", "F:stop-3")
-        )
-      )
-    );
+    args.put("origin", onBoardOrigin(serviceDate, null));
 
     var request = RouteRequestMapper.toRouteRequest(
       testCtx.executionContext(args),
@@ -238,13 +196,46 @@ class RouteRequestMapperTest {
 
     assertEquals(
       TripLocation.of(
-        TripOnDateReference.ofTripIdAndServiceDate(
-          FeedScopedId.parseStrict("F:trip-10"),
-          serviceDate
-        ),
-        FeedScopedId.parseStrict("F:stop-3")
+        onBoardTripReference(serviceDate),
+        FeedScopedId.parseStrict(ON_BOARD_STOP_ID)
       ),
       request.from().tripLocation()
+    );
+  }
+
+  @Test
+  void testInvalidStopLocationId() {
+    var args = testCtx.basicRequest();
+    args.put("origin", Map.of("location", Map.of("stopLocation", Map.of("stopLocationId", "foo"))));
+    var env = testCtx.executionContext(args);
+
+    var exception = assertThrows(IllegalArgumentException.class, () ->
+      RouteRequestMapper.toRouteRequest(env, testCtx.context())
+    );
+    assertEquals("Stop id foo is not of valid format.", exception.getMessage());
+  }
+
+  private static Map<String, Object> onBoardOrigin(
+    LocalDate serviceDate,
+    @Nullable OffsetDateTime scheduledDepartureTime
+  ) {
+    var tripLocation = new HashMap<String, Object>();
+    tripLocation.put("tripId", ON_BOARD_TRIP_ID);
+    tripLocation.put("serviceDate", serviceDate);
+    tripLocation.put("stopLocationId", ON_BOARD_STOP_ID);
+    if (scheduledDepartureTime != null) {
+      tripLocation.put("scheduledDepartureTime", scheduledDepartureTime);
+    }
+    return Map.ofEntries(
+      entry("label", ON_BOARD_LABEL),
+      entry("location", Map.of("tripLocation", tripLocation))
+    );
+  }
+
+  private static TripOnDateReference onBoardTripReference(LocalDate serviceDate) {
+    return TripOnDateReference.ofTripIdAndServiceDate(
+      FeedScopedId.parseStrict(ON_BOARD_TRIP_ID),
+      serviceDate
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/RouteRequestMapperTest.java
@@ -254,6 +254,28 @@ class RouteRequestMapperTest {
     );
   }
 
+  /**
+   * A start-on-board search is pinned to the boarding time of a single dated trip, so there are
+   * no other pages and paging arguments are rejected.
+   */
+  @Test
+  void testOnBoardTripLocationRejectsPaging() {
+    for (var pagingArgument : List.of("before", "after")) {
+      var args = testCtx.basicRequest();
+      args.put("origin", onBoardOrigin(LocalDate.of(2026, 7, 28), null));
+      args.put(pagingArgument, "cursor");
+      var env = testCtx.executionContext(args);
+
+      var exception = assertThrows(InvalidInputException.class, () ->
+        RouteRequestMapper.toRouteRequest(env, testCtx.context())
+      );
+      assertEquals(
+        "Paging is not supported for a search starting on board a trip; omit 'before' and 'after'.",
+        exception.getMessage()
+      );
+    }
+  }
+
   private static Map<String, Object> onBoardOrigin(
     LocalDate serviceDate,
     @Nullable OffsetDateTime scheduledDepartureTime

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapperTest.java
@@ -1,0 +1,97 @@
+package org.opentripplanner.routing.algorithm.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.model.plan.SortOrder;
+import org.opentripplanner.model.plan.paging.cursor.PageCursor;
+import org.opentripplanner.model.plan.paging.cursor.PageType;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.TripLocation;
+import org.opentripplanner.routing.api.request.TripOnDateReference;
+import org.opentripplanner.routing.api.response.RoutingResponse;
+import org.opentripplanner.routing.framework.DebugTimingAggregator;
+import org.opentripplanner.service.paging.PagingService;
+
+class RoutingResponseMapperTest {
+
+  private static final Instant DATE_TIME = Instant.parse("2026-07-28T12:00:00Z");
+  private static final PageCursor NEXT_PAGE_CURSOR = pageCursor(PageType.NEXT_PAGE);
+  private static final PageCursor PREVIOUS_PAGE_CURSOR = pageCursor(PageType.PREVIOUS_PAGE);
+
+  @Test
+  void pageCursorsAreReturnedForARegularSearch() {
+    var request = RouteRequest.of()
+      .withFrom(GenericLocation.fromCoordinate(60.0, 25.0))
+      .withTo(GenericLocation.fromCoordinate(60.1, 25.1))
+      .withDateTime(DATE_TIME)
+      .buildRequest();
+
+    var response = map(request);
+
+    assertEquals(NEXT_PAGE_CURSOR, response.getNextPageCursor());
+    assertEquals(PREVIOUS_PAGE_CURSOR, response.getPreviousPageCursor());
+  }
+
+  /**
+   * A start-on-board search is pinned to the boarding time of a single dated trip, so there are
+   * no other pages and no page cursors should be returned.
+   */
+  @Test
+  void pageCursorsAreOmittedForAStartOnBoardSearch() {
+    var tripLocation = TripLocation.of(
+      TripOnDateReference.ofTripIdAndServiceDate(
+        new FeedScopedId("F", "trip-1"),
+        LocalDate.of(2026, 7, 28)
+      ),
+      new FeedScopedId("F", "stop-1")
+    );
+    var request = RouteRequest.of()
+      .withFrom(GenericLocation.fromTripLocation(tripLocation))
+      .withTo(GenericLocation.fromCoordinate(60.1, 25.1))
+      .withDateTime(DATE_TIME)
+      .buildRequest();
+
+    var response = map(request);
+
+    assertNull(response.getNextPageCursor());
+    assertNull(response.getPreviousPageCursor());
+  }
+
+  private static RoutingResponse map(RouteRequest request) {
+    var pagingService = mock(PagingService.class);
+    when(pagingService.nextPageCursor()).thenReturn(NEXT_PAGE_CURSOR);
+    when(pagingService.previousPageCursor()).thenReturn(PREVIOUS_PAGE_CURSOR);
+
+    return RoutingResponseMapper.map(
+      request,
+      List.of(),
+      Set.of(),
+      new DebugTimingAggregator(),
+      null,
+      pagingService
+    );
+  }
+
+  private static PageCursor pageCursor(PageType type) {
+    return new PageCursor(
+      type,
+      SortOrder.STREET_AND_ARRIVAL_TIME,
+      DATE_TIME,
+      null,
+      Duration.ofMinutes(30),
+      null,
+      null
+    );
+  }
+}


### PR DESCRIPTION
### Summary

Adds an on-board trip origin to the GTFS GraphQL `planConnection` query. It exposes OTP's existing start-on-board routing support without changing the routing core.

### Issue

Closes #7266 and complements #7429, which added the same capability to the Transmodel API. The motivating client use case is OneBusAway/onebusaway-android#2057: re-plan a journey while the rider is already aboard a vehicle.

The new `tripLocation` input identifies the dated trip and rider position, following the input design proposed in #7266. The dated trip is identified by a nested `tripReference` (`@oneOf`): either a GTFS trip ID with a service date, or the unique ID of a dated trip as used by NeTEx data sources. The rider position is a stop ID plus an optional scheduled departure time, which disambiguates patterns that visit the same stop more than once.

The mapper converts this input into OTP's existing `TripOnDateReference`, `TripLocation` and `GenericLocation` types. The existing request preprocessor and RAPTOR implementation handle everything after that boundary.

### Error handling and restrictions

Trip locations are supported only as origins. Because `PlanLocationInput` is shared, the field is visible on destination input even though arriving on board is not supported; an on-board destination is rejected with a client error.

- Invalid routing input detected while resolving the request (an unknown trip, a stop not served by the trip, a malformed ID) is reported as a `BadRequestError` naming the problem, matching the Transmodel API behavior.
- Validation failures raised before the routing worker runs, such as the ambiguous-stop error `TRIP_LOCATION_MISSING_SCHEDULED_DEPARTURE_TIME`, are returned in `planConnection.routingErrors` on an otherwise empty plan.
- An arrive-by search (`latestArrival`) combined with an on-board origin is rejected as a client error; #7266 defers arrive-by support.
- Paging is not supported: a start-on-board search is pinned to the boarding time of a single dated trip, so `before`/`after` are rejected as client errors and the response contains no page cursors. The cursor suppression is done in the core response mapper, so the Transmodel API also stops emitting unusable cursors for on-board searches.

### Unit tests

- Mapper tests covering the complete on-board `TripLocation`, the dated-trip-ID reference variant, omitted departure time, malformed IDs, and the arrive-by and paging rejections.
- Tests for the ambiguous-stop GraphQL error mapping and the `planConnection` error translation (client errors and routing errors).
- A core test that page cursors are returned for regular searches and omitted for start-on-board searches.
- Locally passed the mapper, schema, GraphQL formatting, integration and paging tests, Checkstyle and `git diff --check`.

No manual server or performance testing was performed. No material performance impact is expected because the routing path already existed.

### Documentation

The GraphQL schema documents the new inputs, their fields, the routing error, the `planConnection.origin` option, and the restrictions (ignored `dateTime`/`searchWindow`, no arrive-by, no paging). No configuration options or new public Java APIs were added.

### Changelog

This is a user-visible GTFS GraphQL API addition. The PR title is suitable for the generated changelog.

### Bumping the serialization version id

No serialized routing graph fields or types were changed.
