### PR TITLE
Refactor functionality related to graph builder

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -1,9 +1,5 @@
 package org.opentripplanner.graph_builder;
 
-import static org.opentripplanner.datastore.api.FileType.GTFS;
-import static org.opentripplanner.datastore.api.FileType.NETEX;
-import static org.opentripplanner.datastore.api.FileType.OSM;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
@@ -94,11 +90,6 @@ public class GraphBuilder implements Runnable {
     boolean loadStreetGraph,
     boolean saveStreetGraph
   ) {
-    boolean hasOsm = dataSources.has(OSM);
-    boolean hasGtfs = dataSources.has(GTFS);
-    boolean hasNetex = dataSources.has(NETEX);
-    boolean hasTransitData = hasGtfs || hasNetex;
-
     transitRepository.initTimeZone(config.transitModelTimeZone);
 
     GraphBuilderFactory.Builder builder = DaggerGraphBuilderFactory.builder();
@@ -123,22 +114,22 @@ public class GraphBuilder implements Runnable {
 
     var graphBuilder = factory.graphBuilder();
 
-    graphBuilder.hasTransitData = hasTransitData;
+    graphBuilder.hasTransitData = dataSources.hasTransitData();
 
-    if (hasOsm) {
+    if (dataSources.hasOsm()) {
       graphBuilder.addModule(factory.osmModule());
     }
 
-    if (hasGtfs) {
+    if (dataSources.hasGtfs()) {
       graphBuilder.addModule(factory.gtfsModule());
     }
 
-    if (hasNetex) {
+    if (dataSources.hasNetex()) {
       graphBuilder.addModule(factory.netexModule());
     }
 
     // Consolidate stops only if a stop consolidation repo has been provided
-    if (hasTransitData) {
+    if (graphBuilder.hasTransitData) {
       graphBuilder.addModuleOptional(factory.stopConsolidationModule());
       graphBuilder.addModule(factory.tripPatternNamer());
       graphBuilder.addModuleOptional(
@@ -146,7 +137,7 @@ public class GraphBuilder implements Runnable {
         transitRepository.getAgencyTimeZones().size() > 1
       );
 
-      if (hasOsm || graphBuilder.graph.hasStreets) {
+      if (dataSources.hasOsm() || graphBuilder.graph.hasStreets) {
         graphBuilder.addModule(factory.osmBoardingLocationsModule());
       }
     }
@@ -156,14 +147,14 @@ public class GraphBuilder implements Runnable {
     graphBuilder.addModule(factory.streetLinkerModule());
 
     // Avoid applying turn restrictions twice if doing separate street graph and graph builds.
-    if (hasOsm) {
+    if (dataSources.hasOsm()) {
       graphBuilder.addModule(factory.turnRestrictionModule());
     }
 
     // Prune graph connectivity islands after transit stop linking, so that pruning can take into account
     // existence of stops in islands. If an island has a stop, it actually may be a real island and should
     // not be removed quite as easily
-    if ((hasOsm && !saveStreetGraph) || loadStreetGraph) {
+    if ((dataSources.hasOsm() && !saveStreetGraph) || loadStreetGraph) {
       graphBuilder.addModule(factory.pruneIslands());
     }
 
@@ -173,7 +164,7 @@ public class GraphBuilder implements Runnable {
       graphBuilder.addModule(it);
     }
 
-    if (hasTransitData) {
+    if (graphBuilder.hasTransitData) {
       // Add links to flex areas after the streets has been split, so that also the split edges are connected
       graphBuilder.addModuleOptional(factory.areaStopsToVerticesMapper(), OTPFeature.FlexRouting);
 
@@ -191,7 +182,7 @@ public class GraphBuilder implements Runnable {
       );
     }
 
-    if (loadStreetGraph || hasOsm) {
+    if (loadStreetGraph || dataSources.hasOsm()) {
       graphBuilder.addModule(factory.graphCoherencyCheckerModule());
     }
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
@@ -91,8 +91,6 @@ public class GraphBuilderDataSources implements Closeable {
     include(cli.doBuildStreet(), CACHE);
     include(cli.doBuildTransit(), GTFS);
     include(cli.doBuildTransit(), NETEX);
-    include(cli.doBuildTransit(), EMISSION);
-    include(cli.doBuildTransit(), EMPIRICAL_DATA);
 
     selectFilesToImport();
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
@@ -110,8 +110,37 @@ public class GraphBuilderDataSources implements Closeable {
    * @return {@code true} if and only if the data source exist, proper command line parameters is
    * set and not disabled by the loaded configuration files.
    */
-  public boolean has(FileType type) {
+  private boolean has(FileType type) {
     return inputData.containsKey(type);
+  }
+
+  private boolean hasOneOf(FileType... types) {
+    for (FileType type : types) {
+      if (has(type)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean hasOsm() {
+    return has(OSM);
+  }
+
+  public boolean hasDem() {
+    return has(DEM);
+  }
+
+  public boolean hasGtfs() {
+    return has(GTFS);
+  }
+
+  public boolean hasNetex() {
+    return has(NETEX);
+  }
+
+  public boolean hasTransitData() {
+    return hasOneOf(GTFS, NETEX);
   }
 
   public Iterable<ConfiguredDataSource<OsmExtractParameters>> getOsmConfiguredDataSource() {
@@ -283,15 +312,6 @@ public class GraphBuilderDataSources implements Closeable {
     );
   }
 
-  private boolean hasOneOf(FileType... types) {
-    for (FileType type : types) {
-      if (has(type)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private void logSkippedAndSelectedFiles() {
     LOG.info("Data source location(s): {}", String.join(", ", store.getRepositoryDescriptions()));
 
@@ -315,7 +335,7 @@ public class GraphBuilderDataSources implements Closeable {
 
   private void validateCliMatchesInputData(CommandLineParameters cli) {
     if (cli.build) {
-      if (!hasOneOf(OSM, GTFS, NETEX)) {
+      if (!hasOsm() && !hasTransitData()) {
         throw new OtpAppException("Unable to build graph, no transit nor OSM data available.");
       }
     } else if (cli.buildStreet) {
@@ -336,7 +356,7 @@ public class GraphBuilderDataSources implements Closeable {
           store.getStreetGraph().path()
         );
       }
-      if (!hasOneOf(GTFS, NETEX)) {
+      if (!hasTransitData()) {
         throw new OtpAppException("Unable to build transit graph, no transit data available.");
       }
     }

--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
@@ -91,6 +91,8 @@ public class GraphBuilderDataSources implements Closeable {
     include(cli.doBuildStreet(), CACHE);
     include(cli.doBuildTransit(), GTFS);
     include(cli.doBuildTransit(), NETEX);
+    include(cli.doBuildTransit(), EMISSION);
+    include(cli.doBuildTransit(), EMPIRICAL_DATA);
 
     selectFilesToImport();
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
@@ -108,23 +108,6 @@ public class GraphBuilderDataSources implements Closeable {
     return outputGraph;
   }
 
-  /**
-   * @return {@code true} if and only if the data source exist, proper command line parameters is
-   * set and not disabled by the loaded configuration files.
-   */
-  private boolean has(FileType type) {
-    return inputData.containsKey(type);
-  }
-
-  private boolean hasOneOf(FileType... types) {
-    for (FileType type : types) {
-      if (has(type)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public boolean hasOsm() {
     return has(OSM);
   }
@@ -229,6 +212,23 @@ public class GraphBuilderDataSources implements Closeable {
   }
 
   /* private methods */
+
+  /**
+   * @return {@code true} if and only if the data source exist, proper command line parameters is
+   * set and not disabled by the loaded configuration files.
+   */
+  private boolean has(FileType type) {
+    return inputData.containsKey(type);
+  }
+
+  private boolean hasOneOf(FileType... types) {
+    for (FileType type : types) {
+      if (has(type)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   private ConfiguredDataSource<OsmExtractParameters> mapOsmData(DataSource dataSource) {
     var p = buildConfig.osm.parameters

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.graph_builder.module.configure;
 
-import static org.opentripplanner.datastore.api.FileType.DEM;
-
 import dagger.Module;
 import dagger.Provides;
 import jakarta.inject.Singleton;
@@ -239,7 +237,7 @@ public class GraphBuilderModules {
       gridCoverageFactories.add(
         createNedElevationFactory(dataSources.getNedCacheDirectory(), config)
       );
-    } else if (dataSources.has(DEM)) {
+    } else if (dataSources.hasDem()) {
       gridCoverageFactories.addAll(
         createDemGeotiffGridCoverageFactories(dataSources.getDemConfiguredDataSource())
       );

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsBundle.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsBundle.java
@@ -1,14 +1,39 @@
 package org.opentripplanner.gtfs.graphbuilder;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.onebusaway.csv_entities.CsvInputSource;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.model.Area;
+import org.onebusaway.gtfs.model.FareLegRule;
+import org.onebusaway.gtfs.model.FareMedium;
+import org.onebusaway.gtfs.model.FareProduct;
+import org.onebusaway.gtfs.model.FareTransferRule;
+import org.onebusaway.gtfs.model.RiderCategory;
+import org.onebusaway.gtfs.model.RouteNetworkAssignment;
+import org.onebusaway.gtfs.model.StopAreaElement;
+import org.onebusaway.gtfs.serialization.GtfsReader;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.datastore.api.CompositeDataSource;
+import org.opentripplanner.framework.application.OTPFeature;
 import org.opentripplanner.gtfs.config.GtfsFeedParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class GtfsBundle {
+
+  private static final Set<Class<?>> FARES_V2_CLASSES = Set.of(
+    Area.class,
+    FareProduct.class,
+    FareLegRule.class,
+    FareMedium.class,
+    FareTransferRule.class,
+    RiderCategory.class,
+    RouteNetworkAssignment.class,
+    StopAreaElement.class
+  );
 
   private static final Logger LOG = LoggerFactory.getLogger(GtfsBundle.class);
 
@@ -81,5 +106,38 @@ public final class GtfsBundle {
 
   public String feedInfo() {
     return "GTFS bundle at " + dataSource.path() + " (" + getFeedId() + ")";
+  }
+
+  public GtfsRelationalDao loadDao() throws IOException {
+    var dao = new GtfsRelationalDaoImpl();
+    dao.setPackShapePoints(true);
+    LOG.info("reading {}", feedInfo());
+
+    GtfsReader reader = new GtfsReader();
+    reader.setInputSource(getCsvInputSource());
+    reader.setEntityStore(dao);
+    reader.setInternStrings(true);
+    reader.setDefaultAgencyId(getFeedId());
+
+    dao.open();
+    for (Class<?> entityClass : reader.getEntityClasses()) {
+      if (skipEntityClass(entityClass)) {
+        LOG.info("Skipping entity: {}", entityClass.getName());
+        continue;
+      }
+      LOG.info("Reading entity: {}", entityClass.getName());
+      reader.readEntities(entityClass);
+    }
+    dao.close();
+    return dao;
+  }
+
+  /**
+   * Since GTFS Fares V2 is a very new, constantly evolving standard there might be a lot of errors
+   * in the data. We only want to try to parse them when the feature flag is explicitly enabled as
+   * it can easily lead to graph build failures.
+   */
+  private boolean skipEntityClass(Class<?> entityClass) {
+    return OTPFeature.FaresV2.isOff() && FARES_V2_CLASSES.contains(entityClass);
   }
 }

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -5,17 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
-import org.onebusaway.gtfs.model.Area;
-import org.onebusaway.gtfs.model.FareLegRule;
-import org.onebusaway.gtfs.model.FareMedium;
-import org.onebusaway.gtfs.model.FareProduct;
-import org.onebusaway.gtfs.model.FareTransferRule;
-import org.onebusaway.gtfs.model.RiderCategory;
-import org.onebusaway.gtfs.model.RouteNetworkAssignment;
-import org.onebusaway.gtfs.model.StopAreaElement;
-import org.onebusaway.gtfs.serialization.GtfsReader;
-import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
@@ -47,17 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GtfsModule implements GraphBuilderModule {
-
-  public static final Set<Class<?>> FARES_V2_CLASSES = Set.of(
-    Area.class,
-    FareProduct.class,
-    FareLegRule.class,
-    FareMedium.class,
-    FareTransferRule.class,
-    RiderCategory.class,
-    RouteNetworkAssignment.class,
-    StopAreaElement.class
-  );
 
   private static final Logger LOG = LoggerFactory.getLogger(GtfsModule.class);
   /**
@@ -132,7 +110,7 @@ public class GtfsModule implements GraphBuilderModule {
 
     try {
       for (GtfsBundle gtfsBundle : gtfsBundles) {
-        var gtfsDao = loadBundle(gtfsBundle);
+        var gtfsDao = gtfsBundle.loadDao();
 
         var feedId = gtfsBundle.getFeedId();
         verifyUniqueFeedId(gtfsBundle, feedIdsEncountered, feedId);
@@ -299,41 +277,5 @@ public class GtfsModule implements GraphBuilderModule {
       graph,
       streetDetailsRepository
     );
-  }
-
-  private GtfsRelationalDao loadBundle(GtfsBundle gtfsBundle) throws IOException {
-    var dao = new GtfsRelationalDaoImpl();
-    dao.setPackShapePoints(true);
-    LOG.info("reading {}", gtfsBundle.feedInfo());
-
-    String gtfsFeedId = gtfsBundle.getFeedId();
-
-    GtfsReader reader = new GtfsReader();
-    reader.setInputSource(gtfsBundle.getCsvInputSource());
-    reader.setEntityStore(dao);
-    reader.setInternStrings(true);
-    reader.setDefaultAgencyId(gtfsFeedId);
-
-    dao.open();
-    for (Class<?> entityClass : reader.getEntityClasses()) {
-      if (skipEntityClass(entityClass)) {
-        LOG.info("Skipping entity: {}", entityClass.getName());
-        continue;
-      }
-      LOG.info("Reading entity: {}", entityClass.getName());
-      reader.readEntities(entityClass);
-    }
-
-    dao.close();
-    return dao;
-  }
-
-  /**
-   * Since GTFS Fares V2 is a very new, constantly evolving standard there might be a lot of errors
-   * in the data. We only want to try to parse them when the feature flag is explicitly enabled as
-   * it can easily lead to graph build failures.
-   */
-  private boolean skipEntityClass(Class<?> entityClass) {
-    return OTPFeature.FaresV2.isOff() && FARES_V2_CLASSES.contains(entityClass);
   }
 }


### PR DESCRIPTION
### Summary

This PR refactors functionality related to the data builder:
- Create `hasTransitData`, `hasOsm`, etc. methods in `GraphBuilderDataSources`
- Move `loadBundle` into `GtfsBundle` and rename it to `loadDao`

The refactoring is related to the upcoming `CarPickupZone` PR https://github.com/opentripplanner/OpenTripPlanner/pull/7785

### Issue

Ref https://github.com/opentripplanner/OpenTripPlanner/issues/7772

### Unit tests

no

### Documentation

no