### PR TITLE
Share GBFS manifest loading and send configured headers with the manifest request

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/application/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -1,24 +1,13 @@
 package org.opentripplanner.ext.vehiclerentalservicedirectory;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import org.mobilitydata.gbfs.v3_0.manifest.GBFSDataset;
 import org.mobilitydata.gbfs.v3_0.manifest.GBFSManifest;
-import org.mobilitydata.gbfs.v3_0.manifest.GBFSVersion;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
-import org.opentripplanner.framework.io.HttpHeaders;
-import org.opentripplanner.framework.io.OtpHttpClientException;
 import org.opentripplanner.framework.io.OtpHttpClientFactory;
+import org.opentripplanner.gbfs.manifest.GbfsManifestLoader;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
 import org.opentripplanner.street.linking.VertexLinker;
 import org.opentripplanner.updater.spi.GraphUpdater;
@@ -40,9 +29,6 @@ public class VehicleRentalServiceDirectoryFetcher {
   );
   private static final Duration DEFAULT_FREQUENCY = Duration.ofSeconds(15);
   private static final Duration DEFAULT_STARTUP_RETRY_PERIOD = Duration.ZERO;
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-    .registerModule(new JavaTimeModule())
-    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private final VertexLinker vertexLinker;
   private final VehicleRentalRepository repository;
@@ -65,7 +51,7 @@ public class VehicleRentalServiceDirectoryFetcher {
   ) {
     LOG.info("Fetching GBFS v3 manifest from {}", parameters.getUrl());
 
-    var manifest = loadManifest(parameters);
+    var manifest = GbfsManifestLoader.loadManifest(parameters.getUrl(), parameters.getHeaders());
 
     if (
       manifest == null || manifest.getData() == null || manifest.getData().getDatasets() == null
@@ -102,7 +88,7 @@ public class VehicleRentalServiceDirectoryFetcher {
 
     for (GBFSDataset dataset : manifest.getData().getDatasets()) {
       String networkName = dataset.getSystemId();
-      Optional<String> gbfsUrl = selectBestVersion(dataset);
+      var gbfsUrl = GbfsManifestLoader.selectBestVersion(dataset);
 
       if (gbfsUrl.isEmpty()) {
         LOG.warn("No suitable GBFS version found for system {}", networkName);
@@ -136,24 +122,6 @@ public class VehicleRentalServiceDirectoryFetcher {
     return dataSources;
   }
 
-  /**
-   * Selects the best (newest) GBFS version from the available versions for a dataset.
-   * Prefers v3.0 over v2.x versions.
-   */
-  private static Optional<String> selectBestVersion(GBFSDataset dataset) {
-    if (dataset.getVersions() == null || dataset.getVersions().isEmpty()) {
-      return Optional.empty();
-    }
-
-    // Sort versions by version number (descending) to prefer newer versions
-    return dataset
-      .getVersions()
-      .stream()
-      .sorted(Comparator.comparing(GBFSVersion::getVersion).reversed())
-      .map(GBFSVersion::getUrl)
-      .findFirst();
-  }
-
   private List<GraphUpdater<?>> fetchUpdaterInfoFromDirectoryAndCreateUpdaters(
     List<GbfsVehicleRentalDataSourceParameters> dataSources
   ) {
@@ -182,33 +150,5 @@ public class VehicleRentalServiceDirectoryFetcher {
       otpHttpClientFactory
     );
     return new VehicleRentalUpdater(vehicleRentalParameters, dataSource, vertexLinker, repository);
-  }
-
-  private static GBFSManifest loadManifest(
-    VehicleRentalServiceDirectoryFetcherParameters parameters
-  ) {
-    URI url = parameters.getUrl();
-
-    try {
-      String manifestContent;
-
-      // Check if URL is a file path
-      if ("file".equals(url.getScheme())) {
-        Path filePath = Path.of(url.getPath());
-        manifestContent = Files.readString(filePath);
-        LOG.info("Loaded GBFS manifest from file: {}", filePath);
-      } else {
-        // Load from remote URL
-        var otpHttpClient = new OtpHttpClientFactory().create(LOG);
-        var jsonNode = otpHttpClient.getAndMapAsJsonNode(url, HttpHeaders.empty(), OBJECT_MAPPER);
-        manifestContent = OBJECT_MAPPER.writeValueAsString(jsonNode);
-        LOG.info("Loaded GBFS manifest from URL: {}", url);
-      }
-
-      return OBJECT_MAPPER.readValue(manifestContent, GBFSManifest.class);
-    } catch (OtpHttpClientException | IOException e) {
-      LOG.error("Error loading GBFS manifest from {}", url, e);
-      return null;
-    }
   }
 }

--- a/application/src/main/java/org/opentripplanner/gbfs/GbfsAutoConfiguration.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/GbfsAutoConfiguration.java
@@ -6,7 +6,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.io.HttpHeaders;
 import org.opentripplanner.framework.io.OtpHttpClient;
 import org.opentripplanner.framework.io.OtpHttpClientException;
@@ -70,6 +73,30 @@ public class GbfsAutoConfiguration {
   }
 
   /**
+   * The names of the feeds the system publishes, e.g. {@code geofencing_zones}. Use this to skip
+   * loading a system that does not publish a feed you need, without having to fetch and parse the
+   * feed itself.
+   * <p>
+   * GBFS v3 lists the feeds directly under {@code data}, while v2 nests them per language; the
+   * names are unioned across languages. Returns an empty set if the file declares no feeds.
+   */
+  public Set<String> feedNames() {
+    var data = json.get("data");
+    if (data == null) {
+      return Set.of();
+    }
+    var names = new HashSet<String>();
+    if (data.has("feeds")) {
+      addFeedNames(data.get("feeds"), names);
+    } else {
+      for (var language : data) {
+        addFeedNames(language.get("feeds"), names);
+      }
+    }
+    return Set.copyOf(names);
+  }
+
+  /**
    * Maps the file onto the model class of the GBFS version it declares.
    */
   public <T> T mapTo(Class<T> clazz) {
@@ -90,6 +117,18 @@ public class GbfsAutoConfiguration {
 
   public String url() {
     return url;
+  }
+
+  private static void addFeedNames(@Nullable JsonNode feeds, Set<String> names) {
+    if (feeds == null || !feeds.isArray()) {
+      return;
+    }
+    for (var feed : feeds) {
+      var name = feed.get("name");
+      if (name != null && name.isTextual()) {
+        names.add(name.asText());
+      }
+    }
   }
 
   private static URI toUri(String url) {

--- a/application/src/main/java/org/opentripplanner/gbfs/GbfsFeedLoaderAndMapper.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/GbfsFeedLoaderAndMapper.java
@@ -32,6 +32,27 @@ public class GbfsFeedLoaderAndMapper {
     // Fetched once and handed over to the version-specific loader, since some servers throttle
     // repeated fetches of the same file.
     var autoConfiguration = GbfsAutoConfiguration.fetch(params.url(), params.httpHeaders(), client);
+    return create(params, autoConfiguration, client);
+  }
+
+  /**
+   * Creates a loader from an auto-configuration file the caller has already fetched, for instance
+   * to inspect {@link GbfsAutoConfiguration#feedNames()} before deciding to load the system at all.
+   * Avoids fetching {@code gbfs.json} twice, which some servers throttle.
+   */
+  public static GbfsFeedLoaderAndMapper create(
+    GbfsDataSourceParameters params,
+    GbfsAutoConfiguration autoConfiguration,
+    OtpHttpClientFactory otpHttpClientFactory
+  ) {
+    return create(params, autoConfiguration, otpHttpClientFactory.create(LOG));
+  }
+
+  private static GbfsFeedLoaderAndMapper create(
+    GbfsDataSourceParameters params,
+    GbfsAutoConfiguration autoConfiguration,
+    OtpHttpClient client
+  ) {
     var gbfsFeedVersion = autoConfiguration.version().orElse(null);
 
     return switch (gbfsFeedVersion) {

--- a/application/src/main/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoader.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoader.java
@@ -3,10 +3,7 @@ package org.opentripplanner.gbfs.manifest;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -35,7 +32,7 @@ public class GbfsManifestLoader {
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   /**
-   * Loads the manifest from a remote URL or a local {@code file://} path.
+   * Loads the manifest from a remote URL or a local {@code file:} path.
    *
    * @return the parsed manifest, or {@code null} if it could not be fetched or parsed. Failing to
    *   reach a manifest must not fail the whole graph build or server startup, so this is logged
@@ -43,27 +40,13 @@ public class GbfsManifestLoader {
    */
   @Nullable
   public static GBFSManifest loadManifest(URI url, HttpHeaders headers) {
-    try {
-      String manifestContent;
-
-      if ("file".equals(url.getScheme())) {
-        // Path.of(URI), not Path.of(url.getPath()): on Windows the latter yields "/D:/..." from
-        // "file:///D:/...", which is not a legal path.
-        Path filePath = Path.of(url);
-        manifestContent = Files.readString(filePath);
-        LOG.info("Loaded GBFS manifest from file: {}", filePath);
-      } else {
-        try (var httpClientFactory = new OtpHttpClientFactory()) {
-          var jsonNode = httpClientFactory
-            .create(LOG)
-            .getAndMapAsJsonNode(url, headers, OBJECT_MAPPER);
-          manifestContent = OBJECT_MAPPER.writeValueAsString(jsonNode);
-        }
-        LOG.info("Loaded GBFS manifest from URL: {}", url);
-      }
-
-      return OBJECT_MAPPER.readValue(manifestContent, GBFSManifest.class);
-    } catch (OtpHttpClientException | IOException e) {
+    try (var httpClientFactory = new OtpHttpClientFactory()) {
+      var manifest = httpClientFactory
+        .create(LOG)
+        .getAndMapAsJsonObject(url, headers, OBJECT_MAPPER, GBFSManifest.class);
+      LOG.info("Loaded GBFS manifest from {}", url);
+      return manifest;
+    } catch (OtpHttpClientException e) {
       LOG.error("Error loading GBFS manifest from {}", url, e);
       return null;
     }

--- a/application/src/main/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoader.java
+++ b/application/src/main/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoader.java
@@ -1,0 +1,88 @@
+package org.opentripplanner.gbfs.manifest;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.mobilitydata.gbfs.v3_0.manifest.GBFSDataset;
+import org.mobilitydata.gbfs.v3_0.manifest.GBFSManifest;
+import org.mobilitydata.gbfs.v3_0.manifest.GBFSVersion;
+import org.opentripplanner.framework.io.HttpHeaders;
+import org.opentripplanner.framework.io.OtpHttpClientException;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loads a GBFS v3 {@code manifest.json}, which lists the systems a provider publishes and the GBFS
+ * versions available for each.
+ * <p>
+ * Shared by the two sandboxes that discover their feeds from a manifest: the vehicle rental graph
+ * builder (build phase) and the vehicle rental service directory (serve phase).
+ */
+public class GbfsManifestLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GbfsManifestLoader.class);
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+    .registerModule(new JavaTimeModule())
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  /**
+   * Loads the manifest from a remote URL or a local {@code file://} path.
+   *
+   * @return the parsed manifest, or {@code null} if it could not be fetched or parsed. Failing to
+   *   reach a manifest must not fail the whole graph build or server startup, so this is logged
+   *   and reported to the caller rather than thrown.
+   */
+  @Nullable
+  public static GBFSManifest loadManifest(URI url, HttpHeaders headers) {
+    try {
+      String manifestContent;
+
+      if ("file".equals(url.getScheme())) {
+        // Path.of(URI), not Path.of(url.getPath()): on Windows the latter yields "/D:/..." from
+        // "file:///D:/...", which is not a legal path.
+        Path filePath = Path.of(url);
+        manifestContent = Files.readString(filePath);
+        LOG.info("Loaded GBFS manifest from file: {}", filePath);
+      } else {
+        try (var httpClientFactory = new OtpHttpClientFactory()) {
+          var jsonNode = httpClientFactory
+            .create(LOG)
+            .getAndMapAsJsonNode(url, headers, OBJECT_MAPPER);
+          manifestContent = OBJECT_MAPPER.writeValueAsString(jsonNode);
+        }
+        LOG.info("Loaded GBFS manifest from URL: {}", url);
+      }
+
+      return OBJECT_MAPPER.readValue(manifestContent, GBFSManifest.class);
+    } catch (OtpHttpClientException | IOException e) {
+      LOG.error("Error loading GBFS manifest from {}", url, e);
+      return null;
+    }
+  }
+
+  /**
+   * The URL of the newest GBFS version the dataset publishes, or empty if it publishes none.
+   */
+  public static Optional<String> selectBestVersion(GBFSDataset dataset) {
+    if (dataset.getVersions() == null || dataset.getVersions().isEmpty()) {
+      return Optional.empty();
+    }
+
+    // The generated version enum is declared oldest-first, so its natural order is ascending.
+    return dataset
+      .getVersions()
+      .stream()
+      .sorted(Comparator.comparing(GBFSVersion::getVersion).reversed())
+      .map(GBFSVersion::getUrl)
+      .findFirst();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/gbfs/GbfsAutoConfigurationTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/GbfsAutoConfigurationTest.java
@@ -1,0 +1,45 @@
+package org.opentripplanner.gbfs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.io.HttpHeaders;
+import org.opentripplanner.framework.io.OtpHttpClient;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
+import org.slf4j.LoggerFactory;
+
+class GbfsAutoConfigurationTest {
+
+  private static final OtpHttpClient OTP_HTTP_CLIENT = new OtpHttpClientFactory().create(
+    LoggerFactory.getLogger(GbfsAutoConfigurationTest.class)
+  );
+
+  @Test
+  void listsFeedNamesOfAV2Feed() {
+    var subject = fetch("file:src/test/resources/gbfs/tieroslo/gbfs.json");
+
+    assertThat(subject.feedNames()).containsExactly("system_information", "geofencing_zones");
+  }
+
+  @Test
+  void listsFeedNamesOfAV3Feed() {
+    var subject = fetch("file:src/test/resources/gbfs/duplicate-stations-v3/gbfs.json");
+
+    assertThat(subject.feedNames()).containsExactly(
+      "system_information",
+      "station_information",
+      "station_status"
+    );
+  }
+
+  @Test
+  void feedNamesDoesNotContainAFeedThatIsNotPublished() {
+    var subject = fetch("file:src/test/resources/gbfs/duplicate-stations-v3/gbfs.json");
+
+    assertThat(subject.feedNames()).doesNotContain("geofencing_zones");
+  }
+
+  private static GbfsAutoConfiguration fetch(String url) {
+    return GbfsAutoConfiguration.fetch(url, HttpHeaders.empty(), OTP_HTTP_CLIENT);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/gbfs/GbfsFeedLoaderAndMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/GbfsFeedLoaderAndMapperTest.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.gbfs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.io.HttpHeaders;
+import org.opentripplanner.framework.io.OtpHttpClientFactory;
+import org.opentripplanner.updater.vehicle_rental.datasources.params.GbfsVehicleRentalDataSourceParameters;
+import org.opentripplanner.updater.vehicle_rental.datasources.params.RentalPickupType;
+import org.slf4j.LoggerFactory;
+
+class GbfsFeedLoaderAndMapperTest {
+
+  private static final String TIER_OSLO = "file:src/test/resources/gbfs/tieroslo/gbfs.json";
+
+  /**
+   * A caller that has already fetched the auto-configuration file to inspect it - for instance to
+   * check whether the system publishes geofencing zones at all - must be able to hand it over
+   * rather than have it fetched a second time, since some servers throttle repeated fetches.
+   */
+  @Test
+  void createsALoaderFromAnAlreadyFetchedAutoConfiguration() {
+    try (var httpClientFactory = new OtpHttpClientFactory()) {
+      var autoConfiguration = GbfsAutoConfiguration.fetch(
+        TIER_OSLO,
+        HttpHeaders.empty(),
+        httpClientFactory.create(LoggerFactory.getLogger(GbfsFeedLoaderAndMapperTest.class))
+      );
+
+      var subject = GbfsFeedLoaderAndMapper.create(
+        parameters(),
+        autoConfiguration,
+        httpClientFactory
+      );
+      subject.update();
+      // getUpdated() must be called to trigger geofencing zone mapping internally
+      subject.getUpdated();
+
+      assertThat(subject.getGeofencingZones()).isNotEmpty();
+    }
+  }
+
+  private static GbfsVehicleRentalDataSourceParameters parameters() {
+    return new GbfsVehicleRentalDataSourceParameters(
+      TIER_OSLO,
+      "en",
+      false,
+      HttpHeaders.empty(),
+      "tieroslo",
+      true,
+      true,
+      false,
+      RentalPickupType.ALL
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoaderTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoaderTest.java
@@ -30,6 +30,16 @@ class GbfsManifestLoaderTest {
   }
 
   @Test
+  void loadsAManifestFromARelativeFileUri() {
+    var manifest = GbfsManifestLoader.loadManifest(
+      URI.create("file:src/test/resources/gbfs/manifest.json"),
+      HttpHeaders.empty()
+    );
+
+    assertNotNull(manifest);
+  }
+
+  @Test
   void returnsNullWhenTheManifestCannotBeLoaded() {
     var manifest = GbfsManifestLoader.loadManifest(
       Path.of("src/test/resources/gbfs/does-not-exist.json").toAbsolutePath().toUri(),

--- a/application/src/test/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoaderTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoaderTest.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.gbfs.manifest;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -21,7 +23,7 @@ class GbfsManifestLoaderTest {
   void loadsAManifestFromAFile() {
     var manifest = GbfsManifestLoader.loadManifest(MANIFEST, HttpHeaders.empty());
 
-    assertThat(manifest).isNotNull();
+    assertNotNull(manifest);
     assertThat(
       manifest.getData().getDatasets().stream().map(GBFSDataset::getSystemId).toList()
     ).containsExactly("tieroslo", "duplicate-stations");
@@ -34,7 +36,7 @@ class GbfsManifestLoaderTest {
       HttpHeaders.empty()
     );
 
-    assertThat(manifest).isNull();
+    assertNull(manifest);
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoaderTest.java
+++ b/application/src/test/java/org/opentripplanner/gbfs/manifest/GbfsManifestLoaderTest.java
@@ -1,0 +1,69 @@
+package org.opentripplanner.gbfs.manifest;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gbfs.v3_0.manifest.GBFSDataset;
+import org.mobilitydata.gbfs.v3_0.manifest.GBFSVersion;
+import org.opentripplanner.framework.io.HttpHeaders;
+
+class GbfsManifestLoaderTest {
+
+  private static final URI MANIFEST = Path.of("src/test/resources/gbfs/manifest.json")
+    .toAbsolutePath()
+    .toUri();
+
+  @Test
+  void loadsAManifestFromAFile() {
+    var manifest = GbfsManifestLoader.loadManifest(MANIFEST, HttpHeaders.empty());
+
+    assertThat(manifest).isNotNull();
+    assertThat(
+      manifest.getData().getDatasets().stream().map(GBFSDataset::getSystemId).toList()
+    ).containsExactly("tieroslo", "duplicate-stations");
+  }
+
+  @Test
+  void returnsNullWhenTheManifestCannotBeLoaded() {
+    var manifest = GbfsManifestLoader.loadManifest(
+      Path.of("src/test/resources/gbfs/does-not-exist.json").toAbsolutePath().toUri(),
+      HttpHeaders.empty()
+    );
+
+    assertThat(manifest).isNull();
+  }
+
+  @Test
+  void selectsTheNewestPublishedVersion() {
+    var dataset = dataset("2.3", "v2-url", "3.0", "v3-url");
+
+    assertThat(GbfsManifestLoader.selectBestVersion(dataset)).hasValue("v3-url");
+  }
+
+  @Test
+  void selectsNoVersionWhenTheDatasetPublishesNone() {
+    var dataset = new GBFSDataset();
+    dataset.setSystemId("no-versions");
+    dataset.setVersions(List.of());
+
+    assertThat(GbfsManifestLoader.selectBestVersion(dataset)).isEmpty();
+  }
+
+  private static GBFSDataset dataset(String... versionAndUrl) {
+    var versions = new ArrayList<GBFSVersion>();
+    for (int i = 0; i < versionAndUrl.length; i += 2) {
+      var version = new GBFSVersion();
+      version.setVersion(GBFSVersion.Version.fromValue(versionAndUrl[i]));
+      version.setUrl(versionAndUrl[i + 1]);
+      versions.add(version);
+    }
+    var dataset = new GBFSDataset();
+    dataset.setSystemId("test");
+    dataset.setVersions(versions);
+    return dataset;
+  }
+}

--- a/application/src/test/resources/gbfs/manifest.json
+++ b/application/src/test/resources/gbfs/manifest.json
@@ -1,0 +1,31 @@
+{
+  "last_updated": "2025-11-05T12:00:00+00:00",
+  "ttl": 0,
+  "version": "3.0",
+  "data": {
+    "datasets": [
+      {
+        "system_id": "tieroslo",
+        "versions": [
+          {
+            "version": "2.3",
+            "url": "file:src/test/resources/gbfs/tieroslo/gbfs.json"
+          }
+        ]
+      },
+      {
+        "system_id": "duplicate-stations",
+        "versions": [
+          {
+            "version": "2.3",
+            "url": "file:src/test/resources/gbfs/duplicate-stations-v2/gbfs.json"
+          },
+          {
+            "version": "3.0",
+            "url": "file:src/test/resources/gbfs/duplicate-stations-v3/gbfs.json"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Summary

`VehicleRentalServiceDirectoryFetcher` kept GBFS manifest loading and version selection to itself.
This moves both to a shared `GbfsManifestLoader`, so anything else discovering systems from a
manifest can use them, and adds two capabilities on top:

- `GbfsAutoConfiguration.feedNames()`, handling the v2 shape (`data.<lang>.feeds`) and the v3 shape
  (`data.feeds`), so a caller needing one particular feed can skip a system that does not publish it
  without fetching and parsing the feed first.
- A `GbfsFeedLoaderAndMapper.create` overload taking an already-fetched auto-configuration. Probing
  means `gbfs.json` has been fetched, and some servers throttle repeated fetches of that file, which
  the existing code already notes.

One behaviour change: the manifest request now sends the configured `headers`. It previously passed
`HttpHeaders.empty()`, so a deployment setting an identifying header had it applied to every feed
request but not to the manifest itself.

Groundwork for loading GBFS geofencing zones during the graph build, but useful on its own and
reviewable in isolation.

### Unit tests

Yes. `GbfsManifestLoaderTest` covers loading from a file, a missing file, and newest-version
selection. `GbfsAutoConfigurationTest` covers feed-name probing against v2 and v3 fixtures,
including a feed that publishes no geofencing zones. `GbfsFeedLoaderAndMapperTest` covers the new
overload.

### Documentation

Javadoc on the new class and methods, covering the two GBFS shapes and why the overload exists.
No configuration changes.
