### PR TITLE
Treat unstated NeTEx DaysOfWeek as valid for all days

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
@@ -42,6 +42,8 @@ import org.rutebanken.netex.model.UicOperatingPeriod;
  */
 public class DayTypeAssignmentMapper {
 
+  private static final Set<DayOfWeek> EVERY_DAY_OF_WEEK = Set.of(DayOfWeek.values());
+
   // Input data
   private final DayType dayType;
   private final ReadOnlyHierarchicalMapById<OperatingDay> operatingDays;
@@ -104,15 +106,28 @@ public class DayTypeAssignmentMapper {
     return dta.isIsAvailable();
   }
 
+  /**
+   * Resolve the days of the week an operating period assigned to the given {@code dayType} is
+   * restricted to.
+   * <p>
+   * The NeTEx profile makes both {@code properties} and {@code DaysOfWeek} optional.
+   * A day type which does not state any days of the week therefore constrains nothing and is valid
+   * for <em>every</em> day in the period.
+   * <p>
+   * */
   private static Set<DayOfWeek> daysOfWeekForDayType(DayType dayType) {
+    if (dayType.getProperties() == null) {
+      return EVERY_DAY_OF_WEEK;
+    }
+    List<PropertyOfDay> propertyOfDays = dayType.getProperties().getPropertyOfDay();
+
+    if (propertyOfDays.stream().allMatch(p -> p.getDaysOfWeek().isEmpty())) {
+      return EVERY_DAY_OF_WEEK;
+    }
+
     Set<DayOfWeek> result = EnumSet.noneOf(DayOfWeek.class);
-
-    if (dayType.getProperties() != null) {
-      List<PropertyOfDay> propertyOfDays = dayType.getProperties().getPropertyOfDay();
-
-      for (PropertyOfDay p : propertyOfDays) {
-        result.addAll(DayOfWeekMapper.mapDayOfWeeks(p.getDaysOfWeek()));
-      }
+    for (PropertyOfDay p : propertyOfDays) {
+      result.addAll(DayOfWeekMapper.mapDayOfWeeks(p.getDaysOfWeek()));
     }
     return result;
   }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,7 +43,9 @@ import org.rutebanken.netex.model.UicOperatingPeriod;
  */
 public class DayTypeAssignmentMapper {
 
-  private static final Set<DayOfWeek> EVERY_DAY_OF_WEEK = Collections.unmodifiableSet(EnumSet.allOf(DayOfWeek.class));
+  private static final Set<DayOfWeek> EVERY_DAY_OF_WEEK = Collections.unmodifiableSet(
+    EnumSet.allOf(DayOfWeek.class)
+  );
 
   // Input data
   private final DayType dayType;

--- a/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
@@ -42,7 +42,7 @@ import org.rutebanken.netex.model.UicOperatingPeriod;
  */
 public class DayTypeAssignmentMapper {
 
-  private static final Set<DayOfWeek> EVERY_DAY_OF_WEEK = Set.of(DayOfWeek.values());
+  private static final Set<DayOfWeek> EVERY_DAY_OF_WEEK = Collections.unmodifiableSet(EnumSet.allOf(DayOfWeek.class));
 
   // Input data
   private final DayType dayType;

--- a/application/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
+++ b/application/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
@@ -75,15 +75,20 @@ public final class NetexTestDataSupport {
   }
 
   public static DayType createDayType(String id, DayOfWeekEnumeration... daysOfWeek) {
-    DayType dayType = new DayType().withId(id);
-    if (daysOfWeek != null && daysOfWeek.length > 0) {
-      dayType.setProperties(
-        new PropertiesOfDay_RelStructure().withPropertyOfDay(
-          new PropertyOfDay().withDaysOfWeek(daysOfWeek)
-        )
-      );
+    if (daysOfWeek == null || daysOfWeek.length == 0) {
+      return new DayType().withId(id);
     }
-    return dayType;
+    return createDayTypeWithProperties(id, new PropertyOfDay().withDaysOfWeek(daysOfWeek));
+  }
+
+  /**
+   * Create a day type with the given properties, allowing tests to construct day types with an
+   * empty {@code PropertyOfDay} - which states no days of the week at all.
+   */
+  public static DayType createDayTypeWithProperties(String id, PropertyOfDay... properties) {
+    return new DayType()
+      .withId(id)
+      .withProperties(new PropertiesOfDay_RelStructure().withPropertyOfDay(properties));
   }
 
   public static DayTypeRefStructure createDayTypeRef(String id) {

--- a/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
@@ -7,23 +7,30 @@ import static org.opentripplanner.netex.NetexTestDataSupport.createDayType;
 import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeAssignment;
 import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeAssignmentWithOpDay;
 import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeAssignmentWithPeriod;
+import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeWithProperties;
 import static org.opentripplanner.netex.NetexTestDataSupport.createOperatingDay;
 import static org.opentripplanner.netex.NetexTestDataSupport.createOperatingPeriod;
 import static org.opentripplanner.netex.NetexTestDataSupport.createOperatingPeriodWithOperatingDays;
 import static org.opentripplanner.netex.NetexTestDataSupport.createUicOperatingPeriod;
 import static org.rutebanken.netex.model.DayOfWeekEnumeration.EVERYDAY;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.NONE;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.SUNDAY;
 import static org.rutebanken.netex.model.DayOfWeekEnumeration.WEEKDAYS;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMultimap;
 import org.rutebanken.netex.model.DayType;
 import org.rutebanken.netex.model.DayTypeAssignment;
 import org.rutebanken.netex.model.OperatingDay;
 import org.rutebanken.netex.model.OperatingPeriod_VersionStructure;
+import org.rutebanken.netex.model.PropertyOfDay;
 
 class DayTypeAssignmentMapperTest {
 
@@ -337,6 +344,152 @@ class DayTypeAssignmentMapperTest {
         "2020-11-30]",
       toStr(result, DAY_TYPE_1)
     );
+  }
+
+  /**
+   * A day type with a property which does not state any days of the week does not restrict the
+   * assigned operating period - the period is valid for every day.
+   */
+  @Test
+  void periodWithEmptyDayOfWeekPropertyAppliesToEveryDay() {
+    // GIVEN - a day type with '<properties><PropertyOfDay/></properties>'
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+
+    dayTypes.add(createDayTypeWithProperties(DAY_TYPE_1, new PropertyOfDay()));
+    periods.add(createOperatingPeriod(OP_1, D2020_11_01, D2020_11_03));
+    assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+
+    // WHEN - create calendar
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      EMPTY_OPERATING_DAYS,
+      periods,
+      null
+    );
+
+    // THEN - all days in the period, Sunday to Tuesday
+    assertEquals("[2020-11-01, 2020-11-02, 2020-11-03]", toStr(result, DAY_TYPE_1));
+  }
+
+  /** A day type without any properties at all does not restrict the assigned operating period. */
+  @Test
+  void periodWithNoDayTypePropertiesAppliesToEveryDay() {
+    // GIVEN
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+
+    dayTypes.add(createDayType(DAY_TYPE_1));
+    periods.add(createOperatingPeriod(OP_1, D2020_11_01, D2020_11_03));
+    assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+
+    // WHEN - create calendar
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      EMPTY_OPERATING_DAYS,
+      periods,
+      null
+    );
+
+    // THEN - all days in the period, Sunday to Tuesday
+    assertEquals("[2020-11-01, 2020-11-02, 2020-11-03]", toStr(result, DAY_TYPE_1));
+  }
+
+  /**
+   * An explicitly stated NONE is not the same as an unstated day of week - it states that no day
+   * of the week applies.
+   */
+  @Test
+  void periodWithExplicitNoneDayOfWeekHasNoDates() {
+    // GIVEN
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+
+    dayTypes.add(createDayType(DAY_TYPE_1, NONE));
+    periods.add(createOperatingPeriod(OP_1, D2020_11_01, D2020_11_03));
+    assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+
+    var issueStore = new DefaultDataImportIssueStore();
+
+    // WHEN - create calendar
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      EMPTY_OPERATING_DAYS,
+      periods,
+      issueStore
+    );
+
+    // THEN - no dates, and the empty schedule is reported
+    assertEquals("[]", toStr(result, DAY_TYPE_1));
+    assertEquals(
+      List.of("DayTypeScheduleIsEmpty"),
+      issueStore.listIssues().stream().map(DataImportIssue::getType).toList()
+    );
+  }
+
+  /** An empty property must not widen the days of the week stated by a sibling property. */
+  @Test
+  void periodWithStatedAndEmptyDayOfWeekPropertiesUsesStatedDaysOnly() {
+    // GIVEN
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+
+    dayTypes.add(
+      createDayTypeWithProperties(
+        DAY_TYPE_1,
+        new PropertyOfDay().withDaysOfWeek(SUNDAY),
+        new PropertyOfDay()
+      )
+    );
+    periods.add(createOperatingPeriod(OP_1, D2020_11_01, D2020_11_03));
+    assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+
+    // WHEN - create calendar
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      EMPTY_OPERATING_DAYS,
+      periods,
+      null
+    );
+
+    // THEN - only the stated Sunday
+    assertEquals("[2020-11-01]", toStr(result, DAY_TYPE_1));
+  }
+
+  /**
+   * A UIC operating period states its days with valid-day-bits, hence the days of the week of the
+   * day type do not apply.
+   */
+  @Test
+  void uicPeriodIgnoresMissingDayOfWeekProperty() {
+    // GIVEN
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+
+    dayTypes.add(createDayTypeWithProperties(DAY_TYPE_1, new PropertyOfDay()));
+    periods.add(createUicOperatingPeriod(OP_1, D2020_11_01, D2020_11_03, "101"));
+    assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+
+    // WHEN - create calendar
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      EMPTY_OPERATING_DAYS,
+      periods,
+      null
+    );
+
+    // THEN - the valid-day-bits decide, the second day is skipped
+    assertEquals("[2020-11-01, 2020-11-03]", toStr(result, DAY_TYPE_1));
   }
 
   /* private helper methods */


### PR DESCRIPTION
## Summary

A NeTEx `DayType` which does not state any `DaysOfWeek` was mapped to an *empty* set of days of
the week. Since that set is used to filter the dates of an assigned `OperatingPeriod`, every date
was filtered away and the `DayType` ended up with an empty calendar — the journeys referencing it
never run, and the build reports `DayTypeScheduleIsEmpty`.

The NeTEx profile makes both `properties` and `DaysOfWeek` optional, and a stated property acts as
a *constraint* on the assigned operating period (the Nordic profile documents this explicitly for
`Seasons`: "if not stated, the property is valid for all"). A `DayType` which states no days of the
week therefore constrains nothing and should be valid for **every** day in the period.

Example:

```xml
<DayType version="1" id="FIN:DayType:33_20260910">
  <properties><PropertyOfDay/></properties>          <!-- no DaysOfWeek -->
</DayType>
…
<OperatingPeriod version="1" id="FIN:OperatingPeriod:33_20260910">
  <FromOperatingDayRef ref="FIN:OperatingDay:2026-09-07"/>
  <ToOperatingDayRef  ref="FIN:OperatingDay:2026-09-10"/>   <!-- Mon–Thu -->
</OperatingPeriod>
```

All four days were dropped; with this change the period keeps them.

## Changes

`DayTypeAssignmentMapper.daysOfWeekForDayType()` returns all seven days when the `DayType` states
no days of the week — whether that is because there are no `properties` at all, an empty
`PropertyOfDay` list, or `PropertyOfDay` elements without `DaysOfWeek`.

Two cases are deliberately left as they are:

- An explicitly stated `DaysOfWeek` of `NONE` still yields no days. It is an authored value, not an
  absence, so it keeps its meaning (and still reports `DayTypeScheduleIsEmpty`).
- An empty `PropertyOfDay` listed next to a property with stated days does not widen the stated
  constraint — only stated days count.

