### PR TITLE
Split DefaultVehicleRentalService into a Service and a Repository

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/GraphPathFinder.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/GraphPathFinder.java
@@ -100,7 +100,7 @@ class GraphPathFinder {
   private Set<GeofencingZone> computeZonesAtVertices(Set<Vertex> vertices) {
     var zones = new HashSet<GeofencingZone>();
     for (var vertex : vertices) {
-      zones.addAll(geofencingZoneService.zonesContaining(vertex.getCoordinate()));
+      zones.addAll(geofencingZoneService.findZonesContaining(vertex.getCoordinate()));
     }
     return zones;
   }

--- a/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/standalone/api/TestServerContext.java
@@ -35,6 +35,7 @@ import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
 import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.service.worldenvelope.internal.DefaultWorldEnvelopeRepository;
@@ -246,7 +247,7 @@ public class TestServerContext {
   }
 
   public static VehicleRentalService createVehicleRentalService() {
-    return new DefaultVehicleRentalService();
+    return new DefaultVehicleRentalService(new DefaultVehicleRentalRepository());
   }
 
   public static VehicleParkingService createVehicleParkingService() {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -92,6 +92,7 @@ import org.opentripplanner.service.vehicleparking.VehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingService;
 import org.opentripplanner.service.vehicleparking.model.VehicleParking;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
 import org.opentripplanner.service.vehiclerental.model.TestFreeFloatingRentalVehicleBuilder;
 import org.opentripplanner.service.vehiclerental.model.TestVehicleRentalStationBuilder;
@@ -553,10 +554,13 @@ class GraphQLIntegrationTest {
       transitService
     );
 
-    DefaultVehicleRentalService defaultVehicleRentalService = new DefaultVehicleRentalService();
-    defaultVehicleRentalService.addVehicleRentalStation(VEHICLE_RENTAL_STATION);
-    defaultVehicleRentalService.addVehicleRentalStation(RENTAL_VEHICLE_1);
-    defaultVehicleRentalService.addVehicleRentalStation(RENTAL_VEHICLE_2);
+    DefaultVehicleRentalRepository rentalRepository = new DefaultVehicleRentalRepository();
+    rentalRepository.addVehicleRentalStation(VEHICLE_RENTAL_STATION);
+    rentalRepository.addVehicleRentalStation(RENTAL_VEHICLE_1);
+    rentalRepository.addVehicleRentalStation(RENTAL_VEHICLE_2);
+    DefaultVehicleRentalService defaultVehicleRentalService = new DefaultVehicleRentalService(
+      rentalRepository
+    );
 
     var routeRequest = RouteRequest.defaultValue();
     context = new GraphQLRequestContext(

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/LegacyRouteRequestMapperTest.java
@@ -47,6 +47,7 @@ import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehi
 import org.opentripplanner.service.realtimevehicles.internal.RealtimeVehicleRepositoryLifecycle;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingService;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.search.TraverseMode;
@@ -88,7 +89,7 @@ class LegacyRouteRequestMapperTest implements PlanTestConstants {
       transitService,
       transferService,
       new DefaultFareService(),
-      new DefaultVehicleRentalService(),
+      new DefaultVehicleRentalService(new DefaultVehicleRentalRepository()),
       new DefaultVehicleParkingService(new DefaultVehicleParkingRepository()),
       new DefaultRealtimeVehicleService(
         new RealtimeVehicleRepositoryLifecycle().freeze(new DefaultRealtimeVehicleRepository()),

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/routerequest/_RouteRequestTestContext.java
@@ -28,6 +28,7 @@ import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehi
 import org.opentripplanner.service.realtimevehicles.internal.RealtimeVehicleRepositoryLifecycle;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingService;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.transfer.regular.TransferServiceTestFactory;
@@ -80,7 +81,7 @@ class _RouteRequestTestContext {
       transitService,
       transferService,
       new DefaultFareService(),
-      new DefaultVehicleRentalService(),
+      new DefaultVehicleRentalService(new DefaultVehicleRentalRepository()),
       new DefaultVehicleParkingService(new DefaultVehicleParkingRepository()),
       new DefaultRealtimeVehicleService(
         new RealtimeVehicleRepositoryLifecycle().freeze(new DefaultRealtimeVehicleRepository()),

--- a/application/src/test/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalServiceTest.java
@@ -13,18 +13,21 @@ class DefaultVehicleRentalServiceTest {
 
   @Test
   void getVehicleRentalStationForEnvelopeShouldExcludeVehicleRentalVehicle() {
-    DefaultVehicleRentalService defaultVehicleRentalService = new DefaultVehicleRentalService();
+    DefaultVehicleRentalRepository repository = new DefaultVehicleRentalRepository();
+    DefaultVehicleRentalService defaultVehicleRentalService = new DefaultVehicleRentalService(
+      repository
+    );
 
     VehicleRentalStation vehicleRentalStation = new TestVehicleRentalStationBuilder()
       .withCoordinates(1, 1)
       .build();
-    defaultVehicleRentalService.addVehicleRentalStation(vehicleRentalStation);
+    repository.addVehicleRentalStation(vehicleRentalStation);
 
     VehicleRentalVehicle vehicleRentalVehicle = new TestFreeFloatingRentalVehicleBuilder()
       .withLatitude(2)
       .withLongitude(2)
       .build();
-    defaultVehicleRentalService.addVehicleRentalStation(vehicleRentalVehicle);
+    repository.addVehicleRentalStation(vehicleRentalVehicle);
 
     List<VehicleRentalStation> vehicleRentalStationForEnvelope =
       defaultVehicleRentalService.getVehicleRentalStationForEnvelope(0, 0, 10, 10);

--- a/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/configure/RequestScopedFactoryTest.java
@@ -43,6 +43,7 @@ import org.opentripplanner.service.realtimevehicles.internal.RealtimeVehicleRepo
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
 import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
@@ -124,7 +125,7 @@ class RequestScopedFactoryTest {
       .transferService(TransferServiceTestFactory.transferService(transferRepository))
       .worldEnvelopeService(TestServerContext.createWorldEnvelopeService())
       .realtimeVehicleRepositoryHandle(realtimeVehicleRepositoryHandle)
-      .vehicleRentalService(new DefaultVehicleRentalService())
+      .vehicleRentalService(new DefaultVehicleRentalService(new DefaultVehicleRentalRepository()))
       .vehicleParkingService(TestServerContext.createVehicleParkingService())
       .rideHailingServices(List.of())
       .viaTransferResolver(

--- a/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/speed_test/SpeedTest.java
@@ -29,7 +29,7 @@ import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.service.realtimevehicles.internal.DefaultRealtimeVehicleRepository;
 import org.opentripplanner.service.realtimevehicles.internal.RealtimeVehicleRepositoryLifecycle;
 import org.opentripplanner.service.vehicleparking.internal.DefaultVehicleParkingRepository;
-import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 import org.opentripplanner.standalone.OtpStartupInfo;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.standalone.api.TestServerContext;
@@ -157,7 +157,7 @@ public class SpeedTest {
       DeduplicatorService.NOOP,
       VertexLinkerTestFactory.of(graph),
       realtimeVehicleHandle,
-      new DefaultVehicleRentalService(),
+      new DefaultVehicleRentalRepository(),
       new DefaultVehicleParkingRepository(),
       transitRepository,
       // The speed test does not enable the CarPooling feature, so it supplies neither a carpooling

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdaterTest.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.io.HttpHeaders;
-import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.spi.UpdaterConstructionException;
@@ -31,12 +31,13 @@ class VehicleRentalUpdaterTest {
     Duration.ZERO,
     new FakeParams()
   );
-  public static final DefaultVehicleRentalService SERVICE = new DefaultVehicleRentalService();
+  public static final DefaultVehicleRentalRepository REPOSITORY =
+    new DefaultVehicleRentalRepository();
 
   @Test
   void failingDataSourceCountsAsPrimed() {
     var source = new FailingDataSource();
-    var updater = new VehicleRentalUpdater(PARAMS, source, null, SERVICE);
+    var updater = new VehicleRentalUpdater(PARAMS, source, null, REPOSITORY);
 
     assertFalse(updater.isPrimed());
     var manager = new MockManager(updater);
@@ -53,7 +54,7 @@ class VehicleRentalUpdaterTest {
   @Disabled
   void failingSetup() {
     var source = new FailingSetupDataSource();
-    var updater = new VehicleRentalUpdater(PARAMS, source, null, SERVICE);
+    var updater = new VehicleRentalUpdater(PARAMS, source, null, REPOSITORY);
 
     assertFalse(updater.isPrimed());
     var manager = new MockManager(updater);

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/GeofencingZoneService.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/GeofencingZoneService.java
@@ -35,15 +35,15 @@ public interface GeofencingZoneService {
     }
   };
 
-  /** All registered zones (across all data sources) that contain the given coordinate. */
+  /** All registered zones (across all networks) that contain the given coordinate. */
   Set<GeofencingZone> findZonesContaining(Coordinate coord);
 
   /**
-   * Whether any data source has registered a zone index. Cheap short-circuit for callers that
+   * Whether any network has registered a zone index. Cheap short-circuit for callers that
    * want to avoid per-vertex lookups when no zones exist.
    */
   boolean hasIndexedZones();
 
-  /** All zones across all registered data sources. Used by the debug map layer. */
+  /** All zones across all registered networks. Used by the debug map layer. */
   Set<GeofencingZone> listZones();
 }

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/GeofencingZoneService.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/GeofencingZoneService.java
@@ -19,7 +19,7 @@ public interface GeofencingZoneService {
    */
   GeofencingZoneService EMPTY = new GeofencingZoneService() {
     @Override
-    public Set<GeofencingZone> zonesContaining(Coordinate coord) {
+    public Set<GeofencingZone> findZonesContaining(Coordinate coord) {
       return Set.of();
     }
 
@@ -35,7 +35,7 @@ public interface GeofencingZoneService {
   };
 
   /** All registered zones (across all data sources) that contain the given coordinate. */
-  Set<GeofencingZone> zonesContaining(Coordinate coord);
+  Set<GeofencingZone> findZonesContaining(Coordinate coord);
 
   /**
    * Whether any data source has registered a zone index. Cheap short-circuit for callers that

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/GeofencingZoneService.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/GeofencingZoneService.java
@@ -9,8 +9,9 @@ import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
  * the routing layer (and the debug map layer) so they can query zone membership without depending
  * on the rental service implementation.
  *
- * <p>{@link org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService} is
- * the production implementation; tests can use {@link #EMPTY}.
+ * <p>{@link org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository}
+ * holds the zone indices and answers these queries; {@link VehicleRentalService} re-exposes them
+ * to read-only consumers. Tests can use {@link #EMPTY}.
  */
 public interface GeofencingZoneService {
   /**

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/VehicleRentalRepository.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/VehicleRentalRepository.java
@@ -1,13 +1,16 @@
 package org.opentripplanner.service.vehiclerental;
 
+import java.util.Collection;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.vehiclerental.street.geofencing.GeofencingZoneIndex;
 
 /**
- * The writable data store of vehicle rental information.
+ * The writable data store of vehicle rental information. Also exposes raw read access and
+ * geofencing zone queries (via {@link GeofencingZoneService}); the higher-level
+ * {@link VehicleRentalService} provides typed views on top of this.
  */
-public interface VehicleRentalRepository {
+public interface VehicleRentalRepository extends GeofencingZoneService {
   void addVehicleRentalStation(VehicleRentalPlace vehicleRentalStation);
 
   void removeVehicleRentalStation(FeedScopedId vehicleRentalStationId);
@@ -17,5 +20,9 @@ public interface VehicleRentalRepository {
    * updater when zones are applied. Each updater (one per network) registers its own index;
    * re-registering with the same {@code dataSourceName} replaces the previous index.
    */
-  void setGeofencingZoneIndex(String dataSourceName, GeofencingZoneIndex index);
+  void setGeofencingZoneIndex(String network, GeofencingZoneIndex index);
+
+  Collection<VehicleRentalPlace> listRentalPlaces();
+
+  VehicleRentalPlace getRentalPlace(FeedScopedId id);
 }

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/VehicleRentalRepository.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/VehicleRentalRepository.java
@@ -16,9 +16,9 @@ public interface VehicleRentalRepository extends GeofencingZoneService {
   void removeVehicleRentalStation(FeedScopedId vehicleRentalStationId);
 
   /**
-   * Register a geofencing zone index for a specific data source. Called by the vehicle rental
-   * updater when zones are applied. Each updater (one per network) registers its own index;
-   * re-registering with the same {@code dataSourceName} replaces the previous index.
+   * Register a geofencing zone index for a network. Called by the vehicle rental updater when
+   * zones are applied. Each updater (one per network) registers its own index; re-registering
+   * with the same {@code network} replaces the previous index.
    */
   void setGeofencingZoneIndex(String network, GeofencingZoneIndex index);
 

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/configure/VehicleRentalRepositoryModule.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/configure/VehicleRentalRepositoryModule.java
@@ -3,14 +3,11 @@ package org.opentripplanner.service.vehiclerental.configure;
 import dagger.Binds;
 import dagger.Module;
 import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
-import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalService;
+import org.opentripplanner.service.vehiclerental.internal.DefaultVehicleRentalRepository;
 
-/**
- * The service is used during application serve phase, not loading, so we need to provide
- * a module for the service without the repository, which is injected from the loading phase.
- */
+/** Binds the writable {@link VehicleRentalRepository} for the load phase. */
 @Module
 public interface VehicleRentalRepositoryModule {
   @Binds
-  VehicleRentalRepository bindService(DefaultVehicleRentalService service);
+  VehicleRentalRepository bind(DefaultVehicleRentalRepository repository);
 }

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalRepository.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalRepository.java
@@ -1,0 +1,83 @@
+package org.opentripplanner.service.vehiclerental.internal;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.service.vehiclerental.GeofencingZoneService;
+import org.opentripplanner.service.vehiclerental.VehicleRentalRepository;
+import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
+import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
+import org.opentripplanner.service.vehiclerental.street.geofencing.GeofencingZoneIndex;
+
+/**
+ * Default {@link VehicleRentalRepository}. Owns the rental places and the geofencing zone indices,
+ * and answers geofencing zone queries via {@link GeofencingZoneService}.
+ * <p>
+ * The indices are keyed by network. A network has exactly one source of zones, so a later
+ * registration replaces an earlier one rather than adding a second index alongside it.
+ */
+@Singleton
+public class DefaultVehicleRentalRepository implements VehicleRentalRepository {
+
+  private final Map<FeedScopedId, VehicleRentalPlace> rentalPlaces = new ConcurrentHashMap<>();
+
+  private final Map<String, GeofencingZoneIndex> geofencingZoneIndexes = new ConcurrentHashMap<>();
+
+  @Inject
+  public DefaultVehicleRentalRepository() {}
+
+  @Override
+  public void addVehicleRentalStation(VehicleRentalPlace vehicleRentalStation) {
+    rentalPlaces.put(vehicleRentalStation.id(), vehicleRentalStation);
+  }
+
+  @Override
+  public void removeVehicleRentalStation(FeedScopedId vehicleRentalStationId) {
+    rentalPlaces.remove(vehicleRentalStationId);
+  }
+
+  @Override
+  public void setGeofencingZoneIndex(String network, GeofencingZoneIndex index) {
+    geofencingZoneIndexes.put(network, index);
+  }
+
+  @Override
+  public Collection<VehicleRentalPlace> listRentalPlaces() {
+    return rentalPlaces.values();
+  }
+
+  @Override
+  public VehicleRentalPlace getRentalPlace(FeedScopedId id) {
+    return rentalPlaces.get(id);
+  }
+
+  @Override
+  public Set<GeofencingZone> findZonesContaining(Coordinate coord) {
+    return geofencingZoneIndexes
+      .values()
+      .stream()
+      .flatMap(idx -> idx.findZonesContaining(coord).stream())
+      .collect(Collectors.toSet());
+  }
+
+  @Override
+  public boolean hasIndexedZones() {
+    return !geofencingZoneIndexes.isEmpty();
+  }
+
+  @Override
+  public Set<GeofencingZone> listZones() {
+    var zones = new HashSet<GeofencingZone>();
+    for (var idx : geofencingZoneIndexes.values()) {
+      zones.addAll(idx.listZones());
+    }
+    return zones;
+  }
+}

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
@@ -2,7 +2,6 @@ package org.opentripplanner.service.vehiclerental.internal;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -20,7 +19,7 @@ import org.opentripplanner.street.model.RentalFormFactor;
 
 /** Read-side service backed by a {@link VehicleRentalRepository}. */
 @Singleton
-public class DefaultVehicleRentalService implements VehicleRentalService, Serializable {
+public class DefaultVehicleRentalService implements VehicleRentalService {
 
   private final VehicleRentalRepository repository;
 

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
@@ -2,13 +2,10 @@ package org.opentripplanner.service.vehiclerental.internal;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.io.Serializable;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -19,33 +16,33 @@ import org.opentripplanner.service.vehiclerental.model.GeofencingZone;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalVehicle;
-import org.opentripplanner.service.vehiclerental.street.geofencing.GeofencingZoneIndex;
 import org.opentripplanner.street.model.RentalFormFactor;
 
+/** Read-side service backed by a {@link VehicleRentalRepository}. */
 @Singleton
-public class DefaultVehicleRentalService implements VehicleRentalService, VehicleRentalRepository {
+public class DefaultVehicleRentalService implements VehicleRentalService, Serializable {
+
+  private final VehicleRentalRepository repository;
 
   @Inject
-  public DefaultVehicleRentalService() {}
-
-  private final Map<FeedScopedId, VehicleRentalPlace> rentalPlaces = new ConcurrentHashMap<>();
-
-  private final Map<String, GeofencingZoneIndex> geofencingZoneIndexes = new ConcurrentHashMap<>();
+  public DefaultVehicleRentalService(VehicleRentalRepository repository) {
+    this.repository = repository;
+  }
 
   @Override
   public Collection<VehicleRentalPlace> getVehicleRentalPlaces() {
-    return rentalPlaces.values();
+    return repository.listRentalPlaces();
   }
 
   @Override
   public VehicleRentalPlace getVehicleRentalPlace(FeedScopedId id) {
-    return rentalPlaces.get(id);
+    return repository.getRentalPlace(id);
   }
 
   @Override
   public List<VehicleRentalVehicle> getVehicleRentalVehicles() {
-    return rentalPlaces
-      .values()
+    return repository
+      .listRentalPlaces()
       .stream()
       .filter(VehicleRentalVehicle.class::isInstance)
       .map(VehicleRentalVehicle.class::cast)
@@ -54,7 +51,7 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
 
   @Override
   public VehicleRentalVehicle getVehicleRentalVehicle(FeedScopedId id) {
-    VehicleRentalPlace vehicleRentalPlace = rentalPlaces.get(id);
+    VehicleRentalPlace vehicleRentalPlace = repository.getRentalPlace(id);
     return vehicleRentalPlace instanceof VehicleRentalVehicle vehicleRentalVehicle
       ? vehicleRentalVehicle
       : null;
@@ -67,26 +64,16 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
 
   @Override
   public VehicleRentalStation getVehicleRentalStation(FeedScopedId id) {
-    VehicleRentalPlace vehicleRentalPlace = rentalPlaces.get(id);
+    VehicleRentalPlace vehicleRentalPlace = repository.getRentalPlace(id);
     return vehicleRentalPlace instanceof VehicleRentalStation vehicleRentalStation
       ? vehicleRentalStation
       : null;
   }
 
   @Override
-  public void addVehicleRentalStation(VehicleRentalPlace vehicleRentalStation) {
-    rentalPlaces.put(vehicleRentalStation.id(), vehicleRentalStation);
-  }
-
-  @Override
-  public void removeVehicleRentalStation(FeedScopedId vehicleRentalStationId) {
-    rentalPlaces.remove(vehicleRentalStationId);
-  }
-
-  @Override
   public boolean hasRentalBikes() {
-    return rentalPlaces
-      .values()
+    return repository
+      .listRentalPlaces()
       .stream()
       .anyMatch(place -> {
         if (place instanceof VehicleRentalVehicle vehicle) {
@@ -120,48 +107,35 @@ public class DefaultVehicleRentalService implements VehicleRentalService, Vehicl
       .toList();
   }
 
+  @Override
+  public List<VehicleRentalPlace> getVehicleRentalPlacesForEnvelope(Envelope envelope) {
+    return repository
+      .listRentalPlaces()
+      .stream()
+      .filter(vr -> envelope.contains(new Coordinate(vr.longitude(), vr.latitude())))
+      .toList();
+  }
+
   private Stream<VehicleRentalStation> getVehicleRentalStationsAsStream() {
-    return rentalPlaces
-      .values()
+    return repository
+      .listRentalPlaces()
       .stream()
       .filter(VehicleRentalStation.class::isInstance)
       .map(VehicleRentalStation.class::cast);
   }
 
   @Override
-  public List<VehicleRentalPlace> getVehicleRentalPlacesForEnvelope(Envelope envelope) {
-    Stream<VehicleRentalPlace> vehicleRentalPlaceStream = getVehicleRentalPlaces()
-      .stream()
-      .filter(vr -> envelope.contains(new Coordinate(vr.longitude(), vr.latitude())));
-
-    return vehicleRentalPlaceStream.toList();
-  }
-
-  @Override
-  public void setGeofencingZoneIndex(String dataSourceName, GeofencingZoneIndex index) {
-    geofencingZoneIndexes.put(dataSourceName, index);
-  }
-
-  @Override
-  public Set<GeofencingZone> zonesContaining(Coordinate coord) {
-    return geofencingZoneIndexes
-      .values()
-      .stream()
-      .flatMap(idx -> idx.findZonesContaining(coord).stream())
-      .collect(Collectors.toSet());
+  public Set<GeofencingZone> findZonesContaining(Coordinate coord) {
+    return repository.findZonesContaining(coord);
   }
 
   @Override
   public boolean hasIndexedZones() {
-    return !geofencingZoneIndexes.isEmpty();
+    return repository.hasIndexedZones();
   }
 
   @Override
   public Set<GeofencingZone> listZones() {
-    var zones = new HashSet<GeofencingZone>();
-    for (var idx : geofencingZoneIndexes.values()) {
-      zones.addAll(idx.listZones());
-    }
-    return zones;
+    return repository.listZones();
   }
 }

--- a/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
+++ b/street/src/main/java/org/opentripplanner/service/vehiclerental/internal/DefaultVehicleRentalService.java
@@ -17,7 +17,10 @@ import org.opentripplanner.service.vehiclerental.model.VehicleRentalStation;
 import org.opentripplanner.service.vehiclerental.model.VehicleRentalVehicle;
 import org.opentripplanner.street.model.RentalFormFactor;
 
-/** Read-side service backed by a {@link VehicleRentalRepository}. */
+/**
+ * Default implementation of {@link VehicleRentalService}, delegating to the
+ * {@link VehicleRentalRepository} that holds the data.
+ */
 @Singleton
 public class DefaultVehicleRentalService implements VehicleRentalService {
 

--- a/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
+++ b/street/src/main/java/org/opentripplanner/street/linking/VertexLinker.java
@@ -613,7 +613,7 @@ public class VertexLinker {
     var toBoundaries = originalEdge.getToVertex().listGeofencingBoundaries();
     if (!fromBoundaries.isEmpty() || !toBoundaries.isEmpty()) {
       var splitCoord = new Coordinate(x, y);
-      var containingZones = geofencingZoneService.zonesContaining(splitCoord);
+      var containingZones = geofencingZoneService.findZonesContaining(splitCoord);
       var boundaryZones = new HashSet<GeofencingZone>();
       for (var b : fromBoundaries) {
         boundaryZones.add(b.zone());

--- a/street/src/test/java/org/opentripplanner/street/linking/VertexLinkerGeofencingTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/VertexLinkerGeofencingTest.java
@@ -197,7 +197,7 @@ class VertexLinkerGeofencingTest {
     var index = new GeofencingZoneIndex(Set.of(NO_DROP_OFF_ZONE));
     return new GeofencingZoneService() {
       @Override
-      public Set<GeofencingZone> zonesContaining(Coordinate coord) {
+      public Set<GeofencingZone> findZonesContaining(Coordinate coord) {
         return index.findZonesContaining(coord);
       }
 


### PR DESCRIPTION
### Summary

`DefaultVehicleRentalService` implemented both `VehicleRentalService` and `VehicleRentalRepository`,
so read and write access to rental state came from a single class. This splits the implementation
the way the parking domain already does: the repository owns the rental places and the geofencing
zone indices, and the service becomes a thin read-side wrapper delegating to it.

Both interfaces already existed, so only the implementation is split. There is no behaviour change
and no effect on the serialized graph — rental state is not persisted today, so no serialization id
bump is needed.

Two smaller changes come with it:

- Zone indices are keyed by network rather than by an opaque data source name. A network has exactly
  one source of zones, so a later registration replaces an earlier one instead of adding a second
  index alongside it.
- `GeofencingZoneService.zonesContaining` is renamed `findZonesContaining`, matching the `find*`
  convention used for lookups elsewhere.

Groundwork for populating rental data during the graph build, but a self-contained refactor.

### Unit tests

No new tests: this is a refactor with no behaviour change, and the existing rental, geofencing and
serialization tests were updated to the split and all pass. The suite runs at exactly the same test
count as `dev-2.x`.

### Documentation

Javadoc on the new repository describing what it owns and the keying rule.
No configuration changes.
