### PR TITLE
Direction of line restriction in SIRI-SX

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/et/EstimatedCallType.java
@@ -367,12 +367,16 @@ public class EstimatedCallType {
       StopCondition.EXCEPTIONAL_STOP
     );
 
+    var direction = trip.getDirection();
+
     // Quay
     allAlerts.addAll(alertPatchService.getStopAlerts(stopId, stopConditions));
     allAlerts.addAll(
       alertPatchService.getStopAndTripAlerts(stopId, tripId, serviceDate, stopConditions)
     );
-    allAlerts.addAll(alertPatchService.getStopAndRouteAlerts(stopId, routeId, stopConditions));
+    allAlerts.addAll(
+      alertPatchService.getStopAndRouteAlerts(stopId, routeId, stopConditions, direction)
+    );
     // StopPlace
     if (stop.getParentStation() != null) {
       FeedScopedId parentStopId = stop.getParentStation().getId();
@@ -381,7 +385,7 @@ public class EstimatedCallType {
         alertPatchService.getStopAndTripAlerts(parentStopId, tripId, serviceDate, stopConditions)
       );
       allAlerts.addAll(
-        alertPatchService.getStopAndRouteAlerts(parentStopId, routeId, stopConditions)
+        alertPatchService.getStopAndRouteAlerts(parentStopId, routeId, stopConditions, direction)
       );
     }
     // Trip
@@ -392,7 +396,7 @@ public class EstimatedCallType {
     // TODO OTP2 This should probably have a FeedScopeId argument instead of string
     allAlerts.addAll(alertPatchService.getAgencyAlerts(trip.getRoute().getAgency().getId()));
     // Route's direction
-    allAlerts.addAll(alertPatchService.getDirectionAndRouteAlerts(trip.getDirection(), routeId));
+    allAlerts.addAll(alertPatchService.getDirectionAndRouteAlerts(direction, routeId));
 
     long serviceDay = tripTimeOnDate.getServiceDayMidnight();
     long arrivalTime = tripTimeOnDate.getRealtimeArrival();

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
@@ -82,6 +82,8 @@ public sealed interface EntitySelector {
 
   /// EntitySelector for a stop and a route. The stop can optionally be restricted to certain stopConditions
   /// and the line can be restricted to certain directions.
+  ///
+  /// @param directions If set the selector will only match trips with one of the specified directions. An empty list will match nothing.
   record StopAndRoute(
     FeedScopedId stopId,
     FeedScopedId routeId,

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.alertpatch;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
@@ -79,21 +80,24 @@ public sealed interface EntitySelector {
     }
   }
 
+  /// EntitySelector for a stop and a route. The stop can optionally be restricted to certain stopConditions
+  /// and the line can be restricted to certain directions.
   record StopAndRoute(
     FeedScopedId stopId,
     FeedScopedId routeId,
-    Set<StopCondition> stopConditions
+    Set<StopCondition> stopConditions,
+    @Nullable List<Direction> directions
   ) implements EntitySelector {
     public StopAndRoute(FeedScopedId stopId, FeedScopedId routeId) {
-      this(stopId, routeId, Set.of());
+      this(stopId, routeId, Set.of(), null);
     }
 
     public StopAndRoute(
       FeedScopedId stopId,
-      Set<StopCondition> stopConditions,
-      FeedScopedId routeId
+      FeedScopedId routeId,
+      Set<StopCondition> stopConditions
     ) {
-      this(stopId, routeId, stopConditions);
+      this(stopId, routeId, stopConditions, null);
     }
 
     @Override
@@ -106,10 +110,15 @@ public sealed interface EntitySelector {
       if (!(other instanceof EntitySelector.StopAndRoute s)) {
         return false;
       }
+
+      var matchesDirection =
+        directions == null || (s.directions() != null && directions.containsAll(s.directions()));
+
       return (
         stopId.equals(s.stopId) &&
         routeId.equals(s.routeId) &&
-        StopConditionsHelper.matchesStopCondition(stopConditions, s.stopConditions)
+        StopConditionsHelper.matchesStopCondition(stopConditions, s.stopConditions) &&
+        matchesDirection
       );
     }
   }

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -18,6 +18,7 @@ import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.Direction;
 
 /**
  * This class is responsible for finding and adding transit alerts to individual transit legs.
@@ -50,6 +51,7 @@ public class AlertToLegMapper {
 
     FeedScopedId routeId = leg.route().getId();
     FeedScopedId tripId = leg.trip().getId();
+    var direction = leg.trip().getDirection();
     LocalDate serviceDate = leg.serviceDate();
 
     var totalAlerts = new HashSet<TransitAlert>();
@@ -59,7 +61,12 @@ public class AlertToLegMapper {
         ? StopCondition.FIRST_DEPARTURE
         : StopCondition.DEPARTURE;
 
-      Collection<TransitAlert> alerts = getAlertsForStopAndRoute(stop, routeId, stopConditions);
+      Collection<TransitAlert> alerts = getAlertsForStopAndRoute(
+        stop,
+        routeId,
+        stopConditions,
+        direction
+      );
       alerts.addAll(getAlertsForStopAndTrip(stop, tripId, serviceDate, stopConditions));
       alerts.addAll(
         getAlertsForRelatedStops(stop, id -> transitAlertService.getStopAlerts(id, stopConditions))
@@ -68,7 +75,12 @@ public class AlertToLegMapper {
     }
     if (toStop instanceof RegularStop stop) {
       Set<StopCondition> stopConditions = StopCondition.ARRIVING;
-      Collection<TransitAlert> alerts = getAlertsForStopAndRoute(stop, routeId, stopConditions);
+      Collection<TransitAlert> alerts = getAlertsForStopAndRoute(
+        stop,
+        routeId,
+        stopConditions,
+        direction
+      );
       alerts.addAll(getAlertsForStopAndTrip(stop, tripId, serviceDate, stopConditions));
       alerts.addAll(
         getAlertsForRelatedStops(stop, id -> transitAlertService.getStopAlerts(id, stopConditions))
@@ -80,7 +92,12 @@ public class AlertToLegMapper {
       Set<StopCondition> stopConditions = StopCondition.PASSING;
       for (StopArrival visit : leg.listIntermediateStops()) {
         if (visit.place.stop instanceof RegularStop stop) {
-          Collection<TransitAlert> alerts = getAlertsForStopAndRoute(stop, routeId, stopConditions);
+          Collection<TransitAlert> alerts = getAlertsForStopAndRoute(
+            stop,
+            routeId,
+            stopConditions,
+            direction
+          );
           alerts.addAll(getAlertsForStopAndTrip(stop, tripId, serviceDate, stopConditions));
           alerts.addAll(
             getAlertsForRelatedStops(stop, id ->
@@ -138,10 +155,11 @@ public class AlertToLegMapper {
   private Collection<TransitAlert> getAlertsForStopAndRoute(
     RegularStop stop,
     FeedScopedId routeId,
-    Set<StopCondition> stopConditions
+    Set<StopCondition> stopConditions,
+    Direction direction
   ) {
     return getAlertsForRelatedStops(stop, id ->
-      transitAlertService.getStopAndRouteAlerts(id, routeId, stopConditions)
+      transitAlertService.getStopAndRouteAlerts(id, routeId, stopConditions, direction)
     );
   }
 

--- a/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -126,12 +126,13 @@ public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
   public Collection<TransitAlert> getStopAndRouteAlerts(
     FeedScopedId stop,
     FeedScopedId route,
-    Set<StopCondition> stopConditions
+    Set<StopCondition> stopConditions,
+    Direction direction
   ) {
     return transitAlertServices
       .stream()
       .map(transitAlertService ->
-        transitAlertService.getStopAndRouteAlerts(stop, route, stopConditions)
+        transitAlertService.getStopAndRouteAlerts(stop, route, stopConditions, direction)
       )
       .flatMap(Collection::stream)
       .collect(Collectors.toList());

--- a/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/application/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -108,12 +108,14 @@ public class TransitAlertServiceImpl implements TransitAlertService {
   public Collection<TransitAlert> getStopAndRouteAlerts(
     FeedScopedId stop,
     FeedScopedId route,
-    Set<StopCondition> stopConditions
+    Set<StopCondition> stopConditions,
+    Direction direction
   ) {
     EntitySelector.StopAndRoute entitySelector = new EntitySelector.StopAndRoute(
       stop,
       route,
-      stopConditions
+      stopConditions,
+      List.of(direction)
     );
     return findMatchingAlerts(entitySelector);
   }

--- a/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
+++ b/application/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
@@ -62,13 +62,14 @@ public interface TransitAlertService {
   Collection<TransitAlert> getAgencyAlerts(FeedScopedId agency);
 
   default Collection<TransitAlert> getStopAndRouteAlerts(FeedScopedId stop, FeedScopedId route) {
-    return getStopAndRouteAlerts(stop, route, Set.of());
+    return getStopAndRouteAlerts(stop, route, Set.of(), Direction.UNKNOWN);
   }
 
   Collection<TransitAlert> getStopAndRouteAlerts(
     FeedScopedId stop,
     FeedScopedId route,
-    Set<StopCondition> stopConditions
+    Set<StopCondition> stopConditions,
+    Direction direction
   );
 
   default Collection<TransitAlert> getStopAndTripAlerts(

--- a/application/src/main/java/org/opentripplanner/updater/alert/siri/mapping/AffectsMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/alert/siri/mapping/AffectsMapper.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.StopCondition;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.service.TransitService;
@@ -28,6 +29,7 @@ import uk.org.siri.siri21.AffectedVehicleJourneyStructure;
 import uk.org.siri.siri21.AffectsScopeStructure;
 import uk.org.siri.siri21.DataFrameRefStructure;
 import uk.org.siri.siri21.DatedVehicleJourneyRef;
+import uk.org.siri.siri21.DirectionStructure;
 import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
 import uk.org.siri.siri21.LineRef;
 import uk.org.siri.siri21.NetworkRefStructure;
@@ -259,6 +261,8 @@ public class AffectsMapper {
           }
           FeedScopedId affectedRoute = new FeedScopedId(feedId, lineRef.getValue());
 
+          var affectedDirections = mapDirections(line.getDirections());
+
           if (!affectedStops.isEmpty()) {
             for (AffectedStopPointStructure affectedStop : affectedStops) {
               FeedScopedId stop = getStop(
@@ -271,13 +275,20 @@ public class AffectsMapper {
               }
               EntitySelector.StopAndRoute entitySelector = new EntitySelector.StopAndRoute(
                 stop,
+                affectedRoute,
                 resolveStopConditions(affectedStop.getStopConditions()),
-                affectedRoute
+                affectedDirections
               );
               selectors.add(entitySelector);
             }
           } else {
-            selectors.add(new EntitySelector.Route(affectedRoute));
+            if (affectedDirections != null) {
+              for (var dir : affectedDirections) {
+                selectors.add(new EntitySelector.DirectionAndRoute(affectedRoute, dir));
+              }
+            } else {
+              selectors.add(new EntitySelector.Route(affectedRoute));
+            }
           }
         }
       } else {
@@ -291,6 +302,25 @@ public class AffectsMapper {
       }
     }
     return selectors;
+  }
+
+  @Nullable
+  private List<Direction> mapDirections(List<DirectionStructure> directionStructures) {
+    var res = directionStructures
+      .stream()
+      .flatMap(d -> mapDirection(d.getDirectionRef().getValue()).stream())
+      .toList();
+    return res.isEmpty() ? null : res;
+  }
+
+  private Optional<Direction> mapDirection(String directionRef) {
+    return switch (directionRef.toUpperCase()) {
+      case "INBOUND" -> Optional.of(Direction.INBOUND);
+      case "OUTBOUND" -> Optional.of(Direction.OUTBOUND);
+      case "CLOCKWISE" -> Optional.of(Direction.CLOCKWISE);
+      case "ANTICLOCKWISE" -> Optional.of(Direction.ANTICLOCKWISE);
+      default -> Optional.empty();
+    };
   }
 
   private List<EntitySelector> mapStopPoints(AffectsScopeStructure.StopPoints stopPoints) {

--- a/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.updater.alert.siri;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,6 +31,7 @@ import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.StopConditionsHelper;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.DefaultTransitRealTimeUpdateContext;
@@ -44,6 +46,8 @@ import uk.org.siri.siri21.AffectsScopeStructure;
 import uk.org.siri.siri21.DataFrameRefStructure;
 import uk.org.siri.siri21.DatedVehicleJourneyRef;
 import uk.org.siri.siri21.DefaultedTextStructure;
+import uk.org.siri.siri21.DirectionRefStructure;
+import uk.org.siri.siri21.DirectionStructure;
 import uk.org.siri.siri21.FramedVehicleJourneyRefStructure;
 import uk.org.siri.siri21.HalfOpenTimestampOutputRangeStructure;
 import uk.org.siri.siri21.InfoLinkStructure;
@@ -778,6 +782,114 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
   }
 
   @Test
+  public void testSiriSxUpdateForLineAndStopAndDirection() {
+    var routeId = "route0";
+    var stopId0 = "stop0";
+    var stopId1 = "stop1";
+    var situationNumber1 = "TST:SituationNumber:1";
+    var situationNumber2 = "TST:SituationNumber:2";
+
+    var outbound = createServiceDelivery(
+      createPtSituationElement(
+        situationNumber1,
+        ZonedDateTime.parse("2014-01-01T00:00:00+01:00"),
+        ZonedDateTime.parse("2014-01-01T23:59:59+01:00"),
+        createAffectsLineAndDirection(routeId, List.of("OUTBOUND"), stopId0, stopId1)
+      )
+    );
+    var inbound = createServiceDelivery(
+      createPtSituationElement(
+        situationNumber2,
+        ZonedDateTime.parse("2014-01-01T00:00:00+01:00"),
+        ZonedDateTime.parse("2014-01-01T23:59:59+01:00"),
+        createAffectsLineAndDirection(routeId, List.of("INBOUND"), stopId0, stopId1)
+      )
+    );
+
+    alertsUpdateHandler.update(outbound, realTimeUpdateContext);
+    alertsUpdateHandler.update(inbound, realTimeUpdateContext);
+
+    // Line and stop-alerts should result in several TransitAlerts. One for each routeId/stop combination
+    var feedRouteId = new FeedScopedId(FEED_ID, routeId);
+    var feedStop_0_id = new FeedScopedId(FEED_ID, stopId0);
+    var feedStop_1_id = new FeedScopedId(FEED_ID, stopId1);
+
+    var alerts = transitAlertService.getStopAndRouteAlerts(
+      feedStop_0_id,
+      feedRouteId,
+      Set.of(),
+      Direction.OUTBOUND
+    );
+    assertEquals(1, alerts.size());
+
+    var alert = alerts.iterator().next();
+    assertEquals(situationNumber1, alert.getId().getId());
+    assertThat(alert.entities()).containsExactly(
+      new EntitySelector.StopAndRoute(
+        feedStop_0_id,
+        feedRouteId,
+        Set.of(StopCondition.START_POINT, StopCondition.DESTINATION),
+        List.of(Direction.OUTBOUND)
+      ),
+      new EntitySelector.StopAndRoute(
+        feedStop_1_id,
+        feedRouteId,
+        Set.of(StopCondition.START_POINT, StopCondition.DESTINATION),
+        List.of(Direction.OUTBOUND)
+      )
+    );
+  }
+
+  /// For backwards compatability reasons we ignore directions that we don't recognize
+  @Test
+  public void testSiriSxUpdateForLineAndStopAndUnknownDirection() {
+    var routeId = "route0";
+    var stopId0 = "stop0";
+    var stopId1 = "stop1";
+    var situationNumber1 = "TST:SituationNumber:1";
+
+    var unknown = createServiceDelivery(
+      createPtSituationElement(
+        situationNumber1,
+        ZonedDateTime.parse("2014-01-01T00:00:00+01:00"),
+        ZonedDateTime.parse("2014-01-01T23:59:59+01:00"),
+        createAffectsLineAndDirection(routeId, List.of("SomeUnknownString"), stopId0, stopId1)
+      )
+    );
+
+    alertsUpdateHandler.update(unknown, realTimeUpdateContext);
+
+    var feedRouteId = new FeedScopedId(FEED_ID, routeId);
+    var feedStop_0_id = new FeedScopedId(FEED_ID, stopId0);
+    var feedStop_1_id = new FeedScopedId(FEED_ID, stopId1);
+
+    var alerts = transitAlertService.getStopAndRouteAlerts(
+      feedStop_0_id,
+      feedRouteId,
+      Set.of(),
+      Direction.OUTBOUND
+    );
+    assertEquals(1, alerts.size());
+
+    var alert = alerts.iterator().next();
+    assertEquals(situationNumber1, alert.getId().getId());
+    assertThat(alert.entities()).containsExactly(
+      new EntitySelector.StopAndRoute(
+        feedStop_0_id,
+        feedRouteId,
+        Set.of(StopCondition.START_POINT, StopCondition.DESTINATION),
+        null
+      ),
+      new EntitySelector.StopAndRoute(
+        feedStop_1_id,
+        feedRouteId,
+        Set.of(StopCondition.START_POINT, StopCondition.DESTINATION),
+        null
+      )
+    );
+  }
+
+  @Test
   public void testSiriSxWithOpenEndedValidity() {
     assertTrue(transitAlertService.getAllAlerts().isEmpty());
 
@@ -1148,6 +1260,14 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
   }
 
   private AffectsScopeStructure createAffectsLine(String line, String... stopIds) {
+    return createAffectsLineAndDirection(line, List.of(), stopIds);
+  }
+
+  private AffectsScopeStructure createAffectsLineAndDirection(
+    String line,
+    List<String> directions,
+    String... stopIds
+  ) {
     AffectsScopeStructure affects = new AffectsScopeStructure();
 
     AffectsScopeStructure.Networks networks = new AffectsScopeStructure.Networks();
@@ -1168,6 +1288,14 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       affectedRoute.setStopPoints(stopPoints);
       routes.getAffectedRoutes().add(affectedRoute);
       affectedLine.setRoutes(routes);
+    }
+
+    for (String direction : directions) {
+      var directionRef = new DirectionRefStructure();
+      directionRef.setValue(direction);
+      var directionStructure = new DirectionStructure();
+      directionStructure.setDirectionRef(directionRef);
+      affectedLine.getDirections().add(directionStructure);
     }
 
     networks.getAffectedNetworks().add(affectedNetwork);


### PR DESCRIPTION
### Summary

This PR implements support for restricting SIRI-SX messages on a Line to only apply for certain directions. This also works in combination with line + stop points.

As an examlpe a message with the following affects section will only be shown for trips with `inbound` direction.:
```
<Affects>
  <Networks>
    <AffectedNetwork>
      <AffectedLine>
        <LineRef>SE:276:Line:1</LineRef>
        <Direction>
          <DirectionRef>INBOUND</DirectionRef>
        </Direction>
        <Routes>
          <AffectedRoute>
            <StopPoints>
              <AffectedStopPoint>
                <StopPointRef>SE:276:StopPlace:123</StopPointRef>
              </AffectedStopPoint>
            </StopPoints>
          </AffectedRoute>
        </Routes>
      </AffectedLine>
    </AffectedNetwork>
  </Networks>
</Affects>
```

Note:
- In order to not change existing behavior this PR ignores unknown directions. The more strict thing to do would be to not show messages with unknown direction since there won't be any trips with that direction.

### Issue

Closes #7736 

### Unit tests

Yes

### Changelog

Yes

### Bumping the serialization version id

No
