### PR TITLE
Add `runningTimeRanges` filter to canceled trips/calls queries in the GTFS API

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/PatternImpl.java
@@ -19,6 +19,7 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLPatternTripsOnServiceDateArgs;
 import org.opentripplanner.apis.gtfs.service.ApiTransitService;
 import org.opentripplanner.apis.gtfs.support.time.LocalDateRangeUtil;
+import org.opentripplanner.apis.gtfs.support.time.OffsetDateTimeRangeUtil;
 import org.opentripplanner.apis.support.SemanticHash;
 import org.opentripplanner.framework.graphql.GraphQLUtils;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
@@ -260,6 +261,10 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
       var args = new GraphQLTypes.GraphQLPatternCanceledTripsArgs(environment.getArguments());
 
       var serviceDateRanges = LocalDateRangeUtil.mapRanges(args.getGraphQLServiceDateRanges());
+      var runningTimePeriods = OffsetDateTimeRangeUtil.mapRanges(
+        args.getGraphQLRunningTimeRanges(),
+        "runningTimeRanges"
+      );
 
       var requestBuilder = TripOnServiceDateRequest.of().withIncludePatterns(
         FilterValues.ofEmptyIsEverything("patterns", List.of(pattern.getId()))
@@ -267,6 +272,11 @@ public class PatternImpl implements GraphQLDataFetchers.GraphQLPattern {
       if (serviceDateRanges != null) {
         requestBuilder.withIncludeServiceDateRanges(
           FilterValues.ofRequired("serviceDateRanges", serviceDateRanges)
+        );
+      }
+      if (runningTimePeriods != null) {
+        requestBuilder.withIncludeRunningTimePeriods(
+          FilterValues.ofRequired("runningTimeRanges", runningTimePeriods)
         );
       }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -150,32 +150,22 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
         ? List.of(LocalDateRange.ofUnbounded())
         : LocalDateRangeUtil.mapRanges(rawRanges);
       var arrivalDeparture = ArrivalDepartureMapper.map(args.getGraphQLArrivalDeparture());
-      var runningTimePeriods = OffsetDateTimeRangeUtil.mapRanges(
-        args.getGraphQLRunningTimeRanges(),
-        "runningTimeRanges"
+      var callTimePeriods = OffsetDateTimeRangeUtil.mapRanges(
+        args.getGraphQLTimeRanges(),
+        "timeRanges"
       );
       var service = new ApiTransitService(getTransitService(environment));
       return getValue(
         environment,
         stop ->
-          service.findCanceledStopCalls(
-            stop,
-            serviceDateRanges,
-            runningTimePeriods,
-            arrivalDeparture
-          ),
+          service.findCanceledStopCalls(stop, serviceDateRanges, callTimePeriods, arrivalDeparture),
         station ->
           station
             .getChildStops()
             .stream()
             .flatMap(stop ->
               service
-                .findCanceledStopCalls(
-                  stop,
-                  serviceDateRanges,
-                  runningTimePeriods,
-                  arrivalDeparture
-                )
+                .findCanceledStopCalls(stop, serviceDateRanges, callTimePeriods, arrivalDeparture)
                 .stream()
             )
             .collect(Collectors.toList())

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/StopImpl.java
@@ -23,6 +23,7 @@ import org.opentripplanner.apis.gtfs.model.StopCallOnTripOnServiceDate;
 import org.opentripplanner.apis.gtfs.service.ApiTransitService;
 import org.opentripplanner.apis.gtfs.support.filter.PatternByDateFilterUtil;
 import org.opentripplanner.apis.gtfs.support.time.LocalDateRangeUtil;
+import org.opentripplanner.apis.gtfs.support.time.OffsetDateTimeRangeUtil;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
 import org.opentripplanner.model.StopTimesInPattern;
@@ -149,16 +150,33 @@ public class StopImpl implements GraphQLDataFetchers.GraphQLStop {
         ? List.of(LocalDateRange.ofUnbounded())
         : LocalDateRangeUtil.mapRanges(rawRanges);
       var arrivalDeparture = ArrivalDepartureMapper.map(args.getGraphQLArrivalDeparture());
+      var runningTimePeriods = OffsetDateTimeRangeUtil.mapRanges(
+        args.getGraphQLRunningTimeRanges(),
+        "runningTimeRanges"
+      );
       var service = new ApiTransitService(getTransitService(environment));
       return getValue(
         environment,
-        stop -> service.findCanceledStopCalls(stop, serviceDateRanges, arrivalDeparture),
+        stop ->
+          service.findCanceledStopCalls(
+            stop,
+            serviceDateRanges,
+            runningTimePeriods,
+            arrivalDeparture
+          ),
         station ->
           station
             .getChildStops()
             .stream()
             .flatMap(stop ->
-              service.findCanceledStopCalls(stop, serviceDateRanges, arrivalDeparture).stream()
+              service
+                .findCanceledStopCalls(
+                  stop,
+                  serviceDateRanges,
+                  runningTimePeriods,
+                  arrivalDeparture
+                )
+                .stream()
             )
             .collect(Collectors.toList())
       );

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -5206,8 +5206,8 @@ public class GraphQLTypes {
   public static class GraphQLStopCanceledCallsArgs {
 
     private GraphQLArrivalDeparture arrivalDeparture;
-    private List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges;
     private List<GraphQLLocalDateRangeInput> serviceDateRanges;
+    private List<GraphQLOffsetDateTimeRangeInput> timeRanges;
 
     public GraphQLStopCanceledCallsArgs(Map<String, Object> args) {
       if (args != null) {
@@ -5218,18 +5218,16 @@ public class GraphQLTypes {
             (String) args.get("arrivalDeparture")
           );
         }
-        if (args.get("runningTimeRanges") != null) {
-          this.runningTimeRanges = ((List<Map<String, Object>>) args.get(
-              "runningTimeRanges"
-            )).stream()
-            .map(o -> o == null ? null : new GraphQLOffsetDateTimeRangeInput(o))
-            .collect(Collectors.toList());
-        }
         if (args.get("serviceDateRanges") != null) {
           this.serviceDateRanges = ((List<Map<String, Object>>) args.get(
               "serviceDateRanges"
             )).stream()
             .map(o -> o == null ? null : new GraphQLLocalDateRangeInput(o))
+            .collect(Collectors.toList());
+        }
+        if (args.get("timeRanges") != null) {
+          this.timeRanges = ((List<Map<String, Object>>) args.get("timeRanges")).stream()
+            .map(o -> o == null ? null : new GraphQLOffsetDateTimeRangeInput(o))
             .collect(Collectors.toList());
         }
       }
@@ -5239,26 +5237,24 @@ public class GraphQLTypes {
       return this.arrivalDeparture;
     }
 
-    public List<GraphQLOffsetDateTimeRangeInput> getGraphQLRunningTimeRanges() {
-      return this.runningTimeRanges;
-    }
-
     public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
       return this.serviceDateRanges;
+    }
+
+    public List<GraphQLOffsetDateTimeRangeInput> getGraphQLTimeRanges() {
+      return this.timeRanges;
     }
 
     public void setGraphQLArrivalDeparture(GraphQLArrivalDeparture arrivalDeparture) {
       this.arrivalDeparture = arrivalDeparture;
     }
 
-    public void setGraphQLRunningTimeRanges(
-      List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges
-    ) {
-      this.runningTimeRanges = runningTimeRanges;
-    }
-
     public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {
       this.serviceDateRanges = serviceDateRanges;
+    }
+
+    public void setGraphQLTimeRanges(List<GraphQLOffsetDateTimeRangeInput> timeRanges) {
+      this.timeRanges = timeRanges;
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -547,6 +547,7 @@ public class GraphQLTypes {
   public static class GraphQLCanceledTripsFilterSelectInput {
 
     private List<GraphQLTransitMode> modes;
+    private List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges;
     private List<GraphQLLocalDateRangeInput> serviceDateRanges;
 
     public GraphQLCanceledTripsFilterSelectInput(Map<String, Object> args) {
@@ -557,6 +558,13 @@ public class GraphQLTypes {
               item instanceof GraphQLTransitMode ? item : GraphQLTransitMode.valueOf((String) item)
             )
             .map(GraphQLTransitMode.class::cast)
+            .collect(Collectors.toList());
+        }
+        if (args.get("runningTimeRanges") != null) {
+          this.runningTimeRanges = ((List<Map<String, Object>>) args.get(
+              "runningTimeRanges"
+            )).stream()
+            .map(o -> o == null ? null : new GraphQLOffsetDateTimeRangeInput(o))
             .collect(Collectors.toList());
         }
         if (args.get("serviceDateRanges") != null) {
@@ -573,12 +581,22 @@ public class GraphQLTypes {
       return this.modes;
     }
 
+    public List<GraphQLOffsetDateTimeRangeInput> getGraphQLRunningTimeRanges() {
+      return this.runningTimeRanges;
+    }
+
     public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
       return this.serviceDateRanges;
     }
 
     public void setGraphQLModes(List<GraphQLTransitMode> modes) {
       this.modes = modes;
+    }
+
+    public void setGraphQLRunningTimeRanges(
+      List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges
+    ) {
+      this.runningTimeRanges = runningTimeRanges;
     }
 
     public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {
@@ -626,6 +644,7 @@ public class GraphQLTypes {
   public static class GraphQLCanceledTripsSummaryFilterSelectInput {
 
     private List<GraphQLTransitMode> modes;
+    private List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges;
     private List<GraphQLLocalDateRangeInput> serviceDateRanges;
 
     public GraphQLCanceledTripsSummaryFilterSelectInput(Map<String, Object> args) {
@@ -636,6 +655,13 @@ public class GraphQLTypes {
               item instanceof GraphQLTransitMode ? item : GraphQLTransitMode.valueOf((String) item)
             )
             .map(GraphQLTransitMode.class::cast)
+            .collect(Collectors.toList());
+        }
+        if (args.get("runningTimeRanges") != null) {
+          this.runningTimeRanges = ((List<Map<String, Object>>) args.get(
+              "runningTimeRanges"
+            )).stream()
+            .map(o -> o == null ? null : new GraphQLOffsetDateTimeRangeInput(o))
             .collect(Collectors.toList());
         }
         if (args.get("serviceDateRanges") != null) {
@@ -652,12 +678,22 @@ public class GraphQLTypes {
       return this.modes;
     }
 
+    public List<GraphQLOffsetDateTimeRangeInput> getGraphQLRunningTimeRanges() {
+      return this.runningTimeRanges;
+    }
+
     public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
       return this.serviceDateRanges;
     }
 
     public void setGraphQLModes(List<GraphQLTransitMode> modes) {
       this.modes = modes;
+    }
+
+    public void setGraphQLRunningTimeRanges(
+      List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges
+    ) {
+      this.runningTimeRanges = runningTimeRanges;
     }
 
     public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {
@@ -1830,6 +1866,35 @@ public class GraphQLTypes {
     STANDING_ROOM_ONLY,
   }
 
+  public static class GraphQLOffsetDateTimeRangeInput {
+
+    private java.time.OffsetDateTime end;
+    private java.time.OffsetDateTime start;
+
+    public GraphQLOffsetDateTimeRangeInput(Map<String, Object> args) {
+      if (args != null) {
+        this.end = (java.time.OffsetDateTime) args.get("end");
+        this.start = (java.time.OffsetDateTime) args.get("start");
+      }
+    }
+
+    public java.time.OffsetDateTime getGraphQLEnd() {
+      return this.end;
+    }
+
+    public java.time.OffsetDateTime getGraphQLStart() {
+      return this.start;
+    }
+
+    public void setGraphQLEnd(java.time.OffsetDateTime end) {
+      this.end = end;
+    }
+
+    public void setGraphQLStart(java.time.OffsetDateTime start) {
+      this.start = start;
+    }
+  }
+
   public static class GraphQLOpeningHoursDatesArgs {
 
     private List<String> dates;
@@ -1944,10 +2009,18 @@ public class GraphQLTypes {
 
   public static class GraphQLPatternCanceledTripsArgs {
 
+    private List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges;
     private List<GraphQLLocalDateRangeInput> serviceDateRanges;
 
     public GraphQLPatternCanceledTripsArgs(Map<String, Object> args) {
       if (args != null) {
+        if (args.get("runningTimeRanges") != null) {
+          this.runningTimeRanges = ((List<Map<String, Object>>) args.get(
+              "runningTimeRanges"
+            )).stream()
+            .map(o -> o == null ? null : new GraphQLOffsetDateTimeRangeInput(o))
+            .collect(Collectors.toList());
+        }
         if (args.get("serviceDateRanges") != null) {
           this.serviceDateRanges = ((List<Map<String, Object>>) args.get(
               "serviceDateRanges"
@@ -1958,8 +2031,18 @@ public class GraphQLTypes {
       }
     }
 
+    public List<GraphQLOffsetDateTimeRangeInput> getGraphQLRunningTimeRanges() {
+      return this.runningTimeRanges;
+    }
+
     public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
       return this.serviceDateRanges;
+    }
+
+    public void setGraphQLRunningTimeRanges(
+      List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges
+    ) {
+      this.runningTimeRanges = runningTimeRanges;
     }
 
     public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLTypes.java
@@ -5206,6 +5206,7 @@ public class GraphQLTypes {
   public static class GraphQLStopCanceledCallsArgs {
 
     private GraphQLArrivalDeparture arrivalDeparture;
+    private List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges;
     private List<GraphQLLocalDateRangeInput> serviceDateRanges;
 
     public GraphQLStopCanceledCallsArgs(Map<String, Object> args) {
@@ -5216,6 +5217,13 @@ public class GraphQLTypes {
           this.arrivalDeparture = GraphQLArrivalDeparture.valueOf(
             (String) args.get("arrivalDeparture")
           );
+        }
+        if (args.get("runningTimeRanges") != null) {
+          this.runningTimeRanges = ((List<Map<String, Object>>) args.get(
+              "runningTimeRanges"
+            )).stream()
+            .map(o -> o == null ? null : new GraphQLOffsetDateTimeRangeInput(o))
+            .collect(Collectors.toList());
         }
         if (args.get("serviceDateRanges") != null) {
           this.serviceDateRanges = ((List<Map<String, Object>>) args.get(
@@ -5231,12 +5239,22 @@ public class GraphQLTypes {
       return this.arrivalDeparture;
     }
 
+    public List<GraphQLOffsetDateTimeRangeInput> getGraphQLRunningTimeRanges() {
+      return this.runningTimeRanges;
+    }
+
     public List<GraphQLLocalDateRangeInput> getGraphQLServiceDateRanges() {
       return this.serviceDateRanges;
     }
 
     public void setGraphQLArrivalDeparture(GraphQLArrivalDeparture arrivalDeparture) {
       this.arrivalDeparture = arrivalDeparture;
+    }
+
+    public void setGraphQLRunningTimeRanges(
+      List<GraphQLOffsetDateTimeRangeInput> runningTimeRanges
+    ) {
+      this.runningTimeRanges = runningTimeRanges;
     }
 
     public void setGraphQLServiceDateRanges(List<GraphQLLocalDateRangeInput> serviceDateRanges) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapper.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.apis.gtfs.mapping;
 
 import graphql.schema.DataFetchingEnvironment;
+import java.text.ParseException;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -10,16 +12,22 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.opentripplanner.apis.gtfs.support.time.OffsetDateTimeRangeUtil;
 import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.filter.selector.FilterRequest;
 import org.opentripplanner.transit.model.filter.transit.TripOnServiceDateSelectRequest;
 import org.opentripplanner.utils.collection.CollectionUtils;
+import org.opentripplanner.utils.time.OffsetDateTimeParser;
 
 public class CanceledTripsFilterMapper {
+
+  private static final String RUNNING_TIME_RANGES = "runningTimeRanges";
+  private static final String RUNNING_TIME_RANGES_PATH = "filters.*.runningTimeRanges";
 
   public static TripOnServiceDateRequest mapToTripOnServiceDateRequest(
     DataFetchingEnvironment env
@@ -57,7 +65,8 @@ public class CanceledTripsFilterMapper {
   private static TripOnServiceDateSelectRequest toSelectRequest(List<Map<String, Object>> inputs) {
     var modes = toTransitModes(inputs);
     var serviceDateRanges = toServiceDateRanges(inputs);
-    if (modes == null && serviceDateRanges == null) {
+    var runningTimePeriods = toRunningTimePeriods(inputs);
+    if (modes == null && serviceDateRanges == null && runningTimePeriods == null) {
       return null;
     }
 
@@ -67,6 +76,9 @@ public class CanceledTripsFilterMapper {
     }
     if (serviceDateRanges != null) {
       builder.withServiceDateRanges(serviceDateRanges);
+    }
+    if (runningTimePeriods != null) {
+      builder.withRunningTimePeriods(runningTimePeriods);
     }
     return builder.build();
   }
@@ -141,6 +153,54 @@ public class CanceledTripsFilterMapper {
       localDate(rangeInput.get("start"), "filters.*.serviceDateRanges.start"),
       localDate(rangeInput.get("end"), "filters.*.serviceDateRanges.end")
     );
+  }
+
+  @Nullable
+  private static List<TimePeriod> toRunningTimePeriods(List<Map<String, Object>> inputs) {
+    if (inputs == null) {
+      return null;
+    }
+    var periods = inputs
+      .stream()
+      .flatMap(input -> {
+        var rangeInputs = mapList(input.get(RUNNING_TIME_RANGES), RUNNING_TIME_RANGES_PATH);
+        if (rangeInputs == null) {
+          return Stream.<TimePeriod>of();
+        }
+        OffsetDateTimeRangeUtil.requireNonEmpty(rangeInputs, RUNNING_TIME_RANGES_PATH);
+        return rangeInputs.stream().map(CanceledTripsFilterMapper::mapTimePeriod);
+      })
+      .toList();
+
+    return periods.isEmpty() ? null : periods;
+  }
+
+  private static TimePeriod mapTimePeriod(Map<String, Object> rangeInput) {
+    return OffsetDateTimeRangeUtil.mapRange(
+      offsetDateTime(rangeInput.get("start"), RUNNING_TIME_RANGES_PATH + ".start"),
+      offsetDateTime(rangeInput.get("end"), RUNNING_TIME_RANGES_PATH + ".end"),
+      RUNNING_TIME_RANGES_PATH
+    );
+  }
+
+  @Nullable
+  private static OffsetDateTime offsetDateTime(@Nullable Object value, String path) {
+    if (value == null) {
+      return null;
+    }
+    return switch (value) {
+      case OffsetDateTime offsetDateTime -> offsetDateTime;
+      case String stringValue -> parseOffsetDateTime(stringValue, path);
+      default -> throw new InvalidInputException("Expected OffsetDateTime at '" + path + "'.");
+    };
+  }
+
+  private static OffsetDateTime parseOffsetDateTime(String value, String path) {
+    try {
+      return OffsetDateTimeParser.parseLeniently(value);
+    } catch (ParseException e) {
+      throw new InvalidInputException("Expected OffsetDateTime at '" + path + "'.");
+    }
   }
 
   private static TransitMode mapTransitMode(Object value) {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
@@ -98,20 +98,20 @@ public class ApiTransitService {
    * Find the canceled stop calls at the given stop. A call is included if either the trip it
    * belongs to has been canceled, or the visit at this stop has been canceled (skipped). Only calls
    * whose trip's service date is within any of the given service date ranges are returned. If
-   * {@code runningTimePeriods} is non-null, only calls of trips which are scheduled to be running
-   * during one of the periods are returned. The {@code arrivalDeparture} parameter controls whether
-   * drop-off-only calls are included. Each call is paired with the {@link TripOnServiceDate} it
-   * belongs to, which is synthesized when no real one exists.
+   * {@code callTimePeriods} is non-null, only calls where the vehicle is scheduled to visit the
+   * stop during one of the periods are returned. The {@code arrivalDeparture} parameter controls
+   * whether drop-off-only calls are included. Each call is paired with the {@link TripOnServiceDate}
+   * it belongs to, which is synthesized when no real one exists.
    */
   public List<StopCallOnTripOnServiceDate> findCanceledStopCalls(
     StopLocation stop,
     List<LocalDateRange> serviceDateRanges,
-    @Nullable List<TimePeriod> runningTimePeriods,
+    @Nullable List<TimePeriod> callTimePeriods,
     ArrivalDeparture arrivalDeparture
   ) {
     var request = TripTimeOnDateRequest.of(List.of(stop))
       .withServiceDateRanges(serviceDateRanges)
-      .withIncludeRunningTimePeriods(runningTimePeriods)
+      .withIncludeCallTimePeriods(callTimePeriods)
       .withArrivalDeparture(arrivalDeparture)
       .withNumberOfDepartures(Integer.MAX_VALUE)
       .withCancellationPolicy(CancellationPolicy.ONLY_CANCELLATIONS)

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/service/ApiTransitService.java
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.opentripplanner.apis.gtfs.model.StopCallOnTripOnServiceDate;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.transit.api.request.CancellationPolicy;
@@ -95,18 +97,21 @@ public class ApiTransitService {
   /**
    * Find the canceled stop calls at the given stop. A call is included if either the trip it
    * belongs to has been canceled, or the visit at this stop has been canceled (skipped). Only calls
-   * whose trip's service date is within any of the given service date ranges are returned. The
-   * {@code arrivalDeparture} parameter controls whether drop-off-only calls are included. Each
-   * call is paired with the {@link TripOnServiceDate} it belongs to, which is synthesized when no
-   * real one exists.
+   * whose trip's service date is within any of the given service date ranges are returned. If
+   * {@code runningTimePeriods} is non-null, only calls of trips which are scheduled to be running
+   * during one of the periods are returned. The {@code arrivalDeparture} parameter controls whether
+   * drop-off-only calls are included. Each call is paired with the {@link TripOnServiceDate} it
+   * belongs to, which is synthesized when no real one exists.
    */
   public List<StopCallOnTripOnServiceDate> findCanceledStopCalls(
     StopLocation stop,
     List<LocalDateRange> serviceDateRanges,
+    @Nullable List<TimePeriod> runningTimePeriods,
     ArrivalDeparture arrivalDeparture
   ) {
     var request = TripTimeOnDateRequest.of(List.of(stop))
       .withServiceDateRanges(serviceDateRanges)
+      .withIncludeRunningTimePeriods(runningTimePeriods)
       .withArrivalDeparture(arrivalDeparture)
       .withNumberOfDepartures(Integer.MAX_VALUE)
       .withCancellationPolicy(CancellationPolicy.ONLY_CANCELLATIONS)

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/support/time/OffsetDateTimeRangeUtil.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/support/time/OffsetDateTimeRangeUtil.java
@@ -1,0 +1,68 @@
+package org.opentripplanner.apis.gtfs.support.time;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.support.InvalidInputException;
+import org.opentripplanner.core.model.time.TimePeriod;
+
+/**
+ * Utilities for mapping the GraphQL {@code OffsetDateTimeRangeInput} to the domain type
+ * {@link TimePeriod}.
+ */
+public class OffsetDateTimeRangeUtil {
+
+  /**
+   * Maps a list of GraphQL time range inputs to {@link TimePeriod}s. Returns {@code null} when the
+   * input is {@code null}. An empty list throws an exception.
+   */
+  @Nullable
+  public static List<TimePeriod> mapRanges(
+    @Nullable List<GraphQLTypes.GraphQLOffsetDateTimeRangeInput> ranges,
+    String fieldName
+  ) {
+    if (ranges == null) {
+      return null;
+    }
+    requireNonEmpty(ranges, fieldName);
+    return ranges
+      .stream()
+      .map(range -> mapRange(range.getGraphQLStart(), range.getGraphQLEnd(), fieldName))
+      .toList();
+  }
+
+  /**
+   * Maps a single GraphQL time range to a {@link TimePeriod}. The start is inclusive and the end
+   * exclusive and both of them are optional.
+   */
+  public static TimePeriod mapRange(
+    @Nullable OffsetDateTime start,
+    @Nullable OffsetDateTime end,
+    String fieldName
+  ) {
+    try {
+      return TimePeriod.of(
+        start == null ? null : start.toInstant(),
+        end == null ? null : end.toInstant()
+      );
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(
+        "The start of the time range '%s' must not be after its end.".formatted(fieldName)
+      );
+    }
+  }
+
+  /**
+   * Throws an exception if the given list of ranges is empty as an empty filter is ambiguous.
+   */
+  public static void requireNonEmpty(List<?> ranges, String fieldName) {
+    if (ranges.isEmpty()) {
+      throw new InvalidInputException(
+        "Time range filter '%s' must be either null or have at least one entry.".formatted(
+          fieldName
+        )
+      );
+    }
+  }
+}

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -22,6 +23,7 @@ public class TripOnServiceDateRequest {
 
   private final FilterValues<LocalDate> includeServiceDates;
   private final FilterValues<LocalDateRange> includeServiceDateRanges;
+  private final FilterValues<TimePeriod> includeRunningTimePeriods;
   private final FilterValues<FeedScopedId> includeAgencies;
   private final FilterValues<FeedScopedId> includeRoutes;
   private final FilterValues<FeedScopedId> includePatterns;
@@ -34,6 +36,7 @@ public class TripOnServiceDateRequest {
   TripOnServiceDateRequest(
     FilterValues<LocalDate> includeServiceDates,
     FilterValues<LocalDateRange> includeServiceDateRanges,
+    FilterValues<TimePeriod> includeRunningTimePeriods,
     FilterValues<FeedScopedId> includeAgencies,
     FilterValues<FeedScopedId> includeRoutes,
     FilterValues<FeedScopedId> includePatterns,
@@ -45,6 +48,7 @@ public class TripOnServiceDateRequest {
   ) {
     this.includeServiceDates = includeServiceDates;
     this.includeServiceDateRanges = includeServiceDateRanges;
+    this.includeRunningTimePeriods = includeRunningTimePeriods;
     this.includeAgencies = includeAgencies;
     this.includeRoutes = includeRoutes;
     this.includePatterns = includePatterns;
@@ -93,6 +97,13 @@ public class TripOnServiceDateRequest {
 
   public FilterValues<LocalDateRange> includeServiceDateRanges() {
     return includeServiceDateRanges;
+  }
+
+  /**
+   * Periods of time in which the trip must be running, according to its schedule.
+   */
+  public FilterValues<TimePeriod> includeRunningTimePeriods() {
+    return includeRunningTimePeriods;
   }
 
   public FilterValues<TransitMode> includeModes() {

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripOnServiceDateRequestBuilder.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.filter.selector.FilterRequest;
 import org.opentripplanner.transit.model.filter.transit.TripOnServiceDateSelectRequest;
@@ -45,6 +46,10 @@ public class TripOnServiceDateRequestBuilder {
   );
   private FilterValues<LocalDateRange> includeServiceDateRanges = FilterValues.ofEmptyIsEverything(
     "includeServiceDateRanges",
+    List.of()
+  );
+  private FilterValues<TimePeriod> includeRunningTimePeriods = FilterValues.ofEmptyIsEverything(
+    "includeRunningTimePeriods",
     List.of()
   );
   private List<FilterRequest<TripOnServiceDateSelectRequest>> filters = List.of();
@@ -106,6 +111,13 @@ public class TripOnServiceDateRequestBuilder {
     return this;
   }
 
+  public TripOnServiceDateRequestBuilder withIncludeRunningTimePeriods(
+    FilterValues<TimePeriod> runningTimePeriods
+  ) {
+    this.includeRunningTimePeriods = runningTimePeriods;
+    return this;
+  }
+
   public TripOnServiceDateRequestBuilder withFilters(
     List<FilterRequest<TripOnServiceDateSelectRequest>> filters
   ) {
@@ -117,6 +129,7 @@ public class TripOnServiceDateRequestBuilder {
     return new TripOnServiceDateRequest(
       includeServiceDates,
       includeServiceDateRanges,
+      includeRunningTimePeriods,
       includeAgencies,
       includeRoutes,
       includePatterns,

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequest.java
@@ -28,7 +28,7 @@ public class TripTimeOnDateRequest {
 
   private final List<LocalDateRange> serviceDateRanges;
   private final CancellationPolicy cancellationPolicy;
-  private final FilterValues<TimePeriod> includeRunningTimePeriods;
+  private final FilterValues<TimePeriod> includeCallTimePeriods;
   private final FilterValues<FeedScopedId> includeAgencies;
   private final FilterValues<FeedScopedId> includeRoutes;
   private final FilterValues<FeedScopedId> excludeAgencies;
@@ -50,7 +50,7 @@ public class TripTimeOnDateRequest {
     int numberOfDepartures,
     Comparator<TripTimeOnDate> sortOrder,
     CancellationPolicy cancellationPolicy,
-    FilterValues<TimePeriod> includeRunningTimePeriods,
+    FilterValues<TimePeriod> includeCallTimePeriods,
     FilterValues<FeedScopedId> includeAgencies,
     FilterValues<FeedScopedId> includeRoutes,
     FilterValues<FeedScopedId> excludeAgencies,
@@ -67,7 +67,7 @@ public class TripTimeOnDateRequest {
     this.numberOfDepartures = numberOfDepartures;
     this.sortOrder = Objects.requireNonNull(sortOrder);
     this.cancellationPolicy = Objects.requireNonNull(cancellationPolicy);
-    this.includeRunningTimePeriods = includeRunningTimePeriods;
+    this.includeCallTimePeriods = includeCallTimePeriods;
     this.includeAgencies = includeAgencies;
     this.includeRoutes = includeRoutes;
     this.excludeAgencies = excludeAgencies;
@@ -115,12 +115,13 @@ public class TripTimeOnDateRequest {
   }
 
   /**
-   * The periods of time during which a trip has to be running, according to its schedule, for its
-   * calls to be included. A trip is running from the scheduled departure from its first stop until
-   * the scheduled arrival at its last stop.
+   * Limit the returned output to the defined periods of time based on when the vehicle is
+   * scheduled to visit the stop. At least one of the periods has to overlap with the visit at the
+   * stop, which lasts from the scheduled arrival at the stop until the scheduled departure from
+   * it.
    */
-  public FilterValues<TimePeriod> includeRunningTimePeriods() {
-    return includeRunningTimePeriods;
+  public FilterValues<TimePeriod> includeCallTimePeriods() {
+    return includeCallTimePeriods;
   }
 
   public FilterValues<FeedScopedId> includeAgencies() {

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -27,6 +28,7 @@ public class TripTimeOnDateRequest {
 
   private final List<LocalDateRange> serviceDateRanges;
   private final CancellationPolicy cancellationPolicy;
+  private final FilterValues<TimePeriod> includeRunningTimePeriods;
   private final FilterValues<FeedScopedId> includeAgencies;
   private final FilterValues<FeedScopedId> includeRoutes;
   private final FilterValues<FeedScopedId> excludeAgencies;
@@ -48,6 +50,7 @@ public class TripTimeOnDateRequest {
     int numberOfDepartures,
     Comparator<TripTimeOnDate> sortOrder,
     CancellationPolicy cancellationPolicy,
+    FilterValues<TimePeriod> includeRunningTimePeriods,
     FilterValues<FeedScopedId> includeAgencies,
     FilterValues<FeedScopedId> includeRoutes,
     FilterValues<FeedScopedId> excludeAgencies,
@@ -64,6 +67,7 @@ public class TripTimeOnDateRequest {
     this.numberOfDepartures = numberOfDepartures;
     this.sortOrder = Objects.requireNonNull(sortOrder);
     this.cancellationPolicy = Objects.requireNonNull(cancellationPolicy);
+    this.includeRunningTimePeriods = includeRunningTimePeriods;
     this.includeAgencies = includeAgencies;
     this.includeRoutes = includeRoutes;
     this.excludeAgencies = excludeAgencies;
@@ -108,6 +112,15 @@ public class TripTimeOnDateRequest {
 
   public CancellationPolicy cancellationPolicy() {
     return cancellationPolicy;
+  }
+
+  /**
+   * The periods of time during which a trip has to be running, according to its schedule, for its
+   * calls to be included. A trip is running from the scheduled departure from its first stop until
+   * the scheduled arrival at its last stop.
+   */
+  public FilterValues<TimePeriod> includeRunningTimePeriods() {
+    return includeRunningTimePeriods;
   }
 
   public FilterValues<FeedScopedId> includeAgencies() {

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequestBuilder.java
@@ -21,15 +21,15 @@ public class TripTimeOnDateRequestBuilder {
 
   private static final String INCLUDE_AGENCIES = "includeAgencies";
   private static final String INCLUDE_ROUTES = "includeRoutes";
-  private static final String INCLUDE_RUNNING_TIME_PERIODS = "includeRunningTimePeriods";
+  private static final String INCLUDE_CALL_TIME_PERIODS = "includeCallTimePeriods";
   private static final String EXCLUDE_AGENCIES = "excludeAgencies";
   private static final String INCLUDE_MODES = "includeModes";
   private static final String EXCLUDE_ROUTES = "excludeRoutes";
   private static final String EXCLUDE_MODES = "excludeModes";
   private final Collection<StopLocation> stopLocations;
   private CancellationPolicy cancellationPolicy = CancellationPolicy.NO_CANCELLATIONS;
-  private FilterValues<TimePeriod> includeRunningTimePeriods = FilterValues.ofNullIsEverything(
-    INCLUDE_RUNNING_TIME_PERIODS,
+  private FilterValues<TimePeriod> includeCallTimePeriods = FilterValues.ofNullIsEverything(
+    INCLUDE_CALL_TIME_PERIODS,
     null
   );
   private FilterValues<FeedScopedId> includeAgencies = FilterValues.ofNullIsEverything(
@@ -92,16 +92,16 @@ public class TripTimeOnDateRequestBuilder {
   }
 
   /**
-   * Only include trip times of trips which are running, according to their schedule, during one of
-   * the given periods. A trip is running from the scheduled departure from its first stop until the
-   * scheduled arrival at its last stop.
+   * Only include calls where the vehicle is scheduled to visit the stop during one of the given
+   * periods. The visit at a stop lasts from the scheduled arrival at the stop until the scheduled
+   * departure from it.
    */
-  public TripTimeOnDateRequestBuilder withIncludeRunningTimePeriods(
-    @Nullable Collection<TimePeriod> runningTimePeriods
+  public TripTimeOnDateRequestBuilder withIncludeCallTimePeriods(
+    @Nullable Collection<TimePeriod> callTimePeriods
   ) {
-    this.includeRunningTimePeriods = FilterValues.ofNullIsEverything(
-      INCLUDE_RUNNING_TIME_PERIODS,
-      runningTimePeriods
+    this.includeCallTimePeriods = FilterValues.ofNullIsEverything(
+      INCLUDE_CALL_TIME_PERIODS,
+      callTimePeriods
     );
     return this;
   }
@@ -175,7 +175,7 @@ public class TripTimeOnDateRequestBuilder {
       numberOfDepartures,
       sortOrder,
       cancellationPolicy,
-      includeRunningTimePeriods,
+      includeCallTimePeriods,
       includeAgencies,
       includeRoutes,
       excludeAgencies,

--- a/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequestBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/api/request/TripTimeOnDateRequestBuilder.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.basic.TransitMode;
@@ -20,12 +21,17 @@ public class TripTimeOnDateRequestBuilder {
 
   private static final String INCLUDE_AGENCIES = "includeAgencies";
   private static final String INCLUDE_ROUTES = "includeRoutes";
+  private static final String INCLUDE_RUNNING_TIME_PERIODS = "includeRunningTimePeriods";
   private static final String EXCLUDE_AGENCIES = "excludeAgencies";
   private static final String INCLUDE_MODES = "includeModes";
   private static final String EXCLUDE_ROUTES = "excludeRoutes";
   private static final String EXCLUDE_MODES = "excludeModes";
   private final Collection<StopLocation> stopLocations;
   private CancellationPolicy cancellationPolicy = CancellationPolicy.NO_CANCELLATIONS;
+  private FilterValues<TimePeriod> includeRunningTimePeriods = FilterValues.ofNullIsEverything(
+    INCLUDE_RUNNING_TIME_PERIODS,
+    null
+  );
   private FilterValues<FeedScopedId> includeAgencies = FilterValues.ofNullIsEverything(
     INCLUDE_AGENCIES,
     null
@@ -82,6 +88,21 @@ public class TripTimeOnDateRequestBuilder {
     List<LocalDateRange> serviceDateRanges
   ) {
     this.serviceDateRanges = serviceDateRanges;
+    return this;
+  }
+
+  /**
+   * Only include trip times of trips which are running, according to their schedule, during one of
+   * the given periods. A trip is running from the scheduled departure from its first stop until the
+   * scheduled arrival at its last stop.
+   */
+  public TripTimeOnDateRequestBuilder withIncludeRunningTimePeriods(
+    @Nullable Collection<TimePeriod> runningTimePeriods
+  ) {
+    this.includeRunningTimePeriods = FilterValues.ofNullIsEverything(
+      INCLUDE_RUNNING_TIME_PERIODS,
+      runningTimePeriods
+    );
     return this;
   }
 
@@ -154,6 +175,7 @@ public class TripTimeOnDateRequestBuilder {
       numberOfDepartures,
       sortOrder,
       cancellationPolicy,
+      includeRunningTimePeriods,
       includeAgencies,
       includeRoutes,
       excludeAgencies,

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -32,19 +32,6 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 public class TripOnServiceDateMatcherFactory {
 
   /**
-   * Creates a matcher for TripOnServiceDates which never matches filters that require the
-   * scheduled running time of a trip.
-   *
-   * @see #of(TripOnServiceDateRequest, BiFunction, Function)
-   */
-  public static Matcher<TripOnServiceDate> of(
-    TripOnServiceDateRequest request,
-    BiFunction<Trip, LocalDate, TripPattern> patternResolver
-  ) {
-    return of(request, patternResolver, tripOnServiceDate -> null);
-  }
-
-  /**
    * Creates a matcher for TripOnServiceDates.
    *
    * @param request the criteria for filtering TripOnServiceDates.

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -34,14 +34,13 @@ public class TripOnServiceDateMatcherFactory {
   /**
    * Creates a matcher for TripOnServiceDates.
    *
-   * @param request the criteria for filtering TripOnServiceDates.
-   * @param patternResolver resolves the pattern of a trip on a service date, or {@code null} if it
-   *                        has no pattern.
-   * @param runningTimeResolver resolves the period of time a trip is running according to its
-   *                            schedule, from the departure from the first stop to the arrival at
-   *                            the last stop. Returns {@code null} if the running time cannot be
-   *                            resolved, in which case the trip never matches a running time
-   *                            filter.
+   * @param request             the criteria for filtering TripOnServiceDates.
+   * @param patternResolver     resolves the pattern of a trip on a service date, or {@code null} if
+   *                            it has no pattern.
+   * @param runningTimeResolver resolves a trip's runtime according to its schedule, from the
+   *                            departure from the first stop to the arrival at the last stop.
+   *                            Returns {@code null} if the running time cannot be resolved, in
+   *                            which case the trip never matches a running time filter.
    * @return a matcher for filtering TripOnServiceDates.
    */
   public static Matcher<TripOnServiceDate> of(

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -2,8 +2,10 @@ package org.opentripplanner.transit.model.filter.transit;
 
 import java.time.LocalDate;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.modes.AllowTransitModeFilter;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model.basic.NarrowedTransitMode;
@@ -29,24 +31,42 @@ import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 public class TripOnServiceDateMatcherFactory {
 
   /**
-   * Creates a matcher for TripOnServiceDates.
+   * Creates a matcher for TripOnServiceDates which never matches filters that require the
+   * scheduled running time of a trip.
    *
-   * @param request the criteria for filtering TripOnServiceDates.
-   * @param patternResolver resolves the pattern of a trip on a service date, or {@code null} if it
-   *                        has no pattern.
-   * @return a matcher for filtering TripOnServiceDates.
+   * @see #of(TripOnServiceDateRequest, BiFunction, Function)
    */
   public static Matcher<TripOnServiceDate> of(
     TripOnServiceDateRequest request,
     BiFunction<Trip, LocalDate, TripPattern> patternResolver
   ) {
+    return of(request, patternResolver, tripOnServiceDate -> null);
+  }
+
+  /**
+   * Creates a matcher for TripOnServiceDates.
+   *
+   * @param request the criteria for filtering TripOnServiceDates.
+   * @param patternResolver resolves the pattern of a trip on a service date, or {@code null} if it
+   *                        has no pattern.
+   * @param runningTimeResolver resolves the period of time a trip is running according to its
+   *                            schedule, from the departure from the first stop to the arrival at
+   *                            the last stop. Returns {@code null} if the running time cannot be
+   *                            resolved, in which case the trip never matches a running time
+   *                            filter.
+   * @return a matcher for filtering TripOnServiceDates.
+   */
+  public static Matcher<TripOnServiceDate> of(
+    TripOnServiceDateRequest request,
+    BiFunction<Trip, LocalDate, TripPattern> patternResolver,
+    Function<TripOnServiceDate, TimePeriod> runningTimeResolver
+  ) {
     ExpressionBuilder<TripOnServiceDate> expr = ExpressionBuilder.of();
 
     if (!request.filters().isEmpty()) {
       expr.matches(
-        SelectorBasedMatcherFactory.of(
-          request.filters(),
-          TripOnServiceDateMatcherFactory::buildSelectorMatcher
+        SelectorBasedMatcherFactory.of(request.filters(), selector ->
+          buildSelectorMatcher(selector, runningTimeResolver)
         )
       );
     }
@@ -58,6 +78,9 @@ public class TripOnServiceDateMatcherFactory {
     expr.atLeastOneMatch(
       request.includeServiceDateRanges(),
       TripOnServiceDateMatcherFactory::serviceDateRange
+    );
+    expr.atLeastOneMatch(request.includeRunningTimePeriods(), period ->
+      runningTimePeriod(period, runningTimeResolver)
     );
     expr.atLeastOneMatch(request.includeAgencies(), TripOnServiceDateMatcherFactory::agencyId);
     expr.atLeastOneMatch(request.includeRoutes(), TripOnServiceDateMatcherFactory::routeId);
@@ -85,7 +108,8 @@ public class TripOnServiceDateMatcherFactory {
    * agencies, routes, and transport modes with AND logic.
    */
   private static Matcher<TripOnServiceDate> buildSelectorMatcher(
-    TripOnServiceDateSelectRequest selector
+    TripOnServiceDateSelectRequest selector,
+    Function<TripOnServiceDate, TimePeriod> runningTimeResolver
   ) {
     ExpressionBuilder<TripOnServiceDate> expr = ExpressionBuilder.of();
 
@@ -94,6 +118,9 @@ public class TripOnServiceDateMatcherFactory {
     expr.atLeastOneMatch(
       selector.serviceDateRanges(),
       TripOnServiceDateMatcherFactory::serviceDateRange
+    );
+    expr.atLeastOneMatch(selector.runningTimePeriods(), period ->
+      runningTimePeriod(period, runningTimeResolver)
     );
 
     if (!selector.transportModes().includeEverything()) {
@@ -157,6 +184,21 @@ public class TripOnServiceDateMatcherFactory {
     return new GenericUnaryMatcher<>("serviceDateRange", date ->
       dateRange.contains(date.getServiceDate())
     );
+  }
+
+  /**
+   * Matches trips which are running during the given period, according to their schedule. A trip is
+   * running from the scheduled departure from its first stop until the scheduled arrival at its
+   * last stop. Trips whose schedule cannot be resolved never match.
+   */
+  static Matcher<TripOnServiceDate> runningTimePeriod(
+    TimePeriod period,
+    Function<TripOnServiceDate, TimePeriod> runningTimeResolver
+  ) {
+    return new GenericUnaryMatcher<>("runningTimePeriod", tripOnServiceDate -> {
+      var runningTime = runningTimeResolver.apply(tripOnServiceDate);
+      return runningTime != null && period.overlaps(runningTime);
+    });
   }
 
   static Matcher<TripOnServiceDate> alteration(TripAlteration alteration) {

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactory.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.model.filter.transit;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.opentripplanner.core.model.id.FeedScopedId;
@@ -79,9 +80,11 @@ public class TripOnServiceDateMatcherFactory {
       request.includeServiceDateRanges(),
       TripOnServiceDateMatcherFactory::serviceDateRange
     );
-    expr.atLeastOneMatch(request.includeRunningTimePeriods(), period ->
-      runningTimePeriod(period, runningTimeResolver)
-    );
+    if (!request.includeRunningTimePeriods().includeEverything()) {
+      expr.matches(
+        runningTimePeriods(request.includeRunningTimePeriods().get(), runningTimeResolver)
+      );
+    }
     expr.atLeastOneMatch(request.includeAgencies(), TripOnServiceDateMatcherFactory::agencyId);
     expr.atLeastOneMatch(request.includeRoutes(), TripOnServiceDateMatcherFactory::routeId);
     expr.atLeastOneMatch(request.includePatterns(), id -> patternId(id, patternResolver));
@@ -119,9 +122,9 @@ public class TripOnServiceDateMatcherFactory {
       selector.serviceDateRanges(),
       TripOnServiceDateMatcherFactory::serviceDateRange
     );
-    expr.atLeastOneMatch(selector.runningTimePeriods(), period ->
-      runningTimePeriod(period, runningTimeResolver)
-    );
+    if (!selector.runningTimePeriods().includeEverything()) {
+      expr.matches(runningTimePeriods(selector.runningTimePeriods().get(), runningTimeResolver));
+    }
 
     if (!selector.transportModes().includeEverything()) {
       var transportModeFilter = AllowTransitModeFilter.of(
@@ -187,17 +190,28 @@ public class TripOnServiceDateMatcherFactory {
   }
 
   /**
-   * Matches trips which are running during the given period, according to their schedule. A trip is
-   * running from the scheduled departure from its first stop until the scheduled arrival at its
-   * last stop. Trips whose schedule cannot be resolved never match.
+   * Matches trips which are running during at least one of the given periods, according to their
+   * schedule. A trip is running from the scheduled departure from its first stop until the
+   * scheduled arrival at its last stop. Trips whose schedule cannot be resolved never match.
+   * <p>
+   * The running time is resolved once per trip and then tested against every period, so that the
+   * (potentially expensive) {@code runningTimeResolver} is not invoked once per period.
    */
-  static Matcher<TripOnServiceDate> runningTimePeriod(
-    TimePeriod period,
+  static Matcher<TripOnServiceDate> runningTimePeriods(
+    Collection<TimePeriod> periods,
     Function<TripOnServiceDate, TimePeriod> runningTimeResolver
   ) {
     return new GenericUnaryMatcher<>("runningTimePeriod", tripOnServiceDate -> {
       var runningTime = runningTimeResolver.apply(tripOnServiceDate);
-      return runningTime != null && period.overlaps(runningTime);
+      if (runningTime == null) {
+        return false;
+      }
+      for (var period : periods) {
+        if (period.overlaps(runningTime)) {
+          return true;
+        }
+      }
+      return false;
     });
   }
 

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateSelectRequest.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateSelectRequest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -20,6 +21,7 @@ public class TripOnServiceDateSelectRequest {
   private final FilterValues<FeedScopedId> routes;
   private final FilterValues<MainAndSubMode> transportModes;
   private final FilterValues<LocalDateRange> serviceDateRanges;
+  private final FilterValues<TimePeriod> runningTimePeriods;
 
   private TripOnServiceDateSelectRequest(Builder builder) {
     this.agencies = FilterValues.ofNullIsEverything("agencies", builder.agencies);
@@ -28,6 +30,10 @@ public class TripOnServiceDateSelectRequest {
     this.serviceDateRanges = FilterValues.ofNullIsEverything(
       "serviceDateRanges",
       builder.serviceDateRanges
+    );
+    this.runningTimePeriods = FilterValues.ofNullIsEverything(
+      "runningTimePeriods",
+      builder.runningTimePeriods
     );
   }
 
@@ -51,6 +57,13 @@ public class TripOnServiceDateSelectRequest {
     return serviceDateRanges;
   }
 
+  /**
+   * Periods of time in which the entity must be running, according to its schedule.
+   */
+  public FilterValues<TimePeriod> runningTimePeriods() {
+    return runningTimePeriods;
+  }
+
   @Override
   public String toString() {
     var builder = ToStringBuilder.ofEmbeddedType();
@@ -65,6 +78,9 @@ public class TripOnServiceDateSelectRequest {
     }
     if (!serviceDateRanges.includeEverything()) {
       builder.addCol("serviceDateRanges", serviceDateRanges.get());
+    }
+    if (!runningTimePeriods.includeEverything()) {
+      builder.addCol("runningTimePeriods", runningTimePeriods.get());
     }
     return builder.toString();
   }
@@ -83,6 +99,9 @@ public class TripOnServiceDateSelectRequest {
     @Nullable
     private List<LocalDateRange> serviceDateRanges;
 
+    @Nullable
+    private List<TimePeriod> runningTimePeriods;
+
     public Builder withAgencies(List<FeedScopedId> agencies) {
       this.agencies = agencies;
       return this;
@@ -100,6 +119,11 @@ public class TripOnServiceDateSelectRequest {
 
     public Builder withServiceDateRanges(List<LocalDateRange> serviceDateRanges) {
       this.serviceDateRanges = serviceDateRanges;
+      return this;
+    }
+
+    public Builder withRunningTimePeriods(List<TimePeriod> runningTimePeriods) {
+      this.runningTimePeriods = runningTimePeriods;
       return this;
     }
 

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactory.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.TimePeriod;
-import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.modes.AllowTransitModeFilter;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
@@ -124,18 +123,10 @@ public class TripTimeOnDateMatcherFactory {
   @Nullable
   private static TimePeriod scheduledRunningTime(TripTimeOnDate call) {
     var tripTimes = call.getTripTimes();
-    if (tripTimes == null || tripTimes.getNumStops() == 0) {
-      return null;
-    }
-    int departure = tripTimes.getScheduledDepartureTime(0);
-    int arrival = tripTimes.getScheduledArrivalTime(tripTimes.getNumStops() - 1);
-    if (departure == StopTime.MISSING_VALUE || arrival == StopTime.MISSING_VALUE) {
-      return null;
-    }
     long midnight = call.getServiceDayMidnight();
-    return TimePeriod.of(
-      Instant.ofEpochSecond(midnight + departure),
-      Instant.ofEpochSecond(midnight + arrival)
-    );
+    if (tripTimes == null || midnight == TripTimeOnDate.UNDEFINED) {
+      return null;
+    }
+    return tripTimes.scheduledRunningTime(Instant.ofEpochSecond(midnight));
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactory.java
@@ -1,6 +1,10 @@
 package org.opentripplanner.transit.model.filter.transit;
 
+import java.time.Instant;
+import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.core.model.time.TimePeriod;
+import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.modes.AllowTransitModeFilter;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
@@ -41,6 +45,10 @@ public class TripTimeOnDateMatcherFactory {
     expr.atLeastOneMatch(request.includeAgencies(), TripTimeOnDateMatcherFactory::agencyId);
     expr.atLeastOneMatch(request.includeRoutes(), TripTimeOnDateMatcherFactory::routeId);
     expr.atLeastOneMatch(request.includeModes(), TripTimeOnDateMatcherFactory::mode);
+    expr.atLeastOneMatch(
+      request.includeRunningTimePeriods(),
+      TripTimeOnDateMatcherFactory::runningTimePeriod
+    );
     expr.matchesNone(request.excludeAgencies(), TripTimeOnDateMatcherFactory::agencyId);
     expr.matchesNone(request.excludeRoutes(), TripTimeOnDateMatcherFactory::routeId);
     expr.matchesNone(request.excludeModes(), TripTimeOnDateMatcherFactory::mode);
@@ -93,5 +101,41 @@ public class TripTimeOnDateMatcherFactory {
 
   private static Matcher<TripTimeOnDate> mode(TransitMode mode) {
     return new EqualityMatcher<>("mode", mode, t -> t.getTrip().getMode());
+  }
+
+  /**
+   * Matches calls of trips which are running during the given period, according to their schedule.
+   * A trip is running from the scheduled departure from its first stop until the scheduled arrival
+   * at its last stop. Calls whose trip schedule cannot be resolved never match.
+   */
+  private static Matcher<TripTimeOnDate> runningTimePeriod(TimePeriod period) {
+    return new GenericUnaryMatcher<>("runningTimePeriod", call -> {
+      var runningTime = scheduledRunningTime(call);
+      return runningTime != null && period.overlaps(runningTime);
+    });
+  }
+
+  /**
+   * Resolves the period of time the trip of the given call is running on its service date, according
+   * to its schedule.
+   *
+   * @return {@code null} if the schedule of the trip cannot be resolved.
+   */
+  @Nullable
+  private static TimePeriod scheduledRunningTime(TripTimeOnDate call) {
+    var tripTimes = call.getTripTimes();
+    if (tripTimes == null || tripTimes.getNumStops() == 0) {
+      return null;
+    }
+    int departure = tripTimes.getScheduledDepartureTime(0);
+    int arrival = tripTimes.getScheduledArrivalTime(tripTimes.getNumStops() - 1);
+    if (departure == StopTime.MISSING_VALUE || arrival == StopTime.MISSING_VALUE) {
+      return null;
+    }
+    long midnight = call.getServiceDayMidnight();
+    return TimePeriod.of(
+      Instant.ofEpochSecond(midnight + departure),
+      Instant.ofEpochSecond(midnight + arrival)
+    );
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactory.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactory.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.transit.model.filter.transit;
 
 import java.time.Instant;
-import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.TripTimeOnDate;
@@ -45,8 +44,8 @@ public class TripTimeOnDateMatcherFactory {
     expr.atLeastOneMatch(request.includeRoutes(), TripTimeOnDateMatcherFactory::routeId);
     expr.atLeastOneMatch(request.includeModes(), TripTimeOnDateMatcherFactory::mode);
     expr.atLeastOneMatch(
-      request.includeRunningTimePeriods(),
-      TripTimeOnDateMatcherFactory::runningTimePeriod
+      request.includeCallTimePeriods(),
+      TripTimeOnDateMatcherFactory::callTimePeriod
     );
     expr.matchesNone(request.excludeAgencies(), TripTimeOnDateMatcherFactory::agencyId);
     expr.matchesNone(request.excludeRoutes(), TripTimeOnDateMatcherFactory::routeId);
@@ -103,30 +102,31 @@ public class TripTimeOnDateMatcherFactory {
   }
 
   /**
-   * Matches calls of trips which are running during the given period, according to their schedule.
-   * A trip is running from the scheduled departure from its first stop until the scheduled arrival
-   * at its last stop. Calls whose trip schedule cannot be resolved never match.
+   * Matches calls where the vehicle is scheduled to visit the stop during the given period. The
+   * visit lasts from the scheduled arrival at the stop until the scheduled departure from it, and
+   * the period is half-open, meaning that its end is exclusive. Calls without scheduled times, for
+   * example flexible ones, never match.
    */
-  private static Matcher<TripTimeOnDate> runningTimePeriod(TimePeriod period) {
-    return new GenericUnaryMatcher<>("runningTimePeriod", call -> {
-      var runningTime = scheduledRunningTime(call);
-      return runningTime != null && period.overlaps(runningTime);
+  private static Matcher<TripTimeOnDate> callTimePeriod(TimePeriod period) {
+    return new GenericUnaryMatcher<>("callTimePeriod", call -> {
+      if (call.getServiceDayMidnight() == TripTimeOnDate.UNDEFINED || !call.hasScheduledTimes()) {
+        return false;
+      }
+      return visitOverlaps(period, call.scheduledArrival(), call.scheduledDeparture());
     });
   }
 
   /**
-   * Resolves the period of time the trip of the given call is running on its service date, according
-   * to its schedule.
-   *
-   * @return {@code null} if the schedule of the trip cannot be resolved.
+   * Returns {@code true} if the visit at the stop, lasting from {@code arrival} to
+   * {@code departure} (both inclusive), overlaps the given period. A visit which lasts no time at
+   * all matches if the period contains the instant of the visit.
    */
-  @Nullable
-  private static TimePeriod scheduledRunningTime(TripTimeOnDate call) {
-    var tripTimes = call.getTripTimes();
-    long midnight = call.getServiceDayMidnight();
-    if (tripTimes == null || midnight == TripTimeOnDate.UNDEFINED) {
-      return null;
-    }
-    return tripTimes.scheduledRunningTime(Instant.ofEpochSecond(midnight));
+  private static boolean visitOverlaps(TimePeriod period, Instant arrival, Instant departure) {
+    boolean afterStart = period
+      .start()
+      .map(start -> !departure.isBefore(start))
+      .orElse(true);
+    boolean beforeEnd = period.end().map(arrival::isBefore).orElse(true);
+    return afterStart && beforeEnd;
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -5,12 +5,15 @@ import static org.opentripplanner.transit.model.timetable.TimetableValidationErr
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.OptionalInt;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.core.model.i18n.I18NString;
+import org.opentripplanner.core.model.time.TimePeriod;
+import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model.framework.DataValidationException;
 import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 
@@ -195,6 +198,39 @@ public sealed interface TripTimes<T extends TripTimes>
   List<String> getHeadsignVias(int stopPos);
 
   int getNumStops();
+
+  /**
+   * Resolves the period of time this trip is running on a service day, according to its schedule.
+   * The period starts at the scheduled departure from the first stop and ends at the scheduled
+   * arrival at the last stop.
+   * <p>
+   *
+   * @param startOfService the start of the service day the trip is running on, see
+   *                       {@link org.opentripplanner.utils.time.ServiceDateUtils#asStartOfService}.
+   * @return {@code null} if the schedule of the trip cannot be resolved, either because the trip has
+   *         no stops or because the departure from the first stop or the arrival at the last stop is
+   *         missing or inconsistent.
+   */
+  @Nullable
+  default TimePeriod scheduledRunningTime(Instant startOfService) {
+    int numStops = getNumStops();
+    if (numStops == 0) {
+      return null;
+    }
+    int departure = getScheduledDepartureTime(0);
+    int arrival = getScheduledArrivalTime(numStops - 1);
+    if (
+      departure == StopTime.MISSING_VALUE ||
+      arrival == StopTime.MISSING_VALUE ||
+      departure > arrival
+    ) {
+      return null;
+    }
+    return TimePeriod.of(
+      startOfService.plusSeconds(departure),
+      startOfService.plusSeconds(arrival)
+    );
+  }
 
   /**
    * When creating trip times, or wrapping them in updates, we could potentially imply negative

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -200,16 +200,16 @@ public sealed interface TripTimes<T extends TripTimes>
   int getNumStops();
 
   /**
-   * Resolves the period of time this trip is running on a service day, according to its schedule.
-   * The period starts at the scheduled departure from the first stop and ends at the scheduled
-   * arrival at the last stop.
+   * resolves a trip's runtime on a service day, according to its schedule. The period starts at the
+   * scheduled departure from the first stop and ends at the scheduled arrival at the last stop.
    * <p>
    *
    * @param startOfService the start of the service day the trip is running on, see
-   *                       {@link org.opentripplanner.utils.time.ServiceDateUtils#asStartOfService}.
-   * @return {@code null} if the schedule of the trip cannot be resolved, either because the trip has
-   *         no stops or because the departure from the first stop or the arrival at the last stop is
-   *         missing or inconsistent.
+   *                       {@link
+   *                       org.opentripplanner.utils.time.ServiceDateUtils#asStartOfService}.
+   * @return {@code null} if the schedule of the trip cannot be resolved, either because the trip
+   * has no stops or because the departure from the first stop or the arrival at the last stop is
+   * missing or inconsistent.
    */
   @Nullable
   default TimePeriod scheduledRunningTime(Instant startOfService) {

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.ext.flex.FlexIndex;
 import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.model.FeedInfo;
@@ -366,9 +367,46 @@ public class DefaultTransitService implements TransitService {
   public List<TripOnServiceDate> findCanceledTrips(TripOnServiceDateRequest request) {
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      this::findPattern
+      this::findPattern,
+      this::findScheduledRunningTime
     );
     return listCanceledTrips().stream().filter(matcher::match).toList();
+  }
+
+  /**
+   * Resolves the period of time a trip is running on its service date according to its schedule.
+   * The period starts at the scheduled departure from the first stop and ends at the scheduled
+   * arrival at the last stop.
+   *
+   * @return {@code null} if the schedule of the trip cannot be resolved.
+   */
+  @Nullable
+  private TimePeriod findScheduledRunningTime(TripOnServiceDate tripOnServiceDate) {
+    var trip = tripOnServiceDate.getTrip();
+    var serviceDate = tripOnServiceDate.getServiceDate();
+    var pattern = findPattern(trip, serviceDate);
+    if (pattern == null) {
+      return null;
+    }
+    var tripTimes = findTimetable(pattern, serviceDate).getTripTimes(trip);
+    if (tripTimes == null) {
+      tripTimes = pattern.getScheduledTimetable().getTripTimes(trip);
+    }
+    if (tripTimes == null || tripTimes.getNumStops() == 0) {
+      return null;
+    }
+    ZoneId timeZone = trip.getRoute().getAgency().getTimezone();
+    var start = ServiceDateUtils.toZonedDateTime(
+      serviceDate,
+      timeZone,
+      tripTimes.getScheduledDepartureTime(0)
+    );
+    var end = ServiceDateUtils.toZonedDateTime(
+      serviceDate,
+      timeZone,
+      tripTimes.getScheduledArrivalTime(tripTimes.getNumStops() - 1)
+    );
+    return TimePeriod.of(start.toInstant(), end.toInstant());
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -392,21 +392,13 @@ public class DefaultTransitService implements TransitService {
     if (tripTimes == null) {
       tripTimes = pattern.getScheduledTimetable().getTripTimes(trip);
     }
-    if (tripTimes == null || tripTimes.getNumStops() == 0) {
+    if (tripTimes == null) {
       return null;
     }
     ZoneId timeZone = trip.getRoute().getAgency().getTimezone();
-    var start = ServiceDateUtils.toZonedDateTime(
-      serviceDate,
-      timeZone,
-      tripTimes.getScheduledDepartureTime(0)
+    return tripTimes.scheduledRunningTime(
+      ServiceDateUtils.asStartOfService(serviceDate, timeZone).toInstant()
     );
-    var end = ServiceDateUtils.toZonedDateTime(
-      serviceDate,
-      timeZone,
-      tripTimes.getScheduledArrivalTime(tripTimes.getNumStops() - 1)
-    );
-    return TimePeriod.of(start.toInstant(), end.toInstant());
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -374,9 +374,9 @@ public class DefaultTransitService implements TransitService {
   }
 
   /**
-   * Resolves the period of time a trip is running on its service date according to its schedule.
-   * The period starts at the scheduled departure from the first stop and ends at the scheduled
-   * arrival at the last stop.
+   * Resolves a trip's runtime on its service date according to its schedule. The period starts at
+   * the scheduled departure from the first stop and ends at the scheduled arrival at the last
+   * stop.
    *
    * @return {@code null} if the schedule of the trip cannot be resolved.
    */

--- a/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/application/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -640,7 +640,8 @@ public class DefaultTransitService implements TransitService {
   public List<TripOnServiceDate> findTripsOnServiceDate(TripOnServiceDateRequest request) {
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      this::findPattern
+      this::findPattern,
+      this::findScheduledRunningTime
     );
     return listTripsOnServiceDate().stream().filter(matcher::match).toList();
   }

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2443,6 +2443,18 @@ type Stop implements Node & PlaceInterface {
     """
     arrivalDeparture: ArrivalDeparture = EITHER,
     """
+    Only include canceled calls whose trip is scheduled to be running during one of these time
+    ranges. A trip is considered to be running from its scheduled departure from the first stop
+    until its scheduled arrival at the last stop.
+        
+    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
+    value is `null`, no filtering is applied.
+        
+    If both `runningTimeRanges` and `serviceDateRanges` are defined, a call has to match both of
+    them to be returned.
+    """
+    runningTimeRanges: [OffsetDateTimeRangeInput!],
+    """
     Only include canceled calls whose trip's service date is within any of these date ranges.
     If omitted (or `null`), no service date filter is applied and canceled calls across the entire
     transit service period are returned. Defining a range is recommended.

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -1119,6 +1119,18 @@ type Pattern implements Node {
   """
   canceledTrips(
     """
+    Only return canceled trips which are scheduled to be running during one of these time ranges.
+    A trip is considered to be running from its scheduled departure from the first stop until its
+    scheduled arrival at the last stop.
+        
+    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
+    value is `null`, no filtering is applied.
+        
+    If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+    them to be returned.
+    """
+    runningTimeRanges: [OffsetDateTimeRangeInput!],
+    """
     Only return canceled trips whose service date falls within one of these ranges.
     An empty list or a list containing `null` is forbidden.  If this argument is not provided or its
     value is `null`, no filtering is applied.
@@ -4483,6 +4495,15 @@ input CanceledTripsFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
   """
+  Canceled trips are included/excluded based on if they are scheduled to be running during any of
+  these time ranges. A trip is considered to be running from its scheduled departure from the first
+  stop until its scheduled arrival at the last stop.
+    
+  If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+  them to be included/excluded.
+  """
+  runningTimeRanges: [OffsetDateTimeRangeInput!]
+  """
   Canceled trips are included/excluded based on if their service date (but not necessarily their running date)  is within any of these time
   ranges.
   """
@@ -4509,6 +4530,15 @@ input CanceledTripsSummaryFilterInput {
 input CanceledTripsSummaryFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
+  """
+  Canceled trips are included/excluded based on if they are scheduled to be running during any of
+  these time ranges. A trip is considered to be running from its scheduled departure from the first
+  stop until its scheduled arrival at the last stop.
+    
+  If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+  them to be included/excluded.
+  """
+  runningTimeRanges: [OffsetDateTimeRangeInput!]
   """
   Canceled trips are included/excluded based on if their service date is within any of these time
   ranges.
@@ -4772,6 +4802,29 @@ input LocalDateRangeInput {
   dates that are before `end` are selected.
   """
   start: LocalDate
+}
+
+"""
+Filters an entity by a time range. Both ends of the range are optional which makes it possible
+to define a range which is open ended in either or both directions.
+"""
+input OffsetDateTimeRangeInput {
+  """
+  **Exclusive** end time of the filter. This means that an entity which is exactly at `end` is not
+  selected.
+    
+  If `null` this means that no end filter is applied and all entities that are after or at `start`
+  are selected.
+  """
+  end: OffsetDateTime
+  """
+  **Inclusive** start time of the filter. This means that an entity which is exactly at `start` is
+  selected.
+    
+  If `null` this means that no `start` filter is applied and all entities that are before `end` are
+  selected.
+  """
+  start: OffsetDateTime
 }
 
 """

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -2443,23 +2443,23 @@ type Stop implements Node & PlaceInterface {
     """
     arrivalDeparture: ArrivalDeparture = EITHER,
     """
-    Only include canceled calls whose trip is scheduled to be running during one of these time
-    ranges. A trip is considered to be running from its scheduled departure from the first stop
-    until its scheduled arrival at the last stop.
-        
-    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
-    value is `null`, no filtering is applied.
-        
-    If both `runningTimeRanges` and `serviceDateRanges` are defined, a call has to match both of
-    them to be returned.
-    """
-    runningTimeRanges: [OffsetDateTimeRangeInput!],
-    """
     Only include canceled calls whose trip's service date is within any of these date ranges.
     If omitted (or `null`), no service date filter is applied and canceled calls across the entire
     transit service period are returned. Defining a range is recommended.
     """
-    serviceDateRanges: [LocalDateRangeInput!]
+    serviceDateRanges: [LocalDateRangeInput!],
+    """
+    Only include canceled calls where the vehicle is scheduled to visit this stop during one of
+    these time ranges. The visit at a stop lasts from the scheduled arrival at the stop until the
+    scheduled departure from it.
+        
+    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
+    value is `null`, no filtering is applied.
+        
+    If both `timeRanges` and `serviceDateRanges` are defined, a call has to match both of
+    them to be returned.
+    """
+    timeRanges: [OffsetDateTimeRangeInput!]
   ): [StopCallOnTripOnServiceDate!]!
   "The cluster which this stop is part of"
   cluster: Cluster @deprecated(reason : "Not implemented")

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/CanceledTripsFilterMapperTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.apis.support.InvalidInputException;
 import org.opentripplanner.apis.support.graphql.DataFetchingSupport;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 
@@ -214,6 +216,95 @@ class CanceledTripsFilterMapperTest {
     );
     assertEquals(
       "Service date range filter must be either null or have at least one entry.",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  void testIncludeWithRunningTimeRanges() {
+    var start = OffsetDateTime.parse("2026-06-01T10:00:00+02:00");
+    var end = OffsetDateTime.parse("2026-06-01T12:00:00+02:00");
+    Map<String, Object> args = Map.of(
+      "filters",
+      List.of(
+        Map.of(
+          "include",
+          List.of(Map.of("runningTimeRanges", List.of(Map.of("start", start, "end", end))))
+        )
+      )
+    );
+
+    var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(getEnvironment(args));
+    assertThat(request.filters()).hasSize(1);
+    var include = request.filters().getFirst().select().getFirst();
+    assertThat(include.runningTimePeriods().get()).containsExactly(
+      TimePeriod.of(start.toInstant(), end.toInstant())
+    );
+  }
+
+  @Test
+  void testExcludeWithOpenEndedRunningTimeRange() {
+    var start = OffsetDateTime.parse("2026-07-01T00:00:00Z");
+    Map<String, Object> args = Map.of(
+      "filters",
+      List.of(
+        Map.of("exclude", List.of(Map.of("runningTimeRanges", List.of(Map.of("start", start)))))
+      )
+    );
+
+    var request = CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(getEnvironment(args));
+    assertThat(request.filters()).hasSize(1);
+    var exclude = request.filters().getFirst().not().getFirst();
+    assertThat(exclude.runningTimePeriods().get()).containsExactly(
+      TimePeriod.of(start.toInstant(), null)
+    );
+  }
+
+  @Test
+  void testEmptyRunningTimeRanges() {
+    Map<String, Object> args = Map.of(
+      "filters",
+      List.of(Map.of("include", List.of(Map.of("runningTimeRanges", List.of()))))
+    );
+    var environment = getEnvironment(args);
+    var exception = assertThrows(InvalidInputException.class, () ->
+      CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(environment)
+    );
+    assertEquals(
+      "Time range filter 'filters.*.runningTimeRanges' must be either null or have at least one entry.",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  void testRunningTimeRangeWithStartAfterEnd() {
+    Map<String, Object> args = Map.of(
+      "filters",
+      List.of(
+        Map.of(
+          "include",
+          List.of(
+            Map.of(
+              "runningTimeRanges",
+              List.of(
+                Map.of(
+                  "start",
+                  OffsetDateTime.parse("2026-06-02T10:00:00Z"),
+                  "end",
+                  OffsetDateTime.parse("2026-06-01T10:00:00Z")
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    var environment = getEnvironment(args);
+    var exception = assertThrows(InvalidInputException.class, () ->
+      CanceledTripsFilterMapper.mapToTripOnServiceDateRequest(environment)
+    );
+    assertEquals(
+      "The start of the time range 'filters.*.runningTimeRanges' must not be after its end.",
       exception.getMessage()
     );
   }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -291,7 +291,7 @@ class ApiTransitServiceTest {
   }
 
   @Test
-  void canceledStopCallsFilteredByRunningTime() {
+  void canceledStopCallsFilteredByCallTime() {
     var env = envBuilder.addTrip(TRIP1_INPUT).build();
     var rt = GtfsRtTestHelper.of(env);
 
@@ -300,13 +300,26 @@ class ApiTransitServiceTest {
 
     var service = new ApiTransitService(env.transitService());
 
-    // The trip runs from 12:00 to 13:00 on the service date
+    // The vehicle visits STOP_B at 12:30 on the service date
     var overlapping = List.of(
-      TimePeriod.of(instant(LocalTime.of(12, 45)), instant(LocalTime.of(14, 0)))
+      TimePeriod.of(instant(LocalTime.of(12, 15)), instant(LocalTime.of(12, 45)))
     );
     assertThat(
       service.findCanceledStopCalls(STOP_B, SERVICE_DATE_RANGES, overlapping, ArrivalDeparture.BOTH)
     ).hasSize(1);
+
+    // The trip runs from 12:00 until 13:00 but the vehicle does not visit STOP_B during this range
+    var duringTripButNotAtStop = List.of(
+      TimePeriod.of(instant(LocalTime.of(12, 45)), instant(LocalTime.of(13, 0)))
+    );
+    assertThat(
+      service.findCanceledStopCalls(
+        STOP_B,
+        SERVICE_DATE_RANGES,
+        duringTripButNotAtStop,
+        ArrivalDeparture.BOTH
+      )
+    ).isEmpty();
 
     var notOverlapping = List.of(
       TimePeriod.of(instant(LocalTime.of(13, 30)), instant(LocalTime.of(14, 0)))

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/service/ApiTransitServiceTest.java
@@ -17,6 +17,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.plan.leg.ScheduledTransitLegBuilder;
@@ -185,6 +186,7 @@ class ApiTransitServiceTest {
       new ApiTransitService(env.transitService()).findCanceledStopCalls(
         STOP_B,
         SERVICE_DATE_RANGES,
+        null,
         ArrivalDeparture.BOTH
       )
     ).isEmpty();
@@ -193,7 +195,12 @@ class ApiTransitServiceTest {
     assertSuccess(rt.applyTripUpdate(update));
 
     var service = new ApiTransitService(env.transitService());
-    var calls = service.findCanceledStopCalls(STOP_B, SERVICE_DATE_RANGES, ArrivalDeparture.BOTH);
+    var calls = service.findCanceledStopCalls(
+      STOP_B,
+      SERVICE_DATE_RANGES,
+      null,
+      ArrivalDeparture.BOTH
+    );
     assertThat(calls).hasSize(1);
     var call = calls.getFirst();
     assertEquals(TRIP_1_ID, call.stopCall().getTrip().getId().getId());
@@ -218,6 +225,7 @@ class ApiTransitServiceTest {
     var skippedCalls = service.findCanceledStopCalls(
       STOP_B,
       SERVICE_DATE_RANGES,
+      null,
       ArrivalDeparture.BOTH
     );
     assertThat(skippedCalls).hasSize(1);
@@ -227,7 +235,7 @@ class ApiTransitServiceTest {
 
     // Stops that are not skipped and whose trip is not canceled are not returned
     assertThat(
-      service.findCanceledStopCalls(STOP_A, SERVICE_DATE_RANGES, ArrivalDeparture.BOTH)
+      service.findCanceledStopCalls(STOP_A, SERVICE_DATE_RANGES, null, ArrivalDeparture.BOTH)
     ).isEmpty();
   }
 
@@ -246,16 +254,16 @@ class ApiTransitServiceTest {
       LocalDateRange.ofExclusiveEnd(SERVICE_DATE.plusDays(1), SERVICE_DATE.plusDays(2))
     );
     assertThat(
-      service.findCanceledStopCalls(STOP_B, outsideRange, ArrivalDeparture.BOTH)
+      service.findCanceledStopCalls(STOP_B, outsideRange, null, ArrivalDeparture.BOTH)
     ).isEmpty();
 
     // Range that includes the service date returns the canceled call
     var insideRange = List.of(
       LocalDateRange.ofExclusiveEnd(SERVICE_DATE, SERVICE_DATE.plusDays(1))
     );
-    assertThat(service.findCanceledStopCalls(STOP_B, insideRange, ArrivalDeparture.BOTH)).hasSize(
-      1
-    );
+    assertThat(
+      service.findCanceledStopCalls(STOP_B, insideRange, null, ArrivalDeparture.BOTH)
+    ).hasSize(1);
   }
 
   @Test
@@ -275,10 +283,41 @@ class ApiTransitServiceTest {
     // The drop-off-only visit at STOP_C is returned with BOTH but omitted when only departures
     // (pickups) are requested.
     assertThat(
-      service.findCanceledStopCalls(STOP_C, SERVICE_DATE_RANGES, ArrivalDeparture.BOTH)
+      service.findCanceledStopCalls(STOP_C, SERVICE_DATE_RANGES, null, ArrivalDeparture.BOTH)
     ).hasSize(1);
     assertThat(
-      service.findCanceledStopCalls(STOP_C, SERVICE_DATE_RANGES, ArrivalDeparture.DEPARTURES)
+      service.findCanceledStopCalls(STOP_C, SERVICE_DATE_RANGES, null, ArrivalDeparture.DEPARTURES)
+    ).isEmpty();
+  }
+
+  @Test
+  void canceledStopCallsFilteredByRunningTime() {
+    var env = envBuilder.addTrip(TRIP1_INPUT).build();
+    var rt = GtfsRtTestHelper.of(env);
+
+    var update = rt.tripUpdate(TRIP_1_ID, CANCELED).build();
+    assertSuccess(rt.applyTripUpdate(update));
+
+    var service = new ApiTransitService(env.transitService());
+
+    // The trip runs from 12:00 to 13:00 on the service date
+    var overlapping = List.of(
+      TimePeriod.of(instant(LocalTime.of(12, 45)), instant(LocalTime.of(14, 0)))
+    );
+    assertThat(
+      service.findCanceledStopCalls(STOP_B, SERVICE_DATE_RANGES, overlapping, ArrivalDeparture.BOTH)
+    ).hasSize(1);
+
+    var notOverlapping = List.of(
+      TimePeriod.of(instant(LocalTime.of(13, 30)), instant(LocalTime.of(14, 0)))
+    );
+    assertThat(
+      service.findCanceledStopCalls(
+        STOP_B,
+        SERVICE_DATE_RANGES,
+        notOverlapping,
+        ArrivalDeparture.BOTH
+      )
     ).isEmpty();
   }
 
@@ -332,5 +371,9 @@ class ApiTransitServiceTest {
 
   private static GtfsRealtime.TripUpdate skipSecondStop(TripUpdateBuilder builder) {
     return builder.addSkippedStop(1).build();
+  }
+
+  private static Instant instant(LocalTime time) {
+    return SERVICE_DATE.atTime(time).atZone(TIME_ZONE).toInstant();
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/support/time/OffsetDateTimeRangeUtilTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/support/time/OffsetDateTimeRangeUtilTest.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.apis.gtfs.support.time;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
+import org.opentripplanner.apis.support.InvalidInputException;
+import org.opentripplanner.core.model.time.TimePeriod;
+
+class OffsetDateTimeRangeUtilTest {
+
+  private static final OffsetDateTime START = OffsetDateTime.parse("2026-06-01T10:00:00+02:00");
+  private static final OffsetDateTime END = OffsetDateTime.parse("2026-06-01T12:00:00+02:00");
+  private static final String FIELD = "runningTimeRanges";
+
+  @Test
+  void nullRangesAreNotMapped() {
+    assertNull(OffsetDateTimeRangeUtil.mapRanges(null, FIELD));
+  }
+
+  @Test
+  void mapRanges() {
+    var ranges = List.of(
+      new GraphQLTypes.GraphQLOffsetDateTimeRangeInput(Map.of("start", START, "end", END)),
+      new GraphQLTypes.GraphQLOffsetDateTimeRangeInput(Map.of("start", START)),
+      new GraphQLTypes.GraphQLOffsetDateTimeRangeInput(Map.of("end", END)),
+      new GraphQLTypes.GraphQLOffsetDateTimeRangeInput(Map.of())
+    );
+
+    assertThat(OffsetDateTimeRangeUtil.mapRanges(ranges, FIELD))
+      .containsExactly(
+        TimePeriod.of(START.toInstant(), END.toInstant()),
+        TimePeriod.of(START.toInstant(), null),
+        TimePeriod.of(null, END.toInstant()),
+        TimePeriod.ofUnbounded()
+      )
+      .inOrder();
+  }
+
+  @Test
+  void emptyRangesAreForbidden() {
+    var exception = assertThrows(InvalidInputException.class, () ->
+      OffsetDateTimeRangeUtil.mapRanges(List.of(), FIELD)
+    );
+    assertThat(exception.getMessage()).isEqualTo(
+      "Time range filter 'runningTimeRanges' must be either null or have at least one entry."
+    );
+  }
+
+  @Test
+  void startAfterEndIsForbidden() {
+    var exception = assertThrows(InvalidInputException.class, () ->
+      OffsetDateTimeRangeUtil.mapRange(END, START, FIELD)
+    );
+    assertThat(exception.getMessage()).isEqualTo(
+      "The start of the time range 'runningTimeRanges' must not be after its end."
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.time.LocalDateRange;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
@@ -32,7 +35,12 @@ class TripOnServiceDateMatcherFactoryTest {
   private TripOnServiceDate tripOnServiceDateAkt;
   private TripPattern patternRut;
   private TripPattern patternAkt;
+  // The RUT trip runs from 10:00 to 11:00 on its service date, the AKT trip is not running at all
+  private static final Instant RUT_START = Instant.parse("2024-02-22T10:00:00Z");
+  private static final Instant RUT_END = Instant.parse("2024-02-22T11:00:00Z");
+
   private BiFunction<Trip, LocalDate, TripPattern> patternResolver;
+  private Function<TripOnServiceDate, TimePeriod> runningTimeResolver;
 
   @BeforeEach
   void setup() {
@@ -110,6 +118,8 @@ class TripOnServiceDateMatcherFactoryTest {
       }
       return null;
     };
+    runningTimeResolver = tripOnServiceDate ->
+      tripOnServiceDate.equals(tripOnServiceDateRut) ? TimePeriod.of(RUT_START, RUT_END) : null;
   }
 
   @Test
@@ -394,5 +404,114 @@ class TripOnServiceDateMatcherFactoryTest {
     assertTrue(matcher.match(tripOnServiceDateRut));
     assertFalse(matcher.match(tripOnServiceDateRut2));
     assertFalse(matcher.match(tripOnServiceDateAkt));
+  }
+
+  @Test
+  void matchesTripRunningInsidePeriod() {
+    assertTrue(
+      matcher(TimePeriod.of(RUT_START.minusSeconds(60), RUT_END.plusSeconds(60))).match(
+        tripOnServiceDateRut
+      )
+    );
+  }
+
+  @Test
+  void matchesTripOverlappingPeriod() {
+    // The trip arrives one minute before the period ends
+    assertTrue(
+      matcher(TimePeriod.of(RUT_END.minusSeconds(60), RUT_END.plusSeconds(3600))).match(
+        tripOnServiceDateRut
+      )
+    );
+    // The trip departs one minute after the period starts
+    assertTrue(
+      matcher(TimePeriod.of(RUT_START.minusSeconds(3600), RUT_START.plusSeconds(60))).match(
+        tripOnServiceDateRut
+      )
+    );
+  }
+
+  @Test
+  void doesNotMatchTripArrivingExactlyAtStartOfPeriod() {
+    // The end of the running time of a trip is exclusive
+    assertFalse(matcher(TimePeriod.of(RUT_END, null)).match(tripOnServiceDateRut));
+  }
+
+  @Test
+  void doesNotMatchTripDepartingExactlyAtEndOfPeriod() {
+    // The end of the period is exclusive
+    assertFalse(matcher(TimePeriod.of(null, RUT_START)).match(tripOnServiceDateRut));
+  }
+
+  @Test
+  void doesNotMatchTripOutsidePeriod() {
+    assertFalse(
+      matcher(TimePeriod.of(RUT_END.plusSeconds(1), RUT_END.plusSeconds(3600))).match(
+        tripOnServiceDateRut
+      )
+    );
+  }
+
+  @Test
+  void matchesOpenEndedPeriods() {
+    assertTrue(matcher(TimePeriod.ofUnbounded()).match(tripOnServiceDateRut));
+  }
+
+  @Test
+  void matchesTripWithOpenEndedRunningTime() {
+    // A trip whose running time has no known end is running indefinitely
+    runningTimeResolver = tripOnServiceDate ->
+      tripOnServiceDate.equals(tripOnServiceDateRut) ? TimePeriod.of(RUT_START, null) : null;
+
+    assertTrue(matcher(TimePeriod.of(RUT_END.plusSeconds(3600), null)).match(tripOnServiceDateRut));
+    assertFalse(
+      matcher(TimePeriod.of(null, RUT_START.minusSeconds(1))).match(tripOnServiceDateRut)
+    );
+  }
+
+  @Test
+  void doesNotMatchTripWithUnresolvableRunningTime() {
+    assertFalse(matcher(TimePeriod.ofUnbounded()).match(tripOnServiceDateAkt));
+  }
+
+  @Test
+  void matchesSelectorRunningTimePeriods() {
+    var filter = FilterRequest.<TripOnServiceDateSelectRequest>of()
+      .addSelect(
+        TripOnServiceDateSelectRequest.of()
+          .withRunningTimePeriods(List.of(TimePeriod.of(RUT_START, RUT_END)))
+          .build()
+      )
+      .build();
+    var request = TripOnServiceDateRequest.of().withFilters(List.of(filter)).build();
+    var matcher = TripOnServiceDateMatcherFactory.of(request, patternResolver, runningTimeResolver);
+
+    assertTrue(matcher.match(tripOnServiceDateRut));
+    assertFalse(matcher.match(tripOnServiceDateRut2));
+    assertFalse(matcher.match(tripOnServiceDateAkt));
+  }
+
+  @Test
+  void serviceDateAndRunningTimeAreAnded() {
+    var request = TripOnServiceDateRequest.of()
+      .withIncludeRunningTimePeriods(
+        FilterValues.ofRequired("runningTimePeriods", List.of(TimePeriod.ofUnbounded()))
+      )
+      .withIncludeServiceDates(
+        FilterValues.ofRequired("serviceDates", List.of(LocalDate.of(2024, 2, 23)))
+      )
+      .build();
+    var matcher = TripOnServiceDateMatcherFactory.of(request, patternResolver, runningTimeResolver);
+
+    // The running time of the trip on 2024-02-23 cannot be resolved, so it does not match
+    assertFalse(matcher.match(tripOnServiceDateRut));
+    assertFalse(matcher.match(tripOnServiceDateRut2));
+  }
+
+  private Matcher<TripOnServiceDate> matcher(TimePeriod period) {
+    var request = TripOnServiceDateRequest.of()
+      .withIncludeRunningTimePeriods(FilterValues.ofRequired("runningTimePeriods", List.of(period)))
+      .build();
+    return TripOnServiceDateMatcherFactory.of(request, patternResolver, runningTimeResolver);
   }
 }

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
@@ -132,7 +132,8 @@ class TripOnServiceDateMatcherFactoryTest {
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -155,7 +156,8 @@ class TripOnServiceDateMatcherFactoryTest {
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -189,7 +191,8 @@ class TripOnServiceDateMatcherFactoryTest {
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -222,7 +225,8 @@ class TripOnServiceDateMatcherFactoryTest {
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -250,7 +254,8 @@ class TripOnServiceDateMatcherFactoryTest {
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertFalse(matcher.match(tripOnServiceDateRut));
@@ -266,7 +271,8 @@ class TripOnServiceDateMatcherFactoryTest {
     var request = TripOnServiceDateRequest.of().withFilters(List.of(filter)).build();
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -282,7 +288,8 @@ class TripOnServiceDateMatcherFactoryTest {
     var request = TripOnServiceDateRequest.of().withFilters(List.of(filter)).build();
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertFalse(matcher.match(tripOnServiceDateRut));
@@ -300,7 +307,8 @@ class TripOnServiceDateMatcherFactoryTest {
     var request = TripOnServiceDateRequest.of().withFilters(List.of(filter)).build();
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -319,7 +327,8 @@ class TripOnServiceDateMatcherFactoryTest {
     var request = TripOnServiceDateRequest.of().withFilters(List.of(filter)).build();
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -339,7 +348,8 @@ class TripOnServiceDateMatcherFactoryTest {
     var request = TripOnServiceDateRequest.of().withFilters(List.of(filterRut, filterAkt)).build();
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -357,7 +367,8 @@ class TripOnServiceDateMatcherFactoryTest {
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     assertTrue(matcher.match(tripOnServiceDateRut));
@@ -376,7 +387,8 @@ class TripOnServiceDateMatcherFactoryTest {
     // A resolver that cannot resolve a pattern (returns null) must not match the filter.
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      (trip, serviceDate) -> null
+      (trip, serviceDate) -> null,
+      tripOnServiceDate -> null
     );
 
     assertFalse(matcher.match(tripOnServiceDateRut));
@@ -397,7 +409,8 @@ class TripOnServiceDateMatcherFactoryTest {
 
     Matcher<TripOnServiceDate> matcher = TripOnServiceDateMatcherFactory.of(
       request,
-      patternResolver
+      patternResolver,
+      runningTimeResolver
     );
 
     // Same pattern, but only the trip on the matching service date passes.

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripOnServiceDateMatcherFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -422,9 +423,9 @@ class TripOnServiceDateMatcherFactoryTest {
   @Test
   void matchesTripRunningInsidePeriod() {
     assertTrue(
-      matcher(TimePeriod.of(RUT_START.minusSeconds(60), RUT_END.plusSeconds(60))).match(
-        tripOnServiceDateRut
-      )
+      matcher(
+        TimePeriod.of(RUT_START.minus(Duration.ofMinutes(1)), RUT_END.plus(Duration.ofMinutes(1)))
+      ).match(tripOnServiceDateRut)
     );
   }
 
@@ -432,15 +433,15 @@ class TripOnServiceDateMatcherFactoryTest {
   void matchesTripOverlappingPeriod() {
     // The trip arrives one minute before the period ends
     assertTrue(
-      matcher(TimePeriod.of(RUT_END.minusSeconds(60), RUT_END.plusSeconds(3600))).match(
-        tripOnServiceDateRut
-      )
+      matcher(
+        TimePeriod.of(RUT_END.minus(Duration.ofMinutes(1)), RUT_END.plus(Duration.ofHours(1)))
+      ).match(tripOnServiceDateRut)
     );
     // The trip departs one minute after the period starts
     assertTrue(
-      matcher(TimePeriod.of(RUT_START.minusSeconds(3600), RUT_START.plusSeconds(60))).match(
-        tripOnServiceDateRut
-      )
+      matcher(
+        TimePeriod.of(RUT_START.minus(Duration.ofHours(1)), RUT_START.plus(Duration.ofMinutes(1)))
+      ).match(tripOnServiceDateRut)
     );
   }
 
@@ -459,7 +460,7 @@ class TripOnServiceDateMatcherFactoryTest {
   @Test
   void doesNotMatchTripOutsidePeriod() {
     assertFalse(
-      matcher(TimePeriod.of(RUT_END.plusSeconds(1), RUT_END.plusSeconds(3600))).match(
+      matcher(TimePeriod.of(RUT_END.plusSeconds(1), RUT_END.plus(Duration.ofHours(1)))).match(
         tripOnServiceDateRut
       )
     );
@@ -476,7 +477,9 @@ class TripOnServiceDateMatcherFactoryTest {
     runningTimeResolver = tripOnServiceDate ->
       tripOnServiceDate.equals(tripOnServiceDateRut) ? TimePeriod.of(RUT_START, null) : null;
 
-    assertTrue(matcher(TimePeriod.of(RUT_END.plusSeconds(3600), null)).match(tripOnServiceDateRut));
+    assertTrue(
+      matcher(TimePeriod.of(RUT_END.plus(Duration.ofHours(1)), null)).match(tripOnServiceDateRut)
+    );
     assertFalse(
       matcher(TimePeriod.of(null, RUT_START.minusSeconds(1))).match(tripOnServiceDateRut)
     );

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactoryTest.java
@@ -651,9 +651,9 @@ class TripTimeOnDateMatcherFactoryTest {
   }
 
   @Test
-  void includeRunningTimePeriodOverlapping() {
+  void includeCallTimePeriodOverlapping() {
     var request = request()
-      .withIncludeRunningTimePeriods(
+      .withIncludeCallTimePeriods(
         List.of(
           TimePeriod.of(
             Instant.EPOCH.plus(Duration.ofHours(9)),
@@ -664,14 +664,14 @@ class TripTimeOnDateMatcherFactoryTest {
       .build();
     var matcher = TripTimeOnDateMatcherFactory.of(request);
 
-    // The trip runs from 10:00 to 10:05 after the epoch
+    // The vehicle visits the first stop at 10:00 after the epoch
     assertTrue(matcher.match(tripTimeOnDate(ROUTE_1)));
   }
 
   @Test
-  void includeRunningTimePeriodNotOverlapping() {
+  void includeCallTimePeriodNotOverlapping() {
     var request = request()
-      .withIncludeRunningTimePeriods(
+      .withIncludeCallTimePeriods(
         List.of(
           TimePeriod.of(
             Instant.EPOCH.plus(Duration.ofHours(11)),
@@ -685,6 +685,45 @@ class TripTimeOnDateMatcherFactoryTest {
     assertFalse(matcher.match(tripTimeOnDate(ROUTE_1)));
   }
 
+  @Test
+  void includeCallTimePeriodMatchesVisitAtStopAndNotWholeTrip() {
+    // The trip runs from 10:00 to 10:05, so the period is within the trip's running time but the
+    // vehicle visits neither of the stops during it.
+    var request = request()
+      .withIncludeCallTimePeriods(
+        List.of(
+          TimePeriod.of(
+            Instant.EPOCH.plus(Duration.ofHours(10)).plus(Duration.ofMinutes(1)),
+            Instant.EPOCH.plus(Duration.ofHours(10)).plus(Duration.ofMinutes(4))
+          )
+        )
+      )
+      .build();
+    var matcher = TripTimeOnDateMatcherFactory.of(request);
+
+    assertFalse(matcher.match(tripTimeOnDate(ROUTE_1, 0)));
+    assertFalse(matcher.match(tripTimeOnDate(ROUTE_1, 1)));
+  }
+
+  @Test
+  void includeCallTimePeriodMatchesLaterStopOnly() {
+    // The period only contains the visit at the second stop at 10:05
+    var request = request()
+      .withIncludeCallTimePeriods(
+        List.of(
+          TimePeriod.of(
+            Instant.EPOCH.plus(Duration.ofHours(10)).plus(Duration.ofMinutes(1)),
+            Instant.EPOCH.plus(Duration.ofHours(10)).plus(Duration.ofMinutes(10))
+          )
+        )
+      )
+      .build();
+    var matcher = TripTimeOnDateMatcherFactory.of(request);
+
+    assertFalse(matcher.match(tripTimeOnDate(ROUTE_1, 0)));
+    assertTrue(matcher.match(tripTimeOnDate(ROUTE_1, 1)));
+  }
+
   private static TripTimeOnDateRequestBuilder request() {
     return TripTimeOnDateRequest.of(List.of(STOP)).withTime(Instant.EPOCH);
   }
@@ -695,13 +734,17 @@ class TripTimeOnDateMatcherFactoryTest {
       .build();
   }
 
-  private static TripTimeOnDate tripTimeOnDate(Route route1) {
-    final TripPattern pattern = pattern(route1);
+  private static TripTimeOnDate tripTimeOnDate(Route route) {
+    return tripTimeOnDate(route, 0);
+  }
+
+  private static TripTimeOnDate tripTimeOnDate(Route route, int stopPosition) {
+    final TripPattern pattern = pattern(route);
     var tripTimes = ScheduledTripTimes.of()
-      .withTrip(TransitRepositoryForTest.trip("t1").withRoute(route1).build())
+      .withTrip(TransitRepositoryForTest.trip("t1").withRoute(route).build())
       .withArrivalTimes("10:00 10:05")
       .withDepartureTimes("10:00 10:05")
       .build();
-    return new TripTimeOnDate(tripTimes, 0, pattern, DATE, Instant.EPOCH);
+    return new TripTimeOnDate(tripTimes, stopPosition, pattern, DATE, Instant.EPOCH);
   }
 }

--- a/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactoryTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/filter/transit/TripTimeOnDateMatcherFactoryTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.agency;
 import static org.opentripplanner.transit.model._data.TransitRepositoryForTest.route;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.transit.api.request.CancellationPolicy;
 import org.opentripplanner.transit.api.request.TripTimeOnDateRequest;
@@ -645,6 +647,41 @@ class TripTimeOnDateMatcherFactoryTest {
     var matcher = TripTimeOnDateMatcherFactory.of(request);
 
     // A scheduled (non-canceled) trip time is not a cancellation, so it does not match.
+    assertFalse(matcher.match(tripTimeOnDate(ROUTE_1)));
+  }
+
+  @Test
+  void includeRunningTimePeriodOverlapping() {
+    var request = request()
+      .withIncludeRunningTimePeriods(
+        List.of(
+          TimePeriod.of(
+            Instant.EPOCH.plus(Duration.ofHours(9)),
+            Instant.EPOCH.plus(Duration.ofHours(11))
+          )
+        )
+      )
+      .build();
+    var matcher = TripTimeOnDateMatcherFactory.of(request);
+
+    // The trip runs from 10:00 to 10:05 after the epoch
+    assertTrue(matcher.match(tripTimeOnDate(ROUTE_1)));
+  }
+
+  @Test
+  void includeRunningTimePeriodNotOverlapping() {
+    var request = request()
+      .withIncludeRunningTimePeriods(
+        List.of(
+          TimePeriod.of(
+            Instant.EPOCH.plus(Duration.ofHours(11)),
+            Instant.EPOCH.plus(Duration.ofHours(12))
+          )
+        )
+      )
+      .build();
+    var matcher = TripTimeOnDateMatcherFactory.of(request);
+
     assertFalse(matcher.match(tripTimeOnDate(ROUTE_1)));
   }
 

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTimesScheduledRunningTimeTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTimesScheduledRunningTimeTest.java
@@ -1,0 +1,107 @@
+package org.opentripplanner.transit.model.timetable;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
+import org.opentripplanner.utils.time.ServiceDateUtils;
+import org.opentripplanner.utils.time.TimeUtils;
+
+/**
+ * Tests {@link TripTimes#scheduledRunningTime(Instant)}.
+ */
+class TripTimesScheduledRunningTimeTest {
+
+  private static final Trip TRIP = TransitRepositoryForTest.trip("Trip-1").build();
+  private static final ZoneId OSLO = ZoneId.of("Europe/Oslo");
+
+  @Test
+  void runningTimeIsFromFirstDepartureToLastArrival() {
+    var subject = tripTimes(
+      new int[] { TimeUtils.time("10:00"), TimeUtils.time("11:25") },
+      new int[] { TimeUtils.time("10:01"), TimeUtils.time("11:30") }
+    );
+
+    var period = subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 6, 5)));
+
+    assertThat(period).isNotNull();
+    assertThat(period.start()).hasValue(instant("2024-06-05T10:01+02:00"));
+    assertThat(period.end()).hasValue(instant("2024-06-05T11:25+02:00"));
+  }
+
+  @Test
+  void runningTimeAfterMidnightIsOnTheNextDay() {
+    var subject = tripTimes(
+      new int[] { TimeUtils.time("23:50"), TimeUtils.time("24:30") },
+      new int[] { TimeUtils.time("23:50"), TimeUtils.time("24:30") }
+    );
+
+    var period = subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 6, 5)));
+
+    assertThat(period).isNotNull();
+    assertThat(period.start()).hasValue(instant("2024-06-05T23:50+02:00"));
+    assertThat(period.end()).hasValue(instant("2024-06-06T00:30+02:00"));
+  }
+
+  @Test
+  void runningTimeOnDaylightSavingTimeChangeUsesTheStartOfTheServiceDay() {
+    // On 2024-03-31 the clock in Oslo is moved forward one hour at 02:00, hence the service day
+    // starts at 23:00 local time on the previous day.
+    var subject = tripTimes(
+      new int[] { TimeUtils.time("01:30"), TimeUtils.time("10:00") },
+      new int[] { TimeUtils.time("01:30"), TimeUtils.time("10:00") }
+    );
+
+    var period = subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 3, 31)));
+
+    assertThat(period).isNotNull();
+    assertThat(period.start()).hasValue(instant("2024-03-31T00:30+01:00"));
+    assertThat(period.end()).hasValue(instant("2024-03-31T10:00+02:00"));
+  }
+
+  @Test
+  void missingArrivalTimeAtLastStopIsNotResolved() {
+    var subject = tripTimes(
+      new int[] { TimeUtils.time("10:00"), StopTime.MISSING_VALUE },
+      new int[] { TimeUtils.time("10:00"), TimeUtils.time("11:00") }
+    );
+
+    assertThat(subject.getScheduledArrivalTime(1)).isEqualTo(StopTime.MISSING_VALUE);
+    assertThat(subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 6, 5)))).isNull();
+  }
+
+  @Test
+  void arrivalBeforeDepartureIsNotResolved() {
+    var subject = tripTimes(
+      new int[] { TimeUtils.time("10:00"), TimeUtils.time("09:00") },
+      new int[] { TimeUtils.time("10:00"), TimeUtils.time("09:00") }
+    );
+
+    assertThat(subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 6, 5)))).isNull();
+  }
+
+  private static Instant startOfService(LocalDate serviceDate) {
+    return ServiceDateUtils.asStartOfService(serviceDate, OSLO).toInstant();
+  }
+
+  private static Instant instant(String text) {
+    return OffsetDateTime.parse(text).toInstant();
+  }
+
+  /**
+   * Note: the arrival and departure times of the first and the last stop are the only ones used by
+   * the running time, the times in between are irrelevant for these tests.
+   */
+  private static TripTimes tripTimes(int[] arrivalTimes, int[] departureTimes) {
+    return ScheduledTripTimes.of()
+      .withArrivalTimes(arrivalTimes)
+      .withDepartureTimes(departureTimes)
+      .withTrip(TRIP)
+      .build();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTimesScheduledRunningTimeTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/TripTimesScheduledRunningTimeTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.StopTime;
@@ -30,8 +29,8 @@ class TripTimesScheduledRunningTimeTest {
     var period = subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 6, 5)));
 
     assertThat(period).isNotNull();
-    assertThat(period.start()).hasValue(instant("2024-06-05T10:01+02:00"));
-    assertThat(period.end()).hasValue(instant("2024-06-05T11:25+02:00"));
+    assertThat(period.start()).hasValue(instant("2024-06-05T08:01:00Z"));
+    assertThat(period.end()).hasValue(instant("2024-06-05T09:25:00Z"));
   }
 
   @Test
@@ -44,8 +43,8 @@ class TripTimesScheduledRunningTimeTest {
     var period = subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 6, 5)));
 
     assertThat(period).isNotNull();
-    assertThat(period.start()).hasValue(instant("2024-06-05T23:50+02:00"));
-    assertThat(period.end()).hasValue(instant("2024-06-06T00:30+02:00"));
+    assertThat(period.start()).hasValue(instant("2024-06-05T21:50:00Z"));
+    assertThat(period.end()).hasValue(instant("2024-06-05T22:30:00Z"));
   }
 
   @Test
@@ -60,8 +59,8 @@ class TripTimesScheduledRunningTimeTest {
     var period = subject.scheduledRunningTime(startOfService(LocalDate.of(2024, 3, 31)));
 
     assertThat(period).isNotNull();
-    assertThat(period.start()).hasValue(instant("2024-03-31T00:30+01:00"));
-    assertThat(period.end()).hasValue(instant("2024-03-31T10:00+02:00"));
+    assertThat(period.start()).hasValue(instant("2024-03-30T23:30:00Z"));
+    assertThat(period.end()).hasValue(instant("2024-03-31T08:00:00Z"));
   }
 
   @Test
@@ -90,7 +89,7 @@ class TripTimesScheduledRunningTimeTest {
   }
 
   private static Instant instant(String text) {
-    return OffsetDateTime.parse(text).toInstant();
+    return Instant.parse(text);
   }
 
   /**

--- a/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
@@ -24,10 +24,12 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.core.model.id.FeedScopedId;
+import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransitDataTestFactory;
 import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.transit.api.model.FilterValues;
 import org.opentripplanner.transit.api.request.TripOnServiceDateRequest;
 import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
@@ -47,6 +49,7 @@ import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.transit.repository.DefaultTimetableRepository;
@@ -328,6 +331,75 @@ class DefaultTransitServiceTest {
       var busExcludeRequest = TripOnServiceDateRequest.of().withFilters(List.of(filter)).build();
       var excludedBusTrips = service.findCanceledTrips(busExcludeRequest);
       assertThat(excludedBusTrips).isEmpty();
+    }
+
+    /**
+     * The canceled trip on 2024-08-09 is scheduled to run from 11:30 to 11:40 (Europe/Paris).
+     */
+    @Nested
+    class RunningTimeFilter {
+
+      private static final LocalDate SERVICE_DAY = LocalDate.of(2024, 8, 9);
+      private static final Instant DEPARTURE = Instant.parse("2024-08-09T09:30:00Z");
+      private static final Instant ARRIVAL = Instant.parse("2024-08-09T09:40:00Z");
+
+      @Test
+      void findTripsRunningInPeriod() {
+        var trips = findByRunningTimePeriod(
+          TimePeriod.of(DEPARTURE.minusSeconds(600), ARRIVAL.plusSeconds(600))
+        );
+        assertThat(trips).hasSize(1);
+        assertEquals(SERVICE_DAY, trips.getFirst().getServiceDate());
+      }
+
+      @Test
+      void findTripsArrivingJustAfterStartOfPeriod() {
+        var trips = findByRunningTimePeriod(
+          TimePeriod.of(ARRIVAL.minusSeconds(60), ARRIVAL.plusSeconds(3600))
+        );
+        assertThat(trips).hasSize(1);
+        assertEquals(SERVICE_DAY, trips.getFirst().getServiceDate());
+      }
+
+      @Test
+      void endOfPeriodIsExclusive() {
+        var trips = findByRunningTimePeriod(TimePeriod.of(DEPARTURE.minusSeconds(3600), DEPARTURE));
+        assertThat(trips).isEmpty();
+      }
+
+      @Test
+      void findNoTripsOutsidePeriod() {
+        assertThat(
+          findByRunningTimePeriod(TimePeriod.of(ARRIVAL.plusSeconds(1), ARRIVAL.plusSeconds(3600)))
+        ).isEmpty();
+      }
+
+      @Test
+      void serviceDateAndRunningTimeAreCombined() {
+        var request = TripOnServiceDateRequest.of()
+          .withIncludeRunningTimePeriods(
+            FilterValues.ofRequired(
+              "runningTimePeriods",
+              List.of(TimePeriod.of(DEPARTURE.minusSeconds(600), ARRIVAL.plusSeconds(600)))
+            )
+          )
+          .withIncludeServiceDates(
+            FilterValues.ofRequired("serviceDates", List.of(LocalDate.of(2024, 8, 8)))
+          )
+          .build();
+
+        // The trip running within the period is not running on the requested service date
+        assertThat(service.findCanceledTrips(request)).isEmpty();
+      }
+
+      private List<TripOnServiceDate> findByRunningTimePeriod(TimePeriod period) {
+        var request = TripOnServiceDateRequest.of()
+          .withIncludeRunningTimePeriods(
+            FilterValues.ofRequired("runningTimePeriods", List.of(period))
+          )
+          .build();
+        return service.findCanceledTrips(request);
+      }
     }
   }
 

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/canceled-trips.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/canceled-trips.graphql
@@ -7,6 +7,7 @@
           {
             modes: [BUS]
             serviceDateRanges: [{ start: "2024-08-09", end: "2024-08-10" }]
+            runningTimeRanges: [{ start: "2024-01-01T00:00:00Z" }]
           }
         ]
       }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/patterns.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/patterns.graphql
@@ -38,6 +38,7 @@
     }
     canceledTrips(
       serviceDateRanges: [{ start: "2024-08-01", end: "2024-09-01" }]
+      runningTimeRanges: [{ start: "2024-01-01T00:00:00Z" }]
     ) {
       serviceDate
       realTimeTripState {

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
@@ -23,7 +23,7 @@
     }
     canceledCalls(
       serviceDateRanges: [{ start: "2024-08-08", end: "2024-08-10" }]
-      runningTimeRanges: [
+      timeRanges: [
         { start: "2024-08-08T00:00:00Z", end: "2024-08-11T00:00:00Z" }
       ]
       arrivalDeparture: EITHER

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/stops.graphql
@@ -23,6 +23,9 @@
     }
     canceledCalls(
       serviceDateRanges: [{ start: "2024-08-08", end: "2024-08-10" }]
+      runningTimeRanges: [
+        { start: "2024-08-08T00:00:00Z", end: "2024-08-11T00:00:00Z" }
+      ]
       arrivalDeparture: EITHER
     ) {
       tripOnServiceDate {


### PR DESCRIPTION
### Summary

Adds time based filtering to canceled trips and calls queries within the GTFS API.

This work is based on #7896 

### Issue

Relates to https://github.com/opentripplanner/OpenTripPlanner/issues/7499

### Unit tests

Added

### Documentation

No

### Changelog

From title
