### PR TITLE
Restrict Guava usage to a white-list of classes

### DIFF
--- a/DEVELOPMENT_DECISION_RECORDS.md
+++ b/DEVELOPMENT_DECISION_RECORDS.md
@@ -102,6 +102,11 @@ Prefer immutable types over mutable. Use builders where appropriate. See
 
 [Avoid using records if you cannot encapsulate it properly](doc/dev/decisionrecords/RecordsPOJOsBuilders.md#records)
 
+## Restrict-Guava-Usage
+
+Use only Guava classes on the [white-list](doc/dev/decisionrecords/RestrictGuavaUsage.md) enforced
+by the `GuavaArchitectureTest`. Prefer the JDK or the OTP utils where they provide an equivalent.
+
 ## GraphQL Best Practices - API Design
 
 [Follow best practices for designing GraphQL APIs. Our APIs need to be backwards compatible as they are used by hundreds of clients (web-pages/apps/services).](doc/dev/decisionrecords/APIGraphQLDesign.md)

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/AtlantaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/AtlantaFareService.java
@@ -4,7 +4,6 @@ import static org.opentripplanner.transit.model.basic.Money.ZERO_USD;
 import static org.opentripplanner.transit.model.basic.Money.usDollars;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import java.time.Duration;
 import java.time.ZoneId;
@@ -173,7 +172,7 @@ public class AtlantaFareService extends DefaultFareService {
    * values are not available therefore the default test price is used instead.
    */
   protected Money getLegPrice(Leg leg, FareType fareType, Collection<FareRuleSet> fareRules) {
-    return calculateCost(fareType, Lists.newArrayList(leg), fareRules).orElse(Money.ZERO_USD);
+    return calculateCost(fareType, List.of(leg), fareRules).orElse(Money.ZERO_USD);
   }
 
   private static class TransferMeta {

--- a/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/fares/service/gtfs/v1/custom/OrcaFareService.java
@@ -3,7 +3,6 @@ package org.opentripplanner.ext.fares.service.gtfs.v1.custom;
 import static org.opentripplanner.transit.model.basic.Money.ZERO_USD;
 import static org.opentripplanner.transit.model.basic.Money.usDollars;
 
-import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -468,7 +467,7 @@ public class OrcaFareService extends DefaultFareService {
     FareType fareType,
     Collection<FareRuleSet> fareRules
   ) {
-    return calculateCost(fareType, Lists.newArrayList(leg), fareRules);
+    return calculateCost(fareType, List.of(leg), fareRules);
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.flex.template;
 
-import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.core.model.id.FeedScopedId;
@@ -42,7 +41,7 @@ class FlexEgressTemplate extends AbstractFlexTemplate {
   }
 
   protected List<Edge> getTransferEdges(PathTransfer transfer) {
-    return Lists.reverse(transfer.getEdges());
+    return transfer.getEdges().reversed();
   }
 
   protected RegularStop getFinalStop(PathTransfer transfer) {

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureUpdater.java
@@ -11,7 +11,6 @@ import com.azure.messaging.servicebus.administration.ServiceBusAdministrationCli
 import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClientBuilder;
 import com.azure.messaging.servicebus.administration.models.CreateSubscriptionOptions;
 import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import jakarta.xml.bind.JAXBException;
 import java.net.URI;
@@ -331,7 +330,7 @@ public class SiriAzureUpdater implements GraphUpdater<TransitRealTimeUpdateConte
     ServiceBusClientBuilder clientBuilder = new ServiceBusClientBuilder();
 
     if (authenticationType == AuthenticationType.FederatedIdentity) {
-      Preconditions.checkNotNull(
+      Objects.requireNonNull(
         fullyQualifiedNamespace,
         "fullyQualifiedNamespace must be set for FederatedIdentity authentication"
       );
@@ -339,7 +338,7 @@ public class SiriAzureUpdater implements GraphUpdater<TransitRealTimeUpdateConte
         .fullyQualifiedNamespace(fullyQualifiedNamespace)
         .credential(new DefaultAzureCredentialBuilder().build());
     } else if (authenticationType == AuthenticationType.SharedAccessKey) {
-      Preconditions.checkNotNull(
+      Objects.requireNonNull(
         serviceBusUrl,
         "serviceBusUrl must be set for SharedAccessKey authentication"
       );

--- a/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttEstimatedTimetableSource.java
+++ b/application/src/ext/java/org/opentripplanner/ext/siri/updater/mqtt/MqttEstimatedTimetableSource.java
@@ -2,7 +2,6 @@ package org.opentripplanner.ext.siri.updater.mqtt;
 
 import static org.opentripplanner.utils.lang.StringUtils.hasNoValue;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.lifecycle.MqttClientDisconnectedContext;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
@@ -84,17 +83,15 @@ public class MqttEstimatedTimetableSource implements AsyncEstimatedTimetableSour
   public MqttEstimatedTimetableSource(MqttSiriETUpdaterParameters parameters) {
     this.parameters = parameters;
 
-    ThreadFactory primingThreadFactory = new ThreadFactoryBuilder()
-      .setNameFormat("primingSiriMqttUpdater-%d")
-      .build();
+    ThreadFactory primingThreadFactory = Thread.ofPlatform()
+      .name("primingSiriMqttUpdater-", 0)
+      .factory();
     this.primingExecutor = Executors.newFixedThreadPool(
       parameters.numberOfPrimingWorkers(),
       primingThreadFactory
     );
 
-    ThreadFactory liveThreadFactory = new ThreadFactoryBuilder()
-      .setNameFormat("liveSiriMqttUpdater-%d")
-      .build();
+    ThreadFactory liveThreadFactory = Thread.ofPlatform().name("liveSiriMqttUpdater-", 0).factory();
     this.liveExecutor = Executors.newSingleThreadExecutor(liveThreadFactory);
 
     registerMetrics();

--- a/application/src/main/java/org/opentripplanner/apis/support/SemanticHash.java
+++ b/application/src/main/java/org/opentripplanner/apis/support/SemanticHash.java
@@ -4,7 +4,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -35,16 +35,16 @@ public class SemanticHash {
    */
   public static String forTripPattern(TripPattern tripPattern, Trip trip) {
     HashFunction murmur = Hashing.murmur3_32();
-    BaseEncoding encoder = BaseEncoding.base64Url().omitPadding();
+    Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
     StringBuilder sb = new StringBuilder(50);
-    sb.append(encoder.encode(forStopPattern(tripPattern, murmur).asBytes()));
+    sb.append(encoder.encodeToString(forStopPattern(tripPattern, murmur).asBytes()));
     if (trip != null) {
       TripTimes tripTimes = tripPattern.getScheduledTimetable().getTripTimes(trip);
       if (tripTimes == null) {
         return null;
       }
       sb.append(':');
-      sb.append(encoder.encode(forTripTimes(tripTimes, murmur).asBytes()));
+      sb.append(encoder.encodeToString(forTripTimes(tripTimes, murmur).asBytes()));
     }
     return sb.toString();
   }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/TransmodelGraph.java
@@ -39,9 +39,7 @@ class TransmodelGraph {
   final ExecutorService threadPool;
 
   TransmodelGraph(GraphQLSchema schema) {
-    this.threadPool = Executors.newCachedThreadPool(
-      OtpRequestThreadFactory.of("transmodel-api-%d")
-    );
+    this.threadPool = Executors.newCachedThreadPool(OtpRequestThreadFactory.of("transmodel-api-"));
     this.indexSchema = schema;
   }
 

--- a/application/src/main/java/org/opentripplanner/framework/concurrent/OtpRequestThreadFactory.java
+++ b/application/src/main/java/org/opentripplanner/framework/concurrent/OtpRequestThreadFactory.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.framework.concurrent;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.ThreadFactory;
 import org.opentripplanner.framework.application.LogMDCSupport;
 
@@ -27,8 +26,12 @@ public class OtpRequestThreadFactory implements ThreadFactory {
     this.delegate = delegate;
   }
 
-  public static ThreadFactory of(String nameFormat) {
-    var defaultFactory = new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
+  /**
+   * Create a factory whose threads are named with the given prefix followed by an increasing
+   * number, e.g. {@code prefix0, prefix1, ...}.
+   */
+  public static ThreadFactory of(String namePrefix) {
+    var defaultFactory = Thread.ofPlatform().name(namePrefix, 0).factory();
     return new OtpRequestThreadFactory(defaultFactory);
   }
 

--- a/application/src/main/java/org/opentripplanner/framework/transaction/configure/TransactionModule.java
+++ b/application/src/main/java/org/opentripplanner/framework/transaction/configure/TransactionModule.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.framework.transaction.configure;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import dagger.Module;
 import dagger.Provides;
 import jakarta.inject.Singleton;
@@ -33,7 +32,7 @@ public abstract class TransactionModule {
     @TransitDomain RepositoryRegistry repositoryRegistry,
     TimetableSnapshotParameters timetableSnapshotParameters
   ) {
-    var threadFactory = new ThreadFactoryBuilder().setNameFormat("transitWriter").build();
+    var threadFactory = Thread.ofPlatform().name("transitWriter").factory();
     return TransactionFactory.createUpdateManagerWithPeriodicCommits(
       "transit",
       repositoryRegistry,
@@ -66,7 +65,7 @@ public abstract class TransactionModule {
   public static UpdateManager streetUpdateManager(
     @StreetDomain RepositoryRegistry repositoryRegistry
   ) {
-    var threadFactory = new ThreadFactoryBuilder().setNameFormat("streetWriter").build();
+    var threadFactory = Thread.ofPlatform().name("streetWriter").factory();
     return TransactionFactory.createUpdateManagerWithAtomicCommits(
       "street",
       repositoryRegistry,

--- a/application/src/main/java/org/opentripplanner/graph_builder/issue/report/DataImportIssueReporter.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/issue/report/DataImportIssueReporter.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.graph_builder.issue.report;
 
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -11,6 +10,7 @@ import org.opentripplanner.datastore.api.CompositeDataSource;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
+import org.opentripplanner.utils.collection.ListUtils;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,7 +137,7 @@ public class DataImportIssueReporter implements GraphBuilderModule {
 
       // Split the issues to buckets if needed
       if (sortedIssues.size() > 1.2 * maxNumberOfIssuesPerFile) {
-        List<List<DataImportIssue>> partitions = Lists.partition(
+        List<List<DataImportIssue>> partitions = ListUtils.partition(
           sortedIssues,
           maxNumberOfIssuesPerFile
         );

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.graph_builder.module.ned;
 
-import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
@@ -186,7 +185,7 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
       }
       LOG.info("decompressing {}", filename);
       OutputStream os = cacheDir.entry(filename).asOutputStream();
-      ByteStreams.copy(zis, os);
+      zis.transferTo(os);
       os.close();
     }
     zis.close();

--- a/application/src/main/java/org/opentripplanner/inspector/vector/edge/EdgePropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/edge/EdgePropertyMapper.java
@@ -7,6 +7,7 @@ import static org.opentripplanner.utils.lang.DoubleUtils.roundTo2Decimals;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.apis.support.mapping.PropertyMapper;
@@ -75,7 +76,7 @@ public class EdgePropertyMapper extends PropertyMapper<Edge> {
 
   private List<KeyValue> mapEscalatorEdge(EscalatorEdge ee) {
     var props = new ArrayList<>(
-      List.of(
+      Arrays.asList(
         kv("distance", ee.getDistanceMeters()),
         kv("duration", ee.getDuration().map(Duration::toString).orElse(null)),
         kv("fromVertexLabel", ee.getFromVertex().getLabel().toString()),
@@ -91,7 +92,7 @@ public class EdgePropertyMapper extends PropertyMapper<Edge> {
 
   private List<KeyValue> mapStreetEdge(StreetEdge se) {
     var props = new ArrayList<>(
-      List.of(
+      Arrays.asList(
         kv("permission", streetPermissionAsString(se.getPermission())),
         kv("noThruTraffic", noThruTrafficAsString(se)),
         kv("wheelchairAccessible", se.isWheelchairAccessible()),

--- a/application/src/main/java/org/opentripplanner/inspector/vector/edge/EdgePropertyMapper.java
+++ b/application/src/main/java/org/opentripplanner/inspector/vector/edge/EdgePropertyMapper.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.street.model.StreetTraversalPermission.BICYCLE
 import static org.opentripplanner.street.search.TraverseMode.WALK;
 import static org.opentripplanner.utils.lang.DoubleUtils.roundTo2Decimals;
 
-import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,11 +74,13 @@ public class EdgePropertyMapper extends PropertyMapper<Edge> {
   }
 
   private List<KeyValue> mapEscalatorEdge(EscalatorEdge ee) {
-    var props = Lists.newArrayList(
-      kv("distance", ee.getDistanceMeters()),
-      kv("duration", ee.getDuration().map(Duration::toString).orElse(null)),
-      kv("fromVertexLabel", ee.getFromVertex().getLabel().toString()),
-      kv("toVertexLabel", ee.getToVertex().getLabel().toString())
+    var props = new ArrayList<>(
+      List.of(
+        kv("distance", ee.getDistanceMeters()),
+        kv("duration", ee.getDuration().map(Duration::toString).orElse(null)),
+        kv("fromVertexLabel", ee.getFromVertex().getLabel().toString()),
+        kv("toVertexLabel", ee.getToVertex().getLabel().toString())
+      )
     );
     var inclinedEdgeLevelInfoOptional = streetDetailsService.findInclinedEdgeLevelInfo(ee);
     if (inclinedEdgeLevelInfoOptional.isPresent()) {
@@ -89,13 +90,15 @@ public class EdgePropertyMapper extends PropertyMapper<Edge> {
   }
 
   private List<KeyValue> mapStreetEdge(StreetEdge se) {
-    var props = Lists.newArrayList(
-      kv("permission", streetPermissionAsString(se.getPermission())),
-      kv("noThruTraffic", noThruTrafficAsString(se)),
-      kv("wheelchairAccessible", se.isWheelchairAccessible()),
-      kv("maximumSlope", roundTo2Decimals(se.getMaxSlope())),
-      kv("fromVertexLabel", se.getFromVertex().getLabel().toString()),
-      kv("toVertexLabel", se.getToVertex().getLabel().toString())
+    var props = new ArrayList<>(
+      List.of(
+        kv("permission", streetPermissionAsString(se.getPermission())),
+        kv("noThruTraffic", noThruTrafficAsString(se)),
+        kv("wheelchairAccessible", se.isWheelchairAccessible()),
+        kv("maximumSlope", roundTo2Decimals(se.getMaxSlope())),
+        kv("fromVertexLabel", se.getFromVertex().getLabel().toString()),
+        kv("toVertexLabel", se.getToVertex().getLabel().toString())
+      )
     );
     if (se.getPermission().allows(BICYCLE)) {
       props.add(kv("bicycleSafetyFactor", roundTo2Decimals(se.getBicycleSafetyFactor())));

--- a/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/RaptorEnvironmentFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/routerconfig/RaptorEnvironmentFactory.java
@@ -33,7 +33,7 @@ public class RaptorEnvironmentFactory {
       @Override
       public ExecutorService threadPool() {
         return threadPoolSize > 0
-          ? Executors.newFixedThreadPool(threadPoolSize, OtpRequestThreadFactory.of("raptor-%d"))
+          ? Executors.newFixedThreadPool(threadPoolSize, OtpRequestThreadFactory.of("raptor-"))
           : null;
       }
     };

--- a/application/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
@@ -3,7 +3,6 @@ package org.opentripplanner.standalone.server;
 import static org.opentripplanner.framework.application.ApplicationShutdownSupport.addShutdownHook;
 import static org.opentripplanner.framework.application.ApplicationShutdownSupport.removeShutdownHook;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
@@ -73,7 +72,7 @@ public class GrizzlyServer {
     int nHandlerThreads = getMaxThreads();
     ThreadPoolConfig threadPoolConfig = ThreadPoolConfig.defaultConfig()
       .setPoolName("grizzly")
-      .setThreadFactory(new ThreadFactoryBuilder().setNameFormat("grizzly-%d").build())
+      .setThreadFactory(Thread.ofPlatform().name("grizzly-", 0).factory())
       .setCorePoolSize(nHandlerThreads)
       .setMaxPoolSize(nHandlerThreads)
       .setQueueLimit(-1);

--- a/application/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/application/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +58,7 @@ public class GraphUpdaterManager implements GraphUpdaterStatus {
     Runnable shutdownGraphWriter,
     List<GraphUpdater<?>> updaters
   ) {
-    var updaterThreadFactory = new ThreadFactoryBuilder().setNameFormat("updater-%d").build();
+    var updaterThreadFactory = Thread.ofPlatform().name("updater-", 0).factory();
     this.pollingUpdaterPool = Executors.newScheduledThreadPool(
       Math.max(MIN_POLLING_UPDATER_THREADS, Runtime.getRuntime().availableProcessors()),
       updaterThreadFactory
@@ -229,31 +228,31 @@ public class GraphUpdaterManager implements GraphUpdaterStatus {
    * mostly idle, and it is short-lived, so the busy-wait is a compromise.
    */
   private void reportReadinessForUpdaters() {
-    Executors.newSingleThreadExecutor(
-      new ThreadFactoryBuilder().setNameFormat("updater-ready").build()
-    ).submit(() -> {
-      boolean otpIsShuttingDown = false;
+    Executors.newSingleThreadExecutor(Thread.ofPlatform().name("updater-ready").factory()).submit(
+      () -> {
+        boolean otpIsShuttingDown = false;
 
-      while (!otpIsShuttingDown) {
-        try {
-          if (updaterList.stream().allMatch(GraphUpdater::isPrimed)) {
-            LOG.info(
-              "OTP UPDATERS INITIALIZED ({} updaters) - OTP {} is ready for routing!",
-              updaterList.size(),
-              OtpProjectInfo.projectInfo().version
-            );
-            return;
+        while (!otpIsShuttingDown) {
+          try {
+            if (updaterList.stream().allMatch(GraphUpdater::isPrimed)) {
+              LOG.info(
+                "OTP UPDATERS INITIALIZED ({} updaters) - OTP {} is ready for routing!",
+                updaterList.size(),
+                OtpProjectInfo.projectInfo().version
+              );
+              return;
+            }
+            //noinspection BusyWait
+            Thread.sleep(1000);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            otpIsShuttingDown = true;
+            LOG.info("OTP is shutting down, cancelling wait for updaters readiness.");
+          } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
           }
-          //noinspection BusyWait
-          Thread.sleep(1000);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          otpIsShuttingDown = true;
-          LOG.info("OTP is shutting down, cancelling wait for updaters readiness.");
-        } catch (Exception e) {
-          LOG.error(e.getMessage(), e);
         }
       }
-    });
+    );
   }
 }

--- a/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_position/RealtimeVehiclePatternMatcher.java
@@ -8,7 +8,6 @@ import static org.opentripplanner.updater.spi.UpdateErrorType.NO_SERVICE_ON_DATE
 import static org.opentripplanner.updater.spi.UpdateErrorType.TRIP_NOT_FOUND;
 import static org.opentripplanner.updater.spi.UpdateErrorType.TRIP_NOT_FOUND_IN_PATTERN;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -372,7 +371,7 @@ class RealtimeVehiclePatternMatcher {
     }
 
     var serviceDate = Optional.of(vehiclePositionWithTripId.getTrip().getStartDate())
-      .map(Strings::emptyToNull)
+      .filter(s -> !s.isEmpty())
       .flatMap(ServiceDateUtils::parseStringToOptional)
       .orElseGet(() -> inferServiceDate(trip));
 

--- a/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironment.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/transit/model/TransitTestEnvironment.java
@@ -2,7 +2,6 @@ package org.opentripplanner.transit.model;
 
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import org.opentripplanner.LocalTimeParser;
@@ -78,7 +77,7 @@ public final class TransitTestEnvironment {
       timetableSnapshot,
       new TimetableRepositoryLifecycle(timetableSnapshot, false, () -> defaultServiceDate)
     );
-    var threadFactory = new ThreadFactoryBuilder().setNameFormat("test-commit").build();
+    var threadFactory = Thread.ofPlatform().name("test-commit").factory();
     // Use atomic commits (commit immediately after each task) so test assertions see results right away
     this.updateManager = TransactionFactory.createUpdateManagerWithAtomicCommits(
       "test",

--- a/application/src/test/java/org/opentripplanner/GuavaArchitectureTest.java
+++ b/application/src/test/java/org/opentripplanner/GuavaArchitectureTest.java
@@ -1,0 +1,94 @@
+package org.opentripplanner;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner._support.arch.ArchComponent;
+
+/**
+ * Restrict the use of the Guava library to an explicit white-list of classes. Guava is a huge
+ * library and we want to keep the usage of it to a minimum - prefer the JDK or the OTP utils
+ * where they provide an equivalent. If you need another Guava class, add it to the white-list
+ * deliberately - do not work around this test.
+ */
+public class GuavaArchitectureTest {
+
+  private static final String GUAVA_ROOT_PACKAGE = "com.google.common";
+
+  private static final Set<String> WHITE_LISTED_GUAVA_CLASSES = Set.of(
+    "com.google.common.annotations.VisibleForTesting",
+    "com.google.common.cache.Cache",
+    "com.google.common.cache.CacheBuilder",
+    "com.google.common.cache.CacheLoader",
+    "com.google.common.cache.LoadingCache",
+    "com.google.common.collect.ArrayListMultimap",
+    "com.google.common.collect.HashMultimap",
+    "com.google.common.collect.ImmutableListMultimap",
+    "com.google.common.collect.ImmutableMultimap",
+    "com.google.common.collect.ImmutableSetMultimap",
+    "com.google.common.collect.ImmutableSortedSet",
+    "com.google.common.collect.Iterables",
+    "com.google.common.collect.LinkedHashMultimap",
+    "com.google.common.collect.ListMultimap",
+    "com.google.common.collect.MinMaxPriorityQueue",
+    "com.google.common.collect.Multimap",
+    "com.google.common.collect.MultimapBuilder",
+    "com.google.common.collect.Multimaps",
+    "com.google.common.collect.Multiset",
+    "com.google.common.collect.SetMultimap",
+    "com.google.common.collect.Sets",
+    "com.google.common.collect.TreeMultiset",
+    "com.google.common.hash.HashCode",
+    "com.google.common.hash.HashFunction",
+    "com.google.common.hash.Hasher",
+    "com.google.common.hash.Hashing",
+    "com.google.common.html.HtmlEscapers",
+    "com.google.common.util.concurrent.MoreExecutors",
+    // The classes below are never imported, but the byte-code references them because they are
+    // the concrete return types of the white-listed API above (e.g. multimap views and
+    // HtmlEscapers.htmlEscaper()).
+    "com.google.common.collect.ImmutableCollection",
+    "com.google.common.collect.ImmutableList",
+    "com.google.common.collect.ImmutableMultiset",
+    "com.google.common.collect.ImmutableSet",
+    "com.google.common.escape.Escaper"
+  );
+
+  private static final DescribedPredicate<JavaClass> A_GUAVA_CLASS_NOT_IN_THE_WHITE_LIST =
+    new DescribedPredicate<>("a Guava class not in the white-list") {
+      @Override
+      public boolean test(JavaClass javaClass) {
+        return (
+          isInGuava(javaClass) && !WHITE_LISTED_GUAVA_CLASSES.contains(topLevelClassName(javaClass))
+        );
+      }
+    };
+
+  @Test
+  void enforceGuavaClassWhiteList() {
+    noClasses()
+      .should()
+      .dependOnClassesThat(A_GUAVA_CLASS_NOT_IN_THE_WHITE_LIST)
+      .check(ArchComponent.OTP_CLASSES);
+  }
+
+  private static boolean isInGuava(JavaClass javaClass) {
+    var packageName = javaClass.getPackageName();
+    return (
+      packageName.equals(GUAVA_ROOT_PACKAGE) || packageName.startsWith(GUAVA_ROOT_PACKAGE + ".")
+    );
+  }
+
+  /**
+   * Map nested classes (like {@code ImmutableMultimap.Builder}) to their top-level class, so
+   * white-listing a class includes its nested types.
+   */
+  private static String topLevelClassName(JavaClass javaClass) {
+    var name = javaClass.getName();
+    int index = name.indexOf('$');
+    return index < 0 ? name : name.substring(0, index);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/framework/transaction/internal/UpdateManagerMetricsTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/internal/UpdateManagerMetricsTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.framework.transaction.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -21,7 +20,7 @@ class UpdateManagerMetricsTest {
 
   @Test
   void writerThreadExecutorExposesQueueMetrics() {
-    var threadFactory = new ThreadFactoryBuilder().setNameFormat("metrics-test").build();
+    var threadFactory = Thread.ofPlatform().name("metrics-test").factory();
     var updateManager = TransactionFactory.createUpdateManagerWithAtomicCommits(
       "metrics-test",
       TransactionFactory.createRepositoryRegistry(),

--- a/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/TransactionFrameworkTest.java
+++ b/application/src/test/java/org/opentripplanner/framework/transaction/moduletest/TransactionFrameworkTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,7 +91,7 @@ public class TransactionFrameworkTest {
   }
 
   private void setupUpdateManagerWithAutoCommits() {
-    var threadFactory = new ThreadFactoryBuilder().setNameFormat("AutoCommit").build();
+    var threadFactory = Thread.ofPlatform().name("AutoCommit").factory();
     updateManager = TransactionFactory.createUpdateManagerWithAtomicCommits(
       getClass().getSimpleName(),
       registry,
@@ -133,7 +132,7 @@ public class TransactionFrameworkTest {
   }
 
   private void setupUpdateManagerWithPeriodicCommits() {
-    var threadFactory = new ThreadFactoryBuilder().setNameFormat("AutoCommit").build();
+    var threadFactory = Thread.ofPlatform().name("AutoCommit").factory();
     updateManager = TransactionFactory.createUpdateManagerWithPeriodicCommits(
       getClass().getSimpleName(),
       registry,

--- a/application/src/test/java/org/opentripplanner/generate/doc/GraphQLTutorialDocTest.java
+++ b/application/src/test/java/org/opentripplanner/generate/doc/GraphQLTutorialDocTest.java
@@ -8,16 +8,17 @@ import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPL
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.USER_DOC_PATH;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSection;
 
-import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.TemplateUtil;
+import org.opentripplanner.test.support.ResourceLoader;
 
 @GeneratesDocumentation
 public class GraphQLTutorialDocTest {
+
+  private static final ResourceLoader RESOURCES = ResourceLoader.of(GraphQLTutorialDocTest.class);
 
   private static final File TEMPLATE = new File(TEMPLATE_PATH, "GraphQL-Tutorial.md");
 
@@ -46,9 +47,9 @@ public class GraphQLTutorialDocTest {
     assertFileEquals(original, OUT_FILE);
   }
 
-  private static String getGraphQlQuery(String resourceName) throws IOException {
-    var url = Resources.getResource("org/opentripplanner/apis/gtfs/queries/" + resourceName);
-    var query = TemplateUtil.graphQlExample(Resources.toString(url, StandardCharsets.UTF_8));
+  private static String getGraphQlQuery(String resourceName) {
+    var content = RESOURCES.fileToString("/org/opentripplanner/apis/gtfs/queries/" + resourceName);
+    var query = TemplateUtil.graphQlExample(content);
     assertNotNull(query);
     return query;
   }

--- a/doc/dev/decisionrecords/RestrictGuavaUsage.md
+++ b/doc/dev/decisionrecords/RestrictGuavaUsage.md
@@ -1,0 +1,14 @@
+# Restrict Guava Usage
+
+Only Guava classes on the white-list enforced by the `GuavaArchitectureTest` may be used. Prefer the
+JDK or the OTP utils where they provide an equivalent, and extend the white-list deliberately when
+Guava is clearly the best option.
+
+### Context
+
+Guava is a very large general-purpose library, and much of it duplicates functionality that has
+since been added to the JDK (e.g. `Preconditions` vs `Objects.requireNonNull`, `ImmutableList` vs
+`List.of`/`List.copyOf`, `Iterables` vs the Stream API). Unrestricted use leads to two idioms for
+the same thing, makes the code harder to read, and increases the cost of future library upgrades or
+removal. The parts of Guava OTP genuinely benefits from are concentrated in a few areas — above all
+the `Multimap` family, plus a handful of utilities like hashing.

--- a/street/src/main/java/org/opentripplanner/street/model/edge/SplitStreetEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/SplitStreetEdge.java
@@ -1,7 +1,8 @@
 package org.opentripplanner.street.model.edge;
 
-import com.google.common.collect.Iterators;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -14,11 +15,11 @@ public record SplitStreetEdge(StreetEdge head, StreetEdge tail) implements Itera
   @Override
   public Iterator<StreetEdge> iterator() {
     if (head == null && tail == null) {
-      return Iterators.forArray();
+      return Collections.emptyIterator();
     } else if (head != null && tail != null) {
-      return Iterators.forArray(head, tail);
+      return List.of(head, tail).iterator();
     } else {
-      return Iterators.singletonIterator(Objects.requireNonNullElse(head, tail));
+      return List.of(Objects.requireNonNullElse(head, tail)).iterator();
     }
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTraversalDistanceTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeTraversalDistanceTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.street.model.edge;
 import static com.google.common.truth.Truth.assertThat;
 import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
 
-import com.google.common.collect.Range;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.opentripplanner.street.geometry.TestCoordinates;
@@ -23,13 +22,14 @@ public class StreetEdgeTraversalDistanceTest {
     var v0 = intersectionVertex(TestCoordinates.BERLIN_TV_TOWER);
     var v1 = intersectionVertex(TestCoordinates.BERLIN_BRANDENBURG_GATE);
     var edge = StreetModelFactory.streetEdge(v0, v1);
-    var range = Range.closed(2000d, 3000d);
-    assertThat(edge.getDistanceMeters()).isIn(range);
+    assertThat(edge.getDistanceMeters()).isAtLeast(2000d);
+    assertThat(edge.getDistanceMeters()).isAtMost(3000d);
     State s0 = new State(
       v0,
       StreetSearchRequest.copyOf(StreetSearchRequest.DEFAULT).withMode(mode).build()
     );
     State s1 = edge.traverse(s0)[0];
-    assertThat(s1.getTraversalDistanceMeters()).isIn(range);
+    assertThat(s1.getTraversalDistanceMeters()).isAtLeast(2000d);
+    assertThat(s1.getTraversalDistanceMeters()).isAtMost(3000d);
   }
 }

--- a/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
@@ -36,6 +36,32 @@ public class ListUtils {
   }
 
   /**
+   * Partition the list into consecutive sublists with the given {@code maxSize}. Each sublist has
+   * {@code maxSize} elements, except the last one, which may have fewer. For example,
+   * {@code partition([A,B,C,D,E], 2)} yields {@code [[A,B],[C,D],[E]]}.
+   * <p>
+   * The partitioning is computed eagerly - the number of sublists is fixed when this method
+   * returns. The sublists themselves are {@link List#subList(int, int) views} of the original
+   * list, so they must be consumed before the original list is structurally modified (elements
+   * added or removed). Unlike the Guava equivalent, the returned outer list does not reflect
+   * later changes to the input list.
+   *
+   * @param maxSize the maximum number of elements in each sublist, must be at least 1
+   * @throws IllegalArgumentException if {@code maxSize} is less than 1
+   * @throws NullPointerException if {@code list} is {@code null}
+   */
+  public static <T> List<List<T>> partition(List<T> list, int maxSize) {
+    if (maxSize < 1) {
+      throw new IllegalArgumentException("maxSize must be at least 1, but was: " + maxSize);
+    }
+    List<List<T>> partitions = new ArrayList<>();
+    for (int i = 0; i < list.size(); i += maxSize) {
+      partitions.add(list.subList(i, Math.min(i + maxSize, list.size())));
+    }
+    return partitions;
+  }
+
+  /**
    * Take a collection and a {@code keyExtractor} to remove duplicates where the key to be compared
    * is not the entity itself but a field of it.
    * <p>

--- a/utils/src/test/java/org/opentripplanner/utils/collection/ListUtilsTest.java
+++ b/utils/src/test/java/org/opentripplanner/utils/collection/ListUtilsTest.java
@@ -35,6 +35,21 @@ class ListUtilsTest {
     assertEquals(List.of(1, 2, 3, 5, 6, 7), combined);
   }
 
+  @Test
+  void partition() {
+    assertEquals(List.of(), ListUtils.partition(List.of(), 3));
+    assertEquals(List.of(List.of(1, 2, 3)), ListUtils.partition(List.of(1, 2, 3), 3));
+    assertEquals(
+      List.of(List.of(1, 2, 3), List.of(4, 5)),
+      ListUtils.partition(List.of(1, 2, 3, 4, 5), 3)
+    );
+    assertEquals(
+      List.of(List.of(1), List.of(2), List.of(3)),
+      ListUtils.partition(List.of(1, 2, 3), 1)
+    );
+    assertThrows(IllegalArgumentException.class, () -> ListUtils.partition(List.of(1), 0));
+  }
+
   private static String makeHello() {
     return new String("HELLO");
   }


### PR DESCRIPTION
## Summary

Restrict the use of the Guava library to an explicit white-list of classes, enforced by an ArchUnit test. The PR has three commits:

1. **docs** – a decision record ([RestrictGuavaUsage.md](https://github.com/entur/OpenTripPlanner/blob/guava-whitelist/doc/dev/decisionrecords/RestrictGuavaUsage.md)) stating that only white-listed Guava classes may be used, with a summary entry in `DEVELOPMENT_DECISION_RECORDS.md`.
2. **refactor** – replace the Guava classes that have a JDK (or OTP utils) equivalent, see the table below.
3. **test** – `GuavaArchitectureTest`: no class may depend on a Guava class outside the white-list. Nested classes count as their top-level class. The white-list also contains a documented group of classes that are never imported but referenced by the byte-code as return types of white-listed APIs (e.g. `ImmutableSet` from multimap views).

## Replacements

| Guava | Replacement | Notes |
|---|---|---|
| `Preconditions` | `Objects` | `checkNotNull(x, msg)` becomes `requireNonNull(x, msg)` — identical behavior. In `SiriAzureUpdater`. |
| `Strings` | `Optional.filter` | `map(Strings::emptyToNull)` inside an `Optional` chain becomes `filter(s -> !s.isEmpty())` — equivalent. In `RealtimeVehiclePatternMatcher`. |
| `Lists` (newArrayList) | `ArrayList` + `List.of` | Mutable list with initial elements. `List.of` rejects null *elements*, but no call site can produce one; never-mutated lists use plain `List.of`. In `EdgePropertyMapper` and the Orca/Atlanta fare services. |
| `Lists` (reverse) | `List.reversed()` | Both return a reversed view (JDK 21). In `FlexEgressTemplate`. |
| `Lists` (partition) | `ListUtils.partition` | New OTP util with unit test. Same chunking and exceptions, but computed eagerly instead of Guava's lazy view — irrelevant at the call site and documented in the JavaDoc. In `DataImportIssueReporter`. |
| `Iterators` | `List` / `Collections` | `forArray` and `singletonIterator` become `List.of(…).iterator()`; the empty case uses `Collections.emptyIterator()`. In `SplitStreetEdge`. |
| `ByteStreams` | `InputStream` | `copy(in, out)` becomes `in.transferTo(out)` (JDK 9). In `NEDGridCoverageFactoryImpl`. |
| `BaseEncoding` | `Base64` | URL-safe encoder without padding in both — byte-identical output, so semantic hashes are unchanged. In `SemanticHash`. |
| `ThreadFactoryBuilder` | `Thread.ofPlatform()` | The JDK 21 builder's name-prefix + counter produces the same thread names as the old `%d` format (counter starts at 0, as before). `OtpRequestThreadFactory.of()` now takes a name prefix instead of a format. 5 call sites. |

The white-list keeps the classes without a JDK equivalent: the `Multimap` family, the cache and hashing APIs, `HtmlEscapers`, `MinMaxPriorityQueue`, `TreeMultiset`, `Sets` (lazy set-algebra views), `Iterables`, `ImmutableSortedSet`, `MoreExecutors` and `VisibleForTesting`.
