### PR TITLE
Enforce immutability in SiriFuzzyTripMatcherCache

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/application/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -325,7 +325,7 @@ public class UpdaterConfigurator {
 
   private SiriFuzzyTripMatcherCache siriFuzzyTripMatcherCache() {
     if (siriFuzzyTripMatcherCache == null) {
-      siriFuzzyTripMatcherCache = new SiriFuzzyTripMatcherCache(transitRepository);
+      siriFuzzyTripMatcherCache = SiriFuzzyTripMatcherCache.create(transitRepository);
     }
     return siriFuzzyTripMatcherCache;
   }

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcher.java
@@ -71,12 +71,12 @@ public class SiriFuzzyTripMatcher {
       throw UpdateException.of(INVALID_DEPARTURE_TIME);
     }
 
-    Set<Trip> trips = null;
+    Set<Trip> trips = Set.of();
     if (journeyWrapper.vehicleRef().isPresent() && journeyWrapper.isRail()) {
-      trips = cachedTripsByInternalPlanningCode(journeyWrapper.vehicleRef().get());
+      trips = cache.tripsByInternalPlanningCode(journeyWrapper.vehicleRef().get());
     }
 
-    if (trips == null || trips.isEmpty()) {
+    if (trips.isEmpty()) {
       CallWrapper lastCall = calls.getLast();
       // resolves a scheduled stop point id to a quay (regular stop) if necessary
       // quay ids also work
@@ -92,7 +92,7 @@ public class SiriFuzzyTripMatcher {
         trips = getMatchingTripsOnStopOrSiblings(stop, arrivalTime);
       }
     }
-    if (trips == null || trips.isEmpty()) {
+    if (trips.isEmpty()) {
       throw UpdateException.of(NO_FUZZY_TRIP_MATCH);
     }
 
@@ -121,7 +121,7 @@ public class SiriFuzzyTripMatcher {
     LocalDate serviceDate
   ) {
     List<FeedScopedId> matches = new ArrayList<>();
-    for (Trip trip : cachedTripsByInternalPlanningCode(internalPlanningCode)) {
+    for (Trip trip : cache.tripsByInternalPlanningCode(internalPlanningCode)) {
       Set<LocalDate> serviceDates = transitService
         .getTripCalendars()
         .listServiceDates(trip.getServiceId());
@@ -131,10 +131,6 @@ public class SiriFuzzyTripMatcher {
     }
 
     return matches;
-  }
-
-  private static String createStartStopKey(RegularStop stop, int lastStopArrivalTime) {
-    return stop.getId().getId() + ":" + lastStopArrivalTime;
   }
 
   private Set<Trip> getMatchingTripsOnStopOrSiblings(
@@ -152,17 +148,14 @@ public class SiriFuzzyTripMatcher {
       transitService.getTimeZone()
     );
 
-    Set<Trip> trips = cache.startStopTripCache.get(
-      createStartStopKey(lastStop, secondsSinceMidnight)
-    );
-    if (trips == null) {
+    String lastStopId = lastStop.getId().getId();
+    Set<Trip> trips = cache.tripsByLastStopArrival(lastStopId, secondsSinceMidnight);
+    if (trips.isEmpty()) {
       //Attempt to fetch trips that started yesterday - i.e. add 24 hours to arrival-time
-      trips = cache.startStopTripCache.get(
-        createStartStopKey(lastStop, secondsSinceMidnightYesterday)
-      );
+      trips = cache.tripsByLastStopArrival(lastStopId, secondsSinceMidnightYesterday);
     }
 
-    if (trips != null) {
+    if (!trips.isEmpty()) {
       return trips;
     }
 
@@ -171,24 +164,14 @@ public class SiriFuzzyTripMatcher {
       return Set.of();
     }
 
-    trips = new HashSet<>();
+    Set<Trip> tripsOnSiblingQuays = new HashSet<>();
     var allQuays = lastStop.getParentStation().getChildStops();
     for (var quay : allQuays) {
-      Set<Trip> tripSet = cache.startStopTripCache.get(
-        quay.getId().getId() + ":" + secondsSinceMidnight
+      tripsOnSiblingQuays.addAll(
+        cache.tripsByLastStopArrival(quay.getId().getId(), secondsSinceMidnight)
       );
-      if (tripSet != null) {
-        trips.addAll(tripSet);
-      }
     }
-    return trips;
-  }
-
-  private Set<Trip> cachedTripsByInternalPlanningCode(String internalPlanningCode) {
-    if (internalPlanningCode == null) {
-      return null;
-    }
-    return cache.internalPlanningCodeCache.getOrDefault(internalPlanningCode, new HashSet<>());
+    return tripsOnSiblingQuays;
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCache.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCache.java
@@ -23,7 +23,15 @@ public class SiriFuzzyTripMatcherCache {
   private final ImmutableSetMultimap<String, Trip> internalPlanningCodeCache;
   private final ImmutableSetMultimap<String, Trip> startStopTripCache;
 
-  public SiriFuzzyTripMatcherCache(TransitRepository transitRepository) {
+  private SiriFuzzyTripMatcherCache(
+    ImmutableSetMultimap<String, Trip> internalPlanningCodeCache,
+    ImmutableSetMultimap<String, Trip> startStopTripCache
+  ) {
+    this.internalPlanningCodeCache = internalPlanningCodeCache;
+    this.startStopTripCache = startStopTripCache;
+  }
+
+  public static SiriFuzzyTripMatcherCache create(TransitRepository transitRepository) {
     TransitService index = new DefaultTransitService(transitRepository, null);
     var internalPlanningCodes = ImmutableSetMultimap.<String, Trip>builder();
     var startStopTrips = ImmutableSetMultimap.<String, Trip>builder();
@@ -50,11 +58,17 @@ public class SiriFuzzyTripMatcherCache {
       }
     }
 
-    this.internalPlanningCodeCache = internalPlanningCodes.build();
-    this.startStopTripCache = startStopTrips.build();
+    var cache = new SiriFuzzyTripMatcherCache(
+      internalPlanningCodes.build(),
+      startStopTrips.build()
+    );
 
-    LOG.info("Built internalPlanningCode-cache [{}].", internalPlanningCodeCache.keySet().size());
-    LOG.info("Built start-stop-cache [{}].", startStopTripCache.keySet().size());
+    LOG.info(
+      "Built internalPlanningCode-cache [{}].",
+      cache.internalPlanningCodeCache.keySet().size()
+    );
+    LOG.info("Built start-stop-cache [{}].", cache.startStopTripCache.keySet().size());
+    return cache;
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCache.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCache.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.updater.trip.siri;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import com.google.common.collect.ImmutableSetMultimap;
 import java.util.Set;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -22,14 +20,14 @@ public class SiriFuzzyTripMatcherCache {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriFuzzyTripMatcherCache.class);
 
-  final Map<String, Set<Trip>> internalPlanningCodeCache = new HashMap<>();
-  final Map<String, Set<Trip>> startStopTripCache = new HashMap<>();
+  private final ImmutableSetMultimap<String, Trip> internalPlanningCodeCache;
+  private final ImmutableSetMultimap<String, Trip> startStopTripCache;
 
   public SiriFuzzyTripMatcherCache(TransitRepository transitRepository) {
-    initCache(new DefaultTransitService(transitRepository, null));
-  }
+    TransitService index = new DefaultTransitService(transitRepository, null);
+    var internalPlanningCodes = ImmutableSetMultimap.<String, Trip>builder();
+    var startStopTrips = ImmutableSetMultimap.<String, Trip>builder();
 
-  private void initCache(TransitService index) {
     for (Trip trip : index.listTrips()) {
       TripPattern tripPattern = index.findPattern(trip);
 
@@ -40,9 +38,7 @@ public class SiriFuzzyTripMatcherCache {
       if (tripPattern.getRoute().getMode().equals(TransitMode.RAIL)) {
         String internalPlanningCode = trip.getNetexInternalPlanningCode();
         if (internalPlanningCode != null) {
-          internalPlanningCodeCache
-            .computeIfAbsent(internalPlanningCode, key -> new HashSet<>())
-            .add(trip);
+          internalPlanningCodes.put(internalPlanningCode, trip);
         }
       }
       String lastStopId = tripPattern.lastStop().getId().getId();
@@ -50,12 +46,33 @@ public class SiriFuzzyTripMatcherCache {
       TripTimes tripTimes = tripPattern.getScheduledTimetable().getTripTimes(trip);
       if (tripTimes != null) {
         int arrivalTime = tripTimes.getArrivalTime(tripTimes.getNumStops() - 1);
-        String key = lastStopId + ":" + arrivalTime;
-        startStopTripCache.computeIfAbsent(key, k -> new HashSet<>()).add(trip);
+        startStopTrips.put(startStopKey(lastStopId, arrivalTime), trip);
       }
     }
 
-    LOG.info("Built internalPlanningCode-cache [{}].", internalPlanningCodeCache.size());
-    LOG.info("Built start-stop-cache [{}].", startStopTripCache.size());
+    this.internalPlanningCodeCache = internalPlanningCodes.build();
+    this.startStopTripCache = startStopTrips.build();
+
+    LOG.info("Built internalPlanningCode-cache [{}].", internalPlanningCodeCache.keySet().size());
+    LOG.info("Built start-stop-cache [{}].", startStopTripCache.keySet().size());
+  }
+
+  /**
+   * The rail trips with the given NeTEx internal planning code, or an empty set if there are none.
+   */
+  public Set<Trip> tripsByInternalPlanningCode(String internalPlanningCode) {
+    return internalPlanningCodeCache.get(internalPlanningCode);
+  }
+
+  /**
+   * The trips whose scheduled last stop and arrival time (in seconds since start of the service
+   * day) match the given values, or an empty set if there are none.
+   */
+  public Set<Trip> tripsByLastStopArrival(String stopId, int arrivalTime) {
+    return startStopTripCache.get(startStopKey(stopId, arrivalTime));
+  }
+
+  private static String startStopKey(String stopId, int arrivalTime) {
+    return stopId + ":" + arrivalTime;
   }
 }

--- a/application/src/test-fixtures/java/org/opentripplanner/updater/trip/siri/SiriTestHelper.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/updater/trip/siri/SiriTestHelper.java
@@ -20,7 +20,7 @@ public class SiriTestHelper {
     this.transitTestEnvironment = transitTestEnvironment;
     var repo = transitTestEnvironment.transitRepository();
     this.siriAdapter = new SiriRealTimeTripUpdateAdapter(repo, DeduplicatorService.NOOP, null);
-    var cache = new SiriFuzzyTripMatcherCache(repo);
+    var cache = SiriFuzzyTripMatcherCache.create(repo);
     this.siriAdapterWithFuzzyMatching = new SiriRealTimeTripUpdateAdapter(
       repo,
       DeduplicatorService.NOOP,

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCacheTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherCacheTest.java
@@ -1,0 +1,128 @@
+package org.opentripplanner.updater.trip.siri;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model.TripInput;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.utils.time.TimeUtils;
+
+class SiriFuzzyTripMatcherCacheTest implements RealtimeTestConstants {
+
+  private static final String PLANNING_CODE = "47";
+  private static final int LAST_STOP_ARRIVAL = TimeUtils.time("0:20:00");
+
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
+  private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
+  private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
+  private final Route RAIL_ROUTE = ENV_BUILDER.route("RailRoute", r ->
+    r.withMode(TransitMode.RAIL)
+  );
+
+  @Test
+  void railTripIsIndexedByInternalPlanningCode() {
+    var env = ENV_BUILDER.addTrip(railTrip(TRIP_1_ID, PLANNING_CODE)).build();
+
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
+
+    assertThat(tripIds(cache.tripsByInternalPlanningCode(PLANNING_CODE))).containsExactly(
+      TRIP_1_ID
+    );
+  }
+
+  @Test
+  void railTripsWithSamePlanningCodeAreGroupedTogether() {
+    var env = ENV_BUILDER.addTrip(railTrip(TRIP_1_ID, PLANNING_CODE))
+      .addTrip(railTrip(TRIP_2_ID, PLANNING_CODE))
+      .build();
+
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
+
+    assertThat(tripIds(cache.tripsByInternalPlanningCode(PLANNING_CODE))).containsExactly(
+      TRIP_1_ID,
+      TRIP_2_ID
+    );
+  }
+
+  @Test
+  void nonRailTripIsNotIndexedByInternalPlanningCode() {
+    var busRoute = ENV_BUILDER.route("BusRoute", r -> r.withMode(TransitMode.BUS));
+    var busTrip = tripInput(TRIP_1_ID)
+      .withRoute(busRoute)
+      .withNetexInternalPlanningCode(PLANNING_CODE);
+    var env = ENV_BUILDER.addTrip(busTrip).build();
+
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
+
+    assertThat(cache.tripsByInternalPlanningCode(PLANNING_CODE)).isEmpty();
+  }
+
+  @Test
+  void unknownPlanningCodeReturnsEmptySet() {
+    var env = ENV_BUILDER.addTrip(railTrip(TRIP_1_ID, PLANNING_CODE)).build();
+
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
+
+    assertThat(cache.tripsByInternalPlanningCode("unknown")).isEmpty();
+  }
+
+  @Test
+  void tripIsIndexedByLastStopAndScheduledArrivalTime() {
+    var env = ENV_BUILDER.addTrip(tripInput(TRIP_1_ID)).build();
+
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
+
+    assertThat(tripIds(cache.tripsByLastStopArrival(STOP_B_ID, LAST_STOP_ARRIVAL))).containsExactly(
+      TRIP_1_ID
+    );
+  }
+
+  @Test
+  void lookupWithWrongStopOrArrivalTimeReturnsEmptySet() {
+    var env = ENV_BUILDER.addTrip(tripInput(TRIP_1_ID)).build();
+
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
+
+    assertThat(cache.tripsByLastStopArrival(STOP_A_ID, LAST_STOP_ARRIVAL)).isEmpty();
+    assertThat(cache.tripsByLastStopArrival(STOP_B_ID, LAST_STOP_ARRIVAL + 1)).isEmpty();
+  }
+
+  @Test
+  void tripsWithSameLastStopAndArrivalAreGroupedTogether() {
+    var env = ENV_BUILDER.addTrip(tripInput(TRIP_1_ID)).addTrip(tripInput(TRIP_2_ID)).build();
+
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
+
+    assertThat(tripIds(cache.tripsByLastStopArrival(STOP_B_ID, LAST_STOP_ARRIVAL))).containsExactly(
+      TRIP_1_ID,
+      TRIP_2_ID
+    );
+  }
+
+  private TripInput railTrip(String tripId, String internalPlanningCode) {
+    return tripInput(tripId)
+      .withRoute(RAIL_ROUTE)
+      .withNetexInternalPlanningCode(internalPlanningCode);
+  }
+
+  private TripInput tripInput(String tripId) {
+    return TripInput.of(tripId)
+      .addStop(STOP_A, "0:10:00", "0:10:00")
+      .addStop(STOP_B, "0:20:00", "0:20:00");
+  }
+
+  private static Set<String> tripIds(Set<Trip> trips) {
+    return trips
+      .stream()
+      .map(trip -> trip.getId().getId())
+      .collect(Collectors.toSet());
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/SiriFuzzyTripMatcherTest.java
@@ -109,7 +109,7 @@ class SiriFuzzyTripMatcherTest implements RealtimeTestConstants {
   private static TripAndPattern match(EstimatedVehicleJourney evj, TransitTestEnvironment env)
     throws UpdateException {
     var transitService = env.transitService();
-    var cache = new SiriFuzzyTripMatcherCache(env.transitRepository());
+    var cache = SiriFuzzyTripMatcherCache.create(env.transitRepository());
     var fuzzyMatcher = new SiriFuzzyTripMatcher(cache, transitService);
     return fuzzyMatcher.match(
       EstimatedVehicleJourneyWrapper.of(evj),


### PR DESCRIPTION
## Summary

Addresses the TODO "Enforce immutability in `SiriFuzzyTripMatcherCache`" from the Snapshot Framework TODO list (related to #7826, review comment https://github.com/opentripplanner/OpenTripPlanner/pull/7689#discussion_r3594979258).

The cache is built once from the static transit model and shared across all SIRI updaters, so its immutability was load-bearing — but previously only enforced by convention: the two indexes were package-visible mutable `HashMap`s of mutable `HashSet`s, accessed directly by `SiriFuzzyTripMatcher`.

## Changes

- The two indexes are now `private final ImmutableSetMultimap<String, Trip>` (following the precedent in `DefaultTimetableRepository`), so immutability is enforced by type.
- Lookups go through intent-revealing accessors (`tripsByInternalPlanningCode`, `tripsByLastStopArrival`) that return an empty set on a miss; `SiriFuzzyTripMatcher` no longer reaches into the maps, and its null-checks became empty-checks (equivalent, since cached sets are never empty).
- The `stopId + ":" + arrivalTime` key format, previously built in three places, now has a single definition inside the cache.
- The cache is constructed via a static factory method `create(TransitRepository)`; the constructor only assigns fields.
- Added unit tests for `SiriFuzzyTripMatcherCache`.

## Notes

No functional change intended. No serialization version bump needed — the cache is built at updater startup and never serialized.
