### PR TITLE
Remove UNDEFINED alert severity

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/SeverityMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/SeverityMapper.java
@@ -20,7 +20,7 @@ public class SeverityMapper {
       case INFO -> GraphQLAlertSeverityLevelType.INFO;
       case VERY_SLIGHT, SLIGHT, WARNING -> GraphQLAlertSeverityLevelType.WARNING;
       case VERY_SEVERE, SEVERE -> GraphQLAlertSeverityLevelType.SEVERE;
-      case UNDEFINED, UNKNOWN_SEVERITY -> GraphQLAlertSeverityLevelType.UNKNOWN_SEVERITY;
+      case UNKNOWN_SEVERITY -> GraphQLAlertSeverityLevelType.UNKNOWN_SEVERITY;
     };
   }
 }

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/SeverityMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/mapping/SeverityMapper.java
@@ -16,8 +16,6 @@ public class SeverityMapper {
       return "normal";
     }
     switch (severity) {
-      case UNDEFINED:
-        return "undefined";
       case UNKNOWN_SEVERITY:
         return "unknown";
       case INFO:

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.apis.transmodel.model;
 
 import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLEnumValueDefinition;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -366,10 +367,23 @@ public class EnumTypes {
     .value("noImpact", "noImpact", "Situation has no impact on trips.")
     .value("verySlight", "verySlight", "Situation has a very slight impact on trips.")
     .value("slight", "slight", "Situation has a slight impact on trips.")
-    .value("normal", "normal", "Situation has an impact on trips (default).")
+    .value(
+      "normal",
+      "normal",
+      "Situation has an impact on trips (default). Used for SIRI severities `normal` and `undefined`."
+    )
     .value("severe", "severe", "Situation has a severe impact on trips.")
     .value("verySevere", "verySevere", "Situation has a very severe impact on trips.")
-    .value("undefined", "undefined", "Severity is undefined.")
+    .value(
+      GraphQLEnumValueDefinition.newEnumValueDefinition()
+        .name("undefined")
+        .value("undefined")
+        .description("Severity is undefined.")
+        .deprecationReason(
+          "This value is never returned, and filtering on it matches no situations. SIRI severity `undefined` is mapped to `normal`."
+        )
+        .build()
+    )
     .build();
 
   /**

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertSeverity.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertSeverity.java
@@ -5,10 +5,6 @@ package org.opentripplanner.routing.alertpatch;
  */
 public enum AlertSeverity {
   /**
-   * Severity is undefined.
-   */
-  UNDEFINED,
-  /**
    * Situation has unknown impact on trips.
    */
   UNKNOWN_SEVERITY,

--- a/application/src/main/java/org/opentripplanner/updater/alert/siri/mapping/SiriSeverityMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/siri/mapping/SiriSeverityMapper.java
@@ -9,15 +9,16 @@ import uk.org.siri.siri21.SeverityEnumeration;
 public class SiriSeverityMapper {
 
   /**
-   * Returns internal {@link AlertSeverity} enum counterpart for SIRI enum. Defaults to returning
-   * WARNING.
+   * Returns internal {@link AlertSeverity} enum counterpart for SIRI enum. SIRI's {@code undefined}
+   * severity is mapped to {@link AlertSeverity#WARNING}, which is also the default used when the
+   * severity is missing or {@code normal}.
    */
   public static AlertSeverity getAlertSeverityForSiriSeverity(SeverityEnumeration severity) {
     if (severity == null) {
       return AlertSeverity.WARNING;
     }
     return switch (severity) {
-      case UNDEFINED -> AlertSeverity.UNDEFINED;
+      case UNDEFINED -> AlertSeverity.WARNING;
       case UNKNOWN -> AlertSeverity.UNKNOWN_SEVERITY;
       case NO_IMPACT -> AlertSeverity.INFO;
       case VERY_SLIGHT -> AlertSeverity.VERY_SLIGHT;

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1977,14 +1977,14 @@ enum ServiceAlteration {
 enum Severity {
   "Situation has no impact on trips."
   noImpact
-  "Situation has an impact on trips (default)."
+  "Situation has an impact on trips (default). Used for SIRI severities `normal` and `undefined`."
   normal
   "Situation has a severe impact on trips."
   severe
   "Situation has a slight impact on trips."
   slight
   "Severity is undefined."
-  undefined
+  undefined @deprecated(reason : "This value is never returned, and filtering on it matches no situations. SIRI severity `undefined` is mapped to `normal`.")
   "Situation has unknown impact on trips."
   unknown
   "Situation has a very severe impact on trips."

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/SeverityMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/SeverityMapperTest.java
@@ -1,0 +1,41 @@
+package org.opentripplanner.apis.gtfs.mapping;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.apis.gtfs.mapping.SeverityMapper.getGraphQLSeverity;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertSeverityLevelType;
+import org.opentripplanner.routing.alertpatch.AlertSeverity;
+
+class SeverityMapperTest {
+
+  @Test
+  void mapNullToUnknown() {
+    assertThat(getGraphQLSeverity(null)).isEqualTo(GraphQLAlertSeverityLevelType.UNKNOWN_SEVERITY);
+  }
+
+  @Test
+  void mapSeverities() {
+    assertThat(getGraphQLSeverity(AlertSeverity.UNKNOWN_SEVERITY)).isEqualTo(
+      GraphQLAlertSeverityLevelType.UNKNOWN_SEVERITY
+    );
+    assertThat(getGraphQLSeverity(AlertSeverity.INFO)).isEqualTo(
+      GraphQLAlertSeverityLevelType.INFO
+    );
+    assertThat(getGraphQLSeverity(AlertSeverity.VERY_SLIGHT)).isEqualTo(
+      GraphQLAlertSeverityLevelType.WARNING
+    );
+    assertThat(getGraphQLSeverity(AlertSeverity.SLIGHT)).isEqualTo(
+      GraphQLAlertSeverityLevelType.WARNING
+    );
+    assertThat(getGraphQLSeverity(AlertSeverity.WARNING)).isEqualTo(
+      GraphQLAlertSeverityLevelType.WARNING
+    );
+    assertThat(getGraphQLSeverity(AlertSeverity.SEVERE)).isEqualTo(
+      GraphQLAlertSeverityLevelType.SEVERE
+    );
+    assertThat(getGraphQLSeverity(AlertSeverity.VERY_SEVERE)).isEqualTo(
+      GraphQLAlertSeverityLevelType.SEVERE
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/SeverityMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/mapping/SeverityMapperTest.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.apis.transmodel.mapping;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.apis.transmodel.mapping.SeverityMapper.getTransmodelSeverity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.opentripplanner.routing.alertpatch.AlertSeverity;
+
+class SeverityMapperTest {
+
+  @Test
+  void mapNullToNormal() {
+    assertThat(getTransmodelSeverity(null)).isEqualTo("normal");
+  }
+
+  @Test
+  void mapSeverities() {
+    assertThat(getTransmodelSeverity(AlertSeverity.UNKNOWN_SEVERITY)).isEqualTo("unknown");
+    assertThat(getTransmodelSeverity(AlertSeverity.INFO)).isEqualTo("noImpact");
+    assertThat(getTransmodelSeverity(AlertSeverity.VERY_SLIGHT)).isEqualTo("verySlight");
+    assertThat(getTransmodelSeverity(AlertSeverity.SLIGHT)).isEqualTo("slight");
+    assertThat(getTransmodelSeverity(AlertSeverity.WARNING)).isEqualTo("normal");
+    assertThat(getTransmodelSeverity(AlertSeverity.SEVERE)).isEqualTo("severe");
+    assertThat(getTransmodelSeverity(AlertSeverity.VERY_SEVERE)).isEqualTo("verySevere");
+  }
+
+  /**
+   * The deprecated 'undefined' value of the API enum is never returned by OTP.
+   */
+  @ParameterizedTest
+  @EnumSource(AlertSeverity.class)
+  void undefinedIsNeverReturned(AlertSeverity severity) {
+    assertThat(getTransmodelSeverity(severity)).isNotEqualTo("undefined");
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/alert/siri/mapping/SiriSeverityMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/siri/mapping/SiriSeverityMapperTest.java
@@ -1,0 +1,52 @@
+package org.opentripplanner.updater.alert.siri.mapping;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.opentripplanner.updater.alert.siri.mapping.SiriSeverityMapper.getAlertSeverityForSiriSeverity;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.alertpatch.AlertSeverity;
+import uk.org.siri.siri21.SeverityEnumeration;
+
+class SiriSeverityMapperTest {
+
+  @Test
+  void mapNullToWarning() {
+    assertThat(getAlertSeverityForSiriSeverity(null)).isEqualTo(AlertSeverity.WARNING);
+  }
+
+  /**
+   * SIRI does not distinguish between 'no severity given' and 'undefined severity', so both
+   * 'undefined' and 'normal' are mapped to {@link AlertSeverity#WARNING}.
+   */
+  @Test
+  void mapUndefinedToWarning() {
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.UNDEFINED)).isEqualTo(
+      AlertSeverity.WARNING
+    );
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.NORMAL)).isEqualTo(
+      AlertSeverity.WARNING
+    );
+  }
+
+  @Test
+  void mapSeverities() {
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.UNKNOWN)).isEqualTo(
+      AlertSeverity.UNKNOWN_SEVERITY
+    );
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.NO_IMPACT)).isEqualTo(
+      AlertSeverity.INFO
+    );
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.VERY_SLIGHT)).isEqualTo(
+      AlertSeverity.VERY_SLIGHT
+    );
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.SLIGHT)).isEqualTo(
+      AlertSeverity.SLIGHT
+    );
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.SEVERE)).isEqualTo(
+      AlertSeverity.SEVERE
+    );
+    assertThat(getAlertSeverityForSiriSeverity(SeverityEnumeration.VERY_SEVERE)).isEqualTo(
+      AlertSeverity.VERY_SEVERE
+    );
+  }
+}


### PR DESCRIPTION
## PR Instructions
### Summary

This removes UNDEFINED from OTP's internal alert severity model and deprecate it in the transmodel API. SIRI's `undefined` is mapped to `WARNING` (which is the default if the severity is not defined at all).

### Issue

Closes #7877

### Unit tests

Added tests

### Documentation

Updated code and schema doc.

### Changelog

From title