### PR TITLE
Improve how vehicle rental networks and vehicles are presented in the debug client

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugStyleSpec.java
@@ -148,7 +148,8 @@ public class DebugStyleSpec {
     VectorSourceLayer geofencingZones,
     VectorSourceLayer rental,
     VectorSourceLayer transfers,
-    List<BackgroundTileLayer> extraLayers
+    List<BackgroundTileLayer> extraLayers,
+    List<String> rentalNetworks
   ) {
     List<TileSource> vectorSources = Stream.of(
       regularStops,
@@ -192,7 +193,8 @@ public class DebugStyleSpec {
         elevators(edges, vertices),
         vertices(vertices),
         stops(regularStops, areaStops, groupStops)
-      )
+      ),
+      rentalNetworks
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/DebugVectorTilesResource.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.glassfish.grizzly.http.server.Request;
 import org.opentripplanner.apis.support.TileJson;
 import org.opentripplanner.apis.vectortiles.model.LayerParams;
@@ -47,6 +48,7 @@ import org.opentripplanner.inspector.vector.vertex.VertexLayerBuilder;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
+import org.opentripplanner.service.vehiclerental.model.VehicleRentalPlace;
 import org.opentripplanner.service.worldenvelope.WorldEnvelopeService;
 import org.opentripplanner.standalone.config.DebugUiConfig;
 import org.opentripplanner.street.graph.Graph;
@@ -182,8 +184,30 @@ public class DebugVectorTilesResource {
       GEOFENCING_ZONES.toVectorSourceLayer(geofencingSource),
       RENTAL.toVectorSourceLayer(rentalSource),
       TRANSFERS.toVectorSourceLayer(transferSource),
-      debugUiConfig.additionalBackgroundLayers()
+      debugUiConfig.additionalBackgroundLayers(),
+      rentalNetworks()
     );
+  }
+
+  /**
+   * The vehicle rental networks the debug client offers as a filter.
+   * <p>
+   * Rental places and geofencing zones are unioned because a network can have one without the
+   * other: zones applied during the graph build are present before any updater has reported a
+   * vehicle, and a network may equally publish vehicles but no zones.
+   */
+  private List<String> rentalNetworks() {
+    return Stream.concat(
+      vehicleRentalService.getVehicleRentalPlaces().stream().map(VehicleRentalPlace::network),
+      vehicleRentalService
+        .listZones()
+        .stream()
+        .map(zone -> zone.id().getFeedId())
+    )
+      .filter(Objects::nonNull)
+      .distinct()
+      .sorted()
+      .toList();
   }
 
   static String tileJsonUrl(String base, List<LayerParameters<LayerType>> layers) {

--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleSpec.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleSpec.java
@@ -18,11 +18,18 @@ public final class StyleSpec {
   private final String name;
   private final Collection<TileSource> sources;
   private final List<JsonNode> layers;
+  private final List<String> rentalNetworks;
 
-  public StyleSpec(String name, Collection<TileSource> sources, List<StyleBuilder> layers) {
+  public StyleSpec(
+    String name,
+    Collection<TileSource> sources,
+    List<StyleBuilder> layers,
+    List<String> rentalNetworks
+  ) {
     this.name = name;
     this.sources = sources;
     this.layers = layers.stream().map(StyleBuilder::toJson).toList();
+    this.rentalNetworks = List.copyOf(rentalNetworks);
   }
 
   @JsonSerialize
@@ -45,6 +52,17 @@ public final class StyleSpec {
   @JsonSerialize
   public List<JsonNode> layers() {
     return layers;
+  }
+
+  /**
+   * Style-level metadata, which the spec allows to carry arbitrary keys. The debug client uses
+   * {@code rentalNetworks} to offer a per-network filter on the vehicle rental layers; the values
+   * cannot be derived from the tiles, since a tile only tells you about the networks present in
+   * the area currently loaded.
+   */
+  @JsonSerialize
+  public Map<String, Object> metadata() {
+    return Map.of("rentalNetworks", rentalNetworks);
   }
 
   @JsonSerialize

--- a/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -40,7 +40,8 @@ class DebugStyleSpecTest {
       geofencingZones,
       rental,
       transfers,
-      List.of()
+      List.of(),
+      List.of("tier", "voi")
     );
 
     var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);

--- a/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -2311,6 +2311,12 @@
       }
     }
   ],
-  "version" : 8,
-  "glyphs" : "https://cdn.jsdelivr.net/gh/klokantech/klokantech-gl-fonts@master/{fontstack}/{range}.pbf"
+  "metadata" : {
+    "rentalNetworks" : [
+      "tier",
+      "voi"
+    ]
+  },
+  "glyphs" : "https://cdn.jsdelivr.net/gh/klokantech/klokantech-gl-fonts@master/{fontstack}/{range}.pbf",
+  "version" : 8
 }

--- a/client/src/components/ItineraryList/ItineraryGraphiQLBikeRentalStationLink.tsx
+++ b/client/src/components/ItineraryList/ItineraryGraphiQLBikeRentalStationLink.tsx
@@ -1,0 +1,25 @@
+import { bikeRentalStationQueryAsString } from '../../static/query/bikeRentalStationQuery.tsx';
+import { Maybe } from '../../gql/graphql.ts';
+const graphiQLUrl = import.meta.env.VITE_GRAPHIQL_URL;
+
+export function ItineraryGraphiQLBikeRentalStationLink({
+  stationId,
+  legName,
+}: {
+  stationId: string | undefined;
+  legName: Maybe<string> | undefined;
+}) {
+  const queryID = { id: stationId };
+  const formattedQuery = encodeURIComponent(bikeRentalStationQueryAsString);
+  const formattedQueryID = encodeURIComponent(JSON.stringify(queryID));
+
+  return (
+    <a
+      href={graphiQLUrl + '&query=' + formattedQuery + '&variables=' + formattedQueryID}
+      target={'_blank'}
+      rel={'noreferrer'}
+    >
+      {legName}
+    </a>
+  );
+}

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -34,7 +34,7 @@ function readable(value: string | undefined | null): string | undefined {
  *
  * A station keeps its own name, which is a real place, with the network added.
  */
-function placeName(place: Place): string | undefined {
+function placeName(place: Place, withNetwork: boolean): string | undefined {
   const vehicle = place.rentalVehicle;
   if (vehicle) {
     // "human" propulsion is the unremarkable case and only lengthens the line.
@@ -43,25 +43,39 @@ function placeName(place: Place): string | undefined {
       .filter(Boolean)
       .join(' ');
     const description = kind ? `${kind} rental` : 'rental';
-    return vehicle.network ? `${description} (${vehicle.network})` : description;
+    return withNetwork && vehicle.network ? `${description} (${vehicle.network})` : description;
   }
 
   const station = place.bikeRentalStation;
   if (station) {
-    const networks = station.networks?.filter(Boolean).join(', ');
     const name = place.name ?? station.name;
+    const networks = withNetwork ? placeNetwork(place) : undefined;
     return networks ? `${name} (${networks})` : (name ?? undefined);
   }
 
   return place.name ?? undefined;
 }
 
+/** The rental network a place belongs to, whether it holds a vehicle or is a station. */
+function placeNetwork(place: Place): string | undefined {
+  return place.rentalVehicle?.network ?? place.bikeRentalStation?.networks?.filter(Boolean).join(', ') ?? undefined;
+}
+
+/**
+ * You rent from one network for the whole leg, so it belongs to the leg rather than to each end of
+ * it. Undefined on a leg that is not itself the rental - a walk to the vehicle has nowhere else to
+ * put it, so there the place name carries it.
+ */
+function legNetwork(leg: Leg): string | undefined {
+  return placeNetwork(leg.fromPlace);
+}
+
 /**
  * A rental leg's places carry either a free-floating vehicle or a station, and never a quay, so
  * linking to the quay query produced a link with no variables.
  */
-function PlaceLink({ place }: { place: Place }) {
-  const name = placeName(place);
+function PlaceLink({ place, withNetwork }: { place: Place; withNetwork: boolean }) {
+  const name = placeName(place, withNetwork);
   if (place.quay?.id) {
     return <ItineraryGraphiQLQuayLink legId={place.quay.id} legName={name} />;
   }
@@ -73,6 +87,7 @@ function PlaceLink({ place }: { place: Place }) {
 }
 
 export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean }) {
+  const network = legNetwork(leg);
   return (
     <div className="itinerary-leg-details">
       <div className="times">
@@ -83,7 +98,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
       <LegTime aimedTime={leg.aimedStartTime} expectedTime={leg.expectedStartTime} hasRealtime={leg.realtime} /> -{' '}
       <LegTime aimedTime={leg.aimedEndTime} expectedTime={leg.expectedEndTime} hasRealtime={leg.realtime} />
       <div className="mode">
-        <b>{leg.mode}</b>{' '}
+        <b>{leg.mode}</b> {network && <span className="rental-network">{network}</span>}{' '}
         {leg.line && (
           <>
             <ItineraryGraphiQLLineLink legId={leg.line?.id} legName={legName(leg)} />
@@ -93,10 +108,10 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
         {leg.mode !== Mode.Foot && (
           <>
             <br />
-            <PlaceLink place={leg.fromPlace} /> →{' '}
+            <PlaceLink place={leg.fromPlace} withNetwork={!network} /> →{' '}
           </>
         )}{' '}
-        {!isLast && <PlaceLink place={leg.toPlace} />}
+        {!isLast && <PlaceLink place={leg.toPlace} withNetwork={!network} />}
       </div>
     </div>
   );

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -6,6 +6,7 @@ import { InterchangeInfo } from './InterchangeInfo.tsx';
 import { ItineraryGraphiQLLineLink } from './ItineraryGraphiQLLineLink.tsx';
 import { ItineraryGraphiQLQuayLink } from './ItineraryGraphiQLQuayLink.tsx';
 import { ItineraryGraphiQLAuthorityLink } from './ItineraryGraphiQLAuthorityLink.tsx';
+import { ItineraryGraphiQLBikeRentalStationLink } from './ItineraryGraphiQLBikeRentalStationLink.tsx';
 import { Leg } from '../../static/query/tripQueryTypes';
 
 /**
@@ -18,7 +19,44 @@ function legName(leg: Leg): string {
     return leg.line?.name || 'unknown';
   }
 }
+type Place = Leg['fromPlace'];
+
+/**
+ * A rental leg's places carry either a free-floating vehicle or a station, and never a quay, so
+ * linking to the quay query produced a link with no variables.
+ */
+function PlaceLink({ place }: { place: Place }) {
+  if (place.quay?.id) {
+    return <ItineraryGraphiQLQuayLink legId={place.quay.id} legName={place.name} />;
+  }
+  if (place.bikeRentalStation?.id) {
+    return <ItineraryGraphiQLBikeRentalStationLink stationId={place.bikeRentalStation.id} legName={place.name} />;
+  }
+  // Transmodel has no root query for a free-floating vehicle, so there is nothing to link to.
+  return <>{place.name}</>;
+}
+
+/**
+ * Which operator's vehicle this is, and what kind - neither of which the mode alone tells you when
+ * several networks serve the same area.
+ */
+function rentalDescription(leg: Leg): string | undefined {
+  const vehicle = leg.fromPlace.rentalVehicle;
+  if (vehicle) {
+    const formFactor = vehicle.vehicleType?.formFactor?.toLowerCase();
+    const propulsion = vehicle.vehicleType?.propulsionType?.toLowerCase();
+    const kind = [formFactor, propulsion && `(${propulsion})`].filter(Boolean).join(' ');
+    return [vehicle.network, kind].filter(Boolean).join(' · ');
+  }
+  const station = leg.fromPlace.bikeRentalStation;
+  if (station) {
+    return [station.networks?.filter(Boolean).join(', '), 'station'].filter(Boolean).join(' · ');
+  }
+  return undefined;
+}
+
 export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean }) {
+  const rental = rentalDescription(leg);
   return (
     <div className="itinerary-leg-details">
       <div className="times">
@@ -29,7 +67,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
       <LegTime aimedTime={leg.aimedStartTime} expectedTime={leg.expectedStartTime} hasRealtime={leg.realtime} /> -{' '}
       <LegTime aimedTime={leg.aimedEndTime} expectedTime={leg.expectedEndTime} hasRealtime={leg.realtime} />
       <div className="mode">
-        <b>{leg.mode}</b>{' '}
+        <b>{leg.mode}</b> {rental && <span className="rental-info">{rental}</span>}{' '}
         {leg.line && (
           <>
             <ItineraryGraphiQLLineLink legId={leg.line?.id} legName={legName(leg)} />
@@ -39,10 +77,10 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
         {leg.mode !== Mode.Foot && (
           <>
             <br />
-            <ItineraryGraphiQLQuayLink legId={leg.fromPlace.quay?.id} legName={leg.fromPlace.name} /> →{' '}
+            <PlaceLink place={leg.fromPlace} /> →{' '}
           </>
         )}{' '}
-        {!isLast && <ItineraryGraphiQLQuayLink legId={leg.toPlace.quay?.id} legName={leg.toPlace.name} />}
+        {!isLast && <PlaceLink place={leg.toPlace} />}
       </div>
     </div>
   );

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -21,19 +21,40 @@ function legName(leg: Leg): string {
 }
 type Place = Leg['fromPlace'];
 
+/** GBFS form factors are snake_case, e.g. scooter_standing, cargo_bicycle. */
+function readableFormFactor(formFactor: string | undefined): string | undefined {
+  return formFactor?.toLowerCase().replace(/_/g, ' ');
+}
+
+/**
+ * What you collect here, rather than what the operator happens to call it. A free-floating
+ * vehicle's place name is the GBFS vehicle type name, which is free text: the same network yields
+ * "E-scooter" for a scooter and a model number such as "Explorer_5" for a bike, neither of which
+ * says it is a rental or whose it is.
+ */
+function placeName(place: Place): string | undefined {
+  const vehicle = place.rentalVehicle;
+  if (vehicle) {
+    const kind = readableFormFactor(vehicle.vehicleType?.formFactor) ?? 'vehicle';
+    return vehicle.network ? `${kind} rental (${vehicle.network})` : `${kind} rental`;
+  }
+  return place.name ?? undefined;
+}
+
 /**
  * A rental leg's places carry either a free-floating vehicle or a station, and never a quay, so
  * linking to the quay query produced a link with no variables.
  */
 function PlaceLink({ place }: { place: Place }) {
+  const name = placeName(place);
   if (place.quay?.id) {
-    return <ItineraryGraphiQLQuayLink legId={place.quay.id} legName={place.name} />;
+    return <ItineraryGraphiQLQuayLink legId={place.quay.id} legName={name} />;
   }
   if (place.bikeRentalStation?.id) {
-    return <ItineraryGraphiQLBikeRentalStationLink stationId={place.bikeRentalStation.id} legName={place.name} />;
+    return <ItineraryGraphiQLBikeRentalStationLink stationId={place.bikeRentalStation.id} legName={name} />;
   }
   // Transmodel has no root query for a free-floating vehicle, so there is nothing to link to.
-  return <>{place.name}</>;
+  return <>{name}</>;
 }
 
 /**
@@ -43,7 +64,7 @@ function PlaceLink({ place }: { place: Place }) {
 function rentalDescription(leg: Leg): string | undefined {
   const vehicle = leg.fromPlace.rentalVehicle;
   if (vehicle) {
-    const formFactor = vehicle.vehicleType?.formFactor?.toLowerCase();
+    const formFactor = readableFormFactor(vehicle.vehicleType?.formFactor);
     const propulsion = vehicle.vehicleType?.propulsionType?.toLowerCase();
     const kind = [formFactor, propulsion && `(${propulsion})`].filter(Boolean).join(' ');
     return [vehicle.network, kind].filter(Boolean).join(' · ');

--- a/client/src/components/ItineraryList/ItineraryLegDetails.tsx
+++ b/client/src/components/ItineraryList/ItineraryLegDetails.tsx
@@ -21,9 +21,9 @@ function legName(leg: Leg): string {
 }
 type Place = Leg['fromPlace'];
 
-/** GBFS form factors are snake_case, e.g. scooter_standing, cargo_bicycle. */
-function readableFormFactor(formFactor: string | undefined): string | undefined {
-  return formFactor?.toLowerCase().replace(/_/g, ' ');
+/** GBFS enum values are snake_case, e.g. scooter_standing, cargo_bicycle, electric_assist. */
+function readable(value: string | undefined | null): string | undefined {
+  return value?.toLowerCase().replace(/_/g, ' ');
 }
 
 /**
@@ -31,13 +31,28 @@ function readableFormFactor(formFactor: string | undefined): string | undefined 
  * vehicle's place name is the GBFS vehicle type name, which is free text: the same network yields
  * "E-scooter" for a scooter and a model number such as "Explorer_5" for a bike, neither of which
  * says it is a rental or whose it is.
+ *
+ * A station keeps its own name, which is a real place, with the network added.
  */
 function placeName(place: Place): string | undefined {
   const vehicle = place.rentalVehicle;
   if (vehicle) {
-    const kind = readableFormFactor(vehicle.vehicleType?.formFactor) ?? 'vehicle';
-    return vehicle.network ? `${kind} rental (${vehicle.network})` : `${kind} rental`;
+    // "human" propulsion is the unremarkable case and only lengthens the line.
+    const propulsion = readable(vehicle.vehicleType?.propulsionType);
+    const kind = [propulsion === 'human' ? undefined : propulsion, readable(vehicle.vehicleType?.formFactor)]
+      .filter(Boolean)
+      .join(' ');
+    const description = kind ? `${kind} rental` : 'rental';
+    return vehicle.network ? `${description} (${vehicle.network})` : description;
   }
+
+  const station = place.bikeRentalStation;
+  if (station) {
+    const networks = station.networks?.filter(Boolean).join(', ');
+    const name = place.name ?? station.name;
+    return networks ? `${name} (${networks})` : (name ?? undefined);
+  }
+
   return place.name ?? undefined;
 }
 
@@ -57,27 +72,7 @@ function PlaceLink({ place }: { place: Place }) {
   return <>{name}</>;
 }
 
-/**
- * Which operator's vehicle this is, and what kind - neither of which the mode alone tells you when
- * several networks serve the same area.
- */
-function rentalDescription(leg: Leg): string | undefined {
-  const vehicle = leg.fromPlace.rentalVehicle;
-  if (vehicle) {
-    const formFactor = readableFormFactor(vehicle.vehicleType?.formFactor);
-    const propulsion = vehicle.vehicleType?.propulsionType?.toLowerCase();
-    const kind = [formFactor, propulsion && `(${propulsion})`].filter(Boolean).join(' ');
-    return [vehicle.network, kind].filter(Boolean).join(' · ');
-  }
-  const station = leg.fromPlace.bikeRentalStation;
-  if (station) {
-    return [station.networks?.filter(Boolean).join(', '), 'station'].filter(Boolean).join(' · ');
-  }
-  return undefined;
-}
-
 export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean }) {
-  const rental = rentalDescription(leg);
   return (
     <div className="itinerary-leg-details">
       <div className="times">
@@ -88,7 +83,7 @@ export function ItineraryLegDetails({ leg, isLast }: { leg: Leg; isLast: boolean
       <LegTime aimedTime={leg.aimedStartTime} expectedTime={leg.expectedStartTime} hasRealtime={leg.realtime} /> -{' '}
       <LegTime aimedTime={leg.aimedEndTime} expectedTime={leg.expectedEndTime} hasRealtime={leg.realtime} />
       <div className="mode">
-        <b>{leg.mode}</b> {rental && <span className="rental-info">{rental}</span>}{' '}
+        <b>{leg.mode}</b>{' '}
         {leg.line && (
           <>
             <ItineraryGraphiQLLineLink legId={leg.line?.id} legName={legName(leg)} />

--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -21,6 +21,13 @@ interface LayerControlProps {
  *   1. Background (raster) layers (select exactly one to show).
  *   2. Debug layers (vector-like layers) with groupings, toggle on/off individually.
  */
+/** Distinguishes the two lists inside a group: what is drawn, and what it is narrowed to. */
+const subHeadingStyle: React.CSSProperties = {
+  marginLeft: '20px',
+  marginBottom: '3px',
+  opacity: 0.7,
+};
+
 const linkButtonStyle: React.CSSProperties = {
   background: 'none',
   border: 'none',
@@ -212,6 +219,9 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
           (layer) => mapRef?.getMap().getLayoutProperty(layer.id, 'visibility') !== 'none',
         );
 
+        // Networks filter the rental layers, so the group needs a second, labelled list.
+        const showNetworks = groupName === RENTAL_GROUP && rentalNetworks.length > 0;
+
         // Define a helper to toggle all layers in the group at once.
         const toggleGroupVisibility = (checked: boolean) => {
           layers.forEach((layer) => {
@@ -239,32 +249,7 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
               </label>
             </h6>
 
-            {groupName === RENTAL_GROUP && rentalNetworks.length > 0 && (
-              <div style={{ margin: '0 0 6px 20px' }}>
-                <div style={{ display: 'flex', gap: '6px', marginBottom: '3px' }}>
-                  <span style={{ opacity: 0.7 }}>Networks</span>
-                  <button type="button" onClick={() => setAllNetworks(true)} style={linkButtonStyle}>
-                    all
-                  </button>
-                  <button type="button" onClick={() => setAllNetworks(false)} style={linkButtonStyle}>
-                    none
-                  </button>
-                </div>
-                <div style={{ maxHeight: '150px', overflowY: 'auto' }}>
-                  {rentalNetworks.map((network) => (
-                    <label key={network} style={{ display: 'block', cursor: 'pointer' }}>
-                      <input
-                        type="checkbox"
-                        checked={selectedNetworks.has(network)}
-                        onChange={(e) => toggleNetwork(network, e.target.checked)}
-                        style={{ marginRight: '5px' }}
-                      />
-                      {network}
-                    </label>
-                  ))}
-                </div>
-              </div>
-            )}
+            {showNetworks && <div style={subHeadingStyle}>Layers</div>}
 
             {layers.map((layer) => {
               // Figure out if the layer is visible or not:
@@ -289,6 +274,33 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
                 </label>
               );
             })}
+
+            {showNetworks && (
+              <div style={{ marginTop: '8px' }}>
+                <div style={{ ...subHeadingStyle, display: 'flex', gap: '6px' }}>
+                  <span>Networks</span>
+                  <button type="button" onClick={() => setAllNetworks(true)} style={linkButtonStyle}>
+                    all
+                  </button>
+                  <button type="button" onClick={() => setAllNetworks(false)} style={linkButtonStyle}>
+                    none
+                  </button>
+                </div>
+                <div style={{ maxHeight: '150px', overflowY: 'auto' }}>
+                  {rentalNetworks.map((network) => (
+                    <label key={network} style={{ display: 'block', cursor: 'pointer' }}>
+                      <input
+                        type="checkbox"
+                        checked={selectedNetworks.has(network)}
+                        onChange={(e) => toggleNetwork(network, e.target.checked)}
+                        style={{ marginLeft: '20px', marginRight: '5px' }}
+                      />
+                      {network}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         );
       })}

--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { ControlPosition, MapRef } from 'react-map-gl/maplibre';
 import { findSelectedDebugLayers } from '../../util/map.ts';
 
@@ -6,6 +6,9 @@ interface Layer {
   id: string;
   name: string;
 }
+
+/** The group whose layers can be narrowed to a set of vehicle rental networks. */
+const RENTAL_GROUP = 'Rental';
 
 interface LayerControlProps {
   mapRef: MapRef | null;
@@ -18,9 +21,27 @@ interface LayerControlProps {
  *   1. Background (raster) layers (select exactly one to show).
  *   2. Debug layers (vector-like layers) with groupings, toggle on/off individually.
  */
+const linkButtonStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  textDecoration: 'underline',
+  fontSize: 'inherit',
+};
+
 const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayerIds }) => {
   const [rasterLayers, setRasterLayers] = useState<Layer[]>([]);
   const [layerGroups, setLayerGroups] = useState<Record<string, Layer[]>>({});
+  const [rentalNetworks, setRentalNetworks] = useState<string[]>([]);
+  const [selectedNetworks, setSelectedNetworks] = useState<Set<string>>(new Set());
+
+  /**
+   * The filter each rental layer was given by the server, captured before we narrow it. Restoring
+   * it is what makes "all networks selected" identical to an untouched style rather than merely
+   * equivalent to it.
+   */
+  const serverFilters = useRef<Map<string, unknown>>(new Map());
 
   /**
    * Load background + debug layers from the style once the map is ready.
@@ -62,6 +83,12 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
         });
 
       setLayerGroups(groups);
+
+      // The networks cannot be derived from the tiles: a tile only reveals the networks present in
+      // the area currently loaded, so the list would change as you pan and be empty when zoomed out.
+      const networks = (style.metadata as Record<string, string[]> | undefined)?.rentalNetworks ?? [];
+      setRentalNetworks(networks);
+      setSelectedNetworks((previous) => (previous.size === 0 ? new Set(networks) : previous));
     };
 
     if (mapInstance.isStyleLoaded()) {
@@ -89,6 +116,57 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
       setInteractiveLayerIds(selected);
     },
     [mapRef, setInteractiveLayerIds],
+  );
+
+  /**
+   * Narrow the rental layers to the given networks, leaving every other layer untouched.
+   */
+  const applyNetworkFilter = useCallback(
+    (networks: Set<string>) => {
+      if (!mapRef) return;
+      const mapInstance = mapRef.getMap();
+
+      (layerGroups[RENTAL_GROUP] ?? []).forEach((layer) => {
+        if (!serverFilters.current.has(layer.id)) {
+          serverFilters.current.set(layer.id, mapInstance.getFilter(layer.id));
+        }
+        const serverFilter = serverFilters.current.get(layer.id);
+
+        // setFilter replaces rather than merges, so the server's own filter - which selects the
+        // vehicle, station or zone type the layer draws - has to be reapplied alongside ours.
+        const filter =
+          networks.size === rentalNetworks.length
+            ? serverFilter
+            : ['all', serverFilter, ['in', ['get', 'network'], ['literal', [...networks]]]];
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mapInstance.setFilter(layer.id, filter as any);
+      });
+    },
+    [mapRef, layerGroups, rentalNetworks],
+  );
+
+  const toggleNetwork = useCallback(
+    (network: string, isSelected: boolean) => {
+      const next = new Set(selectedNetworks);
+      if (isSelected) {
+        next.add(network);
+      } else {
+        next.delete(network);
+      }
+      setSelectedNetworks(next);
+      applyNetworkFilter(next);
+    },
+    [selectedNetworks, applyNetworkFilter],
+  );
+
+  const setAllNetworks = useCallback(
+    (isSelected: boolean) => {
+      const next = isSelected ? new Set(rentalNetworks) : new Set<string>();
+      setSelectedNetworks(next);
+      applyNetworkFilter(next);
+    },
+    [rentalNetworks, applyNetworkFilter],
   );
 
   /**
@@ -160,6 +238,33 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
                 {groupName}
               </label>
             </h6>
+
+            {groupName === RENTAL_GROUP && rentalNetworks.length > 0 && (
+              <div style={{ margin: '0 0 6px 20px' }}>
+                <div style={{ display: 'flex', gap: '6px', marginBottom: '3px' }}>
+                  <span style={{ opacity: 0.7 }}>Networks</span>
+                  <button type="button" onClick={() => setAllNetworks(true)} style={linkButtonStyle}>
+                    all
+                  </button>
+                  <button type="button" onClick={() => setAllNetworks(false)} style={linkButtonStyle}>
+                    none
+                  </button>
+                </div>
+                <div style={{ maxHeight: '150px', overflowY: 'auto' }}>
+                  {rentalNetworks.map((network) => (
+                    <label key={network} style={{ display: 'block', cursor: 'pointer' }}>
+                      <input
+                        type="checkbox"
+                        checked={selectedNetworks.has(network)}
+                        onChange={(e) => toggleNetwork(network, e.target.checked)}
+                        style={{ marginRight: '5px' }}
+                      />
+                      {network}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {layers.map((layer) => {
               // Figure out if the layer is visible or not:

--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -37,22 +37,6 @@ interface LayerControlProps {
  *   1. Background (raster) layers (select exactly one to show).
  *   2. Debug layers (vector-like layers) with groupings, toggle on/off individually.
  */
-/** Distinguishes the two lists inside a group: what is drawn, and what it is narrowed to. */
-const subHeadingStyle: React.CSSProperties = {
-  marginLeft: '20px',
-  marginBottom: '3px',
-  opacity: 0.7,
-};
-
-const linkButtonStyle: React.CSSProperties = {
-  background: 'none',
-  border: 'none',
-  padding: 0,
-  cursor: 'pointer',
-  textDecoration: 'underline',
-  fontSize: 'inherit',
-};
-
 const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayerIds }) => {
   const [rasterLayers, setRasterLayers] = useState<Layer[]>([]);
   const [layerGroups, setLayerGroups] = useState<Record<string, Layer[]>>({});
@@ -208,18 +192,9 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
   );
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '10px',
-        width: '250px',
-        borderRadius: '4px',
-        overflowY: 'auto',
-      }}
-    >
+    <div className="layer-control">
       {/* BACKGROUND (RASTER) LAYERS */}
-      <h4 style={{ marginTop: 0 }}>Background</h4>
+      <h4>Background</h4>
       <select onChange={(e) => setBackgroundLayer(e.target.value)}>
         {rasterLayers.map((layer) => (
           <option key={layer.id} value={layer.id}>
@@ -229,7 +204,7 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
       </select>
 
       {/* DEBUG (VECTOR) LAYERS */}
-      <h4 style={{ marginTop: '1rem' }}>Debug Layers</h4>
+      <h4>Debug Layers</h4>
       {Object.entries(layerGroups).map(([groupName, layers]) => {
         // Determine if *all* layers in this group are currently visible.
         const allVisible = layers.every(
@@ -247,45 +222,26 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
         };
 
         return (
-          <div key={groupName} style={{ marginBottom: '10px' }}>
-            <h6 style={{ margin: '0 0 5px' }}>
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  cursor: 'pointer',
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={allVisible}
-                  onChange={(e) => toggleGroupVisibility(e.target.checked)}
-                  style={{ marginRight: '5px' }}
-                />
+          <div key={groupName} className="layer-group">
+            <h6>
+              <label className="group-label">
+                <input type="checkbox" checked={allVisible} onChange={(e) => toggleGroupVisibility(e.target.checked)} />
                 {groupName}
               </label>
             </h6>
 
-            {showNetworks && <div style={subHeadingStyle}>Layers</div>}
+            {showNetworks && <div className="sub-heading">Layers</div>}
 
             {layers.map((layer) => {
               // Figure out if the layer is visible or not:
               const isVisible = mapRef?.getMap().getLayoutProperty(layer.id, 'visibility') !== 'none';
 
               return (
-                <label
-                  key={layer.id}
-                  style={{
-                    display: 'block',
-                    cursor: 'pointer',
-                    marginBottom: '5px',
-                  }}
-                >
+                <label key={layer.id} className="toggle">
                   <input
                     type="checkbox"
                     checked={isVisible}
                     onChange={(e) => toggleLayerVisibility(layer.id, e.target.checked)}
-                    style={{ marginLeft: '20px', marginRight: '5px' }}
                   />
                   {layer.name}
                 </label>
@@ -293,24 +249,23 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
             })}
 
             {showNetworks && (
-              <div style={{ marginTop: '8px' }}>
-                <div style={{ ...subHeadingStyle, display: 'flex', gap: '6px' }}>
+              <div className="networks">
+                <div className="sub-heading">
                   <span>Networks</span>
-                  <button type="button" onClick={() => setAllNetworks(true)} style={linkButtonStyle}>
+                  <button type="button" className="link-button" onClick={() => setAllNetworks(true)}>
                     all
                   </button>
-                  <button type="button" onClick={() => setAllNetworks(false)} style={linkButtonStyle}>
+                  <button type="button" className="link-button" onClick={() => setAllNetworks(false)}>
                     none
                   </button>
                 </div>
-                <div style={{ maxHeight: '150px', overflowY: 'auto' }}>
+                <div className="network-list">
                   {rentalNetworks.map((network) => (
-                    <label key={network} style={{ display: 'block', cursor: 'pointer' }}>
+                    <label key={network}>
                       <input
                         type="checkbox"
                         checked={selectedNetworks.has(network)}
                         onChange={(e) => toggleNetwork(network, e.target.checked)}
-                        style={{ marginLeft: '20px', marginRight: '5px' }}
                       />
                       {network}
                     </label>

--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -10,6 +10,22 @@ interface Layer {
 /** The group whose layers can be narrowed to a set of vehicle rental networks. */
 const RENTAL_GROUP = 'Rental';
 
+/**
+ * MapLibre's legacy filter syntax names the property directly, as in ["in", "class", "StreetEdge"],
+ * where the expression syntax wraps it: ["in", ["get", "class"], ["literal", [...]]]. The debug
+ * style uses both - the rental vehicle and station layers are class-filtered in the legacy form,
+ * the geofencing zone layers use expressions - and the two cannot be mixed inside one filter.
+ */
+function isLegacyFilter(filter: unknown): boolean {
+  return Array.isArray(filter) && filter[0] === 'in' && typeof filter[1] === 'string';
+}
+
+function networkFilter(serverFilter: unknown, networks: Set<string>): unknown[] {
+  return isLegacyFilter(serverFilter)
+    ? ['in', 'network', ...networks]
+    : ['in', ['get', 'network'], ['literal', [...networks]]];
+}
+
 interface LayerControlProps {
   mapRef: MapRef | null;
   position: ControlPosition; // not used in inline styling, but you might use it if you want
@@ -140,11 +156,12 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
         const serverFilter = serverFilters.current.get(layer.id);
 
         // setFilter replaces rather than merges, so the server's own filter - which selects the
-        // vehicle, station or zone type the layer draws - has to be reapplied alongside ours.
+        // vehicle, station or zone type the layer draws - has to be reapplied alongside ours, in
+        // the same dialect: an expression cannot be combined with a legacy filter.
         const filter =
           networks.size === rentalNetworks.length
             ? serverFilter
-            : ['all', serverFilter, ['in', ['get', 'network'], ['literal', [...networks]]]];
+            : ['all', serverFilter, networkFilter(serverFilter, networks)];
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         mapInstance.setFilter(layer.id, filter as any);

--- a/client/src/static/query/bikeRentalStationQuery.tsx
+++ b/client/src/static/query/bikeRentalStationQuery.tsx
@@ -1,0 +1,16 @@
+import { graphql } from '../../gql';
+import { print } from 'graphql/index';
+
+export const query = graphql(`
+  query bikeRentalStation($id: String!) {
+    bikeRentalStation(id: $id) {
+      id
+      name
+      networks
+      bikesAvailable
+      spacesAvailable
+    }
+  }
+`);
+
+export const bikeRentalStationQueryAsString = print(query);

--- a/client/src/static/query/selector.fragment.graphql
+++ b/client/src/static/query/selector.fragment.graphql
@@ -25,11 +25,37 @@
                 quay {
                     id
                 }
+                rentalVehicle {
+                    id
+                    network
+                    vehicleType {
+                        formFactor
+                        propulsionType
+                    }
+                }
+                bikeRentalStation {
+                    id
+                    name
+                    networks
+                }
             }
             toPlace {
                 name
                 quay {
                     id
+                }
+                rentalVehicle {
+                    id
+                    network
+                    vehicleType {
+                        formFactor
+                        propulsionType
+                    }
+                }
+                bikeRentalStation {
+                    id
+                    name
+                    networks
                 }
             }
             fromEstimatedCall {

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -737,3 +737,93 @@ input.comma-separated-input[type='number'] {
     max-width: 1140px; /* Bootstrap xl size for lg screens and up */
   }
 }
+
+.layer-control {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  width: 250px;
+  border-radius: 4px;
+  overflow-y: auto;
+}
+
+.layer-control h4 {
+  margin-top: 1rem;
+}
+
+.layer-control h4:first-of-type {
+  margin-top: 0;
+}
+
+.layer-control .layer-group {
+  margin-bottom: 10px;
+}
+
+.layer-control .layer-group h6 {
+  margin: 0 0 5px;
+}
+
+.layer-control .group-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.layer-control .group-label input {
+  margin-right: 5px;
+}
+
+/* Distinguishes the two lists inside a group: what is drawn, and what it is narrowed to. */
+.layer-control .sub-heading {
+  margin-left: 20px;
+  margin-bottom: 3px;
+  opacity: 0.7;
+}
+
+.layer-control .networks {
+  margin-top: 8px;
+}
+
+.layer-control .networks .sub-heading {
+  display: flex;
+  gap: 6px;
+}
+
+.layer-control .network-list {
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.layer-control label.toggle {
+  display: block;
+  cursor: pointer;
+  margin-bottom: 5px;
+}
+
+.layer-control label.toggle input {
+  margin-left: 20px;
+  margin-right: 5px;
+}
+
+.layer-control .network-list label {
+  display: block;
+  cursor: pointer;
+}
+
+.layer-control .network-list input {
+  margin-left: 20px;
+  margin-right: 5px;
+}
+
+.layer-control .link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: inherit;
+}
+
+.itinerary-leg-details .rental-network {
+  opacity: 0.7;
+}


### PR DESCRIPTION
### Summary

Three related shortcomings in the debug client made vehicle rental hard to inspect, especially where
several operators serve the same area.

**The map drew every network at once.** The `Rental` group has five layers — vehicles, stations and
three kinds of geofencing zone — all filtered by type and none by network, so overlapping operators'
zones stacked with no way to tell whose was whose. The layer control now offers a checkbox per
network, narrowing all five layers together so vehicles, stations and zones stay consistent.

<img width="255" height="335" alt="Screenshot 2026-08-12 at 11 36 56" src="https://github.com/user-attachments/assets/f3b584d9-408f-46d4-8506-31f8943bae9a" />

The networks are published in the style's `metadata`. The list unions rental places and geofencing zones, because
a network can have one without the other. Future improvement potential: Move to the vehicle rental service?

**Rental legs said only their mode.** An itinerary showed `scooter` with nothing about which
operator's vehicle it was or what kind. Legs now carry the network and the vehicle, built from the
GBFS enums:

<img width="301" height="290" alt="Screenshot 2026-08-12 at 11 37 20" src="https://github.com/user-attachments/assets/3ee6fc5e-14e7-43cb-bb3c-f7f68ffea5f1" />

The network is stated once per leg — beside the mode where the leg *is* the rental, on the place
name where it is the walk to the vehicle, since that leg has nowhere else to put it.

**The link on a rental leg was broken.** Any leg not on foot rendered a link to the quay query, but
a rental leg's places carry a vehicle or a station and never a quay, so the link opened GraphiQL
with no variables. Now: the quay query where there is a quay, a new `bikeRentalStation` query where
the place is a station, and plain text for a free-floating vehicle — Transmodel API has no root query to
look one up by id.

<img width="572" height="503" alt="Screenshot 2026-08-12 at 11 37 59" src="https://github.com/user-attachments/assets/246f3b5c-1e6a-4cc1-ba1d-be8f86474247" />

Note that a free-floating vehicle's place name is the GBFS vehicle *type* name, which is operator
free text. Neither says it is a rental or whose it is, so the displayed name is derived from
`formFactor`, `propulsionType` and `network` instead, and rendered readably rather than as
snake_case. Rental stations keep their own name, which is a real place.

### Issue

No issue; the problems are described in full above.

### Unit tests

`DebugStyleSpecTest` covers the new `metadata.rentalNetworks` through its style snapshot. The client
changes are checked by `tsc`, eslint and the existing client tests, and were verified by hand
against both rental shapes: a free-floating scooter and a docked city-bike hire.

The itinerary rendering itself has no automated test. The client's test suite covers two components
in total, and adding a harness for this one felt out of proportion to the change — worth saying
plainly rather than implying more coverage than exists.

### Documentation

None needed. `metadata` is part of the MapLibre style spec, which allows arbitrary keys, and the new
key is documented in Javadoc on `StyleSpec`. No configuration changes.
