### PR TITLE
Resolve SIRI added and extra-call real-time times against the start of service

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
@@ -32,6 +32,7 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.UpdateException;
+import org.opentripplanner.utils.time.ServiceDateUtils;
 import org.rutebanken.netex.model.BusSubmodeEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
 import org.slf4j.Logger;
@@ -118,7 +119,7 @@ class AddedTripBuilder {
     timeZone = transitService.getTimeZone();
 
     replacedTrips = getReplacedVehicleJourneys(journey);
-    stopTimesMapper = new StopTimesMapper(entityResolver, timeZone);
+    stopTimesMapper = new StopTimesMapper(entityResolver);
   }
 
   AddedTripBuilder(
@@ -166,7 +167,7 @@ class AddedTripBuilder {
     this.replacedTrips = replacedTrips;
     this.dataSource = dataSource;
     this.vehicleRef = vehicleRef;
-    stopTimesMapper = new StopTimesMapper(entityResolver, timeZone);
+    stopTimesMapper = new StopTimesMapper(entityResolver);
   }
 
   TripUpdate build() throws UpdateException {
@@ -197,14 +198,14 @@ class AddedTripBuilder {
 
     Trip trip = createTrip(route, calServiceId);
 
-    ZonedDateTime departureDate = serviceDate.atStartOfDay(timeZone);
+    ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, timeZone);
 
     // Create the "scheduled version" of the trip
     var aimedStopTimes = new ArrayList<StopTime>();
     for (int stopSequence = 0; stopSequence < calls.size(); stopSequence++) {
       StopTime stopTime = stopTimesMapper.createAimedStopTime(
         trip,
-        departureDate,
+        startOfService,
         stopSequence,
         calls.get(stopSequence),
         stopSequence == 0,
@@ -245,7 +246,7 @@ class AddedTripBuilder {
     // Loop through calls again and apply updates
     for (int stopSequence = 0; stopSequence < calls.size(); stopSequence++) {
       TimetableHelper.applyUpdates(
-        departureDate,
+        startOfService,
         builder,
         stopSequence,
         stopSequence == (calls.size() - 1),

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
@@ -27,6 +27,7 @@ import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.service.TransitEditorService;
 import org.opentripplanner.updater.spi.DataValidationExceptionMapper;
 import org.opentripplanner.updater.spi.UpdateException;
+import org.opentripplanner.utils.time.ServiceDateUtils;
 
 class ExtraCallTripBuilder {
 
@@ -75,7 +76,7 @@ class ExtraCallTripBuilder {
     this.generateTripPatternId = generateTripPatternId;
     timeZone = transitService.getTimeZone();
 
-    stopTimesMapper = new StopTimesMapper(entityResolver, timeZone);
+    stopTimesMapper = new StopTimesMapper(entityResolver);
   }
 
   TripUpdate build() throws UpdateException {
@@ -96,7 +97,7 @@ class ExtraCallTripBuilder {
       throw UpdateException.of(trip.getId(), NO_START_DATE);
     }
 
-    ZonedDateTime departureDate = serviceDate.atStartOfDay(timeZone);
+    ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, timeZone);
 
     // Create the "scheduled version" of the trip
     // We do not reuse the trip times of the original scheduled trip
@@ -107,7 +108,7 @@ class ExtraCallTripBuilder {
       CallWrapper call = calls.get(stopSequence);
       StopTime stopTime = stopTimesMapper.createAimedStopTime(
         trip,
-        departureDate,
+        startOfService,
         stopSequence,
         call,
         stopSequence == 0,
@@ -164,7 +165,7 @@ class ExtraCallTripBuilder {
     // Loop through calls again and apply updates
     for (int stopSequence = 0; stopSequence < calls.size(); stopSequence++) {
       TimetableHelper.applyUpdates(
-        departureDate,
+        startOfService,
         builder,
         stopSequence,
         stopSequence == (calls.size() - 1),

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/StopTimesMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.trip.siri;
 
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
@@ -13,11 +12,9 @@ import org.opentripplanner.utils.time.ServiceDateUtils;
 class StopTimesMapper {
 
   private final EntityResolver entityResolver;
-  private final ZoneId zoneId;
 
-  public StopTimesMapper(EntityResolver entityResolver, ZoneId zoneId) {
+  public StopTimesMapper(EntityResolver entityResolver) {
     this.entityResolver = entityResolver;
-    this.zoneId = zoneId;
   }
 
   /**
@@ -26,7 +23,7 @@ class StopTimesMapper {
   @Nullable
   StopTime createAimedStopTime(
     Trip trip,
-    ZonedDateTime departureDate,
+    ZonedDateTime startOfService,
     int stopSequence,
     CallWrapper call,
     boolean isFirstStop,
@@ -57,9 +54,8 @@ class StopTimesMapper {
       : call.getAimedDepartureTime();
 
     var aimedArrivalTimeSeconds = ServiceDateUtils.secondsSinceStartOfService(
-      departureDate,
-      aimedArrivalTime,
-      zoneId
+      startOfService,
+      aimedArrivalTime
     );
 
     var aimedDepartureTime = call.getAimedDepartureTime() != null
@@ -67,9 +63,8 @@ class StopTimesMapper {
       : call.getAimedArrivalTime();
 
     var aimedDepartureTimeSeconds = ServiceDateUtils.secondsSinceStartOfService(
-      departureDate,
-      aimedDepartureTime,
-      zoneId
+      startOfService,
+      aimedDepartureTime
     );
 
     stopTime.setArrivalTime(aimedArrivalTimeSeconds);

--- a/application/src/test/java/org/opentripplanner/updater/trip/OnEachDstTransitionAndAControlDate.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/OnEachDstTransitionAndAControlDate.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.updater.trip;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.LocalDate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
+
+/**
+ * Runs a test on each of the two daylight-saving transitions in the time zone of
+ * {@link org.opentripplanner.transit.model.TransitTestEnvironment}, and on a control date without
+ * one. The test takes the case name and the service date as its parameters.
+ * <p>
+ * A real-time message reports absolute times, so applying one means subtracting the start of the
+ * service day. That origin is noon minus twelve hours, which is calendar midnight only on a
+ * 24-hour day (see {@code ServiceDateUtils.asStartOfService}). A test that asserts the same
+ * timetable on all three dates therefore pins the origin the times were resolved against: using
+ * calendar midnight instead moves them by an hour, in opposite directions on the two transitions,
+ * and leaves the control date untouched.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(OnEachDstTransitionAndAControlDate.ServiceDates.class)
+public @interface OnEachDstTransitionAndAControlDate {
+  class ServiceDates implements ArgumentsProvider {
+
+    /** Clocks jump 02:00 → 03:00, so the calendar day is 23 hours long. */
+    private static final LocalDate SPRING_FORWARD = LocalDate.of(2024, 3, 31);
+
+    /** Clocks fall back 03:00 → 02:00, so the calendar day is 25 hours long. */
+    private static final LocalDate FALL_BACK = LocalDate.of(2024, 10, 27);
+
+    /** Control: no transition, so calendar midnight and the start of service coincide. */
+    private static final LocalDate NO_TRANSITION = LocalDate.of(2024, 5, 7);
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(
+      ParameterDeclarations parameters,
+      ExtensionContext context
+    ) {
+      return Stream.of(
+        Arguments.of("spring forward (23-hour day)", SPRING_FORWARD),
+        Arguments.of("fall back (25-hour day)", FALL_BACK),
+        Arguments.of("no transition", NO_TRANSITION)
+      );
+    }
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/OnEachDstTransitionAndAControlDate.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/OnEachDstTransitionAndAControlDate.java
@@ -18,12 +18,8 @@ import org.junit.jupiter.params.support.ParameterDeclarations;
  * {@link org.opentripplanner.transit.model.TransitTestEnvironment}, and on a control date without
  * one. The test takes the case name and the service date as its parameters.
  * <p>
- * A real-time message reports absolute times, so applying one means subtracting the start of the
- * service day. That origin is noon minus twelve hours, which is calendar midnight only on a
- * 24-hour day (see {@code ServiceDateUtils.asStartOfService}). A test that asserts the same
- * timetable on all three dates therefore pins the origin the times were resolved against: using
- * calendar midnight instead moves them by an hour, in opposite directions on the two transitions,
- * and leaves the control date untouched.
+ * Applying a real-time update should give the same result whether or not the service date contains
+ * a daylight-saving transition.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DstServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DstServiceDateTest.java
@@ -1,0 +1,65 @@
+package org.opentripplanner.updater.trip.gtfs.moduletests.delay;
+
+import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.ADDED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import java.time.LocalDate;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TripInput;
+import org.opentripplanner.updater.trip.OnEachDstTransitionAndAControlDate;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.gtfs.GtfsRtTestHelper;
+import org.opentripplanner.utils.time.TimeUtils;
+
+/**
+ * A GTFS-RT {@code StopTimeEvent.time} is an absolute POSIX timestamp, so applying it means
+ * subtracting the start of the service day - both on a trip that is already in the timetable and on
+ * one the message creates. See {@link OnEachDstTransitionAndAControlDate}.
+ */
+class DstServiceDateTest implements RealtimeTestConstants {
+
+  @OnEachDstTransitionAndAControlDate
+  void absoluteTimesOnScheduledTrip(String name, LocalDate serviceDate) {
+    var envBuilder = TransitTestEnvironment.of(serviceDate);
+    var stopA = envBuilder.stop(STOP_A_ID);
+    var stopB = envBuilder.stop(STOP_B_ID);
+    var env = envBuilder
+      .addTrip(TripInput.of(TRIP_1_ID).addStop(stopA, "10:00").addStop(stopB, "10:10"))
+      .build();
+    var rt = GtfsRtTestHelper.of(env);
+
+    var tripUpdate = rt
+      .tripUpdateScheduled(TRIP_1_ID)
+      .addStopTime(STOP_A_ID, "10:01")
+      .addStopTime(STOP_B_ID, "10:11")
+      .build();
+
+    assertSuccess(rt.applyTripUpdate(tripUpdate));
+
+    assertEquals("U | A 10:01 10:01 | B 10:11 10:11", env.tripData(TRIP_1_ID).showTimetable());
+  }
+
+  @OnEachDstTransitionAndAControlDate
+  void absoluteTimesOnAddedTrip(String name, LocalDate serviceDate) {
+    var envBuilder = TransitTestEnvironment.of(serviceDate);
+    var stopA = envBuilder.stop(STOP_A_ID);
+    var stopB = envBuilder.stop(STOP_B_ID);
+    var env = envBuilder
+      .addTrip(TripInput.of(TRIP_1_ID).addStop(stopA, "10:00").addStop(stopB, "10:10"))
+      .build();
+    var rt = GtfsRtTestHelper.of(env);
+
+    var tripUpdate = rt
+      .tripUpdate(ADDED_TRIP_ID, ADDED)
+      .addStopTime(STOP_A_ID, "12:01")
+      .addStopTime(STOP_B_ID, "12:11")
+      .build();
+
+    assertSuccess(rt.applyTripUpdate(tripUpdate));
+
+    var tripTimes = env.tripData(ADDED_TRIP_ID).tripTimes();
+    assertEquals(TimeUtils.time("12:01"), tripTimes.getDepartureTime(0));
+    assertEquals(TimeUtils.time("12:11"), tripTimes.getArrivalTime(1));
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DstServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/delay/DstServiceDateTest.java
@@ -13,9 +13,9 @@ import org.opentripplanner.updater.trip.gtfs.GtfsRtTestHelper;
 import org.opentripplanner.utils.time.TimeUtils;
 
 /**
- * A GTFS-RT {@code StopTimeEvent.time} is an absolute POSIX timestamp, so applying it means
- * subtracting the start of the service day - both on a trip that is already in the timetable and on
- * one the message creates. See {@link OnEachDstTransitionAndAControlDate}.
+ * A real-time update should give the same result whether or not it is applied on a service date
+ * with a daylight-saving transition - both on a trip that is already in the timetable and on one
+ * the message creates. See {@link OnEachDstTransitionAndAControlDate}.
  */
 class DstServiceDateTest implements RealtimeTestConstants {
 

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/DstServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/DstServiceDateTest.java
@@ -1,0 +1,59 @@
+package org.opentripplanner.updater.trip.siri.moduletests.extracall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import java.time.LocalDate;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TripInput;
+import org.opentripplanner.updater.trip.OnEachDstTransitionAndAControlDate;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.siri.SiriTestHelper;
+
+class DstServiceDateTest implements RealtimeTestConstants {
+
+  private static final String ROUTE_ID = "route-id";
+
+  /** An extra call keeps the times the message reports on a daylight-saving transition date. */
+  @OnEachDstTransitionAndAControlDate
+  void extraCallOnDstServiceDate(String name, LocalDate serviceDate) {
+    var envBuilder = TransitTestEnvironment.of(serviceDate);
+    var stopA = envBuilder.stopAtStation(STOP_A_ID, "A");
+    var stopB = envBuilder.stopAtStation(STOP_B_ID, "B");
+    var stopC = envBuilder.stopAtStation(STOP_C_ID, "C");
+    var route = envBuilder.route(ROUTE_ID);
+    var env = envBuilder
+      .addTrip(
+        TripInput.of(TRIP_1_ID)
+          .withWithTripOnServiceDate(TRIP_1_ID)
+          .withRoute(route)
+          .addStop(stopA, "10:00", "10:01")
+          .addStop(stopB, "10:20", "10:21")
+      )
+      .build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withLineRef(ROUTE_ID)
+      .withRecordedCalls(builder -> builder.call(stopA).departAimedActual("10:01", "10:05"))
+      .withEstimatedCalls(builder ->
+        builder
+          .call(stopC)
+          .withIsExtraCall(true)
+          .arriveAimedExpected("10:08", "10:10")
+          .departAimedExpected("10:09", "10:15")
+          .call(stopB)
+          .arriveAimedExpected("10:20", "10:33")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    assertSuccess(siri.applyEstimatedTimetable(updates));
+
+    assertEquals(
+      "P U | A [R] 10:05 10:05 | C [EC] 10:10 10:15 | B 10:33 10:33",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/DstServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extrajourney/DstServiceDateTest.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.updater.trip.siri.moduletests.extrajourney;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import java.time.LocalDate;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TripInput;
+import org.opentripplanner.updater.trip.OnEachDstTransitionAndAControlDate;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.siri.SiriTestHelper;
+
+class DstServiceDateTest implements RealtimeTestConstants {
+
+  private static final String ADDED_TRIP_ID = "newJourney";
+  private static final String OPERATOR_ID = "operatorId";
+  private static final String ROUTE_ID = "routeId";
+
+  /** An extra journey keeps the times the message reports on a daylight-saving transition date. */
+  @OnEachDstTransitionAndAControlDate
+  void extraJourneyOnDstServiceDate(String name, LocalDate serviceDate) {
+    var envBuilder = TransitTestEnvironment.of(serviceDate);
+    var stopA = envBuilder.stop(STOP_A_ID);
+    var stopB = envBuilder.stop(STOP_B_ID);
+    var operator = envBuilder.operator(OPERATOR_ID);
+    var route = envBuilder.route(ROUTE_ID, operator);
+    // a scheduled trip is what puts the service date in the calendar
+    var env = envBuilder
+      .addTrip(
+        TripInput.of(TRIP_1_ID).withRoute(route).addStop(stopA, "12:00").addStop(stopB, "12:10")
+      )
+      .build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withEstimatedVehicleJourneyCode(ADDED_TRIP_ID)
+      .withIsExtraJourney(true)
+      .withOperatorRef(OPERATOR_ID)
+      .withLineRef(ROUTE_ID)
+      .withRecordedCalls(builder -> builder.call(stopA).departAimedActual("10:01", "10:02"))
+      .withEstimatedCalls(builder -> builder.call(stopB).arriveAimedExpected("10:03", "10:04"))
+      .buildEstimatedTimetableDeliveries();
+
+    assertSuccess(siri.applyEstimatedTimetable(updates));
+
+    assertEquals(
+      "A U | A [R] 10:02 10:02 | B 10:04 10:04",
+      env.tripData(ADDED_TRIP_ID).showTimetable()
+    );
+    assertEquals(
+      "S | A 10:01 10:01 | B 10:03 10:03",
+      env.tripData(ADDED_TRIP_ID).showScheduledTimetable()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/DstServiceDateTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/update/DstServiceDateTest.java
@@ -1,0 +1,42 @@
+package org.opentripplanner.updater.trip.siri.moduletests.update;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+
+import java.time.LocalDate;
+import org.opentripplanner.transit.model.TransitTestEnvironment;
+import org.opentripplanner.transit.model.TripInput;
+import org.opentripplanner.updater.trip.OnEachDstTransitionAndAControlDate;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+import org.opentripplanner.updater.trip.siri.SiriTestHelper;
+
+class DstServiceDateTest implements RealtimeTestConstants {
+
+  /** An updated trip keeps the times the message reports on a daylight-saving transition date. */
+  @OnEachDstTransitionAndAControlDate
+  void updatedTimesOnDstServiceDate(String name, LocalDate serviceDate) {
+    var envBuilder = TransitTestEnvironment.of(serviceDate);
+    var stopA = envBuilder.stop(STOP_A_ID);
+    var stopB = envBuilder.stop(STOP_B_ID);
+    var env = envBuilder
+      .addTrip(
+        TripInput.of(TRIP_1_ID)
+          .withWithTripOnServiceDate(TRIP_1_ID)
+          .addStop(stopA, "10:00", "10:01")
+          .addStop(stopB, "10:20", "10:21")
+      )
+      .build();
+    var siri = SiriTestHelper.of(env);
+
+    var updates = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withRecordedCalls(builder -> builder.call(stopA).departAimedActual("10:01", "10:05"))
+      .withEstimatedCalls(builder -> builder.call(stopB).arriveAimedExpected("10:20", "10:33"))
+      .buildEstimatedTimetableDeliveries();
+
+    assertSuccess(siri.applyEstimatedTimetable(updates));
+
+    assertEquals("U | A [R] 10:05 10:05 | B 10:33 10:33", env.tripData(TRIP_1_ID).showTimetable());
+  }
+}


### PR DESCRIPTION
## Summary

A SIRI journey that is **added** (`ExtraJourney`) or that **gains an extra call** (`ExtraCall`) is
rebuilt from the calls in the message. Both builders resolved the trip's *aimed* times against the
start of the service day — noon minus twelve hours — but its *real-time* times against **calendar
midnight**, because they handed `TimetableHelper.applyUpdates` a `ZonedDateTime` built with
`LocalDate.atStartOfDay`.

The two origins differ by exactly the offset shift on a service date that contains a daylight-saving
transition, so twice a year every call of such a trip moved by an hour — one hour early in spring,
one hour late in autumn:

| | spring forward (2024-03-31) | fall back (2024-10-27) |
|---|---|---|
| extra journey, expected | `A U \| A [R] 10:02 \| B 10:04` | `A U \| A [R] 10:02 \| B 10:04` |
| extra journey, before this PR | `A U \| A [R] 9:02 \| B 9:04` | `A U \| A [R] 11:02 \| B 11:04` |
| extra call, expected | `P U \| A [R] 10:05 \| C [EC] 10:10 10:15 \| B 10:33` | same |
| extra call, before this PR | `P U \| A [R] 9:05 \| C [EC] 9:10 9:15 \| B 9:33` | `... 11:05 / 11:10 11:15 / 11:33` |

For an added journey the real-time times are the ones routing uses, so such a trip was **published
an hour off**. For an extra call the shift hits an ordinary scheduled trip's whole real-time
timetable. `ModifiedTripBuilder` already used the correct origin, so only these two paths were
affected — and the stop pattern / scheduled times were never affected, because `StopTimesMapper`
reached the three-argument `secondsSinceStartOfService` overload, which discards the
`ZonedDateTime` it is passed and recomputes `asStartOfService` from its `LocalDate`.


