### PR TITLE
Migrate all smaller resources to the new Dagger bridge - Part 1/6

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/vectortiles/VectorTilesResourceTest.java
@@ -18,13 +18,18 @@ class VectorTilesResourceTest {
   void tileJson() {
     // the Grizzly request is awful to instantiate, using Mockito
     var grizzlyRequest = Mockito.mock(Request.class);
+    var serverContext = TestServerContext.createServerContext(
+      new Graph(),
+      new TransitRepository(),
+      TransferServiceTestFactory.defaultTransferRepository(),
+      new DefaultFareService()
+    );
     var resource = new VectorTilesResource(
-      TestServerContext.createServerContext(
-        new Graph(),
-        new TransitRepository(),
-        TransferServiceTestFactory.defaultTransferRepository(),
-        new DefaultFareService()
-      ),
+      serverContext.transitService(),
+      serverContext.vectorTileConfig(),
+      serverContext.worldEnvelopeService(),
+      serverContext.vehicleRentalService(),
+      serverContext.vehicleParkingService(),
       grizzlyRequest,
       "default"
     );

--- a/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/api/resource/DebugRasterTileResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/debugrastertiles/api/resource/DebugRasterTileResource.java
@@ -15,7 +15,8 @@ import org.opentripplanner.api.resource.WebMercatorTile;
 import org.opentripplanner.ext.debugrastertiles.MapTile;
 import org.opentripplanner.ext.debugrastertiles.TileRenderer;
 import org.opentripplanner.ext.debugrastertiles.TileRendererManager;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.street.graph.Graph;
 
 /**
  * Slippy raster map tile API for rendering various graph information for inspection/debugging
@@ -34,10 +35,10 @@ public class DebugRasterTileResource {
 
   private final TileRendererManager tileRendererManager;
 
-  public DebugRasterTileResource(@Context OtpServerRequestContext serverContext) {
+  public DebugRasterTileResource(@Context Graph graph, @Context RouteRequest defaultRouteRequest) {
     this.tileRendererManager = new TileRendererManager(
-      serverContext.graph(),
-      serverContext.defaultRouteRequest().preferences().wheelchair()
+      graph,
+      defaultRouteRequest.preferences().wheelchair()
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/geocoder/GeocoderResource.java
@@ -8,7 +8,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.Map;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import javax.annotation.Nullable;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 
 /**
@@ -20,8 +20,8 @@ public class GeocoderResource {
 
   private final LuceneIndex luceneIndex;
 
-  public GeocoderResource(@Context OtpServerRequestContext requestContext) {
-    luceneIndex = requestContext.lucenceIndex();
+  public GeocoderResource(@Context @Nullable LuceneIndex luceneIndex) {
+    this.luceneIndex = luceneIndex;
   }
 
   @GET

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/resource/OjpResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/resource/OjpResource.java
@@ -16,8 +16,14 @@ import org.opentripplanner.ext.ojp.RequestHandler;
 import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
 import org.opentripplanner.ext.ojp.service.CallAtStopService;
 import org.opentripplanner.ext.ojp.service.OjpService;
+import org.opentripplanner.place.NearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StreetNearbyStopFinder;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,10 +49,21 @@ public class OjpResource {
   private final RequestHandler handler;
   private final RouteRequest defaultRouteRequest;
 
-  public OjpResource(@Context OtpServerRequestContext context) {
-    var transitService = context.transitService();
-    var callAtStopService = new CallAtStopService(transitService, context.nearbyStopFinder());
-    var idMapper = idMapper(context.ojpApiParameters());
+  public OjpResource(
+    @Context TransitService transitService,
+    @Context Graph graph,
+    @Context LinkingContextFactory linkingContextFactory,
+    @Context OjpApiParameters ojpApiParameters,
+    @Context RouteRequest defaultRouteRequest,
+    // Only RoutingService still requires the whole context - it isn't independently
+    // request-scoped/bindable yet, see issue #7441.
+    @Context OtpServerRequestContext context
+  ) {
+    NearbyStopFinder nearbyStopFinder = graph.hasStreets
+      ? StreetNearbyStopFinder.of(linkingContextFactory).build()
+      : new StraightLineNearbyStopFinder(transitService::findRegularStopsByBoundingBox);
+    var callAtStopService = new CallAtStopService(transitService, nearbyStopFinder);
+    var idMapper = idMapper(ojpApiParameters);
     var ojpService = new OjpService(
       callAtStopService,
       context.routingService(),
@@ -54,7 +71,7 @@ public class OjpResource {
       transitService.getTimeZone()
     );
     this.handler = new RequestHandler(ojpService, OjpCodec::serialize, "OJP");
-    this.defaultRouteRequest = context.defaultRouteRequest();
+    this.defaultRouteRequest = defaultRouteRequest;
   }
 
   @POST

--- a/application/src/ext/java/org/opentripplanner/ext/ojp/resource/TriasResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/ojp/resource/TriasResource.java
@@ -24,8 +24,14 @@ import org.opentripplanner.ext.ojp.RequestHandler;
 import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.ext.ojp.service.CallAtStopService;
 import org.opentripplanner.ext.ojp.service.OjpService;
+import org.opentripplanner.place.NearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
+import org.opentripplanner.place.nearbystopfinder.StreetNearbyStopFinder;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,11 +46,21 @@ public class TriasResource {
 
   private final RequestHandler handler;
 
-  public TriasResource(@Context OtpServerRequestContext context) {
-    var transitService = context.transitService();
-    var zoneId = context.triasApiParameters().timeZone().orElse(transitService.getTimeZone());
-    var service = new CallAtStopService(transitService, context.nearbyStopFinder());
-    var idMapper = idMapper(context.triasApiParameters());
+  public TriasResource(
+    @Context TransitService transitService,
+    @Context Graph graph,
+    @Context LinkingContextFactory linkingContextFactory,
+    @Context TriasApiParameters triasApiParameters,
+    // Only RoutingService still requires the whole context - it isn't independently
+    // request-scoped/bindable yet, see issue #7441.
+    @Context OtpServerRequestContext context
+  ) {
+    var zoneId = triasApiParameters.timeZone().orElse(transitService.getTimeZone());
+    NearbyStopFinder nearbyStopFinder = graph.hasStreets
+      ? StreetNearbyStopFinder.of(linkingContextFactory).build()
+      : new StraightLineNearbyStopFinder(transitService::findRegularStopsByBoundingBox);
+    var service = new CallAtStopService(transitService, nearbyStopFinder);
+    var idMapper = idMapper(triasApiParameters);
     var serviceMapper = new OjpService(service, context.routingService(), idMapper, zoneId);
     this.handler = new RequestHandler(serviceMapper, TriasResource::ojpToTrias, "TRIAS");
   }

--- a/application/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
@@ -16,7 +16,7 @@ import org.opentripplanner.place.NearbyStopFinder;
 import org.opentripplanner.place.nearbystopfinder.StraightLineNearbyStopFinder;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehicleparking.model.VehicleParking;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Created by demory on 7/26/18.
@@ -29,20 +29,21 @@ public class ParkAndRideResource {
   private final NearbyStopFinder nearbyStopFinder;
 
   public ParkAndRideResource(
-    @Context OtpServerRequestContext serverContext,
+    @Context VehicleParkingService vehicleParkingService,
+    @Context TransitService transitService,
     /**
      * @deprecated The support for multiple routers are removed from OTP2.
      * See https://github.com/opentripplanner/OpenTripPlanner/issues/2760
      */
     @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
   ) {
-    this.vehicleParkingService = serverContext.vehicleParkingService();
+    this.vehicleParkingService = vehicleParkingService;
 
     // TODO OTP2 - Why are we using the StraightLineNearbyStopFinder here
     //           - This can be replaced with a search done with the SiteRepository
     //           - if we have a radius search there.
     this.nearbyStopFinder = new StraightLineNearbyStopFinder(
-      serverContext.transitService()::findRegularStopsByBoundingBox
+      transitService::findRegularStopsByBoundingBox
     );
   }
 

--- a/application/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
@@ -4,13 +4,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transit.service.TransitService;
 
 public class GraphReportBuilder {
 
-  public static GraphStats build(OtpServerRequestContext context) {
-    var transitService = context.transitService();
-    var graph = context.graph();
+  public static GraphStats build(TransitService transitService, Graph graph) {
     var constrainedTransfers = transitService.getConstrainedTransferService().listAll();
 
     var constrainedTransferCounts = countValues(constrainedTransfers, transfer -> {

--- a/application/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -13,7 +13,7 @@ import org.opentripplanner.ext.reportapi.model.GraphReportBuilder.GraphStats;
 import org.opentripplanner.ext.reportapi.model.TransfersReport;
 import org.opentripplanner.ext.reportapi.model.TransitGroupPriorityReport;
 import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.constrained.ConstrainedTransferService;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -29,12 +29,18 @@ public class ReportResource {
   private final ConstrainedTransferService transferService;
   private final TransitService transitService;
   private final RouteRequest defaultRequest;
+  private final Graph graph;
 
   @SuppressWarnings("unused")
-  public ReportResource(@Context OtpServerRequestContext requestContext) {
-    this.transferService = requestContext.transitService().getConstrainedTransferService();
-    this.transitService = requestContext.transitService();
-    this.defaultRequest = requestContext.defaultRouteRequest();
+  public ReportResource(
+    @Context TransitService transitService,
+    @Context RouteRequest defaultRequest,
+    @Context Graph graph
+  ) {
+    this.transferService = transitService.getConstrainedTransferService();
+    this.transitService = transitService;
+    this.defaultRequest = defaultRequest;
+    this.graph = graph;
   }
 
   @GET
@@ -56,9 +62,9 @@ public class ReportResource {
 
   @GET
   @Path("/graph.json")
-  public Response stats(@Context OtpServerRequestContext serverRequestContext) {
+  public Response stats() {
     return Response.status(Response.Status.OK)
-      .entity(CACHED_STATS.get(() -> GraphReportBuilder.build(serverRequestContext)))
+      .entity(CACHED_STATS.get(() -> GraphReportBuilder.build(transitService, graph)))
       .type("application/json")
       .build();
   }

--- a/application/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -31,17 +31,29 @@ import org.opentripplanner.inspector.vector.LayerBuilder;
 import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.inspector.vector.VectorTileResponseFactory;
 import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.vehicleparking.VehicleParkingService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
+import org.opentripplanner.transit.service.TransitService;
 
 @Path("/routers/{ignoreRouterId}/vectorTiles")
 public class VectorTilesResource {
 
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final VectorTileConfig vectorTileConfig;
+  private final WorldEnvelopeService worldEnvelopeService;
+  private final VehicleRentalService vehicleRentalService;
+  private final VehicleParkingService vehicleParkingService;
   private final String ignoreRouterId;
   private final Locale locale;
 
   public VectorTilesResource(
-    @Context OtpServerRequestContext serverContext,
+    @Context TransitService transitService,
+    @Context VectorTileConfig vectorTileConfig,
+    @Context WorldEnvelopeService worldEnvelopeService,
+    @Context VehicleRentalService vehicleRentalService,
+    @Context VehicleParkingService vehicleParkingService,
     @Context Request grizzlyRequest,
     /**
      * @deprecated The support for multiple routers are removed from OTP2.
@@ -50,7 +62,11 @@ public class VectorTilesResource {
     @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
   ) {
     this.locale = grizzlyRequest.getLocale();
-    this.serverContext = serverContext;
+    this.transitService = transitService;
+    this.vectorTileConfig = vectorTileConfig;
+    this.worldEnvelopeService = worldEnvelopeService;
+    this.vehicleRentalService = vehicleRentalService;
+    this.vehicleParkingService = vehicleParkingService;
     this.ignoreRouterId = ignoreRouterId;
   }
 
@@ -69,9 +85,9 @@ public class VectorTilesResource {
       z,
       locale,
       Arrays.asList(requestedLayers.split(",")),
-      serverContext.vectorTileConfig().layers(),
+      vectorTileConfig.layers(),
       VectorTilesResource::createLayerBuilder,
-      serverContext
+      new LayerBuilderContext(transitService, vehicleRentalService, vehicleParkingService)
     );
   }
 
@@ -83,11 +99,11 @@ public class VectorTilesResource {
     @Context HttpHeaders headers,
     @PathParam("layers") String requestedLayers
   ) {
-    var envelope = serverContext.worldEnvelopeService().envelope().orElseThrow();
+    var envelope = worldEnvelopeService.envelope().orElseThrow();
 
     List<String> rLayers = Arrays.asList(requestedLayers.split(","));
 
-    var config = serverContext.vectorTileConfig();
+    var config = vectorTileConfig;
     var url = config
       .basePath()
       .map(overrideBasePath ->
@@ -109,11 +125,10 @@ public class VectorTilesResource {
   }
 
   private List<FeedInfo> getFeedInfos() {
-    return serverContext
-      .transitService()
+    return transitService
       .listFeedIds()
       .stream()
-      .map(serverContext.transitService()::getFeedInfo)
+      .map(transitService::getFeedInfo)
       .filter(Predicate.not(Objects::isNull))
       .toList();
   }
@@ -121,7 +136,7 @@ public class VectorTilesResource {
   private static LayerBuilder<?> createLayerBuilder(
     LayerParameters<LayerType> layerParameters,
     Locale locale,
-    OtpServerRequestContext context
+    LayerBuilderContext context
   ) {
     return switch (layerParameters.type()) {
       case Stop -> new StopsLayerBuilder(context.transitService(), layerParameters, locale);
@@ -168,4 +183,12 @@ public class VectorTilesResource {
   public interface LayersParameters<T extends Enum<T>> {
     List<LayerParameters<T>> layers();
   }
+
+  /** The subset of services {@link #createLayerBuilder} needs, passed through {@link
+   * VectorTileResponseFactory#create} as its generic context parameter. */
+  private record LayerBuilderContext(
+    TransitService transitService,
+    VehicleRentalService vehicleRentalService,
+    VehicleParkingService vehicleParkingService
+  ) {}
 }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/configure/SchemaModule.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/configure/SchemaModule.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.SchemaFactory;
 import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.standalone.configure.StaticRouteRequestDefaults;
 
 /**
  * The schema is used during application serve phase, not loading, and it depends on the default
@@ -22,7 +23,7 @@ public class SchemaModule {
   @Singleton
   @Nullable
   @GtfsSchema
-  public GraphQLSchema provideSchema(RouteRequest defaultRouteRequest) {
+  public GraphQLSchema provideSchema(@StaticRouteRequestDefaults RouteRequest defaultRouteRequest) {
     return OTPFeature.GtfsGraphQlApi.isOn()
       ? SchemaFactory.createSchemaWithDefaultInjection(defaultRouteRequest)
       : null;

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/configure/TransmodelSchemaModule.java
@@ -13,6 +13,7 @@ import org.opentripplanner.apis.transmodel.mapping.FixedFeedIdGenerator;
 import org.opentripplanner.framework.time.ZoneIdFallback;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.config.RouterConfig;
+import org.opentripplanner.standalone.configure.StaticRouteRequestDefaults;
 import org.opentripplanner.transit.service.TransitRepository;
 
 @Module
@@ -23,7 +24,7 @@ public class TransmodelSchemaModule {
   @Nullable
   @TransmodelSchema
   public GraphQLSchema provideTransmodelSchema(
-    RouteRequest defaultRouteRequest,
+    @StaticRouteRequestDefaults RouteRequest defaultRouteRequest,
     TransitRepository transitRepository,
     RouterConfig routerConfig
   ) {

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
@@ -45,7 +45,13 @@ import org.opentripplanner.inspector.vector.stop.StopLayerBuilder;
 import org.opentripplanner.inspector.vector.transfers.TransfersLayerBuilder;
 import org.opentripplanner.inspector.vector.vertex.VertexLayerBuilder;
 import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
+import org.opentripplanner.standalone.config.DebugUiConfig;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transfer.regular.RegularTransferService;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * Slippy map vector tile API for rendering various graph information for inspection/debugging
@@ -77,10 +83,30 @@ public class DebugVectorTilesResource {
   );
   public static final String PATH = "/otp/debug/vectortiles/";
 
-  private final OtpServerRequestContext serverContext;
+  private final TransitService transitService;
+  private final Graph graph;
+  private final DebugUiConfig debugUiConfig;
+  private final WorldEnvelopeService worldEnvelopeService;
+  private final VehicleRentalService vehicleRentalService;
+  private final StreetDetailsService streetDetailsService;
+  private final RegularTransferService transferService;
 
-  public DebugVectorTilesResource(@Context OtpServerRequestContext serverContext) {
-    this.serverContext = serverContext;
+  public DebugVectorTilesResource(
+    @Context TransitService transitService,
+    @Context Graph graph,
+    @Context DebugUiConfig debugUiConfig,
+    @Context WorldEnvelopeService worldEnvelopeService,
+    @Context VehicleRentalService vehicleRentalService,
+    @Context StreetDetailsService streetDetailsService,
+    @Context RegularTransferService transferService
+  ) {
+    this.transitService = transitService;
+    this.graph = graph;
+    this.debugUiConfig = debugUiConfig;
+    this.worldEnvelopeService = worldEnvelopeService;
+    this.vehicleRentalService = vehicleRentalService;
+    this.streetDetailsService = streetDetailsService;
+    this.transferService = transferService;
   }
 
   @GET
@@ -101,7 +127,13 @@ public class DebugVectorTilesResource {
       Arrays.asList(requestedLayers.split(",")),
       DEBUG_LAYERS,
       DebugVectorTilesResource::createLayerBuilder,
-      serverContext
+      new LayerBuilderContext(
+        transitService,
+        vehicleRentalService,
+        graph,
+        streetDetailsService,
+        transferService
+      )
     );
   }
 
@@ -113,7 +145,7 @@ public class DebugVectorTilesResource {
     @Context HttpHeaders headers,
     @PathParam("layers") String requestedLayers
   ) {
-    var envelope = serverContext.worldEnvelopeService().envelope().orElseThrow();
+    var envelope = worldEnvelopeService.envelope().orElseThrow();
     List<FeedInfo> feedInfos = feedInfos();
     List<String> layers = Arrays.asList(requestedLayers.split(","));
 
@@ -150,7 +182,7 @@ public class DebugVectorTilesResource {
       GEOFENCING_ZONES.toVectorSourceLayer(geofencingSource),
       RENTAL.toVectorSourceLayer(rentalSource),
       TRANSFERS.toVectorSourceLayer(transferSource),
-      serverContext.debugUiConfig().additionalBackgroundLayers()
+      debugUiConfig.additionalBackgroundLayers()
     );
   }
 
@@ -163,11 +195,10 @@ public class DebugVectorTilesResource {
   }
 
   private List<FeedInfo> feedInfos() {
-    return serverContext
-      .transitService()
+    return transitService
       .listFeedIds()
       .stream()
-      .map(serverContext.transitService()::getFeedInfo)
+      .map(transitService::getFeedInfo)
       .filter(Predicate.not(Objects::isNull))
       .toList();
   }
@@ -175,7 +206,7 @@ public class DebugVectorTilesResource {
   private static LayerBuilder<?> createLayerBuilder(
     LayerParameters<LayerType> layerParameters,
     Locale locale,
-    OtpServerRequestContext context
+    LayerBuilderContext context
   ) {
     return switch (layerParameters.type()) {
       case RegularStop -> new StopLayerBuilder<>(layerParameters, locale, e ->
@@ -208,4 +239,14 @@ public class DebugVectorTilesResource {
       );
     };
   }
+
+  /** The subset of services {@link #createLayerBuilder} needs, passed through {@link
+   * VectorTileResponseFactory#create} as its generic context parameter. */
+  private record LayerBuilderContext(
+    TransitService transitService,
+    VehicleRentalService vehicleRentalService,
+    Graph graph,
+    StreetDetailsService streetDetailsService,
+    RegularTransferService transferService
+  ) {}
 }

--- a/application/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/VectorTileResponseFactory.java
@@ -10,22 +10,21 @@ import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.api.resource.WebMercatorTile;
 import org.opentripplanner.framework.io.HttpUtils;
-import org.opentripplanner.standalone.api.OtpServerRequestContext;
 
 /**
  * Common functionality for creating a vector tile response.
  */
 public class VectorTileResponseFactory {
 
-  public static <LayerType extends Enum<LayerType>> Response create(
+  public static <LayerType extends Enum<LayerType>, C> Response create(
     int x,
     int y,
     int z,
     Locale locale,
     List<String> requestedLayers,
     List<LayerParameters<LayerType>> availableLayers,
-    LayerBuilderFactory<LayerType> layerBuilderFactory,
-    OtpServerRequestContext context
+    LayerBuilderFactory<LayerType, C> layerBuilderFactory,
+    C context
   ) {
     VectorTile.Tile.Builder mvtBuilder = VectorTile.Tile.newBuilder();
     Envelope envelope = WebMercatorTile.tile2Envelope(x, y, z);
@@ -73,11 +72,11 @@ public class VectorTileResponseFactory {
   }
 
   @FunctionalInterface
-  public interface LayerBuilderFactory<LayerType extends Enum<LayerType>> {
+  public interface LayerBuilderFactory<LayerType extends Enum<LayerType>, C> {
     LayerBuilder<?> createLayerBuilder(
       LayerParameters<LayerType> layerParameters,
       Locale locale,
-      OtpServerRequestContext context
+      C context
     );
   }
 }

--- a/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/ConstructApplicationFactory.java
@@ -218,7 +218,7 @@ public interface ConstructApplicationFactory {
     Builder empiricalDelayRepository(EmpiricalDelayRepository empiricalDelayRepository);
 
     @BindsInstance
-    Builder schema(RouteRequest defaultRouteRequest);
+    Builder schema(@StaticRouteRequestDefaults RouteRequest defaultRouteRequest);
 
     @BindsInstance
     Builder streetStreetRepository(StreetRepository streetRepository);

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -3,8 +3,11 @@ package org.opentripplanner.standalone.configure;
 import dagger.Subcomponent;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
+import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
+import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -55,6 +58,12 @@ public interface RequestScopedFactory {
   RegularTransferService transferService();
 
   VectorTileConfig vectorTileConfig();
+
+  LinkingContextFactory linkingContextFactory();
+
+  OjpApiParameters ojpApiParameters();
+
+  TriasApiParameters triasApiParameters();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -3,6 +3,7 @@ package org.opentripplanner.standalone.configure;
 import dagger.Subcomponent;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
@@ -29,6 +30,8 @@ public interface RequestScopedFactory {
   Graph graph();
 
   RouteRequest defaultRouteRequest();
+
+  VehicleParkingService vehicleParkingService();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.standalone.configure;
 
 import dagger.Subcomponent;
+import javax.annotation.Nullable;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
@@ -32,6 +34,9 @@ public interface RequestScopedFactory {
   RouteRequest defaultRouteRequest();
 
   VehicleParkingService vehicleParkingService();
+
+  @Nullable
+  LuceneIndex luceneIndex();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -2,8 +2,10 @@ package org.opentripplanner.standalone.configure;
 
 import dagger.Subcomponent;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -23,6 +25,10 @@ public interface RequestScopedFactory {
   TransitService transitService();
 
   OtpServerRequestContext createServerContext();
+
+  Graph graph();
+
+  RouteRequest defaultRouteRequest();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -5,10 +5,15 @@ import javax.annotation.Nullable;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -37,6 +42,16 @@ public interface RequestScopedFactory {
 
   @Nullable
   LuceneIndex luceneIndex();
+
+  DebugUiConfig debugUiConfig();
+
+  WorldEnvelopeService worldEnvelopeService();
+
+  VehicleRentalService vehicleRentalService();
+
+  StreetDetailsService streetDetailsService();
+
+  RegularTransferService transferService();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -12,6 +12,7 @@ import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.config.DebugUiConfig;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.service.TransitService;
@@ -52,6 +53,8 @@ public interface RequestScopedFactory {
   StreetDetailsService streetDetailsService();
 
   RegularTransferService transferService();
+
+  VectorTileConfig vectorTileConfig();
 
   @Subcomponent.Builder
   interface Builder {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -23,6 +23,7 @@ import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.filterchain.ext.EmissionDecorator;
 import org.opentripplanner.routing.algorithm.filterchain.framework.spi.ItineraryDecorator;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.routing.via.ViaCoordinateTransferFactory;
@@ -73,6 +74,15 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static RouteRequest defaultRouteRequest(
+    RouterConfig routerConfig,
+    LauncherRequestDecorator launcherRequestDecorator
+  ) {
+    return launcherRequestDecorator.intercept(routerConfig.routingRequestDefaults());
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -82,6 +92,7 @@ public class RequestScopedModule {
     VertexLinker vertexLinker,
     TransactionScope transactionScope,
     TransitService transitService,
+    RouteRequest defaultRequest,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -103,8 +114,6 @@ public class RequestScopedModule {
     @Nullable LuceneIndex luceneIndex,
     FareService fareService
   ) {
-    var defaultRequest = launcherRequestDecorator.intercept(routerConfig.routingRequestDefaults());
-
     var transitRoutingConfig = routerConfig.transitTuningConfig();
     var triasApiParameters = routerConfig.triasApiParameters();
     var ojpApiParameters = routerConfig.ojpApiParameters();

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -134,7 +134,6 @@ public class RequestScopedModule {
     @Nullable @TransmodelSchema GraphQLSchema transmodelSchema,
     @Nullable EmpiricalDelayService empiricalDelayService,
     @Nullable SorlandsbanenNorwayService sorlandsbanenService,
-    LauncherRequestDecorator launcherRequestDecorator,
     @Nullable LuceneIndex luceneIndex,
     FareService fareService
   ) {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -36,6 +36,7 @@ import org.opentripplanner.standalone.api.HttpRequestScoped;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
 import org.opentripplanner.standalone.server.DefaultServerRequestContext;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.linking.VertexLinker;
@@ -83,6 +84,12 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static VectorTileConfig vectorTileConfig(RouterConfig routerConfig) {
+    return routerConfig.vectorTileConfig();
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -93,6 +100,7 @@ public class RequestScopedModule {
     TransactionScope transactionScope,
     TransitService transitService,
     RouteRequest defaultRequest,
+    VectorTileConfig vectorTileConfig,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -118,7 +126,6 @@ public class RequestScopedModule {
     var triasApiParameters = routerConfig.triasApiParameters();
     var ojpApiParameters = routerConfig.ojpApiParameters();
     var gtfsApiConfig = routerConfig.gtfsApiParameters();
-    var vectorTileConfig = routerConfig.vectorTileConfig();
     var flexParameters = routerConfig.flexParameters();
     var transmodelAPIParameters = routerConfig.transmodelApi();
 

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -54,6 +54,19 @@ import org.opentripplanner.transit.service.TransitService;
  * Provides the bindings that live inside {@link RequestScopedFactory}. A single {@link
  * TransactionScope} is captured once per request, and every other binding here is derived from
  * that same scope, so they all see a consistent, pinned view of real-time data.
+ * <p>
+ * Every {@code @Provides} method below <b>must</b> also be annotated {@link HttpRequestScoped}
+ * (enforced by {@link RequestScopedModuleTest}). Without it, Dagger treats the binding as
+ * unscoped and re-invokes the provider — constructing a brand-new instance — every single time
+ * something depends on that type, even within the same {@link RequestScopedFactory} instance.
+ * That matters because {@link org.opentripplanner.standalone.server.DaggerToJerseyBridge}
+ * registers a separate HK2 accessor lambda for every binding here, and different resources
+ * handling the same HTTP request pull from those lambdas lazily, at different times. An unscoped
+ * binding would let two resources in one request each trigger a fresh call and get two different
+ * instances — e.g. two {@link TransitService}s each wrapping a different {@code
+ * TimetableRepositorySnapshot} if real-time data changed in between. {@code @HttpRequestScoped}
+ * is what turns "derived from the same scope" into an actual guarantee: one instance per request,
+ * shared by every consumer, instead of silently rebuilt on each lookup.
  */
 @Module
 public class RequestScopedModule {

--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedModule.java
@@ -13,6 +13,8 @@ import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBin
 import org.opentripplanner.ext.empiricaldelay.EmpiricalDelayService;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.ext.interactivelauncher.api.LauncherRequestDecorator;
+import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
+import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.ext.ridehailing.RideHailingService;
 import org.opentripplanner.ext.sorlandsbanen.SorlandsbanenNorwayService;
 import org.opentripplanner.ext.stopconsolidation.StopConsolidationService;
@@ -90,6 +92,18 @@ public class RequestScopedModule {
 
   @Provides
   @HttpRequestScoped
+  static OjpApiParameters ojpApiParameters(RouterConfig routerConfig) {
+    return routerConfig.ojpApiParameters();
+  }
+
+  @Provides
+  @HttpRequestScoped
+  static TriasApiParameters triasApiParameters(RouterConfig routerConfig) {
+    return routerConfig.triasApiParameters();
+  }
+
+  @Provides
+  @HttpRequestScoped
   static OtpServerRequestContext serverRequestContext(
     RouterConfig routerConfig,
     DebugUiConfig debugUiConfig,
@@ -101,6 +115,8 @@ public class RequestScopedModule {
     TransitService transitService,
     RouteRequest defaultRequest,
     VectorTileConfig vectorTileConfig,
+    OjpApiParameters ojpApiParameters,
+    TriasApiParameters triasApiParameters,
     RegularTransferService transferService,
     WorldEnvelopeService worldEnvelopeService,
     RealtimeVehicleRepository realtimeVehicleRepository,
@@ -123,8 +139,6 @@ public class RequestScopedModule {
     FareService fareService
   ) {
     var transitRoutingConfig = routerConfig.transitTuningConfig();
-    var triasApiParameters = routerConfig.triasApiParameters();
-    var ojpApiParameters = routerConfig.ojpApiParameters();
     var gtfsApiConfig = routerConfig.gtfsApiParameters();
     var flexParameters = routerConfig.flexParameters();
     var transmodelAPIParameters = routerConfig.transmodelApi();

--- a/application/src/main/java/org/opentripplanner/standalone/configure/StaticRouteRequestDefaults.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/StaticRouteRequestDefaults.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.standalone.configure;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifies the raw, app-singleton {@link org.opentripplanner.routing.api.request.RouteRequest}
+ * bound from {@link org.opentripplanner.standalone.config.RouterConfig#routingRequestDefaults()}
+ * at startup — used only for one-off, build-time consumers (e.g. GraphQL schema generation).
+ * Distinguishes it from the unqualified, request-scoped {@code RouteRequest} inside {@link
+ * RequestScopedFactory}, which is a fresh, launcher-decorated copy per HTTP request. Same shape
+ * of problem as {@code StaticTransitService} — Dagger does not support a subcomponent overriding
+ * an ancestor's binding for the same, unqualified type.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+public @interface StaticRouteRequestDefaults {}

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
 import org.opentripplanner.street.graph.Graph;
@@ -51,6 +52,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::createServerContext, OtpServerRequestContext.class);
     bridge(factory, RequestScopedFactory::graph, Graph.class);
     bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
+    bridge(factory, RequestScopedFactory::vehicleParkingService, VehicleParkingService.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -5,8 +5,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
+import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -47,6 +49,8 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     // Binding for all request-scoped services used by resources
     bridge(factory, RequestScopedFactory::transitService, TransitService.class);
     bridge(factory, RequestScopedFactory::createServerContext, OtpServerRequestContext.class);
+    bridge(factory, RequestScopedFactory::graph, Graph.class);
+    bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -6,7 +6,10 @@ import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
+import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
+import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.linking.LinkingContextFactory;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -67,6 +70,9 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::streetDetailsService, StreetDetailsService.class);
     bridge(factory, RequestScopedFactory::transferService, RegularTransferService.class);
     bridge(factory, RequestScopedFactory::vectorTileConfig, VectorTileConfig.class);
+    bridge(factory, RequestScopedFactory::linkingContextFactory, LinkingContextFactory.class);
+    bridge(factory, RequestScopedFactory::ojpApiParameters, OjpApiParameters.class);
+    bridge(factory, RequestScopedFactory::triasApiParameters, TriasApiParameters.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -13,6 +13,7 @@ import org.opentripplanner.service.vehiclerental.VehicleRentalService;
 import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.config.DebugUiConfig;
+import org.opentripplanner.standalone.config.routerconfig.VectorTileConfig;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.RegularTransferService;
@@ -65,6 +66,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::vehicleRentalService, VehicleRentalService.class);
     bridge(factory, RequestScopedFactory::streetDetailsService, StreetDetailsService.class);
     bridge(factory, RequestScopedFactory::transferService, RegularTransferService.class);
+    bridge(factory, RequestScopedFactory::vectorTileConfig, VectorTileConfig.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -7,10 +7,15 @@ import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
+import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.standalone.configure.RequestScopedFactory;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.transfer.regular.RegularTransferService;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -55,6 +60,11 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
     bridge(factory, RequestScopedFactory::vehicleParkingService, VehicleParkingService.class);
     bridge(factory, RequestScopedFactory::luceneIndex, LuceneIndex.class);
+    bridge(factory, RequestScopedFactory::debugUiConfig, DebugUiConfig.class);
+    bridge(factory, RequestScopedFactory::worldEnvelopeService, WorldEnvelopeService.class);
+    bridge(factory, RequestScopedFactory::vehicleRentalService, VehicleRentalService.class);
+    bridge(factory, RequestScopedFactory::streetDetailsService, StreetDetailsService.class);
+    bridge(factory, RequestScopedFactory::transferService, RegularTransferService.class);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.opentripplanner.ext.geocoder.LuceneIndex;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
@@ -53,6 +54,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
     bridge(factory, RequestScopedFactory::graph, Graph.class);
     bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);
     bridge(factory, RequestScopedFactory::vehicleParkingService, VehicleParkingService.class);
+    bridge(factory, RequestScopedFactory::luceneIndex, LuceneIndex.class);
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResourceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResourceTest.java
@@ -29,13 +29,20 @@ class DebugVectorTilesResourceTest {
 
   @Test
   void tileJson() {
+    var serverContext = TestServerContext.createServerContext(
+      new Graph(),
+      new TransitRepository(),
+      TransferServiceTestFactory.defaultTransferRepository(),
+      new NoopFareServiceFactory().makeFareService()
+    );
     var resource = new DebugVectorTilesResource(
-      TestServerContext.createServerContext(
-        new Graph(),
-        new TransitRepository(),
-        TransferServiceTestFactory.defaultTransferRepository(),
-        new NoopFareServiceFactory().makeFareService()
-      )
+      serverContext.transitService(),
+      serverContext.graph(),
+      serverContext.debugUiConfig(),
+      serverContext.worldEnvelopeService(),
+      serverContext.vehicleRentalService(),
+      serverContext.streetDetailsService(),
+      serverContext.transferService()
     );
     var req = HttpForTest.containerRequest();
     var tileJson = resource.getTileJson(req.getUriInfo(), req, "l1,l2");

--- a/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedModuleTest.java
@@ -1,0 +1,36 @@
+package org.opentripplanner.standalone.configure;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import dagger.Provides;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.standalone.api.HttpRequestScoped;
+
+/**
+ * Every binding in {@link RequestScopedModule} must be pinned to the {@link HttpRequestScoped}
+ * scope — an unscoped {@code @Provides} method would be re-created on every injection point
+ * instead of once per HTTP request, breaking the consistent view of real-time data the module is
+ * meant to guarantee.
+ */
+class RequestScopedModuleTest {
+
+  @Test
+  void everyProvidesMethodIsHttpRequestScoped() {
+    var unscoped = List.of(RequestScopedModule.class.getDeclaredMethods())
+      .stream()
+      .filter(method -> method.isAnnotationPresent(Provides.class))
+      .filter(method -> !method.isAnnotationPresent(HttpRequestScoped.class))
+      .map(Method::getName)
+      .toList();
+
+    assertWithMessage(
+      "All @Provides methods in %s must also be annotated @HttpRequestScoped, but these are not: %s",
+      RequestScopedModule.class.getSimpleName(),
+      unscoped
+    )
+      .that(unscoped)
+      .isEmpty();
+  }
+}


### PR DESCRIPTION
### Summary

Migrates six resources (`DebugRasterTileResource`, `ParkAndRideResource`, `GeocoderResource`,
`DebugVectorTilesResource`, `VectorTilesResource`, `ReportResource`) plus `OjpResource`/`TriasResource`
(partially) off `OtpServerRequestContext`, each declaring only the individual services it needs.

### Issue

Part of #7441. Builds on top of #7833 (`@HttpRequestScoped`/`RequestScopedFactory` foundation).

Each resource gets its own new `RequestScopedComponent` accessor(s) — `Graph`, `RouteRequest`,
`VehicleParkingService`, `LuceneIndex`, `VectorTileConfig`, `LinkingContextFactory`,
`OjpApiParameters`, `TriasApiParameters` — instead of the whole context. `DebugVectorTilesResource`/
`VectorTilesResource` needed `VectorTileResponseFactory`/`LayerBuilderFactory` generified over a
context type parameter so each resource can pass its own small service bundle instead of hardcoding
`OtpServerRequestContext`.

`OjpResource`/`TriasResource` are only **partially** migrated: `OtpServerRequestContext` stays as a
constructor field solely for `context.routingService()`. Making `RoutingService` independently
request-scoped touches the core routing pipeline and is out of scope here — it's handled in a later
PR in this series (`request-scoped-5-remove-request-context`), which fully unblocks both.

### Unit tests

✅ Existing resource tests updated where constructors changed (e.g. `VectorTilesResourceTest`). No
new behavior — pure constructor/wiring refactor.

### Documentation

🟥 No new public API; internal wiring only.

### Changelog

🟥 No user-visible behaviour change. Suggest `+Skip Changelog`.

### Bumping the serialization version id

🟥 No serialized graph fields changed.
