### PR TITLE
SIRI: Map terminal times as provided by the feed

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
@@ -1,8 +1,5 @@
 package org.opentripplanner.transit.model.timetable;
 
-import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.NEGATIVE_DWELL_TIME;
-import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.NEGATIVE_HOP_TIME;
-
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -13,7 +10,6 @@ import java.util.OptionalInt;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.core.model.i18n.I18NString;
-import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 import org.opentripplanner.utils.lang.IntUtils;
 
@@ -298,43 +294,6 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
   @Override
   public boolean isTripPatternModified() {
     return state.tripPatternModified();
-  }
-
-  /**
-   * When creating a scheduled TripTimes or wrapping it in updates, we could potentially imply
-   * negative running or dwell times. We really don't want those being used in routing. This method
-   * checks that all internal times are increasing. Thus, this check should be used at the end of
-   * updating trip times, after any propagating or interpolating delay operations.
-   *
-   * @throws DataValidationException of the first error found.
-   *                                 <p>
-   *                                 Note! This is a duplicate (almost) of the same method in
-   *                                 ScheduledTripTimes. We should aim for just one implementation.
-   *                                 We need to decide how to do this. A common abstract base class
-   *                                 would simplify it, but may lead to other problems and
-   *                                 performance overhead. We should look back on this after
-   *                                 refactoring the rest of the timetable classes
-   *                                 (calendar/patterns).
-   */
-  private void validateNonIncreasingTimes() {
-    final int nStops = scheduledTripTimes.getNumStops();
-    int prevDep = -9_999_999;
-    for (int s = 0; s < nStops; s++) {
-      final int arr = getArrivalTime(s);
-      final int dep = getDepartureTime(s);
-
-      if (dep < arr) {
-        throw new DataValidationException(
-          new TimetableValidationError(NEGATIVE_DWELL_TIME, s, getTrip())
-        );
-      }
-      if (prevDep > arr) {
-        throw new DataValidationException(
-          new TimetableValidationError(NEGATIVE_HOP_TIME, s, getTrip())
-        );
-      }
-      prevDep = dep;
-    }
   }
 
   @Nullable

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
@@ -1,8 +1,5 @@
 package org.opentripplanner.transit.model.timetable;
 
-import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.NEGATIVE_DWELL_TIME;
-import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.NEGATIVE_HOP_TIME;
-
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -399,44 +396,6 @@ public final class ScheduledTripTimes implements TripTimes<ScheduledTripTimes> {
     validateTimeInRange("arrivalTime", arrivalTimes, arrivalTimes.length - 1);
     // TODO: This class is used by FLEX, so we can not validate increasing TripTimes
     // validateNonIncreasingTimes();
-  }
-
-  /**
-   * When creating scheduled trip times we could potentially imply negative running or dwell times.
-   * We really don't want those being used in routing. This method checks that all times are
-   * increasing. The first stop arrival time and the last stops departure time is NOT checked -
-   * these should be ignored by raptor.
-   *
-   * TODO: This should be make private as the constructor should ensure the data consistency
-   */
-  public void validateNonIncreasingTimes() {
-    final int lastStopPos = arrivalTimes.length - 1;
-
-    // This check is currently used since Flex trips may have only one stop. This class should
-    // not be used to represent FLEX, so remove this check and create new data classes for FLEX
-    // trips.
-    if (lastStopPos < 1) {
-      return;
-    }
-    int prevDep = getDepartureTime(0);
-
-    for (int i = 1; true; ++i) {
-      final int arr = getArrivalTime(i);
-      final int dep = getDepartureTime(i);
-
-      if (prevDep > arr) {
-        throw new DataValidationException(new TimetableValidationError(NEGATIVE_HOP_TIME, i, trip));
-      }
-      if (i == lastStopPos) {
-        return;
-      }
-      if (dep < arr) {
-        throw new DataValidationException(
-          new TimetableValidationError(NEGATIVE_DWELL_TIME, i, trip)
-        );
-      }
-      prevDep = dep;
-    }
   }
 
   private int timeShifted(int time) {

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.transit.model.timetable;
 
+import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.NEGATIVE_DWELL_TIME;
+import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.NEGATIVE_HOP_TIME;
+
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.Comparator;
@@ -8,6 +11,7 @@ import java.util.OptionalInt;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 
 /**
@@ -191,6 +195,46 @@ public sealed interface TripTimes<T extends TripTimes>
   List<String> getHeadsignVias(int stopPos);
 
   int getNumStops();
+
+  /**
+   * When creating trip times, or wrapping them in updates, we could potentially imply negative
+   * running or dwell times. We really don't want those being used in routing. This method checks
+   * that the times are increasing at every stop. It should therefore be used at the end of updating
+   * trip times, after any propagating or interpolating delay operations.
+   * <p>
+   * The dwell time at the first and at the last stop is checked as well, even though raptor ignores
+   * those times. Scheduled times of a real-time added trip are used as-is when the trip is later
+   * cancelled, so they must pass the very same validation as the real-time times, or the
+   * cancellation would be rejected and the trip would be stuck in the graph as running.
+   *
+   * @throws DataValidationException of the first error found.
+   */
+  default void validateNonIncreasingTimes() {
+    final int nStops = getNumStops();
+
+    // This check is currently used since Flex trips may have only one stop. This interface should
+    // not be used to represent FLEX, so remove this check and create new data classes for FLEX
+    // trips.
+    if (nStops < 2) {
+      return;
+    }
+
+    for (int stopPos = 0; stopPos < nStops; ++stopPos) {
+      final int arrival = getArrivalTime(stopPos);
+      final int departure = getDepartureTime(stopPos);
+
+      if (departure < arrival) {
+        throw new DataValidationException(
+          new TimetableValidationError(NEGATIVE_DWELL_TIME, stopPos, getTrip())
+        );
+      }
+      if (stopPos > 0 && getDepartureTime(stopPos - 1) > arrival) {
+        throw new DataValidationException(
+          new TimetableValidationError(NEGATIVE_HOP_TIME, stopPos, getTrip())
+        );
+      }
+    }
+  }
 
   Accessibility getWheelchairAccessibility();
 

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
@@ -72,9 +72,8 @@ class StopTimesMapper {
       zoneId
     );
 
-    // Use departure time for first stop, and arrival time for last stop, to avoid negative dwell times
-    stopTime.setArrivalTime(isFirstStop ? aimedDepartureTimeSeconds : aimedArrivalTimeSeconds);
-    stopTime.setDepartureTime(isLastStop ? aimedArrivalTimeSeconds : aimedDepartureTimeSeconds);
+    stopTime.setArrivalTime(aimedArrivalTimeSeconds);
+    stopTime.setDepartureTime(aimedDepartureTimeSeconds);
 
     // Update destination display
     var destinationDisplay = call.destinationDisplay();

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/cancellation/CancellationTest.java
@@ -143,10 +143,8 @@ class CancellationTest implements RealtimeTestConstants {
 
     changeQuayAndCancelTrip(siri, ADDED_TRIP_ID);
 
-    // the arrival time on first stop is adjusted to the departure time to avoid negative dwell time
-    // conversely the departure time on last stop is adjusted to the arrival time
     assertEquals(
-      "C U | A 0:00:11 0:00:11 | B 0:00:20 0:00:20",
+      "C U | A 0:00:10 0:00:11 | B 0:00:20 0:00:21",
       env.tripData(ADDED_TRIP_ID).showTimetable()
     );
     assertThat(env.raptorData().summarizePatterns()).containsExactly(

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/ExtraJourneyTest.java
@@ -197,6 +197,80 @@ class ExtraJourneyTest implements RealtimeTestConstants {
     assertFailure(UpdateErrorType.NEGATIVE_HOP_TIME, result);
   }
 
+  /**
+   * Terminal times that imply a negative dwell are not repaired: the update is rejected. The aimed
+   * times of an added trip must be valid even when a prediction would make the real-time times
+   * valid, because a later cancellation falls back to the aimed times: were the trip accepted here,
+   * the cancellation would be rejected and the trip would be stuck in the graph as running.
+   */
+  @Test
+  void testAddedJourneyWithNegativeDwellAtOriginIsRejected() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
+      .withIsExtraJourney(true)
+      .withOperatorRef(OPERATOR_ID)
+      .withLineRef(ROUTE_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_C)
+          // the aimed arrival at the origin is after the aimed departure
+          .arriveAimedExpected("00:05", null)
+          .departAimedExpected("00:02", "00:02")
+          .call(STOP_D)
+          .arriveAimedExpected("00:07", "00:08")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updates);
+
+    assertFailure(UpdateErrorType.NEGATIVE_DWELL_TIME, result);
+    assertNull(env.transitService().getTrip(id(ADDED_TRIP_ID)));
+  }
+
+  /**
+   * An added trip must always be cancellable: the cancellation reverts to the aimed times, which
+   * are validated when the trip is added.
+   */
+  @Test
+  void testAddedJourneyWithTerminalTimesCanBeCancelled() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var creation = siri
+      .etBuilder()
+      .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
+      .withIsExtraJourney(true)
+      .withOperatorRef(OPERATOR_ID)
+      .withLineRef(ROUTE_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_C)
+          .arriveAimedExpected("00:01", "00:02")
+          .departAimedExpected("00:02", "00:03")
+          .call(STOP_D)
+          .arriveAimedExpected("00:04", "00:05")
+          .departAimedExpected("00:05", "00:06")
+      )
+      .buildEstimatedTimetableDeliveries();
+    assertSuccess(siri.applyEstimatedTimetable(creation));
+
+    var cancellation = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(ADDED_TRIP_ID)
+      .withCancellation(true)
+      .buildEstimatedTimetableDeliveries();
+
+    assertSuccess(siri.applyEstimatedTimetable(cancellation));
+
+    assertTrue(env.tripData(ADDED_TRIP_ID).tripTimes().isCanceled());
+    // the cancelled trip falls back to the aimed times, terminal times included
+    assertEquals("C U | C 0:01 0:02 | D 0:04 0:05", env.tripData(ADDED_TRIP_ID).showTimetable());
+  }
+
   @Test
   void testRejectUnmonitoredExtraJourney() {
     var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
@@ -338,6 +412,78 @@ class ExtraJourneyTest implements RealtimeTestConstants {
       "S | A 0:01 0:01 | B 0:03 0:05 | C 0:07 0:07",
       env.tripData(ADDED_TRIP_ID).showScheduledTimetable()
     );
+  }
+
+  /**
+   * The arrival at the first stop and the departure from the last stop are ignored by routing, but
+   * they carry information for the APIs and are therefore mapped as provided by the feed, both for
+   * the aimed and for the real-time times.
+   */
+  @Test
+  void testAddJourneyKeepsTerminalTimes() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
+      .withIsExtraJourney(true)
+      .withOperatorRef(OPERATOR_ID)
+      .withLineRef(ROUTE_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_C)
+          // the vehicle is ready for boarding at the origin one minute before it departs
+          .arriveAimedExpected("00:01", "00:02")
+          .departAimedExpected("00:02", "00:03")
+          .call(STOP_D)
+          .arriveAimedExpected("00:04", "00:05")
+          // the vehicle leaves the destination for the depot
+          .departAimedExpected("00:05", "00:06")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    assertSuccess(siri.applyEstimatedTimetable(updates));
+
+    assertEquals(
+      "S | C 0:01 0:02 | D 0:04 0:05",
+      env.tripData(ADDED_TRIP_ID).showScheduledTimetable()
+    );
+    assertEquals("A U | C 0:02 0:03 | D 0:05 0:06", env.tripData(ADDED_TRIP_ID).showTimetable());
+  }
+
+  /**
+   * A terminal time that is not provided by the feed falls back to the other time at the same stop.
+   * This is the common case: SIRI feeds normally do not report an arrival at the origin nor a
+   * departure from the destination.
+   */
+  @Test
+  void testAddJourneyFallsBackToTheOtherTerminalTime() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
+      .withIsExtraJourney(true)
+      .withOperatorRef(OPERATOR_ID)
+      .withLineRef(ROUTE_ID)
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_C)
+          .departAimedExpected("00:01", "00:02")
+          .call(STOP_D)
+          .arriveAimedExpected("00:03", "00:04")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    assertSuccess(siri.applyEstimatedTimetable(updates));
+
+    assertEquals(
+      "S | C 0:01 0:01 | D 0:03 0:03",
+      env.tripData(ADDED_TRIP_ID).showScheduledTimetable()
+    );
+    assertEquals("A U | C 0:02 0:02 | D 0:04 0:04", env.tripData(ADDED_TRIP_ID).showTimetable());
   }
 
   /**


### PR DESCRIPTION


## Summary

The SIRI-ET updater collapsed the times at the terminals of an added trip (first stop: `arrival = departure`, last stop: `departure = arrival`) to avoid negative dwell times. GTFS-RT performs no such normalization, so identical feed content produced different times depending on the format, and the arrival at the origin — the time the vehicle is ready for boarding — was discarded.

Both times are now mapped as provided. A missing terminal time still falls back to the other time at the same stop, so neither of them becomes required.

## Why the validator had to change too

Real-time terminal times that imply a negative dwell are now rejected rather than repaired. But this is not enough to cover the specific case of the cancellation of an added trip: an added trip that is cancelled is reverted to its "scheduled times" (aimed times). These aimed times must also be validated, otherwise they would be rejected when converted into real-times trip times, making it impossible to cancel the added trip.

The validation of trip times is now unified across the sealed class hierarchy so that terminal times are validated for both scheduled and real-time trip times.

Blast radius is narrow: `RealTimeTripTimes.validateNonIncreasingTimes()`  is unchanged and the only callers of `ScheduledTripTimes.validateNonIncreasingTimes()` are `AddedTripBuilder` and `ExtraCallTripBuilder`. Static GTFS/NeTEx graph building never calls it (it is commented out in validate() because of FLEX), and the single-stop FLEX guard is preserved.

## Behaviour change to be aware of

A producer that sends an **inverted** aimed pair at a terminal now gets the added trip dropped with `NEGATIVE_DWELL_TIME`, where it was previously silently masked. Distinct-but-ordered terminal times (a normal layover at the origin) are unaffected and are now preserved instead of discarded.

# Issue
closes #7776

