### PR TITLE
Add pickup/drop off filter to canceledCalls

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -18,6 +18,7 @@ import org.opentripplanner.apis.gtfs.GraphQLRequestContext;
 import org.opentripplanner.apis.gtfs.GraphQLUtils;
 import org.opentripplanner.apis.gtfs.generated.GraphQLDataFetchers;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.gtfs.mapping.ArrivalDepartureMapper;
 import org.opentripplanner.apis.gtfs.model.StopCallOnTripOnServiceDate;
 import org.opentripplanner.apis.gtfs.service.ApiTransitService;
 import org.opentripplanner.apis.gtfs.support.filter.PatternByDateFilterUtil;
@@ -142,9 +143,7 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
       var serviceDateRanges = rawRanges == null
         ? List.of(LocalDateRange.ofUnbounded())
         : LocalDateRangeUtil.mapRanges(rawRanges);
-      var arrivalDeparture = args.getGraphQLOmitNonPickups()
-        ? ArrivalDeparture.DEPARTURES
-        : ArrivalDeparture.BOTH;
+      var arrivalDeparture = ArrivalDepartureMapper.map(args.getGraphQLArrivalDeparture());
       var service = new ApiTransitService(getTransitService(environment));
       return getValue(
         environment,

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -142,15 +142,20 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
       var serviceDateRanges = rawRanges == null
         ? List.of(LocalDateRange.ofUnbounded())
         : LocalDateRangeUtil.mapRanges(rawRanges);
+      var arrivalDeparture = args.getGraphQLOmitNonPickups()
+        ? ArrivalDeparture.DEPARTURES
+        : ArrivalDeparture.BOTH;
       var service = new ApiTransitService(getTransitService(environment));
       return getValue(
         environment,
-        stop -> service.findCanceledStopCalls(stop, serviceDateRanges),
+        stop -> service.findCanceledStopCalls(stop, serviceDateRanges, arrivalDeparture),
         station ->
           station
             .getChildStops()
             .stream()
-            .flatMap(stop -> service.findCanceledStopCalls(stop, serviceDateRanges).stream())
+            .flatMap(stop ->
+              service.findCanceledStopCalls(stop, serviceDateRanges, arrivalDeparture).stream()
+            )
             .collect(Collectors.toList())
       );
     };

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -549,6 +549,12 @@ public class GraphQLDataFetchers {
     }
   }
 
+  /**
+   * A textual message about a transit entity that is already known at planning time.
+   *
+   * It is not intended to convey real-time or emergency updates of the transit system but information that
+   * is known well ahead of time.
+   */
   public interface GraphQLNotice {
     public DataFetcher<String> text();
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -190,6 +190,13 @@ public class GraphQLTypes {
     }
   }
 
+  /** Enum for limiting the returned calls depending on pickup/drop off status on a stop. */
+  public enum GraphQLArrivalDeparture {
+    ARRIVALS,
+    DEPARTURES,
+    EITHER,
+  }
+
   public static class GraphQLBicycleParkingPreferencesInput {
 
     private List<GraphQLParkingFilterInput> filters;
@@ -5093,12 +5100,18 @@ public class GraphQLTypes {
 
   public static class GraphQLStopCanceledCallsArgs {
 
-    private Boolean omitNonPickups;
+    private GraphQLArrivalDeparture arrivalDeparture;
     private List<GraphQLLocalDateRangeInput> serviceDateRanges;
 
     public GraphQLStopCanceledCallsArgs(Map<String, Object> args) {
       if (args != null) {
-        this.omitNonPickups = (Boolean) args.get("omitNonPickups");
+        if (args.get("arrivalDeparture") instanceof GraphQLArrivalDeparture) {
+          this.arrivalDeparture = (GraphQLArrivalDeparture) args.get("arrivalDeparture");
+        } else if (args.get("arrivalDeparture") != null) {
+          this.arrivalDeparture = GraphQLArrivalDeparture.valueOf(
+            (String) args.get("arrivalDeparture")
+          );
+        }
         if (args.get("serviceDateRanges") != null) {
           this.serviceDateRanges = ((List<Map<String, Object>>) args.get(
               "serviceDateRanges"
@@ -5109,16 +5122,16 @@ public class GraphQLTypes {
       }
     }
 
-    public Boolean getGraphQLOmitNonPickups() {
-      return this.omitNonPickups;
+    public GraphQLArrivalDeparture getGraphQLArrivalDeparture() {
+      return this.arrivalDeparture;
     }
 
     public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
       return this.serviceDateRanges;
     }
 
-    public void setGraphQLOmitNonPickups(Boolean omitNonPickups) {
-      this.omitNonPickups = omitNonPickups;
+    public void setGraphQLArrivalDeparture(GraphQLArrivalDeparture arrivalDeparture) {
+      this.arrivalDeparture = arrivalDeparture;
     }
 
     public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -5093,10 +5093,12 @@ public class GraphQLTypes {
 
   public static class GraphQLStopCanceledCallsArgs {
 
+    private Boolean omitNonPickups;
     private List<GraphQLLocalDateRangeInput> serviceDateRanges;
 
     public GraphQLStopCanceledCallsArgs(Map<String, Object> args) {
       if (args != null) {
+        this.omitNonPickups = (Boolean) args.get("omitNonPickups");
         if (args.get("serviceDateRanges") != null) {
           this.serviceDateRanges = ((List<Map<String, Object>>) args.get(
               "serviceDateRanges"
@@ -5107,8 +5109,16 @@ public class GraphQLTypes {
       }
     }
 
+    public Boolean getGraphQLOmitNonPickups() {
+      return this.omitNonPickups;
+    }
+
     public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
       return this.serviceDateRanges;
+    }
+
+    public void setGraphQLOmitNonPickups(Boolean omitNonPickups) {
+      this.omitNonPickups = omitNonPickups;
     }
 
     public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -190,7 +190,10 @@ public class GraphQLTypes {
     }
   }
 
-  /** Enum for limiting the returned calls depending on pickup/drop off status on a stop. */
+  /**
+   * Enum for limiting the returned calls depending on pickup/drop off status on a stop
+   * based on the original schedules.
+   */
   public enum GraphQLArrivalDeparture {
     ARRIVALS,
     DEPARTURES,

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/ArrivalDepartureMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/ArrivalDepartureMapper.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.apis.gtfs.mapping;
+
+import javax.annotation.Nullable;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLArrivalDeparture;
+import org.opentripplanner.transit.service.ArrivalDeparture;
+
+/**
+ * Maps the GraphQL API's {@code ArrivalDeparture} enum onto the internal {@link ArrivalDeparture}.
+ */
+public final class ArrivalDepartureMapper {
+
+  /**
+   * Maps the API enum to the internal one. If no value is given, calls that either allow pickup
+   * or drop off are included by returning {@link ArrivalDeparture#BOTH}.
+   */
+  public static ArrivalDeparture map(@Nullable GraphQLArrivalDeparture arrivalDeparture) {
+    if (arrivalDeparture == null) {
+      return ArrivalDeparture.BOTH;
+    }
+    return switch (arrivalDeparture) {
+      case ARRIVALS -> ArrivalDeparture.ARRIVALS;
+      case EITHER -> ArrivalDeparture.BOTH;
+      case DEPARTURES -> ArrivalDeparture.DEPARTURES;
+    };
+  }
+}

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
@@ -92,17 +92,19 @@ public class ApiTransitService {
   /**
    * Find the canceled stop calls at the given stop. A call is included if either the trip it
    * belongs to has been canceled, or the visit at this stop has been canceled (skipped). Only calls
-   * whose trip's service date is within any of the given service date ranges are returned. Each
+   * whose trip's service date is within any of the given service date ranges are returned. The
+   * {@code arrivalDeparture} parameter controls whether drop-off-only calls are included. Each
    * call is paired with the {@link TripOnServiceDate} it belongs to, which is synthesized when no
    * real one exists.
    */
   public List<StopCallOnTripOnServiceDate> findCanceledStopCalls(
     StopLocation stop,
-    List<LocalDateRange> serviceDateRanges
+    List<LocalDateRange> serviceDateRanges,
+    ArrivalDeparture arrivalDeparture
   ) {
     var request = TripTimeOnDateRequest.of(List.of(stop))
       .withServiceDateRanges(serviceDateRanges)
-      .withArrivalDeparture(ArrivalDeparture.BOTH)
+      .withArrivalDeparture(arrivalDeparture)
       .withNumberOfDepartures(Integer.MAX_VALUE)
       .withCancellationPolicy(CancellationPolicy.ONLY_CANCELLATIONS)
       .build();

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2401,6 +2401,8 @@ type Stop implements Node & PlaceInterface {
   Sunday morning at 1am to 3am, might have the previous Saturday's service date.
   """
   canceledCalls(
+    "If true, only those departures which allow boarding are returned"
+    omitNonPickups: Boolean = false,
     """
     Only include canceled calls whose trip's service date is within any of these date ranges.
     If omitted (or `null`), no service date filter is applied and canceled calls across the entire

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2401,8 +2401,11 @@ type Stop implements Node & PlaceInterface {
   Sunday morning at 1am to 3am, might have the previous Saturday's service date.
   """
   canceledCalls(
-    "If true, only those departures which allow boarding are returned"
-    omitNonPickups: Boolean = false,
+    """
+    Selects if only calls where boarding is allowed, only calls where alighting is allowed, or calls
+    where either boarding or alighting is possible.
+    """
+    arrivalDeparture: ArrivalDeparture = EITHER,
     """
     Only include canceled calls whose trip's service date is within any of these date ranges.
     If omitted (or `null`), no service date filter is applied and canceled calls across the entire
@@ -3375,6 +3378,16 @@ enum AlertSeverityLevelType {
   with irregular schedules.
   """
   WARNING
+}
+
+"Enum for limiting the returned calls depending on pickup/drop off status on a stop."
+enum ArrivalDeparture {
+  "Only include calls where alighting from the vehicle is allowed."
+  ARRIVALS
+  "Only include calls where boarding the vehicle is allowed."
+  DEPARTURES
+  "Include calls where either boarding or alighting is allowed."
+  EITHER
 }
 
 enum BikesAllowed {

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2403,7 +2403,7 @@ type Stop implements Node & PlaceInterface {
   canceledCalls(
     """
     Selects if only calls where boarding is allowed, only calls where alighting is allowed, or calls
-    where either boarding or alighting is possible.
+    where either boarding or alighting is possible (according to the original schedule).
     """
     arrivalDeparture: ArrivalDeparture = EITHER,
     """
@@ -3380,7 +3380,10 @@ enum AlertSeverityLevelType {
   WARNING
 }
 
-"Enum for limiting the returned calls depending on pickup/drop off status on a stop."
+"""
+Enum for limiting the returned calls depending on pickup/drop off status on a stop
+based on the original schedules.
+"""
 enum ArrivalDeparture {
   "Only include calls where alighting from the vehicle is allowed."
   ARRIVALS

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/ArrivalDepartureMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/ArrivalDepartureMapperTest.java
@@ -1,21 +1,25 @@
 package org.opentripplanner.apis.gtfs.mapping;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLArrivalDeparture;
 import org.opentripplanner.transit.service.ArrivalDeparture;
 
 class ArrivalDepartureMapperTest {
 
-  @ParameterizedTest
-  @EnumSource(GraphQLArrivalDeparture.class)
-  void mapAllValues(GraphQLArrivalDeparture graphQLValue) {
-    assertThat(ArrivalDepartureMapper.map(graphQLValue)).isEqualTo(
-      ArrivalDeparture.valueOf(graphQLValue.name())
+  @Test
+  void mapAllValues() {
+    assertEquals(
+      ArrivalDeparture.ARRIVALS,
+      ArrivalDepartureMapper.map(GraphQLArrivalDeparture.ARRIVALS)
     );
+    assertEquals(
+      ArrivalDeparture.DEPARTURES,
+      ArrivalDepartureMapper.map(GraphQLArrivalDeparture.DEPARTURES)
+    );
+    assertEquals(ArrivalDeparture.BOTH, ArrivalDepartureMapper.map(GraphQLArrivalDeparture.EITHER));
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/ArrivalDepartureMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/ArrivalDepartureMapperTest.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.apis.gtfs.mapping;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLArrivalDeparture;
+import org.opentripplanner.transit.service.ArrivalDeparture;
+
+class ArrivalDepartureMapperTest {
+
+  @ParameterizedTest
+  @EnumSource(GraphQLArrivalDeparture.class)
+  void mapAllValues(GraphQLArrivalDeparture graphQLValue) {
+    assertThat(ArrivalDepartureMapper.map(graphQLValue)).isEqualTo(
+      ArrivalDeparture.valueOf(graphQLValue.name())
+    );
+  }
+
+  @Test
+  void nullDefaultsToBoth() {
+    assertThat(ArrivalDepartureMapper.map(null)).isEqualTo(ArrivalDeparture.BOTH);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.gtfs.service;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
@@ -188,9 +189,7 @@ class ApiTransitServiceTest {
       )
     ).isEmpty();
 
-    var update = rt
-      .tripUpdate(TRIP_1_ID, GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED)
-      .build();
+    var update = rt.tripUpdate(TRIP_1_ID, CANCELED).build();
     assertSuccess(rt.applyTripUpdate(update));
 
     var service = new ApiTransitService(env.transitService());
@@ -237,9 +236,7 @@ class ApiTransitServiceTest {
     var env = envBuilder.addTrip(TRIP1_INPUT).build();
     var rt = GtfsRtTestHelper.of(env);
 
-    var update = rt
-      .tripUpdate(TRIP_1_ID, GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED)
-      .build();
+    var update = rt.tripUpdate(TRIP_1_ID, CANCELED).build();
     assertSuccess(rt.applyTripUpdate(update));
 
     var service = new ApiTransitService(env.transitService());
@@ -270,9 +267,7 @@ class ApiTransitServiceTest {
     var env = envBuilder.addTrip(tripInput).build();
     var rt = GtfsRtTestHelper.of(env);
 
-    var update = rt
-      .tripUpdate("TestTrip3", GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED)
-      .build();
+    var update = rt.tripUpdate("TestTrip3", CANCELED).build();
     assertSuccess(rt.applyTripUpdate(update));
 
     var service = new ApiTransitService(env.transitService());

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -16,6 +16,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
 import org.opentripplanner.model.plan.leg.StreetLeg;
@@ -180,7 +181,11 @@ class ApiTransitServiceTest {
     var rt = GtfsRtTestHelper.of(env);
 
     assertThat(
-      new ApiTransitService(env.transitService()).findCanceledStopCalls(STOP_B, SERVICE_DATE_RANGES)
+      new ApiTransitService(env.transitService()).findCanceledStopCalls(
+        STOP_B,
+        SERVICE_DATE_RANGES,
+        ArrivalDeparture.BOTH
+      )
     ).isEmpty();
 
     var update = rt
@@ -189,7 +194,7 @@ class ApiTransitServiceTest {
     assertSuccess(rt.applyTripUpdate(update));
 
     var service = new ApiTransitService(env.transitService());
-    var calls = service.findCanceledStopCalls(STOP_B, SERVICE_DATE_RANGES);
+    var calls = service.findCanceledStopCalls(STOP_B, SERVICE_DATE_RANGES, ArrivalDeparture.BOTH);
     assertThat(calls).hasSize(1);
     var call = calls.getFirst();
     assertEquals(TRIP_1_ID, call.stopCall().getTrip().getId().getId());
@@ -211,14 +216,20 @@ class ApiTransitServiceTest {
     var service = new ApiTransitService(env.transitService());
 
     // The skipped visit at STOP_B is returned
-    var skippedCalls = service.findCanceledStopCalls(STOP_B, SERVICE_DATE_RANGES);
+    var skippedCalls = service.findCanceledStopCalls(
+      STOP_B,
+      SERVICE_DATE_RANGES,
+      ArrivalDeparture.BOTH
+    );
     assertThat(skippedCalls).hasSize(1);
     var call = skippedCalls.getFirst();
     assertEquals(TRIP_1_ID, call.stopCall().getTrip().getId().getId());
     assertThat(call.stopCall().isCancelledStop()).isTrue();
 
     // Stops that are not skipped and whose trip is not canceled are not returned
-    assertThat(service.findCanceledStopCalls(STOP_A, SERVICE_DATE_RANGES)).isEmpty();
+    assertThat(
+      service.findCanceledStopCalls(STOP_A, SERVICE_DATE_RANGES, ArrivalDeparture.BOTH)
+    ).isEmpty();
   }
 
   @Test
@@ -237,13 +248,43 @@ class ApiTransitServiceTest {
     var outsideRange = List.of(
       LocalDateRange.ofExclusiveEnd(SERVICE_DATE.plusDays(1), SERVICE_DATE.plusDays(2))
     );
-    assertThat(service.findCanceledStopCalls(STOP_B, outsideRange)).isEmpty();
+    assertThat(
+      service.findCanceledStopCalls(STOP_B, outsideRange, ArrivalDeparture.BOTH)
+    ).isEmpty();
 
     // Range that includes the service date returns the canceled call
     var insideRange = List.of(
       LocalDateRange.ofExclusiveEnd(SERVICE_DATE, SERVICE_DATE.plusDays(1))
     );
-    assertThat(service.findCanceledStopCalls(STOP_B, insideRange)).hasSize(1);
+    assertThat(service.findCanceledStopCalls(STOP_B, insideRange, ArrivalDeparture.BOTH)).hasSize(
+      1
+    );
+  }
+
+  @Test
+  void canceledStopCallsOmitNonPickups() {
+    // TRIP_3 stops at STOP_C for drop-off only (no boarding/pickup allowed).
+    var tripInput = TripInput.of("TestTrip3")
+      .addStop(STOP_A, "12:00:00", "12:00:00", PickDrop.SCHEDULED, PickDrop.SCHEDULED)
+      .addStop(STOP_C, "12:30:00", "12:30:00", PickDrop.NONE, PickDrop.SCHEDULED);
+    var env = envBuilder.addTrip(tripInput).build();
+    var rt = GtfsRtTestHelper.of(env);
+
+    var update = rt
+      .tripUpdate("TestTrip3", GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED)
+      .build();
+    assertSuccess(rt.applyTripUpdate(update));
+
+    var service = new ApiTransitService(env.transitService());
+
+    // The drop-off-only visit at STOP_C is returned with BOTH but omitted when only departures
+    // (pickups) are requested.
+    assertThat(
+      service.findCanceledStopCalls(STOP_C, SERVICE_DATE_RANGES, ArrivalDeparture.BOTH)
+    ).hasSize(1);
+    assertThat(
+      service.findCanceledStopCalls(STOP_C, SERVICE_DATE_RANGES, ArrivalDeparture.DEPARTURES)
+    ).isEmpty();
   }
 
   private static GtfsRealtime.TripUpdate skipSecondStop(TripUpdateBuilder builder) {

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
@@ -23,6 +23,7 @@
     }
     canceledCalls(
       serviceDateRanges: [{ start: "2024-08-08", end: "2024-08-10" }]
+      arrivalDeparture: BOTH
     ) {
       tripOnServiceDate {
         serviceDate

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
@@ -23,7 +23,7 @@
     }
     canceledCalls(
       serviceDateRanges: [{ start: "2024-08-08", end: "2024-08-10" }]
-      arrivalDeparture: BOTH
+      arrivalDeparture: EITHER
     ) {
       tripOnServiceDate {
         serviceDate


### PR DESCRIPTION
### Summary

Adds `arrivalDeparture` filter to the `canceledCalls` fields of the `Stop` type in the GTFS API.

### Issue

No issue

### Unit tests

Added

### Documentation

No

### Changelog

From title