### PR TITLE
Fix TransitAlertService is null for vector tiles

### DIFF
--- a/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
+++ b/application/src/main/java/org/opentripplanner/standalone/configure/RequestScopedFactory.java
@@ -11,6 +11,7 @@ import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.framework.transaction.api.TransactionScope;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -38,6 +39,8 @@ public interface RequestScopedFactory {
   TransactionScope transactionScope();
 
   TransitService transitService();
+
+  TransitAlertService transitAlertService();
 
   OtpServerRequestContext createServerContext();
 

--- a/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
+++ b/application/src/main/java/org/opentripplanner/standalone/server/DaggerToJerseyBridge.java
@@ -13,6 +13,7 @@ import org.opentripplanner.ext.ojp.parameters.OjpApiParameters;
 import org.opentripplanner.ext.ojp.parameters.TriasApiParameters;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.linking.LinkingContextFactory;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.service.streetdetails.StreetDetailsService;
 import org.opentripplanner.service.vehicleparking.VehicleParkingService;
 import org.opentripplanner.service.vehiclerental.VehicleRentalService;
@@ -62,6 +63,7 @@ final class DaggerToJerseyBridge extends AbstractBinder {
 
     // Binding for all request-scoped services used by resources
     bridge(factory, RequestScopedFactory::transitService, TransitService.class);
+    bridge(factory, RequestScopedFactory::transitAlertService, TransitAlertService.class);
     bridge(factory, RequestScopedFactory::createServerContext, OtpServerRequestContext.class);
     bridge(factory, RequestScopedFactory::graph, Graph.class);
     bridge(factory, RequestScopedFactory::defaultRouteRequest, RouteRequest.class);


### PR DESCRIPTION
### Summary

Recent changes to have made it so that TransitAlertService doesn't get initialised in DigitransitRealtimeStopPropertyMapper. Added the service to dagger so that it's available for vector tile needs.

### Issue

Digitransit realtime stop vector tiles do not work at all. 